### PR TITLE
fix(gauntlet): use moveaxis not .T in ema_smooth for rank-3+ safety

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -1146,13 +1146,14 @@ def run_gauntlet_batched(
 def ema_smooth(values: Array, halflife: float = 50.0) -> Array:
     """Exponential-moving-average smoothing along the last axis."""
     decay = 0.5 ** (1.0 / halflife)
+    time_major = jnp.moveaxis(values, -1, 0)
 
     def step(carry: Array, v: Array) -> tuple[Array, Array]:
         new = decay * carry + (1.0 - decay) * v
         return new, new
 
-    _, smoothed = jax.lax.scan(step, values[..., 0], values.T)
-    return smoothed.T
+    _, smoothed = jax.lax.scan(step, values[..., 0], time_major)
+    return jnp.moveaxis(smoothed, 0, -1)
 
 
 def steps_to_criterion(sq_segment: Array, threshold: float) -> Array:

--- a/tests/test_environment_schedule_horizon.py
+++ b/tests/test_environment_schedule_horizon.py
@@ -17,6 +17,7 @@ from alberta_framework.streams.gauntlet import (
     LIFETIME_GAUNTLET_STATE_SCHEMA,
     GauntletConfig,
     LifetimeGauntletStream,
+    ema_smooth,
     load_lifetime_gauntlet_checkpoint,
     migrate_legacy_lifetime_gauntlet_state,
     save_lifetime_gauntlet_checkpoint,
@@ -34,6 +35,27 @@ from alberta_framework.streams.recurring_multiagent import (
 INT32_MAX = 2**31 - 1
 UINT32_MAX = 2**32 - 1
 pytestmark = pytest.mark.unit
+
+
+def test_ema_smooth_preserves_leading_batch_axes() -> None:
+    """EMA smoothing follows the last axis for higher-rank measurements."""
+    values = jnp.arange(24, dtype=jnp.float32).reshape(2, 3, 4)
+
+    actual = ema_smooth(values, halflife=1.0)
+
+    expected = jnp.asarray(
+        [
+            [[0.0, 0.5, 1.25, 2.125], [4.0, 4.5, 5.25, 6.125], [8.0, 8.5, 9.25, 10.125]],
+            [
+                [12.0, 12.5, 13.25, 14.125],
+                [16.0, 16.5, 17.25, 18.125],
+                [20.0, 20.5, 21.25, 22.125],
+            ],
+        ],
+        dtype=jnp.float32,
+    )
+    chex.assert_shape(actual, values.shape)
+    chex.assert_trees_all_close(actual, expected)
 
 
 def _words(value: int) -> jax.Array:


### PR DESCRIPTION
Closes #155.

## What changed

`ema_smooth` in `alberta_framework/streams/gauntlet.py` used `values.T` to move the last axis to the front before `jax.lax.scan`, then `.T` again to move it back. `.T` reverses *every* axis, not just the last one — for a rank-2 array this happens to coincide with moving only the last axis to the front, but for rank-3+ it scrambles the batch structure instead of relocating only the scan axis. Fixed by using `jnp.moveaxis(values, -1, 0)` / `jnp.moveaxis(smoothed, 0, -1)`, which move only the target axis regardless of rank.

confirmed independently before touching the source:

```text
>>> values.shape
(2, 3, 4)
>>> values.T.shape
(4, 3, 2)          # wrong: batch and feature axes swapped
>>> jnp.moveaxis(values, -1, 0).shape
(4, 2, 3)          # correct: only the last axis moved to front
>>> # rank-2 case: both approaches agree
>>> jnp.zeros((2, 3)).T.shape
(3, 2)
>>> jnp.moveaxis(jnp.zeros((2, 3)), -1, 0).shape
(3, 2)
```

## Reachability (honest)

`ema_smooth` is called by `steps_to_criterion`, which is called by `gauntlet_scorecard` — publicly exported from `alberta_framework/streams/__init__.py` alongside `run_gauntlet`/`run_gauntlet_batched`. Every real call path currently passes rank-2 `sq_errors` (`(n_seeds, num_steps)`, per `run_gauntlet_batched`'s own docstring), so this is not currently producing wrong numbers in the shipped gauntlet pipeline. It's a latent bug in a publicly-exported, general-purpose function whose docstring promises "along the last axis" for arbitrary rank — the first rank-3+ caller gets silently corrupted output, no error, no warning.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_environment_schedule_horizon.py -q -o addopts=""
15 passed in 4.82s

$ .venv/bin/python -m ruff check alberta_framework/streams/gauntlet.py tests/test_environment_schedule_horizon.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_ema_smooth_preserves_leading_batch_axes` in `tests/test_environment_schedule_horizon.py`, a `(2, 3, 4)` array checked against an independently-derived expected EMA recurrence (not against the function's own output).

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/gauntlet.py`, kept the test), reran — 1/15 failed with `TypeError: add got incompatible shapes for broadcasting: (2, 3), (3, 2)` from inside `jax.lax.scan`. Restored the fix, 15/15 green again.

## Evidence

<!-- evidence-head -->
5e76f8f089518c30df3d15261b347529aec45f13

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_environment_schedule_horizon.py -q -o addopts="" -k ema_smooth
FAILED tests/test_environment_schedule_horizon.py::test_ema_smooth_preserves_leading_batch_axes
TypeError: add got incompatible shapes for broadcasting: (2, 3), (3, 2).
1 failed, 14 deselected in 0.84s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_environment_schedule_horizon.py -q -o addopts=""
15 passed in 4.82s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp
values = jnp.arange(24.0).reshape(2, 3, 4)
print('T:', values.T.shape)
print('moveaxis:', jnp.moveaxis(values, -1, 0).shape)
print('rank-2 T:', jnp.zeros((2, 3)).T.shape)
print('rank-2 moveaxis:', jnp.moveaxis(jnp.zeros((2, 3)), -1, 0).shape)
"
T: (4, 3, 2)
moveaxis: (4, 2, 3)
rank-2 T: (3, 2)
rank-2 moveaxis: (3, 2)
```
confirms the rank-2 case is identical under both approaches (why this stayed hidden) and the rank-3 case diverges exactly as claimed.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reproduced the rank-2 vs rank-3 divergence myself in a fresh interpreter, reran the full test file, ruff, and mypy myself, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
