### PR TITLE
Do not multiply V(s') when Gymnasium VALUE gamma is zero

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -53,6 +53,13 @@ class PredictionMode(Enum):
     VALUE = "value"
 
 
+def _discounted_bootstrap(gamma: float, next_value: float) -> float:
+    """Return ``gamma * V(s')``, or 0 when gamma is 0 so 0*inf stays 0."""
+    if float(gamma) == 0.0:
+        return 0.0
+    return float(gamma) * float(next_value)
+
+
 def _flatten_space(space: gymnasium.spaces.Space[Any]) -> int:
     """Get the flattened dimension of a Gymnasium space.
 
@@ -260,7 +267,7 @@ def collect_trajectory(
             # estimator (documented on PredictionMode.VALUE) and on
             # termination, where the post-terminal value is defined as zero.
             if value_estimator is not None and not terminated:
-                bootstrap = gamma * float(value_estimator(next_obs))
+                bootstrap = _discounted_bootstrap(gamma, float(value_estimator(next_obs)))
             else:
                 bootstrap = 0.0
             target = jnp.atleast_1d(
@@ -475,7 +482,7 @@ class GymnasiumStream:
             else:
                 next_value = 0.0
 
-            target = reward + self._gamma * next_value
+            target = reward + _discounted_bootstrap(self._gamma, next_value)
             return jnp.atleast_1d(jnp.array(target, dtype=jnp.float32))
 
         else:
@@ -630,7 +637,7 @@ class TDStream:
             target = jnp.atleast_1d(jnp.array(reward, dtype=jnp.float32))
         else:
             bootstrap = self._value_fn(next_features)
-            target_val = float(reward) + self._gamma * float(bootstrap)
+            target_val = float(reward) + _discounted_bootstrap(self._gamma, float(bootstrap))
             target = jnp.atleast_1d(jnp.array(target_val, dtype=jnp.float32))
 
         self._step_count += 1

--- a/tests/test_gymnasium_bootstrap.py
+++ b/tests/test_gymnasium_bootstrap.py
@@ -1,0 +1,21 @@
+"""Tests for Gymnasium VALUE bootstrap algebra that do not need Gymnasium."""
+
+from __future__ import annotations
+
+import math
+
+from alberta_framework.streams.gymnasium import _discounted_bootstrap
+
+
+def test_zero_gamma_skips_inf_bootstrap() -> None:
+    """gamma=0 is no bootstrap; 0 * inf V(s') is NaN.
+
+    Fail-closed: a zero discount does not multiply the later value.
+    """
+    assert _discounted_bootstrap(0.0, float("inf")) == 0.0
+    assert math.isfinite(_discounted_bootstrap(0.0, float("inf")))
+
+
+def test_positive_gamma_keeps_finite_and_inf_products() -> None:
+    assert _discounted_bootstrap(0.5, 10.0) == 5.0
+    assert math.isinf(_discounted_bootstrap(0.99, float("inf")))

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -146,6 +146,18 @@ class TestGymnasiumStreamValueMode:
         # So targets with estimator should generally be larger
         assert sum(targets_with_estimator) > sum(targets_without)
 
+    def test_zero_gamma_skips_inf_bootstrap(self) -> None:
+        """gamma=0 is the next reward; 0 * inf V(s') is NaN.
+
+        Fail-closed: a zero discount does not multiply the bootstrap value.
+        """
+        env = gymnasium.make("CartPole-v1")
+        stream = GymnasiumStream(env, mode=PredictionMode.VALUE, gamma=0.0, seed=0)
+        stream.set_value_estimator(lambda _obs: float("inf"))
+        target = stream._construct_target(1.25, jnp.ones(4, dtype=jnp.float32), terminated=False)
+        assert bool(jnp.isfinite(target).all())
+        assert float(target[0]) == pytest.approx(1.25)
+
 
 class TestGymnasiumStreamAutoReset:
     """Tests for auto-reset behavior on episode boundaries."""
@@ -305,6 +317,17 @@ class TestTDStream:
         # Non-terminal targets with V(s')=5 should be larger: r + 0.99*5 vs r + 0.99*0
         # At least some should be larger (terminal states will be the same)
         assert sum(targets_with_value) > sum(targets_zero)
+
+    def test_zero_gamma_skips_inf_value_function(self) -> None:
+        """gamma=0 times inf V(s') is NaN in TDStream targets.
+
+        Fail-closed: a zero discount does not multiply the value function.
+        """
+        env = gymnasium.make("CartPole-v1")
+        stream = TDStream(env, gamma=0.0, seed=0)
+        stream.update_value_function(lambda _obs: float("inf"))
+        target = next(stream).target
+        assert bool(jnp.isfinite(target).all())
 
     def test_episode_tracking(self):
         """TDStream should track episode count."""
@@ -488,6 +511,23 @@ class TestCollectTrajectoryValueMode:
         assert bool(jnp.all(bootstrapped | terminal))
         # Random CartPole rollouts of 60 steps contain non-terminal steps.
         assert bool(jnp.any(bootstrapped))
+
+    def test_zero_gamma_skips_inf_bootstrap(self) -> None:
+        """gamma=0 times inf V(s') is NaN in collected VALUE targets.
+
+        Fail-closed: a zero discount does not multiply the estimator.
+        """
+        env = gymnasium.make("CartPole-v1")
+        _, targets = collect_trajectory(
+            env,
+            None,
+            num_steps=20,
+            mode=PredictionMode.VALUE,
+            seed=11,
+            value_estimator=lambda _obs: float("inf"),
+            gamma=0.0,
+        )
+        assert bool(jnp.all(jnp.isfinite(targets)))
 
     def test_estimator_receives_next_observation(self):
         """The bootstrap value is computed from the next observation."""


### PR DESCRIPTION
## Summary
- Gymnasium VALUE targets are \`reward + gamma * V(s')\`. With \`gamma=0\` this is the immediate reward, but an inf bootstrap is \`0 * inf = NaN\`.
- Fail-closed: a zero discount does not multiply the value estimator in \`collect_trajectory\`, \`GymnasiumStream\`, and \`TDStream\`. Finite rewards stay equal to themselves.
- Helper tests run without the Gymnasium extra. Stream tests in \`tests/test_gymnasium_streams.py\` cover the same algebra when Gymnasium is installed.

## Test plan
- [x] \`.venv/bin/python -m pytest tests/test_gymnasium_bootstrap.py tests/test_gymnasium_streams.py -q\`
- [x] \`.venv/bin/python -m ruff check alberta_framework/streams/gymnasium.py tests/test_gymnasium_bootstrap.py tests/test_gymnasium_streams.py\`

No Slop measured-run receipt. Made with Cursor.

Made with [Cursor](https://cursor.com)