### PR TITLE
Do not form 0*inf evidence in associative memory

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -216,10 +216,15 @@ def _softmax(logits: Array) -> Array:
 
 def _masked_softmax(logits: Array, mask: Array) -> Array:
     active = mask > 0
+    n_active = jnp.maximum(jnp.sum(active.astype(jnp.float32)), 1.0)
+    uniform = jnp.where(active, 1.0 / n_active, 0.0)
+    uniform = jnp.where(jnp.any(active), uniform, jnp.full_like(logits, 1.0 / logits.shape[0]))
+    finite_active = jnp.all(jnp.where(active, jnp.isfinite(logits), True))
     masked = jnp.where(active, logits, -1.0e9)
     shifted = masked - jnp.max(masked)
     exp = jnp.where(active, jnp.exp(shifted), 0.0)
-    return exp / jnp.maximum(jnp.sum(exp), 1e-12)
+    probabilities = exp / jnp.maximum(jnp.sum(exp), 1e-12)
+    return jnp.where(finite_active, probabilities, uniform)
 
 
 def _cross_entropy_from_logits(logits: Array, label: Array) -> Array:

--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -14,13 +14,20 @@ from __future__ import annotations
 import functools
 import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import Float, Int
+from jaxtyping import Bool, Float, Int
+
+from alberta_framework.core.update_safety import (
+    floating_tree_is_finite,
+    neutralize_array,
+    select_transaction,
+)
 
 AssociativeFeatureFamily = Literal[
     "position_token",
@@ -149,6 +156,7 @@ class AssociativeMemoryUpdateResult:
     predictions: Float[Array, " vocab_size"]
     logits: Float[Array, " vocab_size"]
     metrics: Float[Array, " 8"]
+    update_applied: Bool[Array, ""]
 
 
 @chex.dataclass(frozen=True)
@@ -158,6 +166,16 @@ class AssociativeMemoryLearningResult:
     state: AssociativeMemoryState
     predictions: Float[Array, "steps vocab_size"]
     metrics: Float[Array, "steps 8"]
+    updates_applied: Bool[Array, " steps"]
+
+
+def _finite_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite")
+    return number
 
 
 def _validate_config(config: AssociativeMemoryConfig) -> None:
@@ -191,40 +209,52 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
         raise ValueError("max_weight must be >= min_weight")
     if not math.isfinite(config.logit_scale) or config.logit_scale <= 0.0:
         raise ValueError("logit_scale must be positive")
-    if config.scope_lr < 0.0:
+    for name in (
+        "adaptive_feature_family",
+        "adaptive_window",
+        "adaptive_budget",
+    ):
+        if not isinstance(getattr(config, name), bool):
+            raise ValueError(f"{name} must be a boolean")
+    scope_lr = _finite_real("scope_lr", config.scope_lr)
+    if scope_lr < 0.0:
         raise ValueError("scope_lr must be non-negative")
-    if config.budget_lr < 0.0:
+    budget_lr = _finite_real("budget_lr", config.budget_lr)
+    if budget_lr < 0.0:
         raise ValueError("budget_lr must be non-negative")
-    if not 0.0 < config.initial_budget_fraction <= 1.0:
+    initial_budget_fraction = _finite_real(
+        "initial_budget_fraction",
+        config.initial_budget_fraction,
+    )
+    if not 0.0 < initial_budget_fraction <= 1.0:
         raise ValueError("initial_budget_fraction must be in (0, 1]")
-    if config.min_effective_budget < 1:
+    if isinstance(config.min_effective_budget, bool) or not isinstance(
+        config.min_effective_budget,
+        Integral,
+    ):
+        raise ValueError("min_effective_budget must be an integer")
+    min_effective_budget = int(config.min_effective_budget)
+    if min_effective_budget < 1:
         raise ValueError("min_effective_budget must be positive")
-    if config.min_effective_budget > config.max_features:
+    if min_effective_budget > config.max_features:
         raise ValueError("min_effective_budget must be <= max_features")
-    if config.scope_logit_clip <= 0.0:
+    scope_logit_clip = _finite_real("scope_logit_clip", config.scope_logit_clip)
+    if scope_logit_clip <= 0.0:
         raise ValueError("scope_logit_clip must be positive")
 
 
 def _softmax(logits: Array) -> Array:
-    finite = jnp.all(jnp.isfinite(logits))
     shifted = logits - jnp.max(logits)
     exp = jnp.exp(shifted)
-    probabilities = exp / jnp.maximum(jnp.sum(exp), 1e-12)
-    uniform = jnp.full_like(probabilities, 1.0 / probabilities.shape[0])
-    return jnp.where(finite, probabilities, uniform)
+    return exp / jnp.maximum(jnp.sum(exp), 1e-12)
 
 
 def _masked_softmax(logits: Array, mask: Array) -> Array:
     active = mask > 0
-    n_active = jnp.maximum(jnp.sum(active.astype(jnp.float32)), 1.0)
-    uniform = jnp.where(active, 1.0 / n_active, 0.0)
-    uniform = jnp.where(jnp.any(active), uniform, jnp.full_like(logits, 1.0 / logits.shape[0]))
-    finite_active = jnp.all(jnp.where(active, jnp.isfinite(logits), True))
     masked = jnp.where(active, logits, -1.0e9)
     shifted = masked - jnp.max(masked)
     exp = jnp.where(active, jnp.exp(shifted), 0.0)
-    probabilities = exp / jnp.maximum(jnp.sum(exp), 1e-12)
-    return jnp.where(finite_active, probabilities, uniform)
+    return exp / jnp.maximum(jnp.sum(exp), 1e-12)
 
 
 def _cross_entropy_from_logits(logits: Array, label: Array) -> Array:
@@ -745,25 +775,19 @@ class AssociativeMemoryLearner:
             ],
             dtype=jnp.float32,
         )
