### PR TITLE
Keep IndependentDemonHorde ObGD applies from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -60,6 +60,17 @@ from alberta_framework.core.types import (
     TraceMode,
 )
 
+
+def _floating_tree_is_finite(tree: object) -> Array:
+    """Return whether every floating/complex persistent leaf is finite."""
+    valid = jnp.asarray(True, dtype=jnp.bool_)
+    for leaf in jax.tree.leaves(tree):
+        array = jnp.asarray(leaf)
+        if jnp.issubdtype(array.dtype, jnp.inexact):
+            valid = valid & jnp.all(jnp.isfinite(array))
+    return valid
+
+
 # =============================================================================
 # Types
 # =============================================================================
@@ -457,6 +468,7 @@ class IndependentDemonHorde:
         ``active`` is ``False`` the demon's parameters, traces, and
         optimizer states are preserved unchanged; ``error`` and
         ``mean_step_size`` are returned as NaN to flag inactivity.
+        Non-finite proposed weights (ObGD ``0 * inf``) are also held.
 
         This mirrors the body of ``MLPLearner.update`` but: (a) accepts
         an external active mask so NaN cumulants suppress the update,
@@ -567,30 +579,45 @@ class IndependentDemonHorde:
             biases=tuple(new_biases),
         )
 
-        # 7. Mask inactive demons: keep old params/traces/opt-states/normalizer
+        # Inf error zeros the ObGD step, then error * step is 0*inf=NaN.
+        # Treat that the same as an inactive demon: keep previous finite
+        # params, traces, and optimizer states.
+        proposed_finite = (
+            _floating_tree_is_finite(new_params)
+            & _floating_tree_is_finite(tuple(new_traces))
+            & _floating_tree_is_finite(tuple(new_opt_states))
+        )
+        commit = (
+            active
+            & jnp.all(jnp.isfinite(obs))
+            & jnp.isfinite(error)
+            & proposed_finite
+        )
+
+        # 7. Mask inactive / non-finite updates: keep old params/traces/opt
         new_params = MLPParams(
             weights=tuple(
-                jnp.where(active, new_w, old_w)
+                jnp.where(commit, new_w, old_w)
                 for new_w, old_w in zip(
                     new_params.weights, demon_state.params.weights, strict=True
                 )
             ),
             biases=tuple(
-                jnp.where(active, new_b, old_b)
+                jnp.where(commit, new_b, old_b)
                 for new_b, old_b in zip(
                     new_params.biases, demon_state.params.biases, strict=True
                 )
             ),
         )
         masked_traces = tuple(
-            jnp.where(active, new_t, old_t)
+            jnp.where(commit, new_t, old_t)
             for new_t, old_t in zip(
                 new_traces, demon_state.traces, strict=True
             )
         )
         masked_opt_states = tuple(
             jax.tree.map(
-                lambda new, old: jnp.where(active, new, old),
+                lambda new, old: jnp.where(commit, new, old),
                 new_opt,
                 old_opt,
             )
@@ -604,7 +631,7 @@ class IndependentDemonHorde:
             and new_normalizer_state is not None
         ):
             masked_normalizer_state = jax.tree.map(
-                lambda new, old: jnp.where(active, new, old),
+                lambda new, old: jnp.where(commit, new, old),
                 new_normalizer_state,
                 demon_state.normalizer_state,
             )
@@ -616,7 +643,7 @@ class IndependentDemonHorde:
             optimizer_states=masked_opt_states,
             traces=masked_traces,
             normalizer_state=masked_normalizer_state,
-            step_count=demon_state.step_count + jnp.where(active, 1, 0),
+            step_count=demon_state.step_count + jnp.where(commit, 1, 0),
             birth_timestamp=demon_state.birth_timestamp,
             uptime_s=demon_state.uptime_s,
         )

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -166,6 +166,60 @@ class TestIndependence:
 
 
 # =============================================================================
+# ObGD apply site: inf error * zeroed step must not NaN weights
+# =============================================================================
+
+
+class TestObgdApplyFinite:
+    """Inf TD error zeros the ObGD step, then error*step is 0*inf=NaN."""
+
+    def test_infinite_cumulant_with_obgd_does_not_poison_weights(self) -> None:
+        spec = create_horde_spec(_make_all_gamma0_spec(2))
+        horde = IndependentDemonHorde(
+            horde_spec=spec,
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+        )
+        state = horde.init(3, jr.key(0))
+        obs = jnp.ones(3, dtype=jnp.float32)
+        next_obs = jnp.zeros(3, dtype=jnp.float32)
+
+        poisoned = horde.update(
+            state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), next_obs
+        )
+        d0_old = state.demon_states[0]
+        d0_new = poisoned.state.demon_states[0]  # type: ignore[attr-defined]
+        for w_old, w_new in zip(
+            d0_old.params.weights, d0_new.params.weights, strict=True
+        ):
+            assert bool(jnp.all(jnp.isfinite(w_new)))
+            chex.assert_trees_all_close(w_old, w_new)
+
+        d1_old = state.demon_states[1]
+        d1_new = poisoned.state.demon_states[1]  # type: ignore[attr-defined]
+        any_changed = False
+        for w_old, w_new in zip(
+            d1_old.params.weights, d1_new.params.weights, strict=True
+        ):
+            assert bool(jnp.all(jnp.isfinite(w_new)))
+            if not jnp.allclose(w_old, w_new):
+                any_changed = True
+        assert any_changed, "finite demon 1 should still update"
+        assert int(poisoned.state.step_count) == int(state.step_count) + 1  # type: ignore[attr-defined]
+
+        recovered = horde.update(
+            poisoned.state,  # type: ignore[arg-type]
+            obs,
+            jnp.array([1.0, 0.5], dtype=jnp.float32),
+            next_obs,
+        )
+        for ds in recovered.state.demon_states:  # type: ignore[attr-defined]
+            for w in ds.params.weights:
+                assert bool(jnp.all(jnp.isfinite(w)))
+
+
+# =============================================================================
 # gamma*lamda > 0 with hidden layers must NOT raise (the point of this class)
 # =============================================================================
 


### PR DESCRIPTION
IndependentDemonHorde still multiplies the bounded step by the TD error after ObGD. An inf cumulant drives the bound scale to 0, then `error * step` is `0 * inf` = NaN, and that demon stays poisoned. NaN cumulants already skip the update; inf does not.

The previous finite params, traces, and optimizer states are kept on that demon. A sibling with a finite cumulant still updates. Outer step_count still advances. A later finite cumulant can recover.

Failing-test-first: inf cumulant + ObGDBounding wrote NaN weights on main, then kept the previous finite parameters. `tests/test_independent_demon_horde.py`: 11 passed.

Sibling of #61 (bounder), #63 (MLPLearner apply site), and #66 (Horde actor-critic apply site). Independent of those PRs.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)