### PR TITLE
Hold normalizer statistics when inf observation is inf-inf

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -366,7 +366,15 @@ class Normalizer[
             Normalized observation
         """
         std = jnp.sqrt(state.var)
-        return (observation - state.mean) / (std + self._epsilon)
+        normalized = (observation - state.mean) / (std + self._epsilon)
+        # Inf observation minus an inf mean is inf-inf = NaN. Do not
+        # emit non-finite coordinates; keep zeros so downstream learners
+        # are not poisoned when the update is refused.
+        return jnp.where(
+            jnp.isfinite(observation) & jnp.isfinite(normalized),
+            normalized,
+            jnp.zeros_like(normalized),
+        )
 
     def update_only(
         self,
@@ -473,6 +481,8 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
             Tuple of (normalized_observation, new_state)
         """
         status = self.counter_status(state)
+        observation_valid = jnp.all(jnp.isfinite(observation))
+        update_available = status.update_available & observation_valid
 
         def accepted(_: None) -> tuple[Array, EMANormalizerState]:
             new_words, ignored_capacity = _checked_lifetime_words_increment(
@@ -502,7 +512,7 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
             return self.normalize_only(state, observation), state
 
         normalized, new_state = jax.lax.cond(
-            status.update_available,
+            update_available,
             accepted,
             refused,
             operand=None,
@@ -515,7 +525,7 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
             counter_valid=status.counter_valid,
             lifetime_capacity_available=status.lifetime_capacity_available,
             estimator_capacity_available=status.estimator_capacity_available,
-            update_applied=status.update_available,
+            update_applied=update_available,
         )
 
 
@@ -583,6 +593,8 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
             Tuple of (normalized_observation, new_state)
         """
         status = self.counter_status(state)
+        observation_valid = jnp.all(jnp.isfinite(observation))
+        update_available = status.update_available & observation_valid
 
         def accepted(_: None) -> tuple[Array, WelfordNormalizerState]:
             new_words, ignored_capacity = _checked_lifetime_words_increment(
@@ -612,7 +624,7 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
             return self.normalize_only(state, observation), state
 
         normalized, new_state = jax.lax.cond(
-            status.update_available,
+            update_available,
             accepted,
             refused,
             operand=None,
@@ -625,7 +637,7 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
             counter_valid=status.counter_valid,
             lifetime_capacity_available=status.lifetime_capacity_available,
             estimator_capacity_available=status.estimator_capacity_available,
-            update_applied=status.update_available,
+            update_applied=update_available,
         )
 
 
@@ -685,6 +697,8 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
     ) -> NormalizerUpdateResult:
         """Normalize and conditionally commit BatchNorm-style moments."""
         status = self.counter_status(state)
+        observation_valid = jnp.all(jnp.isfinite(observation))
+        update_available = status.update_available & observation_valid
 
         def accepted(_: None) -> tuple[Array, StreamingBatchNormalizerState]:
             new_words, ignored_capacity = _checked_lifetime_words_increment(
@@ -716,7 +730,7 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
             return self.normalize_only(state, observation), state
 
         normalized, new_state = jax.lax.cond(
-            status.update_available,
+            update_available,
             accepted,
             refused,
             operand=None,
@@ -729,7 +743,7 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
             counter_valid=status.counter_valid,
             lifetime_capacity_available=status.lifetime_capacity_available,
             estimator_capacity_available=status.estimator_capacity_available,
-            update_applied=status.update_available,
+            update_applied=update_available,
         )
 
 

--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -367,11 +367,10 @@ class Normalizer[
         """
         std = jnp.sqrt(state.var)
         normalized = (observation - state.mean) / (std + self._epsilon)
-        # Inf observation minus an inf mean is inf-inf = NaN. Do not
-        # emit non-finite coordinates; keep zeros so downstream learners
-        # are not poisoned when the update is refused.
+        # Inf observation minus an inf mean is inf-inf = NaN. Zero only
+        # those coordinates. Finite-input overflow must stay visible.
         return jnp.where(
-            jnp.isfinite(observation) & jnp.isfinite(normalized),
+            jnp.isfinite(observation),
             normalized,
             jnp.zeros_like(normalized),
         )

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -306,3 +306,21 @@ class TestNormalizerABC:
         assert bool(jnp.all(jnp.isfinite(recovered.var)))
         assert int(recovered.sample_count) == 1
 
+    @pytest.mark.parametrize(
+        "normalizer",
+        [EMANormalizer(), WelfordNormalizer(), StreamingBatchNormalizer()],
+        ids=["EMA", "Welford", "StreamingBatch"],
+    )
+    def test_finite_overflow_is_not_rewritten_to_zero(self, normalizer) -> None:
+        """Finite observation minus a finite opposite-max mean can overflow.
+
+        That is a real arithmetic failure. Do not hide it as a zero feature.
+        """
+        state = normalizer.init(1)
+        max_f32 = jnp.finfo(jnp.float32).max
+        state = state.replace(mean=jnp.array([-max_f32], dtype=jnp.float32))
+        out = normalizer.normalize_only(state, jnp.array([max_f32], dtype=jnp.float32))
+        assert bool(jnp.isfinite(jnp.array([max_f32])))
+        assert not bool(jnp.isfinite(out[0]))
+        assert float(out[0]) != 0.0
+

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -277,3 +277,32 @@ class TestNormalizerABC:
         state = normalizer.init(len(sample_observation))
         new_state = normalizer.update_only(state, sample_observation)
         assert new_state.sample_count == 1.0
+
+    @pytest.mark.parametrize(
+        "normalizer",
+        [EMANormalizer(), WelfordNormalizer(), StreamingBatchNormalizer()],
+        ids=["EMA", "Welford", "StreamingBatch"],
+    )
+    def test_inf_observation_holds_finite_statistics(self, normalizer) -> None:
+        """Inf observation minus an inf mean is inf-inf = NaN.
+
+        Fail-closed: skip the statistics update and keep the previous finite
+        mean/variance so later finite samples are not poisoned.
+        """
+        state = normalizer.init(2)
+        inf_obs = jnp.array([jnp.inf, 1.0], dtype=jnp.float32)
+        out, held = normalizer.normalize(state, inf_obs)
+        assert bool(jnp.all(jnp.isfinite(out)))
+        assert bool(jnp.all(jnp.isfinite(held.mean)))
+        assert bool(jnp.all(jnp.isfinite(held.var)))
+        chex.assert_trees_all_close(held.mean, state.mean)
+        chex.assert_trees_all_close(held.var, state.var)
+        assert int(held.sample_count) == int(state.sample_count)
+
+        finite_obs = jnp.array([0.0, 2.0], dtype=jnp.float32)
+        out2, recovered = normalizer.normalize(held, finite_obs)
+        assert bool(jnp.all(jnp.isfinite(out2)))
+        assert bool(jnp.all(jnp.isfinite(recovered.mean)))
+        assert bool(jnp.all(jnp.isfinite(recovered.var)))
+        assert int(recovered.sample_count) == 1
+


### PR DESCRIPTION
## Summary
- EMA, Welford, and streaming BatchNorm all do `observation - mean`. Inf observation becomes an inf mean, then the next `inf - inf` is NaN variance/mean that never recovers.
- Fail-closed: if any coordinate is non-finite, skip the statistics update. `normalize_only` also emits zero for non-finite coordinates instead of NaN.
- Later finite samples keep learning from the previous finite mean and variance.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_normalizers.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/normalizers.py tests/test_normalizers.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)