### PR TITLE
fix(micro): refuse non-finite wall clocks at shard load

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -860,6 +860,12 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
             raise ValueError(
                 f"{path}: {fieldname} must be finite with shape ({config.n_regimes},)"
             )
+    if (
+        type(payload.get("wall_clock_seconds")) not in (int, float)
+        or not math.isfinite(payload["wall_clock_seconds"])
+        or payload["wall_clock_seconds"] < 0
+    ):
+        raise ValueError(f"{path}: wall_clock_seconds must be a finite, non-negative number")
     if type(payload.get("seed")) is not int or payload["seed"] < 0:
         raise ValueError(f"{path}: seed must be a non-negative integer")
     for fieldname in ("hidden1", "hidden2"):

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -705,6 +705,61 @@ class TestShards:
         with pytest.raises(ValueError, match="stream config"):
             merge_micro_shards([path_a, path_b], bayes_samples=1_000)
 
+    @pytest.mark.parametrize(
+        ("value", "label"),
+        [
+            (math.inf, "inf"),
+            (math.nan, "nan"),
+            (-1.0, "negative"),
+        ],
+    )
+    def test_load_rejects_non_finite_wall_clock_seconds(
+        self, tmp_path: Path, value, label
+    ):
+        """load_micro_shard gates per_regime_accuracy/per_regime_loss/
+        per_regime_plasticity for finiteness but never validated
+        wall_clock_seconds: a shard with an infinite, NaN, or negative
+        wall_clock_seconds loaded cleanly, and merge_micro_shards would carry
+        it straight into both wall_clock_seconds_total and
+        wall_clock_seconds_mean, whose json.dump then emits the non-standard
+        `Infinity`/`NaN` token in place of a number — an artifact this
+        pipeline's own tooling produced but a strict JSON parser (e.g. JS
+        `JSON.parse`) refuses to read back."""
+        payload = micro_shard_payload(self._result())
+        payload["wall_clock_seconds"] = value
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"wall_clock_seconds must be a finite, non-negative number",
+        ):
+            load_micro_shard(path)
+
+    def test_merge_propagates_finite_wall_clock_into_both_totals(
+        self, tmp_path: Path
+    ):
+        """Positive control: shards with genuinely finite, non-negative
+        wall_clock_seconds still load and merge, and merge_micro_shards
+        still sums/averages them into both wall_clock_seconds_total and
+        wall_clock_seconds_mean exactly as before the guard existed."""
+        paths = []
+        wall_clocks = []
+        for seed in (0, 1):
+            payload = micro_shard_payload(self._result(seed=seed))
+            wall_clocks.append(payload["wall_clock_seconds"])
+            path = micro_shard_path(tmp_path, TINY.family, "sgd_raw", seed)
+            write_micro_shard(path, payload)
+            paths.append(path)
+
+        summary = merge_micro_shards(paths, bayes_samples=1_000)
+
+        entry = next(e for e in summary["results"] if e["arm_name"] == "sgd_raw")
+        assert entry["wall_clock_seconds_total"] == round(sum(wall_clocks), 3)
+        assert entry["wall_clock_seconds_mean"] == round(
+            sum(wall_clocks) / len(wall_clocks), 3
+        )
+
 
 # =============================================================================
 # Canonical suite: transfer validation


### PR DESCRIPTION
Closes #118.

## What changed

