### PR TITLE
fix(screening): reject duplicate JSON keys in shards

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6980,9 +6980,22 @@ def shard_payload(result: ScreeningRunResult) -> dict[str, Any]:
     }
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while refusing ambiguous duplicate keys."""
+    parsed: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in parsed:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        parsed[key] = value
+    return parsed
+
+
 def load_shard(path: Path) -> dict[str, Any]:
     """Load and structurally validate one screening shard."""
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    payload = json.loads(
+        Path(path).read_text(encoding="utf-8"),
+        object_pairs_hook=_reject_duplicate_json_keys,
+    )
     if not isinstance(payload, dict) or payload.get("schema") != SHARD_SCHEMA:
         raise ValueError(f"{path}: not an {SHARD_SCHEMA} shard")
     config = IPMNISTConfig(**payload["config"])

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -809,6 +809,30 @@ class TestShardsAndMerge:
         control = next(e for e in summary["results"] if e["config_name"] == "upgd_w_control")
         assert "paired_vs_control" not in control
 
+    def test_load_shard_rejects_duplicate_top_level_key(self, tmp_path, small_data):
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = path.read_text(encoding="utf-8")
+        doctored = payload.replace('"seed": 0', '"seed": 999999, "seed": 0', 1)
+        assert doctored != payload
+        path.write_text(doctored, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=r"duplicate JSON object key: seed"):
+            load_shard(path)
+
+    def test_load_shard_rejects_duplicate_nested_key(self, tmp_path, small_data):
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = path.read_text(encoding="utf-8")
+        doctored = payload.replace(
+            '"config": {"n_tasks":',
+            '"config": {"n_tasks": 999999, "n_tasks":',
+            1,
+        )
+        assert doctored != payload
+        path.write_text(doctored, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=r"duplicate JSON object key: n_tasks"):
+            load_shard(path)
+
     def test_merge_rejects_zero_seed_overlap_with_control(self, tmp_path, small_data):
         """An arm sharing no seeds with a present control must refuse to merge:
         the entry would rank in the summary with no paired_vs_control block and


### PR DESCRIPTION
## Summary

Closes elizaOS/asi#177

Reject duplicate object keys while loading IPMNIST screening shard JSON.

Python’s default `json.loads` behavior silently accepts duplicate keys and keeps the final value. This could hide conflicting shard identity or configuration fields such as `seed` and `config.n_tasks`.

## Changes

- Add a strict JSON object-pairs hook to detect duplicate keys at any nesting level.
- Raise `ValueError` identifying the duplicated key.
- Add regression coverage for:
  - duplicate top-level shard identity fields
  - duplicate nested configuration fields

## Verification

Failing-test-first result:

- `2 failed, 203 deselected`

After the implementation:

- Targeted regression tests: `2 passed, 203 deselected`
- Full screening test module: `205 passed`
- Ruff: passed
- Mypy: passed across 159 source files
- `git diff --check`: passed

## Evidence impact

This is unit-level, nonpromoting validation of development-lane input handling.

- No benchmark executions
- No seed changes
- No modifications under `outputs/`
- No changes to registered evidence source closures
- No scientific or performance claims

## Provenance

- Base: `da8b86cd33a5982215753fb31bd1b3b6132b3c04`
- Head: `9a28786c995266d4a9852fd3893dd2565ebc62cc`
- Provider: OpenAI
- Model: `gpt-5.6-sol`
- Client: Codex `0.142.5`
- ASI contribution skill: `a99f2e649ecadc35896c9d65c8d5136e947333ce`

<!-- evidence-head:9a28786c995266d4a9852fd3893dd2565ebc62cc -->