### PR TITLE
Keep RTU ObGD updates from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -1217,6 +1217,11 @@ def exact_rtrl_gradient(
     )
 
 
+def _replace_nan_with_zero(value: Array) -> Array:
+    """Map ``0 * inf`` NaNs to 0 so genuine infs stay inf."""
+    return jnp.where(jnp.isnan(value), jnp.zeros_like(value), value)
+
+
 def obgd_update(
     traces: Any,
     signal: Array,
@@ -1236,17 +1241,17 @@ def obgd_update(
     z_sum = jnp.asarray(0.0, dtype=signal.dtype)
     for leaf in jax.tree_util.tree_leaves(traces):
         z_sum = z_sum + jnp.sum(jnp.abs(leaf))
-    denominator = jnp.maximum(
-        1.0,
+    bound_term = (
         jnp.asarray(alpha, dtype=signal.dtype)
         * jnp.asarray(kappa, dtype=signal.dtype)
         * jnp.maximum(jnp.abs(signal), 1.0)
-        * z_sum,
+        * z_sum
     )
+    denominator = jnp.maximum(1.0, _replace_nan_with_zero(bound_term))
     scale = jnp.reciprocal(denominator)
     step_size = jnp.asarray(alpha, dtype=signal.dtype) * scale
     updates = jax.tree_util.tree_map(
-        lambda trace: step_size * signal * trace,
+        lambda trace: _replace_nan_with_zero(step_size * signal * trace),
         traces,
     )
     return ObGDUpdate(updates=updates, step_size=step_size, scale=scale)
@@ -1285,7 +1290,7 @@ def adaptive_obgd_update(
     new_second_moment = jax.tree_util.tree_map(
         lambda previous, trace: (
             beta * previous
-            + (1.0 - beta) * jnp.square(signal * trace)
+            + (1.0 - beta) * jnp.square(_replace_nan_with_zero(signal * trace))
         ),
         second_moment,
         traces,
@@ -1304,17 +1309,19 @@ def adaptive_obgd_update(
     z_sum = jnp.asarray(0.0, dtype=signal.dtype)
     for leaf in jax.tree_util.tree_leaves(normalized_traces):
         z_sum = z_sum + jnp.sum(jnp.abs(leaf))
-    denominator = jnp.maximum(
-        1.0,
+    bound_term = (
         jnp.maximum(jnp.abs(signal), 1.0)
         * z_sum
         * jnp.asarray(alpha, dtype=signal.dtype)
-        * jnp.asarray(kappa, dtype=signal.dtype),
+        * jnp.asarray(kappa, dtype=signal.dtype)
     )
+    denominator = jnp.maximum(1.0, _replace_nan_with_zero(bound_term))
     scale = jnp.reciprocal(denominator)
     step_size = jnp.asarray(alpha, dtype=signal.dtype) / denominator
     updates = jax.tree_util.tree_map(
-        lambda normalized_trace: step_size * signal * normalized_trace,
+        lambda normalized_trace: _replace_nan_with_zero(
+            step_size * signal * normalized_trace
+        ),
         normalized_traces,
     )
     return AdaptiveObGDUpdate(

--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -1217,9 +1217,24 @@ def exact_rtrl_gradient(
     )
 
 
-def _replace_nan_with_zero(value: Array) -> Array:
-    """Map ``0 * inf`` NaNs to 0 so genuine infs stay inf."""
-    return jnp.where(jnp.isnan(value), jnp.zeros_like(value), value)
+def _zero_if_collapsed_inf(product: Array, infinite_input: Array, collapsed: Array) -> Array:
+    """Zero ``0 * inf`` only when a bound collapsed an infinite input.
+
+    Genuine upstream NaNs stay NaN. Inactive bounds (``kappa=0``) keep inf.
+    """
+    return jnp.where(
+        collapsed & jnp.isinf(infinite_input) & jnp.isnan(product),
+        jnp.zeros_like(product),
+        product,
+    )
+
+
+def _zero_if_zero_times_inf(product: Array, left: Array, right: Array) -> Array:
+    """Zero a product only when it is the ``0 * inf`` NaN, not a genuine NaN."""
+    zero_times_inf = jnp.isnan(product) & (
+        (jnp.isinf(left) & (right == 0)) | (jnp.isinf(right) & (left == 0))
+    )
+    return jnp.where(zero_times_inf, jnp.zeros_like(product), product)
 
 
 def obgd_update(
@@ -1241,17 +1256,21 @@ def obgd_update(
     z_sum = jnp.asarray(0.0, dtype=signal.dtype)
     for leaf in jax.tree_util.tree_leaves(traces):
         z_sum = z_sum + jnp.sum(jnp.abs(leaf))
-    bound_term = (
-        jnp.asarray(alpha, dtype=signal.dtype)
-        * jnp.asarray(kappa, dtype=signal.dtype)
-        * jnp.maximum(jnp.abs(signal), 1.0)
-        * z_sum
-    )
-    denominator = jnp.maximum(1.0, _replace_nan_with_zero(bound_term))
+    kappa_arr = jnp.asarray(kappa, dtype=signal.dtype)
+    abs_signal = jnp.maximum(jnp.abs(signal), 1.0)
+    weighted_z = _zero_if_zero_times_inf(abs_signal * z_sum, abs_signal, z_sum)
+    bound_core = jnp.asarray(alpha, dtype=signal.dtype) * weighted_z
+    bound_term = _zero_if_zero_times_inf(kappa_arr * bound_core, kappa_arr, bound_core)
+    denominator = jnp.maximum(1.0, bound_term)
     scale = jnp.reciprocal(denominator)
+    collapsed = scale == 0
     step_size = jnp.asarray(alpha, dtype=signal.dtype) * scale
     updates = jax.tree_util.tree_map(
-        lambda trace: _replace_nan_with_zero(step_size * signal * trace),
+        lambda trace: _zero_if_zero_times_inf(
+            _zero_if_collapsed_inf(step_size * signal * trace, signal, collapsed),
+            signal,
+            trace,
+        ),
         traces,
     )
     return ObGDUpdate(updates=updates, step_size=step_size, scale=scale)
@@ -1290,7 +1309,8 @@ def adaptive_obgd_update(
     new_second_moment = jax.tree_util.tree_map(
         lambda previous, trace: (
             beta * previous
-            + (1.0 - beta) * jnp.square(_replace_nan_with_zero(signal * trace))
+            + (1.0 - beta)
+            * jnp.square(_zero_if_zero_times_inf(signal * trace, signal, trace))
         ),
         second_moment,
         traces,
@@ -1309,18 +1329,22 @@ def adaptive_obgd_update(
     z_sum = jnp.asarray(0.0, dtype=signal.dtype)
     for leaf in jax.tree_util.tree_leaves(normalized_traces):
         z_sum = z_sum + jnp.sum(jnp.abs(leaf))
-    bound_term = (
-        jnp.maximum(jnp.abs(signal), 1.0)
-        * z_sum
-        * jnp.asarray(alpha, dtype=signal.dtype)
-        * jnp.asarray(kappa, dtype=signal.dtype)
-    )
-    denominator = jnp.maximum(1.0, _replace_nan_with_zero(bound_term))
+    kappa_arr = jnp.asarray(kappa, dtype=signal.dtype)
+    abs_signal = jnp.maximum(jnp.abs(signal), 1.0)
+    weighted_z = _zero_if_zero_times_inf(abs_signal * z_sum, abs_signal, z_sum)
+    bound_core = weighted_z * jnp.asarray(alpha, dtype=signal.dtype)
+    bound_term = _zero_if_zero_times_inf(kappa_arr * bound_core, kappa_arr, bound_core)
+    denominator = jnp.maximum(1.0, bound_term)
     scale = jnp.reciprocal(denominator)
+    collapsed = scale == 0
     step_size = jnp.asarray(alpha, dtype=signal.dtype) / denominator
     updates = jax.tree_util.tree_map(
-        lambda normalized_trace: _replace_nan_with_zero(
-            step_size * signal * normalized_trace
+        lambda normalized_trace: _zero_if_zero_times_inf(
+            _zero_if_collapsed_inf(
+                step_size * signal * normalized_trace, signal, collapsed
+            ),
+            signal,
+            normalized_trace,
         ),
         normalized_traces,
     )

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -609,6 +609,65 @@ def test_obgd_large_error_contract_applies_signal_once() -> None:
     assert jnp.allclose(update_l1, 1.0 / 2.0)
 
 
+def test_obgd_infinite_signal_zeros_bounded_update() -> None:
+    """Inf signal zeros the ObGD scale, then scale*signal*z is 0*inf=NaN."""
+    traces = {
+        "first": jnp.asarray((2.0, -1.0), dtype=jnp.float32),
+        "second": jnp.asarray((3.0,), dtype=jnp.float32),
+    }
+    result = obgd_update(traces, jnp.asarray(jnp.inf, dtype=jnp.float32), alpha=0.5, kappa=2.0)
+    for leaf in jax.tree_util.tree_leaves(result.updates):
+        assert bool(jnp.all(jnp.isfinite(leaf)))
+        assert bool(jnp.allclose(leaf, 0.0))
+    assert bool(jnp.isfinite(result.scale))
+    assert bool(jnp.allclose(result.scale, 0.0))
+
+    unbounded = obgd_update(
+        traces, jnp.asarray(jnp.inf, dtype=jnp.float32), alpha=0.5, kappa=0.0
+    )
+    for leaf in jax.tree_util.tree_leaves(unbounded.updates):
+        assert bool(jnp.all(jnp.isinf(leaf)))
+
+
+def test_adaptive_obgd_infinite_signal_keeps_finite_updates() -> None:
+    traces = {
+        "first": jnp.asarray((2.0, -1.0), dtype=jnp.float32),
+        "second": jnp.asarray((0.5,), dtype=jnp.float32),
+    }
+    second_moment = {
+        "first": jnp.asarray((0.25, 0.5), dtype=jnp.float32),
+        "second": jnp.asarray((1.0,), dtype=jnp.float32),
+    }
+    result = adaptive_obgd_update(
+        traces,
+        second_moment,
+        jnp.asarray(jnp.inf, dtype=jnp.float32),
+        alpha=0.2,
+        kappa=2.0,
+        beta2=0.9,
+        epsilon=1e-4,
+        step=4,
+    )
+    for leaf in jax.tree_util.tree_leaves(result.updates):
+        assert bool(jnp.all(jnp.isfinite(leaf)))
+        assert bool(jnp.allclose(leaf, 0.0))
+    zero_traces = jax.tree_util.tree_map(jnp.zeros_like, traces)
+    zeroed = adaptive_obgd_update(
+        zero_traces,
+        second_moment,
+        jnp.asarray(jnp.inf, dtype=jnp.float32),
+        alpha=0.2,
+        kappa=2.0,
+        beta2=0.9,
+        epsilon=1e-4,
+        step=4,
+    )
+    for leaf in jax.tree_util.tree_leaves(zeroed.second_moment):
+        assert bool(jnp.all(jnp.isfinite(leaf)))
+    for leaf in jax.tree_util.tree_leaves(zeroed.updates):
+        assert bool(jnp.all(jnp.isfinite(leaf)))
+
+
 def test_adaptive_obgd_matches_memorax_second_moment_formula() -> None:
     traces = {
         "first": jnp.asarray((2.0, -1.0), dtype=jnp.float32),

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -628,6 +628,12 @@ def test_obgd_infinite_signal_zeros_bounded_update() -> None:
     for leaf in jax.tree_util.tree_leaves(unbounded.updates):
         assert bool(jnp.all(jnp.isinf(leaf)))
 
+    genuine_nan = obgd_update(
+        traces, jnp.asarray(jnp.nan, dtype=jnp.float32), alpha=0.5, kappa=0.0
+    )
+    for leaf in jax.tree_util.tree_leaves(genuine_nan.updates):
+        assert bool(jnp.all(jnp.isnan(leaf)))
+
 
 def test_adaptive_obgd_infinite_signal_keeps_finite_updates() -> None:
     traces = {


### PR DESCRIPTION
The RTU actor-critic has its own ObGD, not the Bounder ABC. Inf TD error makes the bound scale 0, then `step_size * signal * z` is `0 * inf` = NaN. Kappa 0 still hits `0 * inf` in the denominator product, so even the unbounded path NaNs. Adaptive ObGD also NaNs the second-moment tree when the trace is 0.

NaN products are mapped to 0 so a bounded inf signal writes a zero update. Unbounded inf (`kappa=0`) stays inf. Finite large-error contracts are unchanged.

Failing-test-first: inf signal wrote NaN updates on main, then wrote zeros (bounded) or inf (unbounded). The four ObGD contract tests in `tests/test_recurrent_trace_actor_critic.py` passed.

Sibling of #61 (Bounder-side ObGD). This copy lives in `recurrent_trace_actor_critic.py` and does not depend on that PR.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)