### PR TITLE
fix(step9): give dream rollouts a dedicated rng stream

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -347,7 +347,7 @@ def step9_update(
         _: Array,
     ) -> tuple[tuple[DifferentialSARSAState, BehaviorModelState, Array], tuple[Array, Array]]:
         ctrl_state, behavior_state, key = carry
-        key, candidate_key = jr.split(key)
+        key, candidate_key, rollout_key = jr.split(key, 3)
         candidate_keys = jr.split(candidate_key, config.dream_candidate_count)
 
         def candidate_step(candidate_item: tuple[Array, Array]) -> tuple[Array, ...]:
@@ -414,7 +414,7 @@ def step9_update(
         anchor_obs = candidate_anchors[selected_index]
         action = candidate_actions[selected_index]
         initial_behavior_state = behavior_state.replace(
-            rng_key=key
+            rng_key=rollout_key
         )
 
         def rollout_step(

--- a/tests/test_step9_rng.py
+++ b/tests/test_step9_rng.py
@@ -1,0 +1,83 @@
+"""Tests for RNG threading through Step 9 dreaming.
+
+Regression coverage for a defect where ``dream_step`` seeded the rollout
+behavior chain with the same post-split ``key`` it returned in the scan
+carry: ``jr.split`` is deterministic, so the next dream's
+``(key, candidate_key)`` pair was bit-identical to the ``(stored, sample)``
+pair the rollout's first ``sample_action`` had already produced from the
+same parent — consecutive dreams drew correlated randomness (issue #160).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.steps.step9 import (
+    Step9DreamingConfig,
+    init_step9_state,
+    make_step9_components,
+    step9_update,
+)
+
+
+def _accepted_dream_result(planning_budget: int, seed: int):
+    cfg = Step9DreamingConfig(
+        observation_dim=2,
+        n_actions=2,
+        model_hidden_sizes=(),
+        model_sparsity=0.0,
+        planning_budget=planning_budget,
+        dream_rollout_horizon=1,
+        dream_candidate_count=1,
+        dreaming_warmup_steps=0,
+        dreaming_max_model_error=1e30,
+    )
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent, model, buffer,
+        key=jr.key(seed),
+        initial_observation=jnp.zeros(2),
+    )
+    return step9_update(
+        cfg, agent, model, buffer,
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+
+
+class TestStep9DreamRng:
+    def test_rollout_seed_is_not_the_carried_dream_key(self) -> None:
+        """The rollout behavior chain must not be seeded with the carried key.
+
+        On the defective path the returned behavior rng after one accepted
+        horizon-1 dream equals ``split(split(scan_key)[0])[0]`` — the exact
+        chain the next dream would re-derive by re-splitting the carry.
+        """
+        result = _accepted_dream_result(planning_budget=1, seed=7)
+        assert bool(result.dream_accepted[0])
+        scan_key = result.real_control_result.state.rng_key
+        collided_chain = jr.split(jr.split(scan_key)[0])[0]
+        final_behavior = result.state.behavior_model_state.rng_key
+        assert not jnp.array_equal(
+            jr.key_data(final_behavior), jr.key_data(collided_chain)
+        ), (
+            "dream rollout was seeded with the carried scan key: the next "
+            "dream re-splits that key into the exact (stored, sample) pair "
+            "the rollout's first sample_action already consumed"
+        )
+
+    def test_dream_key_streams_are_pairwise_distinct(self) -> None:
+        """The carry, candidate, and rollout streams must never share a key."""
+        result = _accepted_dream_result(planning_budget=2, seed=11)
+        scan_key = result.real_control_result.state.rng_key
+        carry_1, candidate_1, rollout_1 = jr.split(scan_key, 3)
+        carry_2, candidate_2, rollout_2 = jr.split(carry_1, 3)
+        derived = [carry_1, candidate_1, rollout_1, carry_2, candidate_2, rollout_2]
+        raw = [jr.key_data(k) for k in derived]
+        for i in range(len(raw)):
+            for j in range(i + 1, len(raw)):
+                assert not jnp.array_equal(raw[i], raw[j]), (
+                    f"derived dream key streams {i} and {j} collide"
+                )


### PR DESCRIPTION
Closes #160.

## Issue

`step9_update`'s dream loop reuses a PRNG key for two purposes: after `key, candidate_key = jr.split(key)`, the post-split `key` seeds the rollout behavior chain **and** returns in the scan carry, where the next dream re-splits it. Because `jr.split` is deterministic, dream *i+1*'s `(key, candidate_key)` is bit-for-bit the `(stored, sample)` pair dream *i*'s first `sample_action` already derived from the same parent — consecutive dreams draw correlated randomness (anchors, imagined actions) instead of independent streams. Step 7's planning loop had its RNG discipline hardened previously (`tests/test_step7_rng.py`); Step 9's dreaming loop was left out.

## Symptoms

At `main` `da8b86cd33a5982215753fb31bd1b3b6132b3c04` (full falsifier in #160), the collision is visible from returned states alone — accepted horizon-1 dream, `planning_budget=1`, seed `jr.key(7)`:

```text
final behavior rng == split(split(scan_key)[0])[0]: True   # the exact chain dream 2 would re-derive
dream2.candidate_key == dream1 rollout sample_key: True    # both = jr.split(key1)[1], bit-identical
```

## New state

`dream_step` splits three ways — `key, candidate_key, rollout_key = jr.split(key, 3)` — and seeds the rollout behavior chain with the dedicated `rollout_key`. Candidate sampling, selection, gating, and acceptance logic are unchanged; dream randomness necessarily changes (that is the fix), and no test pins exact Step 9 dream values. The adjacent aliasing of the scan's initial carry with the control state's own key is #160's noted-out-of-scope contract.

Failing-test-first evidence, measured at head `65c5645cc176b99b737d4cf1b3e5799bb8996ef4` (baseline `da8b86c`):

- red phase: `tests/test_step9_rng.py::test_rollout_seed_is_not_the_carried_dream_key` fails on the unmodified baseline (`jr.key_data` equality with the recomputed collided chain) — `1 failed, 1 passed`;
- green phase: `.venv/bin/python -m pytest tests/test_step9_rng.py tests/test_step9_production.py -q -o addopts=""` — `29 passed`;
- `.venv/bin/python -m ruff check .` — clean; `.venv/bin/python -m mypy` — clean, 159 source files, strict py312; `git diff --check` — clean.

Dedup check at filing time: no open or closed issue or PR touches `steps/step9.py` or any `steps/` file; #101 targets `core/dreaming.py`, a different module. No benchmark seed, learner run, `outputs/` artifact, scientific evidence, or promotion claim is created or modified. This session is CLI-only and cannot mint immutable GitHub user-attachment URLs, so the run output above is inline; the falsifier in #160 reproduces it deterministically at the stated SHAs.

AI-assisted: `anthropic/claude-fable-5` via Claude Code under the slop.cash `contribute-to-asi` skill flow. Receipt disclosure: the measured-run window for this contribution was closed out of order, so the signed receipt below covers a near-empty post-hoc window and attributes 0 tokens; receipts are supporting evidence only and cannot create score.

```text
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi
Attribution status: self-reported
— [prabhat1308]
```

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M02YSBCAMTCXZARF2QHM0BZ1","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-15T14:56:32.138Z","completed_at":"2026-08-15T14:56:33.429Z","skill_sha256":"7c2862bebdc3a2d3ff6656de6d673fec94aaf79aa0c1b445dab3d2aab6e6ad7b","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"hTf1IpWoGRD1OPrJ64zBh6-gpNF7QZGs0PHaSP6Uw2A4Ov2QdoznpuK5gOj3HWhF2AaMbnXYfP5iLQa6XjVYBw"}} -->
