### PR TITLE
Do not form 0*inf Horde actor-critic bootstraps at termination

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -75,6 +75,11 @@ def _commit_scan_safe_actor_state(
     return state, update_applied
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _rollback_critic_result(
     result: HordeUpdateResult,
     previous_state: MultiHeadMLPState,
@@ -446,7 +451,9 @@ class QHordeActorCriticAgent:
             if cfg.critic_target == "sampled_sarsa"
             else jnp.dot(next_policy, q_next)
         )
-        target = jnp.asarray(reward, dtype=jnp.float32) + effective_gamma * next_value
+        target = jnp.asarray(reward, dtype=jnp.float32) + _skip_zero_scale(
+            effective_gamma, next_value
+        )
         q_old = q_previous[safe_last_action]
         td_error = target - q_old
 
@@ -477,8 +484,12 @@ class QHordeActorCriticAgent:
         )
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
         actor_decay = effective_gamma * cfg.actor_lamda
-        actor_trace_weights = actor_decay * state.actor_trace_weights + actor_grad_weights
-        actor_trace_bias = actor_decay * state.actor_trace_bias + actor_grad_bias
+        actor_trace_weights = (
+            _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
+        )
+        actor_trace_bias = (
+            _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
+        )
         actor_scale = (
             jnp.array(1.0, dtype=jnp.float32)
             if cfg.actor_update == "expected_advantage"
@@ -526,7 +537,7 @@ class QHordeActorCriticAgent:
             & jnp.all(jnp.isfinite(old_policy))
             & jnp.all(jnp.isfinite(next_policy))
             & jnp.all(jnp.isfinite(q_previous))
-            & jnp.all(jnp.isfinite(q_next))
+            & ((effective_gamma == 0.0) | jnp.all(jnp.isfinite(q_next)))
             & jnp.isfinite(target)
             & jnp.isfinite(td_error)
             & jnp.isfinite(bound_metric)
@@ -808,8 +819,12 @@ class HordeActorCriticAgent:
         actor_grad_bias = (one_hot - old_policy) / cfg.temperature
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
         actor_decay = value_discount * cfg.actor_lamda
-        actor_trace_weights = actor_decay * state.actor_trace_weights + actor_grad_weights
-        actor_trace_bias = actor_decay * state.actor_trace_bias + actor_grad_bias
+        actor_trace_weights = (
+            _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
+        )
+        actor_trace_bias = (
+            _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
+        )
         actor_steps: tuple[Array, ...] = (
             cfg.actor_step_size * actor_trace_weights,
             cfg.actor_step_size * actor_trace_bias,
@@ -851,7 +866,7 @@ class HordeActorCriticAgent:
             & (value_discount <= 1.0)
             & jnp.all(jnp.isfinite(old_policy))
             & jnp.isfinite(value)
-            & jnp.isfinite(next_value)
+            & ((value_discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(td_error)
             & jnp.isfinite(bound_metric)
             & jnp.all(jnp.isfinite(next_policy))
@@ -1540,13 +1555,17 @@ class NonlinearHordeActorCriticAgent:
 
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):
-            new_trunk_traces.append(actor_decay * state.actor_trunk_traces[2 * i] + grad_trunk_w[i])
             new_trunk_traces.append(
-                actor_decay * state.actor_trunk_traces[2 * i + 1] + grad_trunk_b[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i])
+                + grad_trunk_w[i]
+            )
+            new_trunk_traces.append(
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1])
+                + grad_trunk_b[i]
             )
 
-        new_head_trace_w = actor_decay * state.actor_head_trace_w + grad_head_w
-        new_head_trace_b = actor_decay * state.actor_head_trace_b + grad_head_b
+        new_head_trace_w = _skip_zero_scale(actor_decay, state.actor_head_trace_w) + grad_head_w
+        new_head_trace_b = _skip_zero_scale(actor_decay, state.actor_head_trace_b) + grad_head_b
 
         # Per-weight Autostep updates: step = alpha_i * z_i; caller applies error * step
         new_trunk_opt_states: list[AutostepParamState] = []
