### PR TITLE
Keep LMS silent-feature deltas from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -504,8 +504,11 @@ class LMS(Optimizer[LMSState]):
         alpha = state.step_size
         error_scalar = jnp.squeeze(error)
 
-        # Weight update: alpha * error * x
+        # Weight update: alpha * error * x. 0 * inf is NaN; genuine infs stay inf.
         weight_delta = alpha * error_scalar * observation
+        weight_delta = jnp.where(
+            jnp.isnan(weight_delta), jnp.zeros_like(weight_delta), weight_delta
+        )
 
         # Bias update: alpha * error
         bias_delta = alpha * error_scalar

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -48,6 +48,23 @@ class TestLMS:
 
         assert result.new_state.step_size == state.step_size
 
+    def test_infinite_error_on_zero_feature_does_not_poison_delta(self):
+        """inf * x=0 is NaN; that channel's LMS delta stays 0."""
+        optimizer = LMS(step_size=0.1)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.isfinite(poisoned.weight_delta[0]))
+        assert bool(jnp.allclose(poisoned.weight_delta[0], 0.0))
+        assert bool(jnp.isinf(poisoned.weight_delta[1]))
+        recovered = optimizer.update(
+            poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.isfinite(recovered.weight_delta[0]))
+        assert bool(jnp.allclose(recovered.weight_delta[0], 0.0))
+
 
 class TestIDBD:
     """Tests for the IDBD optimizer."""


### PR DESCRIPTION
LMS still does `alpha * error * x`. A silent feature (`x=0`) against an inf error is `0 * inf` = NaN, so that channel's delta is not a real 0 and any caller that adds it poisons the weight. Nonzero features still take an unbounded inf step.

NaN products are mapped to 0. Genuine infs stay inf. LMS has no persistent optimizer state, so a later finite error on the same silent feature is a real 0.

Failing-test-first: inf error with a zero feature wrote a NaN weight delta on main, then wrote 0. `tests/test_optimizers.py::TestLMS`: 4 passed.

Sibling of #70 (IDBD traces) and #71 (NADALINE). Independent of #61 (ObGD bounder) even though both touch `optimizers.py`.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)