### PR TITLE
fix(screening): refuse to merge shards with mismatched hyperparameters

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7046,6 +7046,21 @@ def merge_shards(
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):
         seeds = sorted(per_seed)
+        reference_hp = per_seed[seeds[0]]["hyperparameters"]
+        mismatched = [s for s in seeds if per_seed[s]["hyperparameters"] != reference_hp]
+        if mismatched:
+            # A registry entry is not literally immutable while a config is
+            # still being tuned; shards from before and after a hyperparameter
+            # change can land in the same directory. Without this check they
+            # merge silently under one config_name, average per-task accuracy
+            # across genuinely different mechanisms, and report only
+            # seeds[0]'s hyperparameters as if representative of the whole arm.
+            raise ValueError(
+                f"config {name!r} has inconsistent hyperparameters across seeds: "
+                f"seed {seeds[0]} used {reference_hp!r}, seed(s) {mismatched} used "
+                "different values; refusing to merge runs of different mechanisms "
+                "under one config_name"
+            )
         acc = np.stack(
             [np.asarray(per_seed[s]["per_task_accuracy"], dtype=np.float64) for s in seeds]
         )

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -988,6 +988,29 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
+    def test_merge_rejects_hyperparameter_drift_across_seeds(self, tmp_path, small_data):
+        """Two shards under one config_name with different hyperparameters must
+        not merge: nothing else catches a registry value that changed between
+        two `run` invocations, and a silent merge would average per-task
+        accuracy across genuinely different mechanisms while reporting only
+        the first seed's hyperparameters as if representative of the arm."""
+        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        p1 = self._make_shard(tmp_path, small_data, "upgd_l2init", 0)
+        p2 = self._make_shard(tmp_path, small_data, "upgd_l2init", 1)
+
+        payload2 = json.loads(p2.read_text(encoding="utf-8"))
+        payload2["hyperparameters"] = {
+            **payload2["hyperparameters"],
+            "meta_step_size": 999.0,
+        }
+        p2.write_text(json.dumps(payload2), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"'upgd_l2init' has inconsistent hyperparameters across seeds",
+        ):
+            merge_shards([p0, p1, p2], control_name="upgd_w_control", slope_window=2)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"


### PR DESCRIPTION
Closes #96.

## What changed

`merge_shards` now requires every seed merged under one `config_name` to carry identical `hyperparameters`, raising a deterministic `ValueError` naming the config and the mismatched seed(s) when they differ, instead of quietly taking `seeds[0]`'s hyperparameters as representative of the whole arm and averaging per-task accuracy across what could be genuinely different mechanisms.

reproduced the gap directly against the merged code before writing the fix: two `upgd_l2init` shards (seeds 0 and 1) with one seed's `hyperparameters` mutated (`meta_step_size` changed) merged into a single `paired_vs_control` entry with zero warning, reporting only seed 0's values. same failure mode as the #44/#45/#49/#50/#53 family, a merge that should refuse instead produces a schema-valid summary that reads as one coherent measurement.

out of scope (see #96): `load_shard`'s structural validation doesn't have registry access at load time to compare a shard's hyperparameters against the *current* registry entry, this PR only closes the merge-time cross-seed consistency gap, not that separate load-time boundary.

## Verification

failing-test-first in `TestShardsAndMerge::test_merge_rejects_hyperparameter_drift_across_seeds`. confirmed red before the guard (temporarily reverted just the source fix, kept the test, mutation was silently accepted like before): `DID NOT RAISE ValueError`. restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""
204 passed in 81.49s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:19e1e8d95a76cb72a40c88e5681c7f964bc20316 -->
<!-- evidence-row:logs -->
- [x] logs: full focused-suite, ruff, and mypy transcript pasted above (204/204 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript above (red before the fix, green after) is the artifact, a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
No Slop run receipt: this session runs as Sonnet 5, not the approved `claude-fable-5` identifier for Claude Code measured runs, so `run-receipt.mjs start/finish` wasn't invoked. the fix, reproduction, and tests above are real and independently verified, only the receipt-capture pipeline was skipped.
