### PR TITLE
Refuse inf rewards before STOMP Q-updates turn 0*inf into NaN

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1026,8 +1026,23 @@ def _differential_q_update(
     action_mask = jax.nn.one_hot(last_action, n_actions, dtype=jnp.float32)
     new_traces = lam * traces + action_mask[:, None] * last_obs[None, :]
     delta_w = alpha * td_error * new_traces
-    new_q_weights = q_weights + delta_w
-    new_average_reward = average_reward + beta * td_error
+    proposed_q = q_weights + delta_w
+    proposed_rbar = average_reward + beta * td_error
+    inputs_valid = (
+        jnp.all(jnp.isfinite(last_obs))
+        & jnp.isfinite(jnp.asarray(reward, dtype=jnp.float32))
+        & jnp.all(jnp.isfinite(next_obs))
+    )
+    proposed_finite = (
+        jnp.all(jnp.isfinite(proposed_q))
+        & jnp.all(jnp.isfinite(new_traces))
+        & jnp.isfinite(proposed_rbar)
+    )
+    new_q_weights, new_traces, new_average_reward = jax.lax.cond(
+        inputs_valid & proposed_finite,
+        lambda: (proposed_q, new_traces, proposed_rbar),
+        lambda: (q_weights, traces, average_reward),
+    )
     return new_q_weights, new_traces, new_average_reward, td_error
 
 
@@ -1089,8 +1104,25 @@ def _differential_semidp_q_update(
     action_mask = jax.nn.one_hot(last_action, n_actions, dtype=jnp.float32)
     new_traces = lam * traces + action_mask[:, None] * last_obs[None, :]
     delta_w = alpha * td_error * new_traces
-    new_q_weights = q_weights + delta_w
-    new_average_reward = average_reward + beta * td_error
+    proposed_q = q_weights + delta_w
+    proposed_rbar = average_reward + beta * td_error
+    inputs_valid = (
+        jnp.all(jnp.isfinite(last_obs))
+        & jnp.isfinite(jnp.asarray(reward, dtype=jnp.float32))
+        & jnp.all(jnp.isfinite(next_obs))
+        & jnp.isfinite(baseline_coefficient)
+        & jnp.isfinite(gamma_o)
+    )
+    proposed_finite = (
+        jnp.all(jnp.isfinite(proposed_q))
+        & jnp.all(jnp.isfinite(new_traces))
+        & jnp.isfinite(proposed_rbar)
+    )
+    new_q_weights, new_traces, new_average_reward = jax.lax.cond(
+        inputs_valid & proposed_finite,
+        lambda: (proposed_q, new_traces, proposed_rbar),
+        lambda: (q_weights, traces, average_reward),
+    )
     return new_q_weights, new_traces, new_average_reward, td_error
 
 
@@ -1262,8 +1294,25 @@ def _update_intra_option_policy(
 
     action_mask = jax.nn.one_hot(last_intra_action, n_primitive_actions, dtype=jnp.float32)
     new_traces_i = rho * (lam * traces_i + action_mask[:, None] * last_obs[None, :])
-    new_q_i = q_i + alpha * td_error * new_traces_i
-    new_avg_r_i = avg_r_i + beta * rho * td_error
+    proposed_q_i = q_i + alpha * td_error * new_traces_i
+    proposed_avg_r_i = avg_r_i + beta * rho * td_error
+    inputs_valid = (
+        jnp.all(jnp.isfinite(last_obs))
+        & jnp.isfinite(jnp.asarray(pseudo_reward, dtype=jnp.float32))
+        & jnp.all(jnp.isfinite(next_obs))
+        & jnp.isfinite(transition_discount)
+        & jnp.isfinite(rho)
+    )
+    proposed_finite = (
+        jnp.all(jnp.isfinite(proposed_q_i))
+        & jnp.all(jnp.isfinite(new_traces_i))
+        & jnp.isfinite(proposed_avg_r_i)
+    )
+    new_q_i, new_traces_i, new_avg_r_i = jax.lax.cond(
+        inputs_valid & proposed_finite,
+        lambda: (proposed_q_i, new_traces_i, proposed_avg_r_i),
+        lambda: (q_i, traces_i, avg_r_i),
+    )
 
     n_opts = option_policies.average_rewards.shape[0]
     option_mask = jnp.arange(n_opts, dtype=jnp.int32) == option_idx

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -15,6 +15,8 @@ from alberta_framework.core.options import (
     STOMPSpecArrays,
     STOMPState,
     SubtaskSpec,
+    _differential_q_update,
+    _differential_semidp_q_update,
     load_stomp_state_with_migration,
     replace_dispatched_primitive_action,
     stomp_state_to_checkpoint_payload,
@@ -259,3 +261,53 @@ def test_primitive_only_stomp_has_typed_empty_option_state_and_base_only_updates
             n_primitive_actions=N_PRIMITIVE,
             option_planning_backups_per_step=1,
         )
+
+
+def test_differential_q_infinite_reward_does_not_poison_weights() -> None:
+    """Inf reward is 0*inf = NaN on silent features and unused actions."""
+    n_actions, dim = 2, 2
+    q = jnp.zeros((n_actions, dim), dtype=jnp.float32)
+    z = jnp.zeros((n_actions, dim), dtype=jnp.float32)
+    rbar = jnp.array(0.0, dtype=jnp.float32)
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    action = jnp.int32(0)
+    nxt = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    kw = dict(step_size=0.1, avg_reward_step_size=0.01, trace_decay=0.0, n_actions=n_actions)
+
+    new_q, new_z, new_rbar, _td = _differential_q_update(
+        q, z, rbar, obs, action, jnp.array(jnp.inf, dtype=jnp.float32), nxt, **kw
+    )
+    chex.assert_trees_all_close(new_q, q)
+    chex.assert_trees_all_close(new_z, z)
+    chex.assert_trees_all_close(new_rbar, rbar)
+
+    recovered_q, _, recovered_rbar, _ = _differential_q_update(
+        new_q, new_z, new_rbar, obs, action, jnp.array(1.0, dtype=jnp.float32), nxt, **kw
+    )
+    chex.assert_tree_all_finite(recovered_q)
+    chex.assert_tree_all_finite(recovered_rbar)
+
+
+def test_semidp_q_infinite_reward_does_not_poison_weights() -> None:
+    n_actions, dim = 2, 2
+    q = jnp.zeros((n_actions, dim), dtype=jnp.float32)
+    z = jnp.zeros((n_actions, dim), dtype=jnp.float32)
+    rbar = jnp.array(0.0, dtype=jnp.float32)
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    action = jnp.int32(0)
+    nxt = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    kw = dict(
+        step_size=0.1,
+        avg_reward_step_size=0.01,
+        trace_decay=0.0,
+        n_actions=n_actions,
+        baseline_mass=jnp.array(1.0, dtype=jnp.float32),
+        discount=jnp.array(1.0, dtype=jnp.float32),
+    )
+
+    new_q, new_z, new_rbar, _td = _differential_semidp_q_update(
+        q, z, rbar, obs, action, jnp.array(jnp.inf, dtype=jnp.float32), nxt, **kw
+    )
+    chex.assert_trees_all_close(new_q, q)
+    chex.assert_trees_all_close(new_z, z)
+    chex.assert_trees_all_close(new_rbar, rbar)


### PR DESCRIPTION
STOMP's differential Q helpers do `alpha * delta * z`. Inf reward against a silent feature is `0 * inf` = NaN, and unused actions get the same product on zero traces, so the whole Q table can go NaN.

Hold previous finite Q weights, traces, and rbar when the observation, reward, next observation, or proposed arrays are non-finite. Same guard on the semi-MDP helper and the intra-option policy update (including inf IS ratio).

Failing-test-first: inf reward wrote NaN into unused actions on main. `tests/test_options.py`: 15 passed.

Independent of #74 (average-reward Differential SARSA already had this contract).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)