### PR TITLE
fix(screening): validate shard noise modes

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6992,8 +6992,20 @@ def load_shard(path: Path) -> dict[str, Any]:
             raise ValueError(f"{path}: {fieldname} must be finite with shape ({config.n_tasks},)")
     if type(payload.get("seed")) is not int or payload["seed"] < 0:
         raise ValueError(f"{path}: seed must be a non-negative integer")
-    if payload.get("config_name") not in SCREENING_REGISTRY:
-        raise ValueError(f"{path}: unknown config_name {payload.get('config_name')!r}")
+    config_name = payload.get("config_name")
+    if not isinstance(config_name, str) or config_name not in SCREENING_REGISTRY:
+        raise ValueError(f"{path}: unknown config_name {config_name!r}")
+    spec = SCREENING_REGISTRY[config_name]
+    noise_mode = payload.get("noise_mode", "step")
+    if noise_mode not in ("step", "pool"):
+        raise ValueError(
+            f"{path}: noise_mode must be 'step' or 'pool', got {noise_mode!r}"
+        )
+    if noise_mode == "pool" and spec.noise_update is None:
+        raise ValueError(
+            f"{path}: noise_mode='pool' is unsupported for {config_name!r}: "
+            "the arm declares no noise-consuming update"
+        )
     return payload
 
 

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -809,6 +809,36 @@ class TestShardsAndMerge:
         control = next(e for e in summary["results"] if e["config_name"] == "upgd_w_control")
         assert "paired_vs_control" not in control
 
+    def test_load_shard_rejects_unknown_noise_mode(self, tmp_path, small_data):
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["noise_mode"] = "teleport"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="noise_mode must be 'step' or 'pool'"):
+            load_shard(path)
+
+    def test_load_shard_rejects_pool_for_unsupported_arm(self, tmp_path, small_data):
+        path = self._make_shard(tmp_path, small_data, "upgd_idbd", 0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["noise_mode"] = "pool"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="declares no noise-consuming update"):
+            load_shard(path)
+
+    def test_load_shard_treats_missing_noise_mode_as_legacy_step(
+        self, tmp_path, small_data
+    ):
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        del payload["noise_mode"]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_shard(path)
+
+        assert "noise_mode" not in loaded
+
     def test_merge_rejects_zero_seed_overlap_with_control(self, tmp_path, small_data):
         """An arm sharing no seeds with a present control must refuse to merge:
         the entry would rank in the summary with no paired_vs_control block and


### PR DESCRIPTION
Closes #124

## What changed

- validate that shard noise_mode is either step or pool when loading
- reject pool-mode shards for arms that declare no noise-consuming update
- preserve legacy shards with no noise_mode field as step-mode records
- validate config_name before consulting the registry

## Why

run_screening_config already rejects impossible noise modes, but load_shard accepted hand-edited or corrupted shard metadata. Those invalid records could enter later merge and reporting paths as if they came from an executable configuration.

## Verification

- failing-first: both invalid-mode regressions failed with DID NOT RAISE before the guard
- `.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""` — 206 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py` — passed
- `.venv/bin/python -m mypy` — passed, 159 source files
- `git diff --check` — passed

No scientific benchmark was executed, and no benchmark seed or output artifact was consumed or modified. The full repository suite is not claimed; focused validation is proportional to this loader-only contract.

## Disclosure

Implemented with OpenAI gpt-5.6-sol through Codex desktop. The required external receipt authorization endpoint returned HTTP 404 during publication; this draft was therefore opened through the operator-authorized, authenticated `gh` CLI without a receipt footer.

<!-- evidence-head:ff3ee321a4cf2117b02604d0376f3881594ec41b -->