### PR TITLE
fix(screening): refuse cross-seed base_learner drift in merge

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7046,6 +7046,21 @@ def merge_shards(
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):
         seeds = sorted(per_seed)
+        # base_learner is reported from seeds[0] below; a registry edit that
+        # reclassifies a config_name's learner family mid-wave would otherwise
+        # blend two families' curves under one arm while the summary
+        # misreports what ran for every seed but the first (#107).
+        reference_base_learner = per_seed[seeds[0]]["base_learner"]
+        mismatched_base_learner = sorted(
+            s for s in seeds if per_seed[s]["base_learner"] != reference_base_learner
+        )
+        if mismatched_base_learner:
+            raise ValueError(
+                f"config {name!r} has inconsistent base_learner across seeds: "
+                f"seed {seeds[0]} used {reference_base_learner!r}, seed(s) "
+                f"{mismatched_base_learner} used different values; refusing to "
+                "merge runs of different learner families under one config_name"
+            )
         acc = np.stack(
             [np.asarray(per_seed[s]["per_task_accuracy"], dtype=np.float64) for s in seeds]
         )

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -981,6 +981,24 @@ class TestShardsAndMerge:
         ):
             merge_shards(paths, control_name="upgd_w_contrl", slope_window=2)
 
+    def test_merge_rejects_base_learner_drift_across_seeds(self, tmp_path, small_data):
+        """A registry edit that reclassifies a config_name's learner family
+        between runs must refuse to merge, not report seeds[0]'s base_learner
+        while blending both families' curves (#107; the field #97's
+        hyperparameters guard leaves out)."""
+        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        p1 = self._make_shard(tmp_path, small_data, "upgd_w_control", 1)
+
+        payload1 = json.loads(p1.read_text(encoding="utf-8"))
+        payload1["base_learner"] = "adamw"
+        p1.write_text(json.dumps(payload1), encoding="utf-8")
+
+        with pytest.raises(
+            ValueError,
+            match=r"inconsistent base_learner across seeds",
+        ):
+            merge_shards([p0, p1], control_name="upgd_w_control", slope_window=2)
+
     def test_merge_rejects_duplicate_seed(self, tmp_path, small_data):
         p1 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
         p2 = tmp_path / "dup.json"


### PR DESCRIPTION
Closes #107.

## What changed

`merge_shards` (`ipmnist_screening.py`) reported `seeds[0]`'s `base_learner` as representative of the whole `config_name` while blending every seed's curves — the exact `seeds[0]`-is-representative gap #96/#97 closes for `hyperparameters`, on the field #97's own scoping leaves out (its guard and its `test_merge_rejects_hyperparameter_drift_across_seeds` assert only `hyperparameters`). The per-arm loop now refuses a merge whose seeds disagree on `base_learner`, with a deterministic `ValueError` naming the config, the reference value, and the mismatched seed(s). No behavior change for any merge whose seeds already agree.

Before, on `main` `da8b86c` (two `upgd_w_control` shards, `SMALL` config, seeds {0,1}; seed 1's `base_learner` overwritten `"upgd_w"` → `"adamw"`): `merge_shards` raised no error and the summary reported `base_learner: "upgd_w"`, `n_seeds: 2`. After: 

```text
ValueError: config 'upgd_w_control' has inconsistent base_learner across seeds:
seed 0 used 'upgd_w', seed(s) [1] used different values; refusing to merge runs
of different learner families under one config_name
```

Failing-test-first in `TestShardsAndMerge` (`tests/test_ipmnist_screening.py`): `test_merge_rejects_base_learner_drift_across_seeds` builds two real shards via `_make_shard`, mutates seed 1's `base_learner`, asserts the refusal — red on `main` (`DID NOT RAISE ValueError`), green at head.

**Anti-collision, stated plainly:** this guard lives inside the same per-`config_name` loop where open PR #97's `hyperparameters` guard will land, and my open #110/#115 also touch this file (merge-global checks / `load_shard`). The hunks are line-adjacent but non-overlapping; whichever lands later takes a mechanical rebase. #107's issue text anticipated exactly this ("extend #97's guard or land alongside it").

## Evidence

Lane: deterministic unit tests, non-promoting; no benchmark runs, no `outputs/` artifacts touched. Environment: macOS arm64, CPU, Python 3.12.14, jax 0.11.0 (stock `uv.lock`). Commit measured: `2db796e5d305da7b338e6584b05adccb331cbea3`.

<!-- evidence-head:2db796e5d305da7b338e6584b05adccb331cbea3 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below.

```text
# RED (guard stashed, test present)
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -k "base_learner_drift" -q -o addopts=""
FAILED ...::test_merge_rejects_base_learner_drift_across_seeds
1 failed, 203 deselected in 5.07s

# GREEN targeted, then full touched file
1 passed, 203 deselected in 3.71s
204 passed in 71.55s (0:01:11)

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py
All checks passed!
$ .venv/bin/python -m mypy alberta_framework/benchmarks/ipmnist_screening.py
Success: no issues found in 1 source file
```

Historical safety: all 459 pinned raw shards under `outputs/ipmnist_screening/` scanned — 133 `(directory, config_name)` groups, **zero** with more than one distinct `base_learner`; this guard would not have refused any committed historical merge.

## Provenance

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@a99f2e649ecadc35896c9d65c8d5136e947333ce:skills/contribute-to-asi
Attribution status: self-reported (installed-skill receipt run `run_01M030S40YWY69BZZ51YX85Y62` is open for this work; the private-trace upload and device-signed finish await the operator's one-time identity OAuth, which never blocks contribution per SKILL.md — the signed footer will be appended here once completed)
— [nxn-claude-code]
