### PR TITLE
fix(visualization): align smoothed curves with complete windows

### DIFF
--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -153,9 +153,17 @@ def plot_learning_curves(
             ]
         )
 
+        # ``compute_running_mean`` preserves length by padding the leading
+        # positions with the first complete trailing-window mean. Do not plot
+        # those future-informed padding values at earlier time steps.
+        first_complete_window = (
+            window_size - 1 if metric_array.shape[1] >= window_size else 0
+        )
+        smoothed = smoothed[:, first_complete_window:]
+
         mean, ci_lower, ci_upper = compute_timeseries_statistics(smoothed)
 
-        steps = np.arange(len(mean))
+        steps = np.arange(first_complete_window, first_complete_window + len(mean))
         ax.plot(steps, mean, color=color, label=label, linewidth=_current_style["line_width"])
 
         if show_ci:

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -123,6 +123,36 @@ def test_plot_learning_curves_returns_figure_and_axes(results) -> None:
     assert {line.get_label() for line in ax.lines} == {"lms", "idbd"}
 
 
+def test_plot_learning_curves_omits_future_informed_running_mean_padding() -> None:
+    values = np.arange(6, dtype=float)[None, :]
+    finals = values[:, -1]
+    result = AggregatedResults(
+        config_name="linear",
+        seeds=[0],
+        metric_arrays={"squared_error": values},
+        summary={
+            "squared_error": MetricSummary(
+                mean=float(finals.mean()),
+                std=float(finals.std()),
+                min=float(finals.min()),
+                max=float(finals.max()),
+                n_seeds=1,
+                values=finals,
+            )
+        },
+    )
+
+    _, ax = plot_learning_curves(
+        {"linear": result},
+        window_size=3,
+        show_ci=False,
+        log_scale=False,
+    )
+
+    np.testing.assert_array_equal(ax.lines[0].get_xdata(), np.arange(2, 6))
+    np.testing.assert_allclose(ax.lines[0].get_ydata(), (1.0, 2.0, 3.0, 4.0))
+
+
 def test_plot_final_performance_bars(results) -> None:
     fig, ax = plot_final_performance_bars(results)
     assert isinstance(fig, plt.Figure)


### PR DESCRIPTION
Closes #175.

## What changed

`compute_running_mean` (`alberta_framework/utils/metrics.py`) is length-preserving by design — its own docstring documents that "the first `window_size - 1` entries are padded with the first fully-windowed mean (they are not partial-window means)." `plot_learning_curves` plotted this padded array directly against `steps = np.arange(len(mean))` — against x = 0, 1, 2, .... Since the first `window_size - 1` positions are padded with the mean of the *first complete window* (which summarizes steps `0` through `window_size - 1`), plotting them at earlier steps backdates a future-informed measurement onto time steps before that window actually closed, visually making a learning curve look smooth/converged from the first step instead of showing the real early trajectory.

confirmed directly before touching the source, raw values `[0, 1, 2, 3, 4, 5]` with a 3-step trailing mean:

```text
raw steps: [0, 1, 2, 3, 4, 5]
3-step valid means: [1.0, 2.0, 3.0, 3.9999999999999996]
plotted y: [1.0, 1.0, 1.0, 2.0, 3.0, 4.0]
plotted x: [0, 1, 2, 3, 4, 5]
correct trailing-window x: [2, 3, 4, 5]
```

fix: strip the padded prefix from the smoothed array whenever the input is at least one full window long, and start the plotted x coordinates at `window_size - 1`. Inputs shorter than the requested window retain their original data and step coordinates, matching `compute_running_mean`'s own documented behavior of returning short inputs unchanged.

## Reachability

`plot_learning_curves` is imported and included in `__all__` by `alberta_framework.utils`, publicly reachable as `alberta_framework.utils.plot_learning_curves`, accepting real `AggregatedResults.metric_arrays` with no hardcoded-safe input constraints. `create_comparison_figure` (also publicly exported) calls it directly for its top-left panel. Neither is re-exported from the top-level `alberta_framework/__init__.py`.

## Verification

```text
$ MPLCONFIGDIR=/tmp/asi-mpl-cache .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""
9 passed in 1.50s

$ .venv/bin/python -m ruff check alberta_framework/utils/visualization.py tests/test_utils_smoke.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

New test: `test_plot_learning_curves_omits_future_informed_running_mean_padding`, asserting the exact rendered matplotlib line's x/y data (`[2, 3, 4, 5]` / `[1, 2, 3, 4]`) for the independent three-step example above, matching the sibling `test_plot_learning_curves_returns_figure_and_axes` file style.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/utils/visualization.py`, kept the test), reran — failed with `Arrays are not equal (shapes (6,), (4,) mismatch), ACTUAL: [0 1 2 3 4 5], DESIRED: [2 3 4 5]`. Restored the fix, 9/9 green again.

## Evidence

<!-- evidence-head -->
c6c3062798993c792b2d110f6857a6f6661e6412

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ MPLCONFIGDIR=/tmp/asi-mpl-cache .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts="" -k omits_future_informed
AssertionError: Arrays are not equal
(shapes (6,), (4,) mismatch)
ACTUAL: array([0, 1, 2, 3, 4, 5])
DESIRED: array([2, 3, 4, 5])
1 failed, 8 deselected in 0.71s

green (fix restored):
$ MPLCONFIGDIR=/tmp/asi-mpl-cache .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""
9 passed in 1.50s
```

<!-- evidence-row:domain-artifact -->
```text
$ MPLCONFIGDIR=/tmp/asi-mpl-cache .venv/bin/python -c "
import matplotlib; matplotlib.use('Agg', force=True)
import numpy as np
from alberta_framework.utils.visualization import plot_learning_curves
from alberta_framework.utils.experiments import AggregatedResults, MetricSummary
values = np.arange(6, dtype=float)[None, :]
finals = values[:, -1]
result = AggregatedResults(config_name='linear', seeds=[0], metric_arrays={'squared_error': values},
    summary={'squared_error': MetricSummary(mean=float(finals.mean()), std=float(finals.std()), min=float(finals.min()), max=float(finals.max()), n_seeds=1, values=finals)})
_, ax = plot_learning_curves({'linear': result}, window_size=3, show_ci=False, log_scale=False)
print('xdata:', ax.lines[0].get_xdata())
print('ydata:', ax.lines[0].get_ydata())
"
xdata: [2 3 4 5]
ydata: [1. 2. 3. 4.]
```
independently reproduced against the fixed head, and independently confirmed `compute_running_mean`'s own docstring documents the exact padding behavior this fix corrects for.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the corrected x/y alignment on a real rendered matplotlib line, verified the public export chain and `compute_running_mean`'s documented contract directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
