### PR TITLE
fix(screening): bind new shards to executable provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made new IPMNIST screening shards and summaries strict v2 artifacts bound to a clean Git
+  commit/tree, the actual tracked package and `uv.lock` bytes, runtime/JAX details, and the
+  canonical materialized MNIST feature/label bytes. The run CLI now captures these bindings
+  before execution and verifies them again before immutable publication; merge and proxy
+  validation reject mixed or mismatched provenance while legacy v1 shards remain readable.
 - Moved plotting, dataset, progress, and parallel-execution dependencies from the base
   installation into a `research` extra; the `dev` extra retains the complete contributor
   toolchain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made new IPMNIST screening shards and summaries strict v2 artifacts bound to a clean Git
   commit/tree, the actual tracked package and `uv.lock` bytes, runtime/JAX details, and the
   canonical materialized MNIST feature/label bytes. The run CLI now captures these bindings
-  before execution and verifies them again before immutable publication; merge and proxy
-  validation reject mixed or mismatched provenance while legacy v1 shards remain readable.
+  before execution and verifies them again before immutable publication. Merge and proxy
+  validation now bind their exact input files and live derivation environment, enforce strict
+  policy, hyperparameter, metric-domain, device, and tolerance contracts, and reject changed or
+  mismatched provenance while legacy v1 shards remain readable.
 - Moved plotting, dataset, progress, and parallel-execution dependencies from the base
   installation into a `research` extra; the `dev` extra retains the complete contributor
   toolchain.

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6660,6 +6660,7 @@ def _untracked_python_sources(repo_root: Path) -> bytes:
         "--exclude-standard",
         "--",
         "*.py",
+        "*.pyc",
     )
 
 
@@ -7731,6 +7732,55 @@ def _is_finite_json_number(value: object) -> bool:
         return False
 
 
