### PR TITLE
Keep ObGD bounds from turning 0*inf into NaN weights

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -275,7 +275,7 @@ class AGCBounding(Bounder):
             scale = max_norm / jnp.maximum(g_norm, 1e-6)
             needs_clip = g_norm > max_norm
             clipped_step = jnp.where(needs_clip, step * scale, step)
-            clipped.append(clipped_step)
+            clipped.append(_replace_nan_with_zero(clipped_step))
 
             total_units += needs_clip.size
             clipped_units = clipped_units + jnp.sum(needs_clip.astype(jnp.float32))

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -71,6 +71,11 @@ class Bounder(ABC):
         ...
 
 
+def _replace_nan_with_zero(value: Array) -> Array:
+    """Turn 0*inf NaNs into a no-op while leaving genuine infs intact."""
+    return jnp.where(jnp.isnan(value), jnp.zeros_like(value), value)
+
+
 def _apply_obgd_bound(
     steps: tuple[Array, ...],
     error: Array,
@@ -83,7 +88,7 @@ def _apply_obgd_bound(
         total_step = total_step + jnp.sum(jnp.abs(s))
     delta_bar = jnp.maximum(jnp.abs(error_scalar), 1.0)
     scale = 1.0 / jnp.maximum(kappa * delta_bar * total_step, 1.0)
-    return tuple(scale * s for s in steps), scale
+    return tuple(_replace_nan_with_zero(scale * s) for s in steps), scale
 
 
 class ObGDBounding(Bounder):
@@ -1325,9 +1330,10 @@ class ObGD(Optimizer[ObGDState]):
         # Effective step-size: alpha / max(M, 1)
         alpha_eff = alpha / jnp.maximum(dot_product, 1.0)
 
-        # Weight and bias deltas
-        weight_delta = alpha_eff * error_scalar * new_traces
-        bias_delta = alpha_eff * error_scalar * new_bias_trace
+        # Weight and bias deltas. alpha_eff=0 against inf error is 0*inf=NaN;
+        # the bound's intent is a no-op, not a poisoned update.
+        weight_delta = _replace_nan_with_zero(alpha_eff * error_scalar * new_traces)
+        bias_delta = _replace_nan_with_zero(alpha_eff * error_scalar * new_bias_trace)
 
         new_state = ObGDState(
             step_size=alpha,

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -71,9 +71,17 @@ class Bounder(ABC):
         ...
 
 
-def _replace_nan_with_zero(value: Array) -> Array:
-    """Turn 0*inf NaNs into a no-op while leaving genuine infs intact."""
-    return jnp.where(jnp.isnan(value), jnp.zeros_like(value), value)
+def _zero_if_collapsed_inf(product: Array, infinite_input: Array, collapsed: Array) -> Array:
+    """Map 0*inf to 0 only when a bound collapsed an infinite input.
+
+    Genuine upstream NaNs stay NaN so an inactive or unclipped bound cannot
+    hide a numerical failure as a zero no-op.
+    """
+    return jnp.where(
+        jnp.isnan(product) & jnp.isinf(infinite_input) & collapsed,
+        jnp.zeros_like(product),
+        product,
+    )
 
 
 def _apply_obgd_bound(
@@ -88,7 +96,11 @@ def _apply_obgd_bound(
         total_step = total_step + jnp.sum(jnp.abs(s))
     delta_bar = jnp.maximum(jnp.abs(error_scalar), 1.0)
     scale = 1.0 / jnp.maximum(kappa * delta_bar * total_step, 1.0)
-    return tuple(_replace_nan_with_zero(scale * s) for s in steps), scale
+    collapsed = scale == 0
+    return (
+        tuple(_zero_if_collapsed_inf(scale * s, s, collapsed) for s in steps),
+        scale,
+    )
 
 
 class ObGDBounding(Bounder):
@@ -275,7 +287,8 @@ class AGCBounding(Bounder):
             scale = max_norm / jnp.maximum(g_norm, 1e-6)
             needs_clip = g_norm > max_norm
             clipped_step = jnp.where(needs_clip, step * scale, step)
-            clipped.append(_replace_nan_with_zero(clipped_step))
+            collapsed = needs_clip & (scale == 0)
+            clipped.append(_zero_if_collapsed_inf(clipped_step, step, collapsed))
 
             total_units += needs_clip.size
             clipped_units = clipped_units + jnp.sum(needs_clip.astype(jnp.float32))
@@ -1331,9 +1344,17 @@ class ObGD(Optimizer[ObGDState]):
         alpha_eff = alpha / jnp.maximum(dot_product, 1.0)
 
         # Weight and bias deltas. alpha_eff=0 against inf error is 0*inf=NaN;
-        # the bound's intent is a no-op, not a poisoned update.
-        weight_delta = _replace_nan_with_zero(alpha_eff * error_scalar * new_traces)
-        bias_delta = _replace_nan_with_zero(alpha_eff * error_scalar * new_bias_trace)
+        # the bound's intent is a no-op, not a poisoned update. Genuine NaN
+        # error is not an infinite collapse and stays NaN.
+        raw_weight_step = error_scalar * new_traces
+        raw_bias_step = error_scalar * new_bias_trace
+        collapsed = alpha_eff == 0
+        weight_delta = _zero_if_collapsed_inf(
+            alpha_eff * raw_weight_step, error_scalar, collapsed
+        )
+        bias_delta = _zero_if_collapsed_inf(
+            alpha_eff * raw_bias_step, error_scalar, collapsed
+        )
 
         new_state = ObGDState(
             step_size=alpha,

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -46,7 +46,7 @@ from jax import Array
 from jaxtyping import Float
 
 from alberta_framework.core.initializers import sparse_init
-from alberta_framework.core.optimizers import Bounder, ObGDBounding, _replace_nan_with_zero
+from alberta_framework.core.optimizers import Bounder, ObGDBounding, _zero_if_collapsed_inf
 from alberta_framework.core.types import MLPParams
 
 # =============================================================================
@@ -1781,7 +1781,11 @@ class UPGDLearner:
         delta_bar = jnp.maximum(jnp.abs(error_scalar), 1.0)
         bound_magnitude = kappa * delta_bar * total_step
         scale = 1.0 / jnp.maximum(bound_magnitude, 1.0)
-        return tuple(_replace_nan_with_zero(scale * step) for step in steps), scale
+        collapsed = scale == 0
+        return (
+            tuple(_zero_if_collapsed_inf(scale * step, step, collapsed) for step in steps),
+            scale,
+        )
 
     @staticmethod
     def _tuple_dot(xs: tuple[Array, ...], ys: tuple[Array, ...]) -> Array:

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -46,7 +46,7 @@ from jax import Array
 from jaxtyping import Float
 
 from alberta_framework.core.initializers import sparse_init
-from alberta_framework.core.optimizers import Bounder, ObGDBounding
+from alberta_framework.core.optimizers import Bounder, ObGDBounding, _replace_nan_with_zero
 from alberta_framework.core.types import MLPParams
 
 # =============================================================================
@@ -1781,7 +1781,7 @@ class UPGDLearner:
         delta_bar = jnp.maximum(jnp.abs(error_scalar), 1.0)
         bound_magnitude = kappa * delta_bar * total_step
         scale = 1.0 / jnp.maximum(bound_magnitude, 1.0)
-        return tuple(scale * step for step in steps), scale
+        return tuple(_replace_nan_with_zero(scale * step) for step in steps), scale
 
     @staticmethod
     def _tuple_dot(xs: tuple[Array, ...], ys: tuple[Array, ...]) -> Array:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -11,6 +11,7 @@ from alberta_framework import (
     Autostep,
     AutostepGTDLambda,
     ObGD,
+    ObGDBounding,
     optimizer_from_config,
 )
 
@@ -571,6 +572,54 @@ class TestObGD:
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.bias_delta)
 
+    def test_infinite_error_bound_does_not_nan_weight_delta(self):
+        """Inf error drives alpha_eff to 0; 0 * inf * z must not NaN the step.
+
+        The bound's intent at M=inf is a no-op, not a poisoned weight update.
+        """
+        optimizer = ObGD(step_size=1.0, kappa=2.0)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+
+        result = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
+        assert bool(jnp.isfinite(result.bias_delta))
+        chex.assert_trees_all_close(result.weight_delta, jnp.zeros(2, dtype=jnp.float32))
+        assert float(result.bias_delta) == pytest.approx(0.0)
+
+        recovered = optimizer.update(
+            result.new_state, jnp.array(1.0, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.weight_delta)))
+        assert bool(jnp.isfinite(recovered.bias_delta))
+
+
+class TestObGDBounding:
+    """Tests for the shared ObGD bounder used by MLP/UPGD learners."""
+
+    def test_infinite_step_times_zero_scale_is_zero_not_nan(self):
+        """Inf LMS steps against inf error make scale=0; 0*inf was NaN.
+
+        The bounder is supposed to prevent overshooting. At M=inf that means
+        emit a zero step, not poison the weights for every later finite update.
+        """
+        bounder = ObGDBounding(kappa=2.0)
+        steps = (
+            jnp.array([jnp.inf, jnp.inf], dtype=jnp.float32),
+            jnp.array(jnp.inf, dtype=jnp.float32),
+        )
+        bounded, scale = bounder.bound(
+            steps,
+            jnp.array(jnp.inf, dtype=jnp.float32),
+            tuple(jnp.zeros_like(step) for step in steps),
+        )
+        assert float(scale) == pytest.approx(0.0)
+        for actual in bounded:
+            assert bool(jnp.all(jnp.isfinite(actual)))
+            chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
+
 
 class TestAdaptiveObGDBounding:
     """Tests for the adaptive ObGD bounder."""
@@ -613,6 +662,22 @@ class TestAdaptiveObGDBounding:
         assert scale == pytest.approx(1.0)
         chex.assert_trees_all_close(bounded[0], steps[0] / rms)
         chex.assert_trees_all_close(bounded[1], steps[1] / rms)
+
+    def test_infinite_step_times_zero_scale_is_zero_not_nan(self):
+        bounder = AdaptiveObGDBounding(kappa=2.0)
+        steps = (
+            jnp.array([jnp.inf, jnp.inf], dtype=jnp.float32),
+            jnp.array(jnp.inf, dtype=jnp.float32),
+        )
+        bounded, scale = bounder.bound(
+            steps,
+            jnp.array(jnp.inf, dtype=jnp.float32),
+            tuple(jnp.zeros_like(step) for step in steps),
+        )
+        assert float(scale) == pytest.approx(0.0)
+        for actual in bounded:
+            assert bool(jnp.all(jnp.isfinite(actual)))
+            chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
 
     def test_produces_finite_zero_steps(self):
         """Zero steps should remain finite and unchanged."""

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -8,6 +8,7 @@ from alberta_framework import (
     IDBD,
     LMS,
     AdaptiveObGDBounding,
+    AGCBounding,
     Autostep,
     AutostepGTDLambda,
     ObGD,
@@ -617,6 +618,29 @@ class TestObGDBounding:
         )
         assert float(scale) == pytest.approx(0.0)
         for actual in bounded:
+            assert bool(jnp.all(jnp.isfinite(actual)))
+            chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
+
+
+class TestAGCBounding:
+    """Tests for Adaptive Gradient Clipping."""
+
+    def test_infinite_step_times_zero_scale_is_zero_not_nan(self):
+        """Inf g_norm drives clip scale to 0; 0*inf was NaN."""
+        bounder = AGCBounding(clip_factor=0.01)
+        steps = (
+            jnp.array([jnp.inf, jnp.inf], dtype=jnp.float32),
+            jnp.array(jnp.inf, dtype=jnp.float32),
+        )
+        params = (
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        clipped, frac = bounder.bound(
+            steps, jnp.array(jnp.inf, dtype=jnp.float32), params
+        )
+        assert float(frac) == pytest.approx(1.0)
+        for actual in clipped:
             assert bool(jnp.all(jnp.isfinite(actual)))
             chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -596,6 +596,18 @@ class TestObGD:
         assert bool(jnp.all(jnp.isfinite(recovered.weight_delta)))
         assert bool(jnp.isfinite(recovered.bias_delta))
 
+    def test_unbounded_nan_error_is_not_silenced_to_zero(self):
+        """kappa=0 does not collapse, so a NaN error must stay a NaN delta."""
+        optimizer = ObGD(step_size=1.0, kappa=0.0)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.ones(2, dtype=jnp.float32)
+
+        result = optimizer.update(
+            state, jnp.array(jnp.nan, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.all(jnp.isnan(result.weight_delta)))
+        assert bool(jnp.isnan(result.bias_delta))
+
 
 class TestObGDBounding:
     """Tests for the shared ObGD bounder used by MLP/UPGD learners."""
@@ -621,6 +633,23 @@ class TestObGDBounding:
             assert bool(jnp.all(jnp.isfinite(actual)))
             chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
 
+    def test_inactive_bound_preserves_genuine_nan_step(self):
+        """kappa=0 leaves scale=1, so an upstream NaN must not become 0."""
+        bounder = ObGDBounding(kappa=0.0)
+        steps = (
+            jnp.array([jnp.nan, 0.5], dtype=jnp.float32),
+            jnp.array(0.25, dtype=jnp.float32),
+        )
+        bounded, scale = bounder.bound(
+            steps,
+            jnp.array(1.0, dtype=jnp.float32),
+            tuple(jnp.zeros_like(step) for step in steps),
+        )
+        # kappa=0 still lets a NaN L1 total make scale itself NaN; the
+        # helper must not rewrite that NaN step to a silent zero.
+        assert bool(jnp.isnan(bounded[0][0]))
+        assert not bool(jnp.isfinite(scale) and float(scale) == 0.0)
+
 
 class TestAGCBounding:
     """Tests for Adaptive Gradient Clipping."""
@@ -643,6 +672,24 @@ class TestAGCBounding:
         for actual in clipped:
             assert bool(jnp.all(jnp.isfinite(actual)))
             chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
+
+    def test_unclipped_branch_preserves_genuine_nan_step(self):
+        """A finite-norm NaN that never trips the clip must stay NaN."""
+        bounder = AGCBounding(clip_factor=100.0)
+        steps = (
+            jnp.array([jnp.nan, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        params = (
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        clipped, _frac = bounder.bound(
+            steps, jnp.array(1.0, dtype=jnp.float32), params
+        )
+        assert bool(jnp.isnan(clipped[0][0]))
+        chex.assert_trees_all_close(clipped[0][1], jnp.array(0.0, dtype=jnp.float32))
+        chex.assert_trees_all_close(clipped[1], jnp.array(0.0, dtype=jnp.float32))
 
 
 class TestAdaptiveObGDBounding:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -675,6 +675,22 @@ class TestUpdateMetrics:
             chex.assert_tree_all_finite(result.predictions)
             state = result.state
 
+    def test_obgd_kappa_path_infinite_step_is_zero_not_nan(self):
+        """Inf LMS steps against inf error make scale=0; 0*inf was NaN."""
+        steps = (
+            jnp.array([jnp.inf, jnp.inf], dtype=jnp.float32),
+            jnp.array(jnp.inf, dtype=jnp.float32),
+        )
+        bounded, scale = UPGDLearner._obgd_bound_with_kappa(
+            steps,
+            jnp.array(jnp.inf, dtype=jnp.float32),
+            jnp.array(2.0, dtype=jnp.float32),
+        )
+        assert float(scale) == 0.0
+        for actual in bounded:
+            assert bool(jnp.all(jnp.isfinite(actual)))
+            chex.assert_trees_all_close(actual, jnp.zeros_like(actual))
+
     def test_sum_loss_normalization_scales_multihead_gradient(self):
         """Sum loss should avoid diluting gradients by active head count."""
         base_kwargs = dict(


### PR DESCRIPTION
ObGD's overshoot bound is supposed to prevent a huge error from moving the weights. On inf error it correctly drives `scale` / `alpha_eff` to 0, then multiplies that by an inf LMS step. `0 * inf` is NaN, and applying that poisons weights for every later finite update.

The same formula lives in three ObGD sites plus AGC: the linear `ObGD` optimizer, `_apply_obgd_bound` (`ObGDBounding` and `AdaptiveObGDBounding` on the MLP/UPGD path), UPGD's internal `_obgd_bound_with_kappa` (adaptive-kappa campaign path), and `AGCBounding` (`step * 0` after the clip ratio collapses). All four now replace those NaNs with zeros so the bound's intended no-op holds. Genuine infs when the bound is inactive (`kappa=0`, scale=1) stay inf.

Failing-test-first: inf error / inf steps produced NaN on main, then zeros. `tests/test_optimizers.py` plus the UPGD bound pin and `tests/test_mlp_learner.py`: 128 passed after the ObGD commit; AGC pin added on top.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)