@@ -1673,7 +1692,7 @@ class NonlinearHordeActorCriticAgent:
             & (value_discount >= 0.0)
             & (value_discount <= 1.0)
             & jnp.isfinite(value)
-            & jnp.isfinite(next_value)
+            & ((value_discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(td_error)
             & jnp.isfinite(bound_metric)
             & jnp.all(jnp.isfinite(next_policy))
@@ -2077,7 +2096,9 @@ class NonlinearQHordeActorCriticAgent:
             if cfg.critic_target == "sampled_sarsa"
             else jnp.dot(next_policy, q_next)
         )
-        target = jnp.asarray(reward, dtype=jnp.float32) + effective_gamma * next_value
+        target = jnp.asarray(reward, dtype=jnp.float32) + _skip_zero_scale(
+            effective_gamma, next_value
+        )
         td_error = target - q_previous[safe_last_action]
 
         cumulants = jnp.full(self._critic.n_demons, jnp.nan, dtype=jnp.float32)
@@ -2142,13 +2163,15 @@ class NonlinearQHordeActorCriticAgent:
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):
             new_trunk_traces.append(
-                actor_decay * state.actor_trunk_traces[2 * i] + grad_trunk_w[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i])
+                + grad_trunk_w[i]
             )
             new_trunk_traces.append(
-                actor_decay * state.actor_trunk_traces[2 * i + 1] + grad_trunk_b[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1])
+                + grad_trunk_b[i]
             )
-        new_head_trace_w = actor_decay * state.actor_head_trace_w + grad_head_w
-        new_head_trace_b = actor_decay * state.actor_head_trace_b + grad_head_b
+        new_head_trace_w = _skip_zero_scale(actor_decay, state.actor_head_trace_w) + grad_head_w
+        new_head_trace_b = _skip_zero_scale(actor_decay, state.actor_head_trace_b) + grad_head_b
 
         new_trunk_opt_states: list[AutostepParamState] = []
         trunk_w_steps: list[Array] = []
@@ -2267,7 +2290,7 @@ class NonlinearQHordeActorCriticAgent:
             & jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(next_policy))
             & jnp.all(jnp.isfinite(q_previous))
-            & jnp.all(jnp.isfinite(q_next))
+            & ((effective_gamma == 0.0) | jnp.all(jnp.isfinite(q_next)))
             & jnp.isfinite(target)
             & jnp.isfinite(td_error)
             & jnp.isfinite(bound_metric)

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -568,7 +568,9 @@ class QHordeActorCriticAgent:
                 update_applied, q_previous, jnp.zeros_like(q_previous)
             ),
             next_q_values=jnp.where(
-                update_applied, q_next, jnp.zeros_like(q_next)
+                update_applied & (effective_gamma != 0.0),
+                q_next,
+                jnp.zeros_like(q_next),
             ),
             target=jnp.where(update_applied, target, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),
@@ -895,7 +897,9 @@ class HordeActorCriticAgent:
                 update_applied, next_policy, jnp.zeros_like(next_policy)
             ),
             value=jnp.where(update_applied, value, 0.0),
-            next_value=jnp.where(update_applied, next_value, 0.0),
+            next_value=jnp.where(
+                update_applied & (value_discount != 0.0), next_value, 0.0
+            ),
             td_error=jnp.where(update_applied, td_error, 0.0),
             bound_metric=jnp.where(update_applied, bound_metric, 0.0),
             critic_result=committed_critic_result,
@@ -1722,7 +1726,9 @@ class NonlinearHordeActorCriticAgent:
                 update_applied, next_policy, jnp.zeros_like(next_policy)
             ),
             value=jnp.where(update_applied, value, 0.0),
-            next_value=jnp.where(update_applied, next_value, 0.0),
+            next_value=jnp.where(
+                update_applied & (value_discount != 0.0), next_value, 0.0
+            ),
             td_error=jnp.where(update_applied, td_error, 0.0),
             bound_metric=jnp.where(update_applied, bound_metric, 0.0),
             critic_result=committed_critic_result,
