### PR TITLE
Keep SwiftTD meta-updates finite

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -330,6 +330,10 @@ class SwiftTD:
         new_prev_weight_update = jnp.where(
             finite_delta, delta_w, state.prev_weight_update
         )
+        # TDLinearLearner always applies weight_delta/bias_delta. Returning
+        # the inf product would commit inf weights, so the next real TD
+        # error cannot recover. Hold a zero primary update instead.
+        returned_delta_w = jnp.where(finite_delta, delta_w, jnp.zeros_like(delta_w))
 
         # Decay eligibility-side traces for the next transition.
         decay_factor = gamma_scalar * state.trace_decay
@@ -355,8 +359,8 @@ class SwiftTD:
 
         weight_alphas = jnp.exp(new_log_step_sizes[:-1])
         return SwiftTDUpdate(
-            weight_delta=delta_w[:-1],
-            bias_delta=delta_w[-1],
+            weight_delta=returned_delta_w[:-1],
+            bias_delta=returned_delta_w[-1],
             new_state=new_state,
             metrics={
                 "mean_step_size": jnp.mean(weight_alphas),

--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -308,18 +308,28 @@ class SwiftTD:
         delta_w = delta * z_ext - z_delta * v_delta
 
         # Meta-update: beta_i += (theta / alpha_i) * (delta' - v_delta) * p_i,
-        # clipped to [ln(eta_min), ln(eta)].
-        new_log_step_sizes = log_alphas + (theta / jnp.exp(log_alphas)) * (
-            delta - v_delta
-        ) * p_ext
-        new_log_step_sizes = jnp.clip(
-            new_log_step_sizes, jnp.log(state.eta_min), jnp.log(eta)
+        # clipped to [ln(eta_min), ln(eta)]. inf * p=0 is NaN; clip(NaN) is
+        # NaN, so skip that channel instead of poisoning log step-sizes.
+        meta_delta = (theta / jnp.exp(log_alphas)) * (delta - v_delta) * p_ext
+        new_log_step_sizes = jnp.where(
+            jnp.isfinite(meta_delta),
+            jnp.clip(
+                log_alphas + meta_delta, jnp.log(state.eta_min), jnp.log(eta)
+            ),
+            log_alphas,
         )
 
-        # h-trace generation shift.
-        new_h_old = h_ext
-        new_h = h_temp_ext + delta * z_bar_ext - z_delta * v_delta
-        new_h_temp = new_h
+        # h-trace generation shift. Non-finite delta would store inf/NaN h
+        # and prev_weight_update, so the next finite TD error becomes inf
+        # via v_delta and never recovers.
+        finite_delta = jnp.isfinite(delta)
+        updated_h = h_temp_ext + delta * z_bar_ext - z_delta * v_delta
+        new_h_old = jnp.where(finite_delta, h_ext, state.h_old_traces)
+        new_h = jnp.where(finite_delta, updated_h, state.h_traces)
+        new_h_temp = jnp.where(finite_delta, new_h, state.h_temp_traces)
+        new_prev_weight_update = jnp.where(
+            finite_delta, delta_w, state.prev_weight_update
+        )
 
         # Decay eligibility-side traces for the next transition.
         decay_factor = gamma_scalar * state.trace_decay
@@ -335,7 +345,7 @@ class SwiftTD:
             h_traces=new_h,
             h_old_traces=new_h_old,
             h_temp_traces=new_h_temp,
-            prev_weight_update=delta_w,
+            prev_weight_update=new_prev_weight_update,
             meta_step_size=theta,
             trace_decay=state.trace_decay,
             eta=eta,

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -383,6 +383,10 @@ class TestSwiftTDBehavior:
         )
         assert bool(jnp.all(jnp.isfinite(poisoned.new_state.h_traces)))
         chex.assert_trees_all_close(poisoned.new_state.h_traces, state.h_traces)
+        chex.assert_trees_all_close(
+            poisoned.weight_delta, jnp.zeros(2, dtype=jnp.float32)
+        )
+        chex.assert_trees_all_close(poisoned.bias_delta, jnp.array(0.0, dtype=jnp.float32))
 
         recovered = optimizer.update(
             poisoned.new_state,
@@ -393,6 +397,40 @@ class TestSwiftTDBehavior:
         )
         assert bool(jnp.all(jnp.isfinite(recovered.new_state.log_step_sizes)))
         assert bool(jnp.all(jnp.isfinite(recovered.new_state.h_traces)))
+
+    def test_infinite_reward_through_td_linear_learner_keeps_weights_finite(self):
+        """TDLinearLearner always applies the returned deltas.
+
+        Recovery must go through the learner, not a second optimizer call
+        with a hand-injected finite TD error.
+        """
+        learner = TDLinearLearner(optimizer=SwiftTD(initial_step_size=0.01))
+        state = learner.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        next_obs = observation * 0.9
+        gamma = jnp.array(0.99, dtype=jnp.float32)
+
+        poisoned = learner.update(
+            state,
+            observation,
+            jnp.array(jnp.inf, dtype=jnp.float32),
+            next_obs,
+            gamma,
+        )
+        chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+        chex.assert_trees_all_close(poisoned.state.bias, state.bias)
+        assert bool(jnp.all(jnp.isfinite(poisoned.state.optimizer_state.log_step_sizes)))
+
+        recovered = learner.update(
+            poisoned.state,
+            observation,
+            jnp.array(1.0, dtype=jnp.float32),
+            next_obs,
+            gamma,
+        )
+        chex.assert_tree_all_finite(recovered.state.weights)
+        chex.assert_tree_all_finite(recovered.state.bias)
+        assert bool(jnp.isfinite(recovered.td_error))
 
     def test_integrates_with_td_linear_learner(self):
         """SwiftTD follows the TDOptimizer interface and drives TDLinearLearner."""

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -361,6 +361,39 @@ class TestSwiftTDBehavior:
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.9))
         assert float(jnp.max(jnp.abs(result.new_state.eligibility_traces))) > 0.0
 
