### PR TITLE
fix(streams): preserve initial x-distribution segment in XDistShiftStream

### DIFF
--- a/alberta_framework/streams/alberta_plan_step1.py
+++ b/alberta_framework/streams/alberta_plan_step1.py
@@ -350,7 +350,9 @@ class XDistShiftStream:
 
         # Decide whether to redraw scales this step. Always sample candidate
         # scales (jit-friendly) and use jnp.where to commit conditionally.
-        should_change = state.step_count % self._scale_change_interval == 0
+        should_change = (state.step_count > 0) & (
+            state.step_count % self._scale_change_interval == 0
+        )
         candidate_scales = jr.uniform(
             k_scales,
             (self._feature_dim,),

--- a/tests/test_alberta_plan_step1_streams.py
+++ b/tests/test_alberta_plan_step1_streams.py
@@ -222,6 +222,22 @@ class TestXDistShiftStream:
         chex.assert_tree_all_finite(timestep.observation)
         chex.assert_tree_all_finite(timestep.target)
 
+    def test_initial_scales_last_for_the_first_full_segment(self):
+        stream = XDistShiftStream(
+            feature_dim=4,
+            num_relevant=2,
+            scale_change_interval=3,
+        )
+        state = stream.init(jr.key(7))
+        initial_scales = state.current_scales
+
+        for i in range(3):
+            _, state = stream.step(state, jnp.array(i))
+            chex.assert_trees_all_equal(state.current_scales, initial_scales)
+
+        _, state = stream.step(state, jnp.array(3))
+        assert not bool(jnp.array_equal(state.current_scales, initial_scales))
+
     def test_xdist_shift_stream_input_scale_changes(self):
         """Per-feature input std must measurably differ between segments
         separated by a scale change."""


### PR DESCRIPTION
Closes #173.

## What changed

`XDistShiftStream`'s docstring documents its non-stationarity contract: "every `scale_change_interval` steps a new per-feature scale vector ... is drawn." `init()` samples an initial per-feature scale vector and sets `step_count=0`. `step()` decided whether to redraw with `state.step_count % self._scale_change_interval == 0`, which is `True` when `step_count == 0` since `0 % n == 0` for any `n`. So the freshly-sampled initial scales from `init()` were discarded before a single observation used them — the first scale segment was one event short of the documented `scale_change_interval`-length window.

confirmed directly before touching the source (`scale_change_interval=3`):

```text
initial: [2.1393795  2.658569   0.45619124 9.794587  ]
after step 0: changed=True   (should be False — still within the first segment)
```

fix: require `state.step_count > 0` in addition to the existing divisibility check (using `&` for jit-compatibility, matching the surrounding "Always sample candidate scales (jit-friendly)" pattern), so the initial scales stay active for the first `scale_change_interval` observations and redraws only happen at positive interval boundaries.

## Reachability

`alberta_framework.__init__` (and `alberta_framework.steps.__init__`) publicly export `Step1KernelConfig`, `make_step1_stream`, and `run_step1_smoke`. A real call with `Step1KernelConfig(stream="xdist_shift")` reaches `make_step1_stream`, constructs `XDistShiftStream`, and `run_step1_smoke` drives its `step` method with sampled JAX observations — a public, exercised entry point, not a benchmark-only path.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_alberta_plan_step1_streams.py -q -o addopts=""
18 passed in 14.02s

$ .venv/bin/python -m ruff check alberta_framework/streams/alberta_plan_step1.py tests/test_alberta_plan_step1_streams.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_initial_scales_last_for_the_first_full_segment`, checking scales stay fixed across the first `scale_change_interval` (3) steps and change on the next one.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/alberta_plan_step1.py`, kept the test), reran — failed with a chex assertion showing the scales changed after step 0 instead of staying fixed (`ACTUAL: [9.876885, 0.295386, 0.546747, 9.371794]` vs `DESIRED: [2.13938, 2.658569, 0.456191, 9.794587]`, the true initial scales). Restored the fix, 18/18 green again.

## Evidence

<!-- evidence-head -->
16626ba4e8f92c237b713a5c68bc8bed1ca38b71

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_alberta_plan_step1_streams.py -q -o addopts="" -k test_initial_scales_last_for_the_first_full_segment
AssertionError: [Chex] Assertion assert_trees_all_equal failed
Mismatched elements: 4 / 4 (100%)
ACTUAL: [9.876885, 0.295386, 0.546747, 9.371794]
DESIRED: [2.13938, 2.658569, 0.456191, 9.794587]
1 failed, 17 deselected in 1.08s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_alberta_plan_step1_streams.py -q -o addopts=""
18 passed in 13.72s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.random as jr, jax.numpy as jnp
from alberta_framework.streams.alberta_plan_step1 import XDistShiftStream
stream = XDistShiftStream(feature_dim=4, num_relevant=2, scale_change_interval=3)
state = stream.init(jr.key(7))
initial = state.current_scales
print('initial:', initial)
for i in range(4):
    _, state = stream.step(state, jnp.array(i))
    changed = not bool(jnp.array_equal(state.current_scales, initial))
    print(f'after step {i}: changed={changed}')
"
initial: [2.1393795  2.658569   0.45619124 9.794587  ]
after step 0: changed=False
after step 1: changed=False
after step 2: changed=False
after step 3: changed=True
```
independently reproduced against the fixed head, confirming scales stay fixed for exactly the first `scale_change_interval` (3) steps and change on the 4th, matching the docstring's documented contract.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the corrected interval semantics, verified the docstring's documented contract and the public export chain directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
