### PR TITLE
fix(streams): reject invalid Pavlovian contingencies

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -217,6 +217,11 @@ class ClassicalConditioningStream:
             raise ValueError(f"need 0 <= iti_min <= iti_max, got {iti_min}, {iti_max}")
 
         for phase in phases:
+            if not 0.0 <= phase.cs_us_contingency <= 1.0:
+                raise ValueError(
+                    f"phase {phase.name!r} cs_us_contingency must be in [0, 1], "
+                    f"got {phase.cs_us_contingency}"
+                )
             for cs_idx in phase.cs_active:
                 if not (0 <= cs_idx < n_cs):
                     raise ValueError(

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -406,6 +406,20 @@ def test_construct_rejects_bad_cs_index():
         raise AssertionError("expected ValueError for invalid CS index")
 
 
+@pytest.mark.parametrize("contingency", [-0.1, 1.1, float("nan")])
+def test_construct_rejects_invalid_phase_contingency(contingency: float):
+    """Every phase contingency must be a finite probability."""
+    bad_phase = PavlovianPhase(
+        name="bad",
+        n_steps=10,
+        cs_us_contingency=contingency,
+        cs_active=(0,),
+    )
+
+    with pytest.raises(ValueError, match="cs_us_contingency must be in"):
+        ClassicalConditioningStream(phases=(bad_phase,), n_cs=1)
+
+
 def test_partial_reinforcement_rejects_invalid_p():
     """``p`` outside [0, 1] is rejected."""
     for bad_p in (-0.1, 1.1):


### PR DESCRIPTION
Closes #162.

## What changed

`ClassicalConditioningStream` validates `iti_min`/`iti_max` and each phase's `cs_active` indices at construction, but never checked `cs_us_contingency` itself against the probability contract its own docstring documents (`P(US | trial onset)`, i.e. `[0, 1]`). The step logic uses the value directly as a threshold: `will_reinforce = u < contingency`, where `u` is a uniform `[0, 1)` sample. A negative contingency silently behaves like zero reinforcement, a value above 1 silently behaves like certain reinforcement, and `NaN` makes the comparison always false — none of these raise, they just quietly build a stream that doesn't implement the requested protocol.

confirmed directly before touching the source:

```text
contingency=-0.25: accepted, US count=0
contingency=+1.25: accepted, US count=100
Probability contract: valid contingencies must satisfy 0 <= p <= 1.
```

fix: reject any phase whose `cs_us_contingency` isn't in `[0, 1]` in the same phase-validation loop that already checks `cs_active`. The chained comparison naturally rejects `NaN` too, since neither bound comparison succeeds.

## Reachability (honest)

`ClassicalConditioningStream`/`PavlovianPhase` are public, direct-module APIs (`alberta_framework.streams.pavlovian`), not re-exported from `alberta_framework/__init__.py` or `alberta_framework/streams/__init__.py` — so not on the package-root export surface, but the documented public constructor for the module, reachable with any real caller-built phase list. The module's scenario factories all supply fixed safe contingencies, and `partial_reinforcement_scenario` already validates its own `p` argument separately — this constructor gap is the one place the module's own probability contract wasn't enforced.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_pavlovian_stream.py -q -o addopts=""
20 passed in 37.08s

$ .venv/bin/python -m ruff check alberta_framework/streams/pavlovian.py tests/test_pavlovian_stream.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_construct_rejects_invalid_phase_contingency`, parameterized over `-0.1`, `1.1`, `NaN`, in `tests/test_pavlovian_stream.py`, following the existing `test_construct_rejects_bad_cs_index`/`test_partial_reinforcement_rejects_invalid_p` style in the same file.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/pavlovian.py`, kept the test), reran — all 3 parameterized cases failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 20/20 green again.

## Evidence

<!-- evidence-head -->
caa8590da06ca8af0b4ed1383bc6a40078972e2b

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_pavlovian_stream.py -q -o addopts="" -k invalid_phase_contingency
FAILED tests/test_pavlovian_stream.py::test_construct_rejects_invalid_phase_contingency[-0.1]
FAILED tests/test_pavlovian_stream.py::test_construct_rejects_invalid_phase_contingency[1.1]
FAILED tests/test_pavlovian_stream.py::test_construct_rejects_invalid_phase_contingency[nan]
3 failed, 17 deselected in 0.87s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_pavlovian_stream.py -q -o addopts=""
20 passed in 37.08s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework.streams.pavlovian import ClassicalConditioningStream, PavlovianPhase
for c in (-0.25, 1.25, float('nan')):
    try:
        ClassicalConditioningStream(phases=(PavlovianPhase(name='p', n_steps=10, cs_us_contingency=c, cs_active=(0,)),), n_cs=1)
        print(f'contingency={c}: accepted (BUG if this prints)')
    except ValueError as e:
        print(f'contingency={c}: rejected -> {e}')
"
contingency=-0.25: rejected -> phase 'p' cs_us_contingency must be in [0, 1], got -0.25
contingency=1.25: rejected -> phase 'p' cs_us_contingency must be in [0, 1], got 1.25
contingency=nan: rejected -> phase 'p' cs_us_contingency must be in [0, 1], got nan
```
independently reproduced against the fixed head, confirming the guard actually rejects all three invalid inputs with the documented error.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the constructor rejecting all three invalid inputs, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
