### PR TITLE
fix(screening): refuse mixed protocol configs in proxy validation

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7152,6 +7152,7 @@ def validate_proxy(
     proxy_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     full_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     n_tasks_seen: set[int] = set()
+    seen_shards: set[tuple[str, int]] = set()
     for path in shard_paths:
         shard = load_shard(Path(path))
         if shard.get("noise_mode", "step") != "step":
@@ -7165,6 +7166,12 @@ def validate_proxy(
         if learner is None:
             raise ValueError(f"{path}: proxy validation accepts only control shards")
         seed = shard["seed"]
+        shard_identity = (shard["config_name"], seed)
+        if shard_identity in seen_shards:
+            raise ValueError(
+                f"duplicate proxy shard for config={shard['config_name']} seed={seed}"
+            )
+        seen_shards.add(shard_identity)
         n_tasks = int(shard["config"]["n_tasks"])
         n_tasks_seen.add(n_tasks)
         partial_path = partials_dir / f"{learner}_seed{seed}.json"

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7153,12 +7153,19 @@ def validate_proxy(
     full_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     n_tasks_seen: set[int] = set()
     seen_shards: set[tuple[str, int]] = set()
+    reference_config: dict[str, Any] | None = None
     for path in shard_paths:
         shard = load_shard(Path(path))
         if shard.get("noise_mode", "step") != "step":
             raise ValueError(
                 f"{path}: proxy validation requires noise_mode='step' shards "
                 f"(got {shard.get('noise_mode')!r})"
+            )
+        if reference_config is None:
+            reference_config = shard["config"]
+        elif shard["config"] != reference_config:
+            raise ValueError(
+                "shards span multiple protocol configs; validate them separately"
             )
         learner = {"upgd_w_control": "upgd_w", "adamw_control": "adamw"}.get(
             shard["config_name"]

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -1014,6 +1014,38 @@ class TestShardsAndMerge:
         ):
             validate_proxy([path, path], partials, atol=1e-6)
 
+    def test_validate_proxy_rejects_mixed_protocol_configs(self, tmp_path, small_data):
+        """Shards from different protocol configs must not validate together:
+        the ordering means behind proxy_validated would compare curves of
+        different horizons, a mixture merge_shards already refuses (issue
+        #154)."""
+        x, y = small_data
+        other = IPMNISTConfig(
+            n_tasks=2, task_length=20, input_dim=12, hidden1=8, hidden2=6, n_classes=5
+        )
+        partials = tmp_path / "partials"
+        partials.mkdir()
+        paths = []
+        for cfg, learner, name, seed in (
+            (SMALL, "upgd_w", "upgd_w_control", 0),
+            (other, "adamw", "adamw_control", 1),
+        ):
+            full = run_ipmnist(x, y, learner, seeds=[seed], config=cfg)
+            (partials / f"{learner}_seed{seed}.json").write_text(
+                json.dumps({"per_task_accuracy": full.per_task_accuracy.tolist()}),
+                encoding="utf-8",
+            )
+            proxy = run_screening_config(x, y, screening_spec(name), seed=seed, config=cfg)
+            path = tmp_path / f"{name}_seed{seed}.json"
+            path.write_text(json.dumps(shard_payload(proxy)), encoding="utf-8")
+            paths.append(path)
+
+        with pytest.raises(
+            ValueError,
+            match=r"shards span multiple protocol configs; validate them separately",
+        ):
+            validate_proxy(paths, partials, atol=1e-6)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -988,6 +988,32 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
+    def test_validate_proxy_rejects_duplicate_shards(self, tmp_path, small_data):
+        """The same (config_name, seed) shard listed twice must refuse: every
+        occurrence re-enters proxy_avg/full_avg, so one seed's curve carries
+        double weight in the ordering means behind proxy_validated (issue #152).
+        merge_shards already refuses this identity; the validation harness
+        did not."""
+        x, y = small_data
+        partials = tmp_path / "partials"
+        partials.mkdir()
+        full = run_ipmnist(x, y, "upgd_w", seeds=[0], config=SMALL)
+        (partials / "upgd_w_seed0.json").write_text(
+            json.dumps({"per_task_accuracy": full.per_task_accuracy.tolist()}),
+            encoding="utf-8",
+        )
+        proxy = run_screening_config(
+            x, y, screening_spec("upgd_w_control"), seed=0, config=SMALL
+        )
+        path = tmp_path / "upgd_w_control_seed0.json"
+        path.write_text(json.dumps(shard_payload(proxy)), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"duplicate proxy shard for config=upgd_w_control seed=0",
+        ):
+            validate_proxy([path, path], partials, atol=1e-6)
+
     def test_validate_proxy_prefix_and_ordering(self, tmp_path, small_data):
         x, y = small_data
         partials = tmp_path / "partials"


### PR DESCRIPTION
Closes #154. Stacked on #153 (same `validate_proxy` loop): this head contains #153's commit; merge #153 first and this collapses to its own single commit with no rebase.

## Issue

`merge_shards()` refuses shards spanning protocol configs; `validate_proxy()` performs no config-uniformity check. Shards from different geometries and horizons validate together into one report, and the ordering means behind `proxy_preserves_upgd_over_adamw` / `full_prefix_preserves_upgd_over_adamw` / `proxy_validated` compare curves of different lengths as one measurement. The report's `n_tasks` field records the mixture; nothing refuses it.

## Symptoms

At `main` `da8b86c` (full falsifier in #154), an `upgd_w_control` shard at `n_tasks=3, task_length=30` against an `adamw_control` shard at `n_tasks=2, task_length=20`:

```text
validate_proxy(paths, partials, atol=1e-6)  # no error raised
n_tasks in report: [2, 3]
proxy_preserves_upgd_over_adamw: True   # 3-task mean vs 2-task mean
```

## New state

More than one distinct protocol config among the validated shards refuses with the merge boundary's phrasing — `shards span multiple protocol configs; validate them separately` — checked per shard immediately after the noise-mode gate. Unique-config behavior is byte-for-byte unchanged; no schema or CLI change; per-shard prefix checks are unaffected.

Failing-test-first evidence, measured at head `8b9459d869e20cde5cd58cc3ea93fa62f5bcfeb5` (baseline `da8b86c`, stacked over #153's `1cf1efed`):

- red phase: the new regression test fails on the baseline (single cross-horizon report produced — `DID NOT RAISE`);
- green phase: `.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""` — `205 passed`;
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier in #154 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow; the signed local-usage receipt footer follows.

```text
Compute receipt: 198289 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M02XW6BE4R9KT28KCDSG3KB4","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-15T14:40:36.718Z","completed_at":"2026-08-15T14:42:55.959Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":11,"output_tokens":970,"cache_creation_tokens":9802,"cache_read_tokens":187506,"total_tokens":198289,"cost_micro_usd":"179321","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"V71KHWOTMH3VDsozOShW1jkwO0D5xSTrqp5oXnIVsrlyCRX9JzpK7RLKOa5aWsbrhgyvGY_Yh7YnAOKzHQncDw"}} -->