-        accepted = (
-            jnp.all(jnp.isfinite(prediction.logits))
-            & jnp.all(jnp.isfinite(prediction.probabilities))
+        update_applied = (
+            floating_tree_is_finite(state)
+            & floating_tree_is_finite(prediction)
             & jnp.isfinite(loss)
-            & jnp.all(jnp.isfinite(next_state.values))
-            & jnp.all(jnp.isfinite(next_state.prior))
-            & jnp.all(jnp.isfinite(next_state.utility))
-            & jnp.isfinite(next_state.budget_logit)
+            & floating_tree_is_finite(next_state)
             & jnp.all(jnp.isfinite(metrics))
         )
-        committed = jax.lax.cond(accepted, lambda: next_state, lambda: state)
-        zero_metrics = jnp.zeros_like(metrics)
         return AssociativeMemoryUpdateResult(
-            state=committed,
-            predictions=jnp.where(
-                accepted, prediction.probabilities, jnp.zeros_like(prediction.probabilities)
-            ),
-            logits=jnp.where(accepted, prediction.logits, jnp.zeros_like(prediction.logits)),
-            metrics=jnp.where(accepted, metrics, zero_metrics),
+            state=select_transaction(update_applied, next_state, state),
+            predictions=neutralize_array(update_applied, prediction.probabilities),
+            logits=neutralize_array(update_applied, prediction.logits),
+            metrics=neutralize_array(update_applied, metrics),
+            update_applied=update_applied,
         )
 
 
@@ -778,12 +802,16 @@ def run_associative_memory_arrays(
     def step_fn(
         carry: AssociativeMemoryState,
         inputs: tuple[Array, Array],
-    ) -> tuple[AssociativeMemoryState, tuple[Array, Array]]:
+    ) -> tuple[AssociativeMemoryState, tuple[Array, Array, Array]]:
         context_t, label_t = inputs
         result = learner.update(carry, context_t, label_t)
-        return result.state, (result.predictions, result.metrics)
+        return result.state, (
+            result.predictions,
+            result.metrics,
+            result.update_applied,
+        )
 
-    final_state, (predictions, metrics) = jax.lax.scan(
+    final_state, (predictions, metrics, updates_applied) = jax.lax.scan(
         step_fn,
         state,
         (contexts, labels),
@@ -792,4 +820,5 @@ def run_associative_memory_arrays(
         state=final_state,
         predictions=predictions,
         metrics=metrics,
+        updates_applied=updates_applied,
     )

--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -177,19 +177,19 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
         raise ValueError("unknown feature_family")
     if config.max_features < 1:
         raise ValueError("max_features must be positive")
-    if config.write_lr <= 0.0:
+    if not math.isfinite(config.write_lr) or config.write_lr <= 0.0:
         raise ValueError("write_lr must be positive")
-    if not 0.0 <= config.retention <= 1.0:
+    if not math.isfinite(config.retention) or not 0.0 <= config.retention <= 1.0:
         raise ValueError("retention must be in [0, 1]")
-    if config.utility_lr < 0.0:
+    if not math.isfinite(config.utility_lr) or config.utility_lr < 0.0:
         raise ValueError("utility_lr must be non-negative")
-    if not 0.0 <= config.utility_decay <= 1.0:
+    if not math.isfinite(config.utility_decay) or not 0.0 <= config.utility_decay <= 1.0:
         raise ValueError("utility_decay must be in [0, 1]")
-    if config.min_weight <= 0.0:
+    if not math.isfinite(config.min_weight) or config.min_weight <= 0.0:
         raise ValueError("min_weight must be positive")
-    if config.max_weight < config.min_weight:
+    if not math.isfinite(config.max_weight) or config.max_weight < config.min_weight:
         raise ValueError("max_weight must be >= min_weight")
-    if config.logit_scale <= 0.0:
+    if not math.isfinite(config.logit_scale) or config.logit_scale <= 0.0:
         raise ValueError("logit_scale must be positive")
     if config.scope_lr < 0.0:
         raise ValueError("scope_lr must be non-negative")
@@ -206,9 +206,12 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
 
 
 def _softmax(logits: Array) -> Array:
+    finite = jnp.all(jnp.isfinite(logits))
     shifted = logits - jnp.max(logits)
     exp = jnp.exp(shifted)
-    return exp / jnp.maximum(jnp.sum(exp), 1e-12)
+    probabilities = exp / jnp.maximum(jnp.sum(exp), 1e-12)
+    uniform = jnp.full_like(probabilities, 1.0 / probabilities.shape[0])
+    return jnp.where(finite, probabilities, uniform)
 
 
 def _masked_softmax(logits: Array, mask: Array) -> Array:
@@ -465,7 +468,13 @@ class AssociativeMemoryLearner:
         window_scope, window_probs = self._window_scope_weights(state)
         scope_weights = family_scope * window_scope * mask.astype(jnp.float32)
         weights = base_weights * scope_weights
-        evidence = jnp.sum(weights[:, None] * row_values, axis=0)
+        weight_col = weights[:, None]
+        # Silent features have weight 0. An inf stored value times that
+        # weight is 0*inf = NaN. Skip the product on exact zeros.
+        evidence = jnp.sum(
+            jnp.where(weight_col == 0.0, jnp.zeros_like(row_values), weight_col * row_values),
+            axis=0,
+        )
         # The decayed label-frequency prior enters with a small fixed weight:
         # it dominates only when no feature rows match (evidence is zero, so
         # the prediction falls back to base rates) and is otherwise a weak
@@ -731,11 +740,25 @@ class AssociativeMemoryLearner:
             ],
             dtype=jnp.float32,
         )
+        accepted = (
+            jnp.all(jnp.isfinite(prediction.logits))
+            & jnp.all(jnp.isfinite(prediction.probabilities))
+            & jnp.isfinite(loss)
+            & jnp.all(jnp.isfinite(next_state.values))
+            & jnp.all(jnp.isfinite(next_state.prior))
+            & jnp.all(jnp.isfinite(next_state.utility))
+            & jnp.isfinite(next_state.budget_logit)
+            & jnp.all(jnp.isfinite(metrics))
+        )
+        committed = jax.lax.cond(accepted, lambda: next_state, lambda: state)
+        zero_metrics = jnp.zeros_like(metrics)
         return AssociativeMemoryUpdateResult(
-            state=next_state,
-            predictions=prediction.probabilities,
-            logits=prediction.logits,
-            metrics=metrics,
+            state=committed,
+            predictions=jnp.where(
+                accepted, prediction.probabilities, jnp.zeros_like(prediction.probabilities)
+            ),
+            logits=jnp.where(accepted, prediction.logits, jnp.zeros_like(prediction.logits)),
+            metrics=jnp.where(accepted, metrics, zero_metrics),
         )
 
 

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -69,6 +69,27 @@ def test_silent_feature_does_not_turn_inf_value_into_nan() -> None:
     chex.assert_trees_all_close(result.state.values, poisoned.values)
 
 
+def test_masked_family_softmax_stays_finite_on_inf_logits() -> None:
+    """All-inf family logits minus their max is inf-inf = NaN."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=3,
+            suffix_length=2,
+            max_features=8,
+            adaptive_feature_family=True,
+        )
+    )
+    state = learner.init().replace(
+        family_logits=jnp.full((2,), jnp.inf, dtype=jnp.float32)
+    )
+    context = jnp.asarray([1, 2, 3], dtype=jnp.int32)
+    prediction = learner.predict(state, context)
+    chex.assert_tree_all_finite(prediction.logits)
+    chex.assert_tree_all_finite(prediction.probabilities)
+    assert float(jnp.sum(prediction.probabilities)) == pytest.approx(1.0)
+
+
 def test_associative_prediction_is_before_write() -> None:
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(vocab_size=5, block_size=4, suffix_length=3)

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="attr-defined"
 """Tests for the Step 2 fixed-budget associative memory."""
 
 import math
@@ -47,6 +48,44 @@ def test_config_rejects_infinite_write_lr() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "invalid_values"),
+    [
+        (
+            "scope_lr",
+            (float("nan"), float("inf"), float("-inf"), -0.01, True, "0.1"),
+        ),
+        (
+            "budget_lr",
+            (float("nan"), float("inf"), float("-inf"), -0.01, True, "0.1"),
+        ),
+        (
+            "initial_budget_fraction",
+            (float("nan"), float("inf"), float("-inf"), 0.0, 1.01, True, "0.5"),
+        ),
+        (
+            "scope_logit_clip",
+            (float("nan"), float("inf"), float("-inf"), 0.0, True, "8.0"),
+        ),
+        ("min_effective_budget", (float("nan"), 1.5, True, "1")),
+        ("adaptive_feature_family", (0, 1, "yes")),
+        ("adaptive_window", (0, 1, "yes")),
+        ("adaptive_budget", (0, 1, "yes")),
+    ],
+)
+def test_config_rejects_invalid_adaptive_scalars(
+    field: str,
+    invalid_values: tuple[object, ...],
+) -> None:
+    base = AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2)
+
+    for invalid in invalid_values:
+        payload = base.to_config()
+        payload[field] = invalid
+        with pytest.raises(ValueError, match=field):
+            AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
+
+
 def test_silent_feature_does_not_turn_inf_value_into_nan() -> None:
     """Weight 0 times an inf stored row is 0*inf = NaN in the evidence sum."""
     learner = AssociativeMemoryLearner(
@@ -66,11 +105,15 @@ def test_silent_feature_does_not_turn_inf_value_into_nan() -> None:
     assert float(jnp.sum(prediction.probabilities)) == pytest.approx(1.0)
 
     result = learner.update(poisoned, context, jnp.asarray(1, dtype=jnp.int32))
-    chex.assert_trees_all_close(result.state.values, poisoned.values)
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, poisoned)
+    chex.assert_trees_all_equal(result.predictions, jnp.zeros_like(result.predictions))
+    chex.assert_trees_all_equal(result.logits, jnp.zeros_like(result.logits))
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
 
 
-def test_masked_family_softmax_stays_finite_on_inf_logits() -> None:
-    """All-inf family logits minus their max is inf-inf = NaN."""
+def test_corrupted_active_family_logits_remain_fail_visible() -> None:
+    """An invalid active gate must not masquerade as a uniform valid gate."""
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(
             vocab_size=4,
@@ -80,14 +123,90 @@ def test_masked_family_softmax_stays_finite_on_inf_logits() -> None:
             adaptive_feature_family=True,
         )
     )
-    state = learner.init().replace(
-        family_logits=jnp.full((2,), jnp.inf, dtype=jnp.float32)
-    )
+    state = learner.init().replace(family_logits=jnp.full((2,), jnp.inf, dtype=jnp.float32))
     context = jnp.asarray([1, 2, 3], dtype=jnp.int32)
     prediction = learner.predict(state, context)
-    chex.assert_tree_all_finite(prediction.logits)
-    chex.assert_tree_all_finite(prediction.probabilities)
-    assert float(jnp.sum(prediction.probabilities)) == pytest.approx(1.0)
+
+    assert not bool(jnp.all(jnp.isfinite(prediction.family_probs)))
+    result = learner.update(state, context, jnp.asarray(1, dtype=jnp.int32))
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+
+
+@pytest.mark.parametrize(
+    "leaf",
+    [
+        "values",
+        "utility",
+        "counts",
+        "prior",
+        "family_logits",
+        "window_logits",
+        "budget_logit",
+    ],
+)
+def test_update_rejects_nonfinite_source_state_leaf(leaf: str) -> None:
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=3,
+            suffix_length=2,
+            max_features=8,
+            adaptive_feature_family=True,
+            adaptive_window=True,
+            adaptive_budget=True,
+        )
+    )
+    state = learner.init()
+    poison = jnp.asarray(jnp.nan, dtype=jnp.float32)
+    if leaf == "values":
+        state = state.replace(values=state.values.at[0, 0].set(poison))
+    elif leaf == "utility":
+        state = state.replace(utility=state.utility.at[0].set(poison))
+    elif leaf == "counts":
+        state = state.replace(counts=state.counts.at[0].set(poison))
+    elif leaf == "prior":
+        state = state.replace(prior=state.prior.at[0].set(poison))
+    elif leaf == "family_logits":
+        state = state.replace(family_logits=state.family_logits.at[0].set(poison))
+    elif leaf == "window_logits":
+        state = state.replace(window_logits=state.window_logits.at[0].set(poison))
+    else:
+        state = state.replace(budget_logit=poison)
+
+    result = learner.update(
+        state,
+        jnp.asarray([1, 2, 3], dtype=jnp.int32),
+        jnp.asarray(1, dtype=jnp.int32),
+    )
+
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_tree_all_finite((result.predictions, result.logits, result.metrics))
+    chex.assert_trees_all_equal(result.predictions, jnp.zeros_like(result.predictions))
+    chex.assert_trees_all_equal(result.logits, jnp.zeros_like(result.logits))
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
+
+
+def test_array_runner_exposes_rejected_update_mask() -> None:
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init().replace(
+        counts=learner.init().counts.at[0].set(jnp.asarray(jnp.inf, dtype=jnp.float32))
+    )
+    contexts = jnp.asarray([[1, 2, 3], [2, 3, 0]], dtype=jnp.int32)
+    labels = jnp.asarray([1, 2], dtype=jnp.int32)
+
+    result = run_associative_memory_arrays(learner, state, contexts, labels)
+
+    chex.assert_trees_all_equal(
+        result.updates_applied,
+        jnp.zeros((contexts.shape[0],), dtype=jnp.bool_),
+    )
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(result.predictions, jnp.zeros_like(result.predictions))
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
 
 
 def test_associative_prediction_is_before_write() -> None:
@@ -100,6 +219,7 @@ def test_associative_prediction_is_before_write() -> None:
     before = learner.predict(state, context)
     result = learner.update(state, context, jnp.asarray(2, dtype=jnp.int32))
 
+    assert bool(result.update_applied)
     chex.assert_trees_all_close(before.probabilities, jnp.full((5,), 0.2))
     chex.assert_trees_all_close(result.predictions, before.probabilities)
     assert int(result.state.step_count) == 1
@@ -148,6 +268,10 @@ def test_associative_memory_learns_repeated_binding() -> None:
 
     result = run_associative_memory_arrays(learner, learner.init(), contexts, labels)
     chex.assert_tree_all_finite((result.predictions, result.metrics))
+    chex.assert_trees_all_equal(
+        result.updates_applied,
+        jnp.ones((contexts.shape[0],), dtype=jnp.bool_),
+    )
 
     initial_nll = float(jnp.mean(result.metrics[:4, 0]))
     final_nll = float(jnp.mean(result.metrics[-4:, 0]))

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -35,6 +35,40 @@ def test_associative_config_roundtrip() -> None:
     chex.assert_shape(learner.init().keys, (31, 5))
 
 
+def test_config_rejects_infinite_write_lr() -> None:
+    with pytest.raises(ValueError, match="write_lr"):
+        AssociativeMemoryLearner(
+            AssociativeMemoryConfig(
+                vocab_size=4,
+                block_size=3,
+                suffix_length=2,
+                write_lr=float("inf"),
+            )
+        )
+
+
+def test_silent_feature_does_not_turn_inf_value_into_nan() -> None:
+    """Weight 0 times an inf stored row is 0*inf = NaN in the evidence sum."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    poisoned = state.replace(
+        values=state.values.at[0].set(jnp.full((4,), jnp.inf, dtype=jnp.float32))
+    )
+    context = jnp.asarray([1, 2, 3], dtype=jnp.int32)
+    raw = jnp.array([0.0], dtype=jnp.float32)[:, None] * poisoned.values[0][None, :]
+    assert not bool(jnp.all(jnp.isfinite(raw)))
+
+    prediction = learner.predict(poisoned, context)
+    chex.assert_tree_all_finite(prediction.logits)
+    chex.assert_tree_all_finite(prediction.probabilities)
+    assert float(jnp.sum(prediction.probabilities)) == pytest.approx(1.0)
+
+    result = learner.update(poisoned, context, jnp.asarray(1, dtype=jnp.int32))
+    chex.assert_trees_all_close(result.state.values, poisoned.values)
+
+
 def test_associative_prediction_is_before_write() -> None:
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(vocab_size=5, block_size=4, suffix_length=3)


### PR DESCRIPTION
## Summary\n- Skip exact zero-weight row contributions before multiplication, preventing inactive stored infinities from creating 0 * inf NaNs.\n- Reject non-finite or out-of-domain adaptive controller scalars, including non-boolean adaptive flags and non-integral effective budgets.\n- Treat an update as a fail-closed transaction: validate the complete floating source, prediction, and candidate trees; retain the source state and neutralize outputs when rejected.\n- Expose update_applied on one-step results and updates_applied through the scan runner.\n- Keep corrupted active family logits non-finite and fail-visible; they are no longer disguised as a uniform valid gate.\n\n## Validation\n- [x] 28 focused associative-memory tests\n- [x] 53 tests across associative memory, Step 2 theory invariants, and pipeline integration\n- [x] Ruff on the changed source and tests\n- [x] Repository-wide strict mypy: 163 source files\n\nOriginal contribution made with Cursor. Repair and adversarial validation completed by a maintainer.