### PR TITLE
Skip feature-discovery 0*inf utility and resource decay

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -45,9 +45,24 @@ from alberta_framework.core.update_safety import (
 )
 
 
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
-    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+def _skip_zero_scale(scale: float, value: Array) -> Array:
+    """Keep finite multiplication exact while repairing zero-scaled poison."""
+    product = scale * value
+    if scale != 0.0:
+        return product
+    return jnp.where(jnp.isfinite(value), product, jnp.zeros_like(value))
+
+
+def _recover_nonfinite_at_zero_scale(scale: float, value: Array) -> Array:
+    """Repair only non-finite history that a zero scale is configured to forget."""
+    if scale != 0.0:
+        return value
+    return jnp.where(
+        ~jnp.isfinite(value),
+        jnp.zeros_like(value),
+        value,
+    )
+
 
 GENERATOR_RANDOM = 0
 GENERATOR_MUTATE_PARENT = 1
@@ -558,10 +573,10 @@ class FixedBudgetFeatureLearner:
         active_mask: Array,
     ) -> Array:
         """Track active target heads for opt-in task-balanced utility."""
-        decay = jnp.asarray(self._task_activity_decay, dtype=old_activity.dtype)
-        return _skip_zero_scale(decay, old_activity) + (
-            1.0 - decay
-        ) * active_mask.astype(jnp.float32)
+        return (
+            _skip_zero_scale(self._task_activity_decay, old_activity)
+            + (1.0 - self._task_activity_decay) * active_mask.astype(jnp.float32)
+        )
 
     def _output_utility_signal(
         self,
@@ -752,16 +767,21 @@ class FixedBudgetFeatureLearner:
 
     def _utility_update(self, old_utilities: Array, utility_signal: Array) -> Array:
         """Update utility, optionally retaining recurrent-context peaks longer."""
-        decay = jnp.asarray(self._utility_decay, dtype=old_utilities.dtype)
-        ema = _skip_zero_scale(decay, old_utilities) + (1.0 - decay) * utility_signal
+        ema = (
+            _skip_zero_scale(self._utility_decay, old_utilities)
+            + (1.0 - self._utility_decay) * utility_signal
+        )
         if self._utility_retention_decay is None:
             return ema
-        retention = jnp.asarray(self._utility_retention_decay, dtype=old_utilities.dtype)
-        retained = _skip_zero_scale(retention, old_utilities)
+        retained = _skip_zero_scale(self._utility_retention_decay, old_utilities)
         return jnp.maximum(ema, retained)
 
     def _resource_weights(self, log_weights: Array) -> Array:
         """Return a soft resource allocation with optional exploration."""
+        log_weights = _recover_nonfinite_at_zero_scale(
+            self._resource_discount,
+            log_weights,
+        )
         weights = jax.nn.softmax(log_weights)
         if self._resource_exploration > 0.0:
             uniform = jnp.full_like(weights, 1.0 / weights.shape[0])
@@ -788,9 +808,8 @@ class FixedBudgetFeatureLearner:
             -self._resource_advantage_clip,
             self._resource_advantage_clip,
         )
-        discount = jnp.asarray(self._resource_discount, dtype=log_weights.dtype)
         new_log_weights = (
-            _skip_zero_scale(discount, log_weights)
+            _skip_zero_scale(self._resource_discount, log_weights)
             + self._resource_learning_rate * advantages
         )
         return new_log_weights - jnp.mean(new_log_weights)
@@ -926,17 +945,21 @@ class FixedBudgetFeatureLearner:
     ) -> FeatureDiscoveryUpdateResult:
         """Perform one temporally-uniform feature-discovery update."""
         previous_checked = state
-        if self._utility_decay == 0.0:
-            previous_checked = previous_checked.replace(
+        utility_history_discarded = self._utility_decay == 0.0 and (
+            self._utility_retention_decay is None
+            or self._utility_retention_decay == 0.0
+        )
+        if utility_history_discarded:
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 utilities=jnp.zeros_like(state.utilities),
                 candidate_utilities=jnp.zeros_like(state.candidate_utilities),
             )
         if self._task_activity_decay == 0.0:
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 task_activity_ema=jnp.zeros_like(state.task_activity_ema),
             )
