### PR TITLE
Keep screening IDBD and Autostep meta-updates finite

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -203,6 +203,20 @@ _IDBD_LOG_ALPHA_MAX = 0.0  # alpha <= 1 keeps per-weight decay factors positive
 _AUTOSTEP_ALPHA_MIN = 1e-8
 _AUTOSTEP_ALPHA_MAX = 1.0
 
+
+def _clip_finite_log_alpha(log_alpha: Array, meta_delta: Array) -> Array:
+    """Clip an IDBD log-step-size update; skip a non-finite meta-gradient.
+
+    ``clip(NaN)`` is NaN, so inf * h=0 (or a float32 overflow of a finite
+    product) would permanently poison ``log_alpha``. Core IDBD (#42/#43)
+    keeps the previous value on that channel; screening copies must too.
+    """
+    return jnp.where(
+        jnp.isfinite(meta_delta),
+        jnp.clip(log_alpha + meta_delta, _IDBD_LOG_ALPHA_MIN, _IDBD_LOG_ALPHA_MAX),
+        log_alpha,
+    )
+
 # Metrics returned by every screening step: (accuracy, loss, plasticity).
 StepMetrics = tuple[Array, Array, Array]
 ScreeningStepFn = Callable[
@@ -402,10 +416,8 @@ def upgd_idbd_update(
     for name in params:
         keep = 1.0 - gate[name]
         z = grads[name] * keep
-        log_alpha = jnp.clip(
-            state.log_alpha[name] + meta * z * state.trace[name],
-            _IDBD_LOG_ALPHA_MIN,
-            _IDBD_LOG_ALPHA_MAX,
+        log_alpha = _clip_finite_log_alpha(
+            state.log_alpha[name], meta * z * state.trace[name]
         )
         alpha = jnp.exp(log_alpha)
         new_params[name] = params[name] * (1.0 - alpha * wd) - alpha * (
@@ -459,10 +471,8 @@ def upgd_idbd_swift_update(
     log_alpha_all: dict[str, Array] = {}
     for name in params:
         z_all[name] = grads[name] * (1.0 - gate[name])
-        log_alpha_all[name] = jnp.clip(
-            state.log_alpha[name] + meta * z_all[name] * state.trace[name],
-            _IDBD_LOG_ALPHA_MIN,
-            _IDBD_LOG_ALPHA_MAX,
+        log_alpha_all[name] = _clip_finite_log_alpha(
+            state.log_alpha[name], meta * z_all[name] * state.trace[name]
         )
     alpha_all = {name: jnp.exp(log_alpha_all[name]) for name in params}
     tau = jnp.sum(
@@ -584,21 +594,33 @@ def upgd_autostep_update(
     for name in params:
         z = z_all[name]
         meta_gradient = z * state.trace[name]
+        finite_meta = jnp.isfinite(meta_gradient)
         abs_meta = jnp.abs(meta_gradient)
         v_update = state.normalizer[name] + (1.0 / tau) * state.alpha[name] * z * z * (
             abs_meta - state.normalizer[name]
         )
-        v_new = jnp.maximum(abs_meta, v_update)
+        v_new = jnp.where(
+            finite_meta, jnp.maximum(abs_meta, v_update), state.normalizer[name]
+        )
         safe_v = jnp.maximum(v_new, 1e-38)
         raw_alpha[name] = jnp.where(
-            v_new > 0.0,
+            finite_meta & (v_new > 0.0),
             state.alpha[name] * jnp.exp(mu * meta_gradient / safe_v),
             state.alpha[name],
         )
         new_normalizer[name] = v_new
     effective = jnp.sum(
         jnp.stack(
-            [jnp.sum(raw_alpha[name] * z_all[name] * z_all[name]) for name in sorted(params)]
+            [
+                jnp.sum(
+                    jnp.where(
+                        jnp.isfinite(z_all[name] * z_all[name]),
+                        raw_alpha[name] * z_all[name] * z_all[name],
+                        0.0,
+                    )
+                )
+                for name in sorted(params)
+            ]
         )
     )
     m_factor = jnp.maximum(effective, 1.0)
@@ -613,7 +635,11 @@ def upgd_autostep_update(
             (grads[name] + noise[name]) * keep
         )
         new_alpha[name] = alpha
-        new_trace[name] = state.trace[name] * (1.0 - alpha * z * z) + alpha * z
+        new_trace[name] = jnp.where(
+            jnp.isfinite(z),
+            state.trace[name] * (1.0 - alpha * z * z) + alpha * z,
+            state.trace[name],
+        )
     return new_params, UPGDAutostepState(  # type: ignore[call-arg]
         utility=utility,
         step=count,
@@ -2667,10 +2693,8 @@ def upgd_alpha_utility_update(
     new_trace: dict[str, Array] = {}
     for name in params:
         g = grads[name]
-        la = jnp.clip(
-            state.log_alpha[name] + meta * g * state.trace[name],
-            _IDBD_LOG_ALPHA_MIN,
-            _IDBD_LOG_ALPHA_MAX,
+        la = _clip_finite_log_alpha(
+            state.log_alpha[name], meta * g * state.trace[name]
         )
         alpha = jnp.exp(la)
         new_log_alpha[name] = la

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -48,6 +48,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     _make_sgd_momentum_gate_learner,
     _make_snr_ema_norm_learner,
     _make_upgd_alpha_utility_learner,
+    _make_upgd_autostep_learner,
     _make_upgd_ema_norm_ext_learner,
     _make_upgd_ema_norm_learner,
     _make_upgd_idbd_learner,
@@ -74,6 +75,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     shift_adaptive_normalize,
     snr_maybe_reset_layer,
     upgd_alpha_utility_update,
+    upgd_autostep_update,
     upgd_idbd_swift_update,
     upgd_idbd_update,
     upgd_l2init_update,
@@ -301,6 +303,57 @@ class TestIDBDCombo:
             assert bool(jnp.all(state.log_alpha[n] <= 0.0))
             assert bool(jnp.all(jnp.isfinite(params[n])))
 
+    def test_infinite_gated_gradient_does_not_poison_log_alpha(self):
+        """Inf * h=0 is NaN; clip(NaN) used to leave log_alpha permanently NaN,
+        the same class core IDBD closed in #42/#43. Skip that channel."""
+        params = init_mlp_params(jr.key(0), SMALL)
+        hp = dict(UPGD_W_PROTOCOL_HYPERPARAMETERS)
+        hp.update({"meta_step_size": 0.01, "initial_step_size": 0.01})
+        init_fn, _ = _make_upgd_idbd_learner(hp)
+        state = init_fn(params)
+        grads = {n: jnp.zeros_like(v) for n, v in params.items()}
+        grads["w1"] = jnp.full_like(params["w1"], jnp.inf)
+        noise = {n: jnp.zeros_like(v) for n, v in params.items()}
+
+        _, poisoned = upgd_idbd_update(params, state, grads, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(poisoned.log_alpha["w1"])))
+        np.testing.assert_array_equal(
+            np.asarray(poisoned.log_alpha["w1"]), np.asarray(state.log_alpha["w1"])
+        )
+
+        finite = {n: jnp.ones_like(v) * 0.1 for n, v in params.items()}
+        _, recovered = upgd_idbd_update(params, poisoned, finite, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(recovered.log_alpha["w1"])))
+
+
+class TestAutostepCombo:
+    def test_infinite_gated_gradient_does_not_poison_normalizers(self):
+        """Table-1 v = max(NaN, ...) stays NaN, then clip(NaN) on alpha. The
+        screening copy still has the leak core Autostep #55 names."""
+        params = init_mlp_params(jr.key(0), SMALL)
+        hp = dict(UPGD_W_PROTOCOL_HYPERPARAMETERS)
+        hp.update({"meta_step_size": 0.01, "initial_step_size": 0.01, "tau": 1e4})
+        init_fn, _ = _make_upgd_autostep_learner(hp)
+        state = init_fn(params)
+        grads = {n: jnp.zeros_like(v) for n, v in params.items()}
+        grads["w1"] = jnp.full_like(params["w1"], jnp.inf)
+        noise = {n: jnp.zeros_like(v) for n, v in params.items()}
+
+        _, poisoned = upgd_autostep_update(params, state, grads, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(poisoned.normalizer["w1"])))
+        assert bool(jnp.all(jnp.isfinite(poisoned.alpha["w1"])))
+        np.testing.assert_array_equal(
+            np.asarray(poisoned.normalizer["w1"]), np.asarray(state.normalizer["w1"])
+        )
+        np.testing.assert_array_equal(
+            np.asarray(poisoned.alpha["w1"]), np.asarray(state.alpha["w1"])
+        )
+
+        finite = {n: jnp.ones_like(v) * 0.1 for n, v in params.items()}
+        _, recovered = upgd_autostep_update(params, poisoned, finite, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(recovered.normalizer["w1"])))
+        assert bool(jnp.all(jnp.isfinite(recovered.alpha["w1"])))
+
 
 class TestFadeHead:
     """FADE meta-learned per-parameter weight decay on the output layer."""
@@ -475,6 +528,21 @@ class TestIDBDSwift:
                     np.asarray(state_swift.trace[n]), np.asarray(state_plain.trace[n])
                 )
             params = p_swift
+
+    def test_infinite_gated_gradient_does_not_poison_log_alpha(self):
+        params = init_mlp_params(jr.key(0), SMALL)
+        hp = self._hp()
+        init_fn, _ = _make_upgd_idbd_learner(hp)
+        state = init_fn(params)
+        grads = {n: jnp.zeros_like(v) for n, v in params.items()}
+        grads["w1"] = jnp.full_like(params["w1"], jnp.inf)
+        noise = {n: jnp.zeros_like(v) for n, v in params.items()}
+
+        _, poisoned = upgd_idbd_swift_update(params, state, grads, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(poisoned.log_alpha["w1"])))
+        np.testing.assert_array_equal(
+            np.asarray(poisoned.log_alpha["w1"]), np.asarray(state.log_alpha["w1"])
+        )
 
     def test_overshoot_bound_triggers_and_caps_effective_step(self):
         """Large alpha: sum_i alpha_i z_i^2 >> eta, so the applied step is the
@@ -1532,7 +1600,21 @@ class TestAlphaUtility:
                 np.testing.assert_array_equal(
                     np.asarray(new_params[n]), np.asarray(expected)
                 )
-            params = new_params
+
+    def test_infinite_raw_gradient_does_not_poison_log_alpha(self):
+        params = init_mlp_params(jr.key(0), SMALL)
+        hp = self._hp()
+        init_fn, _ = _make_upgd_alpha_utility_learner(hp)
+        state = init_fn(params)
+        grads = {n: jnp.zeros_like(v) for n, v in params.items()}
+        grads["w1"] = jnp.full_like(params["w1"], jnp.inf)
+        noise = {n: jnp.zeros_like(v) for n, v in params.items()}
+
+        _, poisoned = upgd_alpha_utility_update(params, state, grads, noise, hp)
+        assert bool(jnp.all(jnp.isfinite(poisoned.log_alpha["w1"])))
+        np.testing.assert_array_equal(
+            np.asarray(poisoned.log_alpha["w1"]), np.asarray(state.log_alpha["w1"])
+        )
 
     def test_consistent_gradient_earns_more_protection(self):
         """A weight with a persistent-sign gradient must end with higher

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -1600,6 +1600,7 @@ class TestAlphaUtility:
                 np.testing.assert_array_equal(
                     np.asarray(new_params[n]), np.asarray(expected)
                 )
+            params = new_params
 
     def test_infinite_raw_gradient_does_not_poison_log_alpha(self):
         params = init_mlp_params(jr.key(0), SMALL)


### PR DESCRIPTION
The IPMNIST screening copies of IDBD, Swift-IDBD, Autostep, and the alpha-utility gate still poison per-weight step-size state on a non-finite meta-gradient. Fresh traces are zero, so `inf * h` is NaN; `clip(NaN)` and Autostep's `max(NaN, v)` stay NaN, and every later finite update inherits it.

That is the same class core IDBD closed in #42/#43. Core Autostep is #55. These screening kernels are a separate copy on the open climbing lane, so a NaN here corrupts paired campaign measurements rather than just a library optimizer.

The meta-update now skips a non-finite channel and keeps the previous `log_alpha` / `v` / `alpha`. Autostep's M-factor and traces also ignore non-finite `z^2` so the global rescale cannot re-poison a skipped channel. On the poisoned path that is a semantic choice, not only a guard: non-finite `z^2` channels are dropped from the sum that builds `M`, so a skipped channel does not inflate the network-wide normalizer. Finite trajectories are unchanged: existing meta=0 reduction pins and the Swift-vs-IDBD bit-exact pin still pass.

Failing-test-first on inf gated/raw gradients: all four kernels went NaN on pristine main, then recovered. Restored the `params = new_params` carry in `test_meta_zero_reduces_to_half_gated_step` so that pin is still a 3-step trajectory. `tests/test_ipmnist_screening.py`: 207 passed.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)