### PR TITLE
Keep MLPLearner from committing ObGD 0*inf NaN weights

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -774,6 +774,16 @@ def metrics_to_dicts(metrics: Array, normalized: bool = False) -> list[dict[str,
 # =============================================================================
 
 
+def _floating_tree_is_finite(tree: object) -> Array:
+    """Return whether every floating/complex persistent leaf is finite."""
+    valid = jnp.asarray(True, dtype=jnp.bool_)
+    for leaf in jax.tree.leaves(tree):
+        array = jnp.asarray(leaf)
+        if jnp.issubdtype(array.dtype, jnp.inexact):
+            valid = valid & jnp.all(jnp.isfinite(array))
+    return valid
+
+
 class MLPLearner:
     """Multi-layer perceptron with composable optimizer, bounder, and normalizer.
 
@@ -1323,7 +1333,7 @@ class MLPLearner:
                 for i in range(len(self._hidden_sizes))
             )
 
-        new_state = MLPLearnerState(
+        proposed_state = MLPLearnerState(
             params=new_params,
             optimizer_states=tuple(new_opt_states),
             traces=tuple(new_traces),
@@ -1333,6 +1343,11 @@ class MLPLearner:
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
+        # Inf target/obs, or a 0*inf ObGD apply, would commit NaN weights.
+        # MultiHead already refuses that; keep the previous finite state.
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.isfinite(target_scalar)
+        update_applied = inputs_valid & _floating_tree_is_finite(proposed_state)
+        new_state = jax.lax.cond(update_applied, lambda: proposed_state, lambda: state)
 
         squared_error = error**2
 

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -98,6 +98,38 @@ class TestMLPLearner:
         # State should have same structure
         assert len(result.state.params.weights) == len(state.params.weights)
 
+    def test_infinite_target_with_obgd_does_not_poison_weights(self):
+        """Inf target makes ObGD scale 0, then error*step is 0*inf=NaN.
+
+        MultiHead already refuses inf targets (NaN is the missing-head
+        sentinel). MLPLearner used to commit the NaN weights. Keep the
+        previous finite state so a later finite target can recover.
+        """
+        learner = MLPLearner(
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            optimizer=LMS(0.1),
+        )
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        observation = jnp.ones(3, dtype=jnp.float32)
+
+        poisoned = learner.update(
+            state, observation, jnp.array(jnp.inf, dtype=jnp.float32)
+        )
+        for new_w, old_w in zip(
+            poisoned.state.params.weights, state.params.weights, strict=True
+        ):
+            assert bool(jnp.all(jnp.isfinite(new_w)))
+            chex.assert_trees_all_close(new_w, old_w)
+        assert int(poisoned.state.step_count) == int(state.step_count)
+
+        recovered = learner.update(
+            poisoned.state, observation, jnp.array(1.0, dtype=jnp.float32)
+        )
+        for new_w in recovered.state.params.weights:
+            assert bool(jnp.all(jnp.isfinite(new_w)))
+
     def test_update_reduces_error(self):
         """Multiple updates on a fixed target should reduce error."""
         learner = MLPLearner(


### PR DESCRIPTION
MLPLearner still commits weight updates after ObGD bounding. Inf error drives the bound scale to 0, then `param += error * step` is `0 * inf` = NaN, and every later finite target inherits a poisoned net.

MultiHead already refuses that: inf is not a legal target (NaN is the missing-head sentinel), and a proposed state with non-finite floats is not committed. MLPLearner now uses the same fail-closed rule. The previous finite parameters, traces, and step count stay put so a later finite target can recover.

Failing-test-first: inf target + ObGDBounding wrote NaN weights on main, then kept the previous finite state. `tests/test_mlp_learner.py`: 74 passed.

Sibling of #61 (bounder-side 0*inf). This is the apply site the bounder cannot see.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)