-        if self._resource_discount == 0.0:
-            previous_checked = previous_checked.replace(
+        if self._learn_feature_resources and self._resource_discount == 0.0:
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 generator_log_weights=jnp.zeros_like(state.generator_log_weights),
                 generator_utility_ema=jnp.zeros_like(state.generator_utility_ema),
                 plasticity_log_weights=jnp.zeros_like(state.plasticity_log_weights),
@@ -1504,13 +1527,14 @@ class FixedBudgetFeatureLearner:
                 new_candidate_utilities,
                 candidate_generator,
             )
-            resource_discount = jnp.asarray(
-                self._resource_discount, dtype=generator_utility_ema.dtype
+            generator_utility_ema = _recover_nonfinite_at_zero_scale(
+                self._resource_discount,
+                generator_utility_ema,
             )
             generator_utility_ema = jnp.where(
                 generator_finite,
-                _skip_zero_scale(resource_discount, generator_utility_ema)
-                + (1.0 - resource_discount) * generator_scores,
+                _skip_zero_scale(self._resource_discount, generator_utility_ema)
+                + (1.0 - self._resource_discount) * generator_scores,
                 generator_utility_ema,
             )
             generator_log_weights = self._resource_log_weight_update(
@@ -1553,9 +1577,10 @@ class FixedBudgetFeatureLearner:
             plasticity_scores = jnp.stack(
                 [-pressure, jnp.array(0.0, dtype=jnp.float32), pressure]
             )
-            plasticity_signal_ema = _skip_zero_scale(
-                resource_discount, plasticity_signal_ema
-            ) + (1.0 - resource_discount) * plasticity_scores
+            plasticity_signal_ema = (
+                _skip_zero_scale(self._resource_discount, plasticity_signal_ema)
+                + (1.0 - self._resource_discount) * plasticity_scores
+            )
             plasticity_log_weights = self._resource_log_weight_update(
                 plasticity_log_weights,
                 plasticity_weights,

--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -44,6 +44,11 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
 GENERATOR_RANDOM = 0
 GENERATOR_MUTATE_PARENT = 1
 GENERATOR_IMPRINT = 2
@@ -553,10 +558,10 @@ class FixedBudgetFeatureLearner:
         active_mask: Array,
     ) -> Array:
         """Track active target heads for opt-in task-balanced utility."""
-        return (
-            self._task_activity_decay * old_activity
-            + (1.0 - self._task_activity_decay) * active_mask.astype(jnp.float32)
-        )
+        decay = jnp.asarray(self._task_activity_decay, dtype=old_activity.dtype)
+        return _skip_zero_scale(decay, old_activity) + (
+            1.0 - decay
+        ) * active_mask.astype(jnp.float32)
 
     def _output_utility_signal(
         self,
@@ -747,13 +752,12 @@ class FixedBudgetFeatureLearner:
 
     def _utility_update(self, old_utilities: Array, utility_signal: Array) -> Array:
         """Update utility, optionally retaining recurrent-context peaks longer."""
-        ema = (
-            self._utility_decay * old_utilities
-            + (1.0 - self._utility_decay) * utility_signal
-        )
+        decay = jnp.asarray(self._utility_decay, dtype=old_utilities.dtype)
+        ema = _skip_zero_scale(decay, old_utilities) + (1.0 - decay) * utility_signal
         if self._utility_retention_decay is None:
             return ema
-        retained = self._utility_retention_decay * old_utilities
+        retention = jnp.asarray(self._utility_retention_decay, dtype=old_utilities.dtype)
+        retained = _skip_zero_scale(retention, old_utilities)
         return jnp.maximum(ema, retained)
 
     def _resource_weights(self, log_weights: Array) -> Array:
@@ -784,8 +788,9 @@ class FixedBudgetFeatureLearner:
             -self._resource_advantage_clip,
             self._resource_advantage_clip,
         )
+        discount = jnp.asarray(self._resource_discount, dtype=log_weights.dtype)
         new_log_weights = (
-            self._resource_discount * log_weights
+            _skip_zero_scale(discount, log_weights)
             + self._resource_learning_rate * advantages
         )
         return new_log_weights - jnp.mean(new_log_weights)
@@ -920,7 +925,24 @@ class FixedBudgetFeatureLearner:
         targets: Array,
     ) -> FeatureDiscoveryUpdateResult:
         """Perform one temporally-uniform feature-discovery update."""
-        source_state_finite = floating_tree_is_finite(state)
+        previous_checked = state
+        if self._utility_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                utilities=jnp.zeros_like(state.utilities),
+                candidate_utilities=jnp.zeros_like(state.candidate_utilities),
+            )
+        if self._task_activity_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                task_activity_ema=jnp.zeros_like(state.task_activity_ema),
+            )
+        if self._resource_discount == 0.0:
+            previous_checked = previous_checked.replace(
+                generator_log_weights=jnp.zeros_like(state.generator_log_weights),
+                generator_utility_ema=jnp.zeros_like(state.generator_utility_ema),
+                plasticity_log_weights=jnp.zeros_like(state.plasticity_log_weights),
+                plasticity_signal_ema=jnp.zeros_like(state.plasticity_signal_ema),
+            )
+        source_state_finite = floating_tree_is_finite(previous_checked)
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(targets) | jnp.isnan(targets))
@@ -1482,10 +1504,13 @@ class FixedBudgetFeatureLearner:
                 new_candidate_utilities,
                 candidate_generator,
             )
