### PR TITLE
Keep associative-memory utility finite past inf-inf cross-entropy

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -221,9 +221,14 @@ def _masked_softmax(logits: Array, mask: Array) -> Array:
 
 def _cross_entropy_from_logits(logits: Array, label: Array) -> Array:
     safe_label = jnp.clip(label.astype(jnp.int32), 0, logits.shape[0] - 1)
+    logits_finite = jnp.all(jnp.isfinite(logits))
     shifted = logits - jnp.max(logits)
     log_z = jnp.log(jnp.sum(jnp.exp(shifted))) + jnp.max(logits)
-    return log_z - logits[safe_label]
+    loss = log_z - logits[safe_label]
+    # Inf logits are inf-inf = NaN in the log-sum-exp. Report uniform
+    # loss instead of poisoning utility and replacement.
+    uniform = jnp.log(jnp.asarray(logits.shape[0], dtype=jnp.float32))
+    return jnp.where(logits_finite & jnp.isfinite(loss), loss, uniform)
 
 
 class AssociativeMemoryLearner:
@@ -499,7 +504,8 @@ class AssociativeMemoryLearner:
         empty = (state.counts <= 0.0) & eligible
         has_empty = jnp.any(empty)
         empty_slot = jnp.argmax(empty.astype(jnp.int32))
-        utility_score = jnp.where(eligible & (~empty), state.utility, jnp.inf)
+        occupied = eligible & (~empty) & jnp.isfinite(state.utility)
+        utility_score = jnp.where(occupied, state.utility, jnp.inf)
         low_utility_slot = jnp.argmin(utility_score)
         return jnp.where(has_empty, empty_slot, low_utility_slot), has_empty
 
@@ -661,6 +667,9 @@ class AssociativeMemoryLearner:
             # caps how deeply a row can saturate and keeps the number of
             # opposing-sign updates needed to recover bounded.
             new_utility = jnp.clip(new_utility, -8.0, 8.0)
+            new_utility = jnp.where(
+                jnp.isfinite(new_utility), new_utility, old_utility
+            )
             new_row = old_row * self._config.retention
             new_row = new_row.at[label].add(self._config.write_lr)
             active_bool = active > 0

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -9,6 +9,7 @@ import pytest
 from alberta_framework.core.associative_memory import (
     AssociativeMemoryConfig,
     AssociativeMemoryLearner,
+    _cross_entropy_from_logits,
     run_associative_memory_arrays,
 )
 from alberta_framework.steps.step2 import (
@@ -245,3 +246,40 @@ def test_step2_associative_facade_smoke_and_roundtrip() -> None:
     assert result.finite
     assert result.metrics_shape == (64, 8)
     assert result.final_window_nll < result.initial_window_nll
+
+
+def test_inf_logits_cross_entropy_is_finite_uniform() -> None:
+    """Inf logits are inf-inf = NaN in the log-sum-exp.
+
+    Fail-closed: report uniform loss instead of poisoning utility.
+    """
+    loss = _cross_entropy_from_logits(
+        jnp.array([jnp.inf, 0.0, 0.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+    )
+    assert bool(jnp.isfinite(loss))
+    assert float(loss) == pytest.approx(math.log(3), abs=1e-5)
+
+
+def test_nan_utility_is_not_selected_as_lowest() -> None:
+    """argmin treats NaN as the lowest occupied slot.
+
+    Fail-closed: ignore non-finite utilities so a finite low-utility row
+    is replaced instead.
+    """
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(
+            vocab_size=5,
+            block_size=4,
+            suffix_length=3,
+            max_features=4,
+        )
+    )
+    state = learner.init()
+    state = state.replace(
+        counts=jnp.ones((4,), dtype=jnp.float32),
+        utility=jnp.array([jnp.nan, 0.5, -1.0, 0.2], dtype=jnp.float32),
+    )
+    slot, has_empty = learner._replacement_slot(state)
+    assert not bool(has_empty)
+    assert int(slot) == 2


### PR DESCRIPTION
## Summary
- Cross-entropy on inf logits is `inf - inf = NaN`. That NaN is clipped into stored utility, and `argmin` then treats the NaN row as the lowest-utility occupant.
- Fail-closed: non-finite logits report uniform loss. Non-finite utility updates keep the previous finite value. Replacement ignores non-finite utilities.
- Finite rows still compete normally.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_associative_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/associative_memory.py tests/test_associative_memory.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)