### PR TITLE
Refuse inf rewards before RLS reward model turns 0*inf into NaN

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -183,8 +183,21 @@ class RLSRewardModel:
             abs_error_ema=next_abs_error_ema,
             step_count=state.step_count + 1,
         )
+        # Inf reward * a silent feature's zero gain is 0*inf = NaN, and
+        # that channel stays poisoned. Hold the previous finite state.
+        inputs_valid = jnp.all(jnp.isfinite(x)) & jnp.isfinite(jnp.squeeze(target))
+        proposed_finite = (
+            jnp.all(jnp.isfinite(next_weights))
+            & jnp.all(jnp.isfinite(next_covariance))
+            & jnp.isfinite(next_abs_error_ema)
+        )
+        committed = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: next_state,
+            lambda: state,
+        )
         return RLSRewardModelUpdateResult(
-            state=next_state,
+            state=committed,
             prediction=prediction,
             error=error,
             gain=gain,

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -67,3 +67,23 @@ def test_rls_reward_model_rejects_invalid_config() -> None:
             pass
         else:
             raise AssertionError(f"expected ValueError for {config}")
+
+
+def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
+    """Inf reward * a silent feature's zero gain is 0*inf = NaN."""
+    model = RLSRewardModel(
+        RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0)
+    )
+    state = model.init()
+    features = jnp.array([0.0, 1.0], dtype=jnp.float32)
+
+    poisoned = model.update(state, features, jnp.array(jnp.inf, dtype=jnp.float32))
+    chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+    chex.assert_trees_all_close(poisoned.state.covariance, state.covariance)
+    assert int(poisoned.state.step_count) == int(state.step_count)
+
+    recovered = model.update(
+        poisoned.state, features, jnp.array(1.0, dtype=jnp.float32)
+    )
+    chex.assert_tree_all_finite(recovered.state.weights)
+    chex.assert_tree_all_finite(recovered.state.covariance)


### PR DESCRIPTION
Linear RLS does `w += gain * error`. Inf reward against a silent feature (zero gain on that channel) is `0 * inf` = NaN, and that weight stays poisoned after later finite rewards.

Hold the previous finite weights, covariance, and error EMA when the features, reward, or proposed arrays are non-finite.

Failing-test-first: inf reward wrote `[nan, inf]` weights on main. `tests/test_reward_model.py`: 4 passed.

Independent of the ObGD/TD apply-site PRs.

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)