### PR TITLE
Hold UPGD-memory EMAs and slots on inf observations

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -245,6 +245,16 @@ def _active_mse(prediction: Array, target: Array) -> Array:
     return jnp.sum(squared) / jnp.maximum(jnp.sum(active.astype(jnp.float32)), 1.0)
 
 
+def _hold_ema(previous: Array, value: Array, decay: Array, *, hold: Array) -> Array:
+    """Blend an EMA, or keep previous when value is non-finite or hold is set."""
+    one_minus = 1.0 - decay
+    decayed_prev = jnp.where(decay == 0.0, jnp.zeros_like(previous), decay * previous)
+    safe_value = jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value))
+    decayed_new = jnp.where(one_minus == 0.0, jnp.zeros_like(safe_value), one_minus * safe_value)
+    blended = decayed_prev + decayed_new
+    return jnp.where(hold | ~jnp.isfinite(value), previous, blended)
+
+
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
     return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
@@ -446,14 +456,16 @@ class UPGDMemoryLearner:
             return _active_mse(probe_prediction, target)
 
         dloss_dlogit = jax.grad(blend_loss)(state.memory_logit)
-        next_memory_logit = state.memory_logit - (
+        logit_step = (
             jnp.asarray(self._config.memory_logit_step_size, dtype=jnp.float32) * dloss_dlogit
         )
-        # Bound the learned base logit: sigmoid(+/-8) is already ~0.9997, so
-        # the clip costs nothing in gate range but stops unbounded drift during
-        # long one-sided regimes, keeping the additive confidence/reliability
-        # terms able to reverse the gate after a regime change.
-        next_memory_logit = jnp.clip(next_memory_logit, -8.0, 8.0)
+        obs_finite = jnp.all(jnp.isfinite(observation))
+        logit_ok = obs_finite & jnp.isfinite(dloss_dlogit) & jnp.isfinite(logit_step)
+        next_memory_logit = jnp.where(
+            logit_ok,
+            jnp.clip(state.memory_logit - logit_step, -8.0, 8.0),
+            state.memory_logit,
+        )
 
         threshold = jnp.exp(state.novelty_log_threshold)
         upgd_result = self._upgd.update(state.upgd_state, observation, target)
@@ -465,51 +477,71 @@ class UPGDMemoryLearner:
         )
         allocated = memory_result.metrics[5]
         decay = jnp.asarray(self._config.reliability_decay, dtype=jnp.float32)
-        one_minus_decay = 1.0 - decay
-        next_allocation_ema = decay * state.allocation_ema + one_minus_decay * allocated
+        hold = ~obs_finite
+        next_allocation_ema = _hold_ema(
+            state.allocation_ema, allocated, decay, hold=hold
+        )
         allocation_error = next_allocation_ema - jnp.asarray(
             self._config.target_allocation_rate,
             dtype=jnp.float32,
         )
