### PR TITLE
fix: give Kondo evaluation lanes an honest backward summary type

### DIFF
--- a/alberta_framework/core/kondo_sparse_actor.py
+++ b/alberta_framework/core/kondo_sparse_actor.py
@@ -375,6 +375,30 @@ class KondoActorBackwardResult:
 
 
 @chex.dataclass(frozen=True)
+class KondoActorBackwardSummary:
+    """Committed backward accounting without the per-slot autodiff auxiliaries.
+
+    The full :class:`KondoActorBackwardResult` also carries the per-slot
+    ``selected_log_probability`` and ``delight`` auxiliaries that fall out of the
+    canonical ``value_and_grad(_actor_loss, has_aux=True)`` backward pass.  Some
+    evaluation and development lanes reconstruct a backward record from an
+    already-committed :class:`KondoSparseActorResult` transaction, which does not
+    carry those two per-slot quantities; there is no honest local source for
+    them at those sites.  Every consumer of a backward record reads only ``loss``,
+    ``gradient``, ``selected_count``, and ``gradient_finite`` — so those lanes
+    carry exactly that committed subset here rather than fabricating per-slot
+    values to satisfy the full constructor.  Keeping the two types distinct means
+    the core producer at :func:`_actor_backward` still errors if it ever omits a
+    real auxiliary.
+    """
+
+    loss: Float[Array, ""]
+    gradient: KondoActorParameters
+    selected_count: Int[Array, ""]
+    gradient_finite: Bool[Array, ""]
+
+
+@chex.dataclass(frozen=True)
 class KondoSparseActorResult:
     """One proposed/committed Kondo actor transaction."""
 
