### PR TITLE
fix(initializers): validate shape dimensions and sparsity in sparse_init

### DIFF
--- a/alberta_framework/core/initializers.py
+++ b/alberta_framework/core/initializers.py
@@ -4,6 +4,8 @@ Implements sparse initialization following Elsayed et al. 2024
 ("Streaming Deep Reinforcement Learning Finally Works").
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -36,6 +38,11 @@ def sparse_init(
     Returns:
         Weight matrix of given shape with specified sparsity
 
+    Raises:
+        ValueError: If shape is not a 2-tuple, dimensions are not positive integers,
+            sparsity is not a finite real number in [0.0, 1.0], or init_type is not
+            'uniform' or 'normal'.
+
     Examples:
     ```python
     import jax.random as jr
@@ -46,7 +53,29 @@ def sparse_init(
     # weights has shape (128, 10), ~90% zeros per row
     ```
     """
+    if not isinstance(shape, (tuple, list)) or len(shape) != 2:
+        raise ValueError(f"shape must be a 2-tuple (fan_out, fan_in), got {shape!r}")
     fan_out, fan_in = shape
+    if (
+        isinstance(fan_out, bool)
+        or isinstance(fan_in, bool)
+        or not isinstance(fan_out, (int, jnp.integer))
+        or not isinstance(fan_in, (int, jnp.integer))
+        or fan_out <= 0
+        or fan_in <= 0
+    ):
+        raise ValueError(
+            f"shape dimensions must be positive integers, got fan_out={fan_out}, fan_in={fan_in}"
+        )
+    if (
+        isinstance(sparsity, bool)
+        or not isinstance(sparsity, (int, float, jnp.floating, jnp.integer))
+        or not math.isfinite(sparsity)
+        or not (0.0 <= sparsity <= 1.0)
+    ):
+        raise ValueError(
+            f"sparsity must be a finite real number in [0.0, 1.0], got {sparsity!r}"
+        )
     num_zeros = int(sparsity * fan_in + 0.5)  # round to nearest int
 
     # Split key for init and sparsity mask

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -90,3 +90,44 @@ class TestSparseInit:
         actual_sparsity = float(total_zeros) / total_elements
 
         assert actual_sparsity == pytest.approx(0.9, abs=0.01)
+
+    def test_one_sparsity(self):
+        """With sparsity=1.0, all weights should be zero."""
+        key = jr.key(42)
+        weights = sparse_init(key, (32, 16), sparsity=1.0)
+
+        chex.assert_shape(weights, (32, 16))
+        assert jnp.all(weights == 0)
+
+    @pytest.mark.parametrize(
+        "invalid_shape",
+        [
+            (0, 10),
+            (10, 0),
+            (-1, 10),
+            (10, -5),
+            (0, 0),
+            (10,),
+            (10, 10, 10),
+            (),
+            (True, 10),
+            (10, False),
+            (10.5, 5),
+            (10, 5.5),
+        ],
+    )
+    def test_invalid_shapes_raise(self, invalid_shape):
+        """Invalid shape tuples should raise ValueError."""
+        key = jr.key(42)
+        with pytest.raises(ValueError, match=r"shape|dimension"):
+            sparse_init(key, invalid_shape)
+
+    @pytest.mark.parametrize(
+        "invalid_sparsity",
+        [-0.1, 1.1, float("nan"), float("inf"), float("-inf"), True, False, "0.5"],
+    )
+    def test_invalid_sparsity_raises(self, invalid_sparsity):
+        """Out-of-bounds or non-finite sparsity should raise ValueError."""
+        key = jr.key(42)
+        with pytest.raises(ValueError, match="sparsity"):
+            sparse_init(key, (32, 16), sparsity=invalid_sparsity)


### PR DESCRIPTION
Closes #132.

## What changed

1. `sparse_init` in `alberta_framework/core/initializers.py` now strictly validates input parameters:
   - `shape` must be a 2-tuple of positive integers (`fan_out > 0`, `fan_in > 0`). Non-positive dimensions (0, negative integers), wrong tuple lengths, boolean dimensions, float dimensions, and non-sequence shapes now raise a deterministic `ValueError`.
   - `sparsity` must be a finite real number in `[0.0, 1.0]`. Out-of-bounds numbers (< 0.0, > 1.0), non-finite values (`nan`, `inf`, `-inf`), booleans, and non-numeric types now raise a deterministic `ValueError`.
2. Added `Raises: ValueError` section to `sparse_init` docstring documenting the input constraints.
3. `tests/test_initializers.py` adds `test_one_sparsity` (testing `sparsity=1.0` returns all zeros) and comprehensive parametrized test cases for invalid shapes, non-positive dimensions, bool/float dimensions, non-finite sparsity, out-of-range sparsity, and boolean sparsity.

## Verification

Failing-test-first in `tests/test_initializers.py`:
- Verified red on unvalidated shapes / out-of-bounds/non-finite sparsity before the validation guards.
- Verified green on the complete test suite after applying the validation guards.

```text
$ .venv/bin/python -m pytest tests/test_initializers.py -q -o addopts=""
29 passed in 6.10s

$ .venv/bin/python -m ruff check alberta_framework/core/initializers.py tests/test_initializers.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files

$ git diff --check
(clean)

$ .venv/bin/python -m pytest tests/test_release_metadata.py tests/test_utils_smoke.py -q -o addopts=""
10 passed in 3.33s
```

Lane: deterministic unit tests, non-promoting. No seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:48fbf1f0a24b99d6e8ce7aa06410c21b4620058d -->
<!-- evidence-row:logs -->
- [x] logs: pytest, ruff, and mypy clean (29/29 initializer tests passed, lint and types clean).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: deterministic unit test verification (mutation resistance confirmed red before fix and green after).

## Provenance

AI provider/model: google / gemini-3.7-flash (fix, test suite verification, type checks)
Client / agent tooling: antigravity CLI (agy)
Receipt limitation: External automated receipt tool currently not provisioned for this environment/model; verification transcript and exact head SHA recorded truthfully above.