### PR TITLE
fix(statistics): return point intervals for one-seed time series

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -132,6 +132,13 @@ def compute_timeseries_statistics(
     """
     n_seeds = metric_array.shape[0]
     mean = np.mean(metric_array, axis=0)
+
+    if n_seeds == 1:
+        # One seed has no between-seed spread estimate; return the degenerate
+        # point interval, matching compute_statistics([x]). The ddof=1 /
+        # Student-t path below would produce all-NaN bounds (df=0).
+        return mean, mean.copy(), mean.copy()
+
     std = np.std(metric_array, axis=0, ddof=1)
     sem = std / np.sqrt(n_seeds)
 

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,8 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -107,6 +109,31 @@ class TestTimeseriesStatistics:
         mean, lo, hi = compute_timeseries_statistics(arr, confidence_level=0.95)
         assert mean.shape == lo.shape == hi.shape == (6,)
         for step in range(6):
+            s = compute_statistics(arr[:, step], confidence_level=0.95)
+            assert mean[step] == pytest.approx(s.mean)
+            assert lo[step] == pytest.approx(s.ci_lower)
+            assert hi[step] == pytest.approx(s.ci_upper)
+
+    def test_single_seed_returns_finite_point_interval(self) -> None:
+        """One seed yields the point trajectory, finite, without any warning."""
+        arr = np.asarray([[1.0, 2.0, 3.0]], dtype=np.float64)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mean, lo, hi = compute_timeseries_statistics(arr, confidence_level=0.95)
+        assert mean.shape == lo.shape == hi.shape == (3,)
+        np.testing.assert_array_equal(mean, np.asarray([1.0, 2.0, 3.0]))
+        np.testing.assert_array_equal(lo, mean)
+        np.testing.assert_array_equal(hi, mean)
+        assert np.isfinite(mean).all()
+        assert np.isfinite(lo).all()
+        assert np.isfinite(hi).all()
+
+    def test_single_seed_matches_per_column_compute_statistics(self) -> None:
+        """The n_seeds == 1 contract agrees with the scalar degenerate case."""
+        rng = np.random.default_rng(8)
+        arr = rng.normal(0.0, 1.0, size=(1, 5))
+        mean, lo, hi = compute_timeseries_statistics(arr, confidence_level=0.95)
+        for step in range(5):
             s = compute_statistics(arr[:, step], confidence_level=0.95)
             assert mean[step] == pytest.approx(s.mean)
             assert lo[step] == pytest.approx(s.ci_lower)


### PR DESCRIPTION
<!-- evidence-head:bf76fe395d3e320eb7fe3dd5e992f6a631626d7f -->

Relates to #26.

## What this fixes

`compute_timeseries_statistics()` unconditionally computed `np.std(..., ddof=1)` and a Student-t quantile with `df = n_seeds - 1`, so a valid one-seed metric trajectory returned all-NaN `ci_lower`/`ci_upper` (df=0) and emitted `RuntimeWarning: Degrees of freedom <= 0 for slice` and `invalid value encountered in divide`. The scalar companion `compute_statistics([x])` already defines the degenerate contract: the point interval `[x, x]`.

## The change

Only the `n_seeds == 1` contract in `compute_timeseries_statistics()` (`alberta_framework/utils/statistics.py`):

- mean trajectory computed exactly as before;
- for exactly one seed, return finite `ci_lower == ci_upper == mean` without entering the `ddof=1` / Student-t path (no warnings);
- `n_seeds >= 2` is byte-for-byte unchanged — the guard is inserted before the `std` line and the existing path is untouched;
- empty / zero-seed input is unchanged (that contract is #29/#30).

Not touched, per the issue's scope: `compute_statistics()`, `get_metric_timeseries()`, visualization, confidence-level validation, the SciPy fallback, benchmarks, and everything under `outputs/`.

## Evidence (failing-test-first)

Baseline: `ee075f85d95211208f3590b65eb9f0e7571e83ca` (upstream `main` at branch time). Head: `bf76fe395d3e320eb7fe3dd5e992f6a631626d7f`.

Two new tests in `TestTimeseriesStatistics` (`tests/test_statistics_validation.py`):

- `test_single_seed_returns_finite_point_interval` — one-seed trajectory `[[1, 2, 3]]` returns `mean == ci_lower == ci_upper` elementwise, all finite, shape `(n_steps,)`, and raises no warning (run under `warnings.simplefilter("error")`);
- `test_single_seed_matches_per_column_compute_statistics` — the vectorized `n_seeds == 1` result matches per-column `compute_statistics()`.

Commands and results, run in a fresh `.venv` (Python 3.12) at each commit:

| Command | Baseline `ee075f85` | Head `bf76fe39` |
|---|---|---|
| `.venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""` | **2 failed** (the two new tests), 41 passed | **43 passed** |
| `.venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""` | — | 8 passed |
| `.venv/bin/python -m ruff check .` | — | All checks passed |
| `.venv/bin/python -m mypy` | — | Success: no issues in 159 source files |
| `git diff --check` | — | clean |

The existing `n_seeds >= 2` parity test (`test_matches_per_column_compute_statistics`) is unchanged and passes.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This is a development-grade measurement-presentation fix and promotes nothing. Evidence above is inline (commands + counts); no run artifacts were produced to attach.

AI-assisted: anthropic / claude-fable-5 / claude-code / contribute-to-asi @ 1bde21d6

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [asi-26-point-interval]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M007X3F9S8PZ7B63DBVF96SJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T13:38:09.001Z","completed_at":"2026-08-14T13:41:35.966Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdRcn5CNZRVTJaBf8Yxmkpw_SH19JLPOaO5MjHwdXvvY","device_key_id":"fe92c3b6ed35529d61c4e68c63be0e526d486bb88353f0f9fec91e856469b518","device_signature":"r6PwxQo6wkiGBnhueWtH_15sTU_sSnHdaumNj_k0c46MlMylFOjJx18DX0Ai_hRmx0m5BtRvj6SCuX_w38ZsDQ"}} -->
