### PR TITLE
fix(prototype-agent): reject negative subtask counts

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -208,6 +208,9 @@ def feature_to_subtask_specs(
         Tuple of up to ``n_subtasks`` :class:`SubtaskSpec` instances, ordered
         by descending feature importance.
     """
+    if isinstance(n_subtasks, bool) or not isinstance(n_subtasks, int) or n_subtasks < 0:
+        raise ValueError("n_subtasks must be a non-negative integer")
+
     bls = oak_state.stomp_state.base_learner_state
     trunk_ws = bls.trunk_params.weights
     if len(trunk_ws) == 0:

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -565,6 +565,13 @@ class TestAutoSubtaskSpecs:
 
 
 class TestFeatureToSubtaskSpecs:
+    def test_rejects_negative_subtask_count(self) -> None:
+        agent = PrototypeAgent(_minimal_config())
+        state = agent.init(jr.key(0))
+
+        with pytest.raises(ValueError, match="n_subtasks"):
+            feature_to_subtask_specs(state.oak_state, n_subtasks=-1)
+
     def test_returns_correct_count(self) -> None:
         agent = PrototypeAgent(_minimal_config())
         state = agent.init(jr.key(0))


### PR DESCRIPTION
Closes #178.

## What changed

`feature_to_subtask_specs` accepted a negative `n_subtasks` with no validation. The implementation computes `n = min(n_subtasks, obs_dim)` then `ranking[:n]` — a negative `n` is a *valid* Python slice (`ranking[:-1]` drops the last element) rather than an error, so `n_subtasks=-1` on a four-feature agent silently returned 3 subtask specs instead of rejecting the invalid count, which can unexpectedly expand the next curation cycle instead of failing loudly.

confirmed directly before touching the source:

```text
requested=-1 returned=3
[0, 2, 1]
```

fix: validate `n_subtasks` before ranking — must be a non-negative integer and must not be a `bool` (Python's `bool` is an `int` subclass, so `isinstance(True, int)` is `True`; excluding it explicitly keeps the check meaning "an actual integer count"). Zero remains valid and returns an empty tuple.

## Reachability

`feature_to_subtask_specs` is genuinely package-root exported (`alberta_framework/core/__init__.py` and `alberta_framework/__init__.py`, both import and `__all__`). `PrototypeAgent.auto_subtask_specs` — a public method — accepts `n_subtasks` from its own caller and forwards it directly through. Reachable via both the top-level public helper and a public agent method, not a hardcoded-safe-only internal path.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts="" -k "TestFeatureToSubtaskSpecs or TestAutoSubtaskSpecs"
9 passed, 55 deselected in 23.82s

$ .venv/bin/python -m ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 159 source files
```

The full file (`tests/test_prototype_agent.py`, 64 tests) is a long-running JAX suite (~10 minutes); scoped verification to the two affected test classes (`TestFeatureToSubtaskSpecs`, `TestAutoSubtaskSpecs`) for the focused check, per the original Codex run's own full-file 64/64 pass already on record.

New test: `test_rejects_negative_subtask_count` in the existing `TestFeatureToSubtaskSpecs` class, matching the file's style.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/core/prototype_agent.py`, kept the test), reran the one affected test — failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, passed again.

## Evidence

<!-- evidence-head -->
4e33458480ed6ad6eed9257ea70c9b7b05e6e899

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts="" -k test_rejects_negative_subtask_count
FAILED tests/test_prototype_agent.py::TestFeatureToSubtaskSpecs::test_rejects_negative_subtask_count - Failed: DID NOT RAISE ValueError
1 failed, 63 deselected in 1.47s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts="" -k test_rejects_negative_subtask_count
1 passed, 63 deselected in 1.09s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.random as jr
from alberta_framework.core.prototype_agent import PrototypeAgent, feature_to_subtask_specs
from tests.test_prototype_agent import _minimal_config
agent = PrototypeAgent(_minimal_config())
state = agent.init(jr.key(0))
try:
    result = feature_to_subtask_specs(state.oak_state, n_subtasks=-1)
    print(f'requested=-1 returned={len(result)} (BUG if this prints)')
except ValueError as e:
    print(f'rejected -> {e}')
"
rejected -> n_subtasks must be a non-negative integer
```
independently reproduced against the fixed head, and independently confirmed `feature_to_subtask_specs` is genuinely package-root exported and reachable through `PrototypeAgent.auto_subtask_specs` before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the two affected test classes, ruff, and mypy myself, independently reproduced the guard rejecting the invalid input, verified the public export and real caller chain directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
