### PR TITLE
Skip temporal-context 0*inf EMA decay

### DIFF
--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -157,8 +157,13 @@ class TemporalContextFeaturizer:
         decay = jnp.asarray(self._config.ema_decay, dtype=jnp.float32)
         obs = jnp.asarray(observation, dtype=jnp.float32)
         observation_valid = jnp.all(jnp.isfinite(obs))
+        decayed_ema = jnp.where(
+            decay == 0.0,
+            jnp.zeros_like(state.observation_ema),
+            decay * state.observation_ema,
+        )
         proposed = TemporalContextState(
-            observation_ema=decay * state.observation_ema + (1.0 - decay) * obs,
+            observation_ema=decayed_ema + (1.0 - decay) * obs,
             step_count=state.step_count + 1,
         )
         return cast(

--- a/tests/test_temporal_context.py
+++ b/tests/test_temporal_context.py
@@ -44,6 +44,22 @@ def test_temporal_context_step_is_causal() -> None:
     assert int(next_state.step_count) == 1
 
 
+def test_zero_ema_decay_does_not_multiply_inf_ema() -> None:
+    """ema_decay=0 times an infinite tracker is NaN and would be committed."""
+    config = TemporalContextConfig(input_dim=2, ema_decay=0.0, periods=())
+    featurizer = TemporalContextFeaturizer(config)
+    state = featurizer.init().replace(
+        observation_ema=jnp.asarray([jnp.inf, jnp.inf], dtype=jnp.float32)
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    observation = jnp.asarray([2.0, -1.0], dtype=jnp.float32)
+    next_state = featurizer.update(state, observation)
+    chex.assert_trees_all_close(next_state.observation_ema, observation)
+    assert int(next_state.step_count) == 1
+
+
 def test_temporal_context_phase_products_expand_with_input() -> None:
     config = TemporalContextConfig(
         input_dim=2,


### PR DESCRIPTION
## Summary
- Temporal context advances `decay * ema + (1-decay) * obs`. When `ema_decay` is 0, an infinite stored EMA is IEEE NaN.
- Unlike the finite-state learners, this update commits the proposed EMA whenever the observation is finite, so the NaN lands in state instead of being held.
- Skip the product when decay is 0 so the tracker becomes the current observation.

## Test plan
- [x] `tests/test_temporal_context.py` (7 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)