### PR TITLE
Hold gated state-builder eligibility on inf events

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -1401,11 +1401,17 @@ class OnlineGatedStateBuilder:
 
         gate_weights, gate_bias, _, _ = self._unpack_parameters(state.parameters)
         gate = jax.nn.sigmoid(gate_weights @ event + gate_bias)
-        new_sensitivity = direct_sensitivity + ((1.0 - gate)[:, None] * state.parameter_sensitivity)
+        carry = (1.0 - gate)[:, None]
+        # Closed gates must not multiply an inf eligibility (0*inf).
+        carried_sensitivity = jnp.where(carry == 0.0, 0.0, carry * state.parameter_sensitivity)
+        new_sensitivity = direct_sensitivity + carried_sensitivity
+        event_finite = jnp.all(jnp.isfinite(event))
         next_state = OnlineGatedStateBuilderState(
             parameters=state.parameters,
-            hidden=new_hidden,
-            parameter_sensitivity=new_sensitivity,
+            hidden=jnp.where(event_finite, new_hidden, state.hidden),
+            parameter_sensitivity=jnp.where(
+                event_finite, new_sensitivity, state.parameter_sensitivity
+            ),
             step_count=_saturating_int32_increment(state.step_count),
             update_count=state.update_count,
             last_gradient_norm=state.last_gradient_norm,

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -255,6 +255,38 @@ def test_online_gated_episode_reset_preserves_learning_and_lifetime_counters() -
     assert bool(jnp.any(restarted_state.parameter_sensitivity != 0.0))
 
 
+def test_online_gated_builder_holds_sensitivity_on_inf_observation() -> None:
+    """Inf events poison RTRL sensitivity via jacfwd and 0*inf gate carry.
+
+    Fail-closed: hold the previous finite hidden state and eligibility so a
+    later finite observation can still learn.
+    """
+    builder = OnlineGatedStateBuilder(
+        OnlineGatedStateBuilderConfig(
+            observation_dim=2,
+            hidden_dim=3,
+            step_size=0.05,
+        )
+    )
+    state, _ = builder.start(builder.init(jr.key(7)), jnp.asarray([1.0, 1.0]))
+    finite_hidden = state.hidden
+    finite_sensitivity = state.parameter_sensitivity
+    inf_obs = jnp.asarray([jnp.inf, 0.0])
+    poisoned, _ = builder.update(state, inf_obs, -1, 0.0, 1.0)
+    twice, _ = builder.update(poisoned, inf_obs, -1, 0.0, 1.0)
+    recovered, _ = builder.update(twice, jnp.asarray([0.0, 0.0]), -1, 0.0, 1.0)
+    learned, diagnostics = builder.learn(
+        recovered, jnp.concatenate([jnp.zeros(2), jnp.ones(3)])
+    )
+
+    chex.assert_trees_all_close(poisoned.hidden, finite_hidden)
+    chex.assert_trees_all_close(poisoned.parameter_sensitivity, finite_sensitivity)
+    chex.assert_tree_all_finite(twice)
+    chex.assert_tree_all_finite(recovered)
+    assert bool(diagnostics.valid)
+    chex.assert_tree_all_finite(learned)
+
+
 def _online_learning_source() -> tuple[
     OnlineGatedStateBuilder,
     object,


### PR DESCRIPTION
## Summary
- The online gated state builder advances RTRL parameter sensitivity through \`jacfwd\` of the GRU-style write/hold unit. An inf observation makes that Jacobian non-finite. A closed gate is also \`(1 - gate) * sensitivity = 0 * inf\`.
- Fail-closed: skip the hidden-state and eligibility update when the event is non-finite, and do not multiply a zero carry by an inf trace.
- Later finite observations keep a finite eligibility, so delayed representation-gradient learning can still apply.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_state_builder.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/core/state_builder.py tests/test_state_builder.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)