### PR TITLE
fix(statistics): reject one-sample t-test and Cohen's d with ValueError

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -163,15 +163,25 @@ def cohens_d(
 
     Returns:
         Cohen's d (positive means a > b)
+
+    Raises:
+        ValueError: If either group has fewer than 2 values; the pooled
+            degrees of freedom ``n_a + n_b - 2`` would be zero.
     """
     a = np.asarray(values_a)
     b = np.asarray(values_b)
 
-    mean_a = np.mean(a)
-    mean_b = np.mean(b)
-
     n_a = len(a)
     n_b = len(b)
+
+    if n_a < 2 or n_b < 2:
+        raise ValueError(
+            "cohens_d requires at least 2 values in each group "
+            f"(got n_a={n_a}, n_b={n_b}): pooled degrees of freedom would be zero"
+        )
+
+    mean_a = np.mean(a)
+    mean_b = np.mean(b)
 
     # Pooled standard deviation
     var_a = np.var(a, ddof=1) if n_a > 1 else 0.0
@@ -205,9 +215,29 @@ def ttest_comparison(
 
     Returns:
         SignificanceResult with test results
+
+    Raises:
+        ValueError: If ``paired`` and the samples differ in length or hold
+            fewer than 2 pairs, or if either unpaired group has fewer than
+            2 values. One-sample groups leave the t statistic undefined and
+            would emit RuntimeWarning inside SciPy before crashing in
+            ``cohens_d``.
     """
     a = np.asarray(values_a)
     b = np.asarray(values_b)
+
+    if paired:
+        if len(a) != len(b):
+            raise ValueError(
+                f"paired t-test requires equal-length samples (got {len(a)} and {len(b)})"
+            )
+        if len(a) < 2:
+            raise ValueError(f"paired t-test requires at least 2 pairs (got {len(a)})")
+    elif len(a) < 2 or len(b) < 2:
+        raise ValueError(
+            "independent t-test requires at least 2 values in each group "
+            f"(got {len(a)} and {len(b)})"
+        )
 
     try:
         from scipy import stats

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,8 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -215,6 +217,53 @@ class TestPairedTests:
         res = mann_whitney_comparison(a, b, alpha=0.01)
         assert res.test_name == "Mann-Whitney U"
         assert res.significant
+
+
+class TestOneSampleRejection:
+    """Length-1 groups are rejected with ValueError, not divide-by-zero (#35).
+
+    A 1-vs-1 comparison has zero pooled degrees of freedom, so neither the
+    paired/independent t statistic nor Cohen's d is defined. The helpers must
+    reject before SciPy instead of emitting RuntimeWarning and crashing with
+    ZeroDivisionError. Mann-Whitney keeps its defined length-1 behavior.
+    """
+
+    def test_cohens_d_length_one_both_groups_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 2"):
+            cohens_d([1.0], [2.0])
+
+    def test_cohens_d_length_one_either_group_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 2"):
+            cohens_d([1.0, 2.0], [3.0])
+        with pytest.raises(ValueError, match="at least 2"):
+            cohens_d([1.0], [2.0, 3.0])
+
+    def test_paired_ttest_length_one_raises_without_runtime_warning(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="at least 2"):
+                ttest_comparison([1.0], [2.0], paired=True)
+
+    def test_paired_ttest_mismatched_lengths_raise_before_scipy(self) -> None:
+        with pytest.raises(ValueError, match="equal-length"):
+            ttest_comparison([1.0, 2.0], [1.0, 2.0, 3.0], paired=True)
+
+    def test_unpaired_ttest_length_one_raises_without_runtime_warning(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="at least 2"):
+                ttest_comparison([1.0], [2.0], paired=False)
+
+    def test_unpaired_ttest_length_one_either_side_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 2"):
+            ttest_comparison([1.0, 2.0, 3.0], [4.0], paired=False)
+        with pytest.raises(ValueError, match="at least 2"):
+            ttest_comparison([1.0], [2.0, 3.0, 4.0], paired=False)
+
+    def test_mann_whitney_length_one_contract_unchanged(self) -> None:
+        res = mann_whitney_comparison([1.0], [2.0])
+        assert res.p_value == pytest.approx(1.0)
+        assert res.effect_size == pytest.approx(-1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- evidence-head:840cac17974916dfcf07f51c5fa02f385ad11d43 -->

Relates to #35.

## What this fixes

At baseline `main`, `cohens_d()` and `ttest_comparison()` accept length-1 groups they cannot define a statistic for. `cohens_d([1.0], [2.0])` divides by the pooled degrees of freedom `n_a + n_b - 2 == 0` and raises `ZeroDivisionError`; paired `ttest_comparison([1.0], [2.0])` first reaches SciPy `ttest_rel` at `df = 0` and emits `RuntimeWarning: divide by zero encountered in divide` before crashing in `cohens_d`; unpaired 1-vs-1 emits `invalid value encountered in scalar divide` in the same stack. This is the one-sample sibling of #31/#26: the helpers crash or warn instead of rejecting.

## The change

Only the one-sample contract in `alberta_framework/utils/statistics.py`:

- `cohens_d`: either group with `n < 2` raises a descriptive `ValueError` naming both group sizes and the zero pooled degrees of freedom. It does not return `0.0` and pretend the effect is defined.
- `ttest_comparison`: rejects before SciPy — `paired=True` with unequal lengths or fewer than 2 pairs raises `ValueError`; `paired=False` with either group under 2 values raises `ValueError`. No `RuntimeWarning` escapes either path.
- Everything else is untouched, per the issue's scope: #31/#32 identical-sample behavior, #26 one-seed timeseries, #29/#30 zero-seed, #33 spread `ddof`, and the Wilcoxon and Mann–Whitney contracts (`mann_whitney_comparison([1.0], [2.0])` still returns its defined `p=1`, effect `-1`, asserted by a new guard test).

## Evidence (failing-test-first)

Baseline: `ee075f85d95211208f3590b65eb9f0e7571e83ca` (re-fetched upstream `main` at branch time). Head: `840cac17974916dfcf07f51c5fa02f385ad11d43`.

New `TestOneSampleRejection` class in `tests/test_statistics_validation.py` (7 tests):

- `test_cohens_d_length_one_both_groups_raises` / `test_cohens_d_length_one_either_group_raises` — `ValueError` for 1-vs-1 and for a single short group on either side;
- `test_paired_ttest_length_one_raises_without_runtime_warning` — `ValueError` under `warnings.simplefilter("error")`, so any `RuntimeWarning` would fail the test;
- `test_paired_ttest_mismatched_lengths_raise_before_scipy` — the message is this module's own (`equal-length`), not SciPy's;
- `test_unpaired_ttest_length_one_raises_without_runtime_warning` / `test_unpaired_ttest_length_one_either_side_raises` — same contract for the independent test;
- `test_mann_whitney_length_one_contract_unchanged` — guards the out-of-scope surface (this one passes on baseline by design).

Commands and results, run in a fresh `.venv` (Python 3.12) at each commit:

| Command | Baseline `ee075f85` | Head `840cac17` |
|---|---|---|
| `.venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""` | **6 failed** (the six new rejection tests), 42 passed | **48 passed** |
| `.venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""` | — | 8 passed |
| `.venv/bin/python -m ruff check .` | — | All checks passed |
| `.venv/bin/python -m mypy` | — | Success: no issues in 159 source files |
| `git diff --check` | — | clean |

The one pre-existing warning in the file (`Precision loss occurred in moment calculation` from `test_paired_ttest_aligns_adversarial_seed_order`) is #31-adjacent, present on baseline, and untouched here.

Ripple checked: `wilcoxon_comparison` computes its effect size through `cohens_d`, so a 1-vs-1 Wilcoxon now surfaces the descriptive `ValueError` instead of the baseline's `ZeroDivisionError` from the same call — it rejected before and rejects now, with a better message; its own SciPy call is unchanged. `pairwise_comparisons` and the `utils/__init__` re-exports are the only other references; no other module calls these helpers.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This is a development-grade measurement-trust fix and promotes nothing. Evidence above is inline (commands + counts); no run artifacts were produced to attach.

AI-assisted: anthropic / claude-fable-5 / claude-code / contribute-to-asi @ 1bde21d6
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [asi-35-one-sample]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M008CC5MQTY6ZC9H8G27DQKN","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T13:46:29.429Z","completed_at":"2026-08-14T13:51:06.938Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdRcn5CNZRVTJaBf8Yxmkpw_SH19JLPOaO5MjHwdXvvY","device_key_id":"fe92c3b6ed35529d61c4e68c63be0e526d486bb88353f0f9fec91e856469b518","device_signature":"lZBHF5w79Y7M5ZM7ZQOrU7moFdURfKfOb1D_1i2fbWHMnxXwgQmZOzpAvlJ2mFRcfFWQJgsJmoKIAX_mvcj-Ag"}} -->
