### PR TITLE
Refuse inf rho before stacked Horde turns 0*inf into NaN traces

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -269,12 +269,25 @@ class StackedLinearHorde:
         new_traces = rho_vec[:, None] * jnp.where(active[:, None], accumulated, decayed_only)
 
         masked_delta = jnp.where(active, td_errors, 0.0)
-        new_weights = state.weights + cfg.step_size * masked_delta[:, None] * new_traces
-
-        new_state = StackedHordeState(
-            weights=new_weights,
+        proposed_state = StackedHordeState(
+            weights=state.weights + cfg.step_size * masked_delta[:, None] * new_traces,
             traces=new_traces,
             step_count=state.step_count + 1,
+        )
+        # Inf rho * silent feature is 0*inf = NaN in the trace. Inf features
+        # make v = 0 @ inf = NaN at zero init. Hold the previous finite state.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(features))
+            & jnp.all(jnp.isfinite(next_features))
+            & jnp.all(jnp.isfinite(rho_vec))
+        )
+        proposed_finite = jnp.all(jnp.isfinite(proposed_state.weights)) & jnp.all(
+            jnp.isfinite(proposed_state.traces)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: proposed_state,
+            lambda: state,
         )
         return StackedHordeUpdateResult(
             state=new_state,

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -142,6 +142,31 @@ class TestExactSemantics:
             np.asarray(r2.state.traces), 2.0 * np.asarray(r1.state.traces), rtol=1e-6
         )
 
+    def test_infinite_rho_on_zero_feature_does_not_poison_traces(self):
+        """rho * x is 0*inf = NaN on a silent feature; hold the finite state."""
+        cfg = StackedHordeConfig(
+            n_demons=1,
+            feature_dim=2,
+            gammas=(0.9,),
+            lamdas=(0.0,),
+            cumulant_indices=(0,),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+        x = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        c = jnp.array([1.0], dtype=jnp.float32)
+
+        poisoned = horde.update(state, x, x, c, rho=jnp.inf)
+        np.testing.assert_array_equal(np.asarray(poisoned.state.weights), 0.0)
+        np.testing.assert_array_equal(np.asarray(poisoned.state.traces), 0.0)
+        assert int(poisoned.state.step_count) == 0
+
+        recovered = horde.update(poisoned.state, x, x, c, rho=1.0)
+        assert bool(jnp.all(jnp.isfinite(recovered.state.weights)))
+        assert bool(jnp.all(jnp.isfinite(recovered.state.traces)))
+        assert int(recovered.state.step_count) == 1
+
 
 class TestConvergence:
     def test_three_state_cycle_analytic_fixed_point(self):


### PR DESCRIPTION
Stacked linear Horde composes the IS ratio into the trace: `z = rho * (decay * z + x)`. Inf rho against a silent feature is `0 * inf` = NaN, and that column stays poisoned. Inf features also make `0 @ inf` = NaN at zero init.

Hold the previous finite weights and traces when features, next features, rho, or the proposed arrays are non-finite. NaN cumulants still freeze only the matching demons.

Failing-test-first: inf rho wrote `[nan, inf]` traces/weights on main. `tests/test_stacked_horde.py`: 11 passed.

Independent of #75 (off-policy TD file).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)