### PR TITLE
Do not multiply unused inf costs in resource-manager Hedge

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -39,6 +39,15 @@ from jax import Array
 from jaxtyping import Float
 
 
+def _cost_term(cost_weight: float, costs: Array) -> tuple[Array, Array]:
+    """Return ``weight * costs``, skipping 0*inf, plus a per-action cost mask."""
+    weight = jnp.asarray(cost_weight, dtype=jnp.float32)
+    term = jnp.where(weight == 0.0, jnp.zeros_like(costs), weight * costs)
+    term = jnp.where(jnp.isfinite(term), term, jnp.zeros_like(term))
+    cost_ok = (weight == 0.0) | jnp.isfinite(costs)
+    return term, cost_ok
+
+
 def optimal_hedge_learning_rate(
     n_actions: int,
     horizon: int,
@@ -307,14 +316,15 @@ class LearnedResourceManager:
         """
         context = jnp.asarray(context_id, dtype=jnp.int32)
         losses = jnp.asarray(losses, dtype=jnp.float32)
-        finite = jnp.isfinite(losses)
-        safe_losses = jnp.where(finite, losses, 0.0)
         costs = (
-            jnp.zeros_like(safe_losses)
+            jnp.zeros_like(losses)
             if resource_costs is None
             else jnp.asarray(resource_costs, dtype=jnp.float32)
         )
-        adjusted = safe_losses + jnp.asarray(self._cost_weight, dtype=jnp.float32) * costs
+        cost_term, cost_ok = _cost_term(self._cost_weight, costs)
+        finite = jnp.isfinite(losses) & cost_ok
+        safe_losses = jnp.where(finite, losses, 0.0)
+        adjusted = safe_losses + cost_term
 
         weights = self.weights(state, context)
         finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
@@ -662,16 +672,17 @@ class GeneratorMetaResourceManager:
         """
         context = jnp.asarray(context_id, dtype=jnp.int32)
         rewards = jnp.asarray(rewards, dtype=jnp.float32)
-        finite = jnp.isfinite(rewards)
-        if finite_mask is not None:
-            finite = finite & jnp.asarray(finite_mask, dtype=jnp.bool_)
-        safe_rewards = jnp.where(finite, rewards, 0.0)
         costs = (
-            jnp.zeros_like(safe_rewards)
+            jnp.zeros_like(rewards)
             if resource_costs is None
             else jnp.asarray(resource_costs, dtype=jnp.float32)
         )
-        adjusted = safe_rewards - jnp.asarray(self._cost_weight, dtype=jnp.float32) * costs
+        cost_term, cost_ok = _cost_term(self._cost_weight, costs)
+        finite = jnp.isfinite(rewards) & cost_ok
+        if finite_mask is not None:
+            finite = finite & jnp.asarray(finite_mask, dtype=jnp.bool_)
+        safe_rewards = jnp.where(finite, rewards, 0.0)
+        adjusted = safe_rewards - cost_term
 
         weights = self.weights(state, context)
         finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -100,6 +100,30 @@ class TestLearnedResourceManager:
         assert int(jnp.argmax(weights)) == 0
         assert float(weights[0]) > 0.99
 
+    def test_zero_cost_weight_skips_inf_resource_cost(self) -> None:
+        """Default cost_weight is 0: 0 * inf cost is NaN in the Hedge update.
+
+        Fail-closed: a zero cost weight does not multiply the cost channel, so
+        finite losses still shift the allocation.
+        """
+        manager = LearnedResourceManager(
+            n_actions=2,
+            learning_rate=2.0,
+            discount=1.0,
+            cost_weight=0.0,
+        )
+        state = manager.init()
+        losses = jnp.asarray([0.1, 1.0], dtype=jnp.float32)
+        costs = jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32)
+        result = manager.update(state, losses, resource_costs=costs)
+        for _ in range(9):
+            result = manager.update(result.state, losses, resource_costs=costs)
+
+        chex.assert_tree_all_finite(result.advantages)
+        chex.assert_tree_all_finite(result.state.log_weights)
+        assert int(jnp.argmax(manager.weights(result.state))) == 0
+        assert float(manager.weights(result.state)[0]) > 0.99
+
     def test_nan_loss_is_ignored(self) -> None:
         manager = LearnedResourceManager(n_actions=2, learning_rate=1.0)
         state = manager.init()


### PR DESCRIPTION
## Summary
- Learned resource managers add \`cost_weight * resource_costs\` to losses (or subtract them from generator rewards). The default \`cost_weight\` is 0, so inf cost is \`0 * inf = NaN\` and the Hedge/Exp3 preferences collapse.
- Fail-closed: a zero cost weight does not multiply the cost channel. Inf costs are ignored when the weight is positive, matching how NaN losses are already dropped.
- Finite losses still shift the allocation.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_resource_manager.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/core/resource_manager.py tests/test_resource_manager.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)