### PR TITLE
Skip SARSA 0*inf bootstrap and inactive-head trace decay

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -505,9 +505,16 @@ class SARSAAgent:
         )[:n_actions]
 
         # SARSA target: r + gamma * Q(s', a') with terminal handling.
-        # A terminal transition must not multiply Q(s', a'); 0 * inf is NaN.
+        # A terminal or zero-gamma transition must not multiply Q(s', a');
+        # jnp.where still evaluates 0 * inf, which is NaN.
         q_sa_next = q_next[next_action]
-        bootstrap = jnp.where(terminated, 0.0, gamma * q_sa_next)
+        gamma_arr = jnp.asarray(gamma, dtype=q_sa_next.dtype)
+        skip_bootstrap = (terminated != 0) | (gamma_arr == 0.0)
+        bootstrap = jnp.where(
+            skip_bootstrap,
+            jnp.zeros_like(q_sa_next),
+            gamma_arr * q_sa_next,
+        )
         sarsa_target = reward + bootstrap
 
         # Build cumulants: NaN for all except last_action gets sarsa_target
@@ -544,8 +551,14 @@ class SARSAAgent:
             for i in range(n_actions):
                 w_trace, b_trace = head_traces[i]
                 decay = jnp.where(state.last_action == i, 1.0, gl)
-                new_w = jnp.where(terminated, jnp.zeros_like(w_trace), decay * w_trace)
-                new_b = jnp.where(terminated, jnp.zeros_like(b_trace), decay * b_trace)
+                skipped_w = jnp.where(
+                    decay == 0.0, jnp.zeros_like(w_trace), decay * w_trace
+                )
+                skipped_b = jnp.where(
+                    decay == 0.0, jnp.zeros_like(b_trace), decay * b_trace
+                )
+                new_w = jnp.where(terminated, jnp.zeros_like(w_trace), skipped_w)
+                new_b = jnp.where(terminated, jnp.zeros_like(b_trace), skipped_b)
                 head_traces[i] = (new_w, new_b)
             new_learner_state = new_learner_state.replace(head_traces=tuple(head_traces))
 

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -277,6 +277,65 @@ class TestSARSAUpdate:
         q_old = agent.horde.predict(state.learner_state, obs)[0]
         chex.assert_trees_all_close(result.td_error, jnp.float32(1.0) - q_old)
 
+    def test_zero_gamma_inf_next_q_is_not_nan_td_error(self) -> None:
+        """Continuing 0 * inf Q(s', a') is NaN when gamma is exactly 0.
+
+        jnp.where still evaluates both branches, so skip the product when
+        gamma is 0 rather than selecting after 0 * inf.
+        """
+        agent = _make_agent(n_actions=2, gamma=0.0, epsilon_start=0.0, hidden_sizes=())
+        state = agent.init(feature_dim=2, key=jr.key(0))
+        obs = jnp.ones(2, dtype=jnp.float32)
+        state = state.replace(  # type: ignore[attr-defined]
+            last_action=jnp.array(0, dtype=jnp.int32),
+            last_observation=obs,
+        )
+        result = agent.update(
+            state,
+            reward=jnp.array(1.0, dtype=jnp.float32),
+            observation=jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+            terminated=jnp.array(False),
+            next_action=jnp.array(0, dtype=jnp.int32),
+        )
+        assert bool(jnp.isfinite(result.td_error))
+        q_old = agent.horde.predict(state.learner_state, obs)[0]
+        chex.assert_trees_all_close(result.td_error, jnp.float32(1.0) - q_old)
+
+    def test_zero_gamma_does_not_decay_inf_inactive_traces(self) -> None:
+        """Inactive-head decay is gamma*lamda; 0 * inf traces is NaN."""
+        agent = _make_agent(
+            n_actions=2,
+            hidden_sizes=(),
+            gamma=0.0,
+            epsilon_start=0.0,
+            lamda=0.8,
+        )
+        state = agent.init(feature_dim=2, key=jr.key(1))
+        obs = jnp.ones(2, dtype=jnp.float32)
+        inf_w = jnp.full_like(state.learner_state.head_traces[1][0], jnp.inf)
+        inf_b = jnp.full_like(state.learner_state.head_traces[1][1], jnp.inf)
+        traces = list(state.learner_state.head_traces)
+        traces[1] = (inf_w, inf_b)
+        state = state.replace(  # type: ignore[attr-defined]
+            last_action=jnp.array(0, dtype=jnp.int32),
+            last_observation=obs,
+            learner_state=state.learner_state.replace(head_traces=tuple(traces)),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+        result = agent.update(
+            state,
+            reward=jnp.array(0.5, dtype=jnp.float32),
+            observation=obs * 0.5,
+            terminated=jnp.array(False),
+            next_action=jnp.array(0, dtype=jnp.int32),
+        )
+        w_trace, b_trace = result.state.learner_state.head_traces[1]
+        assert bool(jnp.all(jnp.isfinite(w_trace)))
+        assert bool(jnp.all(jnp.isfinite(b_trace)))
+        chex.assert_trees_all_close(w_trace, jnp.zeros_like(w_trace))
+        chex.assert_trees_all_close(b_trace, jnp.zeros_like(b_trace))
+
 
     def test_nan_masking(self):
         """Only the taken action's head receives a weight update."""


### PR DESCRIPTION
## Summary
- Terminal SARSA already skipped `Q(s', a')`, but `jnp.where(terminated, 0, gamma * Q)` still evaluates `0 * inf` when gamma is 0 on a continuing step.
- Inactive control-head traces decay by `gamma * lamda`. That product is also NaN when gamma is 0 and a stored trace is infinite.
- Skip both products before writing zeros. Terminal inf-next-Q behavior is unchanged.

## Test plan
- [x] `test_zero_gamma_inf_next_q_is_not_nan_td_error`
- [x] `test_zero_gamma_does_not_decay_inf_inactive_traces`
- [x] `test_terminated_inf_next_q_is_not_nan_td_error`
- [x] `tests/test_sarsa.py` (38 passed, 2 skipped)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)