### PR TITLE
Do not form 0*inf delight from zero surprisal

### DIFF
--- a/alberta_framework/core/delight.py
+++ b/alberta_framework/core/delight.py
@@ -1907,14 +1907,25 @@ def discrete_delightful_policy_gradient(
     if log_prob.size == 0:
         raise ValueError("at least one policy-gradient sample is required")
 
+    finite = jnp.isfinite(log_prob) & jnp.isfinite(advantage)
+    log_prob = jnp.where(finite, log_prob, jnp.zeros_like(log_prob))
+    advantage = jnp.where(finite, advantage, jnp.zeros_like(advantage))
     action_surprisal = -log_prob
-    delight = jax.lax.stop_gradient(advantage * action_surprisal)
+    # Zero surprisal or zero advantage must not multiply an inf counterpart.
+    delight = jax.lax.stop_gradient(
+        jnp.where(
+            (action_surprisal == 0.0) | (advantage == 0.0),
+            jnp.zeros_like(advantage),
+            advantage * action_surprisal,
+        )
+    )
     if cfg.mode == "ordinary_pg":
         sample_weights = jnp.ones_like(delight)
     else:
         temperature = jnp.asarray(cfg.temperature, dtype=jnp.float32)
         sample_weights = jax.nn.sigmoid(delight / temperature)
     sample_weights = jax.lax.stop_gradient(sample_weights)
+    sample_weights = jnp.where(finite, sample_weights, jnp.zeros_like(sample_weights))
     actor_coefficients = jax.lax.stop_gradient(sample_weights * advantage)
     ordinary_coefficients = jax.lax.stop_gradient(advantage)
 

--- a/tests/test_delight.py
+++ b/tests/test_delight.py
@@ -2121,3 +2121,21 @@ def test_paper_specific_dg_rejects_shape_mismatch_and_empty_batches() -> None:
     )
     with pytest.raises(ValueError, match="rare_mask"):
         stratify_delight_outcomes(result, jnp.zeros((3,), dtype=jnp.bool_))
+
+
+def test_paper_specific_dg_zero_surprisal_does_not_nan_inf_advantage() -> None:
+    """log_prob=0 is zero surprisal: inf advantage is 0*inf = NaN delight.
+
+    Fail-closed: drop the non-finite sample so the remaining finite term
+    keeps a finite actor loss.
+    """
+    result = discrete_delightful_policy_gradient(
+        jnp.array([0.0, -1.0], dtype=jnp.float32),
+        jnp.array([jnp.inf, 1.0], dtype=jnp.float32),
+    )
+    chex.assert_tree_all_finite(result.delight)
+    chex.assert_tree_all_finite(result.actor_loss)
+    chex.assert_tree_all_finite(result.sample_weights)
+    chex.assert_trees_all_close(result.delight[0], jnp.float32(0.0))
+    chex.assert_trees_all_close(result.sample_weights[0], jnp.float32(0.0))
+    chex.assert_trees_all_close(result.delight[1], jnp.float32(1.0))


### PR DESCRIPTION
## Summary
- Paper-defined delight is \`advantage * -log_prob\`. A deterministic action has zero surprisal, so an inf advantage is \`0 * inf = NaN\` and the actor loss, sigmoid gate, and coefficients collapse.
- Fail-closed: replace non-finite log-probabilities and advantages with zeros, skip the zero-factor product, and zero the sample weight so diagnostics are not a NaN gate rate.
- Finite samples in the same batch keep the defined delight product and a finite actor loss.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_delight.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/core/delight.py tests/test_delight.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)