### PR TITLE
Keep TD-IDBD and AutoTDIDBD meta-updates finite

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -1508,36 +1508,47 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
 
         if self._use_semi_gradient:
             gradient_correlation = delta * observation * state.h_traces
-            new_log_step_sizes = state.log_step_sizes + theta * gradient_correlation
+            meta_delta = theta * gradient_correlation
         else:
             feature_diff = gamma_scalar * next_observation - observation
             gradient_correlation = delta * feature_diff * state.h_traces
-            new_log_step_sizes = state.log_step_sizes - theta * gradient_correlation
+            meta_delta = -theta * gradient_correlation
 
-        new_log_step_sizes = jnp.clip(new_log_step_sizes, -10.0, 2.0)
+        # clip(NaN) is NaN, so inf * h=0 must skip adaptation for that weight.
+        new_log_step_sizes = jnp.where(
+            jnp.isfinite(meta_delta),
+            jnp.clip(state.log_step_sizes + meta_delta, -10.0, 2.0),
+            state.log_step_sizes,
+        )
         new_alphas = jnp.exp(new_log_step_sizes)
 
         new_eligibility_traces = gamma_scalar * lam * state.eligibility_traces + observation
         weight_delta = new_alphas * delta * new_eligibility_traces
 
+        finite_delta = jnp.isfinite(delta)
         if self._use_semi_gradient:
             h_decay = jnp.maximum(0.0, 1.0 - new_alphas * observation * new_eligibility_traces)
-            new_h_traces = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
+            updated_h = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
         else:
             feature_diff = gamma_scalar * next_observation - observation
             h_decay = jnp.maximum(0.0, 1.0 + new_alphas * new_eligibility_traces * feature_diff)
-            new_h_traces = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
+            updated_h = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
+        new_h_traces = jnp.where(finite_delta, updated_h, state.h_traces)
 
         # Bias updates
         if self._use_semi_gradient:
             bias_gradient_correlation = delta * state.bias_h_trace
-            new_bias_log_step_size = state.bias_log_step_size + theta * bias_gradient_correlation
+            bias_meta_delta = theta * bias_gradient_correlation
         else:
             bias_feature_diff = gamma_scalar - 1.0
             bias_gradient_correlation = delta * bias_feature_diff * state.bias_h_trace
-            new_bias_log_step_size = state.bias_log_step_size - theta * bias_gradient_correlation
+            bias_meta_delta = -theta * bias_gradient_correlation
 
-        new_bias_log_step_size = jnp.clip(new_bias_log_step_size, -10.0, 2.0)
+        new_bias_log_step_size = jnp.where(
+            jnp.isfinite(bias_meta_delta),
+            jnp.clip(state.bias_log_step_size + bias_meta_delta, -10.0, 2.0),
+            state.bias_log_step_size,
+        )
         new_bias_alpha = jnp.exp(new_bias_log_step_size)
 
         new_bias_eligibility_trace = gamma_scalar * lam * state.bias_eligibility_trace + 1.0
@@ -1545,7 +1556,7 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
 
         if self._use_semi_gradient:
             bias_h_decay = jnp.maximum(0.0, 1.0 - new_bias_alpha * new_bias_eligibility_trace)
