### PR TITLE
Reject non-finite samples before publication statistics

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -69,6 +69,12 @@ def _validate_confidence_level(confidence_level: float) -> None:
         )
 
 
+def _require_finite_values(values: NDArray[np.floating], *, name: str) -> None:
+    """Reject NaN/inf samples so summaries cannot gold-plate a poisoned seed."""
+    if not np.isfinite(values).all():
+        raise ValueError(f"{name} must be finite")
+
+
 def compute_statistics(
     values: NDArray[np.float64] | list[float],
     confidence_level: float = 0.95,
@@ -83,13 +89,14 @@ def compute_statistics(
         StatisticalSummary with all statistics
 
     Raises:
-        ValueError: If values is empty or ``confidence_level`` is not strictly
-            between 0 and 1.
+        ValueError: If values is empty, any sample is non-finite, or
+            ``confidence_level`` is not strictly between 0 and 1.
     """
     arr = np.asarray(values)
     n = len(arr)
     if n == 0:
         raise ValueError("values must be non-empty")
+    _require_finite_values(arr, name="values")
     _validate_confidence_level(confidence_level)
 
     mean = float(np.mean(arr))
@@ -146,12 +153,13 @@ def compute_timeseries_statistics(
         Tuple of (mean, ci_lower, ci_upper) arrays of shape (n_steps,)
 
     Raises:
-        ValueError: If metric_array has no seed rows or ``confidence_level`` is
-            not strictly between 0 and 1.
+        ValueError: If metric_array has no seed rows, any sample is
+            non-finite, or ``confidence_level`` is not strictly between 0 and 1.
     """
     n_seeds = metric_array.shape[0]
     if n_seeds == 0:
         raise ValueError("metric_array must contain at least one seed row")
+    _require_finite_values(metric_array, name="metric_array")
     _validate_confidence_level(confidence_level)
     mean = np.mean(metric_array, axis=0)
 

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -88,6 +88,14 @@ class TestComputeStatistics:
             with pytest.raises(ValueError, match=r"^values must be non-empty$"):
                 compute_statistics(np.array([], dtype=np.float64))
 
+    @pytest.mark.parametrize("poison", [float("nan"), float("inf"), float("-inf")])
+    def test_nonfinite_values_rejected_without_warnings(self, poison: float) -> None:
+        """A NaN or inf seed must not become a NaN mean/CI that looks published."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^values must be finite$"):
+                compute_statistics([1.0, poison, 2.0])
+
     def test_empirical_ci_coverage(self) -> None:
         """95% t-CI covers the true mean ~95% of the time.
 
@@ -143,6 +151,13 @@ class TestTimeseriesStatistics:
                 ValueError, match=r"^metric_array must contain at least one seed row$"
             ):
                 compute_timeseries_statistics(np.empty((0, 3)))
+
+    def test_nonfinite_seed_rejected_without_warnings(self) -> None:
+        arr = np.array([[1.0, 2.0], [np.nan, 3.0]], dtype=np.float64)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^metric_array must be finite$"):
+                compute_timeseries_statistics(arr)
 
     def test_single_seed_returns_finite_point_interval(self) -> None:
         """One seed yields the point trajectory, finite, without any warning."""


### PR DESCRIPTION
## Summary
- `compute_statistics` and `compute_timeseries_statistics` already reject empty arrays and invalid confidence levels. They still summarized `[1.0, nan]` into a NaN mean and CI, including inf-inf bounds.
- Non-finite samples now raise `ValueError`. Finite fixtures and Cohen's d signed-infinity for zero-variance groups are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_statistics_validation.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py`
- [x] `.venv/bin/python -m mypy alberta_framework/utils/statistics.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)