### PR TITLE
fix(micro): refuse to merge cross-seed hyperparameter/mechanism drift

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -911,6 +911,33 @@ def merge_micro_shards(
     for arm_name, per_seed in sorted(by_arm.items()):
         seeds = sorted(per_seed)
         all_seeds.update(seeds)
+        reference_hp = per_seed[seeds[0]]["hyperparameters"]
+        mismatched_hp = [s for s in seeds if per_seed[s]["hyperparameters"] != reference_hp]
+        if mismatched_hp:
+            # A registry entry is not literally immutable while an arm is
+            # still being tuned; shards from before and after a
+            # hyperparameter change can land in the same directory. Without
+            # this check they merge silently under one arm_name, blend
+            # per-regime accuracy across genuinely different mechanisms, and
+            # report only seeds[0]'s hyperparameters as if representative of
+            # the whole arm.
+            raise ValueError(
+                f"arm {arm_name!r} has inconsistent hyperparameters across seeds: "
+                f"seed {seeds[0]} used {reference_hp!r}, seed(s) {mismatched_hp} used "
+                "different values; refusing to merge runs with different "
+                "hyperparameters under one arm_name"
+            )
+        reference_mechanism = per_seed[seeds[0]]["mechanism"]
+        mismatched_mechanism = [
+            s for s in seeds if per_seed[s]["mechanism"] != reference_mechanism
+        ]
+        if mismatched_mechanism:
+            raise ValueError(
+                f"arm {arm_name!r} has inconsistent mechanism across seeds: "
+                f"seed {seeds[0]} used {reference_mechanism!r}, seed(s) "
+                f"{mismatched_mechanism} used different values; refusing to merge "
+                "runs of different mechanisms under one arm_name"
+            )
         curves = np.stack(
             [
                 np.asarray(per_seed[s]["per_regime_accuracy"], dtype=np.float64)

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -705,6 +705,67 @@ class TestShards:
         with pytest.raises(ValueError, match="stream config"):
             merge_micro_shards([path_a, path_b], bayes_samples=1_000)
 
+    def test_merge_rejects_hyperparameter_drift_across_seeds(self, tmp_path: Path):
+        """Two shards under one arm_name with different hyperparameters must
+        not merge: nothing else catches a registry value that changed
+        between two `run` invocations, and a silent merge would blend
+        per-regime accuracy across genuinely different mechanisms while
+        reporting only the first seed's hyperparameters as if
+        representative of the arm."""
+        path0 = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 0)
+        path1 = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 1)
+        result0 = run_micro_arm(TINY, "sgd_raw", seed=0, hidden1=8, hidden2=6)
+        result1 = run_micro_arm(TINY, "sgd_raw", seed=1, hidden1=8, hidden2=6)
+        write_micro_shard(path0, micro_shard_payload(result0))
+        payload1 = micro_shard_payload(result1)
+        payload1["hyperparameters"] = {
+            **payload1["hyperparameters"],
+            "step_size": payload1["hyperparameters"]["step_size"] + 1.0,
+        }
+        write_micro_shard(path1, payload1)
+
+        with pytest.raises(
+            ValueError,
+            match=r"'sgd_raw' has inconsistent hyperparameters across seeds",
+        ):
+            merge_micro_shards([path0, path1], bayes_samples=1_000)
+
+    def test_merge_rejects_mechanism_drift_across_seeds(self, tmp_path: Path):
+        """Same defect as above but on `mechanism`: seed 1's mechanism
+        string is mutated while its hyperparameters stay identical, so only
+        the mechanism check can catch it."""
+        path0 = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 0)
+        path1 = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 1)
+        result0 = run_micro_arm(TINY, "sgd_raw", seed=0, hidden1=8, hidden2=6)
+        result1 = run_micro_arm(TINY, "sgd_raw", seed=1, hidden1=8, hidden2=6)
+        write_micro_shard(path0, micro_shard_payload(result0))
+        payload1 = micro_shard_payload(result1)
+        payload1["mechanism"] = "mutated_mechanism_string"
+        write_micro_shard(path1, payload1)
+
+        with pytest.raises(
+            ValueError,
+            match=r"'sgd_raw' has inconsistent mechanism across seeds",
+        ):
+            merge_micro_shards([path0, path1], bayes_samples=1_000)
+
+    def test_merge_accepts_identical_hyperparameters_and_mechanism(
+        self, tmp_path: Path
+    ):
+        """Positive control: seeds that genuinely share hyperparameters and
+        mechanism must still merge under the new cross-seed consistency
+        check."""
+        paths = []
+        for seed in (0, 1):
+            result = run_micro_arm(TINY, "sgd_raw", seed=seed, hidden1=8, hidden2=6)
+            path = micro_shard_path(tmp_path, TINY.family, "sgd_raw", seed)
+            write_micro_shard(path, micro_shard_payload(result))
+            paths.append(path)
+        summary = merge_micro_shards(paths, bayes_samples=1_000)
+        entry = next(e for e in summary["results"] if e["arm_name"] == "sgd_raw")
+        assert entry["n_seeds"] == 2
+        assert entry["seeds"] == [0, 1]
+
 
 # =============================================================================
 # Canonical suite: transfer validation


### PR DESCRIPTION
Closes #106.

## What changed

