### PR TITLE
Hold a zero behavior-model input gradient on inf observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rejected SIGReg samples, embeddings, directions, and derived projections that are
   non-finite in float32 arithmetic before they can become silent NaN losses, including
   under compiled and vectorized JAX calls.
+- Added an explicit traced validity verdict to behavior-model input gradients so finite neutral
+  payloads from rejected inputs cannot be mistaken for valid state-builder updates; eager,
+  compiled, and vectorized consumers can gate mutation on the same result field.
 - Required automatic feature-to-subtask counts to be non-negative integer scalars before
   ranking, while retaining NumPy/JAX integer-scalar compatibility and zero/oversized bounds.
 - Aligned plotted trailing-window learning-curve means and confidence intervals with the

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -450,12 +450,36 @@ class BehaviorModel:
         loss = -jnp.sum(one_hot * jax.nn.log_softmax(scaled_logits))
         logit_gradient = (probabilities - one_hot) / cfg.temperature
         gradient = state.weights.T @ logit_gradient
+        # Inf observation makes softmax NaN and W.T @ (p - one_hot)
+        # non-finite, including 0*inf on a silent feature. The parameter
+        # update already no-ops; this pre-update bridge must not hand a
+        # NaN gradient to the state builder.
+        inputs_valid = (
+            jnp.all(jnp.isfinite(obs))
+            & (action_id >= 0)
+            & (action_id < cfg.n_actions)
+        )
+        source_finite = jnp.all(jnp.isfinite(state.weights)) & jnp.all(
+            jnp.isfinite(state.bias)
+        )
+        proposed_finite = (
+            jnp.all(jnp.isfinite(logits))
+            & jnp.all(jnp.isfinite(probabilities))
+            & jnp.isfinite(loss)
+            & jnp.all(jnp.isfinite(gradient))
+        )
+        valid = source_finite & inputs_valid & proposed_finite
+        zero_logits = jnp.zeros_like(logits)
+        zero_gradient = jnp.zeros_like(gradient)
+        zero_loss = jnp.asarray(0.0, dtype=jnp.float32)
         return BehaviorModelInputGradient(
-            logits=logits,
-            probabilities=probabilities,
-            loss=loss,
-            gradient=gradient,
-            gradient_norm=jnp.linalg.norm(gradient),
+            logits=jnp.where(valid, logits, zero_logits),
+            probabilities=jnp.where(valid, probabilities, jnp.zeros_like(probabilities)),
+            loss=jnp.where(valid, loss, zero_loss),
+            gradient=jnp.where(valid, gradient, zero_gradient),
+            gradient_norm=jnp.where(
+                valid, jnp.linalg.norm(gradient), zero_loss
+            ),
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -252,7 +252,10 @@ class BehaviorModelInputGradient:
     This result is read-only: computing it does not advance diagnostics, RNG,
     or parameters. ``gradient`` is the derivative of the unfloored softmax
     cross entropy. Probability flooring remains confined to reporting and
-    importance-ratio safety.
+    importance-ratio safety. ``valid`` is the traced transaction verdict for
+    the complete result: callers must gate any downstream state mutation on
+    it. Numeric fields are neutralized when it is false so an invalid operand
+    cannot poison a speculative update.
     """
 
     logits: Float[Array, " n_actions"]
@@ -260,6 +263,7 @@ class BehaviorModelInputGradient:
     loss: Float[Array, ""]
     gradient: Float[Array, " feature_dim"]
     gradient_norm: Float[Array, ""]
+    valid: Bool[Array, ""]
 
 
 @chex.dataclass(frozen=True)
@@ -438,7 +442,9 @@ class BehaviorModel:
         trainable state builder. Callers must invoke it before
         :meth:`update`, and before advancing a recurrent state builder to the
         next observation, so the gradient refers to the representation that
-        produced the scored prediction.
+        produced the scored prediction. Any consumer that proposes a state
+        mutation from this result must commit it only when ``result.valid`` is
+        true.
         """
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
@@ -450,6 +456,7 @@ class BehaviorModel:
         loss = -jnp.sum(one_hot * jax.nn.log_softmax(scaled_logits))
         logit_gradient = (probabilities - one_hot) / cfg.temperature
         gradient = state.weights.T @ logit_gradient
+        gradient_norm = jnp.linalg.norm(gradient)
         # Inf observation makes softmax NaN and W.T @ (p - one_hot)
         # non-finite, including 0*inf on a silent feature. The parameter
         # update already no-ops; this pre-update bridge must not hand a
@@ -467,6 +474,7 @@ class BehaviorModel:
             & jnp.all(jnp.isfinite(probabilities))
             & jnp.isfinite(loss)
             & jnp.all(jnp.isfinite(gradient))
+            & jnp.isfinite(gradient_norm)
         )
         valid = source_finite & inputs_valid & proposed_finite
         zero_logits = jnp.zeros_like(logits)
@@ -477,9 +485,8 @@ class BehaviorModel:
             probabilities=jnp.where(valid, probabilities, jnp.zeros_like(probabilities)),
             loss=jnp.where(valid, loss, zero_loss),
             gradient=jnp.where(valid, gradient, zero_gradient),
-            gradient_norm=jnp.where(
-                valid, jnp.linalg.norm(gradient), zero_loss
-            ),
+            gradient_norm=jnp.where(valid, gradient_norm, zero_loss),
+            valid=valid,
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -119,6 +119,25 @@ def test_infinite_observation_does_not_poison_weights() -> None:
     assert bool(recovered.update_applied)
 
 
