### PR TITLE
Hold history-feature traces when inf observation would poison them

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -186,16 +186,20 @@ class HistoryFeatureExtractor:
         """
         # Select tracked channels
         channel_indices = jnp.asarray(self._channels, dtype=jnp.int32)
-        obs_tracked = observation[channel_indices]  # shape (n_channels,)
+        observation = jnp.asarray(observation, dtype=jnp.float32)
+        observation_valid = jnp.all(jnp.isfinite(observation))
+        safe_observation = jnp.where(
+            jnp.isfinite(observation), observation, jnp.zeros_like(observation)
+        )
+        obs_tracked = observation[channel_indices]
 
-        # EMA decay per trace row
         decay = jnp.asarray(self._decay_rates, dtype=jnp.float32)[:, None]
-        new_traces = decay * state.traces + (1.0 - decay) * obs_tracked[None, :]
+        proposed_traces = decay * state.traces + (1.0 - decay) * obs_tracked[None, :]
+        new_traces = jnp.where(observation_valid, proposed_traces, state.traces)
 
-        # Flatten and concatenate
         flat_traces = new_traces.reshape(-1)
         if self._include_raw:
-            augmented = jnp.concatenate([observation, flat_traces])
+            augmented = jnp.concatenate([safe_observation, flat_traces])
         else:
             augmented = flat_traces
 

--- a/tests/test_history_features.py
+++ b/tests/test_history_features.py
@@ -178,3 +178,24 @@ class TestIntegration:
 
         chex.assert_tree_all_finite(l_state.weights)
         chex.assert_tree_all_finite(h_state.traces)
+
+
+def test_inf_observation_holds_finite_traces() -> None:
+    """Inf observation writes inf traces that never recover on later finite steps.
+
+    Fail-closed: skip the trace update and emit zeros for non-finite raw
+    coordinates.
+    """
+    extractor = HistoryFeatureExtractor(raw_dim=2, decay_rates=(0.5, 0.9))
+    state = extractor.init()
+    inf_obs = jnp.array([jnp.inf, 1.0], dtype=jnp.float32)
+    aug, held = extractor.step(state, inf_obs)
+    assert bool(jnp.all(jnp.isfinite(aug)))
+    assert bool(jnp.all(jnp.isfinite(held.traces)))
+    chex.assert_trees_all_close(held.traces, state.traces)
+
+    finite_obs = jnp.zeros(2, dtype=jnp.float32)
+    aug2, recovered = extractor.step(held, finite_obs)
+    assert bool(jnp.all(jnp.isfinite(aug2)))
+    assert bool(jnp.all(jnp.isfinite(recovered.traces)))
+


### PR DESCRIPTION
## Summary
- History traces are an EMA of selected observation channels. Inf observation writes inf traces that never recover, so later finite samples still emit inf features.
- Fail-closed: skip the trace update when any coordinate is non-finite. The raw prefix uses zeros for those coordinates so the augmented vector stays finite.
- Later finite samples keep learning from the previous finite traces.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_history_features.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/history_features.py tests/test_history_features.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)