### PR TITLE
Skip MLPLearner 0*inf eligibility-trace decay

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -1404,14 +1404,14 @@ class MLPLearner:
         )
         previous_checked = state
         if self._gamma * self._lamda == 0.0:
-            previous_checked = state.replace(
+            previous_checked = state.replace(  # type: ignore[attr-defined]
                 traces=tuple(jnp.zeros_like(trace) for trace in state.traces),
             )
         if (
             state.neuron_utility is not None
             and self._neuron_utility_decay == 0.0
         ):
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 neuron_utility=tuple(
                     jnp.zeros_like(utility) for utility in state.neuron_utility
                 ),

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -1312,11 +1312,24 @@ class MLPLearner:
 
         new_traces = []
         for i in range(n_layers):
-            # Weight trace (index 2*i)
-            new_wt = gamma_lamda * state.traces[2 * i] + weight_grads[i]
+            # Weight trace (index 2*i). Skip 0 * inf before adding the gradient.
+            new_wt = (
+                jnp.where(
+                    gamma_lamda == 0.0,
+                    jnp.zeros_like(state.traces[2 * i]),
+                    gamma_lamda * state.traces[2 * i],
+                )
+                + weight_grads[i]
+            )
             new_traces.append(new_wt)
-            # Bias trace (index 2*i + 1)
-            new_bt = gamma_lamda * state.traces[2 * i + 1] + bias_grads[i]
+            new_bt = (
+                jnp.where(
+                    gamma_lamda == 0.0,
+                    jnp.zeros_like(state.traces[2 * i + 1]),
+                    gamma_lamda * state.traces[2 * i + 1],
+                )
+                + bias_grads[i]
+            )
             new_traces.append(new_bt)
 
         # Per-parameter optimizer step from traces
@@ -1369,8 +1382,13 @@ class MLPLearner:
         if state.neuron_utility is not None:
             decay = jnp.array(self._neuron_utility_decay, dtype=jnp.float32)
             new_neuron_utility = tuple(
-                decay * state.neuron_utility[i]
-                + (1.0 - decay) * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
+                jnp.where(
+                    decay == 0.0,
+                    jnp.zeros_like(state.neuron_utility[i]),
+                    decay * state.neuron_utility[i],
+                )
+                + (1.0 - decay)
+                * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
                 for i in range(len(self._hidden_sizes))
             )
 
@@ -1384,12 +1402,24 @@ class MLPLearner:
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
-        # Inf target/obs, or a 0*inf ObGD apply, would commit NaN weights.
-        # MultiHead already refuses that; keep the previous finite state.
+        previous_checked = state
+        if self._gamma * self._lamda == 0.0:
+            previous_checked = state.replace(
+                traces=tuple(jnp.zeros_like(trace) for trace in state.traces),
+            )
+        if (
+            state.neuron_utility is not None
+            and self._neuron_utility_decay == 0.0
+        ):
+            previous_checked = previous_checked.replace(
+                neuron_utility=tuple(
+                    jnp.zeros_like(utility) for utility in state.neuron_utility
+                ),
+            )
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.isfinite(target_scalar)
         update_applied = (
             inputs_valid
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(proposed_state)
             & normalizer_update_applied
             & jnp.all(jnp.stack(optimizer_updates_applied))

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -156,6 +156,33 @@ class TestMLPLearner:
         for new_w in result.state.params.weights:
             assert bool(jnp.all(jnp.isfinite(new_w)))
 
+    def test_zero_utility_decay_recovers_poisoned_utility(self) -> None:
+        learner = MLPLearner(
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            optimizer=LMS(0.1),
+            track_neuron_utility=True,
+            neuron_utility_decay=0.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(2))
+        assert state.neuron_utility is not None
+        state = state.replace(
+            neuron_utility=tuple(
+                jnp.full_like(utility, jnp.inf) for utility in state.neuron_utility
+            )
+        )
+
+        result = learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        assert result.state.neuron_utility is not None
+        for utility in result.state.neuron_utility:
+            assert bool(jnp.all(jnp.isfinite(utility)))
+
     def test_update_reduces_error(self):
         """Multiple updates on a fixed target should reduce error."""
         learner = MLPLearner(

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -135,6 +135,27 @@ class TestMLPLearner:
             assert bool(jnp.all(jnp.isfinite(new_w)))
         assert bool(recovered.update_applied)
 
+    def test_zero_trace_decay_does_not_multiply_inf_traces(self) -> None:
+        """Default gamma*lamda is 0; 0 * inf traces is NaN and would freeze."""
+        learner = MLPLearner(hidden_sizes=(4,), sparsity=0.0, optimizer=LMS(0.1))
+        state = learner.init(feature_dim=3, key=jr.key(1))
+        poisoned_traces = tuple(
+            jnp.full_like(trace, jnp.inf) for trace in state.traces
+        )
+        state = state.replace(traces=poisoned_traces)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        observation = jnp.ones(3, dtype=jnp.float32)
+        result = learner.update(
+            state, observation, jnp.array(1.0, dtype=jnp.float32)
+        )
+        assert bool(result.update_applied)
+        for trace in result.state.traces:
+            assert bool(jnp.all(jnp.isfinite(trace)))
+        for new_w in result.state.params.weights:
+            assert bool(jnp.all(jnp.isfinite(new_w)))
+
     def test_update_reduces_error(self):
         """Multiple updates on a fixed target should reduce error."""
         learner = MLPLearner(


### PR DESCRIPTION
## Summary
- MLPLearner decays traces with `gamma * lamda * z + grad`. The default decay scale is 0, so an infinite stored trace is IEEE NaN and the finite-state guard freezes the learner.
- Skip the product when the scale is 0 (write the gradient only). On that same path, treat already-infinite traces as skippable so a later finite target can recover.
- The same skip applies to neuron-utility EMA decay when that decay is 0.

## Test plan
- [x] `tests/test_mlp_learner.py::TestMLPLearner::test_zero_trace_decay_does_not_multiply_inf_traces`
- [x] `TestMLPLearner` (12 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)