+def _require_screening_curve_domain(
+    values: np.ndarray, field: str, *, context: str
+) -> None:
+    if field in {"per_task_accuracy", "per_task_plasticity"}:
+        if np.any(values < 0.0) or np.any(values > 1.0):
+            raise ValueError(f"{context}: {field} values must be in [0, 1]")
+    elif field == "per_task_loss" and np.any(values < 0.0):
+        raise ValueError(f"{context}: {field} values must be non-negative")
+
+
+def _validated_nonpromoting_policy(value: object, *, context: str) -> dict[str, object]:
+    policy = _require_exact_keys(
+        value,
+        set(NONPROMOTING_POLICY),
+        context=f"{context} evidence_policy",
+    )
+    if any(
+        type(policy[name]) is not type(expected) or policy[name] != expected
+        for name, expected in NONPROMOTING_POLICY.items()
+    ):
+        raise ValueError(
+            f"{context}: evidence_policy must be the frozen nonpromoting policy"
+        )
+    return dict(policy)
+
+
+def _validated_registered_hyperparameters(
+    value: object, spec: ScreeningSpec, *, context: str
+) -> dict[str, float]:
+    hyperparameters = _require_exact_keys(
+        value,
+        set(spec.hyperparameters),
+        context=f"{context} hyperparameters",
+    )
+    invalid = [
+        name
+        for name, expected in spec.hyperparameters.items()
+        if type(hyperparameters[name]) is not float
+        or not math.isfinite(cast(float, hyperparameters[name]))
+        or cast(float, hyperparameters[name]).hex() != expected.hex()
+    ]
+    if invalid:
+        raise ValueError(
+            f"{context}: hyperparameters must exactly match the registered arm; "
+            f"invalid field(s): {sorted(invalid)}"
+        )
+    return {name: cast(float, hyperparameters[name]) for name in spec.hyperparameters}
+
+
 def _validated_source_provenance(value: object, *, context: str) -> dict[str, Any]:
     provenance = _require_exact_keys(
         value,
@@ -7909,20 +7959,35 @@ def _validated_runtime_environment(value: object, *, context: str) -> dict[str, 
     devices = jax_binding["devices"]
     if not isinstance(devices, list) or not devices:
         raise ValueError(f"{context} runtime environment JAX devices must be non-empty")
+    device_identities: set[tuple[str, int, int]] = set()
     for index, device in enumerate(devices):
         binding = _require_exact_keys(
             device,
             {"id", "platform", "device_kind", "process_index"},
             context=f"{context} runtime environment JAX device {index}",
         )
-        if type(binding["id"]) is not int or type(binding["process_index"]) is not int:
+        device_id = binding["id"]
+        process_index = binding["process_index"]
+        if (
+            type(device_id) is not int
+            or type(process_index) is not int
+            or device_id < 0
+            or process_index < 0
+        ):
             raise ValueError(
-                f"{context} runtime environment JAX device IDs must be integers"
+                f"{context} runtime environment JAX device IDs must be "
+                "non-negative integers"
             )
-        _required_nonempty_string(
+        device_platform = _required_nonempty_string(
             binding["platform"],
             context=f"{context} runtime environment JAX device {index}.platform",
         )
+        identity = (device_platform, process_index, device_id)
+        if identity in device_identities:
+            raise ValueError(
+                f"{context} runtime environment JAX device identities must be unique"
+            )
+        device_identities.add(identity)
         _required_nonempty_string(
             binding["device_kind"],
             context=f"{context} runtime environment JAX device {index}.device_kind",
@@ -7976,8 +8041,9 @@ def shard_payload(
         raise ValueError(
             f"new shard base_learner must match registered arm {spec.base_learner!r}"
         )
-    if result.hyperparameters != spec.hyperparameters:
-        raise ValueError("new shard hyperparameters must exactly match the registered arm")
+    hyperparameters = _validated_registered_hyperparameters(
+        result.hyperparameters, spec, context="new shard"
+    )
     noise_mode = _validated_screening_noise_mode(result.noise_mode, spec)
     noise_pool_steps = _validated_screening_noise_pool_steps(
         noise_mode, result.noise_pool_steps
@@ -7988,10 +8054,6 @@ def shard_payload(
     _validate_dataset_config_binding(dataset_binding, result.config, context="new shard")
     if not isinstance(result.base_learner, str) or not result.base_learner:
         raise ValueError("new shard base_learner must be a non-empty string")
-    if not isinstance(result.hyperparameters, dict) or any(
-        not isinstance(name, str) for name in result.hyperparameters
-    ):
-        raise ValueError("new shard hyperparameters must be an object with string keys")
     curves: dict[str, np.ndarray] = {}
     for field in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
         try:
@@ -8007,6 +8069,7 @@ def shard_payload(
             raise ValueError(
                 f"new shard {field} must be finite with shape ({result.config.n_tasks},)"
             )
+        _require_screening_curve_domain(values, field, context="new shard")
         curves[field] = values
     wall_clock_seconds = _validated_wall_clock_seconds(
         result.wall_clock_seconds, "new shard"
@@ -8016,7 +8079,7 @@ def shard_payload(
         "evidence_policy": dict(NONPROMOTING_POLICY),
         "config_name": result.config_name,
         "base_learner": result.base_learner,
-        "hyperparameters": dict(result.hyperparameters),
+        "hyperparameters": hyperparameters,
         "seed": seed,
         "noise_mode": noise_mode,
         "noise_pool_steps": noise_pool_steps,
@@ -8050,8 +8113,9 @@ def load_shard(path: Path) -> dict[str, Any]:
     is_v2 = schema == SHARD_SCHEMA
     if is_v2:
         _require_exact_keys(payload, _V2_SHARD_FIELDS, context=str(path))
-        if payload["evidence_policy"] != NONPROMOTING_POLICY:
-            raise ValueError(f"{path}: evidence_policy must be the frozen nonpromoting policy")
+        payload["evidence_policy"] = _validated_nonpromoting_policy(
+            payload["evidence_policy"], context=str(path)
+        )
         created_unix = payload["created_unix"]
         if type(created_unix) not in (int, float):
             raise ValueError(f"{path}: created_unix must be a finite, non-negative number")
@@ -8093,6 +8157,8 @@ def load_shard(path: Path) -> dict[str, Any]:
         values = np.asarray(payload[fieldname], dtype=np.float64)
         if values.shape != (config.n_tasks,) or not np.all(np.isfinite(values)):
             raise ValueError(f"{path}: {fieldname} must be finite with shape ({config.n_tasks},)")
+        if is_v2:
+            _require_screening_curve_domain(values, fieldname, context=str(path))
     payload["wall_clock_seconds"] = _validated_wall_clock_seconds(
         payload.get("wall_clock_seconds"), path
     )
@@ -8104,8 +8170,10 @@ def load_shard(path: Path) -> dict[str, Any]:
         raise ValueError(
             f"{path}: base_learner must match registered arm {spec.base_learner!r}"
         )
-    if is_v2 and payload.get("hyperparameters") != spec.hyperparameters:
-        raise ValueError(f"{path}: hyperparameters must exactly match the registered arm")
+    if is_v2:
+        payload["hyperparameters"] = _validated_registered_hyperparameters(
+            payload.get("hyperparameters"), spec, context=str(path)
+        )
     noise_mode = _validated_screening_noise_mode(
         payload.get("noise_mode", "step"), spec, context=path
     )
@@ -8133,6 +8201,73 @@ def load_shard(path: Path) -> dict[str, Any]:
                 "and platform strings"
             )
     return payload
+
+
+def _artifact_file_binding(path: Path, *, context: str) -> dict[str, object]:
+    artifact_path = Path(path)
+    try:
+        raw = artifact_path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"{context}: could not read artifact {artifact_path}") from exc
+    return {
+        "path": artifact_path.as_posix(),
+        "size_bytes": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _artifact_file_bindings(
+    paths: Sequence[Path], *, context: str
+) -> list[dict[str, object]]:
+    return [
+        _artifact_file_binding(Path(path), context=context)
+        for path in paths
+    ]
+
+
+def _require_artifact_bindings_unchanged(
+    paths: Sequence[Path],
+    expected: Sequence[Mapping[str, object]],
+    *,
+    context: str,
+) -> None:
+    current = _artifact_file_bindings(paths, context=context)
+    expected_base = [
+        {
+            "path": binding["path"],
+            "size_bytes": binding["size_bytes"],
+            "sha256": binding["sha256"],
+        }
+        for binding in expected
+    ]
+    if current != expected_base:
+        raise RuntimeError(f"{context} changed while the derived receipt was built")
+
+
+def _require_embedded_artifact_manifest_unchanged(
+    manifest: object, *, context: str
+) -> None:
+    if not isinstance(manifest, list) or not manifest:
+        raise RuntimeError(f"{context} is missing an input artifact manifest")
+    paths: list[Path] = []
+    bindings: list[Mapping[str, object]] = []
+    for item in manifest:
+        if not isinstance(item, Mapping):
+            raise RuntimeError(f"{context} has an invalid input artifact manifest")
+        path = item.get("path")
+        size_bytes = item.get("size_bytes")
+        sha256 = item.get("sha256")
+        if (
+            not isinstance(path, str)
+            or not path
+            or type(size_bytes) is not int
+            or size_bytes < 0
+            or not _is_lower_hex(sha256, 64)
+        ):
+            raise RuntimeError(f"{context} has an invalid input artifact manifest")
+        paths.append(Path(path))
+        bindings.append(cast(Mapping[str, object], item))
+    _require_artifact_bindings_unchanged(paths, bindings, context=context)
 
 
 def _screening_batch_environment(
@@ -8217,13 +8352,28 @@ def _late_window_slope(per_task_accuracy: np.ndarray, window: int) -> float:
     return float(np.sum(x * (tail - tail.mean())) / denom)
 
 
+def _validated_proxy_atol(value: object) -> float:
+    if (
+        type(value) is not float
+        or not math.isfinite(value)
+        or value < 0.0
+        or value > 1e-6
+    ):
+        raise ValueError("proxy validation atol must be a finite float in [0, 1e-6]")
+    return value
+
+
 def merge_shards(
     paths: Sequence[Path],
     control_name: str = "upgd_w_control",
     slope_window: int = 15,
 ) -> dict[str, Any]:
     """Merge shards into a ranked screening summary with paired comparisons."""
-    shards = [load_shard(Path(p)) for p in paths]
+    normalized_paths = [Path(path) for path in paths]
+    input_bindings = _artifact_file_bindings(
+        normalized_paths, context="screening shard input"
+    )
+    shards = [load_shard(path) for path in normalized_paths]
     if not shards:
         raise ValueError("no shards given")
     shard_schemas = {shard["schema"] for shard in shards}
@@ -8245,6 +8395,8 @@ def merge_shards(
     configs = {tuple(sorted(s["config"].items())) for s in shards}
     if len(configs) != 1:
         raise ValueError("shards span multiple protocol configs; merge them separately")
+    if type(slope_window) is not int or slope_window < 2:
+        raise ValueError("slope_window must be a built-in integer of at least 2")
     noise_modes = {s["noise_mode"] for s in shards}
     if len(noise_modes) != 1:
         raise ValueError(
@@ -8391,6 +8543,26 @@ def merge_shards(
     if source_provenance is not None and dataset_provenance is not None:
         summary["source_provenance"] = source_provenance
         summary["dataset_provenance"] = dataset_provenance
+        summary["shard_manifest"] = sorted(
+            (
+                {
+                    **binding,
+                    "config_name": shard["config_name"],
+                    "seed": shard["seed"],
+                }
+                for binding, shard in zip(input_bindings, shards, strict=True)
+            ),
+            key=lambda entry: (
+                cast(str, entry["config_name"]),
+                cast(int, entry["seed"]),
+                cast(str, entry["path"]),
+            ),
+        )
+    _require_artifact_bindings_unchanged(
+        normalized_paths,
+        input_bindings,
+        context="screening shard input",
+    )
     return summary
 
 
@@ -8407,8 +8579,13 @@ def validate_proxy(
     UPGD-W > AdamW ordering both in the proxy runs and in the full-run
     prefixes at the same task index.
     """
+    atol = _validated_proxy_atol(atol)
     partials_dir = Path(partials_dir)
-    shards = [load_shard(Path(path)) for path in shard_paths]
+    normalized_shard_paths = [Path(path) for path in shard_paths]
+    shard_bindings = _artifact_file_bindings(
+        normalized_shard_paths, context="proxy-validation shard input"
+    )
+    shards = [load_shard(path) for path in normalized_shard_paths]
     if not shards:
         raise ValueError("no shards given")
     shard_schemas = {shard["schema"] for shard in shards}
@@ -8487,16 +8664,31 @@ def validate_proxy(
     proxy_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     full_avg: dict[str, list[float]] = {"upgd_w": [], "adamw": []}
     n_tasks_seen: set[int] = set()
+    reference_paths: list[Path] = []
+    reference_bindings: list[dict[str, object]] = []
+    reference_manifest: list[dict[str, object]] = []
     for path, shard in zip(shard_paths, shards, strict=True):
         learner = learner_by_control[shard["config_name"]]
         seed = shard["seed"]
         n_tasks = int(shard["config"]["n_tasks"])
         n_tasks_seen.add(n_tasks)
         partial_path = partials_dir / f"{learner}_seed{seed}.json"
+        reference_binding = _artifact_file_binding(
+            partial_path, context="proxy-validation reference partial"
+        )
         reference = _validated_partial_payload(
             partial_path,
             schema=PARTIAL_SCHEMA_V1,
             seed_field="seeds",
+        )
+        reference_paths.append(partial_path)
+        reference_bindings.append(reference_binding)
+        reference_manifest.append(
+            {
+                **reference_binding,
+                "learner": learner,
+                "seed": seed,
+            }
         )
         if reference["learner"] != learner:
             raise ValueError(
@@ -8580,8 +8772,42 @@ def validate_proxy(
         ),
     }
     if source_provenance is not None and dataset_provenance is not None:
+        report["evidence_policy"] = dict(NONPROMOTING_POLICY)
         report["source_provenance"] = source_provenance
         report["dataset_provenance"] = dataset_provenance
+        report["shard_manifest"] = sorted(
+            (
+                {
+                    **binding,
+                    "config_name": shard["config_name"],
+                    "seed": shard["seed"],
+                }
+                for binding, shard in zip(shard_bindings, shards, strict=True)
+            ),
+            key=lambda entry: (
+                cast(str, entry["config_name"]),
+                cast(int, entry["seed"]),
+                cast(str, entry["path"]),
+            ),
+        )
+        report["reference_partial_manifest"] = sorted(
+            reference_manifest,
+            key=lambda entry: (
+                cast(str, entry["learner"]),
+                cast(int, entry["seed"]),
+                cast(str, entry["path"]),
+            ),
+        )
+    _require_artifact_bindings_unchanged(
+        normalized_shard_paths,
+        shard_bindings,
+        context="proxy-validation shard input",
+    )
+    _require_artifact_bindings_unchanged(
+        reference_paths,
+        reference_bindings,
+        context="proxy-validation reference partial",
+    )
     return report
 
 
@@ -8602,6 +8828,50 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, allow_nan=False, indent=1, sort_keys=True) + "\n"
     ).encode("utf-8")
     atomic_write_new(Path(path), encoded)
+
+
+def _screening_derivation_bindings(
+    shard_paths: Sequence[Path],
+) -> tuple[dict[str, object], dict[str, object]] | None:
+    """Capture the current derivation context only for strict v2 inputs."""
+    if not shard_paths:
+        return None
+    first = load_strict_json_object(Path(shard_paths[0]))
+    if first.get("schema") != SHARD_SCHEMA:
+        return None
+    return _screening_source_provenance(), _screening_runtime_environment()
+
+
+def _require_v2_derivation_context(
+    payload: Mapping[str, Any],
+    bindings: tuple[dict[str, object], dict[str, object]] | None,
+) -> None:
+    schema = payload.get("schema")
+    if schema not in {SUMMARY_SCHEMA, VALIDATION_SCHEMA}:
+        return
+    if bindings is None:
+        raise RuntimeError("v2 derivation did not capture a source/runtime context")
+    source_provenance, runtime_environment = bindings
+    if payload.get("source_provenance") != source_provenance:
+        raise RuntimeError(
+            "v2 derivation source does not match the source recorded by its shards"
+        )
+    if payload.get("environment") != runtime_environment:
+        raise RuntimeError(
+            "v2 derivation runtime does not match the runtime recorded by its shards"
+        )
+    if _screening_source_provenance() != source_provenance:
+        raise RuntimeError("screening source provenance changed during derivation")
+    if _screening_runtime_environment() != runtime_environment:
+        raise RuntimeError("screening runtime environment changed during derivation")
+    _require_embedded_artifact_manifest_unchanged(
+        payload.get("shard_manifest"), context="v2 shard inputs"
+    )
+    if schema == VALIDATION_SCHEMA:
+        _require_embedded_artifact_manifest_unchanged(
+            payload.get("reference_partial_manifest"),
+            context="v2 proxy reference partials",
+        )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -8660,6 +8930,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     output_path = _preflight_new_output(
         args.out if args.command == "run" else args.output
     )
+    derivation_bindings = (
+        _screening_derivation_bindings(args.shards)
+        if args.command in {"merge", "validate-proxy"}
+        else None
+    )
 
     if args.command == "run":
         assert run_seed is not None
@@ -8713,10 +8988,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         summary = merge_shards(
             args.shards, control_name=args.control_name, slope_window=args.slope_window
         )
+        _require_v2_derivation_context(summary, derivation_bindings)
         _atomic_write_json(output_path, summary)
         logger.info("merged %d shards -> %s", summary["n_shards"], args.output)
     elif args.command == "validate-proxy":
         report = validate_proxy(args.shards, args.partials_dir, atol=args.atol)
+        _require_v2_derivation_context(report, derivation_bindings)
         _atomic_write_json(output_path, report)
         logger.info(
             "proxy_validated=%s (prefix_match=%s ordering=%s) -> %s",

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -127,10 +127,13 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.metadata
 import json
 import logging
 import math
+import os
 import platform
+import subprocess
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -183,9 +186,36 @@ from alberta_framework.evaluation.recurring_ipmnist_retention import (
 
 logger = logging.getLogger(__name__)
 
-SHARD_SCHEMA = "alberta.ipmnist_screening.shard.v1"
-SUMMARY_SCHEMA = "alberta.ipmnist_screening.summary.v1"
-VALIDATION_SCHEMA = "alberta.ipmnist_screening.proxy_validation.v1"
+LEGACY_SHARD_SCHEMA = "alberta.ipmnist_screening.shard.v1"
+SHARD_SCHEMA = "alberta.ipmnist_screening.shard.v2"
+LEGACY_SUMMARY_SCHEMA = "alberta.ipmnist_screening.summary.v1"
+SUMMARY_SCHEMA = "alberta.ipmnist_screening.summary.v2"
+LEGACY_VALIDATION_SCHEMA = "alberta.ipmnist_screening.proxy_validation.v1"
+VALIDATION_SCHEMA = "alberta.ipmnist_screening.proxy_validation.v2"
+SOURCE_PROVENANCE_SCHEMA = "alberta.ipmnist_screening.source_provenance.v1"
+DATASET_PROVENANCE_SCHEMA = "alberta.ipmnist_screening.dataset_provenance.v1"
+RUNTIME_SCHEMA = "alberta.ipmnist_screening.runtime.v1"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SOURCE_SCOPE = ("alberta_framework", "pyproject.toml", "uv.lock")
+_SOURCE_SCOPE_LABEL = "tracked:alberta_framework/**,pyproject.toml,uv.lock"
+_RUNTIME_ENVIRONMENT_KEYS = (
+    "CUDA_VISIBLE_DEVICES",
+    "JAX_DEFAULT_MATMUL_PRECISION",
+    "JAX_ENABLE_X64",
+    "JAX_PLATFORM_NAME",
+    "JAX_PLATFORMS",
+    "OMP_NUM_THREADS",
+    "XLA_FLAGS",
+)
+_DATASET_SOURCE = {
+    "provider": "openml",
+    "name": "mnist_784",
+    "version": 1,
+    "row_start": 0,
+    "row_stop_exclusive": 60_000,
+}
+_DATASET_MATERIALIZATION = "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1"
 
 #: Default reduced-horizon proxy: 60 tasks x 5,000 steps. At this horizon the
 #: completed 10-seed full runs separate UPGD-W from AdamW by ~+0.022 average
@@ -6566,10 +6596,394 @@ def _array_bundle_sha256(domain: str, arrays: Mapping[str, object]) -> str:
         digest.update(encoded_name)
         digest.update(len(header).to_bytes(8, "little"))
         digest.update(header)
-        payload = array.tobytes(order="C")
-        digest.update(len(payload).to_bytes(8, "little"))
-        digest.update(payload)
+        digest.update(array.nbytes.to_bytes(8, "little"))
+        digest.update(memoryview(array).cast("B"))
     return digest.hexdigest()
+
+
+def _is_lower_hex(value: object, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _git_capture(repo_root: Path, *args: str) -> bytes:
+    try:
+        completed = subprocess.run(
+            ("git", "-C", str(repo_root), *args),
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            "screening source provenance requires an available Git repository"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(
+            "screening source provenance requires an available Git repository" + suffix
+        )
+    return completed.stdout
+
+
+def _source_scope_status(repo_root: Path) -> bytes:
+    return _git_capture(
+        repo_root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--",
+        *_SOURCE_SCOPE,
+    )
+
+
+def _tracked_worktree_status(repo_root: Path) -> bytes:
+    return _git_capture(
+        repo_root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=no",
+    )
+
+
+def _untracked_python_sources(repo_root: Path) -> bytes:
+    return _git_capture(
+        repo_root,
+        "ls-files",
+        "-z",
+        "--others",
+        "--exclude-standard",
+        "--",
+        "*.py",
+    )
+
+
+def _ignored_python_sources(repo_root: Path) -> bytes:
+    raw = _git_capture(
+        repo_root,
+        "ls-files",
+        "-z",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--",
+        "*.py",
+        "*.pyc",
+    )
+    unsafe: list[bytes] = []
+    for entry in raw.split(b"\0"):
+        parts = entry.split(b"/")
+        if not entry or parts[0] in {b".venv", b"outputs"} or b"__pycache__" in parts:
+            continue
+        unsafe.append(entry)
+    return b"\0".join(unsafe)
+
+
+def _tracked_index_flags(repo_root: Path) -> bytes:
+    return _git_capture(repo_root, "ls-files", "-v", "-z")
+
+
+def _head_source_blobs(raw_tree: bytes) -> dict[Path, str]:
+    blobs: dict[Path, str] = {}
+    try:
+        for raw_entry in raw_tree.split(b"\0"):
+            if not raw_entry:
+                continue
+            metadata, raw_path = raw_entry.split(b"\t", 1)
+            _mode, object_type, object_id = metadata.split(b" ", 2)
+            if object_type != b"blob":
+                raise ValueError("non-blob source object")
+            path = Path(os.fsdecode(raw_path))
+            object_id_text = object_id.decode("ascii")
+            if not _is_lower_hex(object_id_text, 40):
+                raise ValueError("noncanonical source blob ID")
+            blobs[path] = object_id_text
+    except (UnicodeError, ValueError) as exc:
+        raise RuntimeError("screening source provenance could not parse the HEAD tree") from exc
+    return blobs
+
+
+def _screening_source_provenance(repo_root: Path | None = None) -> dict[str, object]:
+    """Bind a clean checkout and the actual package/lock bytes used by a run.
+
+    The cleanliness scope intentionally excludes ``outputs/`` so sequential workers can
+    append immutable shards. Any tracked change in the package/lock scope, including a
+    staged change, is rejected. Untracked or ignored package files are found independently
+    of Git status so an importable local module cannot evade the receipt.
+    """
+    requested_root = _REPO_ROOT if repo_root is None else Path(repo_root)
+    try:
+        root = requested_root.resolve(strict=True)
+    except OSError as exc:
+        raise RuntimeError(
+            "screening source provenance requires an available Git repository"
+        ) from exc
+    top_level_raw = _git_capture(root, "rev-parse", "--show-toplevel")
+    try:
+        top_level = Path(top_level_raw.decode("utf-8").strip()).resolve(strict=True)
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(
+            "screening source provenance could not resolve the Git repository"
+        ) from exc
+    if top_level != root:
+        raise RuntimeError(
+            f"screening source provenance root {root} is not the Git top level {top_level}"
+        )
+
+    if _tracked_worktree_status(root):
+        raise RuntimeError("screening source worktree is not clean: tracked files changed")
+    if (
+        _source_scope_status(root)
+        or _untracked_python_sources(root)
+        or _ignored_python_sources(root)
+    ):
+        raise RuntimeError(
+            "screening source worktree is not clean: untracked Python/package source "
+            "or source-scope file"
+        )
+
+    index_flags = _tracked_index_flags(root)
+    if any(
+        not entry.startswith(b"H ")
+        for entry in index_flags.split(b"\0")
+        if entry
+    ):
+        raise RuntimeError(
+            "screening source worktree is not clean: tracked index flags can hide changes"
+        )
+
+    commit = _git_capture(root, "rev-parse", "--verify", "HEAD").decode("ascii").strip()
+    tree = _git_capture(root, "rev-parse", "--verify", "HEAD^{tree}").decode("ascii").strip()
+    object_format = _git_capture(root, "rev-parse", "--show-object-format").decode(
+        "ascii"
+    ).strip()
+    if object_format != "sha1" or not _is_lower_hex(commit, 40) or not _is_lower_hex(tree, 40):
+        raise RuntimeError("screening source provenance requires canonical SHA-1 Git identities")
+
+    tracked_raw = _git_capture(root, "ls-files", "-z", "--", *_SOURCE_SCOPE)
+    head_tree_raw = _git_capture(root, "ls-tree", "-r", "-z", "HEAD", "--", *_SOURCE_SCOPE)
+    try:
+        tracked = tuple(
+            sorted(
+                Path(os.fsdecode(raw))
+                for raw in tracked_raw.split(b"\0")
+                if raw
+            )
+        )
+    except UnicodeError as exc:
+        raise RuntimeError("screening source provenance requires UTF-8 source paths") from exc
+    head_blobs = _head_source_blobs(head_tree_raw)
+    if set(tracked) != set(head_blobs):
+        raise RuntimeError("screening source inventory does not exactly match HEAD")
+    required = {
+        Path("pyproject.toml"),
+        Path("uv.lock"),
+        Path("alberta_framework/benchmarks/ipmnist_screening.py"),
+    }
+    if not required.issubset(tracked):
+        missing = sorted(path.as_posix() for path in required.difference(tracked))
+        raise RuntimeError(
+            f"screening source provenance is missing tracked source files: {missing}"
+        )
+
+    tracked_set = set(tracked)
+    package_root = root / "alberta_framework"
+    for candidate in package_root.rglob("*"):
+        relative = candidate.relative_to(root)
+        if "__pycache__" in relative.parts:
+            continue
+        if (candidate.is_file() or candidate.is_symlink()) and relative not in tracked_set:
+            raise RuntimeError(
+                "screening source worktree is not clean: untracked package source "
+                f"{relative.as_posix()}"
+            )
+
+    digest = hashlib.sha256()
+    digest.update(b"alberta.ipmnist_screening.relevant_source.v1\0")
+    uv_lock_sha256: str | None = None
+    for relative in tracked:
+        if relative.is_absolute() or ".." in relative.parts:
+            raise RuntimeError(f"invalid tracked source path {relative}")
+        source_path = root / relative
+        if source_path.is_symlink() or not source_path.is_file():
+            raise RuntimeError(f"tracked source is unavailable or not a regular file: {relative}")
+        try:
+            contents = source_path.read_bytes()
+            encoded_path = relative.as_posix().encode("utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeError(f"could not read tracked source bytes: {relative}") from exc
+        git_blob_digest = hashlib.sha1(
+            b"blob " + str(len(contents)).encode("ascii") + b"\0" + contents,
+            usedforsecurity=False,
+        ).hexdigest()
+        if git_blob_digest != head_blobs[relative]:
+            raise RuntimeError(
+                f"screening source worktree is not clean: {relative} differs from HEAD"
+            )
+        digest.update(len(encoded_path).to_bytes(4, "little"))
+        digest.update(encoded_path)
+        digest.update(len(contents).to_bytes(8, "little"))
+        digest.update(contents)
+        if relative == Path("uv.lock"):
+            uv_lock_sha256 = hashlib.sha256(contents).hexdigest()
+
+    if uv_lock_sha256 is None:
+        raise RuntimeError("screening source provenance could not bind uv.lock")
+    final_identity = (
+        _git_capture(root, "rev-parse", "--verify", "HEAD").decode("ascii").strip(),
+        _git_capture(root, "rev-parse", "--verify", "HEAD^{tree}").decode("ascii").strip(),
+        _git_capture(root, "rev-parse", "--show-object-format").decode("ascii").strip(),
+    )
+    final_inventory = _git_capture(root, "ls-files", "-z", "--", *_SOURCE_SCOPE)
+    final_head_tree = _git_capture(
+        root, "ls-tree", "-r", "-z", "HEAD", "--", *_SOURCE_SCOPE
+    )
+    if final_identity != (commit, tree, object_format):
+        raise RuntimeError("screening source identity changed while provenance was captured")
+    if final_inventory != tracked_raw or final_head_tree != head_tree_raw:
+        raise RuntimeError("screening source inventory changed while provenance was captured")
+    if (
+        _tracked_worktree_status(root)
+        or _source_scope_status(root)
+        or _untracked_python_sources(root)
+        or _ignored_python_sources(root)
+        or _tracked_index_flags(root) != index_flags
+    ):
+        raise RuntimeError("screening source files changed while provenance was captured")
+    return {
+        "schema": SOURCE_PROVENANCE_SCHEMA,
+        "git_commit": commit,
+        "git_tree": tree,
+        "git_object_format": object_format,
+        "relevant_source_scope": _SOURCE_SCOPE_LABEL,
+        "relevant_source_file_count": len(tracked),
+        "relevant_source_sha256": digest.hexdigest(),
+        "uv_lock_sha256": uv_lock_sha256,
+        "worktree_clean": True,
+    }
+
+
+def _screening_runtime_environment() -> dict[str, object]:
+    """Return the runtime contract that must stay fixed through a screening run."""
+    try:
+        package_versions = {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
+        }
+        backend = jax.default_backend()
+        devices = [
+            {
+                "id": int(device.id),
+                "platform": str(device.platform),
+                "device_kind": str(device.device_kind),
+                "process_index": int(device.process_index),
+            }
+            for device in jax.devices()
+        ]
+    except Exception as exc:
+        raise RuntimeError("screening runtime provenance is unavailable") from exc
+    if not devices:
+        raise RuntimeError("screening runtime provenance found no JAX devices")
+    return {
+        "schema": RUNTIME_SCHEMA,
+        "python": {
+            "implementation": platform.python_implementation(),
+            "version": platform.python_version(),
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "packages": package_versions,
+        "jax": {
+            "backend": backend,
+            "devices": devices,
+            "config": {
+                "jax_enable_x64": bool(jax.config.jax_enable_x64),
+                "jax_default_matmul_precision": (
+                    None
+                    if jax.config.jax_default_matmul_precision is None
+                    else str(jax.config.jax_default_matmul_precision)
+                ),
+                "jax_disable_jit": bool(jax.config.jax_disable_jit),
+                "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion),
+                "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+                "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+                "jax_threefry_partitionable": bool(
+                    jax.config.jax_threefry_partitionable
+                ),
+                "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+            },
+        },
+        "process_environment": {
+            name: os.environ.get(name) for name in _RUNTIME_ENVIRONMENT_KEYS
+        },
+    }
+
+
+def _materialized_dataset_provenance(
+    data_x: object, data_y: object
+) -> dict[str, object]:
+    """Hash the exact effective float32 features and int32 labels consumed by JAX."""
+    raw_x = np.asarray(jax.device_get(data_x))
+    raw_y = np.asarray(jax.device_get(data_y))
+    if raw_x.dtype.kind not in {"f", "i", "u"} or raw_x.ndim != 2 or raw_x.size == 0:
+        raise ValueError("dataset features must be a non-empty rank-two numeric array")
+    if raw_y.dtype.kind not in {"i", "u"} or raw_y.ndim != 1:
+        raise ValueError("dataset labels must be a rank-one integer array")
+    if raw_x.shape[0] != raw_y.shape[0] or raw_y.size == 0:
+        raise ValueError("dataset feature and label rows must be non-empty and aligned")
+    int32_info = np.iinfo(np.int32)
+    if np.any(raw_y < int32_info.min) or np.any(raw_y > int32_info.max):
+        raise ValueError("dataset labels must be representable as int32")
+    effective_x = _canonical_hash_array(np.asarray(raw_x, dtype=np.float32))
+    effective_y = _canonical_hash_array(np.asarray(raw_y, dtype=np.int32))
+    if not np.all(np.isfinite(effective_x)):
+        raise ValueError("dataset features must remain finite after float32 materialization")
+    return {
+        "schema": DATASET_PROVENANCE_SCHEMA,
+        "source": dict(_DATASET_SOURCE),
+        "materialization": _DATASET_MATERIALIZATION,
+        "x": {
+            "dtype": effective_x.dtype.str,
+            "shape": list(effective_x.shape),
+            "sha256": _array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_x.v1", {"x": effective_x}
+            ),
+        },
+        "y": {
+            "dtype": effective_y.dtype.str,
+            "shape": list(effective_y.shape),
+            "sha256": _array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_y.v1", {"y": effective_y}
+            ),
+        },
+    }
+
+
+def _screening_dataset_provenance(
+    data_x: object, data_y: object
+) -> dict[str, object]:
+    """Bind and validate the frozen OpenML MNIST training materialization."""
+    provenance = _materialized_dataset_provenance(data_x, data_y)
+    x = np.asarray(jax.device_get(data_x), dtype=np.float32)
+    y = np.asarray(jax.device_get(data_y), dtype=np.int32)
+    if x.shape != (60_000, 784) or y.shape != (60_000,):
+        raise ValueError(
+            "screening dataset must materialize OpenML mnist_784 v1 rows 0:60000 "
+            "as x=(60000, 784) and y=(60000,)"
+        )
+    if np.any(x < -1.0) or np.any(x > 1.0):
+        raise ValueError("screening dataset features must use the frozen [-1, 1] scaling")
+    if np.any(y < 0) or np.any(y > 9):
+        raise ValueError("screening dataset labels must be in [0, 9]")
+    return provenance
 
 
 def _validated_permutation(permutation: object, *, input_dim: int) -> np.ndarray:
@@ -7261,45 +7675,421 @@ def run_screening_config(
 # =============================================================================
 
 
-def shard_payload(result: ScreeningRunResult) -> dict[str, Any]:
-    """Serialize one (config, seed) screening run to a mergeable shard."""
+_V2_SHARD_FIELDS = frozenset(
+    {
+        "schema",
+        "evidence_policy",
+        "config_name",
+        "base_learner",
+        "hyperparameters",
+        "seed",
+        "noise_mode",
+        "noise_pool_steps",
+        "config",
+        "per_task_accuracy",
+        "per_task_loss",
+        "per_task_plasticity",
+        "wall_clock_seconds",
+        "created_unix",
+        "source_provenance",
+        "dataset_provenance",
+        "environment",
+    }
+)
+
+
+def _require_exact_keys(
+    value: object, expected: frozenset[str] | set[str], *, context: str
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{context} must be an object")
+    actual = set(value)
+    missing = sorted(expected.difference(actual))
+    unexpected = sorted(actual.difference(expected))
+    if missing or unexpected:
+        parts: list[str] = []
+        if missing:
+            parts.append(f"missing field(s) {missing}")
+        if unexpected:
+            parts.append(f"unexpected field(s) {unexpected}")
+        raise ValueError(f"{context}: {'; '.join(parts)}")
+    return cast(Mapping[str, Any], value)
+
+
+def _required_nonempty_string(value: object, *, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context} must be a non-empty string")
+    return value
+
+
+def _is_finite_json_number(value: object) -> bool:
+    if type(value) not in (int, float):
+        return False
+    try:
+        return math.isfinite(float(cast(int | float, value)))
+    except (OverflowError, ValueError):
+        return False
+
+
+def _validated_source_provenance(value: object, *, context: str) -> dict[str, Any]:
+    provenance = _require_exact_keys(
+        value,
+        {
+            "schema",
+            "git_commit",
+            "git_tree",
+            "git_object_format",
+            "relevant_source_scope",
+            "relevant_source_file_count",
+            "relevant_source_sha256",
+            "uv_lock_sha256",
+            "worktree_clean",
+        },
+        context=f"{context} source provenance",
+    )
+    if provenance["schema"] != SOURCE_PROVENANCE_SCHEMA:
+        raise ValueError(f"{context} source provenance has an unsupported schema")
+    if provenance["git_object_format"] != "sha1":
+        raise ValueError(f"{context} source provenance git_object_format must be 'sha1'")
+    if not _is_lower_hex(provenance["git_commit"], 40) or not _is_lower_hex(
+        provenance["git_tree"], 40
+    ):
+        raise ValueError(f"{context} source provenance must record lowercase Git SHA-1 IDs")
+    if provenance["relevant_source_scope"] != _SOURCE_SCOPE_LABEL:
+        raise ValueError(f"{context} source provenance has an unsupported source scope")
+    file_count = provenance["relevant_source_file_count"]
+    if type(file_count) is not int or file_count <= 0:
+        raise ValueError(f"{context} source provenance file count must be positive")
+    if not _is_lower_hex(provenance["relevant_source_sha256"], 64) or not _is_lower_hex(
+        provenance["uv_lock_sha256"], 64
+    ):
+        raise ValueError(f"{context} source provenance must record lowercase SHA-256 digests")
+    if provenance["worktree_clean"] is not True:
+        raise ValueError(f"{context} source provenance must record a clean source worktree")
+    return dict(provenance)
+
+
+def _validated_dataset_provenance(value: object, *, context: str) -> dict[str, Any]:
+    provenance = _require_exact_keys(
+        value,
+        {"schema", "source", "materialization", "x", "y"},
+        context=f"{context} dataset provenance",
+    )
+    if provenance["schema"] != DATASET_PROVENANCE_SCHEMA:
+        raise ValueError(f"{context} dataset provenance has an unsupported schema")
+    source = _require_exact_keys(
+        provenance["source"],
+        {"provider", "name", "version", "row_start", "row_stop_exclusive"},
+        context=f"{context} dataset provenance source",
+    )
+    if (
+        not isinstance(source["provider"], str)
+        or not isinstance(source["name"], str)
+        or type(source["version"]) is not int
+        or type(source["row_start"]) is not int
+        or type(source["row_stop_exclusive"]) is not int
+        or dict(source) != _DATASET_SOURCE
+    ):
+        raise ValueError(f"{context} dataset provenance has an unsupported source selection")
+    if provenance["materialization"] != _DATASET_MATERIALIZATION:
+        raise ValueError(f"{context} dataset provenance has an unsupported materialization")
+
+    arrays: dict[str, Mapping[str, Any]] = {}
+    expected_ranks = {"x": 2, "y": 1}
+    expected_dtypes = {"x": "<f4", "y": "<i4"}
+    for name in ("x", "y"):
+        binding = _require_exact_keys(
+            provenance[name],
+            {"dtype", "shape", "sha256"},
+            context=f"{context} dataset provenance {name}",
+        )
+        shape = binding["shape"]
+        if (
+            not isinstance(shape, list)
+            or len(shape) != expected_ranks[name]
+            or any(type(dimension) is not int or dimension <= 0 for dimension in shape)
+        ):
+            raise ValueError(
+                f"{context} dataset provenance {name} shape must be a positive "
+                f"rank-{expected_ranks[name]} integer list"
+            )
+        if binding["dtype"] != expected_dtypes[name]:
+            raise ValueError(
+                f"{context} dataset provenance {name} dtype must be {expected_dtypes[name]!r}"
+            )
+        if not _is_lower_hex(binding["sha256"], 64):
+            raise ValueError(
+                f"{context} dataset provenance {name} must record a lowercase SHA-256"
+            )
+        arrays[name] = binding
+    if arrays["x"]["shape"][0] != arrays["y"]["shape"][0]:
+        raise ValueError(f"{context} dataset provenance x/y row counts must match")
+    if arrays["x"]["shape"] != [60_000, 784] or arrays["y"]["shape"] != [60_000]:
+        raise ValueError(
+            f"{context} dataset provenance must bind canonical x=[60000, 784] and "
+            "y=[60000] materializations"
+        )
+    return dict(provenance)
+
+
+def _validate_dataset_config_binding(
+    provenance: Mapping[str, Any], config: IPMNISTConfig, *, context: str
+) -> None:
+    x_binding = cast(Mapping[str, Any], provenance["x"])
+    x_shape = cast(list[int], x_binding["shape"])
+    if config.input_dim != x_shape[1]:
+        raise ValueError(
+            f"{context}: protocol input_dim={config.input_dim} does not match the "
+            f"dataset width {x_shape[1]}"
+        )
+    if config.n_classes != 10:
+        raise ValueError(f"{context}: canonical MNIST protocol n_classes must be 10")
+
+
+def _validated_runtime_environment(value: object, *, context: str) -> dict[str, Any]:
+    environment = _require_exact_keys(
+        value,
+        {"schema", "python", "platform", "packages", "jax", "process_environment"},
+        context=f"{context} runtime environment",
+    )
+    if environment["schema"] != RUNTIME_SCHEMA:
+        raise ValueError(f"{context} runtime environment has an unsupported schema")
+    python = _require_exact_keys(
+        environment["python"],
+        {"implementation", "version"},
+        context=f"{context} runtime environment python",
+    )
+    platform_binding = _require_exact_keys(
+        environment["platform"],
+        {"system", "release", "machine"},
+        context=f"{context} runtime environment platform",
+    )
+    packages = _require_exact_keys(
+        environment["packages"],
+        {"chex", "jax", "jaxlib", "numpy", "scikit-learn"},
+        context=f"{context} runtime environment packages",
+    )
+    jax_binding = _require_exact_keys(
+        environment["jax"],
+        {"backend", "devices", "config"},
+        context=f"{context} runtime environment jax",
+    )
+    jax_config = _require_exact_keys(
+        jax_binding["config"],
+        {
+            "jax_enable_x64",
+            "jax_default_matmul_precision",
+            "jax_disable_jit",
+            "jax_numpy_dtype_promotion",
+            "jax_numpy_rank_promotion",
+            "jax_random_seed_offset",
+            "jax_threefry_partitionable",
+            "jax_default_prng_impl",
+        },
+        context=f"{context} runtime environment jax.config",
+    )
+    process_environment = _require_exact_keys(
+        environment["process_environment"],
+        set(_RUNTIME_ENVIRONMENT_KEYS),
+        context=f"{context} runtime environment process_environment",
+    )
+    for field, item in python.items():
+        _required_nonempty_string(item, context=f"{context} runtime environment python.{field}")
+    for field, item in platform_binding.items():
+        _required_nonempty_string(
+            item, context=f"{context} runtime environment platform.{field}"
+        )
+    for field, item in packages.items():
+        _required_nonempty_string(
+            item, context=f"{context} runtime environment packages.{field}"
+        )
+    _required_nonempty_string(
+        jax_binding["backend"], context=f"{context} runtime environment jax.backend"
+    )
+    devices = jax_binding["devices"]
+    if not isinstance(devices, list) or not devices:
+        raise ValueError(f"{context} runtime environment JAX devices must be non-empty")
+    for index, device in enumerate(devices):
+        binding = _require_exact_keys(
+            device,
+            {"id", "platform", "device_kind", "process_index"},
+            context=f"{context} runtime environment JAX device {index}",
+        )
+        if type(binding["id"]) is not int or type(binding["process_index"]) is not int:
+            raise ValueError(
+                f"{context} runtime environment JAX device IDs must be integers"
+            )
+        _required_nonempty_string(
+            binding["platform"],
+            context=f"{context} runtime environment JAX device {index}.platform",
+        )
+        _required_nonempty_string(
+            binding["device_kind"],
+            context=f"{context} runtime environment JAX device {index}.device_kind",
+        )
+    for field in (
+        "jax_enable_x64",
+        "jax_disable_jit",
+        "jax_threefry_partitionable",
+    ):
+        if type(jax_config[field]) is not bool:
+            raise ValueError(f"{context} runtime environment {field} must be boolean")
+    precision = jax_config["jax_default_matmul_precision"]
+    if precision is not None and (not isinstance(precision, str) or not precision):
+        raise ValueError(
+            f"{context} runtime environment jax_default_matmul_precision must be a "
+            "string or null"
+        )
+    for field in (
+        "jax_numpy_dtype_promotion",
+        "jax_numpy_rank_promotion",
+        "jax_default_prng_impl",
+    ):
+        _required_nonempty_string(
+            jax_config[field], context=f"{context} runtime environment {field}"
+        )
+    if type(jax_config["jax_random_seed_offset"]) is not int:
+        raise ValueError(
+            f"{context} runtime environment jax_random_seed_offset must be an integer"
+        )
+    if any(
+        value is not None and not isinstance(value, str)
+        for value in process_environment.values()
+    ):
+        raise ValueError(
+            f"{context} runtime environment process values must be strings or null"
+        )
+    return dict(environment)
+
+
+def shard_payload(
+    result: ScreeningRunResult,
+    *,
+    source_provenance: Mapping[str, object],
+    dataset_provenance: Mapping[str, object],
+    environment: Mapping[str, object],
+) -> dict[str, Any]:
+    """Serialize one bound (config, seed) screening run as a strict v2 shard."""
     seed = require_jax_seed(result.seed, name="result seed")
     spec = screening_spec(result.config_name)
+    if result.base_learner != spec.base_learner:
+        raise ValueError(
+            f"new shard base_learner must match registered arm {spec.base_learner!r}"
+        )
+    if result.hyperparameters != spec.hyperparameters:
+        raise ValueError("new shard hyperparameters must exactly match the registered arm")
     noise_mode = _validated_screening_noise_mode(result.noise_mode, spec)
     noise_pool_steps = _validated_screening_noise_pool_steps(
         noise_mode, result.noise_pool_steps
     )
-    return {
+    source_binding = _validated_source_provenance(source_provenance, context="new shard")
+    dataset_binding = _validated_dataset_provenance(dataset_provenance, context="new shard")
+    runtime_binding = _validated_runtime_environment(environment, context="new shard")
+    _validate_dataset_config_binding(dataset_binding, result.config, context="new shard")
+    if not isinstance(result.base_learner, str) or not result.base_learner:
+        raise ValueError("new shard base_learner must be a non-empty string")
+    if not isinstance(result.hyperparameters, dict) or any(
+        not isinstance(name, str) for name in result.hyperparameters
+    ):
+        raise ValueError("new shard hyperparameters must be an object with string keys")
+    curves: dict[str, np.ndarray] = {}
+    for field in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
+        try:
+            raw_values = np.asarray(jax.device_get(getattr(result, field)))
+            if raw_values.dtype.kind not in {"i", "u", "f"}:
+                raise TypeError("non-numeric curve")
+            values = np.asarray(raw_values, dtype=np.float64)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"new shard {field} must be finite with shape ({result.config.n_tasks},)"
+            ) from exc
+        if values.shape != (result.config.n_tasks,) or not np.all(np.isfinite(values)):
+            raise ValueError(
+                f"new shard {field} must be finite with shape ({result.config.n_tasks},)"
+            )
+        curves[field] = values
+    wall_clock_seconds = _validated_wall_clock_seconds(
+        result.wall_clock_seconds, "new shard"
+    )
+    payload: dict[str, Any] = {
         "schema": SHARD_SCHEMA,
         "evidence_policy": dict(NONPROMOTING_POLICY),
         "config_name": result.config_name,
         "base_learner": result.base_learner,
-        "hyperparameters": result.hyperparameters,
+        "hyperparameters": dict(result.hyperparameters),
         "seed": seed,
         "noise_mode": noise_mode,
         "noise_pool_steps": noise_pool_steps,
         "config": result.config.to_config(),
-        "per_task_accuracy": [round(float(v), 8) for v in result.per_task_accuracy],
-        "per_task_loss": [round(float(v), 8) for v in result.per_task_loss],
-        "per_task_plasticity": [round(float(v), 8) for v in result.per_task_plasticity],
-        "wall_clock_seconds": round(result.wall_clock_seconds, 2),
+        "per_task_accuracy": [round(float(v), 8) for v in curves["per_task_accuracy"]],
+        "per_task_loss": [round(float(v), 8) for v in curves["per_task_loss"]],
+        "per_task_plasticity": [
+            round(float(v), 8) for v in curves["per_task_plasticity"]
+        ],
+        "wall_clock_seconds": round(wall_clock_seconds, 2),
         "created_unix": time.time(),
-        "environment": {
-            "jax": jax.__version__,
-            "numpy": np.__version__,
-            "python": platform.python_version(),
-            "platform": platform.platform(),
-        },
+        "source_provenance": source_binding,
+        "dataset_provenance": dataset_binding,
+        "environment": runtime_binding,
     }
+    try:
+        json.dumps(payload, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("new shard payload must be strict JSON") from exc
+    return payload
 
 
 def load_shard(path: Path) -> dict[str, Any]:
-    """Load and structurally validate one screening shard."""
+    """Load legacy v1 or strictly validate a source-bound v2 screening shard."""
     payload = load_strict_json_object(path)
-    if payload.get("schema") != SHARD_SCHEMA:
-        raise ValueError(f"{path}: not an {SHARD_SCHEMA} shard")
+    schema = payload.get("schema")
+    if schema not in {LEGACY_SHARD_SCHEMA, SHARD_SCHEMA}:
+        raise ValueError(
+            f"{path}: not a supported {LEGACY_SHARD_SCHEMA} or {SHARD_SCHEMA} shard"
+        )
+    is_v2 = schema == SHARD_SCHEMA
+    if is_v2:
+        _require_exact_keys(payload, _V2_SHARD_FIELDS, context=str(path))
+        if payload["evidence_policy"] != NONPROMOTING_POLICY:
+            raise ValueError(f"{path}: evidence_policy must be the frozen nonpromoting policy")
+        created_unix = payload["created_unix"]
+        if type(created_unix) not in (int, float):
+            raise ValueError(f"{path}: created_unix must be a finite, non-negative number")
+        try:
+            created_value = float(created_unix)
+        except (OverflowError, ValueError) as exc:
+            raise ValueError(
+                f"{path}: created_unix must be a finite, non-negative number"
+            ) from exc
+        if not math.isfinite(created_value) or created_value < 0.0:
+            raise ValueError(f"{path}: created_unix must be a finite, non-negative number")
+        payload["created_unix"] = created_value
+        payload["source_provenance"] = _validated_source_provenance(
+            payload["source_provenance"], context=str(path)
+        )
+        payload["dataset_provenance"] = _validated_dataset_provenance(
+            payload["dataset_provenance"], context=str(path)
+        )
+        payload["environment"] = _validated_runtime_environment(
+            payload["environment"], context=str(path)
+        )
     config = IPMNISTConfig(**payload["config"])
+    if is_v2:
+        _validate_dataset_config_binding(
+            payload["dataset_provenance"], config, context=str(path)
+        )
     for fieldname in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
+        if is_v2:
+            raw_values = payload[fieldname]
+            if (
+                not isinstance(raw_values, list)
+                or len(raw_values) != config.n_tasks
+                or any(not _is_finite_json_number(value) for value in raw_values)
+            ):
+                raise ValueError(
+                    f"{path}: {fieldname} must be a list of finite JSON numbers "
+                    f"with length {config.n_tasks}"
+                )
         values = np.asarray(payload[fieldname], dtype=np.float64)
         if values.shape != (config.n_tasks,) or not np.all(np.isfinite(values)):
             raise ValueError(f"{path}: {fieldname} must be finite with shape ({config.n_tasks},)")
@@ -7310,6 +8100,12 @@ def load_shard(path: Path) -> dict[str, Any]:
     if payload.get("config_name") not in SCREENING_REGISTRY:
         raise ValueError(f"{path}: unknown config_name {payload.get('config_name')!r}")
     spec = SCREENING_REGISTRY[payload["config_name"]]
+    if is_v2 and payload.get("base_learner") != spec.base_learner:
+        raise ValueError(
+            f"{path}: base_learner must match registered arm {spec.base_learner!r}"
+        )
+    if is_v2 and payload.get("hyperparameters") != spec.hyperparameters:
+        raise ValueError(f"{path}: hyperparameters must exactly match the registered arm")
     noise_mode = _validated_screening_noise_mode(
         payload.get("noise_mode", "step"), spec, context=path
     )
@@ -7317,7 +8113,7 @@ def load_shard(path: Path) -> dict[str, Any]:
         noise_mode,
         payload.get("noise_pool_steps", _MISSING_NOISE_POOL_STEPS),
         context=path,
-        allow_unrecorded_pool=True,
+        allow_unrecorded_pool=not is_v2,
     )
     payload["noise_mode"] = noise_mode
     payload["noise_pool_steps"] = noise_pool_steps
@@ -7325,21 +8121,23 @@ def load_shard(path: Path) -> dict[str, Any]:
         raise ValueError(f"{path}: base_learner must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):
         raise ValueError(f"{path}: hyperparameters must be an object")
-    environment = payload.get("environment")
-    required_environment_fields = ("jax", "numpy", "python", "platform")
-    if not isinstance(environment, dict) or any(
-        not isinstance(environment.get(field), str) or not environment[field]
-        for field in required_environment_fields
-    ):
-        raise ValueError(
-            f"{path}: environment must record non-empty jax, numpy, python, and platform strings"
-        )
+    if not is_v2:
+        environment = payload.get("environment")
+        required_environment_fields = ("jax", "numpy", "python", "platform")
+        if not isinstance(environment, dict) or any(
+            not isinstance(environment.get(field), str) or not environment[field]
+            for field in required_environment_fields
+        ):
+            raise ValueError(
+                f"{path}: environment must record non-empty jax, numpy, python, "
+                "and platform strings"
+            )
     return payload
 
 
 def _screening_batch_environment(
     shards: Sequence[dict[str, Any]],
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Return the exact runtime contract shared by one derived artifact."""
     if not shards:
         raise ValueError("no shards given")
@@ -7355,6 +8153,26 @@ def _screening_batch_environment(
             f"separately (mismatched: {environment_mismatches})"
         )
     return dict(reference_environment)
+
+
+def _screening_batch_binding(
+    shards: Sequence[dict[str, Any]], *, field: str, label: str
+) -> dict[str, Any]:
+    """Return an exact provenance binding shared by every v2 shard."""
+    if not shards:
+        raise ValueError("no shards given")
+    reference = shards[0][field]
+    mismatches = [
+        f"{shard['config_name']}/seed={shard['seed']}"
+        for shard in shards
+        if shard[field] != reference
+    ]
+    if mismatches:
+        raise ValueError(
+            f"shards span multiple {label} bindings; process matching runs separately "
+            f"(mismatched: {mismatches})"
+        )
+    return dict(reference)
 
 
 def _validate_screening_arm_contract(
@@ -7408,6 +8226,22 @@ def merge_shards(
     shards = [load_shard(Path(p)) for p in paths]
     if not shards:
         raise ValueError("no shards given")
+    shard_schemas = {shard["schema"] for shard in shards}
+    if len(shard_schemas) != 1:
+        raise ValueError("shards span multiple shard schemas; merge v1 and v2 separately")
+    shard_schema = shard_schemas.pop()
+    source_provenance = (
+        _screening_batch_binding(
+            shards, field="source_provenance", label="source provenance"
+        )
+        if shard_schema == SHARD_SCHEMA
+        else None
+    )
+    dataset_provenance = (
+        _screening_batch_binding(shards, field="dataset_provenance", label="dataset")
+        if shard_schema == SHARD_SCHEMA
+        else None
+    )
     configs = {tuple(sorted(s["config"].items())) for s in shards}
     if len(configs) != 1:
         raise ValueError("shards span multiple protocol configs; merge them separately")
@@ -7540,8 +8374,8 @@ def merge_shards(
         entries.append(entry)
 
     entries.sort(key=lambda e: e["average_online_accuracy_mean"], reverse=True)
-    return {
-        "schema": SUMMARY_SCHEMA,
+    summary: dict[str, Any] = {
+        "schema": SUMMARY_SCHEMA if shard_schema == SHARD_SCHEMA else LEGACY_SUMMARY_SCHEMA,
         "evidence_policy": dict(NONPROMOTING_POLICY),
         "created_unix": time.time(),
         "protocol_config": dict(shards[0]["config"]),
@@ -7554,6 +8388,10 @@ def merge_shards(
         "n_shards": len(shards),
         "results": entries,
     }
+    if source_provenance is not None and dataset_provenance is not None:
+        summary["source_provenance"] = source_provenance
+        summary["dataset_provenance"] = dataset_provenance
+    return summary
 
 
 def validate_proxy(
@@ -7571,6 +8409,27 @@ def validate_proxy(
     """
     partials_dir = Path(partials_dir)
     shards = [load_shard(Path(path)) for path in shard_paths]
+    if not shards:
+        raise ValueError("no shards given")
+    shard_schemas = {shard["schema"] for shard in shards}
+    if len(shard_schemas) != 1:
+        raise ValueError(
+            "proxy-validation shards span multiple shard schemas; validate v1 and v2 "
+            "separately"
+        )
+    shard_schema = shard_schemas.pop()
+    source_provenance = (
+        _screening_batch_binding(
+            shards, field="source_provenance", label="source provenance"
+        )
+        if shard_schema == SHARD_SCHEMA
+        else None
+    )
+    dataset_provenance = (
+        _screening_batch_binding(shards, field="dataset_provenance", label="dataset")
+        if shard_schema == SHARD_SCHEMA
+        else None
+    )
     environment = _screening_batch_environment(shards)
     configs = {tuple(sorted(shard["config"].items())) for shard in shards}
     if len(configs) != 1:
@@ -7696,8 +8555,10 @@ def validate_proxy(
         if full_avg["upgd_w"] and full_avg["adamw"]
         else None
     )
-    return {
-        "schema": VALIDATION_SCHEMA,
+    report: dict[str, Any] = {
+        "schema": (
+            VALIDATION_SCHEMA if shard_schema == SHARD_SCHEMA else LEGACY_VALIDATION_SCHEMA
+        ),
         "created_unix": time.time(),
         "atol": atol,
         "environment": environment,
@@ -7718,6 +8579,10 @@ def validate_proxy(
             and ordering_full_prefix is True
         ),
     }
+    if source_provenance is not None and dataset_provenance is not None:
+        report["source_provenance"] = source_provenance
+        report["dataset_provenance"] = dataset_provenance
+    return report
 
 
 # =============================================================================
@@ -7733,7 +8598,9 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     keeps a duplicate launch from silently replacing another worker's shard.
     """
 
-    encoded = (json.dumps(payload, indent=1, sort_keys=True) + "\n").encode("utf-8")
+    encoded = (
+        json.dumps(payload, allow_nan=False, indent=1, sort_keys=True) + "\n"
+    ).encode("utf-8")
     atomic_write_new(Path(path), encoded)
 
 
@@ -7799,9 +8666,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         seed = run_seed
         spec = screening_spec(args.config_name)
         config = IPMNISTConfig(n_tasks=args.n_tasks, task_length=args.task_length)
+        source_provenance = _screening_source_provenance()
+        runtime_environment = _screening_runtime_environment()
         data_home = args.data_home if args.data_home is not None else default_openml_data_home()
         logger.info("loading MNIST from data_home=%s", data_home)
         data_x, data_y = load_mnist_train(data_home)
+        dataset_provenance = _screening_dataset_provenance(data_x, data_y)
         logger.info(
             "running %s seed=%d for %d tasks x %d steps "
             "(noise_mode=%s, noise_pool_steps=%s)",
@@ -7818,7 +8688,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             noise_mode=args.noise_mode,
             noise_pool_steps=args.noise_pool_steps,
         )
-        _atomic_write_json(output_path, shard_payload(result))
+        if _screening_source_provenance() != source_provenance:
+            raise RuntimeError("screening source provenance changed during execution")
+        if _screening_runtime_environment() != runtime_environment:
+            raise RuntimeError("screening runtime environment changed during execution")
+        if _screening_dataset_provenance(data_x, data_y) != dataset_provenance:
+            raise RuntimeError("screening dataset provenance changed during execution")
+        payload = shard_payload(
+            result,
+            source_provenance=source_provenance,
+            dataset_provenance=dataset_provenance,
+            environment=runtime_environment,
+        )
+        _atomic_write_json(output_path, payload)
         logger.info(
             "%s seed=%d done: avg online acc %.4f (wall %.1fs) -> %s",
             spec.name,

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -9,6 +9,7 @@ import json
 import math
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pathlib import Path
 
 import jax
@@ -21,6 +22,7 @@ import alberta_framework.benchmarks.ipmnist_screening as ipmnist_screening
 from alberta_framework.benchmarks.ipmnist_screening import (
     _CBP_LAYERS,
     CONFIRMATION_THRESHOLD,
+    LEGACY_SHARD_SCHEMA,
     PROXY_N_TASKS,
     SCREENING_REGISTRY,
     SHARD_SCHEMA,
@@ -102,6 +104,99 @@ from alberta_framework.core.normalizers import EMANormalizer
 SMALL = IPMNISTConfig(
     n_tasks=3, task_length=30, input_dim=12, hidden1=8, hidden2=6, n_classes=5
 )
+
+
+def _test_source_provenance(
+    *, source_sha256: str = "3" * 64,
+) -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.source_provenance.v1",
+        "git_commit": "1" * 40,
+        "git_tree": "2" * 40,
+        "git_object_format": "sha1",
+        "relevant_source_scope": "tracked:alberta_framework/**,pyproject.toml,uv.lock",
+        "relevant_source_file_count": 3,
+        "relevant_source_sha256": source_sha256,
+        "uv_lock_sha256": "4" * 64,
+        "worktree_clean": True,
+    }
+
+
+def _test_runtime_environment(
+    *, machine: str = "test-machine",
+) -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.runtime.v1",
+        "python": {"implementation": "CPython", "version": "3.12.12"},
+        "platform": {"system": "TestOS", "release": "1", "machine": machine},
+        "packages": {
+            "chex": "0.1.91",
+            "jax": "0.11.0",
+            "jaxlib": "0.11.0",
+            "numpy": "2.5.1",
+            "scikit-learn": "1.7.1",
+        },
+        "jax": {
+            "backend": "cpu",
+            "devices": [
+                {"id": 0, "platform": "cpu", "device_kind": "test-cpu", "process_index": 0}
+            ],
+            "config": {
+                "jax_enable_x64": False,
+                "jax_default_matmul_precision": None,
+                "jax_disable_jit": False,
+                "jax_numpy_dtype_promotion": "standard",
+                "jax_numpy_rank_promotion": "allow",
+                "jax_random_seed_offset": 0,
+                "jax_threefry_partitionable": True,
+                "jax_default_prng_impl": "threefry2x32",
+            },
+        },
+        "process_environment": {
+            "CUDA_VISIBLE_DEVICES": None,
+            "JAX_DEFAULT_MATMUL_PRECISION": None,
+            "JAX_ENABLE_X64": None,
+            "JAX_PLATFORM_NAME": None,
+            "JAX_PLATFORMS": None,
+            "OMP_NUM_THREADS": "1",
+            "XLA_FLAGS": None,
+        },
+    }
+
+
+def _test_dataset_provenance() -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+        "source": {
+            "provider": "openml",
+            "name": "mnist_784",
+            "version": 1,
+            "row_start": 0,
+            "row_stop_exclusive": 60000,
+        },
+        "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+        "x": {"dtype": "<f4", "shape": [60000, 784], "sha256": "5" * 64},
+        "y": {"dtype": "<i4", "shape": [60000], "sha256": "6" * 64},
+    }
+
+
+def _bound_shard_payload(
+    result: ipmnist_screening.ScreeningRunResult,
+) -> dict[str, object]:
+    artifact_config = IPMNISTConfig(
+        n_tasks=result.config.n_tasks,
+        task_length=result.config.task_length,
+        input_dim=784,
+        hidden1=result.config.hidden1,
+        hidden2=result.config.hidden2,
+        n_classes=10,
+    )
+    return shard_payload(
+        replace(result, config=artifact_config),
+        source_provenance=_test_source_provenance(),
+        dataset_provenance=_test_dataset_provenance(),
+        environment=_test_runtime_environment(),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -912,7 +1007,7 @@ class TestShardsAndMerge:
             config=SMALL,
         )
         path = tmp_path / f"{config_name}_seed{seed}.json"
-        path.write_text(json.dumps(shard_payload(result)), encoding="utf-8")
+        path.write_text(json.dumps(_bound_shard_payload(result)), encoding="utf-8")
         return path
 
     def test_shard_roundtrip_and_merge(self, tmp_path, small_data):
@@ -950,7 +1045,7 @@ class TestShardsAndMerge:
         self, tmp_path: Path, location: str
     ) -> None:
         spec = screening_spec("upgd_w_control")
-        payload = shard_payload(
+        payload = _bound_shard_payload(
             ipmnist_screening.ScreeningRunResult(
                 config_name=spec.name,
                 base_learner=spec.base_learner,
@@ -1014,7 +1109,7 @@ class TestShardsAndMerge:
     def _write_inband_shard(self, tmp_path, config_name, seed, accuracy):
         """Write a structurally valid shard with controlled accuracy."""
         payload = {
-            "schema": SHARD_SCHEMA,
+            "schema": LEGACY_SHARD_SCHEMA,
             "config_name": config_name,
             "base_learner": "upgd_w",
             "hyperparameters": {},
@@ -1546,15 +1641,15 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="duplicate shard"):
             merge_shards([p1, p2])
 
-    def test_merge_rejects_hyperparameter_drift_across_seeds(self, tmp_path, small_data):
+    def test_merge_rejects_hyperparameter_drift_across_seeds(self, tmp_path):
         """Two shards under one config_name with different hyperparameters must
         not merge: nothing else catches a registry value that changed between
         two `run` invocations, and a silent merge would average per-task
         accuracy across genuinely different mechanisms while reporting only
         the first seed's hyperparameters as if representative of the arm."""
-        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
-        p1 = self._make_shard(tmp_path, small_data, "upgd_l2init", 0)
-        p2 = self._make_shard(tmp_path, small_data, "upgd_l2init", 1)
+        p0 = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
+        p1 = self._write_inband_shard(tmp_path, "upgd_l2init", 0, 0.5)
+        p2 = self._write_inband_shard(tmp_path, "upgd_l2init", 1, 0.5)
 
         payload2 = json.loads(p2.read_text(encoding="utf-8"))
         payload2["hyperparameters"] = {
@@ -1569,10 +1664,10 @@ class TestShardsAndMerge:
         ):
             merge_shards([p0, p1, p2], control_name="upgd_w_control", slope_window=2)
 
-    def test_merge_rejects_base_learner_drift_across_seeds(self, tmp_path, small_data):
-        p0 = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
-        p1 = self._make_shard(tmp_path, small_data, "upgd_l2init", 0)
-        p2 = self._make_shard(tmp_path, small_data, "upgd_l2init", 1)
+    def test_merge_rejects_base_learner_drift_across_seeds(self, tmp_path):
+        p0 = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
+        p1 = self._write_inband_shard(tmp_path, "upgd_l2init", 0, 0.5)
+        p2 = self._write_inband_shard(tmp_path, "upgd_l2init", 1, 0.5)
 
         payload2 = json.loads(p2.read_text(encoding="utf-8"))
         payload2["base_learner"] = "adamw"
@@ -1595,12 +1690,7 @@ class TestShardsAndMerge:
         assert summary["environment"] == reference_environment
 
         payload1 = json.loads(p1.read_text(encoding="utf-8"))
-        payload1["environment"] = {
-            "jax": "0.0-test",
-            "numpy": "0.0-test",
-            "python": "0.0-test",
-            "platform": "different-test-platform",
-        }
+        payload1["environment"] = _test_runtime_environment(machine="different-machine")
         p1.write_text(json.dumps(payload1), encoding="utf-8")
 
         with pytest.raises(ValueError, match="shards span multiple runtime environments"):
@@ -1623,7 +1713,7 @@ class TestShardsAndMerge:
         payload["environment"] = environment
         path.write_text(json.dumps(payload), encoding="utf-8")
 
-        with pytest.raises(ValueError, match="environment must record"):
+        with pytest.raises(ValueError, match="runtime environment"):
             load_shard(path)
 
     @pytest.mark.parametrize(
@@ -1655,7 +1745,11 @@ class TestShardsAndMerge:
                 "learner": learner,
                 "hyperparameters": full.hyperparameters,
                 "seeds": [0],
-                "config": full.config.to_config(),
+                "config": {
+                    **full.config.to_config(),
+                    "input_dim": 784,
+                    "n_classes": 10,
+                },
                 "per_task_accuracy": full.per_task_accuracy.tolist(),
                 "per_task_loss": full.per_task_loss.tolist(),
                 "per_task_plasticity": full.per_task_plasticity.tolist(),
@@ -1671,11 +1765,14 @@ class TestShardsAndMerge:
                 )
             )
             path = shard_dir / f"{name}_seed0.json"
-            path.write_text(json.dumps(shard_payload(proxy)), encoding="utf-8")
+            path.write_text(json.dumps(_bound_shard_payload(proxy)), encoding="utf-8")
             shard_paths.append(path)
         report = validate_proxy(shard_paths, partials, atol=1e-6)
         assert report["all_prefixes_match"] is True
         assert report["environment"] == load_shard(shard_paths[0])["environment"]
+        assert report["source_provenance"] == _test_source_provenance()
+        assert report["dataset_provenance"] == _test_dataset_provenance()
+        assert report["schema"].endswith(".v2")
         for check in report["checks"]:
             assert check["max_abs_per_task_diff"] <= 1e-6
         # ordering flags are booleans (tiny-scale runs may order either way)
@@ -1683,12 +1780,7 @@ class TestShardsAndMerge:
         assert isinstance(report["full_prefix_preserves_upgd_over_adamw"], bool)
 
         changed = json.loads(shard_paths[-1].read_text(encoding="utf-8"))
-        changed["environment"] = {
-            "jax": "0.0-test",
-            "numpy": "0.0-test",
-            "python": "0.0-test",
-            "platform": "different-test-platform",
-        }
+        changed["environment"] = _test_runtime_environment(machine="different-machine")
         changed_path = tmp_path / "changed-environment.json"
         changed_path.write_text(json.dumps(changed), encoding="utf-8")
         with pytest.raises(ValueError, match="shards span multiple runtime environments"):
@@ -1770,7 +1862,7 @@ class TestShardsAndMerge:
         changed_path = tmp_path / "changed-base.json"
         changed_path.write_text(json.dumps(changed), encoding="utf-8")
 
-        with pytest.raises(ValueError, match="must record base_learner='adamw'"):
+        with pytest.raises(ValueError, match="base_learner must match registered arm 'adamw'"):
             validate_proxy([upgd, changed_path], tmp_path)
 
     def test_validate_proxy_rejects_misreported_control_hyperparameters(
@@ -1786,7 +1878,7 @@ class TestShardsAndMerge:
         changed_path = tmp_path / "changed-hyperparameters.json"
         changed_path.write_text(json.dumps(changed), encoding="utf-8")
 
-        with pytest.raises(ValueError, match="must record its frozen hyperparameters"):
+        with pytest.raises(ValueError, match="hyperparameters must exactly match"):
             validate_proxy([upgd, changed_path], tmp_path)
 
 
@@ -1830,7 +1922,7 @@ class TestPoolConfirmation:
         )
 
         with pytest.raises(ValueError, match="noise_pool_steps"):
-            shard_payload(result)
+            _bound_shard_payload(result)
 
     def test_pool_control_matches_run_ipmnist_pool(self, small_data):
         """Control arm under pool mode reproduces run_ipmnist's pool chain."""
@@ -1845,7 +1937,7 @@ class TestPoolConfirmation:
         )
         assert ours.noise_mode == "pool"
         assert ours.noise_pool_steps == 8
-        assert shard_payload(ours)["noise_pool_steps"] == 8
+        assert _bound_shard_payload(ours)["noise_pool_steps"] == 8
         np.testing.assert_allclose(
             ours.per_task_accuracy, reference.per_task_accuracy[0], atol=1e-7
         )
@@ -1885,8 +1977,8 @@ class TestPoolConfirmation:
             x, y, screening_spec("upgd_w_localgate"), seed=0, config=SMALL,
             noise_mode="pool", noise_pool_steps=8,
         )
-        exact_payload = shard_payload(exact)
-        pool_payload = shard_payload(pool)
+        exact_payload = _bound_shard_payload(exact)
+        pool_payload = _bound_shard_payload(pool)
         assert exact_payload["noise_mode"] == "step"
         assert exact_payload["noise_pool_steps"] is None
         assert pool_payload["noise_mode"] == "pool"
@@ -1905,7 +1997,7 @@ class TestPoolConfirmation:
             noise_mode="pool", noise_pool_steps=8,
         )
         path = tmp_path / "pool.json"
-        path.write_text(json.dumps(shard_payload(pool)), encoding="utf-8")
+        path.write_text(json.dumps(_bound_shard_payload(pool)), encoding="utf-8")
         with pytest.raises(ValueError, match="noise_mode"):
             validate_proxy([path], tmp_path)
 

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -5,6 +5,7 @@ prefix property), pin combination steps to their reference equations, and
 test shard/merge/validation plumbing. Benchmark executions never run here.
 """
 
+import hashlib
 import json
 import math
 import threading
@@ -23,6 +24,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     _CBP_LAYERS,
     CONFIRMATION_THRESHOLD,
     LEGACY_SHARD_SCHEMA,
+    NONPROMOTING_POLICY,
     PROXY_N_TASKS,
     SCREENING_REGISTRY,
     SHARD_SCHEMA,
@@ -1597,6 +1599,9 @@ class TestShardsAndMerge:
             "proxy_preserves_upgd_over_adamw": accepted,
         }
         monkeypatch.setattr(screening, "validate_proxy", lambda *_args, **_kwargs: report)
+        monkeypatch.setattr(
+            screening, "_screening_derivation_bindings", lambda _paths: None
+        )
         output = tmp_path / f"proxy-{accepted}.json"
 
         status = screening.main(
@@ -1770,9 +1775,17 @@ class TestShardsAndMerge:
         report = validate_proxy(shard_paths, partials, atol=1e-6)
         assert report["all_prefixes_match"] is True
         assert report["environment"] == load_shard(shard_paths[0])["environment"]
+        assert report["evidence_policy"] == NONPROMOTING_POLICY
         assert report["source_provenance"] == _test_source_provenance()
         assert report["dataset_provenance"] == _test_dataset_provenance()
         assert report["schema"].endswith(".v2")
+        assert len(report["shard_manifest"]) == 2
+        assert len(report["reference_partial_manifest"]) == 2
+        for field in ("shard_manifest", "reference_partial_manifest"):
+            for entry in report[field]:
+                raw = Path(entry["path"]).read_bytes()
+                assert entry["size_bytes"] == len(raw)
+                assert entry["sha256"] == hashlib.sha256(raw).hexdigest()
         for check in report["checks"]:
             assert check["max_abs_per_task_diff"] <= 1e-6
         # ordering flags are booleans (tiny-scale runs may order either way)

--- a/tests/test_ipmnist_screening_provenance.py
+++ b/tests/test_ipmnist_screening_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import py_compile
 import subprocess
 from dataclasses import replace
 from pathlib import Path
@@ -175,7 +176,13 @@ def test_clean_source_provenance_binds_head_tree_lock_and_actual_bytes(tmp_path:
 
 @pytest.mark.parametrize(
     "mutation",
-    ["tracked", "tracked-nonsource", "untracked-package", "untracked-python"],
+    [
+        "tracked",
+        "tracked-nonsource",
+        "untracked-package",
+        "untracked-python",
+        "untracked-root-bytecode",
+    ],
 )
 def test_source_provenance_rejects_dirty_or_untracked_package_source(
     tmp_path: Path, mutation: str
@@ -189,8 +196,17 @@ def test_source_provenance_rejects_dirty_or_untracked_package_source(
         (repo / "README.md").write_text("changed\n", encoding="utf-8")
     elif mutation == "untracked-package":
         (repo / "alberta_framework/untracked.py").write_text("VALUE = 2\n", encoding="utf-8")
-    else:
+    elif mutation == "untracked-python":
         (repo / "local_override.py").write_text("VALUE = 2\n", encoding="utf-8")
+    else:
+        source = repo / "bytecode_source.py"
+        source.write_text("VALUE = 7\n", encoding="utf-8")
+        py_compile.compile(
+            str(source),
+            cfile=str(repo / "shadowmodule.pyc"),
+            doraise=True,
+        )
+        source.unlink()
 
     with pytest.raises(RuntimeError, match="source worktree is not clean"):
         screening._screening_source_provenance(repo)
@@ -367,6 +383,58 @@ def test_v2_writer_and_loader_bind_registered_mechanism(
         screening.load_shard(path)
 
 
+@pytest.mark.parametrize(
+    ("field", "alias"),
+    [("noise_std", False), ("gate_beta", 1)],
+)
+def test_v2_writer_and_loader_reject_registered_float_type_aliases(
+    tmp_path: Path, field: str, alias: object
+) -> None:
+    spec = screening.screening_spec("sigma0_shiftnorm_d099")
+    aliased_hyperparameters = {**spec.hyperparameters, field: alias}
+    result = replace(
+        _result(),
+        config_name=spec.name,
+        base_learner=spec.base_learner,
+        hyperparameters=aliased_hyperparameters,
+    )
+    with pytest.raises(ValueError, match="registered arm"):
+        screening.shard_payload(
+            result,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+    payload = _payload()
+    payload["config_name"] = spec.name
+    payload["base_learner"] = spec.base_learner
+    payload["hyperparameters"] = aliased_hyperparameters
+    path = tmp_path / f"aliased-{field}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="registered arm"):
+        screening.load_shard(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "alias"),
+    [("development_only", 1), ("scientific_promotion_allowed", 0)],
+)
+def test_v2_loader_rejects_boolean_policy_number_aliases(
+    tmp_path: Path, field: str, alias: object
+) -> None:
+    payload = _payload()
+    payload["evidence_policy"] = {
+        **screening.NONPROMOTING_POLICY,
+        field: alias,
+    }
+    path = tmp_path / f"aliased-policy-{field}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="frozen nonpromoting policy"):
+        screening.load_shard(path)
+
+
 @pytest.mark.parametrize("value", [True, "0.5"])
 def test_v2_curves_reject_boolean_and_string_numbers(tmp_path: Path, value: object) -> None:
     payload = _payload()
@@ -387,6 +455,38 @@ def test_v2_curves_reject_boolean_and_string_numbers(tmp_path: Path, value: obje
             dataset_provenance=_dataset_binding(),
             environment=_runtime_binding(),
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    [
+        ("per_task_accuracy", -0.01),
+        ("per_task_accuracy", 1.01),
+        ("per_task_loss", -0.01),
+        ("per_task_plasticity", -0.01),
+        ("per_task_plasticity", 1.01),
+    ],
+)
+def test_v2_writer_and_loader_reject_out_of_domain_curves(
+    tmp_path: Path, field: str, invalid: float
+) -> None:
+    curve = np.full(SMALL.n_tasks, 0.5, dtype=np.float64)
+    curve[1] = invalid
+    result = replace(_result(), **{field: curve})
+    with pytest.raises(ValueError, match=field):
+        screening.shard_payload(
+            result,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+    payload = _payload()
+    payload[field] = curve.tolist()
+    path = tmp_path / f"invalid-domain-{field}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match=field):
+        screening.load_shard(path)
 
 
 @pytest.mark.parametrize("failure", ["curve", "wall-clock"])
@@ -456,6 +556,43 @@ def test_v2_loader_is_strict_and_legacy_v1_remains_readable(tmp_path: Path) -> N
     assert screening.load_shard(legacy_path)["schema"].endswith(".v1")
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    ["negative-id", "negative-process", "duplicate-device"],
+)
+def test_v2_writer_and_loader_reject_invalid_runtime_device_topology(
+    tmp_path: Path, mutation: str
+) -> None:
+    environment = _runtime_binding()
+    jax_binding = environment["jax"]
+    assert isinstance(jax_binding, dict)
+    devices = jax_binding["devices"]
+    assert isinstance(devices, list)
+    device = devices[0]
+    assert isinstance(device, dict)
+    if mutation == "negative-id":
+        device["id"] = -1
+    elif mutation == "negative-process":
+        device["process_index"] = -1
+    elif mutation == "duplicate-device":
+        devices.append(dict(device))
+
+    with pytest.raises(ValueError, match="runtime environment"):
+        screening.shard_payload(
+            _result(),
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=environment,
+        )
+
+    payload = _payload()
+    payload["environment"] = environment
+    path = tmp_path / f"invalid-runtime-{mutation}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="runtime environment"):
+        screening.load_shard(path)
+
+
 def test_homogeneous_legacy_merge_emits_legacy_summary(tmp_path: Path) -> None:
     paths = [tmp_path / f"legacy-seed{seed}.json" for seed in (0, 1)]
     for seed, path in enumerate(paths):
@@ -482,6 +619,14 @@ def test_v2_merge_carries_identical_bindings_and_rejects_all_drift(tmp_path: Pat
     assert summary["source_provenance"] == _source_binding()
     assert summary["dataset_provenance"] == _dataset_binding()
     assert summary["environment"] == _runtime_binding()
+    assert [(entry["config_name"], entry["seed"]) for entry in summary["shard_manifest"]] == [
+        ("upgd_w_control", 0),
+        ("upgd_w_control", 1),
+    ]
+    for entry in summary["shard_manifest"]:
+        raw = Path(entry["path"]).read_bytes()
+        assert entry["size_bytes"] == len(raw)
+        assert entry["sha256"] == hashlib.sha256(raw).hexdigest()
 
     for field, replacement, message in (
         ("source_provenance", _source_binding(source_sha256="9" * 64), "source provenance"),
@@ -494,6 +639,12 @@ def test_v2_merge_carries_identical_bindings_and_rejects_all_drift(tmp_path: Pat
         with pytest.raises(ValueError, match=message):
             screening.merge_shards(paths, control_name="upgd_w_control", slope_window=2)
 
+    paths[0].write_text(paths[0].read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="changed"):
+        screening._require_embedded_artifact_manifest_unchanged(
+            summary["shard_manifest"], context="test shard inputs"
+        )
+
 
 def test_merge_rejects_mixed_v1_v2_shards(tmp_path: Path) -> None:
     current = _payload(0)
@@ -504,6 +655,21 @@ def test_merge_rejects_mixed_v1_v2_shards(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="multiple shard schemas"):
         screening.merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+
+
+@pytest.mark.parametrize("slope_window", [True, 0, 1])
+def test_merge_rejects_invalid_slope_window(
+    tmp_path: Path, slope_window: object
+) -> None:
+    path = tmp_path / "shard.json"
+    path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="slope_window"):
+        screening.merge_shards(
+            [path],
+            control_name="upgd_w_control",
+            slope_window=slope_window,  # type: ignore[arg-type]
+        )
 
 
 def test_proxy_validation_refuses_mixed_or_mismatched_v2_provenance(
@@ -521,6 +687,17 @@ def test_proxy_validation_refuses_mixed_or_mismatched_v2_provenance(
     second.write_text(json.dumps(_legacy_payload(1)), encoding="utf-8")
     with pytest.raises(ValueError, match="multiple shard schemas"):
         screening.validate_proxy([first, second], tmp_path)
+
+
+@pytest.mark.parametrize(
+    "atol",
+    [True, 0, -1e-8, 1.000001e-6, float("nan"), float("inf")],
+)
+def test_proxy_validation_rejects_unsafe_tolerance(
+    tmp_path: Path, atol: object
+) -> None:
+    with pytest.raises(ValueError, match="atol"):
+        screening.validate_proxy([], tmp_path, atol=atol)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("drift", ["source", "environment", "dataset"])
@@ -578,3 +755,38 @@ def test_run_cli_binds_before_execution_and_refuses_prepublication_drift(
 
     assert events[:3] == ["source", "environment", "load"]
     assert events[-1] != "publish"
+
+
+@pytest.mark.parametrize("drift", ["source", "environment"])
+def test_v2_derivation_requires_current_shard_binding_before_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
+) -> None:
+    path = tmp_path / "shard.json"
+    path.write_text(json.dumps(_payload()), encoding="utf-8")
+    summary = screening.merge_shards(
+        [path], control_name="upgd_w_control", slope_window=2
+    )
+    source = _source_binding()
+    environment = _runtime_binding()
+    bindings = (source, environment)
+    monkeypatch.setattr(
+        screening,
+        "_screening_source_provenance",
+        lambda: (
+            _source_binding(source_sha256="9" * 64)
+            if drift == "source"
+            else source
+        ),
+    )
+    monkeypatch.setattr(
+        screening,
+        "_screening_runtime_environment",
+        lambda: (
+            _runtime_binding(machine="different")
+            if drift == "environment"
+            else environment
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="changed during derivation"):
+        screening._require_v2_derivation_context(summary, bindings)

--- a/tests/test_ipmnist_screening_provenance.py
+++ b/tests/test_ipmnist_screening_provenance.py
@@ -1,0 +1,580 @@
+"""Fail-closed source/data provenance pins for new IPMNIST screening shards."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import alberta_framework.benchmarks.ipmnist_screening as screening
+from alberta_framework.benchmarks.ipmnist_screening import (
+    IPMNISTConfig,
+    ScreeningRunResult,
+)
+
+SMALL = IPMNISTConfig(
+    n_tasks=3, task_length=30, input_dim=784, hidden1=8, hidden2=6, n_classes=10
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _source_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "source"
+    (repo / "alberta_framework/benchmarks").mkdir(parents=True)
+    (repo / "alberta_framework/__init__.py").write_text("\n", encoding="utf-8")
+    (repo / "alberta_framework/benchmarks/ipmnist_screening.py").write_text(
+        "VALUE = 1\n", encoding="utf-8"
+    )
+    (repo / "pyproject.toml").write_text("[project]\nname='test'\n", encoding="utf-8")
+    (repo / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "fixture")
+    return repo
+
+
+def _source_binding(*, source_sha256: str = "3" * 64) -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.source_provenance.v1",
+        "git_commit": "1" * 40,
+        "git_tree": "2" * 40,
+        "git_object_format": "sha1",
+        "relevant_source_scope": "tracked:alberta_framework/**,pyproject.toml,uv.lock",
+        "relevant_source_file_count": 3,
+        "relevant_source_sha256": source_sha256,
+        "uv_lock_sha256": "4" * 64,
+        "worktree_clean": True,
+    }
+
+
+def _runtime_binding(*, machine: str = "test-machine") -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.runtime.v1",
+        "python": {"implementation": "CPython", "version": "3.12.12"},
+        "platform": {"system": "TestOS", "release": "1", "machine": machine},
+        "packages": {
+            "chex": "0.1.91",
+            "jax": "0.11.0",
+            "jaxlib": "0.11.0",
+            "numpy": "2.5.1",
+            "scikit-learn": "1.7.1",
+        },
+        "jax": {
+            "backend": "cpu",
+            "devices": [
+                {"id": 0, "platform": "cpu", "device_kind": "test-cpu", "process_index": 0}
+            ],
+            "config": {
+                "jax_enable_x64": False,
+                "jax_default_matmul_precision": None,
+                "jax_disable_jit": False,
+                "jax_numpy_dtype_promotion": "standard",
+                "jax_numpy_rank_promotion": "allow",
+                "jax_random_seed_offset": 0,
+                "jax_threefry_partitionable": True,
+                "jax_default_prng_impl": "threefry2x32",
+            },
+        },
+        "process_environment": {
+            "CUDA_VISIBLE_DEVICES": None,
+            "JAX_DEFAULT_MATMUL_PRECISION": None,
+            "JAX_ENABLE_X64": None,
+            "JAX_PLATFORM_NAME": None,
+            "JAX_PLATFORMS": None,
+            "OMP_NUM_THREADS": "1",
+            "XLA_FLAGS": None,
+        },
+    }
+
+
+def _dataset_binding(*, x_sha256: str = "5" * 64) -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+        "source": {
+            "provider": "openml",
+            "name": "mnist_784",
+            "version": 1,
+            "row_start": 0,
+            "row_stop_exclusive": 60000,
+        },
+        "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+        "x": {"dtype": "<f4", "shape": [60000, 784], "sha256": x_sha256},
+        "y": {"dtype": "<i4", "shape": [60000], "sha256": "6" * 64},
+    }
+
+
+def _result(seed: int = 0) -> ScreeningRunResult:
+    spec = screening.screening_spec("upgd_w_control")
+    return ScreeningRunResult(
+        config_name=spec.name,
+        base_learner=spec.base_learner,
+        hyperparameters=dict(spec.hyperparameters),
+        seed=seed,
+        config=SMALL,
+        per_task_accuracy=np.full(SMALL.n_tasks, 0.5),
+        per_task_loss=np.full(SMALL.n_tasks, 0.1),
+        per_task_plasticity=np.full(SMALL.n_tasks, 0.5),
+        wall_clock_seconds=1.0,
+    )
+
+
+def _payload(seed: int = 0) -> dict[str, object]:
+    return screening.shard_payload(
+        _result(seed),
+        source_provenance=_source_binding(),
+        dataset_provenance=_dataset_binding(),
+        environment=_runtime_binding(),
+    )
+
+
+def _legacy_payload(seed: int = 0) -> dict[str, object]:
+    legacy = _payload(seed)
+    legacy["schema"] = "alberta.ipmnist_screening.shard.v1"
+    legacy.pop("source_provenance")
+    legacy.pop("dataset_provenance")
+    legacy["environment"] = {
+        "jax": "0.11.0",
+        "numpy": "2.5.1",
+        "python": "3.12.12",
+        "platform": "legacy-platform",
+    }
+    return legacy
+
+
+def test_clean_source_provenance_binds_head_tree_lock_and_actual_bytes(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+
+    provenance = screening._screening_source_provenance(repo)
+
+    assert provenance["git_commit"] == _git(repo, "rev-parse", "HEAD")
+    assert provenance["git_tree"] == _git(repo, "rev-parse", "HEAD^{tree}")
+    assert provenance["uv_lock_sha256"] == hashlib.sha256(
+        (repo / "uv.lock").read_bytes()
+    ).hexdigest()
+    assert provenance["worktree_clean"] is True
+    assert provenance["relevant_source_file_count"] == 4
+    assert len(str(provenance["relevant_source_sha256"])) == 64
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["tracked", "tracked-nonsource", "untracked-package", "untracked-python"],
+)
+def test_source_provenance_rejects_dirty_or_untracked_package_source(
+    tmp_path: Path, mutation: str
+) -> None:
+    repo = _source_repo(tmp_path)
+    if mutation == "tracked":
+        (repo / "alberta_framework/benchmarks/ipmnist_screening.py").write_text(
+            "VALUE = 2\n", encoding="utf-8"
+        )
+    elif mutation == "tracked-nonsource":
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+    elif mutation == "untracked-package":
+        (repo / "alberta_framework/untracked.py").write_text("VALUE = 2\n", encoding="utf-8")
+    else:
+        (repo / "local_override.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="source worktree is not clean"):
+        screening._screening_source_provenance(repo)
+
+
+def test_source_provenance_allows_append_only_output_files(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    expected = screening._screening_source_provenance(repo)
+    output = repo / "outputs/ipmnist_screening/replication_r1/shards/one.json"
+    output.parent.mkdir(parents=True)
+    output.write_text("{}\n", encoding="utf-8")
+
+    assert screening._screening_source_provenance(repo) == expected
+
+
+def test_source_digest_changes_with_clean_committed_source_bytes(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    first = screening._screening_source_provenance(repo)
+    (repo / "alberta_framework/benchmarks/ipmnist_screening.py").write_text(
+        "VALUE = 2\n", encoding="utf-8"
+    )
+    _git(repo, "add", "alberta_framework/benchmarks/ipmnist_screening.py")
+    _git(repo, "commit", "-qm", "change source")
+
+    second = screening._screening_source_provenance(repo)
+
+    assert second["git_commit"] != first["git_commit"]
+    assert second["git_tree"] != first["git_tree"]
+    assert second["relevant_source_sha256"] != first["relevant_source_sha256"]
+    assert second["uv_lock_sha256"] == first["uv_lock_sha256"]
+
+
+def test_source_provenance_rejects_assume_unchanged_hidden_edit(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    source = repo / "alberta_framework/benchmarks/ipmnist_screening.py"
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+    _git(repo, "update-index", "--assume-unchanged", source.relative_to(repo).as_posix())
+    assert _git(repo, "status", "--short") == ""
+
+    with pytest.raises(RuntimeError, match="index flags|differs from HEAD"):
+        screening._screening_source_provenance(repo)
+
+
+@pytest.mark.parametrize(
+    ("relative", "exclude"),
+    [
+        ("sitecustomize.py", "sitecustomize.py"),
+        ("alberta_framework/sourceless.pyc", "alberta_framework/*.pyc"),
+    ],
+)
+def test_source_provenance_rejects_ignored_importable_source(
+    tmp_path: Path, relative: str, exclude: str
+) -> None:
+    repo = _source_repo(tmp_path)
+    with (repo / ".git/info/exclude").open("a", encoding="utf-8") as stream:
+        stream.write(f"{exclude}\n")
+    source = repo / relative
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(b"hidden source\n")
+    assert _git(repo, "status", "--short") == ""
+
+    with pytest.raises(RuntimeError, match="source worktree is not clean"):
+        screening._screening_source_provenance(repo)
+
+
+def test_source_provenance_fails_when_git_or_lock_is_unavailable(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Git repository"):
+        screening._screening_source_provenance(tmp_path)
+
+    repo = _source_repo(tmp_path)
+    (repo / "uv.lock").unlink()
+    with pytest.raises(RuntimeError, match="source worktree is not clean|uv.lock"):
+        screening._screening_source_provenance(repo)
+
+
+def test_dataset_provenance_hashes_materialized_x_and_y_with_dtype_and_shape() -> None:
+    x = np.arange(24, dtype=np.float64).reshape(3, 8)[:, ::2]
+    y = np.asarray([2, 1, 0], dtype=np.int64)
+
+    first = screening._materialized_dataset_provenance(x, y)
+    second = screening._materialized_dataset_provenance(
+        np.asarray(x, dtype=np.float32), np.asarray(y, dtype=np.int32)
+    )
+    changed = screening._materialized_dataset_provenance(
+        np.asarray(x[::-1], dtype=np.float32), np.asarray(y, dtype=np.int32)
+    )
+
+    assert first == second
+    assert first["x"]["dtype"] == "<f4"
+    assert first["x"]["shape"] == [3, 4]
+    assert first["y"]["dtype"] == "<i4"
+    assert first["y"]["shape"] == [3]
+    assert changed["x"]["sha256"] != first["x"]["sha256"]
+
+
+def test_streamed_array_hash_matches_the_prior_tobytes_contract() -> None:
+    arrays = {
+        "features": np.arange(24, dtype=">f4").reshape(4, 6)[:, ::2],
+        "labels": np.asarray([3, 2, 1, 0], dtype=">i4"),
+    }
+    domain = "alberta.test.array-bundle.v1"
+    expected = hashlib.sha256()
+    expected.update(domain.encode("ascii") + b"\0")
+    for name in sorted(arrays):
+        encoded_name = name.encode("ascii")
+        array = screening._canonical_hash_array(arrays[name])
+        header = json.dumps(
+            {"dtype": array.dtype.str, "shape": list(array.shape)},
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        payload = array.tobytes(order="C")
+        expected.update(len(encoded_name).to_bytes(4, "little"))
+        expected.update(encoded_name)
+        expected.update(len(header).to_bytes(8, "little"))
+        expected.update(header)
+        expected.update(len(payload).to_bytes(8, "little"))
+        expected.update(payload)
+
+    assert screening._array_bundle_sha256(domain, arrays) == expected.hexdigest()
+
+
+def test_direct_shard_payload_refuses_unbound_v2() -> None:
+    with pytest.raises(TypeError, match="source_provenance"):
+        screening.shard_payload(_result())
+
+    inconsistent = replace(
+        _result(),
+        config=IPMNISTConfig(
+            n_tasks=SMALL.n_tasks,
+            task_length=SMALL.task_length,
+            input_dim=12,
+            hidden1=SMALL.hidden1,
+            hidden2=SMALL.hidden2,
+            n_classes=5,
+        ),
+    )
+    with pytest.raises(ValueError, match="dataset width"):
+        screening.shard_payload(
+            inconsistent,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+
+@pytest.mark.parametrize("field", ["base_learner", "hyperparameters"])
+def test_v2_writer_and_loader_bind_registered_mechanism(
+    tmp_path: Path, field: str
+) -> None:
+    result = _result()
+    if field == "base_learner":
+        changed_result = replace(result, base_learner="forged")
+        replacement: object = "forged"
+    else:
+        changed_result = replace(
+            result, hyperparameters={**result.hyperparameters, "step_size": 999.0}
+        )
+        replacement = changed_result.hyperparameters
+    with pytest.raises(ValueError, match="registered arm"):
+        screening.shard_payload(
+            changed_result,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+    payload = _payload()
+    payload[field] = replacement
+    path = tmp_path / f"forged-{field}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="registered arm"):
+        screening.load_shard(path)
+
+
+@pytest.mark.parametrize("value", [True, "0.5"])
+def test_v2_curves_reject_boolean_and_string_numbers(tmp_path: Path, value: object) -> None:
+    payload = _payload()
+    payload["per_task_accuracy"] = [value, 0.5, 0.5]
+    path = tmp_path / "invalid-curve.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="list of finite JSON numbers"):
+        screening.load_shard(path)
+
+    bool_result = replace(
+        _result(), per_task_accuracy=np.asarray([True, False, True], dtype=np.bool_)
+    )
+    with pytest.raises(ValueError, match="per_task_accuracy"):
+        screening.shard_payload(
+            bool_result,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+
+@pytest.mark.parametrize("failure", ["curve", "wall-clock"])
+def test_v2_writer_and_atomic_publish_reject_nonfinite_json(
+    tmp_path: Path, failure: str
+) -> None:
+    result = _result()
+    if failure == "curve":
+        result = replace(
+            result,
+            per_task_loss=np.asarray([0.1, np.nan, 0.1], dtype=np.float64),
+        )
+    else:
+        result = replace(result, wall_clock_seconds=float("inf"))
+    with pytest.raises(ValueError, match="finite"):
+        screening.shard_payload(
+            result,
+            source_provenance=_source_binding(),
+            dataset_provenance=_dataset_binding(),
+            environment=_runtime_binding(),
+        )
+
+    output = tmp_path / "nonfinite.json"
+    with pytest.raises(ValueError, match="JSON compliant|Out of range float"):
+        screening._atomic_write_json(output, {"value": float("nan")})
+    assert not output.exists()
+
+
+def test_v2_loader_is_strict_and_legacy_v1_remains_readable(tmp_path: Path) -> None:
+    v2_path = tmp_path / "v2.json"
+    payload = _payload()
+    v2_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert screening.load_shard(v2_path)["schema"].endswith(".v2")
+
+    changed = dict(payload)
+    changed["unexpected"] = True
+    v2_path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="unexpected field"):
+        screening.load_shard(v2_path)
+
+    changed = json.loads(json.dumps(payload))
+    changed["dataset_provenance"]["x"]["shape"] = [64, 12]
+    changed["dataset_provenance"]["y"]["shape"] = [64]
+    v2_path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="canonical x"):
+        screening.load_shard(v2_path)
+
+    for field, value, message in (
+        ("input_dim", 12, "dataset width"),
+        ("n_classes", 5, "n_classes must be 10"),
+    ):
+        changed = json.loads(json.dumps(payload))
+        changed["config"][field] = value
+        v2_path.write_text(json.dumps(changed), encoding="utf-8")
+        with pytest.raises(ValueError, match=message):
+            screening.load_shard(v2_path)
+
+    changed = json.loads(json.dumps(payload))
+    changed["dataset_provenance"]["source"]["version"] = True
+    v2_path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="source selection"):
+        screening.load_shard(v2_path)
+
+    legacy = _legacy_payload()
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_text(json.dumps(legacy), encoding="utf-8")
+    assert screening.load_shard(legacy_path)["schema"].endswith(".v1")
+
+
+def test_homogeneous_legacy_merge_emits_legacy_summary(tmp_path: Path) -> None:
+    paths = [tmp_path / f"legacy-seed{seed}.json" for seed in (0, 1)]
+    for seed, path in enumerate(paths):
+        path.write_text(json.dumps(_legacy_payload(seed)), encoding="utf-8")
+
+    summary = screening.merge_shards(
+        paths, control_name="upgd_w_control", slope_window=2
+    )
+
+    assert summary["schema"].endswith(".v1")
+    assert "source_provenance" not in summary
+    assert "dataset_provenance" not in summary
+
+
+def test_v2_merge_carries_identical_bindings_and_rejects_all_drift(tmp_path: Path) -> None:
+    paths = []
+    for seed in (0, 1):
+        path = tmp_path / f"seed{seed}.json"
+        path.write_text(json.dumps(_payload(seed)), encoding="utf-8")
+        paths.append(path)
+
+    summary = screening.merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+    assert summary["schema"].endswith(".v2")
+    assert summary["source_provenance"] == _source_binding()
+    assert summary["dataset_provenance"] == _dataset_binding()
+    assert summary["environment"] == _runtime_binding()
+
+    for field, replacement, message in (
+        ("source_provenance", _source_binding(source_sha256="9" * 64), "source provenance"),
+        ("dataset_provenance", _dataset_binding(x_sha256="9" * 64), "dataset"),
+        ("environment", _runtime_binding(machine="other"), "runtime environment"),
+    ):
+        changed = _payload(1)
+        changed[field] = replacement
+        paths[1].write_text(json.dumps(changed), encoding="utf-8")
+        with pytest.raises(ValueError, match=message):
+            screening.merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+
+
+def test_merge_rejects_mixed_v1_v2_shards(tmp_path: Path) -> None:
+    current = _payload(0)
+    legacy = _legacy_payload(1)
+    paths = [tmp_path / "current.json", tmp_path / "legacy.json"]
+    for path, payload in zip(paths, (current, legacy), strict=True):
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="multiple shard schemas"):
+        screening.merge_shards(paths, control_name="upgd_w_control", slope_window=2)
+
+
+def test_proxy_validation_refuses_mixed_or_mismatched_v2_provenance(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    first.write_text(json.dumps(_payload(0)), encoding="utf-8")
+    changed = _payload(1)
+    changed["dataset_provenance"] = _dataset_binding(x_sha256="9" * 64)
+    second.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="multiple dataset bindings"):
+        screening.validate_proxy([first, second], tmp_path)
+
+    second.write_text(json.dumps(_legacy_payload(1)), encoding="utf-8")
+    with pytest.raises(ValueError, match="multiple shard schemas"):
+        screening.validate_proxy([first, second], tmp_path)
+
+
+@pytest.mark.parametrize("drift", ["source", "environment", "dataset"])
+def test_run_cli_binds_before_execution_and_refuses_prepublication_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
+) -> None:
+    events: list[str] = []
+    sources = iter([_source_binding(), _source_binding(source_sha256="9" * 64)])
+    environments = iter([_runtime_binding(), _runtime_binding(machine="other")])
+    datasets = iter([_dataset_binding(), _dataset_binding(x_sha256="9" * 64)])
+
+    def source() -> dict[str, object]:
+        events.append("source")
+        return next(sources) if drift == "source" else _source_binding()
+
+    def environment() -> dict[str, object]:
+        events.append("environment")
+        return next(environments) if drift == "environment" else _runtime_binding()
+
+    def dataset(*_args: object) -> dict[str, object]:
+        events.append("dataset")
+        return next(datasets) if drift == "dataset" else _dataset_binding()
+
+    monkeypatch.setattr(screening, "_screening_source_provenance", source)
+    monkeypatch.setattr(screening, "_screening_runtime_environment", environment)
+    monkeypatch.setattr(screening, "_screening_dataset_provenance", dataset)
+    monkeypatch.setattr(
+        screening,
+        "load_mnist_train",
+        lambda _path: events.append("load") or (np.zeros((1, 12)), np.zeros(1)),
+    )
+    monkeypatch.setattr(
+        screening,
+        "run_screening_config",
+        lambda *_args, **_kwargs: events.append("run") or _result(),
+    )
+    monkeypatch.setattr(
+        screening,
+        "_atomic_write_json",
+        lambda *_args, **_kwargs: events.append("publish"),
+    )
+
+    with pytest.raises(RuntimeError, match="changed during execution"):
+        screening.main(
+            [
+                "run",
+                "--config-name",
+                "upgd_w_control",
+                "--seed",
+                "0",
+                "--out",
+                str(tmp_path / "shard.json"),
+            ]
+        )
+
+    assert events[:3] == ["source", "environment", "load"]
+    assert events[-1] != "publish"


### PR DESCRIPTION
## Summary

- add strict `shard.v2`, `summary.v2`, and `proxy_validation.v2` contracts for new IPMNIST screening runs
- bind every new shard to the clean Git commit/tree and tracked source inventory, `uv.lock`, exact runtime/device configuration, and the consumed MNIST arrays
- bind derived summaries and proxy receipts to exact shard/reference bytes and the live source/runtime that performed the derivation
- enforce exact nonpromoting-policy and registered-hyperparameter types, metric domains, device identities, and a safe proxy tolerance before atomic publication
- revalidate source, runtime, dataset, and input-file identity immediately before immutable publication
- keep homogeneous legacy v1 artifacts readable while refusing mixed-schema or provenance-drifting merges

## Why

Issue #51 requires the launch head and frozen runtime/data identity to be recorded in every shard, but the existing v1 schema cannot establish those facts. This is the code-only prerequisite that makes a future authorized protocol executable and auditable.

It does **not** authorize or execute the preregistered screening run, does not create results, and does not promote evidence. The issue still needs an explicit maintainer protocol decision, project-owner compute/funding authorization, and its required macOS arm64 runner before any launch.

## Verification

- `353 passed` across the full screening and provenance suites
- repository-wide Ruff passed
- strict mypy passed for 163 source files
- integrated source-provenance self-capture passed on a clean committed tree
- both independent adversarial reviews approved the corrected head; 450 valid legacy v1 shards remain readable
- `git diff --check` passed; worktree clean; no `outputs/` changes
- evidence registry remained fail-closed as expected: 5/5 claims invalid, exit 2

No benchmark or scientific run was executed.

Refs #51
