### PR TITLE
fix(upgd): reject aliased run seeds

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -679,6 +679,17 @@ def run_ipmnist(
     Returns:
         Host-side result arrays; see :class:`IPMNISTRunResult`.
     """
+    seed_tuple = tuple(seeds)
+    if not seed_tuple:
+        raise ValueError("at least one seed is required")
+    for seed in seed_tuple:
+        if not isinstance(seed, int) or isinstance(seed, bool):
+            raise ValueError("seeds must be non-boolean Python integers")
+        if not 0 <= seed <= 2**32 - 1:
+            raise ValueError("seeds must be in the inclusive uint32 range")
+    if len(set(seed_tuple)) != len(seed_tuple):
+        raise ValueError("seeds must be unique")
+
     if config is None:
         config = IPMNISTConfig()
     if noise_mode not in ("step", "pool"):
@@ -702,9 +713,6 @@ def run_ipmnist(
     if n_train < config.task_length:
         raise ValueError("dataset smaller than task_length; cannot sample without replacement")
 
-    seed_tuple = tuple(int(seed) for seed in seeds)
-    if not seed_tuple:
-        raise ValueError("at least one seed is required")
     seeds_array = jnp.asarray(seed_tuple, dtype=jnp.uint32)
 
     use_pool = noise_mode == "pool" and learner in _STOCHASTIC_LEARNERS

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -237,6 +237,27 @@ class TestSmoke:
         second = run_ipmnist(data_x, data_y, "upgd_w", seeds=(5,), config=TINY)
         np.testing.assert_array_equal(first.per_task_accuracy, second.per_task_accuracy)
 
+    @pytest.mark.parametrize(
+        ("seeds", "error"),
+        [
+            ((True,), "non-boolean Python integers"),
+            ((1.0,), "non-boolean Python integers"),
+            ((np.int64(1),), "non-boolean Python integers"),
+            ((-1,), "uint32 range"),
+            ((2**32,), "uint32 range"),
+            ((0, 0), "unique"),
+        ],
+    )
+    def test_rejects_noncanonical_run_seeds(self, seeds, error):
+        data_x, data_y = _synthetic_dataset(3, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        with pytest.raises(ValueError, match=error):
+            run_ipmnist(data_x, data_y, "upgd_w", seeds=seeds, config=TINY)
+
+    def test_accepts_unique_uint32_boundary_seeds(self):
+        data_x, data_y = _synthetic_dataset(3, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        result = run_ipmnist(data_x, data_y, "upgd_w", seeds=(0, 2**32 - 1), config=TINY)
+        assert result.seeds == (0, 2**32 - 1)
+
     def test_hyperparameter_override_is_recorded(self):
         data_x, data_y = _synthetic_dataset(3, N_TRAIN, TINY.input_dim, TINY.n_classes)
         result = run_ipmnist(


### PR DESCRIPTION
Closes #128

## What changed

run_ipmnist now validates its seed sequence before any JAX conversion or execution:

- each seed must be a non-boolean Python integer
- values must fall in the inclusive uint32 range
- seed IDs must be unique

The boundary values 0 and 2**32 - 1 remain valid.

## Why

JAX converts run seeds to uint32 keys. Previously, distinct recorded IDs such as 0 and 2**32 could alias to the same executed trajectory, making repeated evidence appear independent.

## Verification

- failing-first: 6 invalid boundary cases failed before the guard; the valid boundary control passed
- `.venv/bin/python -m pytest tests/test_upgd_ipmnist.py -q -o addopts=""` — 41 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/upgd_ipmnist.py tests/test_upgd_ipmnist.py` — passed
- `.venv/bin/python -m mypy` — passed, 159 source files
- `git diff --check` — passed

No frozen lifecycle or benchmark wave was issued or executed, and no output artifact was modified. The full repository suite is not claimed.

## Disclosure

Implemented with OpenAI gpt-5.6-sol through Codex desktop. The required external receipt authorization endpoint returned HTTP 404 during publication; this draft was therefore opened through the operator-authorized, authenticated `gh` CLI without a receipt footer.

<!-- evidence-head:d186b82f22b35a390f1c53964ea3c4438ff710df -->