### PR TITLE
fix(statistics): reject identical samples in Wilcoxon signed-rank comparison

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -314,9 +314,20 @@ def wilcoxon_comparison(
 
     Returns:
         SignificanceResult with test results
+
+    Raises:
+        ValueError: If the paired samples are elementwise identical, for which
+            the signed-rank statistic (over zero nonzero differences) is
+            undefined
     """
     a = np.asarray(values_a)
     b = np.asarray(values_b)
+
+    if a.size > 0 and np.array_equal(a, b):
+        raise ValueError(
+            f"Paired comparison {method_a!r} vs {method_b!r} has identical "
+            "samples; the Wilcoxon signed-rank statistic is undefined"
+        )
 
     try:
         from scipy import stats

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,8 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -484,3 +486,37 @@ class TestPairwiseComparisons:
         result = pairwise_comparisons({"a": a, "b": b}, test="mann_whitney", window=1)
 
         assert result[("a", "b")].statistic == pytest.approx(0.0)
+
+
+class TestWilcoxonIdenticalSamples:
+    """The signed-rank statistic over zero nonzero differences is undefined (#39)."""
+
+    def test_identical_samples_rejected_without_warnings(self) -> None:
+        values = [0.91, 0.88, 0.95]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError,
+                match=r"^Paired comparison 'pin' vs 'base' has identical samples; "
+                r"the Wilcoxon signed-rank statistic is undefined$",
+            ):
+                wilcoxon_comparison(values, list(values), method_a="pin", method_b="base")
+
+    def test_constant_nonzero_shift_stays_out_of_scope(self) -> None:
+        res = wilcoxon_comparison([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        assert res.test_name == "Wilcoxon signed-rank"
+        assert res.statistic == pytest.approx(0.0)
+        assert res.p_value < 1.0
+
+    def test_reduction_pin_pair_rejected_on_wilcoxon_grid(self) -> None:
+        rows = [0.10, 0.11, 0.09]
+        results = {
+            "base_arm": _make_seeded_aggregated("base_arm", [0, 1, 2], rows),
+            "pinned_inert": _make_seeded_aggregated("pinned_inert", [0, 1, 2], list(rows)),
+        }
+        with pytest.raises(
+            ValueError,
+            match=r"^Paired comparison 'base_arm' vs 'pinned_inert' has identical "
+            r"samples; the Wilcoxon signed-rank statistic is undefined$",
+        ):
+            pairwise_comparisons(results, metric="squared_error", test="wilcoxon")


### PR DESCRIPTION
Closes #39. Found while reviewing #32 and filed separately so each PR stays one change.

## What changed

`wilcoxon_comparison` now refuses elementwise-identical paired samples with a deterministic `ValueError` naming both methods, mirroring the paired t-test contract from #31/#32: the signed-rank statistic over an empty set of nonzero differences is undefined, and scipy was coercing it to a defined-looking `statistic=0.0, p=1.0` through a swallowed `RuntimeWarning` (0/0 in the normal approximation; probed on scipy 1.18.0). `pairwise_comparisons(test="wilcoxon")` inherits the refusal, so the bit-exact reduction-pin pair that the screening convention guarantees now fails loud on both paired grids instead of only the t-test one. One guard, one message, no behavior change for any non-degenerate input.

Failing-test-first: `TestWilcoxonIdenticalSamples` (new class appended to `tests/test_statistics_validation.py`, conflict-free with the in-flight #30/#32/#36 hunks) — direct-call refusal under warnings-as-errors, the reduction-pin pair on the `pairwise_comparisons` wilcoxon grid, and a constant-nonzero-shift out-of-scope pin. Red phase: 2 failed / 1 passed before the guard; green after.

Out of scope, matching #32's scoping: near-identical (ulp-divergent) samples, Mann–Whitney (unpaired; defined degenerate behavior), empty inputs (tracked ambiently by the #29/#30 wave), and the one-sample class (#35/#36).

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds, no benchmark, no `outputs/` artifacts. Commit measured: `059e49ade69ae4f2cf31719a2ed90edbdbf68bc3`.

<!-- evidence-head:059e49ade69ae4f2cf31719a2ed90edbdbf68bc3 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red on `main` `ee075f8`, candidate green); immutable attachment URLs can be added on request.

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py::TestWilcoxonIdenticalSamples -q -o addopts=""
FAILED ...::test_identical_samples_rejected_without_warnings
FAILED ...::test_reduction_pin_pair_rejected_on_wilcoxon_grid
2 failed, 1 passed, 1 warning in 1.74s
```

Candidate (full touched file):

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""
44 passed, 1 warning in 2.66s
$ .venv/bin/python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py
All checks passed!
$ git diff --check   # clean
```

Targeted `mypy` on the two touched files reports one pre-existing `no-untyped-def` at the untouched `_paired_replication_rates` helper — byte-identical before and after this change (verified by stash/unstash), documented rather than drive-by-fixed to keep this PR one change.

Deviations from the #39 plan: none. Open: whether the maintainer prefers this guard folded into a shared paired-boundary helper once #32/#36 land; happy to rebase either way.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M009FEQS4SDZQVG3C6NW0MN2","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T14:05:38.937Z","completed_at":"2026-08-14T14:28:33.859Z","skill_sha256":"fb3f7ed89890ac48bfe2e8b78b1b46fc7b6c5a776e67b9a60821500859705959","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"Do1j7jWNGxcc353k6Bfq0i8fFr1YXUJFxoqn1m8h54luP5YW1VMvkB-8vTU2jp9BdBY7QXX4fS8jR7oOnoTJBg"}} -->
