### PR TITLE
fix(ci): clear the 12 ruff violations breaking the fast and full lanes

### DIFF
--- a/alberta_framework/core/hccl_continual_dyad_operational_life_runner.py
+++ b/alberta_framework/core/hccl_continual_dyad_operational_life_runner.py
@@ -557,7 +557,9 @@ def _read_operational_event(
         signals = proposal.signals
         factor_source = proposal.factors
     except AttributeError as error:
-        raise ValueError("operational result does not expose the PP transcript interface") from error
+        raise ValueError(
+            "operational result does not expose the PP transcript interface"
+        ) from error
     regime = _host_array(
         proposal.evaluator_regime_id,
         name="operational PP evaluator_regime_id",

--- a/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
+++ b/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
@@ -557,7 +557,10 @@ def _mechanism_diagnostics(
             dtype=np.bool_,
         ),
         context_allocation_requested=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.context_allocation_requested)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.context_allocation_requested))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         context_full_bank_eviction_requested=np.asarray(
@@ -568,31 +571,52 @@ def _mechanism_diagnostics(
             dtype=np.bool_,
         ),
         context_eviction_target_adjusted=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.context_eviction_target_adjusted)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.context_eviction_target_adjusted))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lineage_transferred=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.lineage_transferred)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.lineage_transferred))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         rescue_incremented=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.rescue_incremented)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.rescue_incremented))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lifecycle_committed=np.asarray(
-            tuple(bool(jax.device_get(agent.lifecycle_proof.lifecycle_committed)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.lifecycle_proof.lifecycle_committed))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lifecycle_selected_active_slots=np.asarray(
-            tuple(int(jax.device_get(agent.lifecycle_proof.selected_active_slot)) for agent in agents),
+            tuple(
+                int(jax.device_get(agent.lifecycle_proof.selected_active_slot))
+                for agent in agents
+            ),
             dtype=np.int32,
         ),
         lifecycle_selected_candidate_slots=np.asarray(
-            tuple(int(jax.device_get(agent.lifecycle_proof.selected_candidate_slot)) for agent in agents),
+            tuple(
+                int(jax.device_get(agent.lifecycle_proof.selected_candidate_slot))
+                for agent in agents
+            ),
             dtype=np.int32,
         ),
         pair_admission_masks=np.stack(
-            tuple(np.asarray(jax.device_get(agent.lifecycle_proof.pair_admission_mask)) for agent in agents)
+            tuple(
+                np.asarray(jax.device_get(agent.lifecycle_proof.pair_admission_mask))
+                for agent in agents
+            )
         ).astype(np.bool_),
         memory_settlements_performed=np.asarray(
             tuple(agent.memory_settle_result is not None for agent in agents),

--- a/tests/test_hccl_continual_dyad_operational_life_runner.py
+++ b/tests/test_hccl_continual_dyad_operational_life_runner.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import json
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 
 import numpy as np
 import pytest

--- a/tests/test_hccl_routed_continual_dyad_operational_runner.py
+++ b/tests/test_hccl_routed_continual_dyad_operational_runner.py
@@ -18,7 +18,6 @@ from alberta_framework.core.hccl_routed_continual_dyad import (
     HCCLRoutedContinualDyadWork,
 )
 
-
 pytestmark = [pytest.mark.unit, pytest.mark.development]
 
 


### PR DESCRIPTION
## Scope

The first CI run on this repository ([31659637709](https://github.com/elizaOS/asi/actions/runs/31659637709)) failed both the `fast (3.12)` and `full (3.13)` lanes at `ruff check .` with 12 violations, so no push or pull request here has had a green gate yet. This clears all 12 and nothing else.

## What changed

**9x E501** in the two HCCL operational runners. Each over-long line is an `np.asarray(tuple(... for agent in agents))` entry, and the same dict literals already contain wrapped versions of the identical pattern — for example `context_full_bank_eviction_requested` immediately above `context_eviction_target_adjusted`. I used that existing style rather than introducing one, so the diff is shape-only:

```python
context_allocation_requested=np.asarray(
    tuple(
        bool(jax.device_get(agent.context_result.context_allocation_requested))
        for agent in agents
    ),
    dtype=np.bool_,
),
```

**2x F401 + 1x I001** in the two matching test modules (`json` and `typing.Any` unused; one unsorted import block), applied with `ruff check --fix`.

No behaviour, no public surface, no research artifact, and no threshold is touched.

## Verification

```
$ ruff check .          # before
Found 12 errors.
[*] 3 fixable with the `--fix` option.

$ ruff check .          # after
All checks passed!
```

Run against this repository's own config (`line-length = 100`, `select = ["E", "F", "I", "N", "W", "UP"]`, `ignore = ["F722"]`).

Two things I deliberately did **not** do:

- **`ruff format` is not run.** It would reformat 757 files, and both workflow lanes gate on `ruff check` only. Keeping the diff to the 12 reported violations.
- **I did not execute the test suite.** It needs a JAX environment I don't have locally, so I verified the touched modules parse and left the suite to CI rather than implying a run I didn't do.

## Evidence-registry check

Per `CLAUDE.md`, registered source hashes are load-bearing and editing a registered file invalidates persisted evidence. Both edited modules — `alberta_framework/core/hccl_continual_dyad_operational_life_runner.py` and `alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py` — appear in neither `evaluation/evidence_manifest.py` nor `PRUNING_REPORT.md`, so no claim's hash set is disturbed by this change.

- AI provider/model: Anthropic / claude-opus-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code"} -->
