### PR TITLE
fix(core): enforce routed executor failure atomicity before any state read

### DIFF
--- a/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
+++ b/alberta_framework/core/hccl_routed_continual_dyad_operational_runner.py
@@ -995,7 +995,19 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
         self,
         next_hard_action_masks: Array | None = None,
     ) -> HCCLRoutedContinualDyadOperationalEventResult:
-        """Compute and bind one result to the owned source before publication."""
+        """Prepare, validate, and bind one result before atomic publication.
+
+        Failure atomicity: no owned attribute is read beyond the executor's own
+        counters and no owned field is written until every gate below has
+        passed, so a failing step leaves ``state`` and ``absolute_step``
+        exactly as they were.  Any non-domain exception raised inside the
+        preparation dispatch surfaces as the typed ``routed-preparation``
+        error; a checkpoint-due candidate is validated before the source and
+        transcript are ever dereferenced, so a rejected candidate surfaces as
+        its checkpoint-stage error rather than an incidental attribute error.
+        The owned source is a frozen pytree, so reading its clock after the
+        dispatch observes the same values it held before.
+        """
 
         if self._absolute_step >= self._maximum_transitions:
             raise HCCLRoutedContinualDyadOperationalError(
@@ -1003,18 +1015,6 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
                 "configured routed life has no remaining transition capacity",
             )
         source = self._state
-        source_words = _host_array(
-            source.hccl_state.world_state.step_words,
-            name="executor routed source clock",
-            shape=(2,),
-            dtype=np.dtype(np.uint32),
-        )
-        source_token = _host_array(
-            source.content_token,
-            name="executor routed source content token",
-            shape=(_TOKEN_NBYTES,),
-            dtype=np.dtype(np.uint8),
-        )
         try:
             result = _execute_routed_operational_event(
                 self._owner,
@@ -1035,24 +1035,60 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
             )
 
         next_step = self._absolute_step + 1
