### PR TITLE
Do not form 0*inf latent-action interactions

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -418,13 +418,21 @@ class LatentWorldModel:
             self._config.n_actions,
             dtype=jnp.float32,
         )
-        features = [z, action_one_hot]
+        latent_valid = jnp.all(jnp.isfinite(z))
+        features_valid = action_valid & latent_valid
+        # Inf latent times a silent one-hot is 0*inf = NaN. Zero both
+        # factors before the product; keep the invalid-action NaN reject.
+        safe_z = jnp.where(features_valid, z, jnp.zeros_like(z))
+        safe_action_one_hot = jnp.where(
+            features_valid, action_one_hot, jnp.zeros_like(action_one_hot)
+        )
+        features = [safe_z, safe_action_one_hot]
         if self._config.include_action_interactions:
-            interactions = (z[:, None] * action_one_hot[None, :]).reshape((-1,))
+            interactions = (safe_z[:, None] * safe_action_one_hot[None, :]).reshape((-1,))
             features.append(interactions)
         encoded = jnp.concatenate(features, axis=0)
         return jnp.where(
-            action_valid,
+            features_valid,
             encoded,
             jnp.full_like(encoded, jnp.nan),
         )

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -137,6 +137,25 @@ def test_latent_world_model_scan_loop_and_config_roundtrip() -> None:
     chex.assert_tree_all_finite(result.prediction_errors)
 
 
+def test_latent_action_interactions_do_not_form_zero_times_inf() -> None:
+    """Inf latent times a silent action one-hot is 0*inf = NaN in the product."""
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=3,
+            latent_dim=2,
+            hidden_sizes=(),
+            include_action_interactions=True,
+        )
+    )
+    latent = jnp.array([jnp.inf, 1.0], dtype=jnp.float32)
+    raw = latent[:, None] * jnp.array([1.0, 0.0, 0.0], dtype=jnp.float32)[None, :]
+    assert not bool(jnp.all(jnp.isfinite(raw)))
+
+    features = model.input_features_from_latent(latent, jnp.array(0, dtype=jnp.int32))
+    assert bool(jnp.all(jnp.isnan(features)))
+
+
 def test_score_dream_candidates_selects_surprising_useful_valid_items() -> None:
     result = score_dream_candidates(
         surprises=jnp.array([0.1, 0.9, 0.7, 0.3], dtype=jnp.float32),


### PR DESCRIPTION
## Summary
- `input_features_from_latent` multiplied latent coordinates by a silent action one-hot, so an inf latent became 0*inf = NaN in the interaction slice.
- Both factors are zeroed before that product. Invalid actions and non-finite latents still return an all-NaN feature vector, matching the existing invalid-action reject.
- Finite interaction paths are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_latent_world_model.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)