### PR TITLE
fix(screening): refuse to merge an arm with zero seed overlap against the control

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7066,6 +7066,16 @@ def merge_shards(
             ),
         }
         common = [s for s in seeds if s in control]
+        if name != control_name and not common:
+            # Every comparison in this campaign is paired on shared seeds; an
+            # arm with no seed in common with the control would still rank in
+            # the summary by raw mean with no paired_vs_control block and
+            # nothing marking it unpaired (issue #49).  Refuse instead.
+            raise ValueError(
+                f"config {name!r} shares no seeds with control {control_name!r} "
+                f"(seeds {seeds} vs {sorted(control)}); refusing to rank an "
+                "unpaired entry in the summary"
+            )
         if name != control_name and common:
             control_avg = np.asarray(
                 [

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -808,6 +808,37 @@ class TestShardsAndMerge:
         control = next(e for e in summary["results"] if e["config_name"] == "upgd_w_control")
         assert "paired_vs_control" not in control
 
+    def test_merge_rejects_zero_seed_overlap_with_control(self, tmp_path, small_data):
+        """An arm sharing no seeds with a present control must refuse to merge:
+        the entry would rank in the summary with no paired_vs_control block and
+        nothing in the artifact marking it unpaired (issue #49)."""
+        paths = [
+            self._make_shard(tmp_path, small_data, "upgd_w_control", 0),
+            self._make_shard(tmp_path, small_data, "upgd_w_control", 1),
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 2),
+        ]
+        with pytest.raises(
+            ValueError,
+            match=r"'upgd_l2init' shares no seeds with control 'upgd_w_control'",
+        ):
+            merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+
+    def test_merge_pairs_on_partial_seed_overlap(self, tmp_path, small_data):
+        """Partial overlap keeps merging and pairs on the intersection, which
+        the block records visibly — the zero-overlap refusal must not
+        over-reach into this legitimate case."""
+        paths = [
+            self._make_shard(tmp_path, small_data, "upgd_w_control", 0),
+            self._make_shard(tmp_path, small_data, "upgd_w_control", 1),
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 1),
+            self._make_shard(tmp_path, small_data, "upgd_l2init", 2),
+        ]
+        summary = merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+        l2 = next(e for e in summary["results"] if e["config_name"] == "upgd_l2init")
+        assert l2["seeds"] == [1, 2]
+        assert l2["paired_vs_control"]["seeds"] == [1]
+        assert len(l2["paired_vs_control"]["per_seed_diff"]) == 1
+
     def test_atomic_writer_refuses_duplicate_without_mutating_first_result(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #49.

## What changed

`merge_shards` now raises a deterministic `ValueError` when a non-control arm shares zero seeds with a present control, instead of silently ranking an unpaired entry. The error names the arm, its seeds, and the control's seeds. **Partial** overlap keeps merging and pairs on the intersection, which the block already records visibly — a new test pins that so the refusal cannot over-reach. The `merge` CLI inherits the refusal. No new flags.

Before, on `main` `a0e3412` (control seeds 0-1, candidate seed 2):

```text
rank entry: upgd_l2init      seeds=[2]    mean=0.2556 paired_vs_control=ABSENT
rank entry: upgd_w_control   seeds=[0, 1] mean=0.2556 paired_vs_control=ABSENT
```

The unpaired arm ranks first with nothing in the artifact marking it unpaired — a cross-seed comparison presented alongside paired ones, reachable through the standard CLI by an incomplete wave or a seed-list typo. After:

```text
ValueError: config 'upgd_l2init' shares no seeds with control 'upgd_w_control' (seeds [2] vs [0, 1]); refusing to rank an unpaired entry in the summary
```

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds consumed, no benchmark runs, no `outputs/` artifacts touched. Environment: macOS arm64, CPU backend, Python 3.12.12, jax 0.11.0 (stock `uv.lock`). Baseline measured at `a0e341263a011c533e19f6c5fb09eba0e54e5857`, fix at the head below.

Failing-test-first in `TestShardsAndMerge`:

- `test_merge_rejects_zero_seed_overlap_with_control` — red on `main` (`Failed: DID NOT RAISE`), green at head.
- `test_merge_pairs_on_partial_seed_overlap` — green on `main` and at head (the pin that partial overlap stays legitimate: entry seeds `[1, 2]`, paired block seeds `[1]`).

Commands, at head in the project venv:

```
.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""   # 199 passed, 1 failed*
.venv/bin/python -m ruff check .                                              # clean
.venv/bin/python -m mypy                                                      # clean, 159 files
```

\* The one failure is `TestSigma0Frontier::test_ext_defaults_reduce_to_upgd_ema_norm_sigma0_bitwise`, the known #46 pin failure on jax 0.11.0 arm64 hosts — it reproduces identically on pristine `main` in this environment, is untouched by this change, and is fixed separately in #48.

Historical safety, verified against the artifacts: all 8 pinned `outputs/ipmnist_screening/summary*.json` carry `paired_vs_control` for every non-control entry (each on its full seed set), so this refusal breaks no sanctioned historical merge.

Composes with #45 (the absent-control refusal from #44): both diffs apply together cleanly and all 15 merge/overlap tests pass with both in place. With #45 absent, an absent control now also refuses here (every arm has zero overlap with an empty control set) with a less specific message; with #45 landed, its earlier check names that case precisely.

<!-- evidence-head:66df4a040c7671a3e16b0376ff7342d45b092f48 -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.githubusercontent.com/swissyai/18d19131bbcd547e8674a1ead0de12ab/raw/7bdf12fc7f206d9777e7eeb9afcc7a1d87eae809/issue49-evidence.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://gist.githubusercontent.com/swissyai/18d19131bbcd547e8674a1ead0de12ab/raw/7bdf12fc7f206d9777e7eeb9afcc7a1d87eae809/overlap_repro.py

URLs are pinned to gist revision `7bdf12fc7f206d9777e7eeb9afcc7a1d87eae809` (immutable per revision); repository-native attachment upload is not reachable from this CLI environment.

## Open / caveats

- Refuse vs annotate was the design fork; refuse follows the house fail-closed style and the #45 precedent, and the historical-artifact check shows no sanctioned flow ever needed the lenient path.
- Out of scope, still open from #44's list: `validate_proxy`'s vacuous `all_prefixes_match: true` over an empty check list (only reachable with an empty shard list at the API level).

AI provider/model: anthropic / claude-fable-5. Client: claude-code.


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [theo]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M0102CYTA5R6CZ4X5G5EQZ30","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-14T20:40:28.379Z","completed_at":"2026-08-14T20:47:27.985Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA0eE-CxpDJaUV8hQdIYhxjFl6HxucJPUs6sR7klcKprw","device_key_id":"79f89a6fa3150933b796e4dfa081eeea44561c98f6b5612a9addea180b134553","device_signature":"H0MEkK22j0X73cZHhPy6JiSxAOPISVSGV-hBJa1I-7thwviaq3ZHFCL1XOMjXksiYLNHNvxjVHfi4XLXSQuQAQ"}} -->