@@ -1296,6 +1320,7 @@ __all__ = [
     "KONDO_SPARSE_ACTOR_SCHEMA",
     "KondoActorBackwardBatch",
     "KondoActorBackwardResult",
+    "KondoActorBackwardSummary",
     "KondoActorParameters",
     "KondoActorProtectedInputs",
     "KondoSparseActor",

--- a/alberta_framework/evaluation/kondo_actor_critic_on_policy_development.py
+++ b/alberta_framework/evaluation/kondo_actor_critic_on_policy_development.py
@@ -48,7 +48,7 @@ from jax.extend import backend as jax_backend
 from alberta_framework.core.kondo_gate import KondoGateConfig
 from alberta_framework.core.kondo_sparse_actor import (
     KondoActorBackwardBatch,
-    KondoActorBackwardResult,
+    KondoActorBackwardSummary,
     KondoActorParameters,
     KondoActorProtectedInputs,
     KondoSparseActor,
@@ -1162,7 +1162,7 @@ class _ActorOutcome:
     uniformly_reserved: Array
     force_keep_mask: Array
     gathered_indices: tuple[int, ...]
-    backward: KondoActorBackwardResult
+    backward: KondoActorBackwardSummary
     backward_leading_shape: int
     sparse_backward: bool
     screen_gather_order: tuple[str, ...]
@@ -1324,7 +1324,7 @@ def _kondo_actor_outcome(
     gathered_indices = tuple(int(item) for item in selected_indices[selected_slots])
     if not bool(np.all(np.asarray(batch.failure_mask) <= np.asarray(result.sparks_joy))):
         raise ValueError("Kondo actor dropped a forced rare-failure row")
-    backward = KondoActorBackwardResult(
+    backward = KondoActorBackwardSummary(
         loss=result.actor_loss,
         gradient=result.gradient,
         selected_count=result.screen.selected_count,

--- a/alberta_framework/evaluation/kondo_actor_critic_replay_development.py
+++ b/alberta_framework/evaluation/kondo_actor_critic_replay_development.py
@@ -53,7 +53,7 @@ from jax.extend import backend as jax_backend
 from alberta_framework.core.kondo_gate import KondoGateConfig
 from alberta_framework.core.kondo_sparse_actor import (
     KondoActorBackwardBatch,
-    KondoActorBackwardResult,
+    KondoActorBackwardSummary,
     KondoActorParameters,
     KondoActorProtectedInputs,
     KondoSparseActor,
@@ -1172,7 +1172,7 @@ class _ActorArmOutcome:
     selected_by_uniform_control: Array
     minimum_random_reserve: Array
     gathered_indices: tuple[int, ...]
-    backward: KondoActorBackwardResult
+    backward: KondoActorBackwardSummary
     backward_leading_shape: int
     sparse_backward: bool
     screen_gather_order: tuple[str, ...]
@@ -1302,7 +1302,7 @@ def _kondo_actor_outcome(
     selected_indices = np.asarray(result.screen.selected_indices, dtype=np.int32)
     slot_mask = np.asarray(result.screen.selected_slot_mask, dtype=np.bool_)
     gathered_indices = tuple(int(item) for item in selected_indices[slot_mask])
-    backward = KondoActorBackwardResult(
+    backward = KondoActorBackwardSummary(
         loss=result.actor_loss,
         gradient=result.gradient,
         selected_count=result.screen.selected_count,

--- a/alberta_framework/evaluation/kondo_sparse_actor_development.py
+++ b/alberta_framework/evaluation/kondo_sparse_actor_development.py
@@ -59,6 +59,7 @@ from alberta_framework.core.kondo_gate import KondoGate, KondoGateConfig
 from alberta_framework.core.kondo_sparse_actor import (
     KondoActorBackwardBatch,
     KondoActorBackwardResult,
+    KondoActorBackwardSummary,
     KondoActorParameters,
     KondoActorProtectedInputs,
     KondoSparseActor,
@@ -724,7 +725,7 @@ def _backward_record(
     behavior_log_probability: Array,
     parameters_before: KondoActorParameters,
     parameters_after: KondoActorParameters,
-    backward: KondoActorBackwardResult,
+    backward: KondoActorBackwardResult | KondoActorBackwardSummary,
     selected_indices: Sequence[int],
     selected_count: int,
     backward_slots: int,
@@ -944,7 +945,7 @@ class KondoSparseActorDevelopmentEvaluator:
         ):
             raise ValueError("Kondo development sparse transaction failed")
         kondo_selected = np.flatnonzero(np.asarray(kondo_result.sparks_joy)).tolist()
-        kondo_backward = KondoActorBackwardResult(
+        kondo_backward = KondoActorBackwardSummary(
             loss=kondo_result.actor_loss,
             gradient=kondo_result.gradient,
             selected_count=kondo_result.screen.selected_count,
@@ -999,7 +1000,7 @@ class KondoSparseActorDevelopmentEvaluator:
         ):
             raise ValueError("Kondo development overflow fallback failed")
         overflow_selected = np.flatnonzero(np.asarray(overflow_result.sparks_joy)).tolist()
-        overflow_backward = KondoActorBackwardResult(
+        overflow_backward = KondoActorBackwardSummary(
             loss=overflow_result.actor_loss,
             gradient=overflow_result.gradient,
             selected_count=overflow_result.screen.selected_count,


### PR DESCRIPTION
Closes #7.

## What changed

The four `development`/`integration` evaluation-lane sites that rebuild an actor
backward record from an already-committed `KondoSparseActorResult` only have four
of the six `KondoActorBackwardResult` fields. The per-slot
`selected_log_probability` and `delight` come out of the core
`value_and_grad(_actor_loss, has_aux=True)` backward pass and have no honest local
source at those sites, so every path through them raised
`TypeError: __init__() missing 2 required positional arguments`.

This takes **Option 2** from the issue: add `KondoActorBackwardSummary` carrying
exactly the committed subset every consumer actually reads (`loss`, `gradient`,
`selected_count`, `gradient_finite`), and construct it at the four sites instead
of fabricating per-slot values to satisfy the full constructor. The full 6-field
`KondoActorBackwardResult` and its core producer are unchanged, so a genuine
auxiliary omission in the core backward path still raises. No zero-filled or
fabricated per-slot data is introduced.

Sites updated: `evaluation/kondo_sparse_actor_development.py` (x2),
`evaluation/kondo_actor_critic_on_policy_development.py`,
`evaluation/kondo_actor_critic_replay_development.py`.

## Evidence

Deterministic unit/development, non-promoting; no seeds, no benchmark, no `outputs/` artifacts.

- **Baseline** `main` @ `9c6eeb884f8ebef6e00e6ac6fa23d67651aba725`:
  `pytest tests/test_kondo_sparse_actor_development_integration.py -q -o addopts=""` -> **6 failed** (`TypeError: missing selected_log_probability and delight`).
- **Candidate**:
  - same file -> **6 passed**.
  - adjacent unit lanes (`test_kondo_sparse_actor`, `test_kondo_sparse_actor_development`, `test_kondo_actor_critic_on_policy_development`, `test_kondo_actor_critic_replay_development`) -> **114 passed**.
  - touched integration modules (`test_kondo_actor_critic_on_policy_development_integration`, `test_kondo_actor_critic_replay_development_integration`) -> **15 passed**.
  - `ruff check` on changed files -> clean; strict `mypy` on changed files -> clean; `git diff --check` -> clean.

Diff: 4 files, +35 / −9.


---
🤖 Authored autonomously by [PrototypicNoise](https://github.com/PrototypicNoise), running on [Emblem:build](https://emblem.build).