### PR TITLE
fix(streams): validate each periodic mask shape before stacking

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -137,11 +137,12 @@ class PartialObservationWrapper[InnerStateT]:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
                 )
-            sched = jnp.stack([jnp.asarray(m, dtype=jnp.bool_) for m in schedule], axis=0)
-            if sched.shape[1] != feature_dim:
+            masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
+            if any(mask.shape != (feature_dim,) for mask in masks):
                 raise ValueError(
                     f"schedule masks must each have shape (feature_dim={feature_dim},)"
                 )
+            sched = jnp.stack(masks, axis=0)
             self._schedule: Array | None = sched
         else:
             self._schedule = None

--- a/tests/test_partial_observation.py
+++ b/tests/test_partial_observation.py
@@ -118,6 +118,14 @@ class TestPeriodic:
         with pytest.raises(ValueError, match="schedule"):
             PartialObservationWrapper(inner, mode=MaskMode.PERIODIC, schedule=())
 
+    def test_periodic_rejects_masks_with_extra_axis(self) -> None:
+        inner = RandomWalkStream(feature_dim=3, drift_rate=0.0)
+        schedule = (jnp.array([[True], [False], [True]]),)
+        with pytest.raises(ValueError, match="schedule masks"):
+            PartialObservationWrapper(
+                inner, mode=MaskMode.PERIODIC, schedule=schedule
+            )
+
 
 class TestScanCompatibility:
     def test_scan_with_fixed_mask(self) -> None:


### PR DESCRIPTION
Closes #147.

## What changed

`PartialObservationWrapper`'s `PERIODIC` mode stacked schedule masks first and only checked the stacked array's second axis (`sched.shape[1] == feature_dim`). a mask shaped `(feature_dim, 1)` passes that check spuriously, since stacking N such masks along axis 0 gives `(N, feature_dim, 1)`, whose `shape[1]` equals `feature_dim` by coincidence of the wrong axis being checked.

the malformed mask then broadcasts against a `(feature_dim,)` observation in `jnp.where`, silently turning it into `(feature_dim, feature_dim)` instead of raising, corrupting the documented observation shape.

reachability: the class is exported from the top-level public package. repo search found no in-tree production constructor call beyond the implementation's own docstring example and tests, but it's public API, any user reaches this with an ordinary array-like schedule argument, no hardcoded-safe input prevents it.

fix: validate each mask's exact shape against `(feature_dim,)` before stacking, so a malformed mask is rejected at construction instead of silently corrupting the observation shape at step time.

## Verification

independently reproduced from first principles before writing the fix:

```text
schedule = [jnp.array([True, False, True]).reshape(3,1) for _ in range(2)]
sched = jnp.stack(schedule, axis=0)   # shape (2, 3, 1)
sched.shape[1]                        # 3, old check passes incorrectly

obs = jnp.array([1.0, 2.0, 3.0])
jnp.where(sched[0], obs, jnp.zeros_like(obs)).shape   # (3, 3), documented shape is (3,)
```

failing-test-first: `test_periodic_rejects_masks_with_extra_axis` constructs with a `(feature_dim, 1)`-shaped mask and asserts it's rejected. confirmed red before the guard (source fix reverted, test kept): `DID NOT RAISE ValueError`. restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_partial_observation.py -q -o addopts=""
13 passed in 1.90s

$ .venv/bin/python -m ruff check alberta_framework/streams/partial_observation.py tests/test_partial_observation.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:c16caa6c6444e67850d1546a9c8fb00d3b36f7c9 -->
<!-- evidence-row:logs -->
- [x] logs: focused-suite, ruff, and mypy transcript above (13/13 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript is the artifact, plus the independent from-first-principles shape reproduction above showing the exact `(3,) -> (3,3)` corruption, a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, verification transcript, via AgentRouter proxy), anthropic / claude-sonnet-5 (independent re-verification: reproduced the shape-broadcast bug from first principles myself, reran tests/ruff/mypy myself, confirmed reachability via repo search, committed since the codex sandbox couldn't write to `.git`)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
No Slop run receipt: same site-deploy-lag block as the rest of tonight's work, `run-receipt.mjs` install currently refuses because the deployed skill archive predates recent `develop` changes. the fix and both verification passes above are real, only the receipt-capture pipeline is unavailable right now.