+    def test_infinite_td_error_does_not_poison_step_sizes(self):
+        """Inf TD error against fresh p=0 must skip meta-adaptation.
+
+        beta += (theta / alpha) * (delta - v_delta) * p with p=0 is inf * 0
+        = NaN, and clip(NaN) leaves every log step-size permanently NaN,
+        the same class as IDBD #42/#43.
+        """
+        optimizer = SwiftTD(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+        next_obs = observation * 0.9
+        gamma = jnp.array(0.99, dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation, next_obs, gamma
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.log_step_sizes)))
+        chex.assert_trees_all_close(
+            poisoned.new_state.log_step_sizes, state.log_step_sizes
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.new_state.h_traces)))
+        chex.assert_trees_all_close(poisoned.new_state.h_traces, state.h_traces)
+
+        recovered = optimizer.update(
+            poisoned.new_state,
+            jnp.array(1.0, dtype=jnp.float32),
+            observation,
+            next_obs,
+            gamma,
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.log_step_sizes)))
+        assert bool(jnp.all(jnp.isfinite(recovered.new_state.h_traces)))
+
     def test_integrates_with_td_linear_learner(self):
         """SwiftTD follows the TDOptimizer interface and drives TDLinearLearner."""
         learner = TDLinearLearner(optimizer=SwiftTD(initial_step_size=0.01))


### PR DESCRIPTION
SwiftTD still poisons per-feature log step-sizes on a non-finite TD error. Fresh p-traces are zero, so `(theta / alpha) * (delta - v_delta) * p` is inf * 0 = NaN, and `clip(NaN)` leaves every beta permanently NaN. The h-trace and `prev_weight_update` also go inf, so the next finite TD error is recovered as inf via `v_delta` and never comes back.

That is the same class as IDBD #42/#43, Autostep #55/#56, screening copies #58, and TD-IDBD #59. SwiftTD is a separate optimizer used by `TDLinearLearner` on Step 1 / XDistShift, so a NaN here corrupts those measurements rather than a supervised library update.

The meta-update now skips a non-finite channel and keeps the previous log step-size. Non-finite delta also holds h, h_temp, h_old, and `prev_weight_update`. Finite trajectories are unchanged: the C++ reference pin, overshoot bound, decay trigger, and XDistShift quality tests still pass.

Failing-test-first on inf TD error against pristine traces: log step-sizes went NaN on main, then recovered. `tests/test_swift_td.py`: 15 passed.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)