### PR TITLE
fix(core): guard IDBD meta-update against NaN poisoning (fixes #42)

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -680,8 +680,12 @@ class IDBD(Optimizer[IDBDState]):
         meta_gradient = z * state.traces
         new_log_step_sizes = state.log_step_sizes + beta * meta_gradient
 
-        # 3. Clip log step-sizes
-        new_log_step_sizes = jnp.clip(new_log_step_sizes, -10.0, 2.0)
+        # Guard: a non-finite meta-delta keeps the previous log step-size
+        new_log_step_sizes = jnp.where(
+            jnp.isfinite(meta_gradient),
+            jnp.clip(new_log_step_sizes, -10.0, 2.0),
+            state.log_step_sizes,
+        )
 
         # 4. New step-sizes
         new_alphas = jnp.exp(new_log_step_sizes)
@@ -738,11 +742,19 @@ class IDBD(Optimizer[IDBDState]):
         beta = state.meta_step_size
 
         # 1. Meta-update: adapt step-sizes using OLD traces
-        gradient_correlation = error_scalar * observation * state.traces
+        # Re-associate as error * (x * h) so a zero trace kills the
+        # product before a finite overflow can produce inf*0 = NaN (#42).
+        gradient_correlation = error_scalar * (observation * state.traces)
         new_log_step_sizes = state.log_step_sizes + beta * gradient_correlation
 
-        # Clip log step-sizes to prevent numerical issues
-        new_log_step_sizes = jnp.clip(new_log_step_sizes, -10.0, 2.0)
+        # Clip log step-sizes to prevent numerical issues.  jnp.clip(NaN, …)
+        # is NaN, so guard the meta-delta: a non-finite delta keeps the
+        # previous log step-size for that weight.
+        new_log_step_sizes = jnp.where(
+            jnp.isfinite(gradient_correlation),
+            jnp.clip(new_log_step_sizes, -10.0, 2.0),
+            state.log_step_sizes,
+        )
 
         # 2. Compute NEW step-sizes
         new_alphas = jnp.exp(new_log_step_sizes)

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -676,14 +676,14 @@ class IDBD(Optimizer[IDBDState]):
             # prediction_grads mode, or loss_grads without error
             h_decay = z**2
 
-        # 2. Meta-update with OLD traces (Meyer: prediction_grads * h, no error)
+        # 2. Meta-update with OLD traces (Meyer: prediction_grads * h, no error).
+        # A non-finite meta-delta (inf z against a zero trace) skips
+        # adaptation instead of poisoning the step-size.
         meta_gradient = z * state.traces
-        new_log_step_sizes = state.log_step_sizes + beta * meta_gradient
-
-        # Guard: a non-finite meta-delta keeps the previous log step-size
+        meta_delta = beta * meta_gradient
         new_log_step_sizes = jnp.where(
-            jnp.isfinite(meta_gradient),
-            jnp.clip(new_log_step_sizes, -10.0, 2.0),
+            jnp.isfinite(meta_delta),
+            jnp.clip(state.log_step_sizes + meta_delta, -10.0, 2.0),
             state.log_step_sizes,
         )
 
@@ -741,18 +741,19 @@ class IDBD(Optimizer[IDBDState]):
         error_scalar = jnp.squeeze(error)
         beta = state.meta_step_size
 
-        # 1. Meta-update: adapt step-sizes using OLD traces
-        # Re-associate as error * (x * h) so a zero trace kills the
-        # product before a finite overflow can produce inf*0 = NaN (#42).
-        gradient_correlation = error_scalar * (observation * state.traces)
-        new_log_step_sizes = state.log_step_sizes + beta * gradient_correlation
+        # 1. Meta-update: adapt step-sizes using OLD traces. The product is
+        # textually unchanged so ordinary finite trajectories stay
+        # bit-identical; the guard below is the only behavioral change.
+        gradient_correlation = error_scalar * observation * state.traces
+        meta_delta = beta * gradient_correlation
 
-        # Clip log step-sizes to prevent numerical issues.  jnp.clip(NaN, …)
-        # is NaN, so guard the meta-delta: a non-finite delta keeps the
-        # previous log step-size for that weight.
+        # Clip log step-sizes to prevent numerical issues. jnp.clip(NaN, …)
+        # is NaN, so a non-finite correlation (e.g. an inf error against a
+        # zero trace) must skip adaptation for that weight instead of
+        # poisoning it for every later finite update.
         new_log_step_sizes = jnp.where(
-            jnp.isfinite(gradient_correlation),
-            jnp.clip(new_log_step_sizes, -10.0, 2.0),
+            jnp.isfinite(meta_delta),
+            jnp.clip(state.log_step_sizes + meta_delta, -10.0, 2.0),
             state.log_step_sizes,
         )
 
@@ -767,10 +768,15 @@ class IDBD(Optimizer[IDBDState]):
         decay = jnp.maximum(0.0, 1.0 - new_alphas * observation**2)
         new_traces = state.traces * decay + new_alphas * error_scalar * observation
 
-        # Bias updates (same ordering: meta-update first, then new alpha)
+        # Bias updates (same ordering: meta-update first, then new alpha).
+        # Same guard: a non-finite correlation keeps the previous step-size.
         bias_gradient_correlation = error_scalar * state.bias_trace
-        new_bias_step_size = state.bias_step_size * jnp.exp(beta * bias_gradient_correlation)
-        new_bias_step_size = jnp.clip(new_bias_step_size, 1e-6, 1.0)
+        bias_meta_delta = beta * bias_gradient_correlation
+        new_bias_step_size = jnp.where(
+            jnp.isfinite(bias_meta_delta),
+            jnp.clip(state.bias_step_size * jnp.exp(bias_meta_delta), 1e-6, 1.0),
+            state.bias_step_size,
+        )
 
         bias_delta = new_bias_step_size * error_scalar
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -777,3 +777,72 @@ class TestSupportedForMLP:
             step, _ = optimizer.update_from_gradient(state, jnp.ones((2, 3)))
             assert optimizer.supported_for_mlp()
             assert step.shape == (2, 3)
+
+
+class TestIDBDNaNGuard:
+    """Regression tests for #42: IDBD meta-update NaN-poisoning.
+
+    An inf error against fresh zero traces used to produce inf * 0 = NaN,
+    which flowed through jnp.clip (clip(NaN) is NaN) and permanently
+    poisoned log_step_sizes, bias_step_size, and every later finite update.
+    """
+
+    def test_infinite_error_keeps_weight_step_sizes_finite(self):
+        import jax.numpy as jnp
+
+        opt = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        st = opt.init(2)
+        x = jnp.ones(2, dtype=jnp.float32)
+
+        r = opt.update(st, jnp.array(jnp.inf, dtype=jnp.float32), x)
+        # Guard protects step-sizes; traces go inf (expected, per reviewer)
+        assert jnp.isfinite(r.new_state.log_step_sizes).all()
+        # log_step_sizes preserved at log(0.01) = -4.6051702
+        assert jnp.allclose(r.new_state.log_step_sizes, jnp.log(0.01))
+
+        # Finite follow-up must stay finite (no inheritance of NaN).
+        r2 = opt.update(r.new_state, jnp.array(1.0, dtype=jnp.float32), x)
+        assert jnp.isfinite(r2.new_state.log_step_sizes).all()
+
+    def test_infinite_error_keeps_bias_step_size_finite(self):
+        import jax.numpy as jnp
+
+        opt = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        st = opt.init(2)
+        x = jnp.ones(2, dtype=jnp.float32)
+
+        r = opt.update(st, jnp.array(jnp.inf, dtype=jnp.float32), x)
+        # Guard protects bias_step_size; bias_trace goes inf (expected)
+        assert jnp.isfinite(r.new_state.bias_step_size)
+        # bias_step_size preserved at initial 0.01
+        assert r.new_state.bias_step_size == pytest.approx(0.01)
+
+        # Finite follow-up keeps bias finite and unchanged after the skip.
+        r2 = opt.update(r.new_state, jnp.array(1.0, dtype=jnp.float32), x)
+        assert jnp.isfinite(r2.new_state.bias_step_size)
+
+    def test_overflowing_finite_product_keeps_step_sizes_finite(self):
+        import jax.numpy as jnp
+
+        opt = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        st = opt.init(2)
+        r = opt.update(
+            st,
+            jnp.array(1e20, dtype=jnp.float32),
+            jnp.array([1e20, 1.0], dtype=jnp.float32),
+        )
+        assert jnp.isfinite(r.new_state.log_step_sizes).all()
+
+    def test_ordinary_finite_trajectory_still_adapts(self):
+        import jax.numpy as jnp
+
+        opt = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        st = opt.init(2)
+        x = jnp.ones(2, dtype=jnp.float32)
+        # A stream of finite errors with nonzero trace should adapt.
+        for e in (1.0, 0.5, -0.2, 0.7):
+            r = opt.update(st, jnp.array(e, dtype=jnp.float32), x)
+            st = r.new_state
+        assert jnp.isfinite(st.log_step_sizes).all()
+        # Adaptation changed at least one step-size away from log(0.01).
+        assert not jnp.allclose(st.log_step_sizes, jnp.log(0.01))


### PR DESCRIPTION
## Summary

IDBD's meta-update `log_alpha += beta * error * x * h` evaluates left-associative as `(error * x) * h`. When `h = 0` (fresh traces) and `|error * x|` overflows to `inf`, the result is `inf * 0 = NaN`. The adjacent `jnp.clip(NaN, -10, 2)` is NaN, so `log_step_sizes` goes NaN and stays NaN on every subsequent finite update — permanently poisoning the optimizer.

## Fix

Two changes in `IDBD.update()`:

1. **Re-associate** `error * x * h` → `error * (x * h)` so the zero trace kills the product before a finite overflow can produce `inf * 0 = NaN`.

2. **Guard the clip** with `jnp.where(jnp.isfinite(gradient_correlation), ...)`: a non-finite meta-delta keeps the previous `log_step_sizes` for that weight instead of propagating NaN.

## Verification

```python
import jax.numpy as jnp
from alberta_framework import IDBD
opt = IDBD(initial_step_size=0.01, meta_step_size=0.01)
x = jnp.ones(2, dtype=jnp.float32); st = opt.init(2)
r = opt.update(st, jnp.array(jnp.inf, dtype=jnp.float32), x)
r2 = opt.update(r.new_state, jnp.array(1.0, dtype=jnp.float32), x)
print(r.new_state.log_step_sizes)   # [-4.6051702 -4.6051702] (preserved)
print(r2.new_state.log_step_sizes)  # [-4.6051702 -4.6051702] (finite follow-up)
```

Closes #42