### PR TITLE
fix: repair the routed-runner test doubles and clear the 12 ruff violations

### DIFF
--- a/alberta_framework/core/hccl_continual_dyad_operational_life_runner.py
+++ b/alberta_framework/core/hccl_continual_dyad_operational_life_runner.py
@@ -557,7 +557,9 @@ def _read_operational_event(
         signals = proposal.signals
         factor_source = proposal.factors
     except AttributeError as error:
-        raise ValueError("operational result does not expose the PP transcript interface") from error
+        raise ValueError(
+            "operational result does not expose the PP transcript interface"
+        ) from error
     regime = _host_array(
         proposal.evaluator_regime_id,
         name="operational PP evaluator_regime_id",

--- a/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
+++ b/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
@@ -557,7 +557,10 @@ def _mechanism_diagnostics(
             dtype=np.bool_,
         ),
         context_allocation_requested=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.context_allocation_requested)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.context_allocation_requested))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         context_full_bank_eviction_requested=np.asarray(
@@ -568,31 +571,52 @@ def _mechanism_diagnostics(
             dtype=np.bool_,
         ),
         context_eviction_target_adjusted=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.context_eviction_target_adjusted)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.context_eviction_target_adjusted))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lineage_transferred=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.lineage_transferred)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.lineage_transferred))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         rescue_incremented=np.asarray(
-            tuple(bool(jax.device_get(agent.context_result.rescue_incremented)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.context_result.rescue_incremented))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lifecycle_committed=np.asarray(
-            tuple(bool(jax.device_get(agent.lifecycle_proof.lifecycle_committed)) for agent in agents),
+            tuple(
+                bool(jax.device_get(agent.lifecycle_proof.lifecycle_committed))
+                for agent in agents
+            ),
             dtype=np.bool_,
         ),
         lifecycle_selected_active_slots=np.asarray(
-            tuple(int(jax.device_get(agent.lifecycle_proof.selected_active_slot)) for agent in agents),
+            tuple(
+                int(jax.device_get(agent.lifecycle_proof.selected_active_slot))
+                for agent in agents
+            ),
             dtype=np.int32,
         ),
         lifecycle_selected_candidate_slots=np.asarray(
-            tuple(int(jax.device_get(agent.lifecycle_proof.selected_candidate_slot)) for agent in agents),
+            tuple(
+                int(jax.device_get(agent.lifecycle_proof.selected_candidate_slot))
+                for agent in agents
+            ),
             dtype=np.int32,
         ),
         pair_admission_masks=np.stack(
-            tuple(np.asarray(jax.device_get(agent.lifecycle_proof.pair_admission_mask)) for agent in agents)
+            tuple(
+                np.asarray(jax.device_get(agent.lifecycle_proof.pair_admission_mask))
+                for agent in agents
+            )
         ).astype(np.bool_),
         memory_settlements_performed=np.asarray(
             tuple(agent.memory_settle_result is not None for agent in agents),

--- a/tests/test_hccl_continual_dyad_operational_life_runner.py
+++ b/tests/test_hccl_continual_dyad_operational_life_runner.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import json
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 
 import numpy as np
 import pytest

--- a/tests/test_hccl_routed_continual_dyad_operational_runner.py
+++ b/tests/test_hccl_routed_continual_dyad_operational_runner.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
+from types import SimpleNamespace
 from typing import Any, cast
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import alberta_framework.core.hccl_routed_continual_dyad_operational_runner as operational
@@ -241,7 +243,38 @@ def test_routed_kernel_uses_only_the_approved_public_preparation_boundary() -> N
     assert "prepared.source_state is not state" in source
 
 
-def _raw_result(state: object) -> operational.HCCLRoutedContinualDyadOperationalEventResult:
+def _fake_source_state(absolute_step: int) -> SimpleNamespace:
+    """Minimal state double satisfying the executor's source clock/token reads.
+
+    ``step()`` host-reads ``state.hccl_state.world_state.step_words`` (the routed
+    source clock, ``(0, absolute_step)`` as uint32 words) and
+    ``state.content_token`` before dispatching to the routed kernel, so the
+    doubles must carry exactly that attribute chain with concrete arrays.
+    """
+
+    return SimpleNamespace(
+        hccl_state=SimpleNamespace(
+            world_state=SimpleNamespace(
+                step_words=np.asarray((0, absolute_step), dtype=np.uint32),
+            ),
+        ),
+        content_token=np.arange(operational._TOKEN_NBYTES, dtype=np.uint8),
+    )
+
+
+def _raw_result(
+    state: object,
+    *,
+    source: SimpleNamespace,
+    next_step: int,
+) -> operational.HCCLRoutedContinualDyadOperationalEventResult:
+    transcript = SimpleNamespace(
+        pre_transaction_words=np.array(
+            source.hccl_state.world_state.step_words, copy=True
+        ),
+        post_transaction_words=np.asarray((0, next_step), dtype=np.uint32),
+        source_state_content_token=np.array(source.content_token, copy=True),
+    )
     result = object.__new__(operational.HCCLRoutedContinualDyadOperationalEventResult)
     object.__setattr__(
         result,
@@ -249,7 +282,7 @@ def _raw_result(state: object) -> operational.HCCLRoutedContinualDyadOperational
         operational.HCCL_ROUTED_CONTINUAL_DYAD_OPERATIONAL_RESULT_SCHEMA,
     )
     object.__setattr__(result, "state", state)
-    object.__setattr__(result, "transcript", object())
+    object.__setattr__(result, "transcript", transcript)
     object.__setattr__(result, "work", object())
     object.__setattr__(result, "update_applied", True)
     return result
@@ -273,7 +306,7 @@ def _raw_executor(
 def test_routed_executor_does_not_publish_when_preparation_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    source = object()
+    source = _fake_source_state(0)
     executor = _raw_executor(owner=object(), state=source, checkpoint_interval=None)
 
     def fail(*_args: object, **_kwargs: object) -> object:
@@ -304,7 +337,7 @@ def test_routed_executor_checks_candidate_before_publication(
         def state_valid(_state: object) -> bool:
             return False
 
-    source = object()
+    source = _fake_source_state(absolute_step)
     candidate = object()
     executor = _raw_executor(
         owner=_RejectingOwner(),
@@ -315,7 +348,11 @@ def test_routed_executor_checks_candidate_before_publication(
     monkeypatch.setattr(
         operational,
         "_execute_routed_operational_event",
-        lambda *_args, **_kwargs: _raw_result(candidate),
+        lambda *_args, **_kwargs: _raw_result(
+            candidate,
+            source=source,
+            next_step=absolute_step + 1,
+        ),
     )
     with pytest.raises(operational.HCCLRoutedContinualDyadOperationalError, match=stage):
         executor.step(cast(Any, object()))

--- a/tests/test_hccl_routed_continual_dyad_operational_runner.py
+++ b/tests/test_hccl_routed_continual_dyad_operational_runner.py
@@ -18,7 +18,6 @@ from alberta_framework.core.hccl_routed_continual_dyad import (
     HCCLRoutedContinualDyadWork,
 )
 
-
 pytestmark = [pytest.mark.unit, pytest.mark.development]
 
 


### PR DESCRIPTION
Two defects, one PR: three tests fail on unmodified `main`, and 12 ruff violations fail both CI lanes at the lint step. Supersedes #1 (closed), which carried only the lint half and named the red suite in its closing comment.

A third, separate blocker is reported at the bottom — not fixed here, because the fix is a maintainer's call rather than an outsider's.

## 1. Three tests fail on `main` — routed-runner executor doubles

On unmodified upstream `27825b7`:

```
$ .venv/bin/python -m pytest tests/test_hccl_routed_continual_dyad_operational_runner.py \
    tests/test_hccl_continual_dyad_operational_life_runner.py -q -o addopts=""
E       AttributeError: 'object' object has no attribute 'hccl_state'
alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py:983: AttributeError
3 failed, 16 passed
```

Failing:
- `test_routed_executor_does_not_publish_when_preparation_fails`
- `test_routed_executor_checks_candidate_before_publication[0-1-periodic-checkpoint]`
- `test_routed_executor_checks_candidate_before_publication[9-None-final-checkpoint]`

**Root cause — test/implementation drift, not a production bug.** `_HCCLRoutedContinualDyadOperationalExecutor.step()` host-reads the routed source clock (`state.hccl_state.world_state.step_words`) and `state.content_token` as a precondition *before* dispatching to `_execute_routed_operational_event`, and after dispatch verifies the result transcript binds to that exact source (`pre_transaction_words == source clock`, `post_transaction_words == (0, next_step)`, token equality). The three tests build their executor from hand-rolled doubles — `_raw_executor(state=object())` and `_raw_result(transcript=object())` — that predate those reads, so they die inside the precondition with `AttributeError` instead of ever reaching the behaviour they assert.

**Fix: repair the doubles, keep the production precondition.** The precondition is a deliberate source-binding check, and the tests assert contracts worth keeping — "do not publish when preparation fails" and "check candidate before publication". This PR:

- adds `_fake_source_state(absolute_step)` carrying exactly the attribute chain the executor host-reads: `step_words = (0, absolute_step)` as `uint32`, plus a concrete 32-byte content token;
- extends `_raw_result` to build a transcript double bound to that source — pre-words equal the source clock, post-words equal `(0, next_step)`, token copied — which is precisely the binding `step()` verifies before publication.

Every original assertion survives unchanged, and **no production line is modified by this half** (the commit touches only the test module).

```
$ .venv/bin/python -m pytest tests/test_hccl_routed_continual_dyad_operational_runner.py \
    tests/test_hccl_continual_dyad_operational_life_runner.py -q -o addopts=""
19 passed
```

## 2. Twelve ruff violations fail both CI lanes

The first CI run on this repository ([31659637709](https://github.com/elizaOS/asi/actions/runs/31659637709)) failed the `fast (3.12)` and `full (3.13)` lanes at `ruff check .`, so no push or PR here has ever had a green gate. Nine `E501` in the two HCCL operational runners, plus two `F401` (`json`, `typing.Any`) and one `I001` in the matching tests.

The over-long `np.asarray(tuple(... for agent in agents))` calls are wrapped in the same multi-line style the surrounding entries in those same dict literals already use (for example `context_full_bank_eviction_requested`), so the diff is shape-only. `ruff format` is deliberately **not** run — it would reformat 757 files, and the workflow gates on `ruff check` only.

```
$ .venv/bin/python -m ruff check .    # before (27825b7)
Found 12 errors.
$ .venv/bin/python -m ruff check .    # after
All checks passed!
```

## 3. Reported, not fixed: the fast lane cannot finish collection

Independent of the above, `pytest tests/` aborts during collection on unmodified `main`:

```
ImportError: cannot import name 'forager_matched_v3_storage_runtime_escape_protocol_v1'
  from 'alberta_framework.benchmarks'
tests/test_forager_matched_v3_storage_runtime_escape_protocol_v1.py:3
!!!! Interrupted: 1 error during collection !!!!
```

`tests/test_forager_matched_v3_storage_runtime_escape_protocol_v1.py` imports a benchmarks module that exists nowhere in the tree, and `alberta_framework/benchmarks/__init__.py` does not export that name. Because it is a *collection* error it aborts the whole run regardless of `-m "not slow"`, so the fast lane will still fail after this PR.

I have not touched it: either the implementation module is arriving in a follow-up commit, or the test is orphaned and should be removed — that is your call, not mine. Happy to send whichever you prefer as a separate PR.

## Verification

- `pytest` on both touched test modules: **19 passed** (was 3 failed / 16 passed on `27825b7`)
- `ruff check .`: **clean** (was 12 errors)
- The test-fix commit modifies **only** `tests/test_hccl_routed_continual_dyad_operational_runner.py`
- Neither edited runner is registered in `alberta_framework/evaluation/evidence_manifest.py` nor listed in `PRUNING_REPORT.md`; no `outputs/` artifact, threshold, or frozen seed is touched, per `CLAUDE.md`'s evidence rules
- Environment: `.venv` on Python 3.12.4, jax 0.11.0, pytest 9.1.1, ruff 0.16.3, installed via `pip install -e '.[dev]'`

Scope note: the wider suite contains further pre-existing failures beyond the collection error above, in modules unrelated to this change. I have not characterised them and make no claim about them here.

---

Built with Claude Code. Attribution, stated honestly: the work was performed by a `claude-fable-5` agent (see the `Co-Authored-By` trailer on the test commit), but our local receipt-model guard read `claude-opus-5` from the enclosing session transcript and refused to sign a `claude-fable-5` usage receipt. That refusal is treated as final, so this PR ships **unmeasured** — no usage receipt — rather than carrying one whose model claim we could not verify.
