### PR TITLE
Keep Autostep traces from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -970,7 +970,12 @@ class Autostep(Optimizer[AutostepState]):
         # Trace update: h_i = h_i*(1 - α_i*z_i²) + α_i*δ*z_i
         trace_decay = 1.0 - new_step_sizes * z_sq
         if error is not None:
-            new_traces = state.traces * trace_decay + new_step_sizes * error_scalar * z
+            # 0 * inf is NaN; a silent feature must not poison h.
+            trace_step = new_step_sizes * error_scalar * z
+            trace_step = jnp.where(
+                jnp.isnan(trace_step), jnp.zeros_like(trace_step), trace_step
+            )
+            new_traces = state.traces * trace_decay + trace_step
         else:
             new_traces = state.traces * trace_decay + new_step_sizes * z
 
@@ -1065,14 +1070,21 @@ class Autostep(Optimizer[AutostepState]):
         new_bias_step_size = jnp.clip(new_bias_step_size, 1e-8, 1.0)
 
         # Weight update with NEW alpha: α_i * δ * x_i
+        # 0 * inf is NaN; leave genuine infs (nonzero x, inf error) as inf.
         weight_delta = new_step_sizes * error_scalar * x
+        weight_delta = jnp.where(
+            jnp.isnan(weight_delta), jnp.zeros_like(weight_delta), weight_delta
+        )
 
         # Bias update: α_bias * δ
         bias_delta = new_bias_step_size * error_scalar
 
         # Trace update: h_i = h_i*(1 - α_i*x_i²) + α_i*δ*x_i
         trace_decay = 1.0 - new_step_sizes * x_sq
-        new_traces = state.traces * trace_decay + new_step_sizes * error_scalar * x
+        trace_step = new_step_sizes * error_scalar * x
+        new_traces = state.traces * trace_decay + jnp.where(
+            jnp.isnan(trace_step), jnp.zeros_like(trace_step), trace_step
+        )
 
         # Bias trace: h_bias = h_bias*(1 - α_bias) + α_bias*δ
         bias_trace_decay = 1.0 - new_bias_step_size

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -261,6 +261,44 @@ class TestAutostep:
         assert "max_step_size" in result.metrics
         assert "mean_normalizer" in result.metrics
 
+    def test_infinite_error_on_zero_feature_does_not_poison_traces(self):
+        """inf * x=0 is NaN; that channel's h-trace and weight delta stay 0."""
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init(feature_dim=2)
+        observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        poisoned = optimizer.update(
+            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
+        )
+        assert bool(jnp.isfinite(poisoned.new_state.traces[0]))
+        assert bool(jnp.allclose(poisoned.new_state.traces[0], 0.0))
+        assert bool(jnp.isfinite(poisoned.weight_delta[0]))
+        assert bool(jnp.allclose(poisoned.weight_delta[0], 0.0))
+        assert bool(jnp.isinf(poisoned.new_state.traces[1]))
+        assert bool(jnp.isinf(poisoned.weight_delta[1]))
+        recovered = optimizer.update(
+            poisoned.new_state,
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+        )
+        assert bool(jnp.isfinite(recovered.new_state.traces[0]))
+        assert bool(jnp.isfinite(recovered.weight_delta[0]))
+
+    def test_update_from_gradient_infinite_error_on_zero_z_keeps_traces(self):
+        """inf * z=0 is NaN; that channel's h-trace must stay 0."""
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init_for_shape((2,))
+        gradient = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        _step, poisoned = optimizer.update_from_gradient(
+            state, gradient, error=jnp.array(jnp.inf)
+        )
+        assert bool(jnp.isfinite(poisoned.traces[0]))
+        assert bool(jnp.allclose(poisoned.traces[0], 0.0))
+        finite_step, recovered = optimizer.update_from_gradient(
+            poisoned, jnp.array([0.1, 0.1], dtype=jnp.float32), error=jnp.array(1.0)
+        )
+        chex.assert_tree_all_finite(finite_step)
+        assert bool(jnp.isfinite(recovered.traces[0]))
+
     def test_overshoot_prevention_bounds_effective_step_size(self):
         """M normalization should prevent sum(alpha_i * x_i^2) from exceeding 1."""
         # Use large step-sizes and large observations to trigger M > 1


### PR DESCRIPTION
#56 already skips Autostep's Eq. 4/5 meta-update when the correlation is non-finite, so step-sizes stay finite. The h-trace and weight delta still do `alpha * error * x`. A silent feature (`x=0`) against an inf error is `0 * inf` = NaN, and that channel stays poisoned. Nonzero features still take an unbounded inf step.

NaN products are mapped to 0. Genuine infs stay inf. Normalizers and the v>0 gate are left to #56.

Failing-test-first: inf error with a zero feature wrote NaN traces and weight deltas on main, then wrote 0 on that channel. The same hole is in `update_from_gradient`. `tests/test_optimizers.py`: 52 passed.

Follow-on to #56 (Autostep meta) and sibling of #70 (IDBD traces). The changed lines sit after #56's Eq. 5 hunks.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)