### PR TITLE
Do not form 0*inf history traces at decay 0

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -30,6 +30,7 @@ nexting work.
 from __future__ import annotations
 
 import functools
+import math
 from typing import Any
 
 import chex
@@ -115,9 +116,9 @@ class HistoryFeatureExtractor:
             include_raw: If True (default), the raw observation is
                 concatenated to the front of the augmented observation.
         """
-        if any((b < 0.0) or (b >= 1.0) for b in decay_rates):
+        if any(not math.isfinite(b) or (b < 0.0) or (b >= 1.0) for b in decay_rates):
             raise ValueError(
-                f"decay_rates must lie in [0, 1); got {decay_rates}"
+                f"decay_rates must be finite and lie in [0, 1); got {decay_rates}"
             )
         if channels is None:
             channels = tuple(range(raw_dim))
@@ -195,8 +196,13 @@ class HistoryFeatureExtractor:
 
         # EMA decay per trace row
         decay = jnp.asarray(self._decay_rates, dtype=jnp.float32)[:, None]
-        proposed_traces = decay * state.traces + (1.0 - decay) * obs_tracked[None, :]
-        new_traces = jnp.where(observation_valid, proposed_traces, state.traces)
+        # decay=0 times an inf stored trace is 0*inf = NaN. Skip that product.
+        carried = jnp.where(decay == 0.0, jnp.zeros_like(state.traces), decay * state.traces)
+        proposed_traces = carried + (1.0 - decay) * obs_tracked[None, :]
+        traces_finite = jnp.all(jnp.isfinite(proposed_traces))
+        new_traces = jnp.where(
+            observation_valid & traces_finite, proposed_traces, state.traces
+        )
 
         # Flatten and concatenate
         flat_traces = new_traces.reshape(-1)

--- a/tests/test_history_features.py
+++ b/tests/test_history_features.py
@@ -52,6 +52,10 @@ class TestValidation:
         with pytest.raises(ValueError, match="decay_rates"):
             HistoryFeatureExtractor(raw_dim=4, decay_rates=(0.5, 1.0))
 
+    def test_invalid_decay_rate_nan(self) -> None:
+        with pytest.raises(ValueError, match="decay_rates"):
+            HistoryFeatureExtractor(raw_dim=4, decay_rates=(float("nan"), 0.9))
+
     def test_invalid_channel_index(self) -> None:
         with pytest.raises(ValueError, match="channels"):
             HistoryFeatureExtractor(raw_dim=4, channels=(0, 5))
@@ -181,6 +185,21 @@ class TestJitAndScan:
             recovered_state.traces,
             jnp.asarray([[2.5, 2.5], [0.58, 0.74]], dtype=jnp.float32),
         )
+
+    def test_zero_decay_does_not_multiply_inf_traces(self) -> None:
+        """decay=0 keeps only the current obs; 0 * inf stored traces is NaN."""
+        ex = HistoryFeatureExtractor(raw_dim=1, decay_rates=(0.0,), include_raw=False)
+        poisoned = HistoryFeatureState(
+            traces=jnp.asarray([[jnp.inf]], dtype=jnp.float32)
+        )  # type: ignore[call-arg]
+        observation = jnp.asarray([3.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * poisoned.traces
+        assert not bool(jnp.all(jnp.isfinite(raw)))
+
+        augmented, next_state = ex.step(poisoned, observation)
+        chex.assert_tree_all_finite((augmented, next_state))
+        chex.assert_trees_all_close(next_state.traces[0], observation)
+        chex.assert_trees_all_close(augmented, observation)
 
     def test_untracked_nonfinite_coordinate_holds_raw_disabled_traces(self) -> None:
         ex = HistoryFeatureExtractor(


### PR DESCRIPTION
## Summary
- History traces are `decay * previous + (1 - decay) * obs`. At `decay=0` an inf stored trace became 0*inf = NaN even when the new observation was finite.
- Zero-decay rows now skip that product and keep the current observation. Proposed traces that still overflow hold the previous state.
- NaN decay rates are rejected at construction. Finite EMA fixtures are bitwise unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_history_features.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/history_features.py tests/test_history_features.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)