### PR TITLE
Keep option value/duration TD from turning 0*inf into NaN

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -283,11 +283,24 @@ class OptionValueDurationLearner:
         updated_option_weights = (
             option_weights + step_sizes[:, None] * td_errors[:, None] * observation[None, :]
         )
-        new_state = state.replace(
+        # Inf reward * silent feature is 0*inf = NaN on the reward head.
+        # The duration head must keep learning. Genuine infs stay inf.
+        updated_option_weights = jnp.where(
+            jnp.isnan(updated_option_weights),
+            option_weights,
+            updated_option_weights,
+        )
+        proposed_state = state.replace(
             weights=state.weights.at[option_index].set(updated_option_weights),
             option_update_counts=state.option_update_counts.at[option_index].add(1),
             step_count=state.step_count + 1,
         )
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(continuation_discount)
+        )
+        new_state = jax.lax.cond(inputs_valid, lambda: proposed_state, lambda: state)
         return OptionValueDurationUpdateResult(
             state=new_state,
             predictions=predictions,

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 import pytest
 
 from alberta_framework.core.option_value_duration import (
+    DURATION_HEAD,
     OptionValueDurationConfig,
     OptionValueDurationLearner,
 )
@@ -165,3 +166,36 @@ def test_reward_rate_prediction_preserves_raw_duration_and_floors_only_score() -
         prediction.reward_rates,
         jnp.array([0.6, 8.0], dtype=jnp.float32),
     )
+
+
+def test_infinite_reward_on_zero_feature_does_not_poison_duration_head() -> None:
+    """Inf reward is 0*inf = NaN on a silent feature of the reward head.
+
+    The duration head's TD error stays finite. Map NaN products back to the
+    previous weight so that head can keep learning, and leave genuine infs.
+    """
+    learner = OptionValueDurationLearner(
+        1,
+        OptionValueDurationConfig(reward_step_size=0.1, duration_step_size=0.2),
+    )
+    state = learner.init(2)
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    nxt = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    option = jnp.array(0, dtype=jnp.int32)
+    discount = jnp.array(0.0, dtype=jnp.float32)
+
+    poisoned = learner.update(
+        state, obs, option, jnp.array(jnp.inf, dtype=jnp.float32), nxt, discount
+    )
+    assert not bool(jnp.any(jnp.isnan(poisoned.state.weights)))
+    chex.assert_tree_all_finite(poisoned.state.weights[0, DURATION_HEAD])
+    chex.assert_trees_all_close(
+        poisoned.state.weights[0, 0, 0],
+        state.weights[0, 0, 0],
+    )
+
+    recovered = learner.update(
+        poisoned.state, obs, option, jnp.array(1.0, dtype=jnp.float32), nxt, discount
+    )
+    assert not bool(jnp.any(jnp.isnan(recovered.state.weights)))
+    chex.assert_tree_all_finite(recovered.state.weights[0, DURATION_HEAD])


### PR DESCRIPTION
Each option has a reward head and a duration head that do `alpha * delta * x`. Inf reward makes the reward-head TD error inf. A silent feature is then `0 * inf` = NaN, and that channel stays poisoned. The duration head's error stays finite and should keep learning.

NaN products are replaced with the previous weight. Genuine infs stay inf. Non-finite observations or discounts hold the previous state.

Failing-test-first: inf reward wrote NaN into the silent reward-head feature on main; the duration head stayed finite. `tests/test_option_value_duration.py`: 5 passed.

Independent of #77 (STOMP Q helpers).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)