### PR TITLE
fix(screening): refuse non-finite wall clocks at shard load

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6990,6 +6990,12 @@ def load_shard(path: Path) -> dict[str, Any]:
         values = np.asarray(payload[fieldname], dtype=np.float64)
         if values.shape != (config.n_tasks,) or not np.all(np.isfinite(values)):
             raise ValueError(f"{path}: {fieldname} must be finite with shape ({config.n_tasks},)")
+    if (
+        type(payload.get("wall_clock_seconds")) not in (int, float)
+        or not math.isfinite(payload["wall_clock_seconds"])
+        or payload["wall_clock_seconds"] < 0
+    ):
+        raise ValueError(f"{path}: wall_clock_seconds must be a finite, non-negative number")
     if type(payload.get("seed")) is not int or payload["seed"] < 0:
         raise ValueError(f"{path}: seed must be a non-negative integer")
     if payload.get("config_name") not in SCREENING_REGISTRY:

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -988,6 +988,49 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
+    @pytest.mark.parametrize(
+        ("value", "label"),
+        [
+            (math.inf, "inf"),
+            (math.nan, "nan"),
+            (-1.0, "negative"),
+        ],
+    )
+    def test_load_shard_rejects_non_finite_wall_clock_seconds(
+        self, tmp_path, small_data, value, label
+    ):
+        """load_shard gates per_task_accuracy/loss/plasticity for finiteness
+        but never validated wall_clock_seconds: a shard with an infinite,
+        NaN, or negative wall_clock_seconds loaded cleanly, and merge_shards
+        would carry it straight into wall_clock_seconds_total, whose
+        json.dump then emits the non-standard `Infinity`/`NaN` token — an
+        artifact the pipeline's own tooling produced but a strict JSON
+        parser (e.g. JS `JSON.parse`) refuses to read back."""
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["wall_clock_seconds"] = value
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"wall_clock_seconds must be a finite, non-negative number",
+        ):
+            load_shard(path)
+
+    def test_merge_propagates_finite_wall_clock_into_total(self, tmp_path, small_data):
+        """Positive control: shards with genuinely finite, non-negative
+        wall_clock_seconds still load and merge, and merge_shards sums them
+        into wall_clock_seconds_total exactly as before the guard."""
+        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        p1 = self._make_shard(tmp_path, small_data, "upgd_w_control", 1)
+        wc0 = json.loads(p0.read_text(encoding="utf-8"))["wall_clock_seconds"]
+        wc1 = json.loads(p1.read_text(encoding="utf-8"))["wall_clock_seconds"]
+
+        summary = merge_shards([p0, p1], control_name="upgd_w_control", slope_window=2)
+
+        entry = next(e for e in summary["results"] if e["config_name"] == "upgd_w_control")
+        assert entry["wall_clock_seconds_total"] == round(wc0 + wc1, 2)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"


### PR DESCRIPTION
Closes #114.

## What changed

`load_shard` (`ipmnist_screening.py:6983`) gates `per_task_accuracy`/`per_task_loss`/`per_task_plasticity` for finiteness, but never validated `wall_clock_seconds` — the one other per-shard numeric field `shard_payload` writes (line 6972). A shard with `wall_clock_seconds = inf`/`NaN`/negative loaded cleanly, and `merge_shards` (line 7077-7079) summed it straight into the published summary's `wall_clock_seconds_total`, whose `json.dump` then emits the non-standard `Infinity`/`NaN` token in place of a number. `load_shard` now additionally requires `wall_clock_seconds` to be a finite, non-negative number, raising a deterministic `ValueError` naming the field — the same shape as the finiteness checks it already runs immediately above, placed between that loop and the existing `seed` check rather than as a separate pass over the payload.

