### PR TITLE
fix(statistics): reject empty samples in mann_whitney and guard empty p-values in bonferroni

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -333,9 +333,17 @@ def mann_whitney_comparison(
 
     Returns:
         SignificanceResult with test results
+
+    Raises:
+        ValueError: If either sample is empty.
     """
     a = np.asarray(values_a)
     b = np.asarray(values_b)
+
+    if len(a) == 0 or len(b) == 0:
+        raise ValueError(
+            f"independent Mann-Whitney test requires non-empty groups (got {len(a)} and {len(b)})"
+        )
 
     try:
         from scipy import stats
@@ -443,6 +451,8 @@ def bonferroni_correction(
         Tuple of (list of significant booleans, corrected alpha)
     """
     n_tests = len(p_values)
+    if n_tests == 0:
+        return [], alpha
     corrected_alpha = alpha / n_tests
     significant = [p < corrected_alpha for p in p_values]
     return significant, corrected_alpha

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -448,6 +448,24 @@ class TestOneSampleRejection:
             with pytest.raises(ValueError, match="non-empty groups"):
                 ttest_comparison(values_a, values_b, paired=False)
 
+    @pytest.mark.parametrize(
+        ("values_a", "values_b"),
+        [
+            ([], [1.0, 2.0]),
+            ([1.0, 2.0], []),
+            ([], []),
+            (np.array([], dtype=np.float64), np.array([1.0, 2.0], dtype=np.float64)),
+            (np.array([1.0, 2.0], dtype=np.float64), np.array([], dtype=np.float64)),
+        ],
+    )
+    def test_mann_whitney_empty_group_raises_without_warning(
+        self, values_a: list[float] | np.ndarray, values_b: list[float] | np.ndarray
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="non-empty groups"):
+                mann_whitney_comparison(values_a, values_b)
+
     def test_mann_whitney_length_one_contract_unchanged(self) -> None:
         res = mann_whitney_comparison([1.0], [2.0])
         assert res.p_value == pytest.approx(1.0)
@@ -460,6 +478,11 @@ class TestOneSampleRejection:
 
 
 class TestCorrections:
+    def test_bonferroni_empty_p_values(self) -> None:
+        significant, corrected_alpha = bonferroni_correction([], alpha=0.05)
+        assert significant == []
+        assert corrected_alpha == 0.05
+
     def test_bonferroni_hand_computed(self) -> None:
         significant, corrected_alpha = bonferroni_correction([0.01, 0.02, 0.04], alpha=0.05)
         assert corrected_alpha == pytest.approx(0.05 / 3)


### PR DESCRIPTION
Closes #122.

## What changed

1. `mann_whitney_comparison` in `alberta_framework/utils/statistics.py` now validates that both sample inputs are non-empty (`len(a) == 0 or len(b) == 0`) and raises `ValueError("independent Mann-Whitney test requires non-empty groups...")`. Previously, passing an empty sample bypassed validation, emitted a `SmallSampleWarning` from `scipy.stats.mannwhitneyu`, and crashed with `ZeroDivisionError: division by zero` in the rank-biserial effect size calculation.
2. `bonferroni_correction` in `alberta_framework/utils/statistics.py` now guards against an empty list of p-values (`p_values = []`), returning `([], alpha)` instead of raising `ZeroDivisionError: division by zero`.

## Verification

Failing-test-first in `tests/test_statistics_validation.py`:
- Parametrized `test_mann_whitney_empty_group_raises_without_warning` across 5 empty input combinations (empty list and empty ndarray).
- `test_bonferroni_empty_p_values` asserting `([], 0.05)` return.

Confirmed red before the fix: `bonferroni_correction([])` failed with `ZeroDivisionError`, `mann_whitney_comparison` failed with `ZeroDivisionError` / `SmallSampleWarning`. Restored fix, all tests passed green.

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""
99 passed, 2 warnings in 6.91s

$ .venv/bin/python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

Lane: deterministic unit tests, non-promoting. No seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:6238fac9fb6dc071fff60a421f3be3ec64330822 -->
<!-- evidence-row:logs -->
- [x] logs: pytest, ruff, and mypy clean (99/99 passed, lint and types clean).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: deterministic unit test verification (mutation resistance confirmed red before fix and green after).

## Provenance

AI provider/model: google / gemini-2.5-pro (fix, test suite verification, type checks)
Client / agent tooling: antigravity CLI (agy)