@@ -2322,7 +2328,9 @@ class NonlinearQHordeActorCriticAgent:
                 update_applied, q_previous, jnp.zeros_like(q_previous)
             ),
             next_q_values=jnp.where(
-                update_applied, q_next, jnp.zeros_like(q_next)
+                update_applied & (effective_gamma != 0.0),
+                q_next,
+                jnp.zeros_like(q_next),
             ),
             target=jnp.where(update_applied, target, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -421,7 +421,44 @@ def test_qhorde_terminal_does_not_multiply_inf_next_value() -> None:
     )
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+    chex.assert_trees_all_equal(result.next_q_values, jnp.zeros((2,), jnp.float32))
+    chex.assert_tree_all_finite(
+        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
+    )
+    chex.assert_tree_all_finite(
+        (result.policy, result.q_values, result.next_q_values, result.td_error)
+    )
     assert bool(jnp.all(jnp.isfinite(result.state.actor_weights)))
+
+
+def test_horde_zero_discount_neutralizes_inf_next_value_diagnostic() -> None:
+    agent = _make_agent()
+    huge = jnp.float32(1e38)
+    state = agent.init(feature_dim=2, key=jr.key(19)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+    poisoned_w = jnp.asarray([[huge, 0.0]], dtype=jnp.float32)
+    head_params = state.critic_state.head_params.replace(weights=(poisoned_w,))
+    state = state.replace(  # type: ignore[attr-defined]
+        critic_state=state.critic_state.replace(head_params=head_params)
+    )
+
+    result = agent.update(
+        state,
+        reward=jnp.array(3.0, dtype=jnp.float32),
+        observation=jnp.array([huge, 0.0], dtype=jnp.float32),
+        discount=jnp.array(0.0, dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    chex.assert_trees_all_equal(result.next_value, jnp.array(0.0, jnp.float32))
+    chex.assert_tree_all_finite(
+        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
+    )
+    chex.assert_tree_all_finite(
+        (result.policy, result.value, result.next_value, result.td_error)
+    )
 
 
 def test_qhorde_actor_critic_auxiliary_prediction_and_terminal_trace_reset() -> None:
@@ -647,6 +684,58 @@ def _init_nlhac(
     state = agent.init(feature_dim=OBS_DIM, key=jr.key(0))
     state, _, _ = agent.start(state, jnp.zeros(OBS_DIM))
     return state
+
+
+def test_nonlinear_horde_zero_discount_neutralizes_inf_next_value() -> None:
+    spec = create_horde_spec(
+        [
+            GVFSpec(  # type: ignore[call-arg]
+                name="value",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.9,
+                lamda=0.0,
+                cumulant_index=-1,
+            )
+        ]
+    )
+    critic = HordeLearner(
+        spec,
+        hidden_sizes=(),
+        step_size=0.1,
+        use_layer_norm=False,
+    )
+    agent = NonlinearHordeActorCriticAgent(
+        NonlinearHordeActorCriticConfig(
+            n_actions=2,
+            hidden_sizes=(),
+            actor_sparsity=0.0,
+        ),
+        critic,
+    )
+    huge = jnp.float32(1e38)
+    state = agent.init(2, jr.key(20))
+    state, _, _ = agent.start(state, jnp.array([0.0, 1.0], jnp.float32))
+    poisoned_w = jnp.asarray([[huge, 0.0]], dtype=jnp.float32)
+    head_params = state.critic_state.head_params.replace(weights=(poisoned_w,))
+    state = state.replace(  # type: ignore[attr-defined]
+        critic_state=state.critic_state.replace(head_params=head_params)
+    )
+
+    result = agent.update(
+        state,
+        jnp.array(3.0, jnp.float32),
+        jnp.array([huge, 0.0], jnp.float32),
+        discount=jnp.array(0.0, jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    chex.assert_trees_all_equal(result.next_value, jnp.array(0.0, jnp.float32))
+    chex.assert_tree_all_finite(
+        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
+    )
+    chex.assert_tree_all_finite(
+        (result.policy, result.value, result.next_value, result.td_error)
+    )
 
 
 class TestNonlinearHordeActorCriticConfig:
@@ -1139,6 +1228,60 @@ class TestNonlinearQHordeActorCritic:
         chex.assert_shape(result.q_values, (N_ACTIONS,))
         chex.assert_tree_all_finite(result.q_values)
         assert int(result.state.step_count) == 1
+
+    def test_terminal_neutralizes_inf_next_q_diagnostic(self) -> None:
+        demons = [
+            GVFSpec(  # type: ignore[call-arg]
+                name=f"q_{action}",
+                demon_type=DemonType.CONTROL,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=-1,
+            )
+            for action in range(2)
+        ]
+        critic = HordeLearner(
+            create_horde_spec(demons),
+            hidden_sizes=(),
+            step_size=0.1,
+            use_layer_norm=False,
+        )
+        agent = NonlinearQHordeActorCriticAgent(
+            NonlinearQHordeActorCriticConfig(
+                n_actions=2,
+                hidden_sizes=(),
+                actor_sparsity=0.0,
+            ),
+            critic,
+        )
+        huge = jnp.float32(1e38)
+        state = agent.init(2, jr.key(21))
+        state, _, _ = agent.start(state, jnp.array([0.0, 1.0], jnp.float32))
+        poisoned_w = jnp.asarray([[huge, 0.0]], dtype=jnp.float32)
+        head_params = state.critic_state.head_params.replace(
+            weights=(poisoned_w, poisoned_w)
+        )
+        state = state.replace(  # type: ignore[attr-defined]
+            critic_state=state.critic_state.replace(head_params=head_params)
+        )
+
+        result = agent.update(
+            state,
+            jnp.array(3.0, jnp.float32),
+            jnp.array([huge, 0.0], jnp.float32),
+            jnp.array(1.0, jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(
+            result.next_q_values, jnp.zeros((2,), jnp.float32)
+        )
+        chex.assert_tree_all_finite(
+            result.state.replace(rng_key=jr.key_data(result.state.rng_key))
+        )
+        chex.assert_tree_all_finite(
+            (result.policy, result.q_values, result.next_q_values, result.td_error)
+        )
 
     def test_infinite_reward_with_obgd_does_not_poison_actor(self) -> None:
         """Inf TD error zeros the ObGD step, then actor_signal*step is 0*inf=NaN."""

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -396,6 +396,34 @@ def test_qhorde_infinite_reward_with_obgd_does_not_poison_actor() -> None:
     assert bool(recovered.update_applied)
 
 
+def test_qhorde_terminal_does_not_multiply_inf_next_value() -> None:
+    """gamma=0 * inf Q(s', a') is 0*inf = NaN and would freeze a terminal update."""
+    agent = _make_qhorde_agent(n_actions=2)
+    huge = jnp.float32(1e38)
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+    poisoned_w = jnp.asarray([[huge, 0.0]], dtype=jnp.float32)
+    head_params = state.critic_state.head_params.replace(weights=(poisoned_w, poisoned_w))
+    state = state.replace(  # type: ignore[attr-defined]
+        critic_state=state.critic_state.replace(head_params=head_params)
+    )
+    next_obs = jnp.array([huge, 0.0], dtype=jnp.float32)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+    assert not bool(jnp.isfinite(raw))
+
+    result = agent.update(
+        state,
+        reward=jnp.array(3.0, dtype=jnp.float32),
+        observation=next_obs,
+        terminated=jnp.array(1.0, dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+    assert bool(jnp.all(jnp.isfinite(result.state.actor_weights)))
+
+
 def test_qhorde_actor_critic_auxiliary_prediction_and_terminal_trace_reset() -> None:
     agent = _make_qhorde_agent(n_actions=2, n_aux=1)
     state = agent.init(feature_dim=2, key=jr.key(11)).replace(  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Linear and MLP Horde actor-critics used `discount * V(s')` / `discount * Q(s', a')` and `discount * lambda * z` at termination. An overflowing next value became 0*inf = NaN and froze the outer transaction.
- Zero-discount bootstraps and traces now skip those products. Finite Q(s') / V(s') is required only when the discount is nonzero.
- Existing ObGD hold and terminal-trace-reset fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_horde_actor_critic.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/horde_actor_critic.py tests/test_horde_actor_critic.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)