+def test_infinite_observation_does_not_poison_input_loss_gradient() -> None:
+    """The state-builder bridge must not emit NaN when update would no-op.
+
+    Inf observation makes softmax NaN and ``W.T @ (p - one_hot)`` non-finite,
+    even on a silent feature coordinate. Return a zero gradient instead of a
+    NaN that callers would apply into the state builder.
+    """
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    obs = jnp.array([0.0, jnp.inf], dtype=jnp.float32)
+
+    result = jax.jit(model.input_loss_gradient)(state, obs, jnp.array(0, dtype=jnp.int32))
+
+    chex.assert_tree_all_finite(result)
+    chex.assert_trees_all_close(result.gradient, jnp.zeros(2, dtype=jnp.float32))
+    assert float(result.loss) == 0.0
+    assert float(result.gradient_norm) == 0.0
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -119,12 +119,12 @@ def test_infinite_observation_does_not_poison_weights() -> None:
     assert bool(recovered.update_applied)
 
 
-def test_infinite_observation_does_not_poison_input_loss_gradient() -> None:
-    """The state-builder bridge must not emit NaN when update would no-op.
+def test_infinite_observation_marks_input_loss_gradient_invalid() -> None:
+    """The state-builder bridge returns a neutral payload with a false verdict.
 
     Inf observation makes softmax NaN and ``W.T @ (p - one_hot)`` non-finite,
-    even on a silent feature coordinate. Return a zero gradient instead of a
-    NaN that callers would apply into the state builder.
+    even on a silent feature coordinate. The explicit verdict prevents the
+    neutral zero gradient from being mistaken for a valid training signal.
     """
     model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.1))
     state = model.init(feature_dim=2, key=jax.random.key(0))
@@ -133,8 +133,73 @@ def test_infinite_observation_does_not_poison_input_loss_gradient() -> None:
     result = jax.jit(model.input_loss_gradient)(state, obs, jnp.array(0, dtype=jnp.int32))
 
     chex.assert_tree_all_finite(result)
+    assert not bool(result.valid)
     chex.assert_trees_all_close(result.gradient, jnp.zeros(2, dtype=jnp.float32))
     assert float(result.loss) == 0.0
+    assert float(result.gradient_norm) == 0.0
+
+
+def test_input_loss_gradient_verdict_is_consistent_eager_jit_and_vmap() -> None:
+    """The traced verdict gates mutation in every supported transform."""
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(1))
+    valid_obs = jnp.array([0.25, -0.5], dtype=jnp.float32)
+    invalid_obs = jnp.array([0.25, jnp.inf], dtype=jnp.float32)
+    action = jnp.array(1, dtype=jnp.int32)
+    builder_state = jnp.array([3.0, -2.0], dtype=jnp.float32)
+
+    def consume(observation: jax.Array) -> tuple[Any, jax.Array]:
+        result = model.input_loss_gradient(state, observation, action)
+        proposal = builder_state - jnp.asarray(0.1, dtype=jnp.float32) * result.gradient
+        committed = jnp.where(result.valid, proposal, builder_state)
+        return result, committed
+
+    with jax.disable_jit():
+        eager_valid, eager_committed = consume(valid_obs)
+        eager_invalid, eager_rejected = consume(invalid_obs)
+    compiled_valid, compiled_committed = jax.jit(consume)(valid_obs)
+    compiled_invalid, compiled_rejected = jax.jit(consume)(invalid_obs)
+    batched_results, batched_committed = jax.vmap(consume)(
+        jnp.stack([valid_obs, invalid_obs])
+    )
+
+    assert bool(eager_valid.valid)
+    assert bool(compiled_valid.valid)
+    assert bool(batched_results.valid[0])
+    assert not bool(eager_invalid.valid)
+    assert not bool(compiled_invalid.valid)
+    assert not bool(batched_results.valid[1])
+    chex.assert_trees_all_close(eager_valid, compiled_valid)
+    chex.assert_trees_all_close(eager_valid, jax.tree.map(lambda x: x[0], batched_results))
+    chex.assert_trees_all_close(eager_committed, compiled_committed)
+    chex.assert_trees_all_close(eager_committed, batched_committed[0])
+    chex.assert_trees_all_close(eager_rejected, builder_state)
+    chex.assert_trees_all_close(compiled_rejected, builder_state)
+    chex.assert_trees_all_close(batched_committed[1], builder_state)
+
+
+def test_input_loss_gradient_rejects_finite_gradient_with_overflowed_norm() -> None:
+    """The verdict covers every numeric field, including derived diagnostics."""
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(2))
+    maximum = jnp.finfo(jnp.float32).max
+    state = state.replace(  # type: ignore[attr-defined]
+        weights=jnp.array(
+            [[maximum, maximum], [-maximum, -maximum]],
+            dtype=jnp.float32,
+        ),
+        bias=jnp.zeros((2,), dtype=jnp.float32),
+    )
+
+    result = model.input_loss_gradient(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+    )
+
+    assert not bool(result.valid)
+    chex.assert_tree_all_finite(result)
+    chex.assert_trees_all_close(result.gradient, jnp.zeros((2,), dtype=jnp.float32))
     assert float(result.gradient_norm) == 0.0
 
 


### PR DESCRIPTION
## Summary
- `BehaviorModel.update` already holds previous finite weights when an inf observation would make softmax NaN and `logit_error * x` become 0*inf.
- The pre-update state-builder bridge `input_loss_gradient` still returned that NaN gradient. Callers that apply it before `update` would poison the representation even though the behavior model itself no-ops.
- Invalid or non-finite inputs now return a zero finite gradient, loss, and probabilities. Finite trajectories are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_behavior_model.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/behavior_model.py tests/test_behavior_model.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)