### PR TITLE
fix(nexting): define degenerate burn-in and window contracts

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -133,7 +133,16 @@ def per_horizon_rmse(
 
     Returns:
         Array of shape ``(H,)`` with RMSE per horizon.
+
+    Raises:
+        ValueError: If ``burn_in`` is negative or consumes the whole trace.
     """
+    n_steps = predictions.shape[0]
+    if not 0 <= burn_in < n_steps:
+        raise ValueError(
+            f"burn_in must satisfy 0 <= burn_in < n_steps "
+            f"(got burn_in={burn_in}, n_steps={n_steps})"
+        )
     if burn_in:
         predictions = predictions[burn_in:]
         forward_returns = forward_returns[burn_in:]
@@ -159,7 +168,17 @@ def per_horizon_running_rmse(
     Returns:
         Array of shape ``(T, H)``. The first ``window_size - 1`` rows are
         equal to ``running_rmse[window_size - 1]``.
+
+    Raises:
+        ValueError: If ``window_size`` is non-positive or longer than the
+            trace.
     """
+    n_steps = predictions.shape[0]
+    if not 1 <= window_size <= n_steps:
+        raise ValueError(
+            f"window_size must satisfy 1 <= window_size <= n_steps "
+            f"(got window_size={window_size}, n_steps={n_steps})"
+        )
     sq_err = (predictions - forward_returns) ** 2  # (T, H)
     cumsum = jnp.cumsum(jnp.concatenate([jnp.zeros((1, sq_err.shape[1])), sq_err]), axis=0)
     window = cumsum[window_size:] - cumsum[:-window_size]

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import chex
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from alberta_framework.utils.nexting import (
     forward_view_returns,
@@ -126,6 +127,34 @@ class TestRMSE:
         assert float(rmse_no_burn[0]) > 0.0
         chex.assert_trees_all_close(rmse_burn, jnp.zeros(h), atol=1e-6)
 
+    def test_burn_in_consuming_whole_trace_rejected(self) -> None:
+        """burn_in >= n_steps must refuse: the empty slice returned all-NaN
+        RMSE with no warning under JAX (issue #158)."""
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        for burn_in in (3, 5):
+            with pytest.raises(
+                ValueError, match=r"burn_in must satisfy 0 <= burn_in < n_steps"
+            ):
+                per_horizon_rmse(preds, truths, burn_in=burn_in)
+
+    def test_negative_burn_in_rejected(self) -> None:
+        """burn_in < 0 must refuse: Python negative-slice semantics silently
+        computed RMSE over only the trailing steps (issue #158)."""
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        with pytest.raises(
+            ValueError, match=r"burn_in must satisfy 0 <= burn_in < n_steps"
+        ):
+            per_horizon_rmse(preds, truths, burn_in=-1)
+
+    def test_burn_in_boundary_unchanged(self) -> None:
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        rmse = per_horizon_rmse(preds, truths, burn_in=2)
+        chex.assert_shape(rmse, (2,))
+        assert bool(jnp.all(jnp.isfinite(rmse)))
+
 
 class TestRunningRMSE:
     def test_shape(self) -> None:
@@ -142,6 +171,34 @@ class TestRunningRMSE:
         running = per_horizon_running_rmse(preds, truths, window_size=5)
         # All windows should contain the same constant error
         np.testing.assert_allclose(np.asarray(running), 2.0, atol=1e-6)
+
+    def test_window_longer_than_trace_rejected(self) -> None:
+        """window_size > n_steps must refuse: the empty windowed array raised
+        a raw IndexError from the pad lookup (issue #158)."""
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        with pytest.raises(
+            ValueError, match=r"window_size must satisfy 1 <= window_size <= n_steps"
+        ):
+            per_horizon_running_rmse(preds, truths, window_size=5)
+
+    def test_non_positive_window_rejected(self) -> None:
+        """window_size <= 0 must refuse: the cumsum algebra raised a raw
+        TypeError from a shape mismatch (issue #158)."""
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        for window_size in (0, -1):
+            with pytest.raises(
+                ValueError, match=r"window_size must satisfy 1 <= window_size <= n_steps"
+            ):
+                per_horizon_running_rmse(preds, truths, window_size=window_size)
+
+    def test_window_equal_to_trace_unchanged(self) -> None:
+        preds = jnp.ones((3, 2))
+        truths = jnp.zeros((3, 2))
+        running = per_horizon_running_rmse(preds, truths, window_size=3)
+        chex.assert_shape(running, (3, 2))
+        assert bool(jnp.all(jnp.isfinite(running)))
 
     def test_decay(self) -> None:
         # First half big errors, second half no errors. Running RMSE


### PR DESCRIPTION
Closes #158.

## Issue

The nexting harness's two public RMSE aggregators have no contract for degenerate `burn_in` / `window_size` values, and each failure mode differs: `per_horizon_rmse` with `burn_in >= n_steps` returns all-NaN **silently** (under JAX the empty-slice mean emits no warning), with a negative `burn_in` it applies Python negative-slice semantics and silently reports RMSE over only the trailing steps — a valid-looking number measuring the wrong thing; `per_horizon_running_rmse` crashes with a raw `IndexError` when the window exceeds the trace and a raw `TypeError` when it is non-positive. Its metrics-module sibling `compute_recovery_lengths` already refuses `window_size < 1` by name.

## Symptoms

At `main` `da8b86cd33a5982215753fb31bd1b3b6132b3c04` (full falsifier in #158), with `preds = jnp.ones((3, 2))`, `rets = jnp.zeros((3, 2))`:

```text
per_horizon_rmse(preds, rets, burn_in=3)   -> [nan nan]   (zero warnings)
per_horizon_rmse(preds, rets, burn_in=-1)  -> [1. 1.]     (silently RMSE of only the last step)
per_horizon_running_rmse(preds, rets, window_size=5) -> IndexError: index is out of bounds for axis 0 with size 0
per_horizon_running_rmse(preds, rets, window_size=0) -> TypeError: sub got incompatible shapes for broadcasting
```

## New state

Both entry points refuse out-of-range values with deterministic `ValueError`s naming both quantities (`burn_in must satisfy 0 <= burn_in < n_steps (got burn_in=3, n_steps=3)`; `window_size must satisfy 1 <= window_size <= n_steps (...)`). All in-range behavior is byte-for-byte unchanged, pinned by boundary tests at `burn_in = n_steps - 1` and `window_size = n_steps`. `forward_view_returns` is untouched — verified via `git merge-tree` that this head composes cleanly with open PR #100's hunks in the same module.

Failing-test-first evidence, measured at head `e977df6417930d3ceb99562537ca04e5af96d82d` (baseline `da8b86c`):

- red phase: the four rejection tests fail on the unmodified baseline (`4 failed, 17 passed` — NaN returned, tail-RMSE returned, `IndexError`/`TypeError` instead of `ValueError`); the two boundary pins pass on baseline by design;
- green phase: `.venv/bin/python -m pytest tests/test_nexting.py -q -o addopts=""` — `21 passed`;
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier in #158 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow; the signed local-usage receipt footer follows.

```text
Compute receipt: 102919 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M02Y0VHHSQM0CFM6X02J9DEY","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-15T14:43:09.489Z","completed_at":"2026-08-15T14:49:17.010Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":8,"output_tokens":1344,"cache_creation_tokens":36258,"cache_read_tokens":65309,"total_tokens":102919,"cost_micro_usd":"292907","session_count":1},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"QkowV6VgEGfbNbfnIi7sWduTkO0v2j26sOt0XZRz-dRpW7nzSRX4EIC7ttLdwCHbWU2hBCoGaf6hLyhlHYNABA"}} -->
