### PR TITLE
fix(rule-discovery): reject duplicate evaluation seeds

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -778,6 +778,11 @@ def evaluate_population(
     Paired evaluation: every genome sees the identical stream and identical
     network init per seed (the screening convention).
     """
+    if not seeds:
+        raise ValueError("seeds must not be empty")
+    if len(set(seeds)) != len(seeds):
+        raise ValueError("seeds must be unique")
+
     genomes = jnp.asarray(genomes, dtype=jnp.float32)
     n_genomes = int(genomes.shape[0])
     total = np.zeros((n_genomes,), dtype=np.float64)

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -335,12 +335,21 @@ def test_describe_genome_names_active_primitives() -> None:
     assert "surprise_budget" not in text
 
 
+@pytest.mark.parametrize("seeds", [(), (0, 0)])
+def test_evaluate_population_rejects_empty_or_duplicate_seeds(seeds: tuple[int, ...]) -> None:
+    config = dataclasses.replace(MICRO_SUITE["M1"], n_tasks=2, task_length=20)
+    genomes = jnp.asarray([champion_form_genome()])
+
+    with pytest.raises(ValueError, match="seeds"):
+        evaluate_population(genomes, config, seeds=seeds)
+
+
 def test_evaluate_population_is_paired_and_bounded() -> None:
     config = dataclasses.replace(MICRO_SUITE["M1"], n_tasks=2, task_length=20)
     genomes = jnp.stack(
         [jnp.asarray(champion_form_genome()), jnp.asarray(champion_form_genome())]
     )
-    accuracy = evaluate_population(genomes, config, seeds=(0,))
+    accuracy = evaluate_population(genomes, config, seeds=(0, 1))
     assert accuracy.shape == (2,)
     assert float(accuracy[0]) == pytest.approx(float(accuracy[1]), abs=1e-7)
     assert 0.0 <= float(accuracy[0]) <= 1.0


### PR DESCRIPTION
Closes #127

## What changed

evaluate_population now rejects empty and duplicate seed sequences before evaluating any genome. The distinct-seed paired positive control remains bounded and deterministic.

## Why

Repeating one deterministic seed counted the same trajectory multiple times in search or holdout fitness. That changed weighting without adding independent evidence and could bias the promoted-rule list.

## Verification

- failing-first: the empty and duplicate cases both failed with DID NOT RAISE before the guard
- `.venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts=""` — 29 passed, with 2 unrelated sklearn/NumPy deprecation warnings
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/rule_discovery.py tests/test_rule_discovery.py` — passed
- `.venv/bin/python -m mypy` — passed, 159 source files
- `git diff --check` — passed

No benchmark wave was executed, and no benchmark seed or output artifact was consumed or modified. The full repository suite is not claimed.

## Disclosure

Implemented with OpenAI gpt-5.6-sol through Codex desktop. The required external receipt authorization endpoint returned HTTP 404 during publication; this draft was therefore opened through the operator-authorized, authenticated `gh` CLI without a receipt footer.

<!-- evidence-head:58a72a35a786c77a88d2a65b2193083020a44809 -->