### PR TITLE
fix(optimizers): keep Autostep step-sizes finite past the v>0 gate

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -942,16 +942,23 @@ class Autostep(Optimizer[AutostepState]):
 
         abs_meta_gradient = jnp.abs(meta_gradient)
 
-        # Eq. 4: v_i = max(|meta_grad|, v_i + (1/τ)*α_i*z_i²*(|meta_grad| - v_i))
+        # Eq. 4: v_i = max(|meta_grad|, v_i + (1/τ)*α_i*z_i²*(|meta_grad| - v_i)).
+        # max(NaN) is NaN, so a non-finite meta-gradient (inf*0 or overflow)
+        # must keep the previous normalizer instead of poisoning v.
         v_update = state.normalizers + (1.0 / tau) * state.step_sizes * z_sq * (
             abs_meta_gradient - state.normalizers
         )
-        new_normalizers = jnp.maximum(abs_meta_gradient, v_update)
+        new_normalizers = jnp.where(
+            jnp.isfinite(meta_gradient),
+            jnp.maximum(abs_meta_gradient, v_update),
+            state.normalizers,
+        )
 
-        # Eq. 5: α_i *= exp(μ * meta_grad / v_i) where v_i > 0
+        # Eq. 5: α_i *= exp(μ * meta_grad / v_i) where v_i > 0. The v>0 gate
+        # is not an isfinite skip: inf/inf = NaN and clip(NaN) is NaN.
         safe_v = jnp.maximum(new_normalizers, 1e-38)
         new_step_sizes = jnp.where(
-            new_normalizers > 0,
+            jnp.logical_and(jnp.isfinite(meta_gradient), new_normalizers > 0),
             state.step_sizes * jnp.exp(mu * meta_gradient / safe_v),
             state.step_sizes,
         )
@@ -1020,16 +1027,22 @@ class Autostep(Optimizer[AutostepState]):
         meta_gradient = error_scalar * x * state.traces
         abs_meta_gradient = jnp.abs(meta_gradient)
 
-        # Eq. 4: v_i update (self-regulated EMA)
+        # Eq. 4: v_i update (self-regulated EMA). max(NaN) is NaN, so a
+        # non-finite meta-gradient must keep the previous normalizer.
         v_update = state.normalizers + (1.0 / tau) * state.step_sizes * x_sq * (
             abs_meta_gradient - state.normalizers
         )
-        new_normalizers = jnp.maximum(abs_meta_gradient, v_update)
+        new_normalizers = jnp.where(
+            jnp.isfinite(meta_gradient),
+            jnp.maximum(abs_meta_gradient, v_update),
+            state.normalizers,
+        )
 
-        # Eq. 5: α_i *= exp(μ * meta_grad / v_i) where v_i > 0
+        # Eq. 5: α_i *= exp(μ * meta_grad / v_i) where v_i > 0. The v>0 gate
+        # is not an isfinite skip: inf/inf = NaN and clip(NaN) is NaN.
         safe_v = jnp.maximum(new_normalizers, 1e-38)
         new_step_sizes = jnp.where(
-            new_normalizers > 0,
+            jnp.logical_and(jnp.isfinite(meta_gradient), new_normalizers > 0),
             state.step_sizes * jnp.exp(mu * meta_gradient / safe_v),
             state.step_sizes,
         )
@@ -1039,16 +1052,22 @@ class Autostep(Optimizer[AutostepState]):
         bias_meta_gradient = error_scalar * state.bias_trace
         abs_bias_meta_gradient = jnp.abs(bias_meta_gradient)
 
-        # Eq. 4 for bias
+        # Eq. 4 for bias. Same guard: a non-finite correlation keeps v.
         bias_v_update = state.bias_normalizer + (1.0 / tau) * state.bias_step_size * (
             abs_bias_meta_gradient - state.bias_normalizer
         )
-        new_bias_normalizer = jnp.maximum(abs_bias_meta_gradient, bias_v_update)
+        new_bias_normalizer = jnp.where(
+            jnp.isfinite(bias_meta_gradient),
+            jnp.maximum(abs_bias_meta_gradient, bias_v_update),
+            state.bias_normalizer,
+        )
 
