### PR TITLE
fix(gvf): reject invalid discount and trace-decay parameters

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -5,6 +5,7 @@ using chex dataclasses for JAX compatibility and jaxtyping for shape annotations
 """
 
 import enum
+import math
 import time
 from collections.abc import Sequence
 from typing import Any
@@ -683,6 +684,14 @@ class GVFSpec:
     lamda: float
     cumulant_index: int
     terminal_reward: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Reject invalid discount and trace-decay parameters."""
+
+        if not math.isfinite(self.gamma) or not 0.0 <= self.gamma <= 1.0:
+            raise ValueError(f"gamma must be finite and in [0, 1], got {self.gamma}")
+        if not math.isfinite(self.lamda) or not 0.0 <= self.lamda <= 1.0:
+            raise ValueError(f"lamda must be finite and in [0, 1], got {self.lamda}")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict.

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -2,6 +2,7 @@
 
 import chex
 import jax.numpy as jnp
+import pytest
 
 from alberta_framework import (
     DemonType,
@@ -86,6 +87,44 @@ class TestGVFSpec:
         assert config["demon_type"] == "control"
         assert config["name"] == "test"
         assert config["gamma"] == 0.99
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("gamma", -0.01),
+            ("gamma", 1.01),
+            ("gamma", float("nan")),
+            ("gamma", float("inf")),
+            ("lamda", -0.01),
+            ("lamda", 1.01),
+            ("lamda", float("nan")),
+            ("lamda", float("inf")),
+        ],
+    )
+    def test_invalid_discount_or_trace_decay_is_rejected(self, field, value):
+        kwargs = {
+            "name": "invalid",
+            "demon_type": DemonType.PREDICTION,
+            "gamma": 0.9,
+            "lamda": 0.8,
+            "cumulant_index": 0,
+        }
+        kwargs[field] = value
+
+        with pytest.raises(ValueError, match=field):
+            GVFSpec(**kwargs)
+
+        config = {
+            "name": "invalid",
+            "demon_type": "prediction",
+            "gamma": 0.9,
+            "lamda": 0.8,
+            "cumulant_index": 0,
+            "terminal_reward": 0.0,
+        }
+        config[field] = value
+        with pytest.raises(ValueError, match=field):
+            GVFSpec.from_config(config)
 
 
 class TestHordeSpec:


### PR DESCRIPTION
Closes #168.

## What changed

`GVFSpec` documents `gamma` as a pseudo-termination discount and `lamda` as an eligibility-trace decay — both bounded `[0, 1]` quantities per the RL literature the docstring cites — but accepted arbitrary floats with no validation. Invalid values were copied unchanged into `HordeSpec.gammas`/`HordeSpec.lamdas`.

`HordeLearner.update` (`alberta_framework/core/horde.py:370-371`) computes:

```python
gammas = self._horde_spec.gammas
targets = cumulants + gammas * next_preds
```

so an out-of-range or non-finite discount directly corrupts TD targets. Horde implementations also use `gamma * lamda` for trace decay, and `gammas` is consumed throughout `horde_actor_critic.py` for value-head discounts.

confirmed directly before touching the source:

```text
constructed GVFSpec(name='bad', demon_type=<DemonType.PREDICTION: 'prediction'>, gamma=1.5, lamda=-0.25, cumulant_index=0, terminal_reward=0.0)
gammas [1.5] lamdas [-0.25]
target from cumulant=1,next_prediction=2: 4.0
```

fix: `GVFSpec.__post_init__` now requires both `gamma` and `lamda` to be finite and within `[0, 1]`. `GVFSpec.from_config` reconstructs via the constructor, so both direct and serialized/deserialized inputs now share the same validation — verified by testing both paths.

## Reachability

`GVFSpec` and `create_horde_spec` are genuinely package-root exported (`alberta_framework/__init__.py` and `alberta_framework/core/__init__.py`, both import and re-export). `HordeLearner.update` reads `self._horde_spec.gammas` directly into the TD-target formula above, and `horde_actor_critic.py` consumes the same per-demon gamma configuration for value-head discounts and per-step discount arrays. Reachable from public entry points with real caller-supplied inputs, not a benchmark-only path.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_gvf_types.py -q -o addopts=""
20 passed in 0.68s

$ .venv/bin/python -m ruff check alberta_framework/core/types.py tests/test_gvf_types.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_invalid_discount_or_trace_decay_is_rejected`, parameterized over `-0.01`, `1.01`, `NaN`, `inf` for both `gamma` and `lamda`, tested through both direct `GVFSpec(...)` construction and `GVFSpec.from_config(...)`.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/core/types.py`, kept the test), reran — all 8 parameterized cases failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 20/20 green again.

## Evidence

<!-- evidence-head -->
b8557aec7451e8c4f472e6a1e4b23722ad7cdd0a

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_gvf_types.py -q -o addopts=""
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[gamma--0.01]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[gamma-1.01]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[gamma-nan]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[gamma-inf]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[lamda--0.01]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[lamda-1.01]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[lamda-nan]
FAILED tests/test_gvf_types.py::TestGVFSpec::test_invalid_discount_or_trace_decay_is_rejected[lamda-inf]
8 failed, 12 passed in 0.54s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_gvf_types.py -q -o addopts=""
20 passed in 0.44s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework import GVFSpec, DemonType
for field, value in [('gamma', 1.5), ('gamma', float('nan')), ('lamda', -0.25), ('lamda', float('inf'))]:
    kwargs = dict(name='bad', demon_type=DemonType.PREDICTION, gamma=0.9, lamda=0.8, cumulant_index=0)
    kwargs[field] = value
    try:
        GVFSpec(**kwargs)
        print(f'{field}={value}: accepted (BUG if this prints)')
    except ValueError as e:
        print(f'{field}={value}: rejected -> {e}')
"
gamma=1.5: rejected -> gamma must be finite and in [0, 1], got 1.5
gamma=nan: rejected -> gamma must be finite and in [0, 1], got nan
lamda=-0.25: rejected -> lamda must be finite and in [0, 1], got -0.25
lamda=inf: rejected -> lamda must be finite and in [0, 1], got inf

$ grep -n "gammas \* next_preds\|cumulants + gammas" alberta_framework/core/horde.py
370:        gammas = self._horde_spec.gammas
371:        targets = cumulants + gammas * next_preds
```
independently confirmed the fixed constructor rejects all four invalid inputs, and independently confirmed the `HordeLearner.update` sink before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting all four invalid inputs, verified both the package-root export claim and the `HordeLearner.update` sink directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
