### PR TITLE
Do not multiply a later return when nexting gamma is zero

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -63,7 +63,9 @@ def forward_view_returns(
     init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
-        new_carry = c + gamma_s * carry
+        # gamma=0 must not multiply an inf later return (0*inf).
+        bootstrap = jnp.where(gamma_s == 0.0, jnp.zeros_like(carry), gamma_s * carry)
+        new_carry = c + bootstrap
         return new_carry, new_carry
 
     _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -21,6 +21,19 @@ class TestForwardViewReturns:
         g = forward_view_returns(c, gamma=0.0)
         chex.assert_trees_all_close(g, c)
 
+    def test_gamma_zero_skips_inf_later_return(self) -> None:
+        """gamma=0 is G_t = c_{t+1}; 0 * inf G_{t+1} is NaN.
+
+        Fail-closed: a zero discount does not multiply the later return.
+        """
+        c = jnp.array([1.0, jnp.inf, 3.0])
+        g = forward_view_returns(c, gamma=0.0)
+        assert bool(jnp.isfinite(g[0]))
+        assert bool(jnp.isfinite(g[2]))
+        chex.assert_trees_all_close(g[0], jnp.float32(1.0))
+        chex.assert_trees_all_close(g[2], jnp.float32(3.0))
+        assert bool(jnp.isinf(g[1]))
+
     def test_gamma_one_undiscounted(self) -> None:
         c = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
         g = forward_view_returns(c, gamma=1.0)


### PR DESCRIPTION
## Summary
- Nexting forward-view returns use \`G_t = c_{t+1} + gamma * G_{t+1}\`. With \`gamma=0\` this is the next cumulant, but an inf later return is \`0 * inf = NaN\` and poisons earlier finite steps.
- Fail-closed: a zero discount does not multiply \`G_{t+1}\`. Finite cumulants stay equal to themselves, matching the existing gamma-zero algebra.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_nexting.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/utils/nexting.py tests/test_nexting.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)