### PR TITLE
Refuse inf rewards before off-policy TD turns 0*inf into NaN

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -62,6 +62,17 @@ from jaxtyping import Float, Int
 
 from alberta_framework.core.types import Observation
 
+
+def _floating_tree_is_finite(tree: object) -> Array:
+    """Return whether every floating/complex persistent leaf is finite."""
+    valid = jnp.asarray(True, dtype=jnp.bool_)
+    for leaf in jax.tree.leaves(tree):
+        array = jnp.asarray(leaf)
+        if jnp.issubdtype(array.dtype, jnp.inexact):
+            valid = valid & jnp.all(jnp.isfinite(array))
+    return valid
+
+
 # =============================================================================
 # State / result types
 # =============================================================================
@@ -330,21 +341,31 @@ class OffPolicyTDLinearLearner:
 
         # Update with rho_clipped * delta * e
         scaled_update = alpha * rho_clipped * td_error
-        new_weights = state.weights + scaled_update * new_e
-        new_bias = state.bias + scaled_update * new_e_b
-
-        new_state = OffPolicyTDState(  # type: ignore[call-arg]
-            weights=new_weights,
-            bias=new_bias,
+        proposed_state = OffPolicyTDState(  # type: ignore[call-arg]
+            weights=state.weights + scaled_update * new_e,
+            bias=state.bias + scaled_update * new_e_b,
             eligibility_traces=new_e,
             bias_eligibility_trace=new_e_b,
             step_count=state.step_count + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
+        # Inf reward makes scaled_update * e = 0*inf = NaN on a silent feature.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(reward_s)
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(gamma_s)
+            & jnp.isfinite(rho_s)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & _floating_tree_is_finite(proposed_state),
+            lambda: proposed_state,
+            lambda: state,
+        )
 
         squared_td = td_error**2
-        mean_e = jnp.mean(jnp.abs(new_e))
+        mean_e = jnp.mean(jnp.abs(new_state.eligibility_traces))
         metrics = jnp.array(
             [squared_td, td_error, rho_clipped, alpha, mean_e],
             dtype=jnp.float32,
@@ -486,12 +507,9 @@ class ETDLinearLearner:
         new_e = rho_s * (trace_decay * state.eligibility_traces + emphasis * observation)
         new_e_b = rho_s * (trace_decay * state.bias_eligibility_trace + emphasis)
 
-        new_weights = state.weights + alpha * td_error * new_e
-        new_bias = state.bias + alpha * td_error * new_e_b
-
-        new_state = ETDState(  # type: ignore[call-arg]
-            weights=new_weights,
-            bias=new_bias,
+        proposed_state = ETDState(  # type: ignore[call-arg]
+            weights=state.weights + alpha * td_error * new_e,
+            bias=state.bias + alpha * td_error * new_e_b,
             eligibility_traces=new_e,
             bias_eligibility_trace=new_e_b,
             follow_on_trace=follow_on,
@@ -500,9 +518,22 @@ class ETDLinearLearner:
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(reward_s)
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(gamma_s)
+            & jnp.isfinite(rho_s)
+            & jnp.isfinite(interest_s)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & _floating_tree_is_finite(proposed_state),
+            lambda: proposed_state,
+            lambda: state,
+        )
 
         squared_td = td_error**2
-        mean_e = jnp.mean(jnp.abs(new_e))
+        mean_e = jnp.mean(jnp.abs(new_state.eligibility_traces))
         metrics = jnp.array(
             [squared_td, td_error, rho_s, alpha, mean_e, follow_on, emphasis],
             dtype=jnp.float32,
@@ -659,13 +690,25 @@ class GradientTDLinearLearner:
         )
         secondary_step = beta * (td_error * traces - secondary_dot_phi * phi)
 
-        new_state = GradientTDState(  # type: ignore[call-arg]
+        proposed_state = GradientTDState(  # type: ignore[call-arg]
             weights=state.weights + primary_step,
             secondary_weights=state.secondary_weights + secondary_step,
             eligibility_traces=traces,
             step_count=state.step_count + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
+        )
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(reward_s)
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(gamma_s)
+            & jnp.isfinite(rho_s)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & _floating_tree_is_finite(proposed_state),
+            lambda: proposed_state,
+            lambda: state,
         )
         metrics = jnp.array(
             [
@@ -674,7 +717,7 @@ class GradientTDLinearLearner:
                 rho_clipped,
                 jnp.sqrt(jnp.mean(new_state.weights**2)),
                 jnp.sqrt(jnp.mean(new_state.secondary_weights**2)),
-                jnp.mean(jnp.abs(traces)),
+                jnp.mean(jnp.abs(new_state.eligibility_traces)),
             ],
             dtype=jnp.float32,
         )

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -557,3 +557,65 @@ class TestBairdStyle:
         chex.assert_tree_all_finite(state.weights)
         # Without clipping this is unbounded; with c=1 it's bounded.
         assert float(jnp.max(jnp.abs(state.weights))) < 50.0
+
+
+class TestInfiniteRewardDoesNotPoisonWeights:
+    def test_off_policy_td(self) -> None:
+        learner = OffPolicyTDLinearLearner(step_size=0.1, trace_decay=0.0)
+        state = learner.init(2)
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.zeros(2, dtype=jnp.float32)
+        gamma = jnp.array(0.0, dtype=jnp.float32)
+        rho = jnp.array(1.0, dtype=jnp.float32)
+
+        poisoned = learner.update(
+            state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+        assert int(poisoned.state.step_count) == int(state.step_count)
+
+        recovered = learner.update(
+            poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_tree_all_finite(recovered.state.weights)
+        assert int(recovered.state.step_count) == int(state.step_count) + 1
+
+    def test_etd(self) -> None:
+        learner = ETDLinearLearner(step_size=0.1, trace_decay=0.0)
+        state = learner.init(2)
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.zeros(2, dtype=jnp.float32)
+        gamma = jnp.array(0.0, dtype=jnp.float32)
+        rho = jnp.array(1.0, dtype=jnp.float32)
+
+        poisoned = learner.update(
+            state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+
+        recovered = learner.update(
+            poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_tree_all_finite(recovered.state.weights)
+
+    def test_gradient_td(self) -> None:
+        learner = GradientTDLinearLearner(step_size=0.1)
+        state = learner.init(2)
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.zeros(2, dtype=jnp.float32)
+        gamma = jnp.array(0.0, dtype=jnp.float32)
+        rho = jnp.array(1.0, dtype=jnp.float32)
+
+        poisoned = learner.update(
+            state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+        chex.assert_trees_all_close(
+            poisoned.state.secondary_weights, state.secondary_weights
+        )
+
+        recovered = learner.update(
+            poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, gamma, rho
+        )
+        chex.assert_tree_all_finite(recovered.state.weights)
+        chex.assert_tree_all_finite(recovered.state.secondary_weights)


### PR DESCRIPTION
Off-policy TD, ETD, and Gradient-TD all do `alpha * delta * z`. A silent feature against an inf reward is `0 * inf` = NaN, and that channel stays poisoned after later finite rewards.

Hold the previous finite state when the observation, reward, next observation, gamma, rho, or proposed weights are non-finite. Same contract as Differential SARSA / the Differential TD PR.

Failing-test-first: inf reward wrote `[nan, inf]` weights on main for all three learners. `tests/test_off_policy_td.py`: 23 passed.

Independent of #74 (average-reward file).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)