### PR TITLE
fix(upgd): validate expected nonpromoting seeds

### DIFF
--- a/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
@@ -436,10 +436,29 @@ def _parse_partial(path: Path, errors: list[str]) -> _Shard | None:
     )
 
 
+def _normalize_expected_seeds(expected_seeds: Sequence[int]) -> tuple[tuple[int, ...], list[str]]:
+    normalized = tuple(expected_seeds)
+    errors: list[str] = []
+    if not normalized:
+        errors.append("expected_seeds must not be empty")
+    for seed in normalized:
+        if isinstance(seed, bool):
+            errors.append("expected_seeds must not contain boolean values")
+        elif not isinstance(seed, int):
+            errors.append("expected_seeds must contain only integers")
+        elif seed < 0:
+            errors.append("expected_seeds must not contain negative values")
+    if not errors and len(set(normalized)) != len(normalized):
+        errors.append("expected_seeds must not contain duplicates")
+    return (normalized if not errors else ()), errors
+
+
 def _parse_partials(
     paths: Sequence[Path], expected_seeds: Sequence[int]
-) -> tuple[list[_Shard], list[str], tuple[tuple[str, str], ...]]:
+) -> tuple[list[_Shard], list[str], tuple[tuple[str, str], ...], tuple[int, ...]]:
     errors: list[str] = []
+    normalized_expected_seeds, seed_errors = _normalize_expected_seeds(expected_seeds)
+    errors.extend(seed_errors)
     normalized_paths = sorted((Path(path) for path in paths), key=lambda path: path.as_posix())
     if not normalized_paths:
         errors.append("no partial result files were supplied")
@@ -458,20 +477,22 @@ def _parse_partials(
     if len(set(observed)) != len(observed):
         errors.append("duplicate learner/seed identities occur across shards")
     expected = {
-        (learner, int(seed)) for learner in EXPECTED_HYPERPARAMETERS for seed in expected_seeds
+        (learner, seed)
+        for learner in EXPECTED_HYPERPARAMETERS
+        for seed in normalized_expected_seeds
     }
     if set(observed) != expected:
         missing = sorted(expected - set(observed))
         extra = sorted(set(observed) - expected)
         errors.append(f"shard coverage mismatch; missing={missing}, extra={extra}")
-    return shards, errors, tuple(digests)
+    return shards, errors, tuple(digests), normalized_expected_seeds
 
 
 def validate_upgd_ipmnist_partials(
     paths: Sequence[Path], *, expected_seeds: Sequence[int] = EXPECTED_SEEDS
 ) -> UPGDIPMNISTValidation:
     """Strictly validate complete raw shard coverage and primitive values."""
-    shards, errors, digests = _parse_partials(paths, expected_seeds)
+    shards, errors, digests, _ = _parse_partials(paths, expected_seeds)
     observed = tuple(sorted((shard.learner, shard.seed) for shard in shards))
     return UPGDIPMNISTValidation(
         valid=not errors,
@@ -603,14 +624,16 @@ def validate_upgd_ipmnist_artifact(
     expected_seeds: Sequence[int] = EXPECTED_SEEDS,
 ) -> UPGDIPMNISTValidation:
     """Recompute and validate a v1 result artifact from its complete shards."""
-    shards, errors, digests = _parse_partials(partial_paths, expected_seeds)
+    shards, errors, digests, normalized_expected_seeds = _parse_partials(
+        partial_paths, expected_seeds
+    )
     artifact_digest: str | None = None
     try:
         artifact, artifact_digest = _strict_json_object_with_sha256(Path(artifact_path))
     except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
         errors.append(f"{artifact_path}: {exc}")
         artifact = {}
-    expected_count = len(EXPECTED_HYPERPARAMETERS) * len(tuple(expected_seeds))
+    expected_count = len(EXPECTED_HYPERPARAMETERS) * len(normalized_expected_seeds)
     # A forged set can have the expected file count while duplicating one
     # learner/seed identity and omitting another.  Recompute aggregates only
     # after the shard matrix itself is valid; otherwise an empty learner stack

--- a/tests/test_upgd_ipmnist_nonpromoting.py
+++ b/tests/test_upgd_ipmnist_nonpromoting.py
@@ -283,6 +283,44 @@ def test_expected_file_count_with_duplicate_identities_fails_without_raising(
 
 
 @pytest.mark.unit
+def test_duplicate_expected_seeds_fail_closed_before_artifact_validation(tmp_path: Path) -> None:
+    paths = _write_shards(tmp_path, seeds=(0,))
+    artifact = tmp_path / "results.v1.json"
+    artifact.write_text("{}", encoding="utf-8")
+
+    validation = validate_upgd_ipmnist_artifact(
+        artifact,
+        paths,
+        expected_seeds=(0, 0),
+    )
+
+    assert not validation.valid
+    assert any("expected_seeds must not contain duplicates" in error for error in validation.errors)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("expected_seeds", "expected_error"),
+    [
+        ((), "expected_seeds must not be empty"),
+        ((False,), "expected_seeds must not contain boolean values"),
+        ((0.0,), "expected_seeds must contain only integers"),
+        (([0],), "expected_seeds must contain only integers"),
+        ((-1,), "expected_seeds must not contain negative values"),
+    ],
+)
+def test_invalid_expected_seeds_fail_closed(
+    tmp_path: Path,
+    expected_seeds: tuple[object, ...],
+    expected_error: str,
+) -> None:
+    validation = validate_upgd_ipmnist_partials([], expected_seeds=expected_seeds)  # type: ignore[arg-type]
+
+    assert not validation.valid
+    assert any(expected_error in error for error in validation.errors)
+
+
+@pytest.mark.unit
 def test_posthoc_provenance_check_fails_when_source_and_cache_are_absent(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #129

## What changed

The nonpromoting UPGD validator now normalizes expected seeds once and rejects empty, duplicate, boolean, non-integer, or negative values. Coverage and expected-count gates use the same normalized tuple.

## Why

Duplicate expected seeds were collapsed for coverage but retained in the expected count. That inconsistency could skip artifact recomputation and allow an otherwise empty artifact payload to validate.

## Verification

- failing-first: the duplicate-seed regression returned validation.valid == true before the fix
- `.venv/bin/python -m pytest tests/test_upgd_ipmnist_nonpromoting.py -q -o addopts=""` — 21 passed
- `.venv/bin/python -m ruff check alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py tests/test_upgd_ipmnist_nonpromoting.py` — passed
- `.venv/bin/python -m mypy` — passed, 159 source files
- `git diff --check` — passed

No pinned artifact was edited or regenerated, and no benchmark seed was consumed. The full repository suite is not claimed.

## Disclosure

Implemented with OpenAI gpt-5.6-sol through Codex desktop. The required external receipt authorization endpoint returned HTTP 404 during publication; this draft was therefore opened through the operator-authorized, authenticated `gh` CLI without a receipt footer.

<!-- evidence-head:b4360a827d40e895e9694603e4354ffaba4f191a -->