### PR TITLE
fix(micro): reject mixed transfer network sizes

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1201,6 +1201,9 @@ def transfer_validation_from_shards(paths: Sequence[Path | str]) -> dict[str, An
     configs = {tuple(sorted(shard["stream_config"].items())) for shard in shards}
     if len(configs) != 1:
         raise ValueError("shards span multiple stream configs; validate them separately")
+    nets = {(shard["hidden1"], shard["hidden2"]) for shard in shards}
+    if len(nets) != 1:
+        raise ValueError("shards span multiple network sizes; validate them separately")
     per_arm: dict[str, dict[int, np.ndarray]] = {}
     for shard in shards:
         per_seed = per_arm.setdefault(shard["arm_name"], {})

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -801,6 +801,24 @@ class TestTransferValidation:
             "adam_decays",
         }
 
+    def test_from_shards_rejects_mixed_network_sizes(self, tmp_path: Path):
+        paths = []
+        for arm in LADDER_ARMS:
+            hidden1, hidden2 = (7, 5) if arm == "gated_norm" else (8, 6)
+            result = run_micro_arm(
+                TINY,
+                arm,
+                seed=0,
+                hidden1=hidden1,
+                hidden2=hidden2,
+            )
+            path = micro_shard_path(tmp_path, TINY.family, arm, 0)
+            write_micro_shard(path, micro_shard_payload(result))
+            paths.append(path)
+
+        with pytest.raises(ValueError, match="network sizes"):
+            transfer_validation_from_shards(paths)
+
     def test_from_shards_rejects_non_m1(self, tmp_path: Path):
         config = tiny("scale_shift")
         result = run_micro_arm(config, "sgd_raw", seed=0, hidden1=8, hidden2=6)


### PR DESCRIPTION
Closes #125

## What changed

transfer_validation_from_shards now requires every shard in one validation set to share the same hidden1 and hidden2 network sizes. A focused regression mixes 7x5 and 8x6 shards and confirms the validator fails closed.

## Why

The transfer validator previously reported the architecture from the first shard while silently aggregating results from different network capacities. That made the resulting comparison structurally misleading.

## Verification

- failing-first: the mixed-architecture regression failed with DID NOT RAISE before the guard
- `.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""` — 79 passed, with 2 unrelated sklearn/NumPy deprecation warnings
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/micro_continual.py tests/test_micro_continual.py` — passed
- `.venv/bin/python -m mypy` — passed, 159 source files
- `git diff --check` — passed

No scientific benchmark was executed, and no benchmark seed or output artifact was consumed or modified. The full repository suite is not claimed.

## Disclosure

Implemented with OpenAI gpt-5.6-sol through Codex desktop. The required external receipt authorization endpoint returned HTTP 404 during publication; this draft was therefore opened through the operator-authorized, authenticated `gh` CLI without a receipt footer.

<!-- evidence-head:14a8053b163d72ad684abdfd3d3a3e813ddddd08 -->