### PR TITLE
Refuse inf rewards before OaK chord updates turn 0*inf into NaN

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -921,16 +921,27 @@ def update_keyboard_chord_learner(
         + (1.0 - config.baseline_decay) * reward_arr
     )
     advantage = reward_arr - state.reward_baseline
-    new_vector = (
+    proposed_vector = (
         state.chord_vector * (1.0 - config.step_size * config.l2_penalty)
         + config.step_size * advantage * chord_norm
     )
-    norm = jnp.linalg.norm(new_vector)
+    norm = jnp.linalg.norm(proposed_vector)
     scale = jnp.minimum(1.0, jnp.asarray(config.max_norm, dtype=jnp.float32) / (norm + 1.0e-8))
-    return KeyboardChordLearnerState(
-        chord_vector=new_vector * scale,
+    proposed_state = KeyboardChordLearnerState(
+        chord_vector=proposed_vector * scale,
         reward_baseline=baseline,
         step_count=state.step_count + 1,
+    )
+    # Inf reward * a zero chord coordinate is 0*inf = NaN, then the
+    # max-norm rescaling is nan/inf and the whole vector stays poisoned.
+    inputs_valid = jnp.all(jnp.isfinite(chord)) & jnp.isfinite(reward_arr)
+    proposed_finite = jnp.all(jnp.isfinite(proposed_state.chord_vector)) & jnp.isfinite(
+        proposed_state.reward_baseline
+    )
+    return jax.lax.cond(
+        inputs_valid & proposed_finite,
+        lambda: proposed_state,
+        lambda: state,
     )
 
 

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -493,6 +493,27 @@ def test_keyboard_chord_learner_max_norm_bounds_vector() -> None:
     assert float(jnp.linalg.norm(updated.chord_vector)) <= 0.750001
 
 
+def test_keyboard_chord_learner_infinite_reward_does_not_poison_vector() -> None:
+    """Inf advantage * a zero chord coordinate is 0*inf = NaN."""
+    cfg = KeyboardChordLearnerConfig(n_options=3, step_size=0.1, max_norm=10.0)
+    state = init_keyboard_chord_learner(cfg)
+    selected = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32)
+
+    poisoned = update_keyboard_chord_learner(
+        cfg, state, selected, jnp.array(jnp.inf, dtype=jnp.float32)
+    )
+    chex.assert_trees_all_close(poisoned.chord_vector, state.chord_vector)
+    chex.assert_trees_all_close(poisoned.reward_baseline, state.reward_baseline)
+    assert int(poisoned.step_count) == int(state.step_count)
+
+    recovered = update_keyboard_chord_learner(
+        cfg, poisoned, selected, jnp.array(1.0, dtype=jnp.float32)
+    )
+    chex.assert_tree_all_finite(recovered.chord_vector)
+    chex.assert_tree_all_finite(recovered.reward_baseline)
+    assert int(recovered.step_count) == int(state.step_count) + 1
+
+
 # ---------------------------------------------------------------------------
 # Smoke test
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The keyboard-chord bandit does `step_size * advantage * chord_norm`. Inf reward against a zero chord coordinate is `0 * inf` = NaN. The max-norm rescaling then becomes nan/inf and the whole vector stays poisoned, including the reward baseline.

Hold the previous finite chord and baseline when the selected chord, reward, or proposed arrays are non-finite.

Failing-test-first: inf reward wrote NaN into every chord coordinate on main. `tests/test_step11_production.py`: 41 passed.

Independent of #77 (STOMP Q) and #78 (option value/duration).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)