### PR TITLE
Keep feature-learner ObGD bounds from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -2827,6 +2827,27 @@ class CompositionalFeatureLearner:
             theta_delta = bounding_scale * theta_delta
             candidate_output_delta = bounding_scale * candidate_output_delta
             candidate_theta_delta = bounding_scale * candidate_theta_delta
+            output_delta = jnp.where(
+                jnp.isnan(output_delta), jnp.zeros_like(output_delta), output_delta
+            )
+            output_bias_delta = jnp.where(
+                jnp.isnan(output_bias_delta),
+                jnp.zeros_like(output_bias_delta),
+                output_bias_delta,
+            )
+            theta_delta = jnp.where(
+                jnp.isnan(theta_delta), jnp.zeros_like(theta_delta), theta_delta
+            )
+            candidate_output_delta = jnp.where(
+                jnp.isnan(candidate_output_delta),
+                jnp.zeros_like(candidate_output_delta),
+                candidate_output_delta,
+            )
+            candidate_theta_delta = jnp.where(
+                jnp.isnan(candidate_theta_delta),
+                jnp.zeros_like(candidate_theta_delta),
+                candidate_theta_delta,
+            )
 
         output_weights = state.output_weights + output_delta
         output_bias = state.output_bias + output_bias_delta

--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -1103,6 +1103,39 @@ class FixedBudgetFeatureLearner:
             candidate_output_delta = bounding_scale * candidate_output_delta
             candidate_weight_delta = bounding_scale * candidate_weight_delta
             candidate_bias_delta = bounding_scale * candidate_bias_delta
+            output_delta = jnp.where(
+                jnp.isnan(output_delta), jnp.zeros_like(output_delta), output_delta
+            )
+            output_bias_delta = jnp.where(
+                jnp.isnan(output_bias_delta),
+                jnp.zeros_like(output_bias_delta),
+                output_bias_delta,
+            )
+            feature_weight_delta = jnp.where(
+                jnp.isnan(feature_weight_delta),
+                jnp.zeros_like(feature_weight_delta),
+                feature_weight_delta,
+            )
+            feature_bias_delta = jnp.where(
+                jnp.isnan(feature_bias_delta),
+                jnp.zeros_like(feature_bias_delta),
+                feature_bias_delta,
+            )
+            candidate_output_delta = jnp.where(
+                jnp.isnan(candidate_output_delta),
+                jnp.zeros_like(candidate_output_delta),
+                candidate_output_delta,
+            )
+            candidate_weight_delta = jnp.where(
+                jnp.isnan(candidate_weight_delta),
+                jnp.zeros_like(candidate_weight_delta),
+                candidate_weight_delta,
+            )
+            candidate_bias_delta = jnp.where(
+                jnp.isnan(candidate_bias_delta),
+                jnp.zeros_like(candidate_bias_delta),
+                candidate_bias_delta,
+            )
 
         feature_weights = state.feature_weights + feature_weight_delta
         feature_biases = state.feature_biases + feature_bias_delta

--- a/tests/test_compositional_features.py
+++ b/tests/test_compositional_features.py
@@ -97,6 +97,35 @@ class TestCompositionalFeatureLearner:
             assert pa_np[i] < i
             assert pb_np[i] < i
 
+    def test_infinite_target_obgd_does_not_nan_weights(self) -> None:
+        """Inf error drives ObGD scale to 0; 0*inf must not NaN the bank."""
+        learner = CompositionalFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            candidate_count=0,
+            use_obgd=True,
+            obgd_kappa=2.0,
+            replacement_interval=100_000,
+            min_feature_age=100_000,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(0))
+        poisoned = learner.update(
+            state,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([jnp.inf], dtype=jnp.float32),
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.state.output_weights)))
+        chex.assert_trees_all_close(
+            poisoned.state.output_weights, state.output_weights
+        )
+
+        recovered = learner.update(
+            poisoned.state,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.state.output_weights)))
+
     def test_forward_pass_topological_order(self) -> None:
         """Build a tiny DAG by hand and verify the forward gives the right values."""
         # Slots: [raw 0, raw 1, product(0, 1)] -> values [x[0], x[1], x[0]*x[1]]

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -216,6 +216,35 @@ class TestFixedBudgetFeatureLearner:
         chex.assert_tree_all_finite(result.metrics)
         assert int(result.state.step_count) == 1
 
+    def test_infinite_target_obgd_does_not_nan_weights(self) -> None:
+        """Inf error drives ObGD scale to 0; 0*inf must not NaN the bank."""
+        learner = FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            candidate_count=0,
+            use_obgd=True,
+            obgd_kappa=2.0,
+            replacement_interval=100_000,
+            min_feature_age=100_000,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(0))
+        poisoned = learner.update(
+            state,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([jnp.inf], dtype=jnp.float32),
+        )
+        assert bool(jnp.all(jnp.isfinite(poisoned.state.output_weights)))
+        chex.assert_trees_all_close(
+            poisoned.state.output_weights, state.output_weights
+        )
+
+        recovered = learner.update(
+            poisoned.state,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        assert bool(jnp.all(jnp.isfinite(recovered.state.output_weights)))
+
     def test_constructed_and_augmented_feature_shapes(self) -> None:
         learner = FixedBudgetFeatureLearner(n_features=6, n_tasks=2)
         state = learner.init(feature_dim=4, key=jr.key(14))


### PR DESCRIPTION
Fixed-budget feature discovery and the compositional DAG learner both default to ObGD bounding. Inf error correctly drives `scale` to 0, then multiplies that by an inf LMS step. `0 * inf` is NaN, which poisons output weights, feature weights, and utilities for every later finite update.

The interaction-feature learner already rejects infinite targets at the door. These two copies do not. They now replace those NaNs with zeros so the bound's intended no-op holds. Finite trajectories are unchanged.

Failing-test-first: inf targets produced NaN banks on main, then recovered. `TestFixedBudgetFeatureLearner` and `TestCompositionalFeatureLearner`: 48 passed.

Sibling of #61 (library ObGD / AGC / UPGD kappa path). Interaction features already fail closed on inf, so they are left alone.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)