### PR TITLE
Do not form 0*inf off-policy TD bootstraps at gamma 0

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -65,6 +65,11 @@ from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
 # =============================================================================
 # State / result types
 # =============================================================================
@@ -328,12 +333,12 @@ class OffPolicyTDLinearLearner:
 
         v_t = jnp.dot(state.weights, observation) + state.bias
         v_next = jnp.dot(state.weights, next_observation) + state.bias
-        td_error = reward_s + gamma_s * v_next - v_t
+        td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
         # IS-weighted accumulating eligibility trace
         decay = gamma_s * lam * rho_clipped
-        new_e = decay * state.eligibility_traces + observation
-        new_e_b = decay * state.bias_eligibility_trace + 1.0
+        new_e = _skip_zero_scale(decay, state.eligibility_traces) + observation
+        new_e_b = _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
 
         # Update with rho_clipped * delta * e
         scaled_update = alpha * rho_clipped * td_error
@@ -350,7 +355,7 @@ class OffPolicyTDLinearLearner:
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.isfinite(reward_s)
-            & jnp.all(jnp.isfinite(next_observation))
+            & ((gamma_s == 0.0) | jnp.all(jnp.isfinite(next_observation)))
             & jnp.isfinite(gamma_s)
             & jnp.isfinite(rho_s)
         )
@@ -504,14 +509,18 @@ class ETDLinearLearner:
 
         v_t = jnp.dot(state.weights, observation) + state.bias
         v_next = jnp.dot(state.weights, next_observation) + state.bias
-        td_error = reward_s + gamma_s * v_next - v_t
+        td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
-        follow_on = rho_s * gamma_s * state.follow_on_trace + interest_s
+        follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
         emphasis = lam * interest_s + (1.0 - lam) * follow_on
 
         trace_decay = gamma_s * lam
-        new_e = rho_s * (trace_decay * state.eligibility_traces + emphasis * observation)
-        new_e_b = rho_s * (trace_decay * state.bias_eligibility_trace + emphasis)
+        new_e = rho_s * (
+            _skip_zero_scale(trace_decay, state.eligibility_traces) + emphasis * observation
+        )
+        new_e_b = rho_s * (
+            _skip_zero_scale(trace_decay, state.bias_eligibility_trace) + emphasis
+        )
 
         proposed_state = ETDState(  # type: ignore[call-arg]
             weights=state.weights + alpha * td_error * new_e,
@@ -527,7 +536,7 @@ class ETDLinearLearner:
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.isfinite(reward_s)
-            & jnp.all(jnp.isfinite(next_observation))
+            & ((gamma_s == 0.0) | jnp.all(jnp.isfinite(next_observation)))
             & jnp.isfinite(gamma_s)
             & jnp.isfinite(rho_s)
             & jnp.isfinite(interest_s)
@@ -694,16 +703,18 @@ class GradientTDLinearLearner:
         next_phi = self._augment(next_observation)
         prediction = jnp.dot(state.weights, phi)
         next_prediction = jnp.dot(state.weights, next_phi)
-        td_error = reward_s + gamma_s * next_prediction - prediction
+        td_error = reward_s + _skip_zero_scale(gamma_s, next_prediction) - prediction
 
-        traces = rho_clipped * (phi + gamma_s * lam * state.eligibility_traces)
+        traces = rho_clipped * (
+            phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces)
+        )
         secondary_dot_trace = jnp.dot(state.secondary_weights, traces)
         secondary_dot_phi = jnp.dot(state.secondary_weights, phi)
 
