### PR TITLE
Hold temporal-context EMA when inf observation is inf-inf

### DIFF
--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -127,13 +127,14 @@ class TemporalContextFeaturizer:
         """Return current causal context features without advancing state."""
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
+        safe_obs = jnp.where(jnp.isfinite(obs), obs, jnp.zeros_like(obs))
         blocks = []
         if cfg.include_raw:
-            blocks.append(obs)
+            blocks.append(safe_obs)
         if cfg.include_ema:
             blocks.append(state.observation_ema)
         if cfg.include_delta:
-            blocks.append(obs - state.observation_ema)
+            blocks.append(safe_obs - state.observation_ema)
         if cfg.periods:
             step = state.step_count.astype(jnp.float32)
             periods = jnp.asarray(cfg.periods, dtype=jnp.float32)
@@ -141,7 +142,7 @@ class TemporalContextFeaturizer:
             phase = jnp.ravel(jnp.stack([jnp.sin(angles), jnp.cos(angles)], axis=1))
             blocks.append(phase)
             if cfg.include_phase_products:
-                blocks.append(jnp.ravel(phase[:, None] * obs[None, :]))
+                blocks.append(jnp.ravel(phase[:, None] * safe_obs[None, :]))
         return jnp.concatenate(blocks, axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -153,9 +154,15 @@ class TemporalContextFeaturizer:
         """Advance the context state after observing one input."""
         decay = jnp.asarray(self._config.ema_decay, dtype=jnp.float32)
         obs = jnp.asarray(observation, dtype=jnp.float32)
-        return TemporalContextState(
+        observation_valid = jnp.all(jnp.isfinite(obs))
+        proposed = TemporalContextState(
             observation_ema=decay * state.observation_ema + (1.0 - decay) * obs,
             step_count=state.step_count + 1,
+        )
+        return jax.lax.cond(
+            observation_valid,
+            lambda: proposed,
+            lambda: state,
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_temporal_context.py
+++ b/tests/test_temporal_context.py
@@ -74,3 +74,26 @@ def test_temporal_context_array_transform_is_jittable() -> None:
     chex.assert_shape(features, (2, config.output_dim()))
     assert int(state.step_count) == 2
     chex.assert_tree_all_finite(features)
+
+
+def test_inf_observation_holds_finite_ema() -> None:
+    """Inf observation minus an inf EMA is inf-inf = NaN in the delta block.
+
+    Fail-closed: skip the EMA update and emit zeros for non-finite raw
+    coordinates so later finite samples are not poisoned.
+    """
+    config = TemporalContextConfig(input_dim=2, ema_decay=0.5, periods=())
+    featurizer = TemporalContextFeaturizer(config)
+    state = featurizer.init()
+    inf_obs = jnp.array([jnp.inf, 1.0], dtype=jnp.float32)
+    held, features = featurizer.step(state, inf_obs)
+    assert bool(jnp.all(jnp.isfinite(features)))
+    assert bool(jnp.all(jnp.isfinite(held.observation_ema)))
+    chex.assert_trees_all_close(held.observation_ema, state.observation_ema)
+    assert int(held.step_count) == int(state.step_count)
+
+    finite_obs = jnp.array([0.0, 2.0], dtype=jnp.float32)
+    recovered, recovered_features = featurizer.step(held, finite_obs)
+    assert bool(jnp.all(jnp.isfinite(recovered_features)))
+    assert bool(jnp.all(jnp.isfinite(recovered.observation_ema)))
+    assert int(recovered.step_count) == 1


### PR DESCRIPTION
## Summary
- Temporal context features include `observation - EMA`. A second inf observation is `inf - inf = NaN` in the delta block, and the inf EMA never recovers.
- Fail-closed: skip the EMA and step-count update when any coordinate is non-finite. Raw, delta, and phase-product blocks use zeros for those coordinates so the feature vector stays finite.
- Later finite samples keep learning from the previous finite EMA.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_temporal_context.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/temporal_context.py tests/test_temporal_context.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)