### PR TITLE
Do not multiply Q(s', a') on a terminal SARSA transition

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -504,9 +504,11 @@ class SARSAAgent:
             state.last_observation,
         )[:n_actions]
 
-        # SARSA target: r + gamma * Q(s', a') with terminal handling
-        effective_gamma = jnp.where(terminated, 0.0, gamma)
-        sarsa_target = reward + effective_gamma * q_next[next_action]
+        # SARSA target: r + gamma * Q(s', a') with terminal handling.
+        # A terminal transition must not multiply Q(s', a'); 0 * inf is NaN.
+        q_sa_next = q_next[next_action]
+        bootstrap = jnp.where(terminated, 0.0, gamma * q_sa_next)
+        sarsa_target = reward + bootstrap
 
         # Build cumulants: NaN for all except last_action gets sarsa_target
         cumulants = jnp.full(self._horde.n_demons, jnp.nan, dtype=jnp.float32)
@@ -538,12 +540,13 @@ class SARSAAgent:
         new_learner_state = horde_result.state
         if self._lamda > 0.0:
             gl = jnp.asarray(gamma * self._lamda, dtype=jnp.float32)
-            carry = 1.0 - jnp.asarray(terminated, dtype=jnp.float32)
             head_traces = list(new_learner_state.head_traces)
             for i in range(n_actions):
                 w_trace, b_trace = head_traces[i]
-                decay = jnp.where(state.last_action == i, 1.0, gl) * carry
-                head_traces[i] = (decay * w_trace, decay * b_trace)
+                decay = jnp.where(state.last_action == i, 1.0, gl)
+                new_w = jnp.where(terminated, jnp.zeros_like(w_trace), decay * w_trace)
+                new_b = jnp.where(terminated, jnp.zeros_like(b_trace), decay * b_trace)
+                head_traces[i] = (new_w, new_b)
             new_learner_state = new_learner_state.replace(head_traces=tuple(head_traces))
 
         # TD error for the taken action

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -253,6 +253,31 @@ class TestSARSAUpdate:
         assert not jnp.isnan(result_nt.td_error)
         assert not jnp.isnan(result_t.td_error)
 
+    def test_terminated_inf_next_q_is_not_nan_td_error(self) -> None:
+        """Terminal 0 * inf Q(s', a') is NaN and poisons the SARSA target.
+
+        Fail-closed: a terminal transition does not multiply Q(s', a').
+        The target is the reward, matching the finite-path algebra.
+        """
+        agent = _make_agent(n_actions=2, gamma=0.99, epsilon_start=0.0, hidden_sizes=())
+        state = agent.init(feature_dim=2, key=jr.key(0))
+        obs = jnp.ones(2, dtype=jnp.float32)
+        state = state.replace(  # type: ignore[attr-defined]
+            last_action=jnp.array(0, dtype=jnp.int32),
+            last_observation=obs,
+        )
+        result = agent.update(
+            state,
+            reward=jnp.array(1.0, dtype=jnp.float32),
+            observation=jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+            terminated=jnp.array(True),
+            next_action=jnp.array(0, dtype=jnp.int32),
+        )
+        assert bool(jnp.isfinite(result.td_error))
+        q_old = agent.horde.predict(state.learner_state, obs)[0]
+        chex.assert_trees_all_close(result.td_error, jnp.float32(1.0) - q_old)
+
+
     def test_nan_masking(self):
         """Only the taken action's head receives a weight update."""
         agent = _make_agent(n_actions=3, gamma=0.9, epsilon_start=0.0)


### PR DESCRIPTION
## Summary
- SARSA used `effective_gamma * Q(s', a')` with `effective_gamma=0` at termination. Inf next-state values are then `0 * inf = NaN`, so the TD error and the Horde target are poisoned.
- Fail-closed: a terminal transition does not multiply `Q(s', a')`. The target is the reward, matching the finite-path algebra.
- Terminal trace resets write zeros instead of `0 * inf` traces.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_sarsa.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/sarsa.py tests/test_sarsa.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)