### PR TITLE
fix(screening): refuse to merge shards with mismatched base_learner (closes #107)

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7046,6 +7046,23 @@ def merge_shards(
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):
         seeds = sorted(per_seed)
+        reference_base = per_seed[seeds[0]]["base_learner"]
+        mismatched_base = [
+            s for s in seeds if per_seed[s]["base_learner"] != reference_base
+        ]
+        if mismatched_base:
+            # `base_learner` is the cost/reporting bucket for an arm; a
+            # registry name normally pins it, but a config that was re-pointed
+            # at a different base learner between `run` invocations can leave
+            # shards of two different mechanisms in one directory. Without this
+            # check they merge silently under one config_name and report only
+            # seeds[0]'s base_learner as if representative of the whole arm.
+            raise ValueError(
+                f"config {name!r} has inconsistent base_learner across seeds: "
+                f"seed {seeds[0]} used {reference_base!r}, seed(s) {mismatched_base} used "
+                "different values; refusing to merge runs of different base learners "
+                "under one config_name"
+            )
         acc = np.stack(
             [np.asarray(per_seed[s]["per_task_accuracy"], dtype=np.float64) for s in seeds]
         )

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -988,6 +988,26 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
+    def test_merge_rejects_base_learner_drift_across_seeds(self, tmp_path, small_data):
+        """Two shards under one config_name with different base_learner must
+        not merge: base_learner is the cost/reporting bucket, and a silent
+        merge would report only seeds[0]'s base_learner as if representative
+        of the whole arm (the gap #107 closes — #97 guards hyperparameters
+        but leaves base_learner unguarded)."""
+        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        p1 = self._make_shard(tmp_path, small_data, "upgd_l2init", 0)
+        p2 = self._make_shard(tmp_path, small_data, "upgd_l2init", 1)
+
+        payload2 = json.loads(p2.read_text(encoding="utf-8"))
+        payload2["base_learner"] = "adamw"
+        p2.write_text(json.dumps(payload2), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"'upgd_l2init' has inconsistent base_learner across seeds",
+        ):
+            merge_shards([p0, p1, p2], control_name="upgd_w_control", slope_window=2)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"


### PR DESCRIPTION
## Summary

`merge_shards` reads `seeds[0]'s` `base_learner` as representative of the whole `config_name` without checking the other seeds. A config re-pointed at a different base learner between `run` invocations leaves shards of two different mechanisms in one directory, which then merge silently and report only the first seed's `base_learner`.

`#97` added the same guard for `hyperparameters` but explicitly left `base_learner` unguarded. This is the gap `#107` closes.

## Changes

- **`alberta_framework/benchmarks/ipmnist_screening.py`** — Added `base_learner` cross-seed consistency check inside the per-`config_name` loop, adjacent to (and line-disjoint from) `#97`'s hyperparameters guard. Raises a deterministic `ValueError` naming the diverging seed(s).

- **`tests/test_ipmnist_screening.py`** — Added `test_merge_rejects_base_learner_drift_across_seeds` that drives the real merge path with two genuine shards and one overwritten `base_learner` — red on `main` `da8b86c`, green at head.

## Validation

- `204/204 passed` (`TestShardsAndMerge`)
- Ruff: clean
- Pre-existing evidence: two shards under the same `config_name` with different `base_learner` values merge silently on `main`; the test's `ValueError` proves the guard fires.

## Anti-collision

- `#97` (hyperparameters guard, open) touches the same file but a different line range inside the same loop — the two diffs are disjoint and compose cleanly in either order.
- `#110` (environment guard, open) is outside the per-`config_name` loop entirely.