-        transcript_pre = _host_array(
-            result.transcript.pre_transaction_words,
-            name="result transcript pre clock",
-            shape=(2,),
-            dtype=np.dtype(np.uint32),
+        final_step = next_step == self._maximum_transitions
+        periodic_due = (
+            self._checkpoint_interval is not None
+            and next_step % self._checkpoint_interval == 0
         )
-        transcript_post = _host_array(
-            result.transcript.post_transaction_words,
-            name="result transcript post clock",
-            shape=(2,),
-            dtype=np.dtype(np.uint32),
-        )
-        transcript_token = _host_array(
-            result.transcript.source_state_content_token,
-            name="result transcript source content token",
-            shape=(_TOKEN_NBYTES,),
-            dtype=np.dtype(np.uint8),
-        )
+        checkpoint_due = final_step or periodic_due
+        stage = "final-checkpoint" if final_step else "periodic-checkpoint"
+        if checkpoint_due:
+            try:
+                _host_true(
+                    self._owner.state_valid(result.state),
+                    name=f"{stage} routed candidate validity",
+                )
+            except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+                raise HCCLRoutedContinualDyadOperationalError(stage, str(error)) from error
+
+        try:
+            source_words = _host_array(
+                source.hccl_state.world_state.step_words,
+                name="executor routed source clock",
+                shape=(2,),
+                dtype=np.dtype(np.uint32),
+            )
+            source_token = _host_array(
+                source.content_token,
+                name="executor routed source content token",
+                shape=(_TOKEN_NBYTES,),
+                dtype=np.dtype(np.uint8),
+            )
+            transcript_pre = _host_array(
+                result.transcript.pre_transaction_words,
+                name="result transcript pre clock",
+                shape=(2,),
+                dtype=np.dtype(np.uint32),
+            )
+            transcript_post = _host_array(
+                result.transcript.post_transaction_words,
+                name="result transcript post clock",
+                shape=(2,),
+                dtype=np.dtype(np.uint32),
+            )
+            transcript_token = _host_array(
+                result.transcript.source_state_content_token,
+                name="result transcript source content token",
+                shape=(_TOKEN_NBYTES,),
+                dtype=np.dtype(np.uint8),
+            )
+        except HCCLRoutedContinualDyadOperationalError:
+            raise
+        except (AttributeError, RuntimeError, TypeError, ValueError) as error:
+            raise HCCLRoutedContinualDyadOperationalError(
+                "source-transcript-binding",
+                str(error),
+            ) from error
         expected_pre = np.asarray((0, self._absolute_step), dtype=np.uint32)
         expected_post = np.asarray((0, next_step), dtype=np.uint32)
         if not (
@@ -1066,21 +1102,7 @@ class _HCCLRoutedContinualDyadOperationalExecutor:
                 "result does not name the executor's exact source token and next clock",
             )
 
-        final_step = next_step == self._maximum_transitions
-        periodic_due = (
-            self._checkpoint_interval is not None
-            and next_step % self._checkpoint_interval == 0
-        )
-        checkpoint_due = final_step or periodic_due
         if checkpoint_due:
-            stage = "final-checkpoint" if final_step else "periodic-checkpoint"
-            try:
-                _host_true(
-                    self._owner.state_valid(result.state),
-                    name=f"{stage} routed candidate validity",
-                )
-            except (AttributeError, RuntimeError, TypeError, ValueError) as error:
-                raise HCCLRoutedContinualDyadOperationalError(stage, str(error)) from error
             result = dataclasses.replace(
                 result,
                 work=dataclasses.replace(


### PR DESCRIPTION
Fixes #2 — the three `Tests (server)`-blocking failures in
`tests/test_hccl_routed_continual_dyad_operational_runner.py`.

## The contract decision the issue asked for

**Reading 2 (the tests are right): `step()` must not dereference owned-state
attributes before its preparation and checkpoint gates.** Three grounds:

1. The module's own contract documents the order — preparation, validation,
   binding, then publication ("Compute and bind one result to the owned source
   before publication"), and the executor's failure-atomicity assertions
   (`state`/`absolute_step` unchanged on any failure) are only meaningful if a
   malformed source cannot detonate outside a typed boundary.
2. The clock read that moved ahead of preparation gains nothing from being
   early: the owned source is a frozen chex pytree, so its
   `step_words`/`content_token` are identical before and after the dispatch.
   Real-state behavior is byte-identical under this reordering.
3. The tests' expected stage errors (`routed-preparation`,
   `periodic-checkpoint`, `final-checkpoint`) match the runner's existing typed
   vocabulary; the raw `AttributeError` escape was the only path that violated
   it.

## What changed (one function, `_RoutedExecutor.step`)

New gate order: bounds → preparation dispatch (non-domain errors wrapped as
`routed-preparation`, unchanged) → result-shape gate (unchanged) →
**checkpoint-stage candidate validation** (moved before any source/transcript
dereference) → **source + transcript reads and binding check** (moved after the
gates; non-domain errors in the read window now wrap as
`source-transcript-binding`, the same error the equality check already used) →
checkpoint work annotation → atomic publication. The docstring now states the
atomicity contract explicitly.

No other file changed; the failing tests themselves are untouched — they were
already asserting this contract.

## Verification

- **Both ways on the target suite** (local, Python 3.12, quiet lane):
  `main` → `3 failed, 6 passed` (the exact three from #2); with this change →
  `9 passed`.
- `ruff check` and strict `mypy` clean on the changed file.
- CI: this PR's own run is the authoritative harness. A pre-flight dispatch on
  my fork (https://github.com/FreeSolDev/asi/actions/runs/31754292872) had all
  four jobs killed by runner shutdown signals ~25 minutes in (infra, not
  tests — ruff printed "All checks passed!" before the kill and the visible
  pytest output was green to the point of cancellation); a rerun is in flight
  there as secondary evidence.

Local-environment disclosure: this machine is an Intel Mac, where jaxlib wheels
stop at 0.4.38 while the tree's import graph needs a newer `jax.jit`; the local
runs above therefore pre-seeded `alberta_framework.core` with a namespace-style
loader to skip the eager package `__init__` (shim used for test execution only,
not part of the change). The fork CI run exercises the real import graph
end-to-end. Incidentally, this means `pyproject.toml`'s `jax>=0.4` floor
understates the real requirement (`jax.jit(static_argnums=...)` factory form in
`ensemble_short_rollouts.py` needs a newer JAX) — happy to file that separately
if useful.

## Provenance

AI-assisted: `anthropic/claude-fable-5` via Claude Code, under the slop.cash
`contribute-to-asi` skill flow (installer currently refuses activation —
"deployed skill revision is stale because canonical skill bytes changed on
develop" — so no signed run receipt is attachable; noting that honestly rather
than omitting it).
