### PR TITLE
Reject non-finite samples before publishing experiment summaries

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -128,6 +128,11 @@ def run_single_experiment(
     )
 
 
+def _require_finite_metric_array(arr: NDArray[np.float64], metric: str) -> None:
+    if arr.size == 0 or not np.all(np.isfinite(arr)):
+        raise ValueError(f"metric {metric!r} contains non-finite samples")
+
+
 def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
     """Aggregate results from multiple seeds into summary statistics.
 
@@ -142,6 +147,9 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
 
     Returns:
         AggregatedResults with aggregated metrics
+
+    Raises:
+        ValueError: If ``results`` is empty, or any metric sample is non-finite.
     """
     if not results:
         raise ValueError("Cannot aggregate empty results list")
@@ -160,6 +168,7 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
             values = np.array([m[key] for m in r.metrics_history])
             arrays.append(values)
         metric_arrays[key] = np.stack(arrays)
+        _require_finite_metric_array(metric_arrays[key], key)
 
     # Compute summary statistics for final values (mean of last 100 steps)
     summary: dict[str, MetricSummary] = {}
@@ -319,6 +328,7 @@ def get_metric_timeseries(
         one-seed aggregate has zero spread and therefore a point band.
     """
     arr = results.metric_arrays[metric]
+    _require_finite_metric_array(arr, metric)
     mean = np.mean(arr, axis=0)
     std = np.zeros_like(mean) if arr.shape[0] == 1 else np.std(arr, axis=0, ddof=1)
     return mean, mean - std, mean + std
@@ -342,11 +352,11 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-    Raises:
-        ValueError: If ``window`` is not positive, or a metric array has no
-            time steps. ``window=0`` is not "the last step": ``arr[:, -0:]``
-            is the full trace, so the helper refuses rather than silently
-            reporting a full-horizon mean.
+        Raises:
+        ValueError: If ``window`` is not positive, a metric array has no
+            time steps, or any metric sample is non-finite. ``window=0`` is
+            not "the last step": ``arr[:, -0:]`` is the full trace, so the
+            helper refuses rather than silently reporting a full-horizon mean.
     """
     if window <= 0:
         raise ValueError(f"window must be positive (got {window})")
@@ -359,6 +369,7 @@ def get_final_performance(
                 f"AggregatedResults {name!r} must contain at least one metric step "
                 f"for {metric!r}"
             )
+        _require_finite_metric_array(arr, metric)
         final_window = min(window, arr.shape[1])
         final_means = np.mean(arr[:, -final_window:], axis=1)
         std = float(np.std(final_means, ddof=1)) if len(final_means) > 1 else 0.0

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -9,11 +9,14 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.learners import LinearLearner
+from alberta_framework.core.optimizers import LMS
 from alberta_framework.streams.base import ScanStream
 from alberta_framework.streams.synthetic import RandomWalkStream
 from alberta_framework.utils.experiments import (
     AggregatedResults,
     ExperimentConfig,
+    SingleRunResult,
+    aggregate_metrics,
     get_final_performance,
     get_metric_timeseries,
     run_multi_seed_experiment,
@@ -243,3 +246,38 @@ def test_get_final_performance_positive_window_is_a_suffix() -> None:
     expected_values = np.asarray([2.5, 25.0], dtype=np.float64)
     assert result["candidate"][0] == pytest.approx(float(np.mean(expected_values)))
     assert result["candidate"][1] == pytest.approx(float(np.std(expected_values, ddof=1)))
+
+
+def _single_run(seed: int, values: list[float]) -> SingleRunResult:
+    learner = LinearLearner(optimizer=LMS(step_size=0.05))
+    return SingleRunResult(
+        config_name="candidate",
+        seed=seed,
+        metrics_history=[{"squared_error": value} for value in values],
+        final_state=learner.init(2),
+    )
+
+
+def test_aggregate_metrics_rejects_nonfinite_samples() -> None:
+    """A NaN seed mean would be published as the method's final performance."""
+    with pytest.raises(ValueError, match="non-finite samples"):
+        aggregate_metrics(
+            [
+                _single_run(0, [1.0, 2.0]),
+                _single_run(1, [3.0, float("nan")]),
+            ]
+        )
+
+
+def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:
+    poisoned = _two_seed_trace()
+    poisoned.metric_arrays["squared_error"][0, 1] = np.inf
+    with pytest.raises(ValueError, match="non-finite samples"):
+        get_metric_timeseries(poisoned)
+
+
+def test_get_final_performance_rejects_nonfinite_samples() -> None:
+    poisoned = _two_seed_trace()
+    poisoned.metric_arrays["squared_error"][1, -1] = np.nan
+    with pytest.raises(ValueError, match="non-finite samples"):
+        get_final_performance({"candidate": poisoned}, window=1)


### PR DESCRIPTION
## Summary
- `aggregate_metrics` averaged the last 100 steps even when a seed trace contained NaN or inf, so a crashed run became a published method mean.
- The same hole existed in `get_metric_timeseries` and `get_final_performance` for hand-built aggregates.
- Non-finite metric arrays now raise `ValueError`. Finite seed-matched fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_experiments_validation.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/utils/experiments.py tests/test_experiments_validation.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)