### PR TITLE
Refuse inf rewards before Differential TD turns 0*inf into NaN

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -846,7 +846,10 @@ class AverageRewardHordeLearner:
     ) -> AverageRewardHordeUpdateResult:
         """Apply one shared-trunk differential Horde update."""
         next_predictions = self._learner.predict(state.learner_state, next_observation)
-        active = ~jnp.isnan(cumulants)
+        # NaN is the inactive-head sentinel. Inf is not NaN, so it used to
+        # stay "active", MultiHead refused the whole trunk, and rbar still
+        # took an inf step.
+        active = jnp.isfinite(cumulants)
         targets = cumulants - state.average_rewards + next_predictions
         targets = jnp.where(active, targets, jnp.nan)
         result = self._learner.update(state.learner_state, observation, targets)
@@ -855,10 +858,19 @@ class AverageRewardHordeLearner:
         new_average_rewards = (
             state.average_rewards + self._average_reward_step_size * safe_td_errors
         )
+        new_average_rewards = jnp.where(
+            result.update_applied,
+            new_average_rewards,
+            state.average_rewards,
+        )
         new_state = state.replace(
             learner_state=result.state,
             average_rewards=new_average_rewards,
-            step_count=_saturating_int32_increment(state.step_count),
+            step_count=jnp.where(
+                result.update_applied,
+                _saturating_int32_increment(state.step_count),
+                state.step_count,
+            ),
         )
         return AverageRewardHordeUpdateResult(
             state=new_state,
@@ -984,7 +996,7 @@ class DifferentialGTDLearner:
         secondary_bias_step = beta * (td_error * bias_trace - secondary_dot_obs)
         new_average_reward = state.average_reward + eta * rho_s * td_error
 
-        new_state = state.replace(
+        proposed_state = state.replace(
             weights=state.weights + primary_weight_step,
             bias=state.bias + primary_bias_step,
             secondary_weights=state.secondary_weights + secondary_weight_step,
@@ -994,13 +1006,35 @@ class DifferentialGTDLearner:
             average_reward=new_average_reward,
             step_count=_saturating_int32_increment(state.step_count),
         )
+        # Inf reward makes alpha * delta * z = 0*inf = NaN on silent features
+        # and sends rbar to inf. Differential SARSA already refuses that.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(reward_s)
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(jnp.squeeze(jnp.asarray(rho, dtype=jnp.float32)))
+        )
+        proposed_finite = (
+            jnp.all(jnp.isfinite(proposed_state.weights))
+            & jnp.isfinite(proposed_state.bias)
+            & jnp.all(jnp.isfinite(proposed_state.secondary_weights))
+            & jnp.isfinite(proposed_state.secondary_bias)
+            & jnp.all(jnp.isfinite(proposed_state.eligibility_traces))
+            & jnp.isfinite(proposed_state.bias_eligibility_trace)
+            & jnp.isfinite(proposed_state.average_reward)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: proposed_state,
+            lambda: state,
+        )
         metrics = jnp.array(
             [
                 td_error**2,
                 td_error,
                 rho_s,
-                new_average_reward,
-                jnp.mean(jnp.abs(traces)),
+                new_state.average_reward,
+                jnp.mean(jnp.abs(new_state.eligibility_traces)),
                 jnp.sqrt(jnp.mean(new_state.secondary_weights**2)),
             ],
             dtype=jnp.float32,
@@ -1011,7 +1045,7 @@ class DifferentialGTDLearner:
             next_prediction=next_prediction,
             td_error=td_error,
             rho_clipped=rho_s,
-            average_reward=new_average_reward,
+            average_reward=new_state.average_reward,
             metrics=metrics,
         )
 
@@ -1112,7 +1146,7 @@ class DifferentialTDLearner:
 
         traces = lamda * state.eligibility_traces + observation
         bias_trace = lamda * state.bias_eligibility_trace + 1.0
-        new_state = state.replace(
+        proposed_state = state.replace(
             weights=state.weights + alpha * td_error * traces,
             bias=state.bias + alpha * td_error * bias_trace,
             eligibility_traces=traces,
@@ -1120,12 +1154,31 @@ class DifferentialTDLearner:
             average_reward=state.average_reward + beta * td_error,
             step_count=_saturating_int32_increment(state.step_count),
         )
+        # Inf reward makes alpha * delta * z = 0*inf = NaN on silent features
+        # and sends rbar to inf. Differential SARSA already refuses that.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(reward_s)
+            & jnp.all(jnp.isfinite(next_observation))
+        )
+        proposed_finite = (
+            jnp.all(jnp.isfinite(proposed_state.weights))
+            & jnp.isfinite(proposed_state.bias)
+            & jnp.all(jnp.isfinite(proposed_state.eligibility_traces))
+            & jnp.isfinite(proposed_state.bias_eligibility_trace)
+            & jnp.isfinite(proposed_state.average_reward)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: proposed_state,
+            lambda: state,
+        )
         metrics = jnp.array(
             [
                 td_error**2,
                 td_error,
                 new_state.average_reward,
-                jnp.mean(jnp.abs(traces)),
+                jnp.mean(jnp.abs(new_state.eligibility_traces)),
             ],
             dtype=jnp.float32,
         )

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -88,6 +88,88 @@ def test_differential_td_update_moves_average_reward_and_is_jittable() -> None:
     chex.assert_tree_all_finite(result)
 
 
+def test_differential_td_infinite_reward_does_not_poison_weights() -> None:
+    """Inf reward is 0*inf = NaN on a silent feature and inf rbar.
+
+    Differential SARSA already refuses non-finite rewards. Hold the
+    previous finite state so a later finite reward can still learn.
+    """
+    learner = DifferentialTDLearner(
+        DifferentialTDConfig(step_size=0.1, average_reward_step_size=0.2, trace_decay=0.0)
+    )
+    state = learner.init(2)
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    nxt = jnp.array([0.0, 1.0], dtype=jnp.float32)
+
+    poisoned = learner.update(state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt)
+    chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+    chex.assert_trees_all_close(poisoned.state.average_reward, state.average_reward)
+    assert int(poisoned.state.step_count) == int(state.step_count)
+
+    recovered = learner.update(
+        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt
+    )
+    chex.assert_tree_all_finite(recovered.state.weights)
+    chex.assert_tree_all_finite(recovered.state.average_reward)
+    assert int(recovered.state.step_count) == int(state.step_count) + 1
+
+
+def test_differential_gtd_infinite_reward_does_not_poison_weights() -> None:
+    """Same 0*inf hole on the GTD primary/secondary products."""
+    learner = DifferentialGTDLearner(
+        DifferentialGTDConfig(value_step_size=0.1, secondary_step_size=0.01)
+    )
+    state = learner.init(2)
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    nxt = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    rho = jnp.array(1.0, dtype=jnp.float32)
+
+    poisoned = learner.update(state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, rho)
+    chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+    chex.assert_trees_all_close(poisoned.state.secondary_weights, state.secondary_weights)
+    chex.assert_trees_all_close(poisoned.state.average_reward, state.average_reward)
+
+    recovered = learner.update(
+        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, rho
+    )
+    chex.assert_tree_all_finite(recovered.state.weights)
+    chex.assert_tree_all_finite(recovered.state.secondary_weights)
+
+
+def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
+    """Inf is not NaN, so it used to keep a demon 'active'.
+
+    MultiHead then refused the whole trunk, while rbar still added the
+    inf TD error. Treat non-finite cumulants as inactive and only move
+    rbar when the nested learner actually commits.
+    """
+    learner = AverageRewardHordeLearner(
+        n_demons=2,
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        use_layer_norm=False,
+        average_reward_step_size=0.01,
+    )
+    state = learner.init(3, jr.key(0))
+    obs = jnp.ones(3, dtype=jnp.float32)
+    nxt = jnp.ones(3, dtype=jnp.float32)
+
+    poisoned = learner.update(
+        state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), nxt
+    )
+    chex.assert_trees_all_close(
+        poisoned.average_rewards[0], state.average_rewards[0]
+    )
+    assert bool(jnp.isfinite(poisoned.average_rewards[1]))
+    assert int(poisoned.state.step_count) == 1
+
+    recovered = learner.update(
+        poisoned.state, obs, jnp.array([0.5, 1.0], dtype=jnp.float32), nxt
+    )
+    chex.assert_tree_all_finite(recovered.average_rewards)
+    assert int(recovered.state.step_count) == 2
+
+
 def test_differential_td_scan_shapes_and_finite_metrics() -> None:
     learner = DifferentialTDLearner(DifferentialTDConfig(trace_decay=0.2))
     state = learner.init(2)


### PR DESCRIPTION
Differential SARSA in this file already refuses non-finite rewards. Linear Differential TD and GTD still did `alpha * delta * z`. A silent feature against an inf reward is `0 * inf` = NaN, and rbar goes inf so later finite rewards stay poisoned.

Hold the previous finite state when the observation, reward, next observation, or proposed weights are non-finite.

The shared-trunk average-reward Horde had the same hole one layer up: inf is not NaN, so an inf cumulant stayed "active", MultiHead refused the whole trunk, and rbar still took the inf TD step. Non-finite cumulants are now inactive, and rbar only moves when the nested learner commits.

Failing-test-first: inf reward wrote `[nan, inf]` weights on main. Inf cumulant on one demon wrote inf then NaN into rbar. `tests/test_average_reward.py`: 21 passed.

Sibling of the LMS/Autostep silent-feature guards. Independent of #73.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)