### PR TITLE
fix(initializers): correct LeCun uniform variance in sparse_init

### DIFF
--- a/alberta_framework/core/initializers.py
+++ b/alberta_framework/core/initializers.py
@@ -53,10 +53,11 @@ def sparse_init(
     init_key, mask_key = jr.split(key)
 
     # LeCun-scale initialization
-    scale = 1.0 / fan_in**0.5
     if init_type == "uniform":
+        scale = (3.0 / fan_in) ** 0.5
         weights = jr.uniform(init_key, shape, dtype=jnp.float32, minval=-scale, maxval=scale)
     elif init_type == "normal":
+        scale = 1.0 / fan_in**0.5
         weights = jr.normal(init_key, shape, dtype=jnp.float32) * scale
     else:
         raise ValueError(f"init_type must be 'uniform' or 'normal', got '{init_type}'")

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -1,6 +1,7 @@
 """Tests for sparse initialization."""
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -37,12 +38,29 @@ class TestSparseInit:
         fan_out, fan_in = 64, 32
         weights = sparse_init(key, (fan_out, fan_in), sparsity=0.5)
 
-        scale = 1.0 / fan_in**0.5
+        scale = (3.0 / fan_in) ** 0.5
         nonzero_mask = weights != 0
         nonzero_values = weights[nonzero_mask]
 
         assert jnp.all(nonzero_values >= -scale)
         assert jnp.all(nonzero_values <= scale)
+
+    def test_uniform_init_matches_lecun_variance_scaling(self):
+        """The dense branch should match canonical LeCun uniform initialization."""
+        key = jr.key(19)
+        shape = (8, 5)
+        init_key, _ = jr.split(key)
+        expected = jax.nn.initializers.variance_scaling(
+            1.0,
+            "fan_in",
+            "uniform",
+            in_axis=1,
+            out_axis=0,
+        )(init_key, shape)
+
+        actual = sparse_init(key, shape, sparsity=0.0, init_type="uniform")
+
+        chex.assert_trees_all_close(actual, expected)
 
     def test_different_keys_give_different_results(self):
         """Different random keys should produce different weight matrices."""


### PR DESCRIPTION
Closes #130.

## What changed

`sparse_init`'s `init_type="uniform"` branch documents itself as "LeCun uniform" but was sampling from `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`. a uniform distribution on `[-a, a]` has variance `a^2/3`, so that bound gives variance `1/(3*fan_in)`, a third of LeCun's actual target `1/fan_in`.

`init_type` defaults to `"uniform"` and every current caller uses that default (`continual_backprop.py`, `horde_actor_critic.py`, `independent_demon_horde.py`, `multi_head_learner.py`, `learners.py`, `upgd.py`, `recurrent_trace_actor_critic.py`), so this has undersized sparse initialization by a factor of `sqrt(3) ≈ 1.73` across the core learner library since this branch was written.

fix: bound becomes `sqrt(3 / fan_in)`, giving the correct `1/fan_in` variance. the normal branch (`1/sqrt(fan_in)` standard deviation) was already correct and is untouched.

## Verification

independently re-derived the variance math before writing the fix:

```text
fan_in = 64
old bound: 0.125 -> variance: 0.005208333333333333 (target ratio: 0.3333333333333333)
new bound: 0.21650635094610965 -> variance: 0.015624999999999998 (target ratio: 0.9999999999999999)
```

failing-test-first: `test_uniform_init_matches_lecun_variance_scaling` compares the dense uniform branch directly against JAX's own `jax.nn.initializers.variance_scaling(1.0, "fan_in", "uniform", in_axis=1, out_axis=0)` reference, same split PRNG key, exact array equality. confirmed red before the guard (source fix reverted, test kept): 40/40 elements mismatched, max relative difference 0.42 (matches the sqrt(3) ratio). restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_initializers.py -q -o addopts=""
9 passed in 3.83s

$ .venv/bin/python -m ruff check alberta_framework/core/initializers.py tests/test_initializers.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:673bfc6825f66db86ae828d54cdfb40a200c1eb9 -->
<!-- evidence-row:logs -->
- [x] logs: focused-suite, ruff, and mypy transcript above (9/9 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript is the artifact, the exact-array comparison against JAX's own reference initializer is a stronger domain proof than a variance-statistics check would be. a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, verification transcript, via AgentRouter proxy), anthropic / claude-sonnet-5 (independent re-verification: re-derived the variance math myself, reran tests/ruff/mypy myself, checked every real caller's blast radius, committed since the codex sandbox couldn't write to `.git`)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
No Slop run receipt: same site-deploy-lag block as the rest of tonight's work, `run-receipt.mjs` install currently refuses because the deployed skill archive predates recent `develop` changes. the fix and both verification passes above are real, only the receipt-capture pipeline is unavailable right now.