-            new_bias_h_trace = (
+            updated_bias_h = (
                 state.bias_h_trace * bias_h_decay
                 + new_bias_alpha * delta * new_bias_eligibility_trace
             )
@@ -1554,10 +1565,11 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
             bias_h_decay = jnp.maximum(
                 0.0, 1.0 + new_bias_alpha * new_bias_eligibility_trace * bias_feature_diff
             )
-            new_bias_h_trace = (
+            updated_bias_h = (
                 state.bias_h_trace * bias_h_decay
                 + new_bias_alpha * delta * new_bias_eligibility_trace
             )
+        new_bias_h_trace = jnp.where(finite_delta, updated_bias_h, state.bias_h_trace)
 
         new_state = TDIDBDState(
             log_step_sizes=new_log_step_sizes,
@@ -1675,7 +1687,9 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         alphas = jnp.exp(state.log_step_sizes)
 
         # Update normalizers
-        abs_weight_update = jnp.abs(delta * feature_diff * state.h_traces)
+        weight_meta = delta * feature_diff * state.h_traces
+        finite_meta = jnp.isfinite(weight_meta)
+        abs_weight_update = jnp.abs(weight_meta)
         normalizer_decay_term = (
             (1.0 / tau)
             * alphas
@@ -1683,12 +1697,20 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             * state.eligibility_traces
             * (jnp.abs(delta * observation * state.h_traces) - state.normalizers)
         )
-        new_normalizers = jnp.maximum(abs_weight_update, state.normalizers - normalizer_decay_term)
+        new_normalizers = jnp.where(
+            finite_meta,
+            jnp.maximum(abs_weight_update, state.normalizers - normalizer_decay_term),
+            state.normalizers,
+        )
         new_normalizers = jnp.maximum(new_normalizers, 1e-8)
 
         # Normalized meta-update
-        normalized_gradient = delta * feature_diff * state.h_traces / new_normalizers
-        new_log_step_sizes = state.log_step_sizes - theta * normalized_gradient
+        normalized_gradient = weight_meta / new_normalizers
+        new_log_step_sizes = jnp.where(
+            finite_meta,
+            state.log_step_sizes - theta * normalized_gradient,
+            state.log_step_sizes,
+        )
 
         # Effective step-size normalization
         effective_step_size = -jnp.sum(
@@ -1697,21 +1719,29 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         normalization_factor = jnp.maximum(effective_step_size, 1.0)
         new_log_step_sizes = new_log_step_sizes - jnp.log(normalization_factor)
 
-        new_log_step_sizes = jnp.clip(new_log_step_sizes, -10.0, 2.0)
+        new_log_step_sizes = jnp.where(
+            jnp.isfinite(new_log_step_sizes),
+            jnp.clip(new_log_step_sizes, -10.0, 2.0),
+            state.log_step_sizes,
+        )
         new_alphas = jnp.exp(new_log_step_sizes)
 
         new_eligibility_traces = gamma_scalar * lam * state.eligibility_traces + observation
         weight_delta = new_alphas * delta * new_eligibility_traces
 
         # Update h traces
+        finite_delta = jnp.isfinite(delta)
         h_decay = jnp.maximum(0.0, 1.0 + new_alphas * feature_diff * new_eligibility_traces)
-        new_h_traces = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
+        updated_h = state.h_traces * h_decay + new_alphas * delta * new_eligibility_traces
+        new_h_traces = jnp.where(finite_delta, updated_h, state.h_traces)
 
         # Bias updates
         bias_alpha = jnp.exp(state.bias_log_step_size)
         bias_feature_diff = gamma_scalar - 1.0
 
-        abs_bias_weight_update = jnp.abs(delta * bias_feature_diff * state.bias_h_trace)
+        bias_meta = delta * bias_feature_diff * state.bias_h_trace
+        finite_bias_meta = jnp.isfinite(bias_meta)
+        abs_bias_weight_update = jnp.abs(bias_meta)
         bias_normalizer_decay_term = (
             (1.0 / tau)
             * bias_alpha
@@ -1719,15 +1749,21 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             * state.bias_eligibility_trace
             * (jnp.abs(delta * state.bias_h_trace) - state.bias_normalizer)
         )
-        new_bias_normalizer = jnp.maximum(
-            abs_bias_weight_update, state.bias_normalizer - bias_normalizer_decay_term
+        new_bias_normalizer = jnp.where(
+            finite_bias_meta,
+            jnp.maximum(
+                abs_bias_weight_update, state.bias_normalizer - bias_normalizer_decay_term
+            ),
+            state.bias_normalizer,
         )
         new_bias_normalizer = jnp.maximum(new_bias_normalizer, 1e-8)
 
-        normalized_bias_gradient = (
-            delta * bias_feature_diff * state.bias_h_trace / new_bias_normalizer
+        normalized_bias_gradient = bias_meta / new_bias_normalizer
+        new_bias_log_step_size = jnp.where(
+            finite_bias_meta,
+            state.bias_log_step_size - theta * normalized_bias_gradient,
+            state.bias_log_step_size,
         )
-        new_bias_log_step_size = state.bias_log_step_size - theta * normalized_bias_gradient
 
         bias_effective_step_size = (
             -jnp.exp(new_bias_log_step_size) * bias_feature_diff * state.bias_eligibility_trace
@@ -1735,7 +1771,11 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         bias_norm_factor = jnp.maximum(bias_effective_step_size, 1.0)
         new_bias_log_step_size = new_bias_log_step_size - jnp.log(bias_norm_factor)
 
-        new_bias_log_step_size = jnp.clip(new_bias_log_step_size, -10.0, 2.0)
+        new_bias_log_step_size = jnp.where(
+            jnp.isfinite(new_bias_log_step_size),
+            jnp.clip(new_bias_log_step_size, -10.0, 2.0),
+            state.bias_log_step_size,
+        )
         new_bias_alpha = jnp.exp(new_bias_log_step_size)
 
         new_bias_eligibility_trace = gamma_scalar * lam * state.bias_eligibility_trace + 1.0
@@ -1744,9 +1784,10 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         bias_h_decay = jnp.maximum(
             0.0, 1.0 + new_bias_alpha * bias_feature_diff * new_bias_eligibility_trace
         )
-        new_bias_h_trace = (
+        updated_bias_h = (
             state.bias_h_trace * bias_h_decay + new_bias_alpha * delta * new_bias_eligibility_trace
         )
+        new_bias_h_trace = jnp.where(finite_delta, updated_bias_h, state.bias_h_trace)
 
         new_state = AutoTDIDBDState(
             log_step_sizes=new_log_step_sizes,

--- a/tests/test_td_optimizers.py
+++ b/tests/test_td_optimizers.py
@@ -135,6 +135,52 @@ class TestTDIDBD:
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.new_state.log_step_sizes)
 
+    def test_infinite_td_error_does_not_poison_step_sizes(self):
+        """An inf TD error against fresh zero h-traces must skip adaptation.
+
+        h=0 means no gradient correlation yet: inf * 0 = NaN used to flow
+        through the clip (clip(NaN) is NaN), leaving log step-sizes and the
+        bias twin permanently NaN, the same class as IDBD #42/#43.
+        """
+        optimizer = TDIDBD(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        next_obs = observation * 0.9
+        gamma = jnp.array(0.99, dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.log_step_sizes)))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_log_step_size))
+        chex.assert_trees_all_close(
+            poisoned.new_state.log_step_sizes, state.log_step_sizes
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.bias_log_step_size, state.bias_log_step_size
+        )
+
+        recovered = optimizer.update(
+            poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.log_step_sizes)))
+        assert bool(jnp.isfinite(recovered.new_state.bias_log_step_size))
+
+    def test_infinite_td_error_does_not_poison_ordinary_gradient(self):
+        optimizer = TDIDBD(
+            initial_step_size=0.01, meta_step_size=0.01, use_semi_gradient=False
+        )
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        next_obs = observation * 0.9
+        gamma = jnp.array(0.99, dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.log_step_sizes)))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_log_step_size))
+
 
 class TestAutoTDIDBD:
     """Tests for the AutoTDIDBD optimizer."""
