### PR TITLE
fix(experiments): refuse a non-positive window in get_final_performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `get_final_performance` now refuses a non-positive `window` and an empty time
+  axis instead of silently averaging the whole trace (`window=0`, because
+  `arr[:, -0:]` is a full slice) or a prefix (`window < 0`) and publishing NaN.
+
 ## [0.29.0] - 2026-08-14
 
 Changes since 0.28.0 are summarized by durable user-visible behavior. Development campaign

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -334,15 +334,31 @@ def get_final_performance(
     Args:
         results: Dictionary of aggregated results
         metric: Metric to evaluate
-        window: Number of final steps to average
+        window: Number of final steps to average. Must be positive. A window
+            longer than the trace uses the whole trace, matching
+            :func:`aggregate_metrics`.
 
     Returns:
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
+
+    Raises:
+        ValueError: If ``window`` is not positive, or a metric array has no
+            time steps. ``window=0`` is not "the last step": ``arr[:, -0:]``
+            is the full trace, so the helper refuses rather than silently
+            reporting a full-horizon mean.
     """
+    if window <= 0:
+        raise ValueError(f"window must be positive (got {window})")
+
     performance: dict[str, tuple[float, float]] = {}
     for name, agg in results.items():
         arr = agg.metric_arrays[metric]
+        if arr.shape[1] == 0:
+            raise ValueError(
+                f"AggregatedResults {name!r} must contain at least one metric step "
+                f"for {metric!r}"
+            )
         final_window = min(window, arr.shape[1])
         final_means = np.mean(arr[:, -final_window:], axis=1)
         std = float(np.std(final_means, ddof=1)) if len(final_means) > 1 else 0.0

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -195,3 +195,51 @@ def test_empty_config_sequence_still_returns_empty_results() -> None:
     assert (
         run_multi_seed_experiment([], seeds=[0], parallel=False, show_progress=False) == {}
     )
+
+
+def _two_seed_trace() -> AggregatedResults:
+    return AggregatedResults(
+        config_name="candidate",
+        seeds=[0, 1],
+        metric_arrays={
+            "squared_error": np.asarray([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]], dtype=np.float64)
+        },
+        summary={},
+    )
+
+
+@pytest.mark.parametrize("window", [0, -1, -5])
+def test_get_final_performance_rejects_non_positive_window(window: int) -> None:
+    """window<=0 is undefined: window=0 slices the whole trace, negatives drop a prefix."""
+    with pytest.raises(ValueError, match=rf"^window must be positive \(got {window}\)$"):
+        get_final_performance({"candidate": _two_seed_trace()}, window=window)
+
+
+def test_get_final_performance_rejects_empty_time_axis() -> None:
+    empty = AggregatedResults(
+        config_name="empty",
+        seeds=[0, 1],
+        metric_arrays={"squared_error": np.zeros((2, 0), dtype=np.float64)},
+        summary={},
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"^AggregatedResults 'empty' must contain at least one metric step "
+        r"for 'squared_error'$",
+    ):
+        get_final_performance({"empty": empty}, window=1)
+
+
+def test_get_final_performance_window_longer_than_trace_uses_full_trace() -> None:
+    """The documented min(window, n_steps) convention is unchanged for window > 0."""
+    result = get_final_performance({"candidate": _two_seed_trace()}, window=100)
+    expected_values = np.asarray([2.0, 20.0], dtype=np.float64)
+    assert result["candidate"][0] == pytest.approx(float(np.mean(expected_values)))
+    assert result["candidate"][1] == pytest.approx(float(np.std(expected_values, ddof=1)))
+
+
+def test_get_final_performance_positive_window_is_a_suffix() -> None:
+    result = get_final_performance({"candidate": _two_seed_trace()}, window=2)
+    expected_values = np.asarray([2.5, 25.0], dtype=np.float64)
+    assert result["candidate"][0] == pytest.approx(float(np.mean(expected_values)))
+    assert result["candidate"][1] == pytest.approx(float(np.std(expected_values, ddof=1)))


### PR DESCRIPTION
Closes #111.

## What changed

`get_final_performance` (`alberta_framework/utils/experiments.py`) is the public helper that turns an `AggregatedResults` timeseries into the `(mean, sample_std)` pair used for publication-style tables and by `extract_hyperparameter_results`. It took `window` last steps via `arr[:, -final_window:]` with no lower bound.

`window=0` is not "the last step": `arr[:, -0:]` is `arr[:, 0:]`, the **entire trace**, so the published "final" mean was the full-horizon mean. A negative window dropped a **prefix** (`arr[:, k:]`). An empty time axis (`shape[1] == 0`) published `NaN` and a `RuntimeWarning`. `pairwise_comparisons` in the sibling module already refuses `window <= 0`; this helper did not.

The helper now matches that contract:

1. `window <= 0` raises `ValueError: window must be positive (got …)`.
2. A metric array with no time steps raises `ValueError` naming the config and metric, instead of publishing NaN.
3. `window > 0` longer than the trace still uses `min(window, n_steps)` — the documented convention in `aggregate_metrics`.

No behavior change for any previously valid call (`window >= 1` with at least one time step). `get_metric_timeseries`, `aggregate_metrics`'s hardcoded 100-step window, and the one-seed zero-spread contract are untouched.

## Tests

Failing-test-first in `tests/test_experiments_validation.py`:

- `window=0`, `window=-1`, `window=-5` raise the deterministic `ValueError`
- empty time axis raises, no NaN
- `window=2` remains a suffix; `window=100` on a 3-step trace still uses the full trace

Red phase (tests added, guard absent on `main` `da8b86c`): 4 failed, 11 passed, plus `RuntimeWarning` on the empty-slice paths. Green after the guard: 15 passed.

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds, no benchmark, no `outputs/` artifacts. Commit measured: `7a88ac9eac5b7684a4341c0a9b1aad88bf0b518a`.

<!-- evidence-head:7a88ac9eac5b7684a4341c0a9b1aad88bf0b518a -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red on `main` `da8b86c`, candidate green).

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_experiments_validation.py -q -o addopts=""
FAILED ...::test_get_final_performance_rejects_non_positive_window[0]
FAILED ...::test_get_final_performance_rejects_non_positive_window[-1]
FAILED ...::test_get_final_performance_rejects_non_positive_window[-5]
FAILED ...::test_get_final_performance_rejects_empty_time_axis
4 failed, 11 passed, 4 warnings in 2.44s
```

Candidate:

```text
$ .venv/bin/python -m pytest tests/test_experiments_validation.py -q -o addopts=""
15 passed in 2.47s
$ .venv/bin/python -m ruff check .
All checks passed!
$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
$ .venv/bin/python -m pytest tests/test_release_metadata.py tests/test_utils_smoke.py -q -o addopts=""
10 passed in 3.41s
$ git diff --check   # clean
```

Deviations from the #111 plan: none. `extract_hyperparameter_results` inherits the new refusal through `get_final_performance` and does not expose `window` itself.

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok CLI
Contribution skill: read `https://slop.cash/SKILL.md`; formal `contribute-to-asi` archive install blocked (site manifest revision `1bde21d` ≠ slopdotcash `develop` `94734a7`). Followed `contribute-to-asi` at `elizaOS/slopdotcash@94734a7`.
Attribution status: self-reported
— [deepanshu-yd]