-        # Eq. 5 for bias
+        # Eq. 5 for bias. Same isfinite skip so inf/inf cannot NaN alpha.
         safe_bias_v = jnp.maximum(new_bias_normalizer, 1e-38)
         new_bias_step_size = jnp.where(
-            new_bias_normalizer > 0,
+            jnp.logical_and(
+                jnp.isfinite(bias_meta_gradient), new_bias_normalizer > 0
+            ),
             state.bias_step_size * jnp.exp(mu * bias_meta_gradient / safe_bias_v),
             state.bias_step_size,
         )

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -303,6 +303,147 @@ class TestAutostep:
         ratio = float(v[2]) / float(jnp.maximum(v[0], 1e-10))
         assert ratio > 4.0  # Well above linear (3), closer to quadratic (9)
 
+    def test_infinite_error_does_not_poison_step_sizes(self):
+        """An inf error against fresh zero traces must skip meta-adaptation.
+
+        h=0 means "no gradient correlation yet": inf * 0 = NaN used to flow
+        through max(v) (max(NaN) is NaN) and stay there. The v>0 gate keeps
+        alpha on that step (NaN>0 is False) but stores a NaN normalizer, so
+        every later finite update keeps a poisoned v.
+        """
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.normalizers)))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_step_size))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_normalizer))
+        chex.assert_trees_all_close(
+            poisoned.new_state.step_sizes, state.step_sizes
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.normalizers, state.normalizers
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.bias_step_size, state.bias_step_size
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.bias_normalizer, state.bias_normalizer
+        )
+
+        recovered = optimizer.update(
+            poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.normalizers)))
+        assert bool(jnp.isfinite(recovered.new_state.bias_step_size))
+        assert bool(jnp.isfinite(recovered.new_state.bias_normalizer))
+
+    def test_finite_overflow_product_keeps_meta_update_zero(self):
+        """|error * x| overflowing float32 must not NaN a zero-trace channel.
+
+        (error * x) * h evaluates inf * 0 = NaN when the finite product
+        overflows; the non-finite guard skips the Eq. 4/5 write for that
+        channel (previous v kept, which is 0). Joint M-normalization may
+        still shrink every alpha when one x_i^2 overflows; that path is
+        not this guard.
+        """
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.array([1e20, 1.0], dtype=jnp.float32)
+
+        result = optimizer.update(
+            state, jnp.array(1e20, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(result.new_state.normalizers)))
+        assert bool(jnp.all(jnp.isfinite(result.new_state.step_sizes)))
+        # Overflowed channel: h=0 so the skipped meta-write leaves v at 0.
+        assert float(result.new_state.normalizers[0]) == 0.0
+        # Quiet channel: meta is 0, v stays 0.
+        assert float(result.new_state.normalizers[1]) == 0.0
+
+    def test_warmed_infinite_error_does_not_poison_step_sizes(self):
+        """Inf error after nonzero h must not NaN alpha via inf/inf.
+
+        Once h and v are finite nonzero, inf error makes meta=inf and
+        v=inf; the v>0 gate then evaluates exp(mu * inf / inf) = NaN and
+        clip(NaN) stores NaN step-sizes (and the bias twin) forever.
+        """
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        for _ in range(5):
+            state = optimizer.update(
+                state, jnp.array(1.0, dtype=jnp.float32), observation
+            ).new_state
+        pre_step = state.step_sizes
+        pre_v = state.normalizers
+        pre_bias_step = state.bias_step_size
+        pre_bias_v = state.bias_normalizer
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.normalizers)))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_step_size))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_normalizer))
+        chex.assert_trees_all_close(poisoned.new_state.step_sizes, pre_step)
+        chex.assert_trees_all_close(poisoned.new_state.normalizers, pre_v)
+        chex.assert_trees_all_close(
+            poisoned.new_state.bias_step_size, pre_bias_step
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.bias_normalizer, pre_bias_v
+        )
+
+        recovered = optimizer.update(
+            poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.normalizers)))
+
+    def test_finite_gradients_still_adapt_after_guard(self):
+        """The non-finite guard must not change ordinary adaptation."""
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.05)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+
+        first = optimizer.update(state, jnp.array(1.0), observation)
+        second = optimizer.update(first.new_state, jnp.array(1.0), observation)
+        # Second step has nonzero h, so correlated errors raise alpha.
+        assert bool(jnp.all(second.new_state.step_sizes > state.step_sizes))
+        assert bool(jnp.all(second.new_state.normalizers > 0))
+
+    def test_update_from_gradient_infinite_z_does_not_poison_step_sizes(self):
+        """The gradient path's meta-update has the same inf * 0 = NaN hole.
+
+        z * traces with fresh zero traces and an inf gradient produced NaN
+        normalizers through max(v), exactly like the linear path.
+        """
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init_for_shape((4, 3))
+
+        gradient = jnp.full((4, 3), jnp.inf, dtype=jnp.float32)
+        step, poisoned = optimizer.update_from_gradient(
+            state, gradient, error=jnp.array(1.0)
+        )
+        del step
+        assert bool(jnp.all(jnp.isfinite(poisoned.step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(poisoned.normalizers)))
+        chex.assert_trees_all_close(poisoned.normalizers, state.normalizers)
+
+        finite_step, recovered = optimizer.update_from_gradient(
+            poisoned, jnp.ones((4, 3)) * 0.1, error=jnp.array(1.0)
+        )
+        chex.assert_tree_all_finite(finite_step)
+        chex.assert_tree_all_finite(recovered.step_sizes)
+        chex.assert_tree_all_finite(recovered.normalizers)
+
 
 class TestAutostepGTDLambda:
     """Tests for the Autostep-for-GTD(lambda) optimizer.


### PR DESCRIPTION
Fixes #55. Sibling of #42/#43 (IDBD), same guard contract.

## What

Autostep's guards are not finiteness guards: `jnp.maximum(NaN, v)` propagates NaN through Eq. 4 (permanently — `max(inf, NaN)` never recovers), and the Eq. 5 `v > 0` gate passes `inf`, computing `alpha * exp(mu * inf / inf) = alpha * exp(NaN)`, which rides through the `clip(…, 1e-8, 1.0)` "numerical safety" as NaN. Zero-trace inf/overflow poisons the normalizers; warm-trace inf poisons the step-sizes; the bias twin has both holes. Full mechanism, reproductions, controls, and the verified non-hole (zero-normalizer division) are in #55.

The fix mirrors #43 exactly: `where(isfinite(meta_gradient), maximum(…), v_prev)` on Eq. 4 and `logical_and(isfinite(meta_gradient), v > 0)` on the Eq. 5 gate, at all three sites (MLP path, linear weights, bias). Guard-only — no expression reassociation (the #43 review lesson): a non-finite meta-gradient skips adaptation for that weight, keeping the previous normalizer and step-size; recovery on the next finite update is automatic. `AutostepGTDLambda` delegates to this path and inherits the fix.

## Verification

- `uv run pytest tests/test_optimizers.py -q` — **55 passed** at this head, including new regressions: zero-trace inf poisoning + recovery, warm-trace inf through the gate + recovery, finite-overflow channel isolation, bias twins, and ordinary-adaptation-preserved.
- Fail-proof: with only `alberta_framework/core/optimizers.py` restored to `origin/main`, **4 of the new regressions fail** with the exact NaN shapes; restored, 55/55.
- **Bit-stability, per the #43 precedent:** deterministic 200-update finite-trajectory probe hashing `step_sizes + normalizers + traces` — `origin/main` and this head both produce `88515992fd4c41c787b2cfd0597dd0cac4712e848b2e48f76051dfde31ac6a72`. The finite path takes the identical branch; the guard is the only behavioral change.
- `uv run ruff check` on both touched files — clean.
- Consistent semantics note (deliberate, matching #43's approved skip-over-saturate choice): non-finite input adapts nothing; the estimator holds where its last finite evidence put it.

## Provenance

Sibling-guard audit, reproductions, and implementation by a local Grok Build lane (xai/grok-4.6, committed as ss251, lane-run bit-probe recorded in its ledger); independently re-verified — suite, fail-proof, ruff, and an independent bit-probe run — and published from a Claude Code session (anthropic/claude-fable-5). Self-reported.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-eliza"} -->
