### PR TITLE
Hold prototype memory on non-finite observations

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -184,7 +184,8 @@ class PrototypeMemoryLearner:
         any_active = jnp.any(state.counts > 0.0, axis=1)
         logits = jnp.where(any_active, logits, -1e9)
         logits = jnp.where(jnp.any(any_active), logits, jnp.zeros_like(logits))
-        return logits
+        finite_obs = jnp.all(jnp.isfinite(x))
+        return jnp.where(finite_obs, logits, jnp.zeros_like(logits))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(
@@ -267,7 +268,9 @@ class PrototypeMemoryLearner:
             )
             old_mean = current.means[head, slot]
             eta = jnp.asarray(self._config.update_rate, dtype=jnp.float32)
-            new_mean = jnp.where(novel, observation, old_mean + eta * (observation - old_mean))
+            residual = observation - old_mean
+            ema = jnp.where(eta == 0.0, old_mean, old_mean + eta * residual)
+            new_mean = jnp.where(novel, observation, ema)
             new_count = jnp.where(novel, 1.0, current.counts[head, slot] + 1.0)
             next_state = PrototypeMemoryState(
                 means=current.means.at[head, slot].set(new_mean),
@@ -290,7 +293,12 @@ class PrototypeMemoryLearner:
                 jnp.array(0.0, dtype=jnp.float32),
             )
 
-        new_state, allocated = jax.lax.cond(valid_target, do_update, skip_update, state)
+        new_state, allocated = jax.lax.cond(
+            valid_target & jnp.all(jnp.isfinite(observation)),
+            do_update,
+            skip_update,
+            state,
+        )
         active = jnp.sum(new_state.counts > 0.0).astype(jnp.float32)
         metrics = jnp.asarray(
             [

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -100,6 +100,44 @@ def test_invalid_target_advances_time_without_allocating() -> None:
     assert float(result.metrics[4]) == 0.0
 
 
+def test_nonfinite_observation_does_not_allocate_or_poison() -> None:
+    """Inf observations must not claim a slot or write inf-inf NaNs into means.
+
+    A first inf sample would allocate an inf prototype. A second is
+    inf - inf in the EMA residual, and argmin treats NaN distances as nearest.
+    Fail-closed: skip the memory write and keep class logits uniform.
+    """
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=2)
+    )
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    seeded = learner.update(
+        learner.init(),
+        jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+        target,
+    ).state
+    finite_means = seeded.means
+    inf_obs = jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32)
+    first = learner.update(seeded, inf_obs, target)
+    second = learner.update(first.state, inf_obs, target)
+    recovered = learner.update(
+        second.state,
+        jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+        target,
+    )
+
+    assert int(first.state.step_count) == int(seeded.step_count) + 1
+    chex.assert_trees_all_close(first.state.means, finite_means)
+    chex.assert_trees_all_close(first.state.counts, seeded.counts)
+    chex.assert_tree_all_finite(second.state)
+    chex.assert_tree_all_finite(learner.predict(seeded, inf_obs))
+    chex.assert_trees_all_close(
+        learner.predict(seeded, inf_obs),
+        jnp.full((2,), 0.5, dtype=jnp.float32),
+    )
+    assert int(jnp.argmax(recovered.predictions)) == 0
+
+
 def test_run_prototype_memory_arrays_is_scan_compatible() -> None:
     """Array runner should return fixed-width predictions and metrics."""
     learner = PrototypeMemoryLearner(


### PR DESCRIPTION
## Summary
- Prototype memory writes an inf observation into an empty slot, then a second inf sample is `inf - inf = NaN` in the EMA residual. NaN distances also win `argmin` as the nearest slot.
- Inf observations versus a finite prototype yield `-inf` logits, so softmax prefers unused classes.
- Fail-closed: skip the memory write when any observation coordinate is non-finite, and return uniform class logits for that query. Later finite samples keep learning from the previous finite prototypes.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_prototype_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/prototype_memory.py tests/test_prototype_memory.py`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)