### PR TITLE
Keep OffPolicyHorde ObGD applies from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -587,18 +587,25 @@ class OffPolicyHordeLearner:
 
             new_w = head_w + error_i * w_step
             new_b = head_b + error_i * b_step
-
-            new_w = jnp.where(active_mask[i], new_w, head_w)
-            new_b = jnp.where(active_mask[i], new_b, head_b)
-            new_w_trace = jnp.where(active_mask[i], new_w_trace, old_w_trace)
-            new_b_trace = jnp.where(active_mask[i], new_b_trace, old_b_trace)
+            # Inf TD error zeros the ObGD step, then error_i * step is 0*inf=NaN.
+            # Hold that head's previous finite params/traces/opt like a NaN cumulant.
+            head_ok = (
+                active_mask[i]
+                & jnp.isfinite(error_i)
+                & jnp.all(jnp.isfinite(new_w))
+                & jnp.all(jnp.isfinite(new_b))
+            )
+            new_w = jnp.where(head_ok, new_w, head_w)
+            new_b = jnp.where(head_ok, new_b, head_b)
+            new_w_trace = jnp.where(head_ok, new_w_trace, old_w_trace)
+            new_b_trace = jnp.where(head_ok, new_b_trace, old_b_trace)
             new_w_opt = jax.tree.map(
-                lambda new, old: jnp.where(active_mask[i], new, old),
+                lambda new, old: jnp.where(head_ok, new, old),
                 new_w_opt,
                 old_w_opt,
             )
             new_b_opt = jax.tree.map(
-                lambda new, old: jnp.where(active_mask[i], new, old),
+                lambda new, old: jnp.where(head_ok, new, old),
                 new_b_opt,
                 old_b_opt,
             )

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -14,7 +14,7 @@ from alberta_framework.core.off_policy_horde import (
     OffPolicyHordeUpdateResult,
     run_off_policy_horde_learning_loop,
 )
-from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.optimizers import LMS, ObGDBounding
 from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec, create_horde_spec
 
 
@@ -118,6 +118,46 @@ def test_ratio_zero_blocks_that_demon_update() -> None:
     assert float(jnp.linalg.norm(result.state.head_params.weights[1] - before_w1)) > 0.0
     assert float(result.clipped_rhos[0]) == pytest.approx(0.0)
     assert float(result.clipped_rhos[1]) == pytest.approx(2.0)
+
+
+def test_infinite_cumulant_with_obgd_does_not_poison_head() -> None:
+    """Inf TD error zeros the ObGD step, then error_i*step is 0*inf=NaN."""
+    learner = OffPolicyHordeLearner(
+        _spec(gammas=(0.0, 0.0)),
+        hidden_sizes=(),
+        optimizer=LMS(step_size=0.1),
+        bounder=ObGDBounding(kappa=2.0),
+        ratio_clip=10.0,
+        sparsity=0.0,
+        use_layer_norm=False,
+    )
+    state = learner.init(2, jax.random.key(0))
+    before_w0 = state.head_params.weights[0]
+    before_w1 = state.head_params.weights[1]
+
+    poisoned = learner.update_with_ratios(
+        state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([jnp.inf, 1.0], dtype=jnp.float32),
+        jnp.zeros(2, dtype=jnp.float32),
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+    )
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.head_params.weights[0])))
+    chex.assert_trees_all_close(poisoned.state.head_params.weights[0], before_w0)
+    assert bool(jnp.all(jnp.isfinite(poisoned.state.head_params.weights[1])))
+    assert float(
+        jnp.linalg.norm(poisoned.state.head_params.weights[1] - before_w1)
+    ) > 0.0
+    assert int(poisoned.state.step_count) == int(state.step_count) + 1
+
+    recovered = learner.update_with_ratios(
+        poisoned.state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([1.0, 0.5], dtype=jnp.float32),
+        jnp.zeros(2, dtype=jnp.float32),
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+    )
+    chex.assert_tree_all_finite(recovered.state.head_params)
 
 
 def test_probability_api_matches_explicit_ratios() -> None:


### PR DESCRIPTION
OffPolicyHordeLearner still multiplies the bounded head step by the TD error after ObGD. An inf cumulant drives the bound scale to 0, then `error_i * step` is `0 * inf` = NaN, and that head stays poisoned. NaN cumulants already skip the update; inf does not. The trunk bounder uses error=1.0, so this hole is head-only.

The previous finite head params, traces, and optimizer states are kept on the inf head. A sibling with a finite cumulant still updates. Outer step_count still advances. A later finite cumulant can recover.

Failing-test-first: inf cumulant + ObGDBounding wrote NaN head weights on main, then kept the previous finite parameters. `tests/test_off_policy_horde.py`: 10 passed.

Sibling of #61 (bounder), #63 (MLPLearner apply site), and #67 (IndependentDemonHorde apply site). Independent of those PRs.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)