`load_micro_shard` (`alberta_framework/benchmarks/micro_continual.py:848`) gates `per_regime_accuracy`/`per_regime_loss`/`per_regime_plasticity` for finiteness, but never validated `wall_clock_seconds` — the one other per-shard numeric field `micro_shard_payload` writes (line 831). A shard with `wall_clock_seconds = inf`/`NaN`/negative loaded cleanly, and `merge_micro_shards` (lines 944-952, pre-patch) summed *and* averaged it straight into the published summary's `wall_clock_seconds_total` **and** `wall_clock_seconds_mean` — two derived fields, versus the single field the sibling `merge_shards` (ipmnist, #115) computes — whose `json.dump` then emitted the non-standard `Infinity`/`NaN` token twice, once per field. `load_micro_shard` now additionally requires `wall_clock_seconds` to be a finite, non-negative number, raising a deterministic `ValueError` naming the field — the same shape as the finiteness checks it already runs immediately above, placed between that loop and the existing `seed` check, mirroring #115's guard on `load_shard` line for line, including its mypy-safe `.get(...)`-for-the-type-check then `[...]`-for-the-value idiom (`strict = true` in this repo's `[tool.mypy]`).

Before, on `main` `da8b86c` (`sgd_raw`, `TINY` M1/`input_permutation` stream config, seeds {0,1}; seed 0 real, seed 1's `wall_clock_seconds` overwritten to `inf`):

```text
seed=0 wall_clock_seconds=0.14
seed=1 wall_clock_seconds=inf

load_micro_shard(seed=1) accepted wall_clock_seconds=inf (no rejection)
merge_micro_shards raised NO error.
wall_clock_seconds_total in published summary: inf
wall_clock_seconds_mean in published summary: inf

Serialized summary JSON contains literal 'Infinity': True
'Infinity' occurrences in serialized JSON: 2

Python json.loads (default, non-strict) reads it back fine:
  wall_clock_seconds_total round-trips as: inf
  wall_clock_seconds_mean round-trips as: inf
```

and the resulting `summary.json` fails under a spec-strict parser even though this pipeline's own `json.loads` reads it back without complaint:

```text
$ node -e "JSON.parse(require('fs').readFileSync('summary.json','utf8'))"
SyntaxError: Unexpected token 'I', ..."s_total": Infinity, "... is not valid JSON
    at JSON.parse (<anonymous>)
```

(`jq` was also tried on the same artifact for comparison: it does not raise on either field — it silently substitutes `1.7976931348623157e+308` (`DBL_MAX`) for both `Infinity` tokens and exits 0, the same failure mode #114 documented for the single-field ipmnist case, here doubled. Noted for completeness; not something this PR can fix in `jq`, and `jq` is not part of this repository.)

After:

```text
seed=0 wall_clock_seconds=0.179
seed=1 wall_clock_seconds=inf
Traceback (most recent call last):
  File "repro_micro_wallclock_issue.py", line 52, in <module>
    loaded = load_micro_shard(paths[1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../alberta_framework/benchmarks/micro_continual.py", line 868, in load_micro_shard
    raise ValueError(f"{path}: wall_clock_seconds must be a finite, non-negative number")
ValueError: .../wc_seed1.json: wall_clock_seconds must be a finite, non-negative number
```

`load_micro_shard` refuses before `merge_micro_shards` is ever reached, so every caller inherits the guard automatically.

Failing-test-first in `TestShards` (`tests/test_micro_continual.py`): `test_load_rejects_non_finite_wall_clock_seconds` is parametrized over `inf`, `NaN`, and a negative value, builds one real shard via the class's existing `_result()`/`micro_shard_payload` helpers, overwrites `wall_clock_seconds`, and asserts `load_micro_shard` raises — red on `main` (`Failed: DID NOT RAISE ValueError`, all three cases), green at head. `test_merge_propagates_finite_wall_clock_into_both_totals` is the positive control: two genuinely finite, non-negative shards still load and merge, and both `wall_clock_seconds_total` and `wall_clock_seconds_mean` still equal their sum/mean (this already passed pre-fix and continues to pass post-fix — it exists to prove the guard doesn't false-positive on legitimate values, not to catch a regression; it is the two-field analogue of #115's single-field `test_merge_propagates_finite_wall_clock_into_total`).

**Anti-collision with open PR #109** (`fix/106-micro-merge-consistency`, also touching `micro_continual.py`): #109 adds a `hyperparameters`/`mechanism` cross-seed consistency check inside `merge_micro_shards`, inserted immediately after `all_seeds.update(seeds)` (pre-patch `micro_continual.py:913-914`, inside the per-arm loop, well before the `entries.append({...})` dict that holds `wall_clock_seconds_total`/`_mean`). This change lives entirely inside `load_micro_shard` (`micro_continual.py:863-868` post-patch, inserted between the existing per-regime finiteness loop and the existing `seed` check), a function that finished at line 869 pre-patch — 14 lines before `merge_micro_shards` even begins, at line 883 pre-patch. Checked this directly rather than by line-range inspection alone: merged `fix/106-micro-merge-consistency` and this branch together in a disposable scratch branch (`git merge --no-commit --no-ff`, not pushed). `alberta_framework/benchmarks/micro_continual.py` auto-merged with **zero conflicts** — confirmation that the two changes sit in genuinely disjoint functions. `tests/test_micro_continual.py` did **not** auto-merge cleanly: both PRs append new test methods to `TestShards` immediately after the same anchor method (`test_merge_rejects_mixed_configs`), so a future merge/rebase needs one manual resolution step to keep both blocks of new tests (order doesn't matter — they share no fixtures or state and don't interact). That is a mechanical line-adjacency conflict from both PRs picking the same insertion point, not a semantic one; flagging it here rather than claiming an unqualified "compose cleanly."

Schema: neither `MICRO_SHARD_SCHEMA` nor `MICRO_SUMMARY_SCHEMA` is bumped. Checked precedent exactly as #115 did: `git log --all -S "MICRO_SHARD_SCHEMA = "` shows the constant was set once, in the commit that introduced the suite (`ab15bdc`), and this change adds no new field to either the shard or the summary — it only narrows which values of an existing field `load_micro_shard` accepts. No version bump is warranted for a validation-only change.

Not touching in this change (per the issue's own scope): any semantic meaning for *why* a wall clock might be non-finite (e.g. a timed-out run) — this closes the gap where an already-degenerate value is invisible, it does not add a new concept to the schema.

## Evidence

Lane: deterministic unit tests, non-promoting; no seeds consumed beyond the existing `TINY` fixture this test class already uses, no benchmark campaign runs, no `outputs/` artifacts touched (repro scripts wrote only to scratch directories outside the repo). Environment: macOS arm64, CPU backend, Python 3.12.14, jax 0.11.0, numpy 2.5.2 (stock `uv.lock`). Commit measured: `f26612583a15d64793c9715e715acf1bc657a1ac`.

<!-- evidence-head:f26612583a15d64793c9715e715acf1bc657a1ac -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below (baseline red, candidate green); immutable attachment URLs can be added on request.

Baseline (guard absent, tests added first):

```text
$ .venv/bin/python -m pytest tests/test_micro_continual.py -k "wall_clock" -q -o addopts=""
FFF.                                                                     [100%]
=================================== FAILURES ===================================
_____ TestShards.test_load_rejects_non_finite_wall_clock_seconds[inf-inf] ______
...
>       with pytest.raises(
            ValueError,
            match=r"wall_clock_seconds must be a finite, non-negative number",
        ):
E       Failed: DID NOT RAISE ValueError
tests/test_micro_continual.py:733: Failed
_____ TestShards.test_load_rejects_non_finite_wall_clock_seconds[nan-nan] ______
...
E       Failed: DID NOT RAISE ValueError
tests/test_micro_continual.py:733: Failed
__ TestShards.test_load_rejects_non_finite_wall_clock_seconds[-1.0-negative] ___
...
E       Failed: DID NOT RAISE ValueError
tests/test_micro_continual.py:733: Failed
=========================== short test summary info ============================
FAILED tests/test_micro_continual.py::TestShards::test_load_rejects_non_finite_wall_clock_seconds[inf-inf]
FAILED tests/test_micro_continual.py::TestShards::test_load_rejects_non_finite_wall_clock_seconds[nan-nan]
FAILED tests/test_micro_continual.py::TestShards::test_load_rejects_non_finite_wall_clock_seconds[-1.0-negative]
3 failed, 1 passed, 78 deselected in 6.70s
```

Candidate, targeted then full touched file:

```text
$ .venv/bin/python -m pytest tests/test_micro_continual.py -k "wall_clock" -q -o addopts=""
....                                                                     [100%]
4 passed, 78 deselected in 6.24s

$ .venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""
........................................................................ [ 87%]
..........                                                               [100%]
82 passed, 2 warnings in 29.12s
# all 78 pre-existing tests plus the 4 new ones (3 parametrized rejection
# cases + 1 positive control) pass; the 2 warnings are a pre-existing
# sklearn deprecation notice in an unrelated digits-features test, not
# introduced by this change

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/micro_continual.py tests/test_micro_continual.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/benchmarks/micro_continual.py
Success: no issues found in 1 source file
```

Exit codes: pytest 0 (targeted), pytest 0 (full file), ruff 0, mypy 0.

Historical safety, verified against the artifacts: a scan of all 42 pinned raw micro shard files under `outputs/micro_continual/**/*.json` (filtered to `schema == "alberta.micro_continual.shard.v1"`, out of 49 total JSON files in that tree — the other 7 are transfer-validation/summary artifacts, not shards) found zero shards with a non-finite or negative `wall_clock_seconds` — this guard would not have refused any committed historical shard load. Like #115's `wall_clock_seconds` scan (and unlike #108's `environment` scan), this is a per-shard field-validity property, directly checkable on each file independently of which summary it fed into — a complete census of the 42 pinned shard files, not a sample limited by reconstructable merge subsets.

## Open / caveats

- This was the last identified sibling of the #114/#115 defect shape in this codebase — the issue's own coverage search (and this PR's re-check) found no further `load_*_shard`-style function with the same unguarded-`wall_clock_seconds` gap. Not an exhaustive audit of every loader in the tree, just confirmation that the `ipmnist_screening.py`/`micro_continual.py` pair #114 named is now fully closed on both sides.
- `tests/test_micro_continual.py` will need one manual conflict resolution against open PR #109 at merge/rebase time (see the anti-collision note above) — both append new `TestShards` methods after the same anchor test. Mechanical, not semantic; keep both blocks.
- `jq`'s silent substitution of `DBL_MAX` for `Infinity` (rather than a parse error) is documented in the issue as an observation, not something in this PR's scope to change — `jq` is not part of this repository.

Deviations from the issue's plan: none.

## Provenance

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@deaa6f128ef16be7a68f6da9940743e6b724b80e:skills/contribute-to-asi
Attribution status: self-reported (device-signed run receipt unavailable: the slop.cash skill manifest was stale at work time — pinned revision fails its own acceptedRevisions contract against slopdotcash develop head; receipt to follow when the lane reopens)
— [nxn-claude-code]
