### PR TITLE
feat(screening): add code-only RLS body L2-init arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rls_head_resid_l1_preset005_nogate`. It has no result artifact and does not authorize a
   benchmark run; execution remains gated by the issue's source receipt and owner-approved
   compute budget.
+- Added the code-only, permanently nonpromoting IPMNIST arm
+  `rls_head_resid_l1_preset005_l2init`, which snapshots and decays exactly `w1`, `b1`, `w2`,
+  and `b2` toward initialization while leaving `w3`, `b3`, the incumbent state/configuration,
+  and the RLS recursion unchanged. It has no result artifact and does not authorize a benchmark
+  run; execution still requires a replacement frozen protocol, fresh eligible seeds, and
+  owner-approved compute.
 
 ### Changed
 

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -3490,6 +3490,25 @@ class RLSHeadState:
 _RLS_HEAD_BODY = ("w1", "b1", "w2", "b2")
 
 
+@chex.dataclass(frozen=True)
+class RLSHeadL2InitState:
+    """Opt-in RLS carry with an immutable body-initialization snapshot.
+
+    This distinct state keeps the incumbent :class:`RLSHeadState` schema
+    unchanged.  ``init_params`` contains exactly the four residual-trained
+    body tensors; the parallel protocol head and the RLS state are not part
+    of the L2-to-initialization mechanism.
+    """
+
+    utility: dict[str, Array]
+    step: Array
+    norm: EMANormState
+    fast_mean: Array
+    p: Array
+    wout: Array
+    init_params: dict[str, Array]
+
+
 def _rls_head_hp(**overrides: float) -> dict[str, float]:
     """Champion (``sigma0_shiftnorm_d099``) constants plus RLS-head defaults.
 
@@ -3522,8 +3541,47 @@ def _rls_head_hp(**overrides: float) -> dict[str, float]:
     return merged
 
 
+def _rls_head_l2init_hp() -> dict[str, float]:
+    """Frozen issue-#14 endpoint: incumbent plus body L2-Init."""
+    return {
+        **_rls_head_hp(
+            rls_lambda=1.0,
+            rls_reset_frac=0.05,
+            head_resid=1.0,
+        ),
+        "decay_to_init": 1.0,
+    }
+
+
+def _make_rls_head_l2init_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    """Build the one frozen body-only L2-Init arm, failing closed on drift."""
+    expected = _rls_head_l2init_hp()
+    if set(hp) != set(expected):
+        raise ValueError(
+            "frozen L2-Init configuration requires exactly the registered keys"
+        )
+    invalid = [
+        name
+        for name, expected_value in expected.items()
+        if type(hp[name]) is not float
+        or not math.isfinite(hp[name])
+        or hp[name].hex() != expected_value.hex()
+    ]
+    if invalid:
+        raise ValueError(
+            "frozen L2-Init configuration differs at: " + ", ".join(invalid)
+        )
+    base_hp = dict(hp)
+    del base_hp["decay_to_init"]
+    return _make_rls_head_learner(base_hp, _decay_to_init=True)
+
+
 def _make_rls_head_learner(
     hp: Mapping[str, float],
+    *,
+    _decay_to_init: bool = False,
 ) -> tuple[LearnerInitFn, ScreeningStepFn]:
     """Champion body + streaming-RLS readout on the penultimate features.
 
@@ -3541,7 +3599,11 @@ def _make_rls_head_learner(
        ``d(0.5*||onehot - wout.T @ phi||^2)/d(body)`` with ``wout`` held
        constant (w3/b3 untouched, zero-utility gate guarded to 0.5).
        The frozen ``gate_scale = 0`` endpoint instead applies plain decayed
-       SGD to that residual gradient and skips all utility bookkeeping.
+       SGD to that residual gradient and skips all utility bookkeeping.  The
+       private, opt-in L2-Init composition changes only the four residual
+       body tensors' decay target; it has a distinct state and strict
+       registered factory so the incumbent path and state schema remain
+       unchanged.
     4. Sherman-Morrison RLS with forgetting ``rls_lambda`` (symmetrized P,
        the rff_rls equations), then the optional detector-driven P reset
        (``mean(shifted) >= rls_reset_frac`` => ``p = eye/ridge``, wout kept).
@@ -3551,7 +3613,8 @@ def _make_rls_head_learner(
     """
     step_size = hp["step_size"]
     utility_decay = hp["utility_decay"]
-    param_decay = 1.0 - step_size * hp["weight_decay"]
+    weight_decay = hp["weight_decay"]
+    param_decay = 1.0 - step_size * weight_decay
     rls_lambda = hp["rls_lambda"]
     ridge_init = hp["rls_ridge_init"]
     reset_frac = hp["rls_reset_frac"]
@@ -3567,6 +3630,8 @@ def _make_rls_head_learner(
     gate_enabled = gate_scale == 1.0
     if not gate_enabled and not resid:
         raise ValueError("gate_scale=0.0 is supported only for the residual body")
+    if _decay_to_init and (not resid or not gate_enabled):
+        raise ValueError("L2-Init is supported only for the gated residual body")
 
     def normalize(
         state: EMANormState, fast_mean: Array, x: Array
@@ -3581,10 +3646,28 @@ def _make_rls_head_learner(
             shift_refractory=hp["shift_refractory"],
         )
 
-    def init_fn(params: dict[str, Array]) -> RLSHeadState:
+    def init_fn(
+        params: dict[str, Array],
+    ) -> RLSHeadState | RLSHeadL2InitState:
         input_dim = params["w1"].shape[0]
         m = params["w2"].shape[1] + 1
         n_classes = params["w3"].shape[1]
+        if _decay_to_init:
+            return RLSHeadL2InitState(  # type: ignore[call-arg]
+                utility={
+                    name: jnp.zeros_like(value) for name, value in params.items()
+                },
+                step=jnp.array(0, dtype=jnp.int32),
+                norm=EMANormState(  # type: ignore[call-arg]
+                    mean=jnp.zeros(input_dim, dtype=jnp.float32),
+                    var=jnp.ones(input_dim, dtype=jnp.float32),
+                    count=jnp.zeros(input_dim, dtype=jnp.float32),
+                ),
+                fast_mean=jnp.zeros(input_dim, dtype=jnp.float32),
+                p=jnp.eye(m, dtype=jnp.float32) / ridge_init,
+                wout=jnp.zeros((m, n_classes), dtype=jnp.float32),
+                init_params={name: params[name] for name in _RLS_HEAD_BODY},
+            )
         return RLSHeadState(  # type: ignore[call-arg]
             utility={name: jnp.zeros_like(value) for name, value in params.items()},
             step=jnp.array(0, dtype=jnp.int32),
@@ -3612,6 +3695,7 @@ def _make_rls_head_learner(
         count: Array,
         names: tuple[str, ...],
         guard_zero_max: bool,
+        init_params: Mapping[str, Array] | None = None,
     ) -> tuple[dict[str, Array], dict[str, Array]]:
         """Champion utility-EMA + global-max sigmoid gate + gated decayed SGD
         over ``names``; other tensors pass through with untouched utility."""
@@ -3630,25 +3714,52 @@ def _make_rls_head_learner(
             global_max = jnp.where(global_max == 0.0, 1.0, global_max)
         new_params = dict(params)
         for name in names:
-            new_params[name] = params[name] * param_decay - step_size * (
-                grads[name]
-                * (
-                    1.0
-                    - jax.nn.sigmoid(
-                        (new_utility[name] / bias_correction) / global_max
+            if init_params is None:
+                # Keep the incumbent expression byte-for-byte unchanged.
+                new_params[name] = params[name] * param_decay - step_size * (
+                    grads[name]
+                    * (
+                        1.0
+                        - jax.nn.sigmoid(
+                            (new_utility[name] / bias_correction) / global_max
+                        )
                     )
                 )
-            )
+            else:
+                new_params[name] = (
+                    params[name]
+                    - step_size
+                    * weight_decay
+                    * (params[name] - init_params[name])
+                    - step_size
+                    * (
+                        grads[name]
+                        * (
+                            1.0
+                            - jax.nn.sigmoid(
+                                (new_utility[name] / bias_correction) / global_max
+                            )
+                        )
+                    )
+                )
         return new_params, new_utility
 
     def full_step(
         params: dict[str, Array],
-        state: RLSHeadState,
+        state: RLSHeadState | RLSHeadL2InitState,
         x: Array,
         y: Array,
         key: Array,
-    ) -> tuple[dict[str, Array], RLSHeadState, StepMetrics]:
+    ) -> tuple[
+        dict[str, Array], RLSHeadState | RLSHeadL2InitState, StepMetrics
+    ]:
         del key  # sigma-0 body, closed-form head: no randomness consumed
+        if _decay_to_init:
+            if not isinstance(state, RLSHeadL2InitState):
+                raise TypeError("L2-Init learner requires RLSHeadL2InitState")
+            init_params: Mapping[str, Array] | None = state.init_params
+        else:
+            init_params = None
         x_norm, new_norm, new_fast, shifted = normalize(
             state.norm, state.fast_mean, x
         )
@@ -3683,6 +3794,7 @@ def _make_rls_head_learner(
                     count,
                     _RLS_HEAD_BODY,
                     guard_zero_max=True,
+                    init_params=init_params,
                 )
             else:
                 # Issue #52's frozen ablation endpoint: do not compute or
@@ -3733,6 +3845,17 @@ def _make_rls_head_learner(
         plasticity = jnp.clip(
             1.0 - loss_after / jnp.maximum(loss, _PLASTICITY_LOSS_FLOOR), 0.0, 1.0
         )
+        if _decay_to_init:
+            assert isinstance(state, RLSHeadL2InitState)
+            return new_params, RLSHeadL2InitState(  # type: ignore[call-arg]
+                utility=new_utility,
+                step=count,
+                norm=new_norm,
+                fast_mean=new_fast,
+                p=new_p,
+                wout=new_wout,
+                init_params=state.init_params,
+            ), (accuracy, loss, plasticity)
         return new_params, RLSHeadState(  # type: ignore[call-arg]
             utility=new_utility,
             step=count,
@@ -6070,6 +6193,23 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                 ),
             )
         )
+    specs.append(
+        ScreeningSpec(
+            name="rls_head_resid_l1_preset005_l2init",
+            base_learner="upgd_w",
+            mechanism="rls_readout",
+            hyperparameters=_rls_head_l2init_hp(),
+            factory=_make_rls_head_l2init_learner,
+            frozen_probe_input=_rls_head_frozen_probe_input,
+            description=(
+                "Code-only issue-#14 endpoint: the exact "
+                "rls_head_resid_l1_preset005 incumbent with decoupled "
+                "L2-to-initialization on w1/b1/w2/b2 only; w3/b3 and the "
+                "RLS recursion are unchanged. This registry entry has no "
+                "result artifact and does not authorize execution."
+            ),
+        )
+    )
     # --- Optimizer-floor hybrid wave (section (s) factories): Adam-class
     # step adaptation under the champion's full stability package.  The
     # naive composition adamw_cbp_ema_norm proved Adam-class task-1

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -210,6 +210,7 @@ class TestRegistry:
             "rls_head_l1_preset003",
             "rls_head_l0999_pcap",
             "rls_head_resid_l1_preset005",
+            "rls_head_resid_l1_preset005_l2init",
             "rls_head_resid_l1_preset005_nogate",
             "rls_head_l0999_preset005_r01",
             "rls_head_l0999_preset005_r003",
@@ -5442,6 +5443,287 @@ class TestRLSHead:
             "rls_head_resid_l1_preset005_nogate"
         ).hyperparameters
         assert nogate_hp == {**incumbent_hp, "gate_scale": 0.0}
+
+
+class TestRLSHeadL2Init:
+    """Issue #14's body-only L2-to-initialization code prerequisite."""
+
+    _BODY = ("w1", "b1", "w2", "b2")
+
+    @staticmethod
+    def _assert_tree_equal(actual, expected):
+        actual_leaves, actual_tree = jax.tree_util.tree_flatten(actual)
+        expected_leaves, expected_tree = jax.tree_util.tree_flatten(expected)
+        assert actual_tree == expected_tree
+        assert len(actual_leaves) == len(expected_leaves)
+        for actual_leaf, expected_leaf in zip(actual_leaves, expected_leaves, strict=True):
+            np.testing.assert_array_equal(
+                np.asarray(actual_leaf), np.asarray(expected_leaf)
+            )
+
+    @staticmethod
+    def _manual_params() -> dict[str, jax.Array]:
+        return {
+            "w1": jnp.full((SMALL.input_dim, SMALL.hidden1), 0.05, jnp.float32),
+            "b1": jnp.full((SMALL.hidden1,), 0.10, jnp.float32),
+            "w2": jnp.full((SMALL.hidden1, SMALL.hidden2), 0.04, jnp.float32),
+            "b2": jnp.full((SMALL.hidden2,), 0.10, jnp.float32),
+            "w3": jnp.full((SMALL.hidden2, SMALL.n_classes), 0.03, jnp.float32),
+            "b3": jnp.full((SMALL.n_classes,), 0.02, jnp.float32),
+        }
+
+    def test_registry_is_exactly_incumbent_plus_frozen_endpoint(self):
+        from alberta_framework.benchmarks.ipmnist_screening import (
+            RLSHeadL2InitState,
+            RLSHeadState,
+            _make_rls_head_l2init_learner,
+            _rls_head_frozen_probe_input,
+        )
+
+        incumbent = screening_spec("rls_head_resid_l1_preset005")
+        candidate = screening_spec("rls_head_resid_l1_preset005_l2init")
+        assert candidate.base_learner == incumbent.base_learner == "upgd_w"
+        assert candidate.mechanism == incumbent.mechanism == "rls_readout"
+        assert candidate.factory is _make_rls_head_l2init_learner
+        assert candidate.frozen_probe_input is _rls_head_frozen_probe_input
+        assert candidate.noise_update is None
+        assert candidate.hyperparameters == {
+            **incumbent.hyperparameters,
+            "decay_to_init": 1.0,
+        }
+
+        params = self._manual_params()
+        incumbent_state = incumbent.factory(incumbent.hyperparameters)[0](params)
+        candidate_state = candidate.factory(candidate.hyperparameters)[0](params)
+        assert type(incumbent_state) is RLSHeadState
+        assert not hasattr(incumbent_state, "init_params")
+        assert type(candidate_state) is RLSHeadL2InitState
+        assert set(candidate_state.init_params) == set(self._BODY)
+        for name in self._BODY:
+            np.testing.assert_array_equal(
+                np.asarray(candidate_state.init_params[name]), np.asarray(params[name])
+            )
+        for field in ("utility", "step", "norm", "fast_mean", "p", "wout"):
+            self._assert_tree_equal(
+                jax.device_get(getattr(candidate_state, field)),
+                jax.device_get(getattr(incumbent_state, field)),
+            )
+
+    def test_factory_rejects_every_nonfrozen_config(self):
+        from alberta_framework.benchmarks.ipmnist_screening import (
+            _make_rls_head_l2init_learner,
+            _rls_head_l2init_hp,
+        )
+
+        expected = _rls_head_l2init_hp()
+        invalid = []
+        without_endpoint = dict(expected)
+        without_endpoint.pop("decay_to_init")
+        invalid.append(without_endpoint)
+        invalid.extend(
+            [
+                {**expected, "decay_to_init": 0.0},
+                {**expected, "decay_to_init": True},
+                {**expected, "step_size": 0.02},
+                {**expected, "rls_lambda": 1},
+                {**expected, "noise_std": -0.0},
+                {**expected, "unexpected": 0.0},
+            ]
+        )
+        for hp in invalid:
+            with pytest.raises(ValueError, match="frozen L2-Init configuration"):
+                _make_rls_head_l2init_learner(hp)
+
+        _make_rls_head_l2init_learner(expected)
+
+    def test_body_and_rls_updates_match_equations_and_freeze_sgd_head(self):
+        import dataclasses
+
+        from alberta_framework.benchmarks.ipmnist_screening import (
+            _make_rls_head_l2init_learner,
+            _rls_head_l2init_hp,
+        )
+
+        hp = _rls_head_l2init_hp()
+        init_fn, step_fn = _make_rls_head_l2init_learner(hp)
+        init_params = self._manual_params()
+        state = init_fn(init_params)
+        params = dict(init_params)
+        for index, name in enumerate(self._BODY, start=1):
+            params[name] = init_params[name] + jnp.asarray(
+                0.01 * index, dtype=jnp.float32
+            )
+
+        m = SMALL.hidden2 + 1
+        wout = jnp.linspace(
+            -0.2, 0.3, m * SMALL.n_classes, dtype=jnp.float32
+        ).reshape((m, SMALL.n_classes))
+        state = dataclasses.replace(
+            state,
+            p=jnp.eye(m, dtype=jnp.float32) * 0.7,
+            wout=wout,
+        )
+        x = jnp.linspace(0.1, 0.4, SMALL.input_dim, dtype=jnp.float32)
+        y = jnp.asarray(2, dtype=jnp.int32)
+
+        x_norm, expected_norm, expected_fast, shifted = shift_adaptive_normalize(
+            state.norm,
+            state.fast_mean,
+            x,
+            decay=hp["norm_decay"],
+            fast_decay=hp["fast_decay"],
+            epsilon=hp["norm_epsilon"],
+            shift_k=hp["shift_k"],
+            shift_delta=hp["shift_delta"],
+            shift_refractory=hp["shift_refractory"],
+        )
+        assert not bool(jnp.any(shifted))
+
+        body = {name: params[name] for name in self._BODY}
+
+        def residual_loss(
+            body_params: dict[str, jax.Array],
+        ) -> jax.Array:
+            merged = dict(params)
+            merged.update(body_params)
+            a1 = jax.nn.relu(x_norm @ merged["w1"] + merged["b1"])
+            a2 = jax.nn.relu(a1 @ merged["w2"] + merged["b2"])
+            phi = jnp.concatenate(
+                [
+                    a2 * (1.0 / math.sqrt(m)),
+                    jnp.ones((1,), dtype=jnp.float32),
+                ]
+            )
+            logits = state.wout.T @ phi
+            target = jax.nn.one_hot(y, SMALL.n_classes, dtype=jnp.float32)
+            error = target - logits
+            return 0.5 * jnp.sum(error * error)
+
+        grads = jax.grad(residual_loss)(body)
+        count = state.step + jnp.asarray(1, dtype=jnp.int32)
+        utility = dict(state.utility)
+        for name in self._BODY:
+            utility[name] = hp["utility_decay"] * state.utility[name] + (
+                1.0 - hp["utility_decay"]
+            ) * (-grads[name] * params[name])
+        bias_correction = 1.0 - jnp.power(
+            jnp.asarray(hp["utility_decay"], dtype=jnp.float32),
+            count.astype(jnp.float32),
+        )
+        global_max = jnp.max(
+            jnp.stack([jnp.max(utility[name]) for name in sorted(self._BODY)])
+        )
+        global_max = jnp.where(global_max == 0.0, 1.0, global_max)
+        expected_params = dict(params)
+        for name in self._BODY:
+            gated_gradient = grads[name] * (
+                1.0
+                - jax.nn.sigmoid((utility[name] / bias_correction) / global_max)
+            )
+            expected_params[name] = (
+                params[name]
+                - hp["step_size"]
+                * hp["weight_decay"]
+                * (params[name] - state.init_params[name])
+                - hp["step_size"] * gated_gradient
+            )
+
+        a1 = jax.nn.relu(x_norm @ params["w1"] + params["b1"])
+        a2 = jax.nn.relu(a1 @ params["w2"] + params["b2"])
+        phi = jnp.concatenate(
+            [
+                a2 * (1.0 / math.sqrt(m)),
+                jnp.ones((1,), dtype=jnp.float32),
+            ]
+        )
+        target = jax.nn.one_hot(y, SMALL.n_classes, dtype=jnp.float32)
+        error = target - state.wout.T @ phi
+        pp = state.p @ phi
+        gain = pp / (hp["rls_lambda"] + phi @ pp)
+        expected_wout = state.wout + jnp.outer(gain, error)
+        expected_p = (state.p - jnp.outer(gain, pp)) / hp["rls_lambda"]
+        expected_p = 0.5 * (expected_p + expected_p.T)
+
+        new_params, new_state, _ = step_fn(params, state, x, y, jr.key(99))
+
+        for name in self._BODY:
+            np.testing.assert_array_equal(
+                np.asarray(new_params[name]), np.asarray(expected_params[name]), name
+            )
+            np.testing.assert_array_equal(
+                np.asarray(new_state.utility[name]), np.asarray(utility[name]), name
+            )
+            np.testing.assert_array_equal(
+                np.asarray(new_state.init_params[name]),
+                np.asarray(state.init_params[name]),
+                name,
+            )
+        for name in ("w3", "b3"):
+            np.testing.assert_array_equal(
+                np.asarray(new_params[name]), np.asarray(params[name]), name
+            )
+            np.testing.assert_array_equal(
+                np.asarray(new_state.utility[name]),
+                np.asarray(state.utility[name]),
+                name,
+            )
+        assert not np.array_equal(np.asarray(expected_p), np.asarray(state.p))
+        assert not np.array_equal(np.asarray(expected_wout), np.asarray(state.wout))
+        np.testing.assert_array_equal(
+            np.asarray(new_state.p), np.asarray(expected_p)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(new_state.wout), np.asarray(expected_wout)
+        )
+        self._assert_tree_equal(
+            jax.device_get(new_state.norm), jax.device_get(expected_norm)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(new_state.fast_mean), np.asarray(expected_fast)
+        )
+        assert int(new_state.step) == 1
+
+    def test_jit_and_pytree_state_roundtrip_preserve_initial_snapshot(self):
+        from alberta_framework.benchmarks.ipmnist_screening import (
+            RLSHeadL2InitState,
+            _make_rls_head_l2init_learner,
+            _rls_head_l2init_hp,
+        )
+
+        init_fn, step_fn = _make_rls_head_l2init_learner(_rls_head_l2init_hp())
+        params = self._manual_params()
+        state = init_fn(params)
+        leaves, tree = jax.tree_util.tree_flatten(state)
+        restored = jax.tree_util.tree_unflatten(tree, leaves)
+        assert type(restored) is RLSHeadL2InitState
+        self._assert_tree_equal(jax.device_get(restored), jax.device_get(state))
+
+        compiled = jax.jit(step_fn)
+        x = jnp.linspace(-0.2, 0.4, SMALL.input_dim, dtype=jnp.float32)
+        new_params, new_state, metrics = compiled(
+            params, restored, x, jnp.asarray(1, jnp.int32), jr.key(7)
+        )
+        assert type(new_state) is RLSHeadL2InitState
+        for name in self._BODY:
+            np.testing.assert_array_equal(
+                np.asarray(new_state.init_params[name]), np.asarray(params[name]), name
+            )
+        for name in ("w3", "b3"):
+            np.testing.assert_array_equal(
+                np.asarray(new_params[name]), np.asarray(params[name]), name
+            )
+        assert all(bool(jnp.isfinite(metric)) for metric in metrics)
+
+    @pytest.mark.integration
+    def test_registered_arm_runs_through_synthetic_screening_harness(self, small_data):
+        x, y = small_data
+        spec = screening_spec("rls_head_resid_l1_preset005_l2init")
+        result = run_screening_config(x, y, spec, seed=2, config=SMALL)
+        assert result.config_name == spec.name
+        assert result.hyperparameters == spec.hyperparameters
+        assert np.all(np.isfinite(result.per_task_accuracy))
+        assert np.all(np.isfinite(result.per_task_loss))
+        assert np.all(np.isfinite(result.per_task_plasticity))
 
 
 class TestNBEnsemble:


### PR DESCRIPTION
## Summary

- add the code-only `rls_head_resid_l1_preset005_l2init` screening arm requested by #14
- snapshot exactly `w1`, `b1`, `w2`, and `b2`, then apply the frozen decoupled L2-to-initialization update
- preserve `w3`/`b3`, the RLS recursion, and the incumbent state/configuration path
- fail closed if the registered endpoint keys, value types, finiteness, or exact float encodings drift

This deliberately contains no result artifact and authorizes no benchmark execution. The preregistration in #14 remains superseded until a replacement protocol, eligible seeds, paired same-runner control budget, and explicit owner compute/funding approval are recorded.

## Validation

- failing-first: 6 failures before implementation
- focused L2-Init regressions: 6 passed
- incumbent RLS family: 27 passed
- full `tests/test_ipmnist_screening.py`: 301 passed
- repo-wide Ruff: passed
- strict mypy: 163 source files passed
- `git diff --check`: passed
- base vs candidate incumbent parity across 11 eager and JIT updates: bit-identical parameters, full `RLSHeadState`, and metrics

Refs #14.