### PR TITLE
Do not form 0*inf actor-critic bootstraps at termination

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -342,7 +342,10 @@ class ActorCriticAgent:
             else:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
-        bootstrap = discount * next_value
+        # Terminal 0 * inf V(s') is NaN and would freeze the critic.
+        bootstrap = jnp.where(
+            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
+        )
         td_error = reward + bootstrap - value
 
         one_hot = jax.nn.one_hot(action, cfg.n_actions, dtype=jnp.float32)
@@ -351,10 +354,38 @@ class ActorCriticAgent:
 
         actor_decay = discount * cfg.actor_lamda
         critic_decay = discount * cfg.critic_lamda
-        actor_trace_weights = actor_decay * state.actor_trace_weights + actor_grad_weights
-        actor_trace_bias = actor_decay * state.actor_trace_bias + actor_grad_bias
-        critic_trace_weights = critic_decay * state.critic_trace_weights + prev_obs
-        critic_trace_bias = critic_decay * state.critic_trace_bias + 1.0
+        actor_trace_weights = (
+            jnp.where(
+                actor_decay == 0.0,
+                jnp.zeros_like(state.actor_trace_weights),
+                actor_decay * state.actor_trace_weights,
+            )
+            + actor_grad_weights
+        )
+        actor_trace_bias = (
+            jnp.where(
+                actor_decay == 0.0,
+                jnp.zeros_like(state.actor_trace_bias),
+                actor_decay * state.actor_trace_bias,
+            )
+            + actor_grad_bias
+        )
+        critic_trace_weights = (
+            jnp.where(
+                critic_decay == 0.0,
+                jnp.zeros_like(state.critic_trace_weights),
+                critic_decay * state.critic_trace_weights,
+            )
+            + prev_obs
+        )
+        critic_trace_bias = (
+            jnp.where(
+                critic_decay == 0.0,
+                jnp.zeros_like(state.critic_trace_bias),
+                critic_decay * state.critic_trace_bias,
+            )
+            + 1.0
+        )
 
         actor_steps: tuple[Array, ...] = (
             cfg.actor_step_size * actor_trace_weights,
@@ -417,7 +448,7 @@ class ActorCriticAgent:
             & (action < cfg.n_actions)
             & jnp.all(jnp.isfinite(old_policy))
             & jnp.isfinite(value)
-            & jnp.isfinite(next_value)
+            & ((discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(actor_metric)
             & jnp.isfinite(critic_metric)
         )
@@ -461,7 +492,9 @@ class ActorCriticAgent:
             ),
             policy=jnp.where(params_ok, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(params_ok, next_value, zero),
+            next_value=jnp.where(
+                params_ok & jnp.isfinite(next_value), next_value, zero
+            ),
             td_error=jnp.where(params_ok, td_error, zero),
             bound_metric=jnp.where(
                 params_ok, (actor_metric + critic_metric) / 2.0, zero
@@ -939,7 +972,10 @@ class ContinuousActorCriticAgent:
             else:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
-        bootstrap = discount * next_value
+        # Terminal 0 * inf V(s') is NaN and would freeze the critic.
+        bootstrap = jnp.where(
+            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
+        )
         td_error = reward + bootstrap - value
 
         sigma_sq = prev_sigma * prev_sigma + 1e-8
@@ -953,11 +989,46 @@ class ContinuousActorCriticAgent:
 
         actor_decay = discount * cfg.actor_lamda
         critic_decay = discount * cfg.critic_lamda
-        mean_trace_weights = actor_decay * state.mean_trace_weights + mean_grad_weights
-        mean_trace_bias = actor_decay * state.mean_trace_bias + mean_grad_bias
-        log_sigma_trace = actor_decay * state.log_sigma_trace + log_sigma_grad
-        critic_trace_weights = critic_decay * state.critic_trace_weights + prev_obs
-        critic_trace_bias = critic_decay * state.critic_trace_bias + 1.0
+        mean_trace_weights = (
+            jnp.where(
+                actor_decay == 0.0,
+                jnp.zeros_like(state.mean_trace_weights),
+                actor_decay * state.mean_trace_weights,
+            )
+            + mean_grad_weights
+        )
+        mean_trace_bias = (
+            jnp.where(
+                actor_decay == 0.0,
+                jnp.zeros_like(state.mean_trace_bias),
+                actor_decay * state.mean_trace_bias,
+            )
+            + mean_grad_bias
+        )
+        log_sigma_trace = (
+            jnp.where(
+                actor_decay == 0.0,
+                jnp.zeros_like(state.log_sigma_trace),
+                actor_decay * state.log_sigma_trace,
+            )
+            + log_sigma_grad
+        )
+        critic_trace_weights = (
+            jnp.where(
+                critic_decay == 0.0,
+                jnp.zeros_like(state.critic_trace_weights),
+                critic_decay * state.critic_trace_weights,
+            )
+            + prev_obs
+        )
+        critic_trace_bias = (
+            jnp.where(
+                critic_decay == 0.0,
+                jnp.zeros_like(state.critic_trace_bias),
+                critic_decay * state.critic_trace_bias,
+            )
+            + 1.0
+        )
 
         actor_steps: tuple[Array, ...] = (
             cfg.actor_step_size * mean_trace_weights,
@@ -1028,7 +1099,7 @@ class ContinuousActorCriticAgent:
             & jnp.all(jnp.isfinite(prev_mean))
             & jnp.all(jnp.isfinite(prev_sigma))
             & jnp.isfinite(value)
-            & jnp.isfinite(next_value)
+            & ((discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(actor_metric)
             & jnp.isfinite(critic_metric)
         )
@@ -1071,7 +1142,9 @@ class ContinuousActorCriticAgent:
             mean=jnp.where(params_ok, next_mean, jnp.zeros_like(next_mean)),
             sigma=jnp.where(params_ok, next_sigma, jnp.zeros_like(next_sigma)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(params_ok, next_value, zero),
+            next_value=jnp.where(
+                params_ok & jnp.isfinite(next_value), next_value, zero
+            ),
             td_error=jnp.where(params_ok, td_error, zero),
             bound_metric=jnp.where(
                 params_ok, (actor_metric + critic_metric) / 2.0, zero

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -399,6 +399,33 @@ def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> Non
     assert bool(recovered.update_applied)
 
 
+def test_actor_critic_terminal_does_not_multiply_inf_next_value() -> None:
+    """gamma=0 * inf V(s') is 0*inf = NaN and would freeze a terminal update."""
+    agent = ActorCriticAgent(
+        ActorCriticConfig(n_actions=2, actor_step_size=0.1, critic_step_size=0.1)
+    )
+    huge = jnp.float32(1e38)
+    state = agent.init(feature_dim=2, key=jr.key(1)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+        critic_weights=jnp.array([huge, 0.0], dtype=jnp.float32),
+        critic_bias=jnp.array(0.0, dtype=jnp.float32),
+    )
+    next_obs = jnp.array([huge, 0.0], dtype=jnp.float32)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+    assert not bool(jnp.isfinite(raw))
+
+    result = agent.update(
+        state,
+        reward=jnp.array(3.0, dtype=jnp.float32),
+        observation=next_obs,
+        terminated=jnp.array(True),
+    )
+    assert bool(result.update_applied)
+    chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+    _assert_actor_critic_numeric_state_finite(result.state)
+
+
 def test_actor_critic_exports() -> None:
     assert TopLevelActorCriticAgent is ActorCriticAgent
     assert CoreActorCriticAgent is ActorCriticAgent

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -365,3 +365,34 @@ def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> 
     assert bool(jnp.all(jnp.isfinite(recovered.state.mean_weights)))
     assert bool(jnp.all(jnp.isfinite(recovered.state.critic_weights)))
     assert bool(recovered.update_applied)
+
+
+def test_continuous_actor_critic_terminal_does_not_multiply_inf_next_value() -> None:
+    """gamma=0 * inf V(s') is 0*inf = NaN and would freeze a terminal update."""
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=1,
+            actor_step_size=0.1,
+            critic_step_size=0.1,
+        )
+    )
+    huge = jnp.float32(1e38)
+    state = agent.init(feature_dim=2, key=jr.key(1)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        last_action=jnp.array([0.0], dtype=jnp.float32),
+        critic_weights=jnp.array([huge, 0.0], dtype=jnp.float32),
+        critic_bias=jnp.array(0.0, dtype=jnp.float32),
+    )
+    next_obs = jnp.array([huge, 0.0], dtype=jnp.float32)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+    assert not bool(jnp.isfinite(raw))
+
+    result = agent.update(
+        state,
+        reward=jnp.array(3.0, dtype=jnp.float32),
+        observation=next_obs,
+        terminated=jnp.array(True),
+    )
+    assert bool(result.update_applied)
+    chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+    _assert_continuous_actor_critic_state_finite(result.state)


### PR DESCRIPTION
## Summary
- Discrete and continuous actor-critic used `discount * V(s')` and `discount * lambda * z` even at termination. An overflowing next value became 0*inf = NaN and froze the whole transition.
- Zero discount now skips those products. Finite V(s') is required only when the discount is nonzero. Inf next-value diagnostics are not reported as if they were a real bootstrap.
- Existing finite terminal-trace and ObGD hold fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_actor_critic.py tests/test_continuous_actor_critic.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/actor_critic.py tests/test_actor_critic.py tests/test_continuous_actor_critic.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)