### PR TITLE
Score future-utility 0 on inf error times a silent feature

### DIFF
--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -12,6 +12,15 @@ from jax import Array
 from jaxtyping import Float
 
 
+def _finite_or_zero(value: Array) -> Array:
+    """Replace non-finite entries with zero.
+
+    Inf error * a silent feature is ``0 * inf = NaN`` in the LMS
+    counterfactual. Scoring that as usefulness would poison replacement.
+    """
+    return jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value))
+
+
 def trace_decay_from_half_life(half_life: float | Array) -> Float[Array, ""]:
     """Convert an eligibility half-life in steps to a trace decay.
 
@@ -66,7 +75,7 @@ def one_step_output_loss_reduction(
         / jnp.maximum(count, 1.0)
     )
     reduction = errors[:, None] * delta_prediction - 0.5 * delta_prediction**2
-    reduction = jnp.maximum(reduction, 0.0)
+    reduction = jnp.maximum(_finite_or_zero(reduction), 0.0)
     return jnp.where(active_mask[:, None], reduction, 0.0)
 
 
@@ -110,9 +119,9 @@ def contribution_trace_output_loss_reduction(
     step_size = jnp.asarray(step_size_output, dtype=jnp.float32)
     count = jnp.asarray(active_count, dtype=jnp.float32)
 
-    active_errors = jnp.where(active_mask, errors, 0.0)
+    active_errors = _finite_or_zero(jnp.where(active_mask, errors, 0.0))
     decayed_contribution = decay * contribution_trace
-    new_contribution_trace = decayed_contribution + (
+    new_contribution_trace = decayed_contribution + _finite_or_zero(
         active_errors[:, None] * feature_values[None, :]
     )
     new_contribution_trace = jnp.where(
@@ -120,9 +129,11 @@ def contribution_trace_output_loss_reduction(
         new_contribution_trace,
         decayed_contribution,
     )
-    new_feature_energy_trace = decay * feature_energy_trace + feature_values**2
+    new_feature_energy_trace = decay * feature_energy_trace + _finite_or_zero(
+        feature_values**2
+    )
 
-    delta_weight = (
+    delta_weight = _finite_or_zero(
         step_size
         * active_errors[:, None]
         * feature_values[None, :]
@@ -132,7 +143,7 @@ def contribution_trace_output_loss_reduction(
         delta_weight * new_contribution_trace
         - 0.5 * (delta_weight**2) * new_feature_energy_trace[None, :]
     )
-    reduction = jnp.maximum(reduction, 0.0)
+    reduction = jnp.maximum(_finite_or_zero(reduction), 0.0)
     return (
         jnp.where(active_mask[:, None], reduction, 0.0),
         new_contribution_trace,
@@ -192,25 +203,29 @@ def trace_output_loss_reduction(
     step_size = jnp.asarray(step_size_output, dtype=jnp.float32)
     count = jnp.asarray(active_count, dtype=jnp.float32)
 
-    active_errors = jnp.where(active_mask, errors, 0.0)
+    active_errors = _finite_or_zero(jnp.where(active_mask, errors, 0.0))
     new_error_trace = decay * error_trace + active_errors
     new_error_trace = jnp.where(active_mask, new_error_trace, decay * error_trace)
-    new_feature_trace = decay * feature_trace + feature_values
-    new_feature_energy_trace = decay * feature_energy_trace + feature_values**2
+    new_feature_trace = decay * feature_trace + _finite_or_zero(feature_values)
+    new_feature_energy_trace = decay * feature_energy_trace + _finite_or_zero(
+        feature_values**2
+    )
 
-    delta_weight = (
+    delta_weight = _finite_or_zero(
         step_size
         * active_errors[:, None]
         * feature_values[None, :]
         / jnp.maximum(count, 1.0)
     )
-    recurring_error_feature = new_error_trace[:, None] * new_feature_trace[None, :]
+    recurring_error_feature = _finite_or_zero(
+        new_error_trace[:, None] * new_feature_trace[None, :]
+    )
     recurring_feature_energy = new_feature_energy_trace[None, :]
     reduction = (
         delta_weight * recurring_error_feature
         - 0.5 * (delta_weight**2) * recurring_feature_energy
     )
-    reduction = jnp.maximum(reduction, 0.0)
+    reduction = jnp.maximum(_finite_or_zero(reduction), 0.0)
     return (
         jnp.where(active_mask[:, None], reduction, 0.0),
         new_error_trace,

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -203,3 +203,39 @@ def test_compositional_future_utility_metrics_remain_finite_with_variants() -> N
     chex.assert_tree_all_finite(result.metrics)
     chex.assert_tree_all_finite(result.state.utilities)
     chex.assert_tree_all_finite(result.state.candidate_utilities)
+
+
+def test_inf_error_silent_feature_scores_zero_not_nan() -> None:
+    """Inf error * a silent feature is 0*inf = NaN in the LMS counterfactual.
+
+    Fail-closed: score that pair as zero usefulness instead of poisoning
+    replacement with NaN.
+    """
+    errors = jnp.array([jnp.inf], dtype=jnp.float32)
+    features = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    active_mask = jnp.array([True])
+    one_step = one_step_output_loss_reduction(
+        errors=errors,
+        feature_values=features,
+        active_mask=active_mask,
+        step_size_output=0.1,
+        active_count=1.0,
+    )
+    assert bool(jnp.all(jnp.isfinite(one_step)))
+    chex.assert_trees_all_close(one_step, jnp.zeros((1, 2), dtype=jnp.float32))
+
+    traced, contribution_trace, energy_trace = contribution_trace_output_loss_reduction(
+        errors=errors,
+        feature_values=features,
+        active_mask=active_mask,
+        step_size_output=0.1,
+        active_count=1.0,
+        contribution_trace=jnp.zeros((1, 2), dtype=jnp.float32),
+        feature_energy_trace=jnp.zeros(2, dtype=jnp.float32),
+        trace_decay=0.5,
+    )
+    assert bool(jnp.all(jnp.isfinite(traced)))
+    assert bool(jnp.all(jnp.isfinite(contribution_trace)))
+    assert bool(jnp.all(jnp.isfinite(energy_trace)))
+    chex.assert_trees_all_close(traced, jnp.zeros((1, 2), dtype=jnp.float32))
+


### PR DESCRIPTION
## Summary
- Future-utility LMS counterfactuals multiply error by feature value (and by feature squared). Inf error with a silent feature is `0 * inf = NaN`, so replacement can treat a dead coordinate as useful.
- Fail-closed: non-finite reductions and trace increments become zero. Finite features keep their usual scores.
- This is the estimator used by feature discovery. It does not change the ObGD apply sites on #62.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_future_utility.py tests/test_feature_discovery.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/future_utility.py tests/test_future_utility.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)