### PR TITLE
fix(metrics): reject missing boundary evaluations

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -90,6 +90,12 @@ def _task_trajectories(
     trajectories: list[NDArray[np.float64]] = []
     for task, first_row in enumerate(rows):
         values = matrix[first_row:, task]
+        if not np.isfinite(values[0]):
+            raise ValueError(
+                f"task {task} has no finite evaluation at first-post-exposure checkpoint"
+            )
+        if not np.isfinite(values[-1]):
+            raise ValueError(f"task {task} has no finite final evaluation")
         finite_values = values[np.isfinite(values)]
         if finite_values.size == 0:
             raise ValueError(f"task {task} has no finite evaluation at or after first exposure")

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -170,3 +170,20 @@ def test_task_matrix_validation(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         compute_per_task_forgetting(matrix, first_exposure)
+
+
+@pytest.mark.parametrize(
+    ("matrix", "message"),
+    [
+        ([[np.nan], [0.6]], "first-post-exposure"),
+        ([[0.8], [np.nan]], "final evaluation"),
+    ],
+)
+def test_task_metrics_reject_missing_boundary_evaluations(
+    matrix: list[list[float]],
+    message: str,
+) -> None:
+    """Do not silently backfill required first/final checkpoints."""
+
+    with pytest.raises(ValueError, match=message):
+        compute_per_task_forgetting(matrix, [0])


### PR DESCRIPTION
Closes #120.

## What changed

`_task_trajectories` in `alberta_framework/utils/metrics.py` now requires finite values at both contract-defining boundaries of a task's post-exposure trajectory, the first-post-exposure row and the final checkpoint, before filtering. previously it dropped every non-finite checkpoint first, so a missing final evaluation silently backfilled with the last earlier finite value instead of failing. same edge on a missing first-post-exposure checkpoint. intermediate NaN probe gaps stay supported and filtered exactly as before, this only closes the two boundary edges.

reproduced against the merged code before writing the fix: `performance=[0.8, 0.6, nan]` with `first_exposure=[0]` returned `forgetting=[0.2]` with no error, treating the nonexistent final evaluation as if `0.6` were the real endpoint measurement. the module's own docstring says only values *before* first exposure are allowed to be unevaluated, everything from first exposure onward is a real evaluation by contract, so this backfilling quietly broke that.

## Verification

failing-test-first in `test_task_metrics_reject_missing_boundary_evaluations` (both boundary cases parametrized). confirmed red before the guard (source fix reverted, test kept): both cases `DID NOT RAISE ValueError`. restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_continual_metrics.py -q -o addopts=""
14 passed in 0.52s

$ .venv/bin/python -m ruff check alberta_framework/utils/metrics.py tests/test_continual_metrics.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:23f5c2c75bc195da13954bea528904d7507b5ac9 -->
<!-- evidence-row:logs -->
- [x] logs: focused-suite, ruff, and mypy transcript above (14/14 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript is the artifact here too, both parametrized cases fail red before the fix and pass green after, a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, verification transcript), anthropic / claude-sonnet-5 (independent re-verification: reproduced the pre-fix bug against a stashed copy, reran tests/ruff/mypy myself, committed since the codex sandbox couldn't write to `.git`)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
No Slop run receipt: same site-deploy-lag block as the rest of tonight's work, `run-receipt.mjs` install currently refuses because the deployed skill archive predates recent `develop` changes. the fix and both verification passes above are real, only the receipt-capture pipeline is unavailable right now.
