### PR TITLE
Hold CBP utility finite on inf activation times a silent gradient

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -283,7 +283,12 @@ def update_utility(
     new_ages: list[Array] = []
     for i in range(n_layers):
         contribution = jnp.abs(activations[i] * activation_grads[i])
+        # Inf activation * a silent gradient is 0*inf = NaN. Hold the
+        # previous finite utility so replacement does not treat NaN as
+        # the lowest-utility unit.
+        contribution_finite = jnp.isfinite(contribution)
         u_new = decay * cbp_state.utilities[i] + (1.0 - decay) * contribution
+        u_new = jnp.where(contribution_finite, u_new, cbp_state.utilities[i])
         new_utilities.append(u_new)
         new_ages.append(cbp_state.ages[i] + 1)
 
@@ -305,8 +310,8 @@ def _select_replacement_index(
     exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
     ``False``.
 
-    Implementation: replace the utility of immature units with ``+inf``
-    before taking ``argmin`` so they are never chosen.
+    Implementation: replace the utility of immature or non-finite units
+    with ``+inf`` before taking ``argmin`` so they are never chosen.
 
     Args:
         utility: Per-unit utility array, shape ``(num_units,)``.
@@ -318,8 +323,9 @@ def _select_replacement_index(
         unit (or ``-1``) and ``has_candidate`` is a boolean scalar.
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
-    masked_utility = jnp.where(mature, utility, jnp.inf)
-    has_candidate = jnp.any(mature)
+    eligible = mature & jnp.isfinite(utility)
+    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
     return selected.astype(jnp.int32), has_candidate

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -17,6 +17,7 @@ from alberta_framework.core.continual_backprop import (
     ContinualBackpropConfig,
     ContinualBackpropState,
     ContinualBackpropTracker,
+    _select_replacement_index,
     init_cbp_state,
     maybe_replace_units,
     run_cbp_learning_loop,
@@ -128,6 +129,27 @@ class TestUtilityUpdate:
         assert int(state.ages[0][0]) == 10
         assert int(state.ages[0][1]) == 10
         assert int(state.ages[0][2]) == 10
+
+    def test_inf_activation_silent_grad_holds_finite_utility(self) -> None:
+        """Inf activation * a silent gradient is 0*inf = NaN utility.
+
+        Fail-closed: keep the previous finite EMA for that unit so
+        replacement does not treat NaN as the lowest-utility mature unit.
+        """
+        cbp_state = ContinualBackpropState(  # type: ignore[call-arg]
+            utilities=(jnp.array([0.9, 0.1], dtype=jnp.float32),),
+            ages=(jnp.array([100, 100], dtype=jnp.int32),),
+            replacement_accumulators=jnp.zeros(1, dtype=jnp.float32),
+            rng_key=jr.key(0),
+        )
+        activations = (jnp.array([jnp.inf, 1.0], dtype=jnp.float32),)
+        grads = (jnp.array([0.0, 0.2], dtype=jnp.float32),)
+        new = update_utility(cbp_state, activations, grads, 0.9)
+        assert bool(jnp.all(jnp.isfinite(new.utilities[0])))
+        chex.assert_trees_all_close(new.utilities[0][0], cbp_state.utilities[0][0])
+        idx, has = _select_replacement_index(new.utilities[0], new.ages[0], 10)
+        assert bool(has)
+        assert int(idx) == 1
 
 
 class TestWrapperUtilityGradients:


### PR DESCRIPTION
## Summary
- Continual Backprop utility is `|activation * grad|`. Inf activation with a silent gradient is `0 * inf = NaN`. `argmin` then treats that unit as the lowest-utility mature unit and replaces the wrong weights.
- Fail-closed: keep the previous finite EMA when the contribution is non-finite. Replacement also ignores non-finite utilities.
- Ages still increment. Finite units keep learning.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_continual_backprop.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)