### PR TITLE
Fix inert sigma0 frontier reduction pin

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -1069,6 +1069,29 @@ def _make_upgd_ema_norm_ext_learner(
         (loss, logits), grads = jax.value_and_grad(loss_fn, has_aux=True)(
             params, x_norm, y
         )
+        if not hidden_rms and not local_gate and gate_beta == 1.0:
+            # Keep the inert extension on the authoritative lean-UPGD path.
+            # Repeating the same equations here can produce low-bit parameter
+            # differences under JAX even when the accuracy and loss traces
+            # remain equal, which invalidates the reduction pin's plasticity
+            # metric.  The shared path also preserves the exact noise stream
+            # when a nonzero noise arm uses this factory.
+            lean_state = LeanUPGDState(  # type: ignore[call-arg]
+                utility=state.utility,
+                step=state.step,
+            )
+            lean_hp = {
+                name: hp[name]
+                for name in ("step_size", "utility_decay", "noise_std", "weight_decay")
+            }
+            noise = _sorted_flat_noise(key, params, noise_std)
+            reduced_params, reduced_lean = lean_upgd_w_update(
+                params, lean_state, grads, noise, lean_hp
+            )
+            metrics = _step_metrics(reduced_params, x_norm, y, loss, logits)
+            return reduced_params, UPGDNormState(  # type: ignore[call-arg]
+                utility=reduced_lean.utility, step=reduced_lean.step, norm=new_norm
+            ), metrics
         if noise_std == 0.0:
             # Exactly the zeros the sigma=0 draw produces, minus the draw.
             noise = {name: jnp.zeros_like(value) for name, value in params.items()}


### PR DESCRIPTION
Fixes #18

<!-- evidence-head:c889c9b53a4dca343381344a50c87f2dec12189b -->

## Summary

The inert-default sigma0 frontier extension now delegates to the authoritative lean-UPGD update and metric path. This removes the low-bit divergence in the post-update plasticity metric while preserving extension-only behavior for hidden RMS, local-gate, and non-default gate-temperature arms.

This is a measurement-integrity fix, not a benchmark result: no benchmark seeds were consumed, no frozen artifacts were touched, and no scientific claim is made.

## Lane and metric

- Lane: IPMNIST screening (`alberta_framework.benchmarks.ipmnist_screening`)
- Affected metric: post-update plasticity in the sigma0 frontier reduction pin
- Baseline evidence: pristine `main` at `d4ca66ce14f3a56e9456bb063821700d5f7af895` reproduced the inert-default reduction failure in `TestSigma0Frontier::test_ext_defaults_reduce_to_upgd_ema_norm_sigma0_bitwise`; accuracy and loss matched, while plasticity differed by 1–2 low bits.
- Candidate evidence: the authoritative lean-UPGD update and shared `_step_metrics` path are used when the extension switches are inert; extension-only paths remain unchanged.
- Seeds / n: none; no benchmark or screen run was launched.
- Artifacts: none written under `outputs/`; no registry or frozen evidence files changed.

## Verification

Exact commands run in the isolated worktree:

```text
.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""  # 198 passed in 43.52s
.venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py  # All checks passed!
.venv/bin/python -m mypy alberta_framework/benchmarks/ipmnist_screening.py  # Success: no issues found in 1 source file
git diff origin/main...HEAD --check  # clean
```

The repository-wide attempt was not used as a candidate claim: it remained baseline-red in 36 unrelated option-authority tests at the pre-existing primitive-only `STOMPConfig` validation, after 494 passed and 8 skipped before interruption. No changed file was implicated.

## Scope

One source file changed (`alberta_framework/benchmarks/ipmnist_screening.py`, +23 lines). The fix is limited to the inert-default reduction path and does not consume the preregistered #14 L2-Init screen or any frozen IPMNIST resources. Maintainer review, acceptance, and any later measurement remain outstanding.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@eae7fa94d7903cf191a2a9c49e0950b1bdc65037:skills/contribute-to-asi
Compute receipt: 569114 project-attributed tokens (bounded; device-signed, locally reported)
Attribution status: self-reported
— [sigma0-reduction-fix]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@eae7fa94d7903cf191a2a9c49e0950b1bdc65037:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01KZZD32FNDRHR5VDYD2MC2487","project":"asi","repository":"asi","started_at":"2026-08-14T05:49:33.045Z","completed_at":"2026-08-14T05:50:02.021Z","skill_sha256":"756045abe9f67ec5f5397842b6258eee8fffe61bb97457a1f174e1f3d67db82c","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":9986,"output_tokens":2968,"cache_creation_tokens":0,"cache_read_tokens":556160,"total_tokens":569114,"cost_micro_usd":"417050","session_count":2},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"4d-cKbmGyS2GG6fuy2B1iFzBPSRgpO-ljUfupuaLDhVwkosTy_1pRc9A2M6LmnmilU6LKx7p8RfrpkR27bCvBw"}}
