### PR TITLE
Hold True Online TD finite on inf reward times a silent feature

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -28,7 +28,7 @@ import chex
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import Float
+from jaxtyping import Bool, Float
 
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.normalizers import (
@@ -1752,6 +1752,11 @@ class TrueOnlineTDUpdateResult:
 
     ``metrics`` columns: squared TD error, TD error, mean absolute
     eligibility trace, and the stored ``v_old`` bootstrap value.
+
+    Rejected updates (non-finite input or proposed state) keep the previous
+    learner state and report a zero TD-error diagnostic. ``update_applied``
+    is False on that path so callers do not treat the sentinel as a real
+    TD error.
     """
 
     state: TrueOnlineTDState
@@ -1759,6 +1764,7 @@ class TrueOnlineTDUpdateResult:
     next_prediction: Prediction
     td_error: Float[Array, ""]
     metrics: Float[Array, " 4"]
+    update_applied: Bool[Array, ""]
 
 
 class TrueOnlineTDLearner:
@@ -1864,15 +1870,17 @@ class TrueOnlineTDLearner:
             & jnp.isfinite(proposed_state.bias_eligibility_trace)
             & jnp.isfinite(proposed_state.v_old)
         )
+        accepted = inputs_valid & proposed_finite
         new_state = jax.lax.cond(
-            inputs_valid & proposed_finite,
+            accepted,
             lambda: proposed_state,
             lambda: state,
         )
+        reported_td_error = jnp.where(accepted, td_error, jnp.zeros_like(td_error))
         metrics = jnp.array(
             [
-                td_error**2,
-                td_error,
+                reported_td_error**2,
+                reported_td_error,
                 jnp.mean(jnp.abs(new_state.eligibility_traces)),
                 new_state.v_old,
             ],
@@ -1882,8 +1890,9 @@ class TrueOnlineTDLearner:
             state=new_state,
             prediction=jnp.atleast_1d(value),
             next_prediction=jnp.atleast_1d(next_value),
-            td_error=jnp.atleast_1d(td_error),
+            td_error=jnp.atleast_1d(reported_td_error),
             metrics=metrics,
+            update_applied=accepted,
         )
 
 

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -1839,7 +1839,7 @@ class TrueOnlineTDLearner:
         stored_traces = jnp.where(terminal, jnp.zeros_like(new_traces), new_traces)
         stored_bias_trace = jnp.where(terminal, 0.0, new_bias_trace)
         new_v_old = jnp.where(terminal, 0.0, next_value)
-        new_state = TrueOnlineTDState(
+        proposed_state = TrueOnlineTDState(
             weights=new_weights,
             bias=new_bias,
             eligibility_traces=stored_traces,
@@ -1849,12 +1849,32 @@ class TrueOnlineTDLearner:
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
+        # Inf reward * a silent feature is 0*inf = NaN in the Dutch-trace
+        # update. Hold the previous finite state.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation))
+            & jnp.isfinite(jnp.squeeze(reward))
+            & jnp.all(jnp.isfinite(next_observation))
+            & jnp.isfinite(gamma_scalar)
+        )
+        proposed_finite = (
+            jnp.all(jnp.isfinite(proposed_state.weights))
+            & jnp.isfinite(proposed_state.bias)
+            & jnp.all(jnp.isfinite(proposed_state.eligibility_traces))
+            & jnp.isfinite(proposed_state.bias_eligibility_trace)
+            & jnp.isfinite(proposed_state.v_old)
+        )
+        new_state = jax.lax.cond(
+            inputs_valid & proposed_finite,
+            lambda: proposed_state,
+            lambda: state,
+        )
         metrics = jnp.array(
             [
                 td_error**2,
                 td_error,
-                jnp.mean(jnp.abs(new_traces)),
-                new_v_old,
+                jnp.mean(jnp.abs(new_state.eligibility_traces)),
+                new_state.v_old,
             ],
             dtype=jnp.float32,
         )

--- a/tests/test_true_online_td.py
+++ b/tests/test_true_online_td.py
@@ -72,6 +72,11 @@ class TestInit:
         chex.assert_trees_all_close(result.state.weights, state.weights)
         chex.assert_trees_all_close(result.state.eligibility_traces, state.eligibility_traces)
         chex.assert_trees_all_close(result.state.v_old, state.v_old)
+        assert bool(jnp.all(jnp.isfinite(result.td_error)))
+        assert bool(jnp.all(jnp.isfinite(result.metrics)))
+        chex.assert_trees_all_close(result.td_error, jnp.array([0.0], dtype=jnp.float32))
+        chex.assert_trees_all_close(result.metrics[:2], jnp.zeros(2, dtype=jnp.float32))
+        assert not bool(result.update_applied)
 
 
 # =============================================================================

--- a/tests/test_true_online_td.py
+++ b/tests/test_true_online_td.py
@@ -49,6 +49,30 @@ class TestInit:
         pred = learner.predict(state, jnp.array([1.0, 2.0, 3.0]))
         chex.assert_trees_all_close(pred, jnp.array([0.0]))
 
+    def test_inf_reward_silent_feature_holds_finite_state(self) -> None:
+        """Inf reward * a silent feature is 0*inf = NaN in the Dutch-trace update.
+
+        Fail-closed: keep the previous finite weights, traces, and v_old.
+        """
+        learner = TrueOnlineTDLearner(step_size=0.1, trace_decay=0.5)
+        state = learner.init(2)
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.zeros(2, dtype=jnp.float32)
+        result = learner.update(
+            state,
+            obs,
+            jnp.array(jnp.inf, dtype=jnp.float32),
+            nxt,
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        assert bool(jnp.all(jnp.isfinite(result.state.weights)))
+        assert bool(jnp.isfinite(result.state.bias))
+        assert bool(jnp.all(jnp.isfinite(result.state.eligibility_traces)))
+        assert bool(jnp.isfinite(result.state.v_old))
+        chex.assert_trees_all_close(result.state.weights, state.weights)
+        chex.assert_trees_all_close(result.state.eligibility_traces, state.eligibility_traces)
+        chex.assert_trees_all_close(result.state.v_old, state.v_old)
+
 
 # =============================================================================
 # TD(0) equivalence to supervised LMS for one-step gamma=0 supervision


### PR DESCRIPTION
## Summary
- True Online TD(lambda) Dutch-trace updates multiply `update_scale` by traces and `alpha * correction` by the observation. Inf reward with a silent feature is `0 * inf = NaN`, which writes NaN into one weight while the other goes to inf.
- Fail-closed: if the observation, reward, next observation, gamma, or proposed state is non-finite, keep the previous finite weights, traces, and `v_old`.
- This is the same hole as LMS / off-policy TD / options, in `TrueOnlineTDLearner` only. It does not change the MLP ObGD apply site on #63; the hunks do not overlap.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_true_online_td.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/learners.py tests/test_true_online_td.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)