-        primary_step = alpha * (
-            td_error * traces
-            - gamma_s * (1.0 - lam) * secondary_dot_trace * next_phi
+        bootstrap_correction = _skip_zero_scale(
+            gamma_s * (1.0 - lam) * secondary_dot_trace, next_phi
         )
+        primary_step = alpha * (td_error * traces - bootstrap_correction)
         secondary_step = beta * (td_error * traces - secondary_dot_phi * phi)
 
         proposed_state = GradientTDState(  # type: ignore[call-arg]
@@ -717,7 +728,7 @@ class GradientTDLinearLearner:
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.isfinite(reward_s)
-            & jnp.all(jnp.isfinite(next_observation))
+            & ((gamma_s == 0.0) | jnp.all(jnp.isfinite(next_observation)))
             & jnp.isfinite(gamma_s)
             & jnp.isfinite(rho_s)
         )

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -711,8 +711,12 @@ class GradientTDLinearLearner:
         secondary_dot_trace = jnp.dot(state.secondary_weights, traces)
         secondary_dot_phi = jnp.dot(state.secondary_weights, phi)
 
+        correction_coefficient = gamma_s * (1.0 - lam)
+        scaled_secondary_trace = _skip_zero_scale(
+            correction_coefficient, secondary_dot_trace
+        )
         bootstrap_correction = _skip_zero_scale(
-            gamma_s * (1.0 - lam) * secondary_dot_trace, next_phi
+            scaled_secondary_trace, next_phi
         )
         primary_step = alpha * (td_error * traces - bootstrap_correction)
         secondary_step = beta * (td_error * traces - secondary_dot_phi * phi)

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -655,6 +655,28 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
         chex.assert_tree_all_finite(result.state.weights)
 
+    def test_gradient_td_zero_gamma_branches_before_overflowing_correction(self) -> None:
+        learner = GradientTDLinearLearner(step_size=0.1, secondary_step_size=0.01)
+        state = learner.init(4).replace(  # type: ignore[attr-defined]
+            secondary_weights=jnp.ones((5,), dtype=jnp.float32)
+        )
+        observation = jnp.ones((4,), dtype=jnp.float32)
+        rho = jnp.array(1e38, dtype=jnp.float32)
+        traces = rho * jnp.ones((5,), dtype=jnp.float32)
+        assert not bool(jnp.isfinite(jnp.dot(state.secondary_weights, traces)))
+
+        result = learner.update(
+            state,
+            observation,
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.zeros((4,), dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            rho,
+        )
+
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state)
+
     def test_etd(self) -> None:
         learner = ETDLinearLearner(step_size=0.1, trace_decay=0.0)
         huge = jnp.float32(1e38)

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -629,3 +629,64 @@ class TestInfiniteRewardDoesNotPoisonWeights:
         chex.assert_tree_all_finite(recovered.state.weights)
         chex.assert_tree_all_finite(recovered.state.secondary_weights)
         assert bool(recovered.update_applied)
+
+
+class TestZeroGammaDoesNotMultiplyInfBootstrap:
+    def test_off_policy_td(self) -> None:
+        learner = OffPolicyTDLinearLearner(step_size=0.1, trace_decay=0.0)
+        huge = jnp.float32(1e38)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            weights=jnp.array([huge, 0.0], dtype=jnp.float32)
+        )
+        obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        nxt = jnp.array([huge, 0.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * (huge * huge)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            obs,
+            jnp.array(3.0, dtype=jnp.float32),
+            nxt,
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+        chex.assert_tree_all_finite(result.state.weights)
+
+    def test_etd(self) -> None:
+        learner = ETDLinearLearner(step_size=0.1, trace_decay=0.0)
+        huge = jnp.float32(1e38)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            weights=jnp.array([huge, 0.0], dtype=jnp.float32)
+        )
+        result = learner.update(
+            state,
+            jnp.array([0.0, 1.0], dtype=jnp.float32),
+            jnp.array(3.0, dtype=jnp.float32),
+            jnp.array([huge, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+        chex.assert_tree_all_finite(result.state.weights)
+
+    def test_gradient_td(self) -> None:
+        learner = GradientTDLinearLearner(step_size=0.1, secondary_step_size=0.01)
+        huge = jnp.float32(1e38)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            weights=jnp.array([huge, 0.0, 0.0], dtype=jnp.float32)
+        )
+        result = learner.update(
+            state,
+            jnp.array([0.0, 1.0], dtype=jnp.float32),
+            jnp.array(3.0, dtype=jnp.float32),
+            jnp.array([huge, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
+        chex.assert_tree_all_finite(result.state.weights)


### PR DESCRIPTION
## Summary
- Retrace TD, ETD, and Gradient-TD used `gamma * V(s')` and `gamma * z` even at gamma 0. An overflowing next value became 0*inf = NaN and froze the update, even though the target is the current reward.
- Zero-discount bootstraps, traces, follow-on, and TDC next-feature corrections skip those products. Finite V(s') is required only when gamma is nonzero.
- Existing inf-reward hold fixtures are unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_off_policy_td.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/off_policy_td.py tests/test_off_policy_td.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)