### PR TITLE
fix(streams): enforce exact active pair count under tied scores

### DIFF
--- a/alberta_framework/streams/feature_discovery.py
+++ b/alberta_framework/streams/feature_discovery.py
@@ -339,8 +339,8 @@ class InteractionFeatureDiscoveryStream:
             (self._n_contexts, self._n_tasks, n_pairs),
             dtype=jnp.float32,
         )
-        threshold = jnp.sort(mask_scores, axis=-1)[..., active_count - 1 : active_count]
-        mask = mask_scores <= threshold
+        ranks = jnp.argsort(jnp.argsort(mask_scores, axis=-1), axis=-1)
+        mask = ranks < active_count
         # Same sqrt(#active) normalization as the nonlinear stream: context
         # switches redirect relevance without changing the target scale.
         context_weights = dense_context_weights * mask.astype(jnp.float32)

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -160,6 +160,20 @@ class TestNonlinearFeatureDiscoveryStream:
 class TestInteractionFeatureDiscoveryStream:
     """Tests for the hidden pair-product Step 2 benchmark stream."""
 
+    def test_init_selects_exact_active_count_when_scores_tie(self, monkeypatch) -> None:
+        stream = InteractionFeatureDiscoveryStream(
+            feature_dim=4, n_tasks=1, n_contexts=1, active_pairs_per_context=2
+        )
+
+        def tied_uniform(key, shape, dtype=jnp.float32, **kwargs):
+            return jnp.zeros(shape, dtype=dtype)
+
+        monkeypatch.setattr(
+            "alberta_framework.streams.feature_discovery.jr.uniform", tied_uniform
+        )
+        state = stream.init(jr.key(0))
+        assert int(jnp.count_nonzero(state.context_weights)) == 2
+
     def test_step_shapes(self) -> None:
         stream = InteractionFeatureDiscoveryStream(
             feature_dim=6,


### PR DESCRIPTION
Closes #150.

## What changed

`InteractionFeatureDiscoveryStream.init` selected active interaction pairs via a sort-and-threshold comparison (`mask_scores <= threshold`), where `threshold` is the `active_count`-th order statistic. when multiple scores tie at that threshold, every tied element passes the `<=` comparison, so more than `active_pairs_per_context` pairs got retained.

`jr.uniform`'s finite float representation makes ties a real, reachable condition, not a theoretical one. this breaks the fixed-active-count normalization contract the class documents (context switches redirect relevance without changing the target scale) and can corrupt benchmark comparability between runs that happen to hit or avoid a tie.

reachable through the public `InteractionFeatureDiscoveryStream` (exported from `alberta_framework.__init__`) and `collect_feature_discovery_stream`.

fix: select via index ranks (double `argsort`) instead of a threshold comparison. ranks are a strict total order with no duplicates, so selecting `rank < active_count` always retains exactly `active_count` elements regardless of score ties.

## Verification

independently reproduced from first principles before writing the fix:

```text
scores = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]  # all tied
active_count = 2

old (threshold comparison): 6/6 selected
new (rank-based):           2/6 selected
```

failing-test-first: `test_init_selects_exact_active_count_when_scores_tie` monkeypatches `jr.uniform` to force a tie and asserts exactly `active_count` pairs are selected. confirmed red before the guard (source fix reverted, test kept): `assert 6 == 2`. restored the fix, green again.

```text
$ .venv/bin/python -m pytest tests/test_feature_discovery.py -q -o addopts=""
77 passed in 33.77s

$ .venv/bin/python -m ruff check alberta_framework/streams/feature_discovery.py tests/test_feature_discovery.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

lane: deterministic unit tests, non-promoting. no seeds consumed, no benchmark runs, no `outputs/` artifacts touched.

## Evidence

<!-- evidence-head:8638b63640fa1476a8fea5a81b376ec30da225f6 -->
<!-- evidence-row:logs -->
- [x] logs: focused-suite, ruff, and mypy transcript above (77/77 passed, lint and types clean on both changed files).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the mutation-resistance transcript is the artifact, plus the independent from-first-principles tie reproduction above showing the exact 6-selected-vs-2-configured corruption, a deterministic unit-test lane doesn't produce an `outputs/` shard or summary.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, verification transcript, via AgentRouter proxy), anthropic / claude-sonnet-5 (independent re-verification: reproduced the tie-breaking bug from first principles myself, reran tests/ruff/mypy myself, confirmed the public-export reachability, committed since the codex sandbox couldn't write to `.git`)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
No Slop run receipt: same site-deploy-lag block as the rest of tonight's work, `run-receipt.mjs` install currently refuses because the deployed skill archive predates recent `develop` changes. the fix and both verification passes above are real, only the receipt-capture pipeline is unavailable right now.
