### PR TITLE
fix(checkpoints): protect the reserved _format_version metadata key

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -69,9 +69,8 @@ def save_checkpoint(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    meta_to_save = {_VERSION_KEY: _FORMAT_VERSION}
-    if metadata is not None:
-        meta_to_save.update(metadata)
+    meta_to_save = dict(metadata) if metadata is not None else {}
+    meta_to_save[_VERSION_KEY] = _FORMAT_VERSION
 
     with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
         ckptr.save(

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -3,6 +3,7 @@
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import orbax.checkpoint as ocp
 import pytest
 
 from alberta_framework import (
@@ -183,6 +184,26 @@ class TestMetadata:
         _, loaded_meta = load_checkpoint(state, tmp_path / "nometa")
 
         assert loaded_meta == {}
+
+    def test_user_metadata_cannot_override_internal_format_version(self, tmp_path):
+        """The on-disk format stamp must describe the actual saver format."""
+        learner = LinearLearner()
+        state = learner.init(feature_dim=5)
+        path = tmp_path / "reserved_metadata"
+
+        save_checkpoint(
+            state,
+            path,
+            metadata={"_format_version": 999, "epoch": 7},
+        )
+
+        with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
+            restored = ckptr.restore(
+                str(path),
+                args=ocp.args.Composite(metadata=ocp.args.JsonRestore()),
+            )
+
+        assert dict(restored.metadata) == {"_format_version": 2, "epoch": 7}
 
     def test_checkpoint_directory_created(self, tmp_path):
         """Checkpoint should be saved as a directory with state/ subdirectory."""


### PR DESCRIPTION
Closes #139.

## What changed

`save_checkpoint` built `meta_to_save` starting from `{_VERSION_KEY: _FORMAT_VERSION}` and then called `.update(metadata)`. `dict.update` overwrites existing keys, so caller-supplied metadata containing a `"_format_version"` key silently overwrote the saver's own format stamp. a format-2 checkpoint could end up claiming any arbitrary on-disk format version.

honestly on severity: nothing currently reads `_format_version` on load, both `load_checkpoint` and `load_checkpoint_metadata` just pop and discard it. so today this is a latent integrity gap, not an active behavioral break, and none of the 9 real `save_checkpoint` callers across the framework (world_model_ensemble, state_builder, recurrent_latent_world_model_ensemble, prototype_agent, prototype_feature_lifecycle, interaction_features, model_replay_rehearsal, gauntlet, recurring_multiagent) pass a colliding key today. it's exactly the field a future version-check/migration path would rely on though, so this is fixing the reserved-namespace guarantee before anything actually depends on it being trustworthy.

fix: copy caller metadata first, then assign `_format_version` last, so the saver always owns the reserved provenance field regardless of what the caller passes.

## Verification

reproduced against the merged code before writing the fix: `save_checkpoint(state, path, metadata={"_format_version": 999, "epoch": 7})` left the raw on-disk Orbax metadata as `{'_format_version': 999, 'epoch': 7}`, verified by reading the raw metadata directly since the public loader strips this key before returning it.

failing-test-first: `test_user_metadata_cannot_override_internal_format_version` saves with a colliding `_format_version: 999` key and asserts the raw on-disk stamp stays `2`. confirmed red before the guard (source fix reverted, test kept): `assert {'_format_version': 999, 'epoch': 7} == {'_format_version': 2, 'epoch': 7}` failed as expected. restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_checkpoints.py -q -o addopts=""
24 passed in 2.18s

$ .venv/bin/python -m ruff check alberta_framework/core/checkpoints.py tests/test_checkpoints.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:00419033d58303c155489b570b9bc7c6a5b1dbe3 -->
<!-- evidence-row:logs -->
- [x] logs: focused-suite, ruff, and mypy transcript above (24/24 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript is the artifact, real raw on-disk Orbax metadata inspected before and after the fix, a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, verification transcript, via AgentRouter proxy), anthropic / claude-sonnet-5 (independent re-verification: reran tests/ruff/mypy myself, confirmed nothing currently reads `_format_version` on load and no real caller collides with the key today, committed since the codex sandbox couldn't write to `.git`)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
No Slop run receipt: same site-deploy-lag block as the rest of tonight's work, `run-receipt.mjs` install currently refuses because the deployed skill archive predates recent `develop` changes. the fix and both verification passes above are real, only the receipt-capture pipeline is unavailable right now.
