### PR TITLE
fix: preserve routed executor preparation failure boundary

### DIFF
--- a/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
+++ b/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
@@ -1001,20 +1001,8 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
             raise HCCLRoutedContinualDyadOperationalError(
                 "bounds",
                 "configured routed life has no remaining transition capacity",
-            )
+        )
         source = self._state
-        source_words = _host_array(
-            source.hccl_state.world_state.step_words,
-            name="executor routed source clock",
-            shape=(2,),
-            dtype=np.dtype(np.uint32),
-        )
-        source_token = _host_array(
-            source.content_token,
-            name="executor routed source content token",
-            shape=(_TOKEN_NBYTES,),
-            dtype=np.dtype(np.uint8),
-        )
         try:
             result = _execute_routed_operational_event(
                 self._owner,
@@ -1035,6 +1023,41 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
             )
 
         next_step = self._absolute_step + 1
+        final_step = next_step == self._maximum_transitions
+        periodic_due = (
+            self._checkpoint_interval is not None
+            and next_step % self._checkpoint_interval == 0
+        )
+        checkpoint_due = final_step or periodic_due
+        if checkpoint_due:
+            stage = "final-checkpoint" if final_step else "periodic-checkpoint"
+            try:
+                _host_true(
+                    self._owner.state_valid(result.state),
+                    name=f"{stage} routed candidate validity",
+                )
+            except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+                raise HCCLRoutedContinualDyadOperationalError(stage, str(error)) from error
+            result = dataclasses.replace(
+                result,
+                work=dataclasses.replace(
+                    result.work,
+                    runner_checkpoint_state_validations=1,
+                ),
+            )
+
+        source_words = _host_array(
+            source.hccl_state.world_state.step_words,
+            name="executor routed source clock",
+            shape=(2,),
+            dtype=np.dtype(np.uint32),
+        )
+        source_token = _host_array(
+            source.content_token,
+            name="executor routed source content token",
+            shape=(_TOKEN_NBYTES,),
+            dtype=np.dtype(np.uint8),
+        )
         transcript_pre = _host_array(
             result.transcript.pre_transaction_words,
             name="result transcript pre clock",
@@ -1064,29 +1087,6 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
             raise HCCLRoutedContinualDyadOperationalError(
                 "source-transcript-binding",
                 "result does not name the executor's exact source token and next clock",
-            )
-
-        final_step = next_step == self._maximum_transitions
-        periodic_due = (
-            self._checkpoint_interval is not None
-            and next_step % self._checkpoint_interval == 0
-        )
-        checkpoint_due = final_step or periodic_due
-        if checkpoint_due:
-            stage = "final-checkpoint" if final_step else "periodic-checkpoint"
-            try:
-                _host_true(
-                    self._owner.state_valid(result.state),
-                    name=f"{stage} routed candidate validity",
-                )
-            except (AttributeError, RuntimeError, TypeError, ValueError) as error:
-                raise HCCLRoutedContinualDyadOperationalError(stage, str(error)) from error
-            result = dataclasses.replace(
-                result,
-                work=dataclasses.replace(
-                    result.work,
-                    runner_checkpoint_state_validations=1,
-                ),
             )
 
         self._state = result.state


### PR DESCRIPTION
## Fix

Closes #2.

Move routed executor candidate validation ahead of source publication metadata reads. Preparation failures now reach the existing `HCCLRoutedContinualDyadOperationalError` boundary, and periodic/final checkpoint validation runs before source/transcript binding can touch or publish the candidate.

### Verification

- Head: `6815de9275b245f39ab9ad6df61b0c7d775b73ae`
- Focused reproduction before the fix: 3 failed, 6 passed.
- Focused regression after the fix: `python -m pytest tests/test_hccl_routed_continual_dyad_operational_runner.py -q -o addopts=""` -> 9 passed.
- Lint: `python -m ruff check alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py tests/test_hccl_routed_continual_dyad_operational_runner.py` -> passed.
- Type check: `python -m mypy alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py` -> passed.
- Broader routed-dyad test batches timed out after 5 minutes in the Windows/JAX environment without producing a result; they are not claimed as passed.
- No `outputs/` artifacts were modified.

### Evidence

This is a measurement-trustworthiness fix, not a benchmark claim. The change is one file and preserves the existing tests and error stages.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [routed-dyad-operational-runner]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01KZYR67D0YQNXY4AD2JHFV7WV","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-13T23:44:16.290Z","completed_at":"2026-08-14T00:03:00.290Z","skill_sha256":"e1bc078325628e28f4fc8e8df37a2de0ad968d1a89ccc66b6d1a44c3e5b2d2cd","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwr6e66QmoiS9fl2UJvdMntqyBLxrFe3h1PxCjr4YpQg","device_key_id":"778e6a4d734e2bed4a498790a46f51fb98fcde93a2a65fcb55cc4df4106c4df0","device_signature":"xuY4zqMv39axPx_0ndoRBs7o3qtNlCSiCyfxS-HvBrRBqrHpr493mKktB2hGuG3VW4NJ4cg3ETPAiP7-2ldrDg"}} -->
