### PR TITLE
fix(statistics): refuse empty and unequal-length Wilcoxon pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `wilcoxon_comparison` now refuses empty and unequal-length pairs with a
+  deterministic `ValueError` before SciPy, matching the paired t-test's
+  input contract. Identical-sample refusal is unchanged.
+
 ## [0.29.0] - 2026-08-14
 
 Changes since 0.28.0 are summarized by durable user-visible behavior. Development campaign

--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -393,13 +393,21 @@ def wilcoxon_comparison(
         SignificanceResult with test results
 
     Raises:
-        ValueError: If the non-empty paired samples are identical, for which
-            the Wilcoxon signed-rank statistic is undefined.
+        ValueError: If the samples have unequal length, if there are no
+            pairs, or if the non-empty paired samples are identical, for
+            which the Wilcoxon signed-rank statistic is undefined.
     """
     a = np.asarray(values_a)
     b = np.asarray(values_b)
 
-    if a.size > 0 and np.array_equal(a, b):
+    if len(a) != len(b):
+        raise ValueError(
+            "Wilcoxon signed-rank requires equal-length samples "
+            f"(got {len(a)} and {len(b)})"
+        )
+    if len(a) == 0:
+        raise ValueError(f"Wilcoxon signed-rank requires at least 1 pair (got {len(a)})")
+    if np.array_equal(a, b):
         raise ValueError(
             f"Paired comparison {method_a!r} vs {method_b!r} has identical "
             "samples; the Wilcoxon signed-rank statistic is undefined"

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -378,6 +378,49 @@ class TestIdenticalWilcoxonRejection:
         assert result.p_value < 1.0
 
 
+class TestWilcoxonEmptyAndUnequalRejection:
+    """Empty and unequal pairs fail closed before SciPy (#112).
+
+    The paired t-test already refuses these inputs (#32/#35). Wilcoxon only
+    gained the identical-samples refusal in #39. Length-1 Wilcoxon is left
+    alone: a single nonzero difference is a defined signed-rank observation,
+    and adding an n>=2 floor is out of scope.
+    """
+
+    def test_unequal_lengths_raise_before_scipy(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError,
+                match=r"^Wilcoxon signed-rank requires equal-length samples \(got 2 and 3\)$",
+            ):
+                wilcoxon_comparison([1.0, 2.0], [1.0, 2.0, 3.0])
+
+    @pytest.mark.parametrize("values_a, values_b", [([], [1.0, 2.0]), ([1.0, 2.0], [])])
+    def test_empty_versus_nonempty_is_unequal_length(
+        self,
+        values_a: list[float],
+        values_b: list[float],
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError,
+                match=r"^Wilcoxon signed-rank requires equal-length samples "
+                rf"\(got {len(values_a)} and {len(values_b)}\)$",
+            ):
+                wilcoxon_comparison(values_a, values_b)
+
+    def test_both_empty_raises_without_warning(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError,
+                match=r"^Wilcoxon signed-rank requires at least 1 pair \(got 0\)$",
+            ):
+                wilcoxon_comparison([], [])
+
+
 class TestOneSampleRejection:
     """Undefined one-sample contracts reject without narrowing valid t-tests (#35).
 


### PR DESCRIPTION
Closes #112.

## What changed

`wilcoxon_comparison` already refused elementwise-identical samples (#39/#41). Empty and unequal-length pairs still fell through to `scipy.stats.wilcoxon`:

- unequal lengths: SciPy 1.18.0 raises `ValueError: Array shapes are incompatible for broadcasting` — a version-dependent message, not the house contract
- both empty: SciPy emits `SmallSampleWarning` and would return a NaN statistic

The paired t-test already refuses both (#32/#35). Wilcoxon now has the same paired-input preamble, without reopening #39:

1. Unequal lengths → `Wilcoxon signed-rank requires equal-length samples (got N and M)`
2. Both empty → `Wilcoxon signed-rank requires at least 1 pair (got 0)`
3. Identical non-empty samples stay on the #39 message, unchanged
4. Length-1 Wilcoxon is left alone (a single nonzero difference is a defined signed-rank observation; adding an `n >= 2` floor is out of scope)
5. `mann_whitney_comparison` stays out of scope

`pairwise_comparisons(test="wilcoxon")` inherits the refusal with no further change.

## Tests

Failing-test-first in `TestWilcoxonEmptyAndUnequalRejection` (`tests/test_statistics_validation.py`):

- `[1, 2]` vs `[1, 2, 3]` raises the equal-length `ValueError`, no SciPy warning
- `[]` vs `[1, 2]` and the reverse are unequal-length, not a separate empty path
- `[]` vs `[]` raises the at-least-1-pair `ValueError`, no `SmallSampleWarning`
- existing identical-sample and constant-shift Wilcoxon tests still pass

Red phase (tests added, guard absent on `main` `da8b86c`): 4 failed (plus a length-1 Cohen's-d interaction that is out of scope and was not pinned). Green after the guard: `tests/test_statistics_validation.py` 97 passed.

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds, no benchmark, no `outputs/` artifacts. Commit measured: `835311289bfa05b7bb7b422b09c54cdd3d9de733`.

<!-- evidence-head:835311289bfa05b7bb7b422b09c54cdd3d9de733 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red on `main` `da8b86c`, candidate green).

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py::TestWilcoxonEmptyAndUnequalRejection -q -o addopts=""
FAILED ...::test_unequal_lengths_raise_before_scipy
  AssertionError: Array shapes are incompatible for broadcasting.
FAILED ...::test_empty_versus_nonempty_is_unequal_length[values_a0-values_b0]
FAILED ...::test_empty_versus_nonempty_is_unequal_length[values_a1-values_b1]
FAILED ...::test_both_empty_raises_without_warning
  scipy.stats._axis_nan_policy.SmallSampleWarning: One or more sample arguments is too small
4 failed
```

Candidate:

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""
97 passed, 2 warnings in 4.59s
$ .venv/bin/python -m ruff check .
All checks passed!
$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
$ .venv/bin/python -m pytest tests/test_release_metadata.py -q -o addopts=""
2 passed in 0.88s
$ git diff --check   # clean
```

Deviations from the #112 plan: none. Length-1 Wilcoxon was left alone as proposed; it still dies later in `cohens_d` (pooled df 0), which is #35's contract, not this change.

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok CLI
Contribution skill: read `https://slop.cash/SKILL.md`; formal `contribute-to-asi` archive install blocked (site manifest revision `1bde21d` ≠ slopdotcash `develop` `94734a7`). Followed `contribute-to-asi` at `elizaOS/slopdotcash@94734a7`.
Attribution status: self-reported
— [deepanshu-yd]
