### PR TITLE
fix(screening): require two paired seeds for confirmation_candidate

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7115,7 +7115,16 @@ def merge_shards(
                 ),
                 "all_seeds_improve": bool(np.all(diff > 0.0)),
                 "beats_control": bool(diff.mean() > 0.0),
-                "confirmation_candidate": bool(diff.mean() > CONFIRMATION_THRESHOLD),
+                # A paired mean over one seed has no spread: stderr_diff
+                # reports 0.0 (undefined, not high confidence) and
+                # all_seeds_improve is vacuously true, so a single lucky
+                # seed could green-light the 200-task confirmation budget
+                # alone.  The flag is a compute-spending decision; require
+                # at least two actually-paired seeds.  The merge itself and
+                # this paired block stay available for mid-wave inspection.
+                "confirmation_candidate": bool(
+                    len(common) >= 2 and diff.mean() > CONFIRMATION_THRESHOLD
+                ),
             }
         entries.append(entry)
 

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -840,6 +840,79 @@ class TestShardsAndMerge:
         assert l2["paired_vs_control"]["seeds"] == [1]
         assert len(l2["paired_vs_control"]["per_seed_diff"]) == 1
 
+    def _write_synthetic_shard(self, tmp_path, name, seed, accuracy):
+        """An in-band-valid shard with controlled per-task accuracy.
+
+        The merge/summary logic under test is pure shard arithmetic; real
+        small-scale runs tie at this scale (diff 0.0), so the flag's decision
+        boundary needs shards whose accuracy the test chooses.
+        """
+        payload = {
+            "schema": SHARD_SCHEMA,
+            "config_name": name,
+            "base_learner": "upgd",
+            "hyperparameters": {"step_size": 0.01},
+            "seed": seed,
+            "noise_mode": "step",
+            "config": {
+                "n_tasks": SMALL.n_tasks,
+                "task_length": SMALL.task_length,
+                "input_dim": SMALL.input_dim,
+                "hidden1": SMALL.hidden1,
+                "hidden2": SMALL.hidden2,
+                "n_classes": SMALL.n_classes,
+            },
+            "per_task_accuracy": [accuracy] * SMALL.n_tasks,
+            "per_task_loss": [0.5] * SMALL.n_tasks,
+            "per_task_plasticity": [0.1] * SMALL.n_tasks,
+            "wall_clock_seconds": 1.0,
+        }
+        path = tmp_path / f"synth_{name}_seed{seed}.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_confirmation_candidate_requires_two_paired_seeds(
+        self, tmp_path, small_data
+    ):
+        """``confirmation_candidate`` green-lights 200-task confirmation
+        compute.  With exactly one shared seed the paired mean is a single
+        draw: ``stderr_diff`` reports 0.0 (undefined, not high confidence)
+        and ``all_seeds_improve`` is vacuously true, so a lucky seed could
+        spend the confirmation budget alone.  The flag must stay False until
+        at least two seeds are actually paired, while the merge itself and
+        the paired block stay available for mid-wave inspection."""
+        paths = [
+            self._write_synthetic_shard(tmp_path, "upgd_w_control", 0, 0.70),
+            self._write_synthetic_shard(tmp_path, "upgd_l2init", 0, 0.76),
+            self._write_synthetic_shard(tmp_path, "upgd_l2init", 1, 0.76),
+        ]
+        summary = merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+        l2 = next(e for e in summary["results"] if e["config_name"] == "upgd_l2init")
+        paired = l2["paired_vs_control"]
+        assert paired["seeds"] == [0]
+        assert len(paired["per_seed_diff"]) == 1
+        assert paired["mean_diff"] > 0.005
+        assert paired["confirmation_candidate"] is False
+        assert paired["all_seeds_improve"] is True  # vacuously, on one seed
+
+    def test_confirmation_candidate_true_on_two_paired_seeds(
+        self, tmp_path, small_data
+    ):
+        """The two-seed floor must not over-reach: with two shared seeds
+        clearing the threshold the flag stays True exactly as before."""
+        paths = [
+            self._write_synthetic_shard(tmp_path, "upgd_w_control", 0, 0.70),
+            self._write_synthetic_shard(tmp_path, "upgd_w_control", 1, 0.70),
+            self._write_synthetic_shard(tmp_path, "upgd_l2init", 0, 0.76),
+            self._write_synthetic_shard(tmp_path, "upgd_l2init", 1, 0.76),
+        ]
+        summary = merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+        l2 = next(e for e in summary["results"] if e["config_name"] == "upgd_l2init")
+        paired = l2["paired_vs_control"]
+        assert paired["seeds"] == [0, 1]
+        assert paired["mean_diff"] > 0.005
+        assert paired["confirmation_candidate"] is True
+
     def test_atomic_writer_refuses_duplicate_without_mutating_first_result(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #53.

## What

`merge_shards`'s `confirmation_candidate` additionally requires **at least two actually-paired seeds**. Everything else in the merge and the `paired_vs_control` block is untouched.

## Why

The flag is a compute-spending decision: it green-lights a 200-task confirmation wave. At exactly one shared seed:

- the paired mean is a single draw with no spread, so `stderr_diff` reports `0.0` — which reads as maximal confidence but is *undefined*;
- `all_seeds_improve` is vacuously `true`;
- one lucky seed clearing `CONFIRMATION_THRESHOLD` (0.005) escalates on its own.

Observed on current `main` (`da8b86c`) with synthetic in-band shards — control seed {0}, candidate seeds {0,1,2}, candidate +0.06 on the shared seed:

```text
paired seeds: [0] | stderr_diff: 0.0
all_seeds_improve: True | confirmation_candidate: True
```

This is the n=1 corner of the #49/#50 family: #50 refuses zero overlap, partial overlap with n>=2 is legitimate mid-wave progress (and stays exactly as pinned by `test_merge_pairs_on_partial_seed_overlap`), but n=1 merged silently with a block that read as evidence.

## The change

```python
"confirmation_candidate": bool(
    len(common) >= 2 and diff.mean() > CONFIRMATION_THRESHOLD
),
```

Fail-closed on the escalation decision only; the summary itself keeps merging for mid-wave inspection.

## Verification

- Failing-test-first: `test_confirmation_candidate_requires_two_paired_seeds` failed on pristine `main` (`assert True is False` — the flag was `True` at n=1 clearing the threshold), passes at this head.
- Over-reach guard: `test_confirmation_candidate_true_on_two_paired_seeds` pins n=2 clearing the threshold → `True`, exactly as before.
- `pytest tests/test_ipmnist_screening.py -k "merge or shard or paired or confirmation"` — **21 passed** (including #50's partial-overlap pin, untouched).
- `ruff check` — clean; `mypy` (repo config, 159 files) — clean.

The two new tests use a `_write_synthetic_shard` helper (in-band-valid shards: registry arm names, `SMALL` protocol config, finite vectors) because the merge logic under test is pure shard arithmetic and real small-scale runs tie at 0.0 diff, which cannot exercise the flag's decision boundary. `load_shard` accepts the synthetic shards through the same structural validation as real ones.

No benchmark compute was consumed; no `outputs/` artifact touched.

<!-- evidence-head:5754d3c37db915757a1676fb62204fbd5f0912ec -->
<!-- evidence-row:logs -->
- [x] logs: RED on pristine main (`assert True is False` at n=1) → GREEN at this head; merge-family suite 21 passed — command transcript in the Verification section above

---
AI-assisted contribution (analysis, probe, tests, and fix prepared with agent tooling). No Slop run receipt applies: the work ran outside the approved measured-run clients, so no receipt footer is attached rather than an empty one.