### PR TITLE
Reject non-finite means before crowning a bar-plot winner

### DIFF
--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -208,10 +208,6 @@ def plot_final_performance_bars(
     except ImportError:
         raise ImportError("matplotlib is required. Install with: pip install matplotlib")
 
-    if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = cast("Figure", ax.figure)
     names = list(results.keys())
     if not names:
         raise ValueError("plot_final_performance_bars requires at least one result")
@@ -221,6 +217,11 @@ def plot_final_performance_bars(
     stds_arr = np.asarray(stds, dtype=np.float64)
     if not np.all(np.isfinite(means_arr)) or not np.all(np.isfinite(stds_arr)):
         raise ValueError("plot_final_performance_bars requires finite metric means and stds")
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = cast("Figure", ax.figure)
 
     # Default colors
     default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -213,8 +213,14 @@ def plot_final_performance_bars(
     else:
         fig = cast("Figure", ax.figure)
     names = list(results.keys())
+    if not names:
+        raise ValueError("plot_final_performance_bars requires at least one result")
     means = [results[name].summary[metric].mean for name in names]
     stds = [results[name].summary[metric].std for name in names]
+    means_arr = np.asarray(means, dtype=np.float64)
+    stds_arr = np.asarray(stds, dtype=np.float64)
+    if not np.all(np.isfinite(means_arr)) or not np.all(np.isfinite(stds_arr)):
+        raise ValueError("plot_final_performance_bars requires finite metric means and stds")
 
     # Default colors
     default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -218,6 +218,19 @@ def test_plot_final_performance_bars(results) -> None:
     assert [label.get_text() for label in ax.get_xticklabels()] == ["lms", "idbd"]
 
 
+def test_plot_final_performance_bars_rejects_nonfinite_mean(results) -> None:
+    """np.argmin treats NaN as the best bar, so a failed run would be crowned."""
+    poisoned = dict(results)
+    summary = results["lms"].summary["squared_error"]
+    poisoned["lms"] = results["lms"]._replace(
+        summary={
+            "squared_error": summary._replace(mean=float("nan")),
+        }
+    )
+    with pytest.raises(ValueError, match="finite metric means"):
+        plot_final_performance_bars(poisoned)
+
+
 def test_plot_step_size_evolution(results) -> None:
     fig, ax = plot_step_size_evolution(results)
     assert isinstance(fig, plt.Figure)

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -218,17 +218,34 @@ def test_plot_final_performance_bars(results) -> None:
     assert [label.get_text() for label in ax.get_xticklabels()] == ["lms", "idbd"]
 
 
-def test_plot_final_performance_bars_rejects_nonfinite_mean(results) -> None:
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("mean", float("nan")), ("std", float("inf"))],
+)
+def test_plot_final_performance_bars_rejects_nonfinite_statistic_without_figure(
+    results, field: str, value: float
+) -> None:
     """np.argmin treats NaN as the best bar, so a failed run would be crowned."""
     poisoned = dict(results)
     summary = results["lms"].summary["squared_error"]
     poisoned["lms"] = results["lms"]._replace(
         summary={
-            "squared_error": summary._replace(mean=float("nan")),
+            "squared_error": summary._replace(**{field: value}),
         }
     )
-    with pytest.raises(ValueError, match="finite metric means"):
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="finite metric means and stds"):
         plot_final_performance_bars(poisoned)
+    assert tuple(plt.get_fignums()) == before
+
+
+def test_plot_final_performance_bars_rejects_empty_results_without_figure() -> None:
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="at least one result"):
+        plot_final_performance_bars({})
+    assert tuple(plt.get_fignums()) == before
 
 
 def test_plot_step_size_evolution(results) -> None:


### PR DESCRIPTION
## Summary
- `plot_final_performance_bars` used `numpy.argmin` on method means. A NaN mean is treated as the minimum, so a failed run was drawn as the best method and given the gold outline.
- Empty result maps and non-finite means or stds now raise `ValueError` before any bar is marked.
- Finite publication fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_utils_smoke.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/utils/visualization.py tests/test_utils_smoke.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)