### PR TITLE
Refuse inf observations before the behavior model turns 0*inf into NaN

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -528,8 +528,23 @@ class BehaviorModel:
             accuracy_ema=accuracy_ema,
             confidence_ema=confidence_ema,
         )
+        # Inf observation makes softmax NaN and logit_error * x = 0*inf = NaN
+        # on silent features. Hold the previous finite state.
+        inputs_valid = jnp.all(jnp.isfinite(obs))
+        proposed_finite = (
+            jnp.all(jnp.isfinite(new_state.weights))
+            & jnp.all(jnp.isfinite(new_state.bias))
+            & jnp.isfinite(new_state.nll_ema)
+            & jnp.isfinite(new_state.accuracy_ema)
+            & jnp.isfinite(new_state.confidence_ema)
+        )
+        committed = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: new_state,
+            lambda: state,
+        )
         return BehaviorModelUpdateResult(
-            state=new_state,
+            state=committed,
             logits=logits,
             probabilities=probabilities,
             action_probability=action_prob,

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -93,6 +93,27 @@ def test_init_predict_update_finite_and_shapes() -> None:
     assert float(result.loss) > 0.0
 
 
+def test_infinite_observation_does_not_poison_weights() -> None:
+    """Inf obs makes softmax NaN and logit_error * x = 0*inf on a silent feature."""
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    obs = jnp.array([0.0, jnp.inf], dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+
+    poisoned = model.update(state, obs, action)
+    chex.assert_trees_all_close(poisoned.state.weights, state.weights)
+    chex.assert_trees_all_close(poisoned.state.bias, state.bias)
+    assert int(poisoned.state.step_count) == int(state.step_count)
+
+    recovered = model.update(
+        poisoned.state,
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+        action,
+    )
+    chex.assert_tree_all_finite(recovered.state.weights)
+    chex.assert_tree_all_finite(recovered.state.bias)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
The linear behavior model does `logit_error * x`. Inf observation makes softmax NaN, then a silent feature is `0 * inf` = NaN, and every weight, bias, and NLL EMA stays poisoned.

Hold the previous finite state when the observation or proposed weights/diagnostics are non-finite.

Failing-test-first: inf observation wrote NaN into every weight on main. `tests/test_behavior_model.py`: 20 passed.

Independent of #81 (RLS reward model).

No Slop run receipt: this session is Cursor Grok, not Codex `gpt-5.6-sol` or Claude Code `claude-fable-5`.

Made with [Cursor](https://cursor.com)