### PR TITLE
Fix dynamic STOMP option-template planning setup

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1327,6 +1327,24 @@ class STOMPConfig:
     epsilon_option: float = 0.1
     option_target_epsilon: float | None = None
     option_importance_clip: float = 10.0
+    _allow_empty_option_planning: bool = dataclasses.field(
+        default=False,
+        repr=False,
+        compare=False,
+    )
+
+    @classmethod
+    def for_dynamic_option_template(cls, **kwargs: Any) -> STOMPConfig:
+        """Build an empty template that will materialize options later.
+
+        A dynamic option installer starts with no configured subtasks, then
+        replaces this template with a fixed option set before constructing the
+        live agent.  The planning budget belongs to that eventual materialized
+        agent, so it must be representable on the empty template without
+        weakening the standalone primitive-only configuration guard.
+        """
+
+        return cls(_allow_empty_option_planning=True, **kwargs)
 
     def __post_init__(self) -> None:
         """Validate configuration."""
@@ -1360,7 +1378,11 @@ class STOMPConfig:
             raise ValueError(
                 "option_planning_backups_per_step must be smaller than int32 max"
             )
-        if not self.subtask_specs and self.option_planning_backups_per_step != 0:
+        if (
+            not self.subtask_specs
+            and self.option_planning_backups_per_step != 0
+            and not self._allow_empty_option_planning
+        ):
             raise ValueError(
                 "primitive-only STOMP requires option_planning_backups_per_step == 0"
             )

--- a/tests/test_cumulant_option_installation.py
+++ b/tests/test_cumulant_option_installation.py
@@ -116,7 +116,7 @@ def _composition(
     reserved_observation_suffix: int = 0,
 ) -> CumulantOptionInstallation:
     discovery = CumulantSubtaskDiscovery(_discovery_config())
-    stomp = STOMPConfig(
+    stomp = STOMPConfig.for_dynamic_option_template(
         subtask_specs=(),
         observation_dim=2 + reserved_observation_suffix,
         n_primitive_actions=2,

--- a/tests/test_cumulant_option_scheduler.py
+++ b/tests/test_cumulant_option_scheduler.py
@@ -120,7 +120,7 @@ def _scheduler(
     max_install_attempts: int | None = None,
 ) -> CumulantOptionScheduler:
     discovery = CumulantSubtaskDiscovery(_discovery_config())
-    stomp = STOMPConfig(
+    stomp = STOMPConfig.for_dynamic_option_template(
         subtask_specs=(),
         observation_dim=2,
         n_primitive_actions=2,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -259,3 +259,15 @@ def test_primitive_only_stomp_has_typed_empty_option_state_and_base_only_updates
             n_primitive_actions=N_PRIMITIVE,
             option_planning_backups_per_step=1,
         )
+
+
+def test_dynamic_option_template_can_carry_planning_budget_before_materialization() -> None:
+    config = STOMPConfig.for_dynamic_option_template(
+        subtask_specs=(),
+        observation_dim=OBS_DIM,
+        n_primitive_actions=N_PRIMITIVE,
+        option_planning_backups_per_step=1,
+    )
+
+    assert config.n_options == 0
+    assert config.option_planning_backups_per_step == 1


### PR DESCRIPTION
Fixes #20

<!-- evidence-head:bcd9ceb2079417c63874ea7bc41954ebdfbeb3b6 -->

## Summary

The dynamic cumulant option installer now has an explicit `STOMPConfig.for_dynamic_option_template(...)` construction path. It permits an empty template to carry the planning budget that will be used after option materialization, while plain primitive-only `STOMPConfig(...)` construction remains fail-closed.

The previous guard rejected the installer’s required empty template and caused the scheduler, installation, and authorized option authority suites to fail during setup. No benchmark protocol, seed, or frozen artifact is involved.

## Verification

Exact commands run in the isolated worktree:

```text
.venv/bin/python -m pytest tests/test_options.py tests/test_cumulant_option_installation.py tests/test_cumulant_option_scheduler.py tests/test_authorized_option_replacement.py tests/test_authorized_option_retirement.py -q -o addopts="" --tb=short  # 52 passed in 378.40s
.venv/bin/ruff check alberta_framework/core/options.py tests/test_options.py tests/test_cumulant_option_installation.py tests/test_cumulant_option_scheduler.py  # All checks passed!
.venv/bin/mypy alberta_framework/core/options.py  # Success: no issues found in 1 source file
git diff --check  # clean
```

The adjacent Step 10/11/lifecycle slice reported 115 passed and two unrelated pre-existing facade-contract failures (`test_config_no_subtasks_raises` and `test_oak_config_no_subtasks_raises`); those paths are unchanged and are not claimed as fixed here.

## Contract coverage

- Plain primitive-only STOMP with a nonzero planning budget still raises `ValueError`.
- The explicit dynamic template factory accepts the same budget before materialization.
- The scheduler and authorized installation/replacement/retirement suites now execute instead of failing at configuration construction.
- One source module and three focused test modules changed; no `outputs/` artifacts, registry entries, or benchmark seeds were touched.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/army@eae7fa94d7903cf191a2a9c49e0950b1bdc65037:skills/contribute-to-asi
Attribution status: self-reported
— [dynamic-stomp-template-planning]
<!-- elizaos-contribution-attribution:v2 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/army@eae7fa94d7903cf191a2a9c49e0950b1bdc65037:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01KZZE77YP2DPE3QP5WJBK67CV","project":"asi","repository":"asi","started_at":"2026-08-14T06:09:18.295Z","completed_at":"2026-08-14T06:10:00.808Z","skill_sha256":"756045abe9f67ec5f5397842b6258eee8fffe61bb97457a1f174e1f3d67db82c","usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":29350,"output_tokens":3530,"cache_creation_tokens":0,"cache_read_tokens":2373120,"total_tokens":2406000,"cost_micro_usd":"1388354","session_count":4},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAg1jL1RfjvV5uj6zAzP2fXiqG7yuoADSp0foVe58g_Pg","device_key_id":"734476fdc7c5d36e4b5c6a46c32d00574fce715d7df1bfd2c8d50d63f4913601","device_signature":"87wfT2yyjQHvCC-ue3q468-uMO5y_BubF2b4vzlZJKdwkD0PPXjEAXpSLTarGSMVDdd7TolVDFEcNYxE9pZQCg"}} -->
