### PR TITLE
Keep IDBD traces from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -699,7 +699,10 @@ class IDBD(Optimizer[IDBDState]):
         # when error is None (trunk path), z is already loss gradient direction.
         decay = jnp.maximum(0.0, 1.0 - new_alphas * h_decay)
         if error is not None:
-            new_traces = state.traces * decay - new_alphas * jnp.squeeze(error) * z
+            # 0 * inf is NaN; a silent feature must not poison h.
+            h_step = new_alphas * jnp.squeeze(error) * z
+            h_step = jnp.where(jnp.isnan(h_step), jnp.zeros_like(h_step), h_step)
+            new_traces = state.traces * decay - h_step
         else:
             new_traces = state.traces * decay + new_alphas * z
 
@@ -762,12 +765,19 @@ class IDBD(Optimizer[IDBDState]):
         new_alphas = jnp.exp(new_log_step_sizes)
 
         # 3. Weight updates using NEW alpha: alpha_i * error * x_i
+        # 0 * inf is NaN; leave genuine infs (nonzero x, inf error) as inf.
         weight_delta = new_alphas * error_scalar * observation
+        weight_delta = jnp.where(
+            jnp.isnan(weight_delta), jnp.zeros_like(weight_delta), weight_delta
+        )
 
         # 4. Update traces using NEW alpha: h_i = h_i * decay + alpha_i * error * x_i
         # decay = max(0, 1 - alpha_i * x_i^2)
         decay = jnp.maximum(0.0, 1.0 - new_alphas * observation**2)
-        new_traces = state.traces * decay + new_alphas * error_scalar * observation
+        trace_step = new_alphas * error_scalar * observation
+        new_traces = state.traces * decay + jnp.where(
+            jnp.isnan(trace_step), jnp.zeros_like(trace_step), trace_step
+        )
 
         # Bias updates (same ordering: meta-update first, then new alpha).
         # Same guard: a non-finite correlation keeps the previous step-size.

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -136,6 +136,31 @@ class TestIDBD:
         )
         assert bool(jnp.all(jnp.isfinite(recovered.new_state.log_step_sizes)))
 
+    def test_infinite_error_on_zero_feature_does_not_poison_traces(self):
+        """inf * x=0 is NaN; that channel's h-trace and weight delta stay 0."""
+        optimizer = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.isfinite(poisoned.new_state.traces[0]))
+        assert bool(jnp.allclose(poisoned.new_state.traces[0], 0.0))
+        assert bool(jnp.isfinite(poisoned.weight_delta[0]))
+        assert bool(jnp.allclose(poisoned.weight_delta[0], 0.0))
+        # Nonzero feature still takes an unbounded inf step.
+        assert bool(jnp.isinf(poisoned.new_state.traces[1]))
+        assert bool(jnp.isinf(poisoned.weight_delta[1]))
+
+        recovered = optimizer.update(
+            poisoned.new_state,
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+        )
+        assert bool(jnp.isfinite(recovered.new_state.traces[0]))
+        assert bool(jnp.isfinite(recovered.new_state.log_step_sizes[0]))
+
     def test_finite_overflow_product_keeps_meta_update_zero(self):
         """|error * x| overflowing float32 must not NaN a zero-trace channel.
 
@@ -696,6 +721,26 @@ class TestIDBDParamState:
         )
         chex.assert_tree_all_finite(finite_step)
         chex.assert_tree_all_finite(recovered.log_step_sizes)
+
+    def test_update_from_gradient_infinite_error_on_zero_z_keeps_traces(self):
+        """inf * z=0 is NaN; that channel's h-trace must stay 0."""
+        optimizer = IDBD(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init_for_shape((2, 2))
+        gradient = jnp.array([[0.0, 1.0], [0.5, 0.0]], dtype=jnp.float32)
+        _step, poisoned = optimizer.update_from_gradient(
+            state, gradient, error=jnp.array(jnp.inf)
+        )
+        assert bool(jnp.isfinite(poisoned.traces[0, 0]))
+        assert bool(jnp.allclose(poisoned.traces[0, 0], 0.0))
+        assert bool(jnp.isfinite(poisoned.traces[1, 1]))
+        assert bool(jnp.allclose(poisoned.traces[1, 1], 0.0))
+        finite_step, recovered = optimizer.update_from_gradient(
+            poisoned, jnp.ones((2, 2)) * 0.1, error=jnp.array(1.0)
+        )
+        chex.assert_tree_all_finite(finite_step)
+        chex.assert_tree_all_finite(recovered.log_step_sizes)
+        assert bool(jnp.isfinite(recovered.traces[0, 0]))
+        assert bool(jnp.isfinite(recovered.traces[1, 1]))
 
     def test_update_from_gradient_without_error(self):
         """update_from_gradient should work without error (trunk path)."""


### PR DESCRIPTION
#42 already skips the IDBD meta-update when `error * x * h` is non-finite, so log step-sizes stay finite. The h-trace and weight delta still do `alpha * error * x`. A silent feature (`x=0`) against an inf error is `0 * inf` = NaN, and that channel stays poisoned through later finite updates. Nonzero features still take an unbounded inf step.

NaN products are mapped to 0. Genuine infs stay inf. The existing log-alpha guard is unchanged.

Failing-test-first: inf error with a zero feature wrote NaN traces and weight deltas on main, then wrote 0 on that channel. `tests/test_optimizers.py`: 52 passed.

Follow-on to #42 (meta-update). Independent of #56 (Autostep) and #61 (ObGD bounder).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)