### PR TITLE
Reject non-finite SIGReg embeddings before 0*inf projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rejected SIGReg samples, embeddings, directions, and derived projections that are
+  non-finite in float32 arithmetic before they can become silent NaN losses, including
+  under compiled and vectorized JAX calls.
 - Required automatic feature-to-subtask counts to be non-negative integer scalars before
   ranking, while retaining NumPy/JAX integer-scalar compatibility and zero/oversized bounds.
 - Aligned plotted trailing-window learning-curve means and confidence intervals with the

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -39,6 +39,9 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _KERNEL_WIDTH_ERROR = (
     "kernel_width must be positive and finite in float32 kernel arithmetic"
 )
+_SAMPLES_FINITE_ERROR = "samples must be finite"
+_EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
+_DIRECTIONS_FINITE_ERROR = "directions must be finite"
 
 
 def _normalized_positive_float32(
@@ -198,6 +201,17 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     return _runtime_checked_value(width, predicate, _KERNEL_WIDTH_ERROR)
 
 
+def _require_finite_array(values: Array, message: str) -> Array:
+    """Reject non-finite coordinates without rewriting them to a fake zero."""
+    array = jnp.asarray(values)
+    predicate = jnp.all(jnp.isfinite(array))
+    if not isinstance(predicate, jax.core.Tracer):
+        if not bool(predicate):
+            raise ValueError(message)
+        return array
+    return _runtime_checked_value(array, predicate, message)
+
+
 def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     """Compute the statistic after ``width`` has passed boundary validation."""
     x = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
@@ -247,7 +261,8 @@ def epps_pulley_gaussian_statistic(
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
     width = _validated_kernel_width(kernel_width)
-    return _epps_pulley_gaussian_statistic(samples, width)
+    checked = _require_finite_array(samples, _SAMPLES_FINITE_ERROR)
+    return _epps_pulley_gaussian_statistic(checked, width)
 
 
 def sliced_sigreg_loss(
@@ -272,6 +287,8 @@ def sliced_sigreg_loss(
     if z.ndim < 2:
         raise ValueError("embeddings must have shape (..., latent_dim)")
     width = _validated_kernel_width(kernel_width)
+    z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
+    dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
     projections = flat @ dirs.T
     per_projection = jax.vmap(
@@ -290,6 +307,8 @@ def sigreg_diagnostics(
     cfg = config or SIGRegConfig()
     z = jnp.asarray(embeddings, dtype=jnp.float32)
     dirs = jnp.asarray(directions, dtype=jnp.float32)
+    z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
+    dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
     projected = flat @ dirs.T
     latent_std = jnp.std(flat, axis=0)

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -42,6 +42,7 @@ _KERNEL_WIDTH_ERROR = (
 _SAMPLES_FINITE_ERROR = "samples must be finite"
 _EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
 _DIRECTIONS_FINITE_ERROR = "directions must be finite"
+_PROJECTIONS_FINITE_ERROR = "projected samples must be finite"
 
 
 def _normalized_positive_float32(
@@ -136,9 +137,10 @@ def _runtime_checked_value(
 ) -> Array:
     """Enforce a scalar predicate without breaking valid JAX transforms.
 
-    Eager invalid inputs are rejected before this helper. Under ``jax.jit``
-    or ``jax.vmap``, a failed check surfaces on synchronization as
-    :class:`jax.errors.JaxRuntimeError` wrapping the host ``ValueError``.
+    Eager invalid inputs are rejected before this helper. Under compiled JAX
+    transforms, a failed check surfaces on synchronization as
+    :class:`jax.errors.JaxRuntimeError` wrapping the host ``ValueError``;
+    an uncompiled ``jax.vmap`` may surface the host ``ValueError`` directly.
     """
     predicate = jnp.reshape(jnp.asarray(predicate, dtype=jnp.bool_), ())
 
@@ -261,7 +263,10 @@ def epps_pulley_gaussian_statistic(
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
     width = _validated_kernel_width(kernel_width)
-    checked = _require_finite_array(samples, _SAMPLES_FINITE_ERROR)
+    checked = _require_finite_array(
+        jnp.asarray(samples, dtype=jnp.float32),
+        _SAMPLES_FINITE_ERROR,
+    )
     return _epps_pulley_gaussian_statistic(checked, width)
 
 
@@ -290,7 +295,7 @@ def sliced_sigreg_loss(
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
-    projections = flat @ dirs.T
+    projections = _require_finite_array(flat @ dirs.T, _PROJECTIONS_FINITE_ERROR)
     per_projection = jax.vmap(
         lambda values: _epps_pulley_gaussian_statistic(values, width),
         in_axes=1,
@@ -310,7 +315,7 @@ def sigreg_diagnostics(
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
-    projected = flat @ dirs.T
+    projected = _require_finite_array(flat @ dirs.T, _PROJECTIONS_FINITE_ERROR)
     latent_std = jnp.std(flat, axis=0)
     projected_std = jnp.std(projected, axis=0)
     return SIGRegDiagnostics(

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -258,3 +258,45 @@ def test_sigreg_diagnostics_reject_nonfinite_embeddings() -> None:
 
     with pytest.raises(ValueError, match="embeddings must be finite"):
         sigreg_diagnostics(embeddings, directions)
+
+
+def test_epps_pulley_compiled_finite_check_preserves_valid_values_and_rejects_nan() -> None:
+    valid = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
+    compiled = jax.jit(epps_pulley_gaussian_statistic)
+
+    chex.assert_trees_all_close(
+        compiled(valid),
+        epps_pulley_gaussian_statistic(valid),
+        atol=1.0e-6,
+    )
+    with pytest.raises(jax.errors.JaxRuntimeError, match="samples must be finite"):
+        compiled(valid.at[1].set(jnp.nan)).block_until_ready()
+
+
+def test_sliced_sigreg_compiled_vmap_rejects_nonfinite_lane() -> None:
+    valid = jnp.asarray([[-1.0, 0.5], [0.0, -0.5]], dtype=jnp.float32)
+    directions = jnp.eye(2, dtype=jnp.float32)
+    batches = jnp.stack((valid, valid.at[0, 0].set(jnp.inf)))
+    compiled = jax.jit(jax.vmap(sliced_sigreg_loss, in_axes=(0, None)))
+
+    with pytest.raises(jax.errors.JaxRuntimeError, match="embeddings must be finite"):
+        compiled(batches, directions).block_until_ready()
+
+
+def test_epps_pulley_rejects_samples_that_overflow_float32_narrowing() -> None:
+    with jax.enable_x64():
+        samples = jnp.asarray([1.0e300, 1.0e300], dtype=jnp.float64)
+
+        with pytest.raises(ValueError, match="samples must be finite"):
+            epps_pulley_gaussian_statistic(samples)
+
+
+def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
+    maximum = jnp.finfo(jnp.float32).max
+    embeddings = jnp.asarray([[maximum, maximum], [maximum, maximum]])
+    directions = jnp.asarray([[1.0, 1.0]], dtype=jnp.float32)
+
+    assert bool(jnp.isfinite(embeddings).all())
+    assert bool(jnp.isfinite(directions).all())
+    with pytest.raises(ValueError, match="projected samples must be finite"):
+        sliced_sigreg_loss(embeddings, directions)

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -223,3 +223,38 @@ def test_sigreg_diagnostics_are_finite() -> None:
 
     chex.assert_tree_all_finite(diagnostics)
     chex.assert_shape(diagnostics.loss, ())
+
+
+def test_epps_pulley_rejects_nonfinite_samples() -> None:
+    """Two inf samples make inf-inf diffs, so the kernel statistic is NaN."""
+    samples = jnp.asarray([jnp.inf, jnp.inf], dtype=jnp.float32)
+
+    assert not bool(jnp.isfinite(jnp.mean(samples[:, None] - samples[None, :])))
+    with pytest.raises(ValueError, match="samples must be finite"):
+        epps_pulley_gaussian_statistic(samples)
+
+
+def test_sliced_sigreg_rejects_inf_embedding_times_silent_direction() -> None:
+    """Inf embedding @ a zero direction coordinate is 0*inf = NaN in the slice."""
+    embeddings = jnp.asarray([[jnp.inf, 1.0], [0.0, -0.5]], dtype=jnp.float32)
+    directions = jnp.asarray([[0.0, 1.0]], dtype=jnp.float32)
+
+    assert not bool(jnp.isfinite(embeddings @ directions.T).all())
+    with pytest.raises(ValueError, match="embeddings must be finite"):
+        sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sliced_sigreg_rejects_nonfinite_directions() -> None:
+    embeddings = jnp.asarray([[-1.0, 0.5], [0.0, -0.5]], dtype=jnp.float32)
+    directions = jnp.asarray([[jnp.inf, 0.0]], dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="directions must be finite"):
+        sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sigreg_diagnostics_reject_nonfinite_embeddings() -> None:
+    embeddings = jnp.asarray([[jnp.nan, 0.0]], dtype=jnp.float32)
+    directions = jnp.eye(2, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="embeddings must be finite"):
+        sigreg_diagnostics(embeddings, directions)


### PR DESCRIPTION
## Summary
- SIGReg already rejects a non-finite kernel width. It still projected inf embeddings onto caller-supplied directions, so `inf * 0` in `flat @ dirs.T` and `inf - inf` in the Epps-Pulley kernel both became NaN losses.
- Eager calls now raise `ValueError`; the same check uses the existing compiled callback under `jit`/`vmap`. Genuine finite inputs are unchanged. This does not rewrite NaNs to zero.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_sigreg.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/sigreg.py tests/test_sigreg.py`
- [x] `.venv/bin/python -m mypy alberta_framework/core/sigreg.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)