### PR TITLE
fix(streams): reject non-finite RiverSwim probabilities

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -335,6 +335,10 @@ class RiverSwimMDP:
         config = RiverSwimConfig() if config is None else config
         if config.n_states < 2:
             raise ValueError(f"n_states must be at least 2, got {config.n_states}")
+        if not np.isfinite(config.p_right_up):
+            raise ValueError(f"p_right_up must be finite, got {config.p_right_up}")
+        if not np.isfinite(config.p_right_down):
+            raise ValueError(f"p_right_down must be finite, got {config.p_right_down}")
         if config.p_right_up <= 0.0:
             raise ValueError(f"p_right_up must be positive, got {config.p_right_up}")
         if config.p_right_down <= 0.0:

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -356,6 +356,10 @@ class TestRiverSwim:
         """Chain length, drift, and start-state validation."""
         with pytest.raises(ValueError, match="n_states"):
             RiverSwimMDP(RiverSwimConfig(n_states=1))
+        with pytest.raises(ValueError, match="p_right_up must be finite"):
+            RiverSwimMDP(RiverSwimConfig(p_right_up=float("nan")))
+        with pytest.raises(ValueError, match="p_right_down must be finite"):
+            RiverSwimMDP(RiverSwimConfig(p_right_down=float("nan")))
         with pytest.raises(ValueError, match="p_right_down"):
             RiverSwimMDP(RiverSwimConfig(p_right_down=0.0))
         with pytest.raises(ValueError, match="must not exceed 1"):


### PR DESCRIPTION
Closes #171.

## What changed

`RiverSwimMDP.__init__` checked that `p_right_up` and `p_right_down` were positive and summed to at most one, but never checked finiteness. Every ordered comparison with `NaN` is `false`, so `p_right_up=float("nan")` passed both the `<= 0.0` check and the `p_right_up + p_right_down > 1` check. `_build_transitions` then produced a transition tensor whose row sums were all `NaN`, violating the class's documented row-stochastic-kernel contract.

confirmed directly before touching the source:

```text
p_right_up=nan: constructed
  row sums: [nan nan nan]
  all finite: False
  next state/reward: 0 0.0
p_right_up=nan: rejected with LinAlgError: SVD did not converge in Linear Least Squares
p_right_up=inf: rejected with ValueError: p_right_up + p_right_down must not exceed 1, got inf + 0.05
```

A `NaN`-poisoned environment silently produces a rollout (picking a state from invalid logits) and only fails later, deep inside NumPy's least-squares solver, when the public analytic average-reward helper is called — a confusing failure far removed from the actual invalid input.

fix: explicit `np.isfinite` guards for both transition probabilities, checked before the existing positivity and probability-mass checks (must come first, since `NaN <= 0.0` is also `false`).

## Reachability

`RiverSwimConfig`/`RiverSwimMDP` are imported and listed in `__all__` by `alberta_framework/streams/__init__.py`:

```python
from alberta_framework.streams import RiverSwimConfig, RiverSwimMDP
env = RiverSwimMDP(RiverSwimConfig(p_right_up=user_supplied_probability))
```

Public through the streams subpackage (not re-exported from the top-level `alberta_framework/__init__.py`). The inputs are ordinary config values, not internally hard-coded safe constants — existing control and IA tests already import the environment the same way.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_closed_loop_env.py -q -o addopts=""
19 passed in 2.09s

$ .venv/bin/python -m ruff check alberta_framework/streams/closed_loop.py tests/test_closed_loop_env.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New assertions added to the existing `TestRiverSwim.test_invalid_config_raises` test, for `NaN` in each of `p_right_up` and `p_right_down`, matching the file's existing style exactly.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/closed_loop.py`, kept the test), reran — `test_invalid_config_raises` failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 19/19 green again.

## Evidence

<!-- evidence-head -->
021d41c4408337a990f11a3f045c19c928c9d7fc

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_closed_loop_env.py -q -o addopts="" -k test_invalid_config_raises
FAILED tests/test_closed_loop_env.py::TestRiverSwim::test_invalid_config_raises
1 failed, 1 passed, 17 deselected in 0.80s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_closed_loop_env.py -q -o addopts=""
19 passed in 1.86s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework.streams import RiverSwimConfig, RiverSwimMDP
for val in (float('nan'), float('inf')):
    try:
        RiverSwimMDP(RiverSwimConfig(p_right_up=val))
        print(f'p_right_up={val}: accepted (BUG if this prints)')
    except ValueError as e:
        print(f'p_right_up={val}: rejected -> {e}')
"
p_right_up=nan: rejected -> p_right_up must be finite, got nan
p_right_up=inf: rejected -> p_right_up must be finite, got inf
```
independently confirmed the fixed constructor rejects both invalid inputs, and independently confirmed the public `streams` re-export via `grep` before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting both invalid inputs, verified the public export directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
