### PR TITLE
fix(statistics): reject empty inputs to summary statistics

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -73,9 +73,14 @@ def compute_statistics(
 
     Returns:
         StatisticalSummary with all statistics
+
+    Raises:
+        ValueError: If values is empty
     """
     arr = np.asarray(values)
     n = len(arr)
+    if n == 0:
+        raise ValueError("values must be non-empty")
 
     mean = float(np.mean(arr))
     std = float(np.std(arr, ddof=1)) if n > 1 else 0.0
@@ -129,8 +134,13 @@ def compute_timeseries_statistics(
 
     Returns:
         Tuple of (mean, ci_lower, ci_upper) arrays of shape (n_steps,)
+
+    Raises:
+        ValueError: If metric_array has no seed rows
     """
     n_seeds = metric_array.shape[0]
+    if n_seeds == 0:
+        raise ValueError("metric_array must contain at least one seed row")
     mean = np.mean(metric_array, axis=0)
     std = np.std(metric_array, axis=0, ddof=1)
     sem = std / np.sqrt(n_seeds)

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,8 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -74,6 +76,18 @@ class TestComputeStatistics:
         assert s.ci_upper == pytest.approx(4.2)
         assert s.n_seeds == 1
 
+    def test_empty_values_rejected_without_warnings(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^values must be non-empty$"):
+                compute_statistics([])
+
+    def test_empty_array_rejected_without_warnings(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^values must be non-empty$"):
+                compute_statistics(np.array([], dtype=np.float64))
+
     def test_empirical_ci_coverage(self) -> None:
         """95% t-CI covers the true mean ~95% of the time.
 
@@ -111,6 +125,14 @@ class TestTimeseriesStatistics:
             assert mean[step] == pytest.approx(s.mean)
             assert lo[step] == pytest.approx(s.ci_lower)
             assert hi[step] == pytest.approx(s.ci_upper)
+
+    def test_zero_seed_matrix_rejected_without_warnings(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError, match=r"^metric_array must contain at least one seed row$"
+            ):
+                compute_timeseries_statistics(np.empty((0, 3)))
 
 
 class TestBootstrapCI:


### PR DESCRIPTION
Closes #29.

## Issue

`compute_statistics` and `compute_timeseries_statistics` have no zero-seed contract. The scalar path crashes accidentally (`IndexError` from `np.percentile` after four `RuntimeWarning`s), while the vectorized sibling silently returns all-NaN mean and confidence bounds shaped like real statistics. #26 documents the `n_seeds == 1` timeseries contract and explicitly scopes zero-seed out as a separate contract; this PR defines that contract, fail-closed, in the style of the degenerate-input rejections already in `metrics.py`.

## Symptoms

At `main` `ee075f85d95211208f3590b65eb9f0e7571e83ca` (full falsifier in #29):

```text
compute_statistics([])
  -> RuntimeWarning: Mean of empty slice (x2), invalid value encountered in scalar divide (x2)
  -> IndexError: index -1 is out of bounds for axis 0 with size 0

compute_timeseries_statistics(np.empty((0, 3)))
  -> (array([nan, nan, nan]), array([nan, nan, nan]), array([nan, nan, nan]))  # returned silently
```

## New state

Both public entry points refuse zero-seed input with a deterministic `ValueError` (`values must be non-empty` / `metric_array must contain at least one seed row`) raised before any NumPy warning is emitted; all `n >= 1` behavior is byte-for-byte unchanged. The `n_seeds == 1` timeseries interval remains #26's reserved scope, untouched.

Failing-test-first evidence, measured at head `e53d420ecda01878b02e19ce6d4b07dc6bab6c61` (baseline `ee075f85`):

- red phase: the three new contract tests fail on the unmodified baseline (`3 failed, 41 passed`), with `warnings.simplefilter("error")` proving the current behavior warns before failing or returning;
- green phase: `.venv/bin/python -m pytest tests/test_statistics_validation.py tests/test_experiments_validation.py -q -o addopts=""` — `51 passed`;
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier in #29 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow; the signed local-usage receipt footer follows.

```text
Compute receipt: 104976 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M0048207D4HXT98AS4A3K6MW","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T12:34:13.640Z","completed_at":"2026-08-14T12:38:36.421Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":8,"output_tokens":1319,"cache_creation_tokens":40221,"cache_read_tokens":63428,"total_tokens":104976,"cost_micro_usd":"316110","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"Etw4AK7uOLxDZi62d2MiRJCtLdY8EhXrlF87BiPBP6sK-eTmao-DD6NwHG2A3E1FUny2ZUcekub3Xz8ta5KuAQ"}} -->