`merge_micro_shards` (`alberta_framework/benchmarks/micro_continual.py:883`) now requires every seed merged under one `arm_name` to carry identical `hyperparameters` and identical `mechanism`, raising a deterministic `ValueError` naming the arm, the field, and the mismatched seed(s) instead of silently reporting only `seeds[0]`'s values as representative of the whole arm while `curves.mean(axis=1)` blends per-regime accuracy across every seed regardless of mechanism. This ports #97's `ipmnist_screening.py::merge_shards` guard to this sibling merge, which had never had it, adjusted for this file's field names (`arm_name` instead of `config_name`) and for the extra `mechanism` field this merge also silently discarded. Two separate checks are raised (hyperparameters, then mechanism) so each mismatch is named precisely rather than folded into one ambiguous message. No behavior change for any merge whose seeds already agree. No new flags.

Before, on `main` `da8b86c` (two `sgd_raw` shards, `TINY` stream config, seeds {0,1}; seed 1's `hyperparameters['step_size']` mutated 0.01 -> 1.01 and `mechanism` mutated to a different string):

```text
merge_micro_shards([seed0_path, seed1_path], bayes_samples=2_000)
=> merge_micro_shards raised NO error
merged entry arm_name: sgd_raw
merged entry n_seeds: 2
merged entry hyperparameters (reports only seed 0's): {'step_size': 0.01, 'weight_decay': 0.0}
merged entry mechanism (reports only seed 0's): baseline
average_online_accuracy_mean: 0.32   # blended across two different mechanisms
```

After:

```text
ValueError: arm 'sgd_raw' has inconsistent hyperparameters across seeds: seed 0 used
{'step_size': 0.01, 'weight_decay': 0.0}, seed(s) [1] used different values; refusing
to merge runs with different hyperparameters under one arm_name
```

Failing-test-first in `TestShards` (`tests/test_micro_continual.py`): `test_merge_rejects_hyperparameter_drift_across_seeds` and `test_merge_rejects_mechanism_drift_across_seeds` build two real shards via `run_micro_arm`/`micro_shard_payload`/`write_micro_shard` (the same helpers `test_merge_ranks_and_pairs` uses), then mutate seed 1's `hyperparameters` or `mechanism` respectively before writing it. Both are red on `main` (`Failed: DID NOT RAISE ValueError`), green at head. `test_merge_accepts_identical_hyperparameters_and_mechanism` is the positive control: two genuinely matching seeds must still merge to `n_seeds == 2`.

Not touching in this change (per #106's own scope): the rest of the merge (`stream_config`/`hidden1`/`hidden2` consistency, duplicate-seed refusal — already correct before this PR), the `transfer_validation` ladder checks, or `load_micro_shard`'s structural validation (`load_micro_shard` has no `MICRO_ARM_REGISTRY` access at load time to compare a shard's `hyperparameters`/`mechanism` against the *current* registry entry — the same load-time boundary #96 drew out of scope for `ipmnist_screening.py`'s `load_shard`).

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds consumed beyond the tiny synthetic `TINY` stream config already used by this test class, no benchmark campaign runs, no `outputs/` artifacts touched. Environment: macOS arm64, CPU backend, Python 3.12.14, jax 0.11.0, numpy 2.5.2 (stock `uv.lock`). Commit measured: `bb6b652b5d2f8d985aea2804a88987dbe4a2a271`.

<!-- evidence-head:bb6b652b5d2f8d985aea2804a88987dbe4a2a271 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red, candidate green); immutable attachment URLs can be added on request.

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_micro_continual.py -k "hyperparameter_drift or mechanism_drift or accepts_identical" -q -o addopts=""
FF.                                                                      [100%]
=================================== FAILURES ===================================
_______ TestShards.test_merge_rejects_hyperparameter_drift_across_seeds ________
...
E       Failed: DID NOT RAISE ValueError
tests/test_micro_continual.py:727: Failed
__________ TestShards.test_merge_rejects_mechanism_drift_across_seeds __________
...
E       Failed: DID NOT RAISE ValueError
tests/test_micro_continual.py:746: Failed
=========================== short test summary info ============================
FAILED tests/test_micro_continual.py::TestShards::test_merge_rejects_hyperparameter_drift_across_seeds
FAILED tests/test_micro_continual.py::TestShards::test_merge_rejects_mechanism_drift_across_seeds
2 failed, 1 passed, 78 deselected in 7.03s
```

Candidate, targeted then full touched file:

```text
$ .venv/bin/python -m pytest tests/test_micro_continual.py -k "hyperparameter_drift or mechanism_drift or accepts_identical" -q -o addopts=""
...                                                                      [100%]
3 passed, 78 deselected in 6.14s

$ .venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""
........................................................................ [ 88%]
.........                                                                [100%]
81 passed, 2 warnings in 28.17s
# the 2 warnings are a pre-existing NumPy 2.5 sklearn DeprecationWarning
# in test_digits_features_shapes_and_scaling, unrelated to this change

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/micro_continual.py tests/test_micro_continual.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/benchmarks/micro_continual.py
Success: no issues found in 1 source file
```

Exit codes: pytest 0, ruff 0, mypy 0.

Historical safety, verified against the artifacts: a scan of all 42 pinned raw micro-continual shard files under `outputs/micro_continual/**/*_seed*.json` (18 distinct `(directory, arm_name)` groups across `ladder_m1`, `families_r40`, and `calibration/r1`) found zero groups with more than one distinct `hyperparameters` set or more than one distinct `mechanism` value — this guard would not have refused any committed historical merge.

Deviations from the #106 plan: none.

## Provenance

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@deaa6f128ef16be7a68f6da9940743e6b724b80e:skills/contribute-to-asi
Attribution status: self-reported (device-signed run receipt unavailable: the slop.cash skill manifest was stale at work time — pinned revision fails its own acceptedRevisions contract against slopdotcash develop head; receipt to follow when the lane reopens)
— [nxn-claude-code]
