### PR TITLE
Keep actor-critic ObGD applies from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -32,6 +32,16 @@ from jaxtyping import Float, Int
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 
 
+def _floating_tree_is_finite(tree: object) -> Array:
+    """Return whether every floating/complex persistent leaf is finite."""
+    valid = jnp.asarray(True, dtype=jnp.bool_)
+    for leaf in jax.tree.leaves(tree):
+        array = jnp.asarray(leaf)
+        if jnp.issubdtype(array.dtype, jnp.inexact):
+            valid = valid & jnp.all(jnp.isfinite(array))
+    return valid
+
+
 @dataclasses.dataclass(frozen=True)
 class ActorCriticConfig:
     """Configuration for a linear softmax actor-critic agent.
@@ -399,8 +409,22 @@ class ActorCriticAgent:
             critic_trace_bias=stored_critic_trace_bias,
             step_count=state.step_count + 1,
         )
-        next_action, key, next_policy = self.select_action(updated, observation)
-        new_state = updated.replace(
+        # Inf TD error zeros the ObGD step, then td_error * step is 0*inf=NaN.
+        # Keep previous finite weights/traces; still advance the observation
+        # so a scan loop does not desynchronize.
+        inputs_valid = (
+            jnp.isfinite(jnp.squeeze(reward))
+            & jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(td_error)
+        )
+        params_ok = inputs_valid & _floating_tree_is_finite(updated)
+        held = jax.lax.cond(
+            params_ok,
+            lambda: updated,
+            lambda: state.replace(step_count=state.step_count + 1),  # type: ignore[attr-defined]
+        )
+        next_action, key, next_policy = self.select_action(held, observation)
+        new_state = held.replace(
             last_observation=observation,
             last_action=next_action,
             rng_key=key,
@@ -952,8 +976,19 @@ class ContinuousActorCriticAgent:
             critic_trace_bias=stored_critic_trace_bias,
             step_count=state.step_count + 1,
         )
-        next_action, key, next_mean, next_sigma = self.select_action(updated, observation)
-        new_state = updated.replace(
+        inputs_valid = (
+            jnp.isfinite(jnp.squeeze(reward))
+            & jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(td_error)
+        )
+        params_ok = inputs_valid & _floating_tree_is_finite(updated)
+        held = jax.lax.cond(
+            params_ok,
+            lambda: updated,
+            lambda: state.replace(step_count=state.step_count + 1),  # type: ignore[attr-defined]
+        )
+        next_action, key, next_mean, next_sigma = self.select_action(held, observation)
+        new_state = held.replace(
             last_observation=observation,
             last_action=next_action,
             rng_key=key,

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -358,6 +358,36 @@ def test_actor_critic_bounder_hook_runs() -> None:
     )
 
 
+def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> None:
+    """Inf TD error zeros the ObGD step, then td_error*step is 0*inf=NaN."""
+    agent = ActorCriticAgent(
+        ActorCriticConfig(n_actions=2, actor_step_size=0.1, critic_step_size=0.1),
+        bounder=ObGDBounding(kappa=2.0),
+    )
+    state = agent.init(feature_dim=2, key=jr.key(0))
+    state, _, _ = agent.start(state, jnp.ones(2, dtype=jnp.float32))
+
+    poisoned = agent.update(
+        state,
+        reward=jnp.array(jnp.inf, dtype=jnp.float32),
+        observation=jnp.array([0.5, -1.0], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.actor_weights)))
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
+    chex.assert_trees_all_close(poisoned.state.actor_weights, state.actor_weights)
+    chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
+
+    recovered = agent.update(
+        poisoned.state,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    assert bool(jnp.all(jnp.isfinite(recovered.state.actor_weights)))
+    assert bool(jnp.all(jnp.isfinite(recovered.state.critic_weights)))
+
+
 def test_actor_critic_exports() -> None:
     assert TopLevelActorCriticAgent is ActorCriticAgent
     assert CoreActorCriticAgent is ActorCriticAgent

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -319,3 +319,38 @@ def test_continuous_actor_critic_with_obgd_bounder_is_finite() -> None:
     )
     _assert_continuous_actor_critic_state_finite(result.state)
     chex.assert_tree_all_finite(result.bound_metric)
+
+
+def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> None:
+    """Inf TD error zeros the ObGD step, then td_error*step is 0*inf=NaN."""
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=2,
+            actor_step_size=0.1,
+            critic_step_size=0.1,
+        ),
+        bounder=ObGDBounding(kappa=2.0),
+    )
+    state = agent.init(feature_dim=3, key=jr.key(8))
+    state, _, _, _ = agent.start(
+        state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
+    )
+    poisoned = agent.update(
+        state,
+        reward=jnp.array(jnp.inf, dtype=jnp.float32),
+        observation=jnp.array([0.0, 1.0, 0.5], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.mean_weights)))
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
+    chex.assert_trees_all_close(poisoned.state.mean_weights, state.mean_weights)
+    chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
+
+    recovered = agent.update(
+        poisoned.state,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.array([0.5, 0.0, 0.0], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    assert bool(jnp.all(jnp.isfinite(recovered.state.mean_weights)))
+    assert bool(jnp.all(jnp.isfinite(recovered.state.critic_weights)))


### PR DESCRIPTION
Actor-critic still multiplies the bounded step by the TD error after ObGD. Inf reward drives the bound scale to 0, then `td_error * step` is `0 * inf` = NaN, and both actor and critic stay poisoned. The continuous Gaussian core has the same apply site.

The previous finite weights and traces are kept. Last observation and action still advance so a scan loop does not desynchronize from the stream. A later finite reward can recover.

Failing-test-first: inf reward + ObGDBounding wrote NaN weights on main, then kept the previous finite parameters. `tests/test_actor_critic.py` and `tests/test_continuous_actor_critic.py`: 24 passed.

Sibling of #61 (bounder) and #63 (MLPLearner apply site).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)