Before, on `main` `da8b86c` (`upgd_w_control`, `SMALL` config, seeds {0,1}; seed 0 real, seed 1's `wall_clock_seconds` overwritten to `inf`):

```text
seed=0 wall_clock_seconds=0.37
seed=1 wall_clock_seconds=inf

load_shard(seed=1) accepted wall_clock_seconds=inf (no rejection)
merge_shards raised NO error.
wall_clock_seconds_total in published summary: inf

Serialized summary JSON contains literal 'Infinity': True

Python json.loads (default, non-strict) reads it back fine:
  wall_clock_seconds_total round-trips as: inf
```

and the resulting `summary.json` fails under a spec-strict parser even though this pipeline's own `json.loads` reads it back without complaint:

```text
$ node -e "JSON.parse(require('fs').readFileSync('summary.json','utf8'))"
SyntaxError: Unexpected token 'I', ..."s_total": Infinity}]"... is not valid JSON
    at JSON.parse (<anonymous>)
```

(`jq` was also tried on the same file for comparison: it does not raise — it silently substitutes `1.7976931348623157e+308` (`DBL_MAX`) for the `Infinity` token and exits 0, which is a different and arguably worse failure mode than a parse error. Noted in the issue; not something this PR can fix in `jq`.)

After:

```text
seed=0 wall_clock_seconds=0.36
seed=1 wall_clock_seconds=inf
Traceback (most recent call last):
  ...
  File ".../alberta_framework/benchmarks/ipmnist_screening.py", line 6998, in load_shard
    raise ValueError(f"{path}: wall_clock_seconds must be a finite, non-negative number")
ValueError: .../wc_seed1.json: wall_clock_seconds must be a finite, non-negative number
```

`load_shard` refuses before `merge_shards` is ever reached, so every caller (`merge_shards`, and `validate_proxy`, which never read `wall_clock_seconds` itself but does call `load_shard`) inherits the guard automatically.

Failing-test-first in `TestShardsAndMerge` (`tests/test_ipmnist_screening.py`): `test_load_shard_rejects_non_finite_wall_clock_seconds` is parametrized over `inf`, `NaN`, and a negative value, builds one real shard via `_make_shard`, overwrites `wall_clock_seconds`, and asserts `load_shard` raises — red on `main` (`Failed: DID NOT RAISE ValueError`, all three cases), green at head. `test_merge_propagates_finite_wall_clock_into_total` is the positive control: two genuinely finite, non-negative shards still load and merge, and `wall_clock_seconds_total` still equals their sum (this already passed pre-fix and continues to pass post-fix — it exists to prove the guard doesn't false-positive on legitimate values, not to catch a regression).

Anti-collision with open PRs #97 and #110: both live entirely inside `merge_shards` (`ipmnist_screening.py:7011` pre-patch) — #97 adds a `hyperparameters` guard inside the per-`config_name` loop (`ipmnist_screening.py:7047+`, `for name, per_seed in sorted(by_config.items()):`); #110 adds an `environment` guard as a merge-global check right after `noise_mode = noise_modes.pop()` (`ipmnist_screening.py:7029+`), before `by_config` is even built. This change lives entirely inside `load_shard` (`ipmnist_screening.py:6993-6998` post-patch, inserted between the existing per-task finiteness loop and the existing `seed` check), a separate function that finishes at line 6997 pre-patch — seventeen lines before `merge_shards` even begins at line 7011. None of the three diffs touch a shared line, and since ours is strictly upstream of and outside `merge_shards`, all three should apply and compose cleanly in any order.

Schema: neither `SHARD_SCHEMA` nor `SUMMARY_SCHEMA` is bumped. Checked precedent exactly as #108 did: `git log --all -S "SHARD_SCHEMA = "` shows the constant was set once, in the commit that introduced it, and this change adds no new field to either the shard or the summary — it only narrows which values of an existing field `load_shard` accepts. No version bump is warranted for a validation-only change.

Not touching in this change (per the issue's own scope): `micro_continual.py`'s `load_micro_shard`, which has the identical gap (confirmed on `main`, independent of open PR #109) — left for a follow-up issue, consistent with #96 and #106 having been filed as separate issues, each with its own PR (#97, #109), for the same `ipmnist_screening.py`/`micro_continual.py` split. Also not touched: any semantic meaning for *why* a wall clock might be non-finite (e.g. a timed-out run) — this closes the gap where an already-degenerate value is invisible, it does not add a new concept to the schema.

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds consumed beyond the existing `small_data`/`SMALL`-config fixtures this test class already uses, no benchmark campaign runs, no `outputs/` artifacts touched (repro scripts wrote only to a scratch directory outside the repo). Environment: macOS arm64, CPU backend, Python 3.12.14, jax 0.11.0, numpy 2.5.2 (stock `uv.lock`). Commit measured: `cd41e45bd9c4f52023746752f6db800de8533f11`.

<!-- evidence-head:cd41e45bd9c4f52023746752f6db800de8533f11 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red, candidate green); immutable attachment URLs can be added on request.

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -k "wall_clock" -q -o addopts=""
FFF.                                                                     [100%]
=================================== FAILURES ===================================
_ TestShardsAndMerge.test_load_shard_rejects_non_finite_wall_clock_seconds[inf-inf] _
...
>       with pytest.raises(
            ValueError,
            match=r"wall_clock_seconds must be a finite, non-negative number",
        ):
E       Failed: DID NOT RAISE ValueError
tests/test_ipmnist_screening.py:1014: Failed
_ TestShardsAndMerge.test_load_shard_rejects_non_finite_wall_clock_seconds[nan-nan] _
...
E       Failed: DID NOT RAISE ValueError
tests/test_ipmnist_screening.py:1014: Failed
_ TestShardsAndMerge.test_load_shard_rejects_non_finite_wall_clock_seconds[-1.0-negative] _
...
E       Failed: DID NOT RAISE ValueError
tests/test_ipmnist_screening.py:1014: Failed
=========================== short test summary info ============================
FAILED tests/test_ipmnist_screening.py::TestShardsAndMerge::test_load_shard_rejects_non_finite_wall_clock_seconds[inf-inf]
FAILED tests/test_ipmnist_screening.py::TestShardsAndMerge::test_load_shard_rejects_non_finite_wall_clock_seconds[nan-nan]
FAILED tests/test_ipmnist_screening.py::TestShardsAndMerge::test_load_shard_rejects_non_finite_wall_clock_seconds[-1.0-negative]
3 failed, 1 passed, 203 deselected in 5.16s
```

Candidate, targeted then full touched file:

```text
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -k "wall_clock" -q -o addopts=""
....                                                                     [100%]
4 passed, 203 deselected in 4.97s

$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""
........................................................................ [ 34%]
........................................................................ [ 69%]
...............................................................          [100%]
207 passed in 74.69s (0:01:14)
# all 203 pre-existing tests plus the 4 new ones (3 parametrized rejection
# cases + 1 positive control) pass

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/benchmarks/ipmnist_screening.py
Success: no issues found in 1 source file
```

Exit codes: pytest 0, ruff 0, mypy 0.

Historical safety, verified against the artifacts: a scan of all 459 pinned raw screening shard files under `outputs/ipmnist_screening/**/*.json` (filtered to `schema == "alberta.ipmnist_screening.shard.v1"`) found zero shards with a non-finite or negative `wall_clock_seconds` — this guard would not have refused any committed historical shard load. Unlike #108's `environment` check (a cross-seed consistency property whose verification needed each summary's exact original shard subset reconstructed), `wall_clock_seconds` finiteness is a per-shard property: every individual shard file on disk is directly checkable on its own, independent of which summary it fed into. This scan is therefore a complete census of the 459 pinned shard files, not a sample limited by reconstructable merge subsets — it did not need, and does not carry, #108's "8 summaries could not be re-merged bit-for-bit" caveat.

## Open / caveats

- `micro_continual.py`'s `load_micro_shard` has the identical gap (see issue). Left for a follow-up issue rather than folded into this PR, matching this tracker's one-decision-boundary-per-PR precedent (#96/#106 were separate issues and separate PRs for the equivalent `ipmnist_screening.py`/`micro_continual.py` split).
- `jq`'s silent substitution of `DBL_MAX` for `Infinity` (rather than a parse error) is documented in the issue as an observation, not something in this PR's scope to change — `jq` is not part of this repository.

Deviations from the issue's plan: none.

## Provenance

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@deaa6f128ef16be7a68f6da9940743e6b724b80e:skills/contribute-to-asi
Attribution status: self-reported (device-signed run receipt unavailable: the slop.cash skill manifest was stale at work time — pinned revision fails its own acceptedRevisions contract against slopdotcash develop head; receipt to follow when the lane reopens)
— [nxn-claude-code]
