### PR TITLE
Skip resource-manager 0*inf preference decay and keep softmax finite

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -47,6 +47,33 @@ from alberta_framework.core.update_safety import (
 )
 
 
+def _skip_zero_scale(scale: float, value: Array) -> Array:
+    """Keep finite multiplication exact while repairing zero-scaled poison."""
+    product = scale * value
+    if scale != 0.0:
+        return product
+    return jnp.where(jnp.isfinite(value), product, jnp.zeros_like(value))
+
+
+def _recover_nonfinite_at_zero_scale(scale: float, value: Array) -> Array:
+    """Repair only non-finite history that a zero scale is configured to forget."""
+    if scale != 0.0:
+        return value
+    return jnp.where(~jnp.isfinite(value), jnp.zeros_like(value), value)
+
+
+def _mask_unused_history(
+    history: Array,
+    context: Array,
+    unused: Array,
+) -> Array:
+    """Zero only history entries that the candidate update does not consume."""
+    current = history[context]
+    recoverable = unused & ~jnp.isfinite(current)
+    checked = jnp.where(recoverable, jnp.zeros_like(current), current)
+    return history.at[context].set(checked)
+
+
 def _validated_cost_weight(value: float) -> float:
     """Return a non-negative weight that stays finite and nonzero in float32."""
     numeric = float(value)
@@ -320,6 +347,7 @@ class LearnedResourceManager:
             self._n_contexts,
         )
         logits = state.log_weights[context]
+        logits = _recover_nonfinite_at_zero_scale(self._discount, logits)
         weights = jax.nn.softmax(logits)
         if self._exploration > 0.0:
             uniform = jnp.full_like(weights, 1.0 / float(self._n_actions))
@@ -380,7 +408,8 @@ class LearnedResourceManager:
 
         old_context_logits = state.log_weights[context]
         new_context_logits = (
-            self._discount * old_context_logits + self._learning_rate * advantages
+            _skip_zero_scale(self._discount, old_context_logits)
+            + self._learning_rate * advantages
         )
         # Remove an arbitrary additive constant for numerical stability.
         new_context_logits = new_context_logits - jnp.mean(new_context_logits)
@@ -389,7 +418,8 @@ class LearnedResourceManager:
         old_ema = state.loss_ema[context]
         new_ema = jnp.where(
             valid_actions,
-            self._loss_decay * old_ema + (1.0 - self._loss_decay) * adjusted,
+            _skip_zero_scale(self._loss_decay, old_ema)
+            + (1.0 - self._loss_decay) * adjusted,
             old_ema,
         )
         new_loss_ema = state.loss_ema.at[context].set(new_ema)
@@ -401,9 +431,25 @@ class LearnedResourceManager:
             action_counts=new_counts,
             step_count=state.step_count + 1,
         )
+        checked_log_weights = _mask_unused_history(
+            state.log_weights,
+            context,
+            jnp.asarray(self._discount == 0.0, dtype=jnp.bool_),
+        )
+        checked_loss_ema = _mask_unused_history(
+            state.loss_ema,
+            context,
+            valid_actions & jnp.asarray(self._loss_decay == 0.0, dtype=jnp.bool_),
+        )
+        previous_checked = LearnedResourceManagerState(  # type: ignore[call-arg]
+            log_weights=checked_log_weights,
+            loss_ema=checked_loss_ema,
+            action_counts=state.action_counts,
+            step_count=state.step_count,
+        )
         update_applied = (
             context_valid
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))
             & jnp.all(jnp.isfinite(adjusted))
@@ -668,7 +714,9 @@ class GeneratorMetaResourceManager:
             context_id,
             self._n_contexts,
         )
-        weights = jax.nn.softmax(state.log_weights[context])
+        logits = state.log_weights[context]
+        logits = _recover_nonfinite_at_zero_scale(self._discount, logits)
+        weights = jax.nn.softmax(logits)
         if self._exploration > 0.0:
             uniform = jnp.full_like(weights, 1.0 / float(self.n_policies))
             weights = (1.0 - self._exploration) * weights + self._exploration * uniform
@@ -823,7 +871,8 @@ class GeneratorMetaResourceManager:
 
         old_context_logits = state.log_weights[context]
         new_context_logits = (
-            self._discount * old_context_logits + self._learning_rate * advantages
+            _skip_zero_scale(self._discount, old_context_logits)
+            + self._learning_rate * advantages
         )
         new_context_logits = new_context_logits - jnp.mean(new_context_logits)
         new_log_weights = state.log_weights.at[context].set(new_context_logits)
