### PR TITLE
Skip MultiHeadMLP 0*inf trunk and head trace decay

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -789,25 +789,25 @@ class MultiHeadMLPLearner:
         replacing = self._trace_mode == TraceMode.REPLACING
         previous_checked = state
         if self._gamma * self._lamda == 0.0:
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 trunk_traces=tuple(
                     jnp.zeros_like(trace) for trace in state.trunk_traces
                 ),
             )
         checked_head_traces = []
         for i, (old_w_trace, old_b_trace) in enumerate(state.head_traces):
-            head_gl = (
+            head_decay_value = (
                 self._per_head_gl[i]
                 if self._per_head_gl is not None
                 else self._gamma * self._lamda
             )
-            if head_gl == 0.0:
+            if head_decay_value == 0.0:
                 checked_head_traces.append(
                     (jnp.zeros_like(old_w_trace), jnp.zeros_like(old_b_trace))
                 )
             else:
                 checked_head_traces.append((old_w_trace, old_b_trace))
-        previous_checked = previous_checked.replace(
+        previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
             head_traces=tuple(checked_head_traces),
         )
         if self._utility_decay == 0.0:

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -64,6 +64,11 @@ MULTI_HEAD_LIFETIME_COUNTER_DELTA_NBYTES = 8
 _INT32_MAX = 2**31 - 1
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _extract_mean_step_size(
     opt_state: LMSState | AutostepParamState | IDBDParamState,
 ) -> Array:
@@ -777,12 +782,41 @@ class MultiHeadMLPLearner:
         """
         n_heads = self._n_heads
         counter_status = self._counter_status(state)
-        source_state_finite = _floating_tree_is_finite(state)
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
             jnp.isfinite(targets) | jnp.isnan(targets)
         )
         gamma_lamda = jnp.array(self._gamma * self._lamda, dtype=jnp.float32)
         replacing = self._trace_mode == TraceMode.REPLACING
+        previous_checked = state
+        if self._gamma * self._lamda == 0.0:
+            previous_checked = previous_checked.replace(
+                trunk_traces=tuple(
+                    jnp.zeros_like(trace) for trace in state.trunk_traces
+                ),
+            )
+        checked_head_traces = []
+        for i, (old_w_trace, old_b_trace) in enumerate(state.head_traces):
+            head_gl = (
+                self._per_head_gl[i]
+                if self._per_head_gl is not None
+                else self._gamma * self._lamda
+            )
+            if head_gl == 0.0:
+                checked_head_traces.append(
+                    (jnp.zeros_like(old_w_trace), jnp.zeros_like(old_b_trace))
+                )
+            else:
+                checked_head_traces.append((old_w_trace, old_b_trace))
+        previous_checked = previous_checked.replace(
+            head_traces=tuple(checked_head_traces),
+        )
+        if self._utility_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                hidden_unit_utilities=tuple(
+                    jnp.zeros_like(utility) for utility in state.hidden_unit_utilities
+                ),
+            )
+        source_state_finite = _floating_tree_is_finite(previous_checked)
 
         # 1. Handle NaN targets
         active_mask = ~jnp.isnan(targets)  # (n_heads,)
@@ -884,7 +918,8 @@ class MultiHeadMLPLearner:
             )
             utility_signal = jnp.abs(activations[i] * trunk_bias_grads[i])
             new_hidden_unit_utilities.append(
-                utility_decay * old_utility + (1.0 - utility_decay) * utility_signal
+                _skip_zero_scale(utility_decay, old_utility)
+                + (1.0 - utility_decay) * utility_signal
             )
 
         # 6. Update trunk traces and optimizer
@@ -900,9 +935,11 @@ class MultiHeadMLPLearner:
             old_wt = state.trunk_traces[2 * i]
             if replacing:
                 # Replacing: use grad where nonzero, else decay old trace
-                new_wt = jnp.where(w_grad_i != 0.0, w_grad_i, gamma_lamda * old_wt)
+                new_wt = jnp.where(
+                    w_grad_i != 0.0, w_grad_i, _skip_zero_scale(gamma_lamda, old_wt)
+                )
             else:
-                new_wt = gamma_lamda * old_wt + w_grad_i
+                new_wt = _skip_zero_scale(gamma_lamda, old_wt) + w_grad_i
             new_trunk_traces.append(new_wt)
             w_step, new_w_opt, w_update_applied = _update_from_gradient_with_diagnostics(
                 self._optimizer,
@@ -916,9 +953,11 @@ class MultiHeadMLPLearner:
             b_grad_i = trunk_bias_grads[i]
             old_bt = state.trunk_traces[2 * i + 1]
             if replacing:
-                new_bt = jnp.where(b_grad_i != 0.0, b_grad_i, gamma_lamda * old_bt)
+                new_bt = jnp.where(
+                    b_grad_i != 0.0, b_grad_i, _skip_zero_scale(gamma_lamda, old_bt)
+                )
             else:
-                new_bt = gamma_lamda * old_bt + b_grad_i
+                new_bt = _skip_zero_scale(gamma_lamda, old_bt) + b_grad_i
             new_trunk_traces.append(new_bt)
             b_step, new_b_opt, b_update_applied = _update_from_gradient_with_diagnostics(
                 self._optimizer,
@@ -982,11 +1021,15 @@ class MultiHeadMLPLearner:
                 else gamma_lamda
             )
             if replacing:
-                new_w_trace = jnp.where(w_grad != 0.0, w_grad, head_gl * old_w_trace)
-                new_b_trace = jnp.where(b_grad != 0.0, b_grad, head_gl * old_b_trace)
+                new_w_trace = jnp.where(
+                    w_grad != 0.0, w_grad, _skip_zero_scale(head_gl, old_w_trace)
+                )
+                new_b_trace = jnp.where(
+                    b_grad != 0.0, b_grad, _skip_zero_scale(head_gl, old_b_trace)
+                )
             else:
-                new_w_trace = head_gl * old_w_trace + w_grad
-                new_b_trace = head_gl * old_b_trace + b_grad
+                new_w_trace = _skip_zero_scale(head_gl, old_w_trace) + w_grad
+                new_b_trace = _skip_zero_scale(head_gl, old_b_trace) + b_grad
 
             # Error for this head (masked to 0 for inactive)
             error_i = jnp.where(

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -21,6 +21,7 @@ from alberta_framework import (
     MultiHeadMLPUpdateResult,
     ObGD,
     ObGDBounding,
+    TraceMode,
     WelfordNormalizer,
     multi_head_metrics_to_dicts,
     run_multi_head_learning_loop,
@@ -1202,3 +1203,115 @@ class TestMultiHeadLinearBaseline:
         for w_trace, b_trace in result.state.head_traces:
             assert bool(jnp.all(jnp.isfinite(w_trace)))
             assert bool(jnp.all(jnp.isfinite(b_trace)))
+
+    def test_zero_trace_decay_recovers_inf_trunk_traces(self) -> None:
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            optimizer=LMS(0.1),
+        )
+        state = learner.init(feature_dim=3, key=jr.key(3))
+        state = state.replace(
+            trunk_traces=tuple(
+                jnp.full_like(trace, jnp.inf) for trace in state.trunk_traces
+            )
+        )
+
+        result = learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.array([1.0, 0.5], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        for trace in result.state.trunk_traces:
+            assert bool(jnp.all(jnp.isfinite(trace)))
+
+    def test_replacing_zero_decay_skips_inf_trace_at_zero_gradient(self) -> None:
+        learner = MultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(),
+            sparsity=0.0,
+            optimizer=LMS(0.1),
+            trace_mode=TraceMode.REPLACING,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(4))
+        old_w, old_b = state.head_traces[0]
+        state = state.replace(
+            head_traces=((jnp.full_like(old_w, jnp.inf), old_b),)
+        )
+
+        result = learner.update(
+            state,
+            jnp.zeros(3, dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.state.head_traces[0][0])))
+
+    def test_per_head_zero_decay_only_skips_disabled_head_trace(self) -> None:
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+            optimizer=LMS(0.1),
+            per_head_gamma_lamda=(0.0, 0.5),
+        )
+        state = learner.init(feature_dim=3, key=jr.key(5))
+        first_w, first_b = state.head_traces[0]
+        second_w, second_b = state.head_traces[1]
+        state = state.replace(
+            head_traces=(
+                (jnp.full_like(first_w, jnp.inf), jnp.full_like(first_b, jnp.inf)),
+                (jnp.ones_like(second_w), jnp.ones_like(second_b)),
+            )
+        )
+        observation = jnp.ones(3, dtype=jnp.float32)
+
+        result = learner.update(
+            state,
+            observation,
+            jnp.array([1.0, 0.5], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        first_result_w, first_result_b = result.state.head_traces[0]
+        second_result_w, second_result_b = result.state.head_traces[1]
+        chex.assert_trees_all_close(first_result_w, observation.reshape(1, -1))
+        chex.assert_trees_all_close(first_result_b, jnp.ones_like(first_result_b))
+        chex.assert_trees_all_close(
+            second_result_w,
+            0.5 * jnp.ones_like(second_w) + observation.reshape(1, -1),
+        )
+        chex.assert_trees_all_close(
+            second_result_b,
+            0.5 * jnp.ones_like(second_b) + jnp.ones_like(second_b),
+        )
+
+    def test_zero_utility_decay_recovers_inf_hidden_utilities(self) -> None:
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            optimizer=LMS(0.1),
+            utility_decay=0.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(6))
+        state = state.replace(
+            hidden_unit_utilities=tuple(
+                jnp.full_like(utility, jnp.inf)
+                for utility in state.hidden_unit_utilities
+            )
+        )
+
+        result = learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.array([1.0, 0.5], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        for utility in result.state.hidden_unit_utilities:
+            assert bool(jnp.all(jnp.isfinite(utility)))

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -9,6 +9,7 @@ import jax.random as jr
 import pytest
 
 from alberta_framework import (
+    LMS,
     AGCBounding,
     Autostep,
     AutostepGTDLambda,
@@ -1177,3 +1178,27 @@ class TestMultiHeadLinearBaseline:
         result = learner.update(state, obs, targets)
         chex.assert_tree_all_finite(result.predictions)
         assert result.state.normalizer_state is not None
+
+    def test_zero_trace_decay_does_not_multiply_inf_head_traces(self) -> None:
+        """Default gamma*lamda is 0; 0 * inf head traces is NaN and would freeze."""
+        learner = MultiHeadMLPLearner(
+            n_heads=2, hidden_sizes=(), sparsity=0.0, optimizer=LMS(0.1)
+        )
+        state = learner.init(feature_dim=3, key=jr.key(2))
+        poisoned = [
+            (jnp.full_like(w, jnp.inf), jnp.full_like(b, jnp.inf))
+            for w, b in state.head_traces
+        ]
+        state = state.replace(head_traces=tuple(poisoned))
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.array([1.0, 0.5], dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        for w_trace, b_trace in result.state.head_traces:
+            assert bool(jnp.all(jnp.isfinite(w_trace)))
+            assert bool(jnp.all(jnp.isfinite(b_trace)))


### PR DESCRIPTION
## Summary
- MultiHeadMLPLearner decays trunk and head traces with `gamma * lamda * z`. The default scale is 0, so an infinite stored trace is IEEE NaN and the finite-state guard freezes the learner.
- Skip the product when the scale is 0 in accumulating and replacing modes. Per-head `gamma*lamda` and hidden-unit utility EMA use the same skip.
- On a zero-decay path, treat already-infinite traces as skippable so a later finite target can recover.

## Test plan
- [x] `test_zero_trace_decay_does_not_multiply_inf_head_traces`
- [x] `TestMultiHeadLinearBaseline` and `TestMultiHeadInit` (19 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)