### PR TITLE
Do not form 0*inf stacked-Horde bootstraps at gamma 0

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -261,20 +261,25 @@ class StackedLinearHorde:
 
         v = state.weights @ features  # (n_demons,)
         v_next = state.weights @ next_features
-        raw_td_errors = cumulants + self._gammas * v_next - v
-        prediction_valid = jnp.isfinite(v) & jnp.isfinite(v_next)
+        # gamma=0 must not multiply an inf bootstrap (0*inf).
+        bootstrap = jnp.where(self._gammas == 0.0, 0.0, self._gammas * v_next)
+        raw_td_errors = cumulants + bootstrap - v
+        prediction_valid = jnp.isfinite(v) & (
+            (self._gammas == 0.0) | jnp.isfinite(v_next)
+        )
         channel_valid = (
             active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
         )
         safe_cumulants = jnp.where(channel_valid, cumulants, 0.0)
-        td_errors = safe_cumulants + self._gammas * v_next - v
+        td_errors = safe_cumulants + bootstrap - v
 
         # Per-decision IS with the ratio composed into the trace:
         # z_d = rho_d * (gamma_d * lamda_d * z_d + x).
         decay = (self._gammas * self._lamdas)[:, None]  # (n_demons, 1)
-        accumulated = decay * state.traces + features[None, :]
+        carried = jnp.where(decay == 0.0, jnp.zeros_like(state.traces), decay * state.traces)
+        accumulated = carried + features[None, :]
         # Inactive demons: trace decays but the current gradient is withheld.
-        decayed_only = decay * state.traces
+        decayed_only = carried
         safe_rho = jnp.where(rho_valid, rho_vec, 0.0)
         proposed_traces = safe_rho[:, None] * jnp.where(
             active[:, None], accumulated, decayed_only
@@ -285,25 +290,27 @@ class StackedLinearHorde:
             state.weights
             + cfg.step_size * masked_delta[:, None] * proposed_traces
         )
-        source_finite = (
-            jnp.all(jnp.isfinite(state.weights))
-            & jnp.all(jnp.isfinite(state.traces))
-        )
+        source_weights_finite = jnp.all(jnp.isfinite(state.weights))
+        traces_needed = decay[:, 0] != 0.0
+        traces_usable = (~traces_needed) | jnp.all(jnp.isfinite(state.traces), axis=1)
         shared_inputs_valid = (
             jnp.all(jnp.isfinite(features))
             & jnp.all(jnp.isfinite(next_features))
-            & source_finite
+            & source_weights_finite
         )
         candidate_finite = jnp.all(jnp.isfinite(proposed_weights), axis=1) & jnp.all(
             jnp.isfinite(proposed_traces), axis=1
         )
-        head_updates_applied = shared_inputs_valid & channel_valid & candidate_finite
+        head_updates_applied = (
+            shared_inputs_valid & channel_valid & candidate_finite & traces_usable
+        )
         inactive_trace_applied = (
             shared_inputs_valid
             & ~requested
             & rho_valid
             & prediction_valid
             & candidate_finite
+            & traces_usable
         )
         accepted_channels = head_updates_applied | inactive_trace_applied
         new_weights = jnp.where(

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -175,6 +175,34 @@ class TestExactSemantics:
         assert int(recovered.state.step_count) == 1
         assert bool(recovered.update_applied)
 
+    def test_zero_gamma_does_not_multiply_inf_bootstrap(self):
+        """gamma=0 * inf V(s') is 0*inf = NaN and would freeze a nexting demon."""
+        cfg = StackedHordeConfig(
+            n_demons=1,
+            feature_dim=2,
+            gammas=(0.0,),
+            lamdas=(0.0,),
+            cumulant_indices=(0,),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        huge = jnp.float32(1e38)
+        state = horde.init().replace(
+            weights=jnp.asarray([[huge, 0.0]], dtype=jnp.float32),
+            traces=jnp.asarray([[jnp.inf, jnp.inf]], dtype=jnp.float32),
+        )
+        x = jnp.asarray([0.0, 1.0], dtype=jnp.float32)
+        x_next = jnp.asarray([huge, 0.0], dtype=jnp.float32)
+        c = jnp.asarray([2.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+        assert not bool(jnp.isfinite(raw))
+
+        result = horde.update(state, x, x_next, c, rho=1.0)
+        chex.assert_tree_all_finite(result.state.traces)
+        chex.assert_tree_all_finite(result.td_errors)
+        assert bool(result.update_applied)
+        assert float(result.td_errors[0]) == pytest.approx(2.0)
+
 
 class TestConvergence:
     def test_three_state_cycle_analytic_fixed_point(self):


### PR DESCRIPTION
## Summary
- Stacked TD used `gamma * V(s')` and `gamma * lambda * z` even at gamma 0. An overflowing next value or inf stored trace became 0*inf = NaN and froze a nexting demon whose return is just the current cumulant.
- Zero-discount bootstraps and zero-decay traces skip those products. Finite V(s') is required only when gamma is nonzero.
- Existing rho 0*inf hold behavior and analytic cycle fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_stacked_horde.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/stacked_horde.py tests/test_stacked_horde.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)