@@ -831,7 +880,8 @@ class GeneratorMetaResourceManager:
         old_ema = state.reward_ema[context]
         new_ema = jnp.where(
             finite,
-            self._reward_decay * old_ema + (1.0 - self._reward_decay) * adjusted,
+            _skip_zero_scale(self._reward_decay, old_ema)
+            + (1.0 - self._reward_decay) * adjusted,
             old_ema,
         )
         new_reward_ema = state.reward_ema.at[context].set(new_ema)
@@ -843,10 +893,26 @@ class GeneratorMetaResourceManager:
             action_counts=new_counts,
             step_count=state.step_count + 1,
         )
+        checked_log_weights = _mask_unused_history(
+            state.log_weights,
+            context,
+            jnp.asarray(self._discount == 0.0, dtype=jnp.bool_),
+        )
+        checked_reward_ema = _mask_unused_history(
+            state.reward_ema,
+            context,
+            finite & jnp.asarray(self._reward_decay == 0.0, dtype=jnp.bool_),
+        )
+        previous_checked = GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
+            log_weights=checked_log_weights,
+            reward_ema=checked_reward_ema,
+            action_counts=state.action_counts,
+            step_count=state.step_count,
+        )
         update_applied = (
             context_valid
             & selection_input_valid
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))
             & jnp.all(jnp.isfinite(adjusted))

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -109,6 +110,78 @@ class TestLearnedResourceManager:
         assert result.state.action_counts[0, 0] == pytest.approx(1.0)
         assert result.state.action_counts[0, 1] == pytest.approx(0.0)
 
+    def test_zero_discount_recovers_nonfinite_logits(self) -> None:
+        manager = LearnedResourceManager(
+            n_actions=2,
+            learning_rate=1.0,
+            discount=0.0,
+            exploration=0.0,
+        )
+        finite_state = manager.init().replace(
+            log_weights=jnp.asarray([[2.0, -2.0]], dtype=jnp.float32)
+        )
+        chex.assert_trees_all_equal(
+            manager.weights(finite_state),
+            jax.nn.softmax(finite_state.log_weights[0]),
+        )
+
+        state = finite_state.replace(
+            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+        assert manager.weights(state).tolist() == pytest.approx([0.5, 0.5])
+
+        result = manager.update(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.state.log_weights)))
+        assert bool(jnp.all(jnp.isfinite(result.weights)))
+
+    def test_nonzero_discount_rejects_nonfinite_logits(self) -> None:
+        manager = LearnedResourceManager(n_actions=2, discount=0.5)
+        state = manager.init().replace(
+            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
+        )
+
+        assert not bool(jnp.all(jnp.isfinite(manager.weights(state))))
+        result = manager.update(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_zero_loss_decay_recovers_observed_nonfinite_ema(self) -> None:
+        manager = LearnedResourceManager(n_actions=2, loss_decay=0.0)
+        state = manager.init().replace(
+            loss_ema=jnp.asarray([[jnp.inf, 7.0]], dtype=jnp.float32)
+        )
+
+        result = manager.update(state, jnp.asarray([0.1, jnp.nan], dtype=jnp.float32))
+
+        assert bool(result.update_applied)
+        assert result.state.loss_ema[0].tolist() == pytest.approx([0.1, 7.0])
+
+    def test_zero_loss_decay_rejects_poisoned_ema_in_ignored_slot(self) -> None:
+        manager = LearnedResourceManager(n_actions=2, loss_decay=0.0)
+        state = manager.init().replace(
+            loss_ema=jnp.asarray([[0.0, jnp.inf]], dtype=jnp.float32)
+        )
+
+        result = manager.update(state, jnp.asarray([0.1, jnp.nan], dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_nonzero_loss_decay_rejects_consumed_nonfinite_ema(self) -> None:
+        manager = LearnedResourceManager(n_actions=2, loss_decay=0.5)
+        state = manager.init().replace(
+            loss_ema=jnp.asarray([[jnp.inf, 0.0]], dtype=jnp.float32)
+        )
+
+        result = manager.update(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
     def test_config_roundtrip(self) -> None:
         manager = LearnedResourceManager(
             n_actions=4,
@@ -175,6 +248,100 @@ class TestLearnedResourceManager:
 
 class TestGeneratorMetaResourceManager:
     """Behavioral checks for generator-internal meta-resource policies."""
+
+    @staticmethod
+    def _manager(
+        *,
+        discount: float = 0.995,
+        reward_decay: float = 0.99,
+    ) -> GeneratorMetaResourceManager:
+        return GeneratorMetaResourceManager(
+            policy_names=("safe", "residual"),
+            op_ids=(1, 3),
+            parent_modes=(0, 3),
+            replacement_multipliers=(0.5, 2.0),
+            promotion_margin_multipliers=(1.25, 0.75),
+            candidate_min_age_multipliers=(1.5, 0.5),
+            imprint_scales=(0.0, 1.0),
+            learning_rate=1.0,
+            discount=discount,
+            exploration=0.0,
+            reward_decay=reward_decay,
+        )
+
+    def test_zero_discount_recovers_nonfinite_logits(self) -> None:
+        manager = self._manager(discount=0.0)
+        finite_state = manager.init().replace(  # type: ignore[attr-defined]
+            log_weights=jnp.asarray([[2.0, -2.0]], dtype=jnp.float32)
+        )
+        chex.assert_trees_all_equal(
+            manager.weights(finite_state),
+            jax.nn.softmax(finite_state.log_weights[0]),
+        )
+
+        state = finite_state.replace(  # type: ignore[attr-defined]
+            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
+        )
+        assert manager.weights(state).tolist() == pytest.approx([0.5, 0.5])
+
+        result = manager.update(state, jnp.asarray([1.0, 0.1], dtype=jnp.float32))
+
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.state.log_weights)))
+        assert bool(jnp.all(jnp.isfinite(result.weights)))
+
+    def test_nonzero_discount_rejects_nonfinite_logits(self) -> None:
+        manager = self._manager(discount=0.5)
+        state = manager.init().replace(  # type: ignore[attr-defined]
+            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
+        )
+
+        assert not bool(jnp.all(jnp.isfinite(manager.weights(state))))
+        result = manager.update(state, jnp.asarray([1.0, 0.1], dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_zero_reward_decay_recovers_observed_nonfinite_ema(self) -> None:
+        manager = self._manager(reward_decay=0.0)
+        state = manager.init().replace(  # type: ignore[attr-defined]
+            reward_ema=jnp.asarray([[jnp.inf, 7.0]], dtype=jnp.float32)
+        )
+
+        result = manager.update(
+            state,
+            jnp.asarray([1.0, 0.1], dtype=jnp.float32),
+            finite_mask=jnp.asarray([True, False]),
+        )
+
+        assert bool(result.update_applied)
+        assert result.state.reward_ema[0].tolist() == pytest.approx([1.0, 7.0])
+
+    def test_zero_reward_decay_rejects_poisoned_ema_in_masked_slot(self) -> None:
+        manager = self._manager(reward_decay=0.0)
+        state = manager.init().replace(  # type: ignore[attr-defined]
+            reward_ema=jnp.asarray([[0.0, jnp.inf]], dtype=jnp.float32)
+        )
+
+        result = manager.update(
+            state,
+            jnp.asarray([1.0, 0.1], dtype=jnp.float32),
+            finite_mask=jnp.asarray([True, False]),
+        )
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_nonzero_reward_decay_rejects_consumed_nonfinite_ema(self) -> None:
+        manager = self._manager(reward_decay=0.5)
+        state = manager.init().replace(  # type: ignore[attr-defined]
+            reward_ema=jnp.asarray([[jnp.inf, 0.0]], dtype=jnp.float32)
+        )
+
+        result = manager.update(state, jnp.asarray([1.0, 0.1], dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
 
     def test_contexts_learn_independently_from_rewards(self) -> None:
         manager = GeneratorMetaResourceManager(


### PR DESCRIPTION
## Summary

- Skip IEEE `0 * inf` only for genuinely zero-scaled preference and diagnostic history in both `LearnedResourceManager` and `GeneratorMetaResourceManager`.
- Preserve the established multiplication and softmax results for finite state; non-finite logits are repaired only when the configured preference discount is exactly zero.
- Relax source-state validation only for selected-context zero-discount logits and observed EMA slots that a zero decay replaces. Masked slots retain finite history, while masked poison and every nonzero-scaled poisoned value reject atomically.
- Add symmetric regressions for zero-discount logits, zero loss/reward EMA decay, finite-path equivalence, and fail-closed consumed state.
- Rebased onto `main` at `b775741a0ed09bd216e55a1361171660ad4e16db`.

## Test plan

- [x] `tests/test_resource_manager.py tests/test_late_wave_transactions.py tests/test_compositional_features.py` — 110 passed
- [x] Post-final-rebase `tests/test_resource_manager.py` — 24 passed
- [x] Repository-wide Ruff
- [x] Strict mypy — 163 source files
- [x] `git diff --check`
- [x] No `outputs/**` changes

Original contribution made with Cursor. Maintainer repair performed with Codex; no measured-run receipt was required for this numerical-safety patch.