### PR TITLE
fix(screening): reject duplicate shards in proxy validation

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7152,6 +7152,7 @@ def validate_proxy(
     proxy_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     full_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     n_tasks_seen: set[int] = set()
+    seen_shards: set[tuple[str, int]] = set()
     for path in shard_paths:
         shard = load_shard(Path(path))
         if shard.get("noise_mode", "step") != "step":
@@ -7165,6 +7166,12 @@ def validate_proxy(
         if learner is None:
             raise ValueError(f"{path}: proxy validation accepts only control shards")
         seed = shard["seed"]
+        shard_identity = (shard["config_name"], seed)
+        if shard_identity in seen_shards:
+            raise ValueError(
+                f"duplicate proxy shard for config={shard['config_name']} seed={seed}"
+            )
+        seen_shards.add(shard_identity)
         n_tasks = int(shard["config"]["n_tasks"])
         n_tasks_seen.add(n_tasks)
         partial_path = partials_dir / f"{learner}_seed{seed}.json"

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -988,6 +988,32 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
+    def test_validate_proxy_rejects_duplicate_shards(self, tmp_path, small_data):
+        """The same (config_name, seed) shard listed twice must refuse: every
+        occurrence re-enters proxy_avg/full_avg, so one seed's curve carries
+        double weight in the ordering means behind proxy_validated (issue #152).
+        merge_shards already refuses this identity; the validation harness
+        did not."""
+        x, y = small_data
+        partials = tmp_path / "partials"
+        partials.mkdir()
+        full = run_ipmnist(x, y, "upgd_w", seeds=[0], config=SMALL)
+        (partials / "upgd_w_seed0.json").write_text(
+            json.dumps({"per_task_accuracy": full.per_task_accuracy.tolist()}),
+            encoding="utf-8",
+        )
+        proxy = run_screening_config(
+            x, y, screening_spec("upgd_w_control"), seed=0, config=SMALL
+        )
+        path = tmp_path / "upgd_w_control_seed0.json"
+        path.write_text(json.dumps(shard_payload(proxy)), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"duplicate proxy shard for config=upgd_w_control seed=0",
+        ):
+            validate_proxy([path, path], partials, atol=1e-6)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"


### PR DESCRIPTION
Closes #152.

## Issue

`validate_proxy()` has no duplicate-shard refusal: `merge_shards()` refuses a repeated `(config_name, seed)` identity, but the proxy-validation harness silently accepts the same shard listed any number of times. Each occurrence appends a `checks` entry and re-enters the same per-seed curve into `proxy_avg`/`full_avg` — the means that decide `proxy_preserves_upgd_over_adamw`, `full_prefix_preserves_upgd_over_adamw`, and therefore `proxy_validated`. The `validate-proxy` CLI takes a caller-assembled `--shards` list, so a glob matching a stray copy reaches this silently (the existing duplicate-merge test builds exactly such a copied file).

## Symptoms

At `main` `da8b86cd33a5982215753fb31bd1b3b6132b3c04` (full falsifier in #152), one real control shard listed three times:

```text
validate_proxy([p, p, p], partials, atol=1e-6)  # no error raised
n checks: 3
checks (config, seed): [('upgd_w_control', 0), ('upgd_w_control', 0), ('upgd_w_control', 0)]
proxy_mean: {'upgd_w': 0.31111112, 'adamw': None}
```

With mixed seed sets, one learner's ordering mean carries a double-weighted seed — the verdict becomes a function of list contents rather than measurements.

## New state

The first repeated `(config_name, seed)` identity refuses with `merge_shards`' message contract — `duplicate proxy shard for config=upgd_w_control seed=0` — placed immediately after seed extraction, before the reference read. Unique-shard behavior is byte-for-byte unchanged; no schema or CLI change.

Failing-test-first evidence, measured at head `1cf1efed43fc870966eca938bb5a4273f421ad17` (baseline `da8b86c`):

- red phase: the new regression test fails on the unmodified baseline (the report is produced silently — `DID NOT RAISE`);
- green phase: `.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""` — `204 passed`;
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier in #152 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow; the signed local-usage receipt footer follows.

```text
Compute receipt: 327605 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M02X7WX1VJYF583HBP2DWWQK","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-15T14:29:31.681Z","completed_at":"2026-08-15T14:39:51.086Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":18,"output_tokens":2827,"cache_creation_tokens":62704,"cache_read_tokens":262056,"total_tokens":327605,"cost_micro_usd":"593693","session_count":2},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"5qC6qiFl5cjZDCtzkqdhVByoEf1--Xm72lcD6LTRaKXvsJSFk9s9ZfKcAC7AelMu06v81NxtVurC3_PNxf3cDg"}} -->
