### PR TITLE
Do not multiply unused inf channels in dream scores

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -318,6 +318,12 @@ class BehaviorModelDreamPolicy:
         )
 
 
+def _weighted_term(weight: float, values: Array) -> Array:
+    """Return weight * values, or zeros when weight is 0 so 0*inf stays 0."""
+    w = jnp.asarray(weight, dtype=jnp.float32)
+    return jnp.where(w == 0.0, jnp.zeros_like(values), w * values)
+
+
 def score_dream_candidates(
     surprises: Array,
     utilities: Array,
@@ -368,10 +374,10 @@ def score_dream_candidates(
         & (error_arr <= jnp.asarray(cfg.max_model_error, dtype=jnp.float32))
     )
     raw_scores = (
-        cfg.surprise_weight * surprise_arr
-        + cfg.utility_weight * utility_arr
-        + cfg.confidence_weight * confidence_arr
-        - cfg.model_error_weight * error_arr
+        _weighted_term(cfg.surprise_weight, surprise_arr)
+        + _weighted_term(cfg.utility_weight, utility_arr)
+        + _weighted_term(cfg.confidence_weight, confidence_arr)
+        - _weighted_term(cfg.model_error_weight, error_arr)
     )
     scores = jnp.where(accepted, raw_scores, -jnp.inf)
     selected_indices = jnp.argsort(-scores)[: cfg.max_items].astype(jnp.int32)

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -9,6 +9,7 @@ import jax.random as jr
 from alberta_framework.core.dreaming import (
     DreamBehaviorModelPrediction,
     DreamRolloutConfig,
+    DreamSelectionConfig,
     DreamWorldModelPrediction,
     dream_one_step,
     dream_rollout,
@@ -17,6 +18,7 @@ from alberta_framework.core.dreaming import (
     imagined_transition_to_gvf_item,
     imagined_transition_to_supervised_item,
     init_dream_rollout_state,
+    score_dream_candidates,
     slice_imagined_transition,
 )
 
@@ -262,3 +264,21 @@ def test_rollout_to_sarsa_items_shift_actions_and_mask_last_without_bootstrap() 
         jnp.array(1, dtype=jnp.int32),
     )
     chex.assert_trees_all_close(bootstrapped.weights, rollout.transitions.valid.astype(jnp.float32))
+
+
+def test_score_dream_candidates_zero_weight_skips_inf_confidence() -> None:
+    """Default confidence_weight is 0: 0 * inf confidence is NaN in the score.
+
+    Fail-closed: a zero weight does not multiply that channel, so ranking
+    still follows surprise and utility.
+    """
+    result = score_dream_candidates(
+        surprises=jnp.array([1.0, 0.5], dtype=jnp.float32),
+        utilities=jnp.array([1.0, 0.5], dtype=jnp.float32),
+        confidences=jnp.array([jnp.inf, 1.0], dtype=jnp.float32),
+        config=DreamSelectionConfig(max_items=1, min_utility=0.0),
+    )
+    assert bool(jnp.isfinite(result.scores[0]))
+    chex.assert_trees_all_close(result.scores[0], jnp.float32(2.0))
+    assert int(result.selected_indices[0]) == 0
+    assert bool(result.selected_mask[0])


### PR DESCRIPTION
## Summary
- Dream candidate scores are a weighted sum of surprise, utility, confidence, and model error. The default \`confidence_weight\` is 0, so inf confidence is \`0 * inf = NaN\` and \`argsort\` ranking is undefined.
- Fail-closed: a zero channel weight does not multiply that channel. Unused inf confidence leaves the surprise/utility score finite, so selection still follows the defined ranking.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_dreaming.py tests/test_latent_world_model.py::test_score_dream_candidates_selects_surprising_useful_valid_items -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/core/dreaming.py tests/test_dreaming.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)