### PR TITLE
fix(screening): share the sigma=0 noise short-circuit across pin factories

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -249,7 +249,20 @@ def _sorted_flat_noise(
     Identical construction (sorted names, one flat draw) to the lean UPGD-W
     learner in :mod:`alberta_framework.benchmarks.upgd_ipmnist`, so a combo
     that degenerates to plain UPGD-W consumes the same noise stream.
+
+    ``noise_std`` is a trace-time Python float; at exactly ``0.0`` the draw
+    is skipped and exact zeros are returned.  The values are identical either
+    way (``0.0 * normal`` is exact zeros), but XLA cannot fold the draw away
+    itself (a normal draw is not provably finite), so a factory that keeps
+    the draw and one that shortcuts it compile to structurally different
+    graphs whose fusions can reassociate derived float32 metrics by ~1 ulp
+    on some backends even when every parameter update is bit-identical
+    (issue #46).  The shortcut lives here, not in the callers, so every
+    sigma=0 factory sharing this helper lowers to the same RNG-free graph
+    while still skipping the draw's ~85-90% share of the UPGD step cost.
     """
+    if noise_std == 0.0:
+        return {name: jnp.zeros_like(value) for name, value in params.items()}
     names = sorted(params)
     shapes = [params[name].shape for name in names]
     counts = [int(np.prod(shape)) for shape in shapes]
@@ -1020,10 +1033,11 @@ def _make_upgd_ema_norm_ext_learner(
 
     With every switch at its default the trajectory is bit-exact against
     ``upgd_ema_norm_sigma0`` (pinned by a unit test): the perturbation term
-    is the same explicit zeros the champion's ``noise_std=0`` draw produces,
-    without paying for the 282,160-element normal draw, and the RNG key is
-    left untouched.  ``noise_std > 0`` keeps the champion's exact noise
-    stream (``_sorted_flat_noise``) for completeness.
+    comes from the same ``_sorted_flat_noise`` call as the champion's
+    factory, whose sigma=0 short-circuit skips the 282,160-element normal
+    draw and leaves the RNG key untouched for both factories, so the two
+    lower to identical HLO (pinned; issue #46).  ``noise_std > 0`` keeps
+    the champion's exact noise stream for completeness.
     """
     noise_std = hp["noise_std"]
     step_size = hp["step_size"]
@@ -1082,10 +1096,7 @@ def _make_upgd_ema_norm_ext_learner(
                 name: hp[name]
                 for name in ("step_size", "utility_decay", "noise_std", "weight_decay")
             }
-            if noise_std == 0.0:
-                noise = {name: jnp.zeros_like(value) for name, value in params.items()}
-            else:
-                noise = _sorted_flat_noise(key, params, noise_std)
+            noise = _sorted_flat_noise(key, params, noise_std)
             reduced_params, reduced_lean = lean_upgd_w_update(
                 params, lean_state, grads, noise, lean_hp
             )
@@ -1093,11 +1104,7 @@ def _make_upgd_ema_norm_ext_learner(
             return reduced_params, UPGDNormState(  # type: ignore[call-arg]
                 utility=reduced_lean.utility, step=reduced_lean.step, norm=new_norm
             ), metrics
-        if noise_std == 0.0:
-            # Exactly the zeros the sigma=0 draw produces, minus the draw.
-            noise = {name: jnp.zeros_like(value) for name, value in params.items()}
-        else:
-            noise = _sorted_flat_noise(key, params, noise_std)
+        noise = _sorted_flat_noise(key, params, noise_std)
         count = state.step + jnp.array(1, dtype=jnp.int32)
         utility = {
             name: utility_decay * state.utility[name]

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -49,6 +49,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     _make_snr_ema_norm_learner,
     _make_upgd_alpha_utility_learner,
     _make_upgd_ema_norm_ext_learner,
+    _make_upgd_ema_norm_learner,
     _make_upgd_idbd_learner,
     _make_upgd_shiftnorm_learner,
     _make_upgd_w_fade_head_learner,
@@ -1593,6 +1594,30 @@ class TestSigma0Frontier:
         np.testing.assert_array_equal(ours.per_task_accuracy, ref.per_task_accuracy)
         np.testing.assert_array_equal(ours.per_task_loss, ref.per_task_loss)
         np.testing.assert_array_equal(ours.per_task_plasticity, ref.per_task_plasticity)
+
+    def test_ext_defaults_lower_to_identical_hlo(self):
+        """At inert defaults the extension factory compiles to the same graph
+        as upgd_ema_norm_sigma0's factory.  Identical lowered HLO leaves XLA
+        no fusion or reassociation freedom, so derived float32 metrics cannot
+        drift between the two factories on any backend — value equality alone
+        does not guarantee this (issue #46)."""
+        base = screening_spec("upgd_ema_norm_sigma0")
+        params = init_mlp_params(jr.key(11), SMALL)
+        x = jr.normal(jr.key(12), (SMALL.input_dim,))
+        y = jnp.array(1, jnp.int32)
+        key = jr.key(13)
+
+        def lowered_text(factory, hp):
+            init_fn, step_fn = factory(hp)
+            jitted = jax.jit(lambda p, s, xx, yy, k: step_fn(p, s, xx, yy, k))
+            return jitted.lower(params, init_fn(params), x, y, key).as_text()
+
+        ref = lowered_text(_make_upgd_ema_norm_learner, base.hyperparameters)
+        ext = lowered_text(
+            _make_upgd_ema_norm_ext_learner,
+            {**base.hyperparameters, **self.EXT_DEFAULTS},
+        )
+        assert ref == ext
 
     def test_key_is_unused_on_every_arm(self):
         """sigma0 arms consume no randomness: different RNG keys, same step."""


### PR DESCRIPTION
Fixes #46.

## What changed

`_sorted_flat_noise` now short-circuits to exact zeros when `noise_std == 0.0` (a trace-time Python float), and the two local zeros branches in `_make_upgd_ema_norm_ext_learner` are gone — both pin factories build their perturbation through the same helper call. One new test pins the property that actually failed: at inert defaults the two factories must lower to byte-identical HLO.

Root cause per renzo4web in #46: the reference factory drew the 282,160-element normal vector and zero-scaled it while the ext factory shortcut to `jnp.zeros_like`. XLA cannot fold `normal(key) * 0.0` to constants (a draw is not provably finite), so the two compiled to structurally different graphs, and different fusion choices reassociated the derived float32 plasticity metric by ~1 ulp on some backends — while accuracy, loss, and every parameter update stayed bitwise. This implements the variant kenjohnscreates suggested there: the shared path takes the shortcut, so graph identity comes with the draw skipped rather than restored.

## Why this direction

kenjohnscreates measured the minimal fix (restore the draw in the ext path) at 4.8x per-step cost on the cheap arm family. Sharing the shortcut instead gets HLO identity with no regression — and `upgd_ema_norm_sigma0` itself (the pin's reference, which was still paying for the zero-scaled draw) drops 890 -> 162 us/step (~4.45 -> 0.81 s per 5,000-step task) on this host.

Blast radius: the only registry arm that reaches `_sorted_flat_noise` with `noise_std == 0` is `upgd_ema_norm_sigma0` — `upgd_w_sigma0` has its own dedicated factory, every other sigma=0 arm uses factories that never call this helper, and all noise-carrying arms have sigma > 0 and are untouched. Parameter trajectories are value-identical by construction (`0.0 * normal` was already exact zeros), so no measured accuracy/loss number changes anywhere; future `upgd_ema_norm_sigma0` shards will record smaller `wall_clock_seconds`.

## Evidence

Lane: `alberta_framework.benchmarks.ipmnist_screening` reduction-pin tests. No benchmark shards consumed, no seeds touched, `outputs/` untouched — this is a fix to the measurement path (development infrastructure), not a measured climb.

Environment: macOS arm64 (Apple Silicon), CPU backend, Python 3.12.12, jax/jaxlib 0.11.0 from the stock `uv.lock` env — an independent second reproduction of the environment class reported in #46. Baseline measured at `a0e341263a011c533e19f6c5fb09eba0e54e5857` (current `main`), fix measured at the head below, same host and env.

Red on clean `main` / green at head, failing-test-first:

- `TestSigma0Frontier::test_ext_defaults_reduce_to_upgd_ema_norm_sigma0_bitwise` — FAILED on `a0e3412` (2/3 plasticity elements, max abs diff 1.39698386e-08; accuracy/loss bitwise) -> PASSED at head, still strict `assert_array_equal` on all three vectors.
- new `TestSigma0Frontier::test_ext_defaults_lower_to_identical_hlo` — written first, FAILED on `a0e3412` (ref HLO 43,520 bytes with 4 RNG lines vs ext 33,343 bytes with 0) -> PASSED at head (both factories sha256 `ff0f247ec8077b23`, byte-identical text).

Commands, all at head in the project venv:

```
.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""   # 199 passed
.venv/bin/python -m ruff check .                                              # clean
.venv/bin/python -m mypy                                                      # clean, 159 files
```

Timing of the jitted step at protocol shapes (784 / 300x150 / 10), 2,000 steps after warmup, this host:

| factory | main `a0e3412` | this PR |
|---|---|---|
| ref (`upgd_ema_norm_sigma0`) | 890 us/step (~4.45 s/task) | 162 us/step (~0.81 s/task) |
| ext (inert defaults) | 171 us/step (~0.86 s/task) | 177 us/step (~0.88 s/task) |

<!-- evidence-head:c507f12e62f7c7dee17e64eac2a2cd9a71b142d8 -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.githubusercontent.com/swissyai/e576e91b8d35df127438a38cee849986/raw/ce7ab96b0754d7614ea983d9ed25494a197da2fc/issue46-evidence.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://gist.githubusercontent.com/swissyai/e576e91b8d35df127438a38cee849986/raw/ce7ab96b0754d7614ea983d9ed25494a197da2fc/probe_before.txt and https://gist.githubusercontent.com/swissyai/e576e91b8d35df127438a38cee849986/raw/ce7ab96b0754d7614ea983d9ed25494a197da2fc/probe_after.txt

The URLs above are pinned to gist revision `ce7ab96b0754d7614ea983d9ed25494a197da2fc` (immutable per revision). Repository-native attachment upload is not reachable from this CLI environment; happy to re-attach through the web UI if review needs it.

## Open / caveats

- The new HLO test asserts equality between the two factories on whatever backend runs it — never against a stored hash — so it should hold cross-backend; renzo4web's x86-64 evidence in #46 points the same way, but CI is the arbiter.
- The one-ULP divergence documented in `outputs/ipmnist_screening/AUDIT.md` for the batched/unbatched UPGD-W runners is a different instance of the same reassociation class and is deliberately not touched here.

AI provider/model: anthropic / claude-fable-5. Client: claude-code.


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [theo]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M00X822RX83P8EQFQ1Q42ZH4","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T19:51:08.120Z","completed_at":"2026-08-14T20:05:42.115Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA0eE-CxpDJaUV8hQdIYhxjFl6HxucJPUs6sR7klcKprw","device_key_id":"79f89a6fa3150933b796e4dfa081eeea44561c98f6b5612a9addea180b134553","device_signature":"MfWU408pd6lS1bpcsAVFop8fv4O-RHdt_-0QTx3t9f8mrxEUCiBk0opYW3moGaGzCO4ASaRObHEVIFSzuMb4AQ"}} -->
