### PR TITLE
Do not multiply V(s') when Horde discount is zero

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -368,7 +368,8 @@ class HordeLearner:
         # For gamma=0 demons: target = cumulant (single-step prediction)
         # NaN cumulants stay NaN (inactive demons)
         gammas = self._horde_spec.gammas
-        targets = cumulants + gammas * next_preds
+        bootstrap = jnp.where(gammas == 0.0, 0.0, gammas * next_preds)
+        targets = cumulants + bootstrap
 
         # 3. Delegate to MultiHeadMLPLearner
         result = self._learner.update(state, observation, targets)
@@ -412,7 +413,8 @@ class HordeLearner:
         """
         next_preds = self._learner.predict(state, next_observation)
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
-        targets = cumulants + discounts * next_preds
+        bootstrap = jnp.where(discounts == 0.0, 0.0, discounts * next_preds)
+        targets = cumulants + bootstrap
         result = self._learner.update(state, observation, targets)
 
         return HordeUpdateResult(  # type: ignore[call-arg]

--- a/tests/test_horde.py
+++ b/tests/test_horde.py
@@ -796,3 +796,54 @@ class TestPerHeadGammaLamda:
         restored = MultiHeadMLPLearner.from_config(config)
         restored_config = restored.to_config()
         assert restored_config["per_head_gamma_lamda"] == [0.0, 0.5, 0.9]
+
+
+def test_gamma_zero_inf_next_pred_is_not_nan_target() -> None:
+    """gamma=0 * inf V(s') is 0*inf = NaN and inactivates a prediction demon.
+
+    Fail-closed: a zero discount does not multiply V(s'). The target is the
+    cumulant, matching the finite-path algebra.
+    """
+    spec = create_horde_spec(
+        [
+            GVFSpec(
+                name="p",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+            ),
+            GVFSpec(
+                name="v",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.9,
+                lamda=0.0,
+                cumulant_index=1,
+            ),
+        ]
+    )
+    horde = HordeLearner(
+        horde_spec=spec,
+        hidden_sizes=(),
+        step_size=0.1,
+        sparsity=0.0,
+        bounder=ObGDBounding(kappa=2.0),
+    )
+    state = horde.init(2, jr.key(0))
+    result = horde.update(
+        state,
+        jnp.zeros(2, dtype=jnp.float32),
+        jnp.array([1.25, 0.5], dtype=jnp.float32),
+        jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+    )
+    assert bool(jnp.isfinite(result.td_targets[0]))
+    chex.assert_trees_all_close(result.td_targets[0], jnp.float32(1.25))
+    discounted = horde.update_with_discounts(
+        state,
+        jnp.zeros(2, dtype=jnp.float32),
+        jnp.array([1.25, 0.5], dtype=jnp.float32),
+        jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+        jnp.array([0.0, 0.9], dtype=jnp.float32),
+    )
+    assert bool(jnp.isfinite(discounted.td_targets[0]))
+    chex.assert_trees_all_close(discounted.td_targets[0], jnp.float32(1.25))


### PR DESCRIPTION
## Summary
- Horde TD targets are `cumulant + gamma * V(s')`. For `gamma=0` that product is `0 * inf = NaN` when the next prediction is inf, so a prediction demon is treated as inactive.
- Fail-closed: a zero discount does not multiply `V(s')`. The target is the cumulant, which is the same algebra as the finite path.
- `update_with_discounts` uses the same rule for a zero per-step discount.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_horde.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/horde.py tests/test_horde.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)