### PR TITLE
Hold working-memory traces on non-finite observations

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -157,6 +157,12 @@ def _empty_or_vector(value: Array, dim: int) -> Array:
     return jnp.asarray(value, dtype=jnp.float32).reshape((dim,))
 
 
+def _finite_innovation(value: Array, fast_trace: Array) -> Array:
+    """Return value - fast_trace, or zeros where that difference is non-finite."""
+    delta = value - fast_trace
+    return jnp.where(jnp.isfinite(delta), delta, jnp.zeros_like(delta))
+
+
 def _trace_bank(decay_count: int, dim: int) -> Array:
     return jnp.zeros((decay_count, dim), dtype=jnp.float32)
 
@@ -252,9 +258,11 @@ class WorkingMemoryFeaturizer:
     def _surprise_gate(self, traces: Array, value: Array, threshold: Array) -> Array:
         if (not self._config.gated_update) or traces.shape[0] == 0 or value.size == 0:
             return jnp.asarray(1.0, dtype=jnp.float32)
+        finite = jnp.all(jnp.isfinite(value)) & jnp.all(jnp.isfinite(traces[0]))
         surprise = _root_mean_square(value - traces[0])
         temperature = jnp.asarray(self._config.gate_temperature, dtype=jnp.float32)
-        return jax.nn.sigmoid((surprise - threshold) / temperature)
+        opened = jax.nn.sigmoid((surprise - threshold) / temperature)
+        return jnp.where(finite, opened, jnp.asarray(0.0, dtype=jnp.float32))
 
     @staticmethod
     def _update_trace_bank(
@@ -267,7 +275,12 @@ class WorkingMemoryFeaturizer:
             return traces
         decay = jnp.asarray(decay_rates, dtype=jnp.float32)[:, None]
         update_rate = (1.0 - decay) * gate
-        return traces + update_rate * (value[None, :] - traces)
+        finite_value = jnp.isfinite(value)[None, :]
+        residual = jnp.where(finite_value, value[None, :] - traces, 0.0)
+        # Frozen banks (update_rate=0) must not multiply an inf residual (0*inf).
+        delta = jnp.where(update_rate == 0.0, 0.0, update_rate * residual)
+        proposed = traces + delta
+        return jnp.where(finite_value, proposed, traces)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def features(
@@ -300,11 +313,11 @@ class WorkingMemoryFeaturizer:
             )
         if cfg.include_innovations:
             if len(cfg.observation_decay_rates) > 0:
-                blocks.append(obs - state.observation_traces[0])
+                blocks.append(_finite_innovation(obs, state.observation_traces[0]))
             if len(cfg.action_decay_rates) > 0:
-                blocks.append(act - state.action_traces[0])
+                blocks.append(_finite_innovation(act, state.action_traces[0]))
             if len(cfg.reward_decay_rates) > 0:
-                blocks.append(rew - state.reward_traces[0])
+                blocks.append(_finite_innovation(rew, state.reward_traces[0]))
         return jnp.concatenate(blocks, axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -214,3 +214,83 @@ def test_working_memory_delayed_action_positive_control() -> None:
 
     chex.assert_trees_all_close(memory_mse, 0.0)
     assert float(memory_mse) < float(raw_mse)
+
+
+def test_working_memory_frozen_trace_skips_inf_observation() -> None:
+    """A closed gate is a frozen EMA: 0 * (inf - traces) is 0*inf = NaN.
+
+    Fail-closed: a frozen bank keeps its previous finite traces.
+    """
+    memory = WorkingMemoryFeaturizer(
+        WorkingMemoryConfig(
+            observation_dim=1,
+            action_dim=0,
+            reward_dim=0,
+            observation_decay_rates=(0.5,),
+            include_current_observation=False,
+            include_current_action=False,
+            include_current_reward=False,
+        )
+    )
+    state = memory.update(
+        memory.init(),
+        jnp.asarray([2.0]),
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    poisoned = memory.update(
+        state,
+        jnp.asarray([jnp.inf]),
+        memory.zero_action(),
+        memory.zero_reward(),
+        external_gate=0.0,
+    )
+    assert bool(jnp.all(jnp.isfinite(poisoned.observation_traces)))
+    chex.assert_trees_all_close(poisoned.observation_traces, state.observation_traces)
+
+
+def test_working_memory_inf_observation_does_not_poison_ema() -> None:
+    """A second inf observation is inf - inf = NaN in the EMA residual.
+
+    Fail-closed: skip the trace update on a non-finite coordinate so a later
+    finite sample keeps learning from the previous finite traces.
+    """
+    memory = WorkingMemoryFeaturizer(
+        WorkingMemoryConfig(
+            observation_dim=1,
+            action_dim=0,
+            reward_dim=0,
+            observation_decay_rates=(0.5,),
+            include_current_observation=False,
+            include_current_action=False,
+            include_current_reward=False,
+            include_innovations=True,
+            gated_update=True,
+        )
+    )
+    state = memory.init()
+    state = memory.update(state, jnp.asarray([2.0]), memory.zero_action(), memory.zero_reward())
+    finite_traces = state.observation_traces
+    for _ in range(2):
+        state = memory.update(
+            state,
+            jnp.asarray([jnp.inf]),
+            memory.zero_action(),
+            memory.zero_reward(),
+        )
+    assert bool(jnp.all(jnp.isfinite(state.observation_traces)))
+    chex.assert_trees_all_close(state.observation_traces, finite_traces)
+    recovered = memory.update(
+        state,
+        jnp.asarray([0.0]),
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    assert bool(jnp.all(jnp.isfinite(recovered.observation_traces)))
+    features = memory.features(
+        recovered,
+        jnp.asarray([jnp.inf]),
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    assert bool(jnp.all(jnp.isfinite(features)))


### PR DESCRIPTION
## Summary
- Working-memory EMAs use `traces + update_rate * (value - traces)`. A closed gate is `0 * (inf - traces) = NaN`. A second inf sample is `inf - inf = NaN` in the residual, the surprise gate, and the innovation features.
- Fail-closed: skip the product when the update rate is zero, and hold previous finite traces on a non-finite coordinate.
- Innovation features and surprise gates stay finite so later finite samples keep learning.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_working_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/working_memory.py tests/test_working_memory.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)