### PR TITLE
fix(screening): refuse to merge when the named control is absent

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7029,7 +7029,13 @@ def merge_shards(
             )
         per_seed[shard["seed"]] = shard
 
-    control = by_config.get(control_name, {})
+    if control_name not in by_config:
+        raise ValueError(
+            f"control {control_name!r} is not among the merged shards "
+            f"(present: {sorted(by_config)}); a summary without its control "
+            "would silently carry no paired_vs_control blocks"
+        )
+    control = by_config[control_name]
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):
         seeds = sorted(per_seed)

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -927,6 +927,28 @@ class TestShardsAndMerge:
         assert status == expected_status
         assert json.loads(output.read_text(encoding="utf-8")) == report
 
+    def test_merge_rejects_absent_control(self, tmp_path, small_data):
+        paths = [
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 0),
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 1),
+        ]
+        with pytest.raises(
+            ValueError,
+            match=r"control 'upgd_w_control' is not among the merged shards",
+        ):
+            merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+
+    def test_merge_rejects_typoed_control_name(self, tmp_path, small_data):
+        paths = [
+            self._make_shard(tmp_path, small_data, "upgd_w_control", 0),
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 0),
+        ]
+        with pytest.raises(
+            ValueError,
+            match=r"control 'upgd_w_contrl' is not among the merged shards",
+        ):
+            merge_shards(paths, control_name="upgd_w_contrl", slope_window=2)
+
     def test_merge_rejects_duplicate_seed(self, tmp_path, small_data):
         p1 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
         p2 = tmp_path / "dup.json"


### PR DESCRIPTION
Closes #44.

## What changed

`merge_shards` now raises a deterministic `ValueError` when `control_name` is not among the merged shards' config names, instead of falling back to an empty control dict and publishing a schema-valid ranked summary with zero `paired_vs_control` blocks. The error names the missing control and the config names actually present. The `merge` CLI inherits the refusal. No behavior change for any merge whose control is present — all eight pinned `summary*.json` artifacts under `outputs/ipmnist_screening/` have their control among their results, so no sanctioned historical flow merges without one. No new flags.

Failing-test-first in `TestShardsAndMerge`: absent-control and typo'd-control cases, both asserting the named-control message. Red phase: 2 failed before the guard; green after.

Out of scope (noted in #44): arms with zero seed overlap against a present control, and `validate_proxy`'s vacuous `all_prefixes_match: true` over an empty check list.

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds consumed, no benchmark runs, no `outputs/` artifacts. Commit measured: `c909fab21cd33b115a8121aa930f4544c1b982e7`.

<!-- evidence-head:c909fab21cd33b115a8121aa930f4544c1b982e7 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red, candidate green); immutable attachment URLs can be added on request.

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py::TestShardsAndMerge::test_merge_rejects_absent_control tests/test_ipmnist_screening.py::TestShardsAndMerge::test_merge_rejects_typoed_control_name -q -o addopts=""
2 failed in 5.12s
```

Candidate (full touched file):

```text
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""
1 failed, 199 passed in 60.36s
$ .venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py
All checks passed!
$ git diff --check   # clean
```

The single failure is `TestSigma0Frontier::test_ext_defaults_reduce_to_upgd_ema_norm_sigma0_bitwise`, which fails identically on clean `main` `a0e3412` in this environment (verified by stash/unstash; jax 0.11.0 cpu, Python 3.13, macOS arm64) — pre-existing and unrelated to this change. It looks environment-version-sensitive (the tree's jax floor is `>=0.7.1`); I'll file it separately with the version matrix rather than widen this PR.

Deviations from the #44 plan: none.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M00G5GKNAGPGEDMHKDY4H2RT","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T16:02:33.206Z","completed_at":"2026-08-14T16:07:27.449Z","skill_sha256":"fb3f7ed89890ac48bfe2e8b78b1b46fc7b6c5a776e67b9a60821500859705959","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"sBqaTxXIL389YiNlAnigcvVLi3wfZbFz2K2ORTq7TEYx5SvwbC6_DM_BYNZ_dYJ46BxHY5ZDkyE6EmjoZ145AQ"}} -->
