### PR TITLE
Do not form 0*inf independent-Horde bootstraps at gamma 0

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -520,17 +520,39 @@ class IndependentDemonHorde:
             old_wt = demon_state.traces[2 * i]
             grad_w = weight_grads[i]
             if replacing:
-                new_wt = jnp.where(grad_w != 0.0, grad_w, gamma_lamda * old_wt)
+                new_wt = jnp.where(
+                    grad_w != 0.0,
+                    grad_w,
+                    jnp.where(
+                        gamma_lamda == 0.0,
+                        jnp.zeros_like(old_wt),
+                        gamma_lamda * old_wt,
+                    ),
+                )
             else:
-                new_wt = gamma_lamda * old_wt + grad_w
+                carried = jnp.where(
+                    gamma_lamda == 0.0, jnp.zeros_like(old_wt), gamma_lamda * old_wt
+                )
+                new_wt = carried + grad_w
             new_traces.append(new_wt)
 
             old_bt = demon_state.traces[2 * i + 1]
             grad_b = bias_grads[i]
             if replacing:
-                new_bt = jnp.where(grad_b != 0.0, grad_b, gamma_lamda * old_bt)
+                new_bt = jnp.where(
+                    grad_b != 0.0,
+                    grad_b,
+                    jnp.where(
+                        gamma_lamda == 0.0,
+                        jnp.zeros_like(old_bt),
+                        gamma_lamda * old_bt,
+                    ),
+                )
             else:
-                new_bt = gamma_lamda * old_bt + grad_b
+                carried_b = jnp.where(
+                    gamma_lamda == 0.0, jnp.zeros_like(old_bt), gamma_lamda * old_bt
+                )
+                new_bt = carried_b + grad_b
             new_traces.append(new_bt)
 
         # 4. Per-parameter optimizer step from traces
@@ -747,8 +769,9 @@ class IndependentDemonHorde:
             ]
         )
 
-        # 2. TD targets: r + gamma * V(s')
-        targets = cumulants + gammas * next_preds  # NaN propagates as desired
+        # 2. TD targets: r + gamma * V(s'). gamma=0 must not multiply inf V(s').
+        bootstrap = jnp.where(gammas == 0.0, 0.0, gammas * next_preds)
+        targets = cumulants + bootstrap
 
         # 3. NaN means inactive; other non-finite values are rejected heads.
         requested_mask = ~jnp.isnan(cumulants)

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -227,6 +227,37 @@ class TestObgdApplyFinite:
         assert bool(jnp.all(recovered.head_updates_applied))
 
 
+class TestZeroGammaBootstrap:
+    def test_zero_gamma_does_not_multiply_inf_next_prediction(self) -> None:
+        """gamma=0 * inf V(s') is 0*inf = NaN and would freeze a nexting demon."""
+        spec = create_horde_spec(_make_all_gamma0_spec(1))
+        horde = IndependentDemonHorde(
+            horde_spec=spec,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+        huge = jnp.float32(1e38)
+        state = horde.init(2, jr.key(0))
+        ds = state.demon_states[0]
+        ds = ds.replace(
+            params=ds.params.replace(
+                weights=(jnp.asarray([[huge, 0.0]], dtype=jnp.float32),)
+            )
+        )
+        state = state.replace(demon_states=(ds,))
+        obs = jnp.asarray([0.0, 1.0], dtype=jnp.float32)
+        next_obs = jnp.asarray([huge, 0.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+        assert not bool(jnp.isfinite(raw))
+
+        result = horde.update(state, obs, jnp.asarray([3.0], dtype=jnp.float32), next_obs)
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(result.head_updates_applied, jnp.array([True]))
+        chex.assert_trees_all_close(result.td_errors, jnp.array([3.0], dtype=jnp.float32))
+        for w in result.state.demon_states[0].params.weights:  # type: ignore[attr-defined]
+            assert bool(jnp.all(jnp.isfinite(w)))
+
+
 # =============================================================================
 # gamma*lamda > 0 with hidden layers must NOT raise (the point of this class)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Independent demons used `gamma * V(s')` and `gamma * lambda * z` even at gamma 0. An overflowing next value became 0*inf = NaN and marked a nexting demon inactive.
- Zero-discount bootstraps and zero-decay traces skip those products. Finite-ObGD hold behavior is unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_independent_demon_horde.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/independent_demon_horde.py tests/test_independent_demon_horde.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)