### PR TITLE
Keep prototype-memory softmax finite on inf observations

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -18,6 +18,7 @@ the packaged Step 2 retained-view memory
 from __future__ import annotations
 
 import functools
+import math
 from typing import Any, cast
 
 import chex
@@ -119,11 +120,11 @@ def _validate_config(config: PrototypeMemoryConfig) -> None:
         raise ValueError("n_classes must be at least 2")
     if config.slots_per_class < 1:
         raise ValueError("slots_per_class must be positive")
-    if not 0.0 < config.update_rate <= 1.0:
+    if not 0.0 < config.update_rate <= 1.0 or not math.isfinite(config.update_rate):
         raise ValueError("update_rate must be in (0, 1]")
-    if config.novelty_threshold < 0.0:
+    if config.novelty_threshold < 0.0 or not math.isfinite(config.novelty_threshold):
         raise ValueError("novelty_threshold must be non-negative")
-    if config.bandwidth <= 0.0:
+    if config.bandwidth <= 0.0 or not math.isfinite(config.bandwidth):
         raise ValueError("bandwidth must be positive")
 
 
@@ -202,7 +203,14 @@ class PrototypeMemoryLearner:
         observation: Float[Array, " feature_dim"],
     ) -> Float[Array, " n_classes"]:
         """Return class probabilities for one observation."""
-        return _softmax(self.class_logits(state, observation))
+        logits = self.class_logits(state, observation)
+        probabilities = _softmax(logits)
+        n_classes = logits.shape[0]
+        uniform = jnp.full_like(probabilities, 1.0 / n_classes)
+        # Inf observation makes distances inf and class_logits NaN. Softmax
+        # of those logits is NaN (including -inf - -inf). Fall back to the
+        # empty-memory uniform instead of a non-finite simplex.
+        return jnp.where(jnp.all(jnp.isfinite(logits)), probabilities, uniform)
 
     @staticmethod
     def valid_one_hot_target(target: Array) -> Array:

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -4,6 +4,7 @@
 import chex
 import jax
 import jax.numpy as jnp
+import pytest
 
 from alberta_framework.core.prototype_memory import (
     PrototypeMemoryConfig,
@@ -35,6 +36,34 @@ def test_empty_memory_predicts_uniformly() -> None:
     prediction = learner.predict(state, jnp.asarray([1.0, -1.0], dtype=jnp.float32))
 
     chex.assert_trees_all_close(prediction, jnp.full((4,), 0.25, dtype=jnp.float32))
+
+
+def test_infinite_observation_predicts_uniformly() -> None:
+    """Inf observation makes all-active logits -inf, then softmax is inf-inf NaN."""
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=3, slots_per_class=2)
+    )
+    state = learner.init()
+    target = jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32)
+    state = learner.update(
+        state, jnp.asarray([0.25, 0.75], dtype=jnp.float32), target
+    ).state
+    obs = jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32)
+
+    logits = learner.class_logits(state, obs)
+    assert not bool(jnp.all(jnp.isfinite(logits)))
+    prediction = learner.predict(state, obs)
+
+    chex.assert_tree_all_finite(prediction)
+    chex.assert_trees_all_close(prediction, jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32))
+    assert float(jnp.sum(prediction)) == pytest.approx(1.0)
+
+
+def test_config_rejects_nonfinite_bandwidth() -> None:
+    with pytest.raises(ValueError, match="bandwidth"):
+        PrototypeMemoryLearner(
+            PrototypeMemoryConfig(feature_dim=2, n_classes=2, bandwidth=float("inf"))
+        )
 
 
 def test_repeated_update_moves_prediction_to_target_class() -> None:


### PR DESCRIPTION
## Summary
- `class_logits` already returns NaN when the observation is non-finite. `predict` still ran softmax on those logits, so all-`-inf` distances became inf-inf NaN probabilities.
- Non-finite logits now fall back to the empty-memory uniform simplex. Infinite `bandwidth` is rejected at learner construction.
- Finite classification fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_prototype_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/prototype_memory.py tests/test_prototype_memory.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)