@@ -235,6 +281,38 @@ class TestAutoTDIDBD:
 
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.new_state.log_step_sizes)
+
+    def test_infinite_td_error_does_not_poison_step_sizes(self):
+        """Inf TD error against h=0 must not NaN AutoStep normalizers or alphas.
+
+        max(NaN, v) is NaN, and the 1e-8 floor does not rescue it; the
+        normalized meta-update then writes NaN log step-sizes forever.
+        """
+        optimizer = AutoTDIDBD(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        next_obs = observation * 0.9
+        gamma = jnp.array(0.99, dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.log_step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.normalizers)))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_log_step_size))
+        assert bool(jnp.isfinite(poisoned.new_state.bias_normalizer))
+        chex.assert_trees_all_close(
+            poisoned.new_state.log_step_sizes, state.log_step_sizes
+        )
+        chex.assert_trees_all_close(
+            poisoned.new_state.normalizers, state.normalizers
+        )
+
+        recovered = optimizer.update(
+            poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.log_step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.normalizers)))
 
 
 class TestTDOptimizerComparison:


### PR DESCRIPTION
TD-IDBD and AutoTDIDBD still poison per-weight step-size state on a non-finite TD error. Fresh h-traces are zero, so `inf * h` is NaN; `clip(NaN)` and AutoStep's `max(NaN, v)` stay NaN, and every later finite update inherits it. The bias twin has the same hole. Both the semi-gradient and ordinary-gradient TD-IDBD paths were affected.

That is the same class core IDBD closed in #42/#43. Core Autostep is #55/#56. Screening copies are #58. These are the TD optimizers used by `TDLinearLearner`, so a NaN here corrupts Step 3+ measurements rather than just a supervised library update.

The meta-update now skips a non-finite channel and keeps the previous log step-size / normalizer. Non-finite TD error also holds the previous h-trace so recovery is not sitting on inf/NaN correlation. Finite trajectories are unchanged: existing semi-vs-ordinary, terminal-state, and effective-step-size pins still pass.

Failing-test-first on inf TD error against pristine traces: both optimizers went NaN on main, then recovered. `tests/test_td_optimizers.py` and `tests/test_td_learners.py`: 48 passed.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)