-        next_log_threshold = state.novelty_log_threshold + (
+        log_step = (
             jnp.asarray(self._config.novelty_adaptation_rate, dtype=jnp.float32) * allocation_error
         )
-        next_log_threshold = jnp.clip(
-            next_log_threshold,
-            jnp.log(jnp.asarray(self._config.min_novelty_threshold, dtype=jnp.float32)),
-            jnp.log(jnp.asarray(self._config.max_novelty_threshold, dtype=jnp.float32)),
+        next_log_threshold = jnp.where(
+            obs_finite & jnp.isfinite(log_step),
+            jnp.clip(
+                state.novelty_log_threshold + log_step,
+                jnp.log(jnp.asarray(self._config.min_novelty_threshold, dtype=jnp.float32)),
+                jnp.log(jnp.asarray(self._config.max_novelty_threshold, dtype=jnp.float32)),
+            ),
+            state.novelty_log_threshold,
         )
 
+        next_upgd_state = jax.lax.cond(
+            obs_finite,
+            lambda: upgd_result.state,
+            lambda: state.upgd_state,
+        )
+        next_memory_state = jax.lax.cond(
+            obs_finite,
+            lambda: memory_result.state,
+            lambda: state.memory_state,
+        )
         next_state = UPGDMemoryState(
-            upgd_state=upgd_result.state,
-            memory_state=memory_result.state,
+            upgd_state=next_upgd_state,
+            memory_state=next_memory_state,
             memory_logit=next_memory_logit,
             novelty_log_threshold=next_log_threshold,
-            upgd_loss_ema=decay * state.upgd_loss_ema + one_minus_decay * upgd_loss,
-            memory_loss_ema=decay * state.memory_loss_ema + one_minus_decay * memory_loss,
-            blended_loss_ema=(decay * state.blended_loss_ema + one_minus_decay * blended_loss),
+            upgd_loss_ema=_hold_ema(state.upgd_loss_ema, upgd_loss, decay, hold=hold),
+            memory_loss_ema=_hold_ema(state.memory_loss_ema, memory_loss, decay, hold=hold),
+            blended_loss_ema=_hold_ema(
+                state.blended_loss_ema, blended_loss, decay, hold=hold
+            ),
             allocation_ema=next_allocation_ema,
             step_count=state.step_count + 1,
         )
+        safe_prediction = jnp.where(obs_finite, prediction, jnp.zeros_like(prediction))
+        safe_errors = jnp.where(obs_finite, errors, jnp.zeros_like(errors))
         metrics = jnp.asarray(
             [
-                blended_loss,
-                upgd_loss,
-                memory_loss,
-                gate,
+                jnp.where(obs_finite & jnp.isfinite(blended_loss), blended_loss, 0.0),
+                jnp.where(obs_finite & jnp.isfinite(upgd_loss), upgd_loss, 0.0),
+                jnp.where(obs_finite & jnp.isfinite(memory_loss), memory_loss, 0.0),
+                jnp.where(obs_finite & jnp.isfinite(gate), gate, 0.0),
                 next_memory_logit,
                 threshold,
                 next_allocation_ema,
-                jnp.sum(memory_result.state.counts > 0.0).astype(jnp.float32),
-                jnp.max(upgd_prediction),
-                jnp.max(memory_prediction),
+                jnp.sum(next_memory_state.counts > 0.0).astype(jnp.float32),
+                jnp.where(obs_finite, jnp.max(upgd_prediction), 0.0),
+                jnp.where(obs_finite, jnp.max(memory_prediction), 0.0),
             ],
             dtype=jnp.float32,
         )
         return UPGDMemoryUpdateResult(
             state=next_state,
-            predictions=prediction,
-            errors=errors,
+            predictions=safe_prediction,
+            errors=safe_errors,
             metrics=metrics,
         )
 

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -180,3 +180,46 @@ def test_upgd_memory_novelty_threshold_adapts() -> None:
         ).state
 
     assert float(jnp.exp(state.novelty_log_threshold)) > config.initial_novelty_threshold
+
+
+def test_upgd_memory_holds_state_on_inf_observation() -> None:
+    """Inf observations NaN the loss EMAs and allocate inf prototypes.
+
+    Fail-closed: skip UPGD/memory writes and hold finite EMAs and blend
+    logit so a later finite sample can still learn.
+    """
+    learner = UPGDMemoryLearner(
+        UPGDMemoryConfig(
+            feature_dim=2,
+            n_heads=2,
+            hidden_sizes=(4,),
+            slots_per_class=2,
+            target_trace_blend_scale=0.0,
+        )
+    )
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    seeded = learner.update(
+        learner.init(jr.key(1)),
+        jnp.asarray([1.0, -1.0], dtype=jnp.float32),
+        target,
+    ).state
+    inf_obs = jnp.asarray([jnp.inf, -1.0], dtype=jnp.float32)
+    poisoned = learner.update(seeded, inf_obs, target)
+    twice = learner.update(poisoned.state, inf_obs, target)
+    recovered = learner.update(
+        twice.state,
+        jnp.asarray([1.0, -1.0], dtype=jnp.float32),
+        target,
+    )
+
+    chex.assert_trees_all_close(poisoned.state.upgd_loss_ema, seeded.upgd_loss_ema)
+    chex.assert_trees_all_close(poisoned.state.memory_loss_ema, seeded.memory_loss_ema)
+    chex.assert_trees_all_close(poisoned.state.memory_logit, seeded.memory_logit)
+    chex.assert_trees_all_close(poisoned.state.memory_state.means, seeded.memory_state.means)
+    assert bool(jnp.all(jnp.isfinite(twice.state.upgd_loss_ema)))
+    assert bool(jnp.all(jnp.isfinite(twice.state.memory_loss_ema)))
+    assert bool(jnp.all(jnp.isfinite(twice.state.memory_logit)))
+    assert bool(jnp.all(jnp.isfinite(twice.state.memory_state.means)))
+    chex.assert_tree_all_finite(poisoned.metrics)
+    chex.assert_tree_all_finite(recovered.metrics)
+    assert int(recovered.state.memory_state.step_count) >= int(seeded.memory_state.step_count)


### PR DESCRIPTION
## Summary
- UPGD-memory blends UPGD and prototype memory with loss EMAs. An inf observation makes \`pred - target\` inf-inf in MSE, so the reliability EMAs and the blend-logit gradient become NaN. Prototype memory also writes an inf slot that a second inf sample turns into NaN means.
- Fail-closed: skip UPGD and memory writes when any observation coordinate is non-finite. Hold previous finite EMAs, blend logit, and novelty threshold. Frozen decay does not multiply an inf residual.
- Later finite samples keep learning from the previous finite hybrid state.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_upgd_memory.py tests/test_upgd_memory_grad.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)