+            resource_discount = jnp.asarray(
+                self._resource_discount, dtype=generator_utility_ema.dtype
+            )
             generator_utility_ema = jnp.where(
                 generator_finite,
-                self._resource_discount * generator_utility_ema
-                + (1.0 - self._resource_discount) * generator_scores,
+                _skip_zero_scale(resource_discount, generator_utility_ema)
+                + (1.0 - resource_discount) * generator_scores,
                 generator_utility_ema,
             )
             generator_log_weights = self._resource_log_weight_update(
@@ -1528,10 +1553,9 @@ class FixedBudgetFeatureLearner:
             plasticity_scores = jnp.stack(
                 [-pressure, jnp.array(0.0, dtype=jnp.float32), pressure]
             )
-            plasticity_signal_ema = (
-                self._resource_discount * plasticity_signal_ema
-                + (1.0 - self._resource_discount) * plasticity_scores
-            )
+            plasticity_signal_ema = _skip_zero_scale(
+                resource_discount, plasticity_signal_ema
+            ) + (1.0 - resource_discount) * plasticity_scores
             plasticity_log_weights = self._resource_log_weight_update(
                 plasticity_log_weights,
                 plasticity_weights,

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -336,6 +336,32 @@ class TestFixedBudgetFeatureLearner:
         chex.assert_tree_all_finite(result.metrics)
         assert int(result.state.step_count) == 1
 
+    def test_zero_utility_decay_does_not_multiply_inf_utilities(self) -> None:
+        """utility_decay=0 times an infinite tracker is NaN and would freeze."""
+        learner = FixedBudgetFeatureLearner(
+            n_features=4,
+            n_tasks=2,
+            candidate_count=2,
+            replacement_interval=0,
+            utility_decay=0.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(4))
+        state = state.replace(
+            utilities=jnp.full_like(state.utilities, jnp.inf),
+            candidate_utilities=jnp.full_like(state.candidate_utilities, jnp.inf),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.array([0.1, -0.2, 0.3], dtype=jnp.float32),
+            jnp.array([1.0, -1.0], dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.state.utilities)))
+        assert bool(jnp.all(jnp.isfinite(result.state.candidate_utilities)))
+
     def test_constructed_and_augmented_feature_shapes(self) -> None:
         learner = FixedBudgetFeatureLearner(n_features=6, n_tasks=2)
         state = learner.init(feature_dim=4, key=jr.key(14))

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -37,6 +37,7 @@ from alberta_framework.core.interaction_features import (
     load_interaction_feature_checkpoint,
     save_interaction_feature_checkpoint,
 )
+from alberta_framework.core.update_safety import floating_tree_is_finite
 
 
 def test_one_step_output_loss_reduction_is_causal_lms_counterfactual() -> None:
@@ -361,6 +362,116 @@ class TestFixedBudgetFeatureLearner:
         assert bool(result.update_applied)
         assert bool(jnp.all(jnp.isfinite(result.state.utilities)))
         assert bool(jnp.all(jnp.isfinite(result.state.candidate_utilities)))
+
+    def test_zero_decays_recover_poisoned_forgotten_trackers(self) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=3,
+            n_tasks=2,
+            candidate_count=2,
+            replacement_interval=0,
+            utility_decay=0.0,
+            task_activity_decay=0.0,
+            learn_feature_resources=True,
+            resource_discount=0.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(40)).replace(
+            utilities=jnp.full((3,), jnp.inf, dtype=jnp.float32),
+            candidate_utilities=jnp.full((2,), -jnp.inf, dtype=jnp.float32),
+            task_activity_ema=jnp.array([jnp.inf, jnp.nan], dtype=jnp.float32),
+            generator_log_weights=jnp.array(
+                [jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32
+            ),
+            generator_utility_ema=jnp.array(
+                [jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32
+            ),
+            plasticity_log_weights=jnp.array(
+                [jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32
+            ),
+            plasticity_signal_ema=jnp.array(
+                [jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32
+            ),
+            birth_timestamp=0.0,
+        )
+        recovered_weights = learner._resource_weights(state.generator_log_weights)
+
+        chex.assert_tree_all_finite(recovered_weights)
+        assert float(jnp.sum(recovered_weights)) == pytest.approx(1.0)
+
+        result = jax.jit(learner.update)(
+            state,
+            jnp.array([0.1, -0.2, 0.3], dtype=jnp.float32),
+            jnp.array([1.0, -1.0], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        assert bool(floating_tree_is_finite(result.state))
+        chex.assert_tree_all_finite(result.metrics)
+        chex.assert_trees_all_equal(
+            result.state.generator_utility_ema[1:],
+            jnp.zeros((2,), dtype=jnp.float32),
+        )
+
+    def test_zero_utility_decay_rejects_poison_consumed_by_retention(self) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=1,
+            n_tasks=1,
+            replacement_interval=1,
+            min_feature_age=0,
+            utility_decay=0.0,
+            utility_retention_decay=0.9,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(41)).replace(
+            utilities=jnp.array([jnp.inf], dtype=jnp.float32),
+            birth_timestamp=0.0,
+        )
+
+        result = jax.jit(learner.update)(
+            state,
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.ones((1,), dtype=jnp.float32),
+        )
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+        chex.assert_trees_all_equal(result.predictions, jnp.zeros((1,), jnp.float32))
+        chex.assert_trees_all_equal(result.errors, jnp.zeros((1,), jnp.float32))
+        chex.assert_trees_all_equal(result.metrics, jnp.zeros((7,), jnp.float32))
+        assert int(result.replaced_slot) == -1
+
+    def test_zero_resource_discount_preserves_finite_resource_state_semantics(
+        self,
+    ) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            replacement_interval=0,
+            learn_feature_resources=True,
+            resource_discount=0.0,
+            resource_exploration=0.0,
+        )
+        logits = jnp.array([2.0, -1.0, 0.5], dtype=jnp.float32)
+        state = learner.init(feature_dim=2, key=jr.key(42)).replace(
+            generator_log_weights=logits,
+            generator_utility_ema=jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32),
+        )
+
+        chex.assert_trees_all_equal(
+            learner._resource_weights(logits),
+            jax.nn.softmax(logits),
+        )
+        result = learner.update(
+            state,
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.ones((1,), dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        # Only generator zero has members; unavailable finite EMA slots retain
+        # their previous values even though the configured discount is zero.
+        chex.assert_trees_all_equal(
+            result.state.generator_utility_ema[1:],
+            state.generator_utility_ema[1:],
+        )
 
     def test_constructed_and_augmented_feature_shapes(self) -> None:
         learner = FixedBudgetFeatureLearner(n_features=6, n_tasks=2)


### PR DESCRIPTION
## Summary\n\n- Skip zero-scaled feature utility, task-activity, and resource history without producing IEEE 0 * inf NaNs.\n- Recover poisoned resource logits before the current-step softmax when resource_discount is exactly zero, and repair non-finite unavailable EMA slots without changing finite masked-slot retention.\n- Relax source-state validation only when every consumer forgets the old value; a nonzero utility-retention decay remains fail-closed.\n- Preserve the original arithmetic and exact finite one-step result digest.\n- Rebased onto main at 51e34ee69e2dc7639ee2894c46db76b17db0e26d.\n\n## Test plan\n\n- [x] Adversarial zero-decay recovery under eager/JIT execution\n- [x] Atomic rejection when nonzero retention consumes poisoned utility\n- [x] Exact finite resource-allocation and masked-EMA semantics\n- [x] All affected consumers: 167 passed\n- [x] Repository-wide ruff\n- [x] Strict mypy: 163 source files\n\nOriginal contribution made with Cursor. Maintainer repair performed with Codex; no measured-run receipt was required for this numerical-safety patch.