### PR TITLE
fix(statistics): reject empty bootstrap_ci instead of publishing NaN intervals

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -548,8 +548,16 @@ def bootstrap_ci(
 
     Returns:
         Tuple of (point_estimate, ci_lower, ci_upper)
+
+    Raises:
+        ValueError: If ``values`` is empty.
     """
     arr = np.asarray(values)
+    if len(arr) == 0:
+        raise ValueError(
+            "bootstrap_ci requires at least one value; got an empty array "
+            "(a NaN interval would be indistinguishable from a real CI)"
+        )
     rng = np.random.default_rng(seed)
 
     stat_func = np.mean if statistic == "mean" else np.median

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,8 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -146,6 +148,20 @@ class TestBootstrapCI:
             covered += int(lo <= true_mean <= hi)
         coverage = covered / n_reps
         assert 0.85 <= coverage <= 0.99, f"coverage {coverage} outside [0.85, 0.99]"
+
+    @pytest.mark.parametrize(
+        "empty", [[], np.array([], dtype=np.float64)], ids=["list", "ndarray"]
+    )
+    def test_empty_input_rejected(self, empty: list[float] | np.ndarray) -> None:
+        """Empty input raises a descriptive ValueError, with no RuntimeWarning.
+
+        Before the guard, ``np.mean([])`` warned and the helper returned
+        ``(nan, nan, nan)`` — a NaN interval indistinguishable from a real CI.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="empty"):
+                bootstrap_ci(empty)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- evidence-head:3c56fbe9d1fd92ba57ada8aa588e43c8470d12a5 -->

Relates to #37.

## What this fixes

At baseline `main`, `bootstrap_ci([])` takes the percentile-bootstrap path on an empty array: `np.mean([])` / `np.median([])` emit `RuntimeWarning: Mean of empty slice` and return `nan`, `rng.choice(arr, size=0, replace=True)` resamples nothing, and the helper returns `(nan, nan, nan)` — a NaN interval indistinguishable from a successful CI. This is the bootstrap sibling of #29/#30: a caller that hits a missing metric vector can publish a NaN interval that still looks like a real result.

## The change

Only the empty-input contract on `bootstrap_ci` in `alberta_framework/utils/statistics.py`:

- `len(arr) == 0` raises a descriptive `ValueError` immediately after `np.asarray`, before any NumPy reduction or `rng.choice`, so no `RuntimeWarning` is ever emitted.
- Non-empty `n >= 1` paths are untouched (a single value keeps its defined degenerate percentile-bootstrap interval), per the issue's scope: not #29/#30 (`compute_statistics` / zero-seed timeseries), not #35, not #33 `ddof`, no experiment aggregation changes.

## Evidence (failing-test-first)

Baseline: `ee075f85d95211208f3590b65eb9f0e7571e83ca` (re-fetched upstream `main` at branch time). Head: `3c56fbe9d1fd92ba57ada8aa588e43c8470d12a5`.

New `TestBootstrapCI.test_empty_input_rejected` in `tests/test_statistics_validation.py`, parametrized over `[]` and `np.array([], dtype=np.float64)`, run under `warnings.simplefilter("error")` inside the `pytest.raises(ValueError)` block — so the baseline's `RuntimeWarning` (or any other warning) fails the test rather than passing silently. The existing non-empty fixtures (`test_deterministic_and_brackets_estimate`, `test_median_statistic`, `test_empirical_coverage`) guard the untouched `n >= 1` contract.

Commands and results, run in a fresh `.venv` (Python 3.12, uv-synced) at each commit:

| Command | Baseline `ee075f85` | Head `3c56fbe9` |
|---|---|---|
| `.venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""` | **2 failed** (the two new empty-input tests, failing with `RuntimeWarning: Mean of empty slice`), 41 passed | **43 passed** |
| `.venv/bin/python -m ruff check .` | — | All checks passed |
| `.venv/bin/python -m mypy` | — | Success: no issues found in 159 source files |
| `git diff --check` | — | clean |

The one pre-existing warning in the file (`Precision loss occurred in moment calculation` from `test_paired_ttest_aligns_adversarial_seed_order`) is #31-adjacent, present on baseline, and untouched here.

Ripple checked: `bootstrap_ci` is defined once in `utils/statistics.py`; its only other references are the `utils/__init__.py` re-export and this test file. No production caller passes a possibly-empty array today — the guard is at the shared entry point, so every future caller gets the rejection.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This is a development-grade measurement-trust fix and promotes nothing. Evidence above is inline (commands + counts); no run artifacts were produced to attach.

AI-assisted: anthropic / claude-fable-5 / claude-code / contribute-to-asi @ 1bde21d6
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [statistics-validation]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M00944BNM1VZX7ASC2RSPNDM","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T13:59:27.861Z","completed_at":"2026-08-14T14:02:23.263Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdRcn5CNZRVTJaBf8Yxmkpw_SH19JLPOaO5MjHwdXvvY","device_key_id":"fe92c3b6ed35529d61c4e68c63be0e526d486bb88353f0f9fec91e856469b518","device_signature":"0MbXa4CUFd8FHuHP-5IdGlxLGxKC70BGa7BgKit2e5hGnipO8RJ79N9d93zcNc0jPD1l-wu04Zcrmz-D2AOjBg"}} -->
