### PR TITLE
fix(experiments): reject duplicate seeds before execution

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -196,7 +196,8 @@ def run_multi_seed_experiment(
 
     Args:
         configs: List of experiment configurations to run. Names must be unique.
-        seeds: Number of seeds (generates 0..n-1) or explicit list of seeds
+        seeds: Number of seeds (generates 0..n-1) or explicit list of seeds.
+            Explicit seeds must be unique.
         parallel: Whether to use parallel execution (requires joblib)
         n_jobs: Number of parallel jobs (-1 for all CPUs)
         show_progress: Whether to show progress bar (requires tqdm)
@@ -205,7 +206,8 @@ def run_multi_seed_experiment(
         Dictionary mapping config name to AggregatedResults
 
     Raises:
-        ValueError: If two or more configurations have the same name
+        ValueError: If two or more configurations have the same name, or if the
+            explicit seed list contains duplicates
     """
     seen_names: set[str] = set()
     duplicate_names: set[str] = set()
@@ -226,6 +228,18 @@ def run_multi_seed_experiment(
         seed_list = list(range(seeds))
     else:
         seed_list = list(seeds)
+
+    seen_seeds: set[int] = set()
+    duplicate_seeds: set[int] = set()
+    for seed in seed_list:
+        if seed in seen_seeds:
+            duplicate_seeds.add(seed)
+        else:
+            seen_seeds.add(seed)
+
+    if duplicate_seeds:
+        formatted_seeds = ", ".join(str(seed) for seed in sorted(duplicate_seeds))
+        raise ValueError(f"Experiment seeds must be unique; duplicates: {formatted_seeds}")
 
     # Build list of (config, seed) pairs
     tasks: list[tuple[ExperimentConfig, int]] = []

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -93,6 +93,39 @@ def test_multiple_duplicate_names_are_reported_deterministically() -> None:
     )
 
 
+def test_duplicate_seeds_reject_before_factories_execute() -> None:
+    configs = [
+        _config(
+            "baseline",
+            learner_factory=_fail_if_called,
+            stream_factory=_fail_if_called,
+        )
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Experiment seeds must be unique; duplicates: 0$",
+    ):
+        run_multi_seed_experiment(configs, seeds=[0, 0, 1], parallel=False, show_progress=False)
+
+
+def test_multiple_duplicate_seeds_are_reported_deterministically() -> None:
+    configs = [
+        _config(
+            "baseline",
+            learner_factory=_fail_if_called,
+            stream_factory=_fail_if_called,
+        )
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        run_multi_seed_experiment(
+            configs, seeds=[7, 3, 7, 0, 3, 7], parallel=False, show_progress=False
+        )
+
+    assert str(exc_info.value) == "Experiment seeds must be unique; duplicates: 3, 7"
+
+
 def test_unique_names_preserve_config_and_seed_order() -> None:
     results = run_multi_seed_experiment(
         [_config("second"), _config("first")],


### PR DESCRIPTION
Closes #27.

## Issue

`run_multi_seed_experiment()` validates configuration-name identity (#25) but not seed identity. Runs are seed-deterministic — each task derives its stream from `jr.key(seed)` with fresh factories — so a duplicated entry in an explicit seed list re-executes the identical trajectory and `aggregate_metrics` counts it as an additional independent sample. After #24, `pairwise_comparisons` rejects exactly those aggregates for duplicate seeds, but summary-only consumers (`MetricSummary`, `get_final_performance`) have no guard. Every other seed-consuming public boundary in the repository (forager, causal-map forager, foragax open screen, matched statistics, recurring feature gate) already rejects duplicate seeds; this runner was the outlier.

## Symptoms

At `main` `ee075f85d95211208f3590b65eb9f0e7571e83ca`, `seeds=[0, 0, 1]` on a 50-step `LinearLearner`/`RandomWalkStream` diagnostic completes silently and reports pseudo-replicated aggregates (full falsifier in #27):

```text
run_multi_seed_experiment(seeds=[0, 0, 1]) completed WITHOUT error
reported seeds: [0, 0, 1]
row0 == row1 elementwise: True
summary.n_seeds: 3
summary.std (with duplicate): 2.6266074239
honest two-seed std:          2.7859378814
pairwise_comparisons on the SAME aggregates: rejected with: AggregatedResults 'baseline' contains duplicate seeds
```

## New state

A duplicate explicit seed list is rejected at the public runner boundary before any learner or stream factory executes, with #25's deterministic message contract: `Experiment seeds must be unique; duplicates: 3, 7` (sorted). The integer count form (`seeds=30`) generates `range(n)` and is unaffected; `aggregate_metrics()` is out of scope per #27.

Failing-test-first evidence, measured at head `fa41b6c1b3caa94d347b4bd2c9e901ec62853d92` (baseline `ee075f85`):

- red phase: the two new contract tests fail on the unmodified baseline (`_fail_if_called` factories execute) — `2 failed, 5 passed`;
- green phase: `.venv/bin/python -m pytest tests/test_experiments_validation.py tests/test_statistics_validation.py -q -o addopts=""` — `48 passed` (7 + 41);
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier script in #27 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow; the signed local-usage receipt footer follows.

```text
Compute receipt: 134308 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M002J4SHKEGDG4QZR3552M0S","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T12:04:47.026Z","completed_at":"2026-08-14T12:23:23.381Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":9,"output_tokens":921,"cache_creation_tokens":37573,"cache_read_tokens":95805,"total_tokens":134308,"cost_micro_usd":"305804","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"Ic4vDCixv9HMxH-hFo3kJcdIsIKn_HCiukzpNjV2UOgDIwomNdLZJxcX_11qdrCKxtuyDnFaEyxSpask9hh9Bw"}} -->
