### PR TITLE
Refuse inf observations before cumulant discovery turns 0*inf into NaN

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -252,20 +252,31 @@ class CumulantDiscovery:
 
         # Predictor update (per-candidate semi-gradient TD step)
         # weights_i += alpha * td_i * obs
-        new_weights = state.weights + alpha * td[:, None] * observation[None, :]
-        new_biases = state.biases + alpha * td
-
-        # Utility EMA on squared surprise
-        new_utility = decay * state.utility + (1.0 - decay) * (td**2)
-        new_ages = state.ages + 1
-
-        return CumulantDiscoveryState(  # type: ignore[call-arg]
+        proposed_weights = state.weights + alpha * td[:, None] * observation[None, :]
+        proposed_biases = state.biases + alpha * td
+        proposed_utility = decay * state.utility + (1.0 - decay) * (td**2)
+        proposed_state = CumulantDiscoveryState(  # type: ignore[call-arg]
             projections=state.projections,
-            weights=new_weights,
-            biases=new_biases,
-            utility=new_utility,
-            ages=new_ages,
+            weights=proposed_weights,
+            biases=proposed_biases,
+            utility=proposed_utility,
+            ages=state.ages + 1,
             key=state.key,
+        )
+        # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
+        # alpha * nan * obs poisons every candidate. Hold the finite state.
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
+            jnp.isfinite(next_observation)
+        )
+        proposed_finite = (
+            jnp.all(jnp.isfinite(proposed_weights))
+            & jnp.all(jnp.isfinite(proposed_biases))
+            & jnp.all(jnp.isfinite(proposed_utility))
+        )
+        return jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: proposed_state,
+            lambda: state,
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -112,6 +112,25 @@ class TestStep:
         s2 = d.step(s0, jnp.array([0.0, 0.0]), jnp.array([2.0, 0.0]))
         assert float(s2.utility[0]) > 0.0
 
+    def test_infinite_next_obs_does_not_poison_predictors(self) -> None:
+        """Zero init V(s') is 0 @ inf = NaN, then alpha * nan * obs poisons all."""
+        d = CumulantDiscovery(raw_dim=2, n_candidates=3, predictor_step_size=0.1)
+        state = d.init(jr.key(0))
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.array([jnp.inf, 1.0], dtype=jnp.float32)
+
+        poisoned = d.step(state, obs, nxt)
+        chex.assert_trees_all_close(poisoned.weights, state.weights)
+        chex.assert_trees_all_close(poisoned.biases, state.biases)
+        chex.assert_trees_all_close(poisoned.utility, state.utility)
+        chex.assert_trees_all_close(poisoned.ages, state.ages)
+
+        recovered = d.step(poisoned, obs, jnp.array([1.0, 1.0], dtype=jnp.float32))
+        chex.assert_tree_all_finite(recovered.weights)
+        chex.assert_tree_all_finite(recovered.biases)
+        chex.assert_tree_all_finite(recovered.utility)
+        chex.assert_trees_all_close(recovered.ages, state.ages + 1)
+
     def test_predictor_reduces_td_error(self) -> None:
         d = CumulantDiscovery(
             raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0


### PR DESCRIPTION
Candidate predictors do `V(s') = w @ x'`. At zero init that is `0 @ inf` = NaN. The TD update `alpha * delta * x` then writes NaN into every candidate weight, bias, and surprise utility, so later finite observations cannot recover.

Hold the previous finite state when the observation, next observation, or proposed predictor arrays are non-finite.

Failing-test-first: inf next observation wrote NaN weights/utility on main. `tests/test_cumulant_discovery.py`: 19 passed.

Independent of #75 (off-policy TD predictors) and #78 (option value/duration).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)