### PR TITLE
fix(sigreg): reject invalid kernel widths before NaN loss

### DIFF
--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -24,6 +24,7 @@ References:
 from __future__ import annotations
 
 import dataclasses
+import math
 from typing import Any
 
 import chex
@@ -115,6 +116,8 @@ def epps_pulley_gaussian_statistic(
     BHEP form of Baringhaus & Henze 1988). It is zero only when the projected
     distribution matches the target Gaussian in the population limit.
     """
+    if not math.isfinite(kernel_width) or kernel_width <= 0.0:
+        raise ValueError("kernel_width must be positive and finite")
     width = jnp.asarray(kernel_width, dtype=jnp.float32)
     x = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
     diffs = x[:, None] - x[None, :]

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.sigreg import (
     SIGRegConfig,
@@ -38,6 +39,16 @@ def test_epps_pulley_statistic_penalizes_collapsed_samples() -> None:
     collapsed_loss = epps_pulley_gaussian_statistic(collapsed)
 
     assert float(collapsed_loss) > float(gaussian_loss)
+
+
+@pytest.mark.parametrize("kernel_width", [0.0, -1.0, float("nan"), float("inf")])
+def test_epps_pulley_statistic_rejects_invalid_kernel_width(
+    kernel_width: float,
+) -> None:
+    samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="positive and finite"):
+        epps_pulley_gaussian_statistic(samples, kernel_width=kernel_width)
 
 
 def test_sliced_sigreg_penalizes_shifted_and_collapsed_embeddings() -> None:


### PR DESCRIPTION
Closes #166.

## What changed

`epps_pulley_gaussian_statistic` implements the closed-form biased Gaussian-kernel MMD, which requires a positive, finite kernel bandwidth — but the function accepted zero, negative, `NaN`, and infinite `kernel_width` without complaint. A zero bandwidth evaluates the diagonal kernel terms as `0 / 0`, silently returning a `NaN` regularization measurement instead of raising. `sliced_sigreg_loss` propagates the same `NaN` since it calls through to this function.

confirmed directly before touching the source:

```text
direct_width_0 = nan
sliced_width_0 = nan
direct_width_1 = 0.004662454
```

(the finite-width case is the well-defined reference value from the same closed-form formula, confirming the zero-width case is a genuine defect rather than an edge case with no defined answer).

fix: reject non-positive or non-finite `kernel_width` with an explicit `ValueError` before the statistic's arithmetic runs.

## Reachability

Both `epps_pulley_gaussian_statistic` and `sliced_sigreg_loss` are genuinely package-root exported (`alberta_framework/core/__init__.py` and `alberta_framework/__init__.py`, both import and `__all__`). `sigreg_diagnostics` also calls through `sliced_sigreg_loss`. Honest note: there are no internal production callers outside `core/sigreg.py` today, so this is a gap in a public library surface — any real external caller supplying `kernel_width` directly hits it — rather than an active benchmark path currently producing wrong numbers in a shipped pipeline.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_sigreg.py -q -o addopts=""
8 passed in 2.58s

$ .venv/bin/python -m ruff check alberta_framework/core/sigreg.py tests/test_sigreg.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_epps_pulley_statistic_rejects_invalid_kernel_width`, parameterized over `0.0`, `-1.0`, `NaN`, `inf`, in `tests/test_sigreg.py`.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/core/sigreg.py`, kept the test), reran — all 4 parameterized cases failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 8/8 green again.

## Evidence

<!-- evidence-head -->
a039e0c9e655616a2ea0f2d234532b9e101ffb6d

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_sigreg.py -q -o addopts=""
FAILED tests/test_sigreg.py::test_epps_pulley_statistic_rejects_invalid_kernel_width[0.0]
FAILED tests/test_sigreg.py::test_epps_pulley_statistic_rejects_invalid_kernel_width[-1.0]
FAILED tests/test_sigreg.py::test_epps_pulley_statistic_rejects_invalid_kernel_width[nan]
FAILED tests/test_sigreg.py::test_epps_pulley_statistic_rejects_invalid_kernel_width[inf]
4 failed, 4 passed in 2.95s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_sigreg.py -q -o addopts=""
8 passed in 2.38s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp
from alberta_framework.core.sigreg import epps_pulley_gaussian_statistic
samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
for w in (0.0, -1.0, float('nan'), float('inf')):
    try:
        r = epps_pulley_gaussian_statistic(samples, kernel_width=w)
        print(f'width={w}: accepted -> {r}')
    except ValueError as e:
        print(f'width={w}: rejected -> {e}')
"
width=0.0: rejected -> kernel_width must be positive and finite
width=-1.0: rejected -> kernel_width must be positive and finite
width=nan: rejected -> kernel_width must be positive and finite
width=inf: rejected -> kernel_width must be positive and finite
```
independently confirmed the fixed function rejects all four invalid inputs, and independently confirmed both functions are genuinely package-root exported via `grep` on both `__init__.py` files before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting all four invalid widths, verified the package-root export claim directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
