### PR TITLE
Do not form 0*inf option bootstraps at termination

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -277,7 +277,13 @@ class OptionValueDurationLearner:
         cumulants = jnp.stack(
             (reward, jnp.array(1.0, dtype=jnp.float32)),
         )
-        td_targets = cumulants + continuation_discount * next_predictions
+        terminated = continuation_discount == 0.0
+        bootstrap = jnp.where(
+            terminated,
+            jnp.zeros_like(next_predictions),
+            continuation_discount * next_predictions,
+        )
+        td_targets = cumulants + bootstrap
         td_errors = td_targets - predictions
         step_sizes = jnp.array(
             [
@@ -290,9 +296,10 @@ class OptionValueDurationLearner:
             option_weights + step_sizes[:, None] * td_errors[:, None] * observation[None, :]
         )
         source_finite = jnp.all(jnp.isfinite(state.weights))
+        next_needed = continuation_discount != 0.0
         shared_inputs_valid = (
             jnp.all(jnp.isfinite(observation))
-            & jnp.all(jnp.isfinite(next_observation))
+            & ((~next_needed) | jnp.all(jnp.isfinite(next_observation)))
             & jnp.isfinite(continuation_discount)
             & (continuation_discount >= 0.0)
             & (continuation_discount <= 1.0)
@@ -329,7 +336,9 @@ class OptionValueDurationLearner:
                 head_updates_applied, predictions, jnp.zeros_like(predictions)
             ),
             next_predictions=jnp.where(
-                head_updates_applied, next_predictions, jnp.zeros_like(next_predictions)
+                head_updates_applied & (~terminated),
+                next_predictions,
+                jnp.zeros_like(next_predictions),
             ),
             td_targets=jnp.where(
                 head_updates_applied, td_targets, jnp.zeros_like(td_targets)

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -137,6 +137,40 @@ def test_termination_discount_zeros_bootstrap_and_no_average_reward_is_subtracte
     assert not hasattr(result.state, "average_reward")
 
 
+def test_termination_does_not_multiply_inf_next_prediction() -> None:
+    """gamma=0 * inf V(s') is 0*inf = NaN and would freeze both option heads."""
+    learner = OptionValueDurationLearner(
+        1,
+        OptionValueDurationConfig(
+            reward_step_size=0.1,
+            duration_step_size=0.0,
+        ),
+    )
+    state = learner.init(1).replace(  # type: ignore[attr-defined]
+        weights=jnp.array([[[2.0], [7.0]]], dtype=jnp.float32)
+    )
+    next_obs = jnp.array([jnp.inf], dtype=jnp.float32)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (jnp.array([2.0], dtype=jnp.float32) @ next_obs)
+    assert not bool(jnp.isfinite(raw))
+
+    result = learner.update(
+        state,
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(5.0, dtype=jnp.float32),
+        next_obs,
+        jnp.array(0.0, dtype=jnp.float32),
+    )
+
+    chex.assert_trees_all_close(
+        result.td_targets,
+        jnp.array([5.0, 1.0], dtype=jnp.float32),
+    )
+    chex.assert_tree_all_finite(result.state.weights)
+    chex.assert_tree_all_finite(result.next_predictions)
+    assert bool(result.update_applied)
+
+
 def test_reward_rate_prediction_preserves_raw_duration_and_floors_only_score() -> None:
     learner = OptionValueDurationLearner(
         2,


### PR DESCRIPTION
## Summary
- Option value/duration targets used `discount * V(s')` even at termination. An inf successor became 0*inf = NaN and froze both heads, even though the conventional target is just `[reward, 1]`.
- Zero discount now skips that product and does not require a finite next observation. Returned next-prediction diagnostics are zeroed on termination so inf does not leak.
- The existing finite large-successor termination fixture is unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_option_value_duration.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/option_value_duration.py tests/test_option_value_duration.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)