### PR TITLE
Skip compositional-feature 0*inf utility and score-trace decay

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -2526,16 +2526,16 @@ class CompositionalFeatureLearner:
         """Perform one temporally-uniform compositional-feature update."""
         previous_checked = state
         if self._utility_decay == 0.0:
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 utilities=jnp.zeros_like(state.utilities),
                 candidate_utilities=jnp.zeros_like(state.candidate_utilities),
             )
         if self._future_utility_task_activity_decay == 0.0:
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 task_activity_ema=jnp.zeros_like(state.task_activity_ema),
             )
         if self._candidate_score_trace_decay == 0.0:
-            previous_checked = previous_checked.replace(
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
                 feature_score_residual_trace=jnp.zeros_like(
                     state.feature_score_residual_trace
                 ),

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -47,6 +47,11 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
 OP_RAW = 0
 OP_PRODUCT = 1
 OP_SUM = 2
@@ -2030,7 +2035,9 @@ class CompositionalFeatureLearner:
         if self._retention_slow_utility_decay == 0.0:
             return previous_slow_utility
         decay = jnp.asarray(self._retention_slow_utility_decay, dtype=jnp.float32)
-        return decay * previous_slow_utility + (1.0 - decay) * utility_signal
+        return _skip_zero_scale(decay, previous_slow_utility) + (
+            1.0 - decay
+        ) * utility_signal
 
     def _retention_score(
         self,
@@ -2054,9 +2061,13 @@ class CompositionalFeatureLearner:
             self._candidate_score_trace_decay, dtype=jnp.float32
         )
         new_residual_trace = (
-            trace_decay * residual_trace + errors[:, None] * feature_values[None, :]
+            _skip_zero_scale(trace_decay, residual_trace)
+            + errors[:, None] * feature_values[None, :]
         )
-        new_energy_trace = trace_decay * energy_trace + feature_values * feature_values
+        new_energy_trace = (
+            _skip_zero_scale(trace_decay, energy_trace)
+            + feature_values * feature_values
+        )
         score = jnp.mean(jnp.abs(new_residual_trace), axis=0) / jnp.sqrt(
             new_energy_trace + self._candidate_score_energy_epsilon
         )
@@ -2075,7 +2086,7 @@ class CompositionalFeatureLearner:
             self._candidate_score_trace_decay, dtype=jnp.float32
         )
         new_correlation_trace = (
-            trace_decay * candidate_active_correlation_trace
+            _skip_zero_scale(trace_decay, candidate_active_correlation_trace)
             + candidate_feature_values[:, None] * active_feature_values[None, :]
         )
         denom = jnp.sqrt(
@@ -2513,7 +2524,35 @@ class CompositionalFeatureLearner:
         context_id: Array | int = 0,
     ) -> CompositionalFeatureUpdateResult:
         """Perform one temporally-uniform compositional-feature update."""
-        source_state_finite = floating_tree_is_finite(state)
+        previous_checked = state
+        if self._utility_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                utilities=jnp.zeros_like(state.utilities),
+                candidate_utilities=jnp.zeros_like(state.candidate_utilities),
+            )
+        if self._future_utility_task_activity_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                task_activity_ema=jnp.zeros_like(state.task_activity_ema),
+            )
+        if self._candidate_score_trace_decay == 0.0:
+            previous_checked = previous_checked.replace(
+                feature_score_residual_trace=jnp.zeros_like(
+                    state.feature_score_residual_trace
+                ),
+                feature_score_energy_trace=jnp.zeros_like(
+                    state.feature_score_energy_trace
+                ),
+                candidate_score_residual_trace=jnp.zeros_like(
+                    state.candidate_score_residual_trace
+                ),
+                candidate_score_energy_trace=jnp.zeros_like(
+                    state.candidate_score_energy_trace
+                ),
+                candidate_active_correlation_trace=jnp.zeros_like(
+                    state.candidate_active_correlation_trace
+                ),
+            )
+        source_state_finite = floating_tree_is_finite(previous_checked)
         context_input = jnp.asarray(context_id)
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
@@ -2524,11 +2563,12 @@ class CompositionalFeatureLearner:
         active_mask = ~jnp.isnan(targets)
         safe_targets = jnp.where(active_mask, targets, 0.0)
         active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
-        task_activity_ema = (
-            self._future_utility_task_activity_decay * state.task_activity_ema
-            + (1.0 - self._future_utility_task_activity_decay)
-            * active_mask.astype(jnp.float32)
+        activity_decay = jnp.asarray(
+            self._future_utility_task_activity_decay, dtype=jnp.float32
         )
+        task_activity_ema = _skip_zero_scale(
+            activity_decay, state.task_activity_ema
+        ) + (1.0 - activity_decay) * active_mask.astype(jnp.float32)
 
         feature_values = _compute_feature_values(
             state.ops,
@@ -2621,10 +2661,10 @@ class CompositionalFeatureLearner:
                 state.feature_score_residual_trace,
                 state.feature_score_energy_trace,
             )
-        new_utilities = (
-            self._utility_decay * state.utilities
-            + (1.0 - self._utility_decay) * utility_signal
-        )
+        utility_decay = jnp.asarray(self._utility_decay, dtype=jnp.float32)
+        new_utilities = _skip_zero_scale(utility_decay, state.utilities) + (
+            1.0 - utility_decay
+        ) * utility_signal
         retention_slow_utilities = self._retention_slow_utility(
             state.retention_slow_utilities,
             utility_signal,
@@ -2741,10 +2781,9 @@ class CompositionalFeatureLearner:
                     )
                 )
                 candidate_signal = candidate_signal * novelty_gate
-            new_candidate_utilities = (
-                self._utility_decay * state.candidate_utilities
-                + (1.0 - self._utility_decay) * candidate_signal
-            )
+            new_candidate_utilities = _skip_zero_scale(
+                utility_decay, state.candidate_utilities
+            ) + (1.0 - utility_decay) * candidate_signal
         candidate_retention_slow_utilities = self._retention_slow_utility(
             state.candidate_retention_slow_utilities,
             candidate_signal if self._candidate_count > 0 else new_candidate_utilities,

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -47,11 +47,6 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
-
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
-    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
-
 OP_RAW = 0
 OP_PRODUCT = 1
 OP_SUM = 2
@@ -2035,9 +2030,7 @@ class CompositionalFeatureLearner:
         if self._retention_slow_utility_decay == 0.0:
             return previous_slow_utility
         decay = jnp.asarray(self._retention_slow_utility_decay, dtype=jnp.float32)
-        return _skip_zero_scale(decay, previous_slow_utility) + (
-            1.0 - decay
-        ) * utility_signal
+        return decay * previous_slow_utility + (1.0 - decay) * utility_signal
 
     def _retention_score(
         self,
@@ -2057,17 +2050,17 @@ class CompositionalFeatureLearner:
         energy_trace: Array,
     ) -> tuple[Array, Array, Array]:
         """Return online matching-pursuit residual scores."""
-        trace_decay = jnp.asarray(
-            self._candidate_score_trace_decay, dtype=jnp.float32
-        )
-        new_residual_trace = (
-            _skip_zero_scale(trace_decay, residual_trace)
-            + errors[:, None] * feature_values[None, :]
-        )
-        new_energy_trace = (
-            _skip_zero_scale(trace_decay, energy_trace)
-            + feature_values * feature_values
-        )
+        residual_increment = errors[:, None] * feature_values[None, :]
+        energy_increment = feature_values * feature_values
+        if self._candidate_score_trace_decay == 0.0:
+            new_residual_trace = residual_increment
+            new_energy_trace = energy_increment
+        else:
+            trace_decay = jnp.asarray(
+                self._candidate_score_trace_decay, dtype=jnp.float32
+            )
+            new_residual_trace = trace_decay * residual_trace + residual_increment
+            new_energy_trace = trace_decay * energy_trace + energy_increment
         score = jnp.mean(jnp.abs(new_residual_trace), axis=0) / jnp.sqrt(
             new_energy_trace + self._candidate_score_energy_epsilon
         )
@@ -2082,13 +2075,19 @@ class CompositionalFeatureLearner:
         candidate_active_correlation_trace: Array,
     ) -> tuple[Array, Array]:
         """Return correlation novelty gates for candidate utility scores."""
-        trace_decay = jnp.asarray(
-            self._candidate_score_trace_decay, dtype=jnp.float32
+        correlation_increment = (
+            candidate_feature_values[:, None] * active_feature_values[None, :]
         )
-        new_correlation_trace = (
-            _skip_zero_scale(trace_decay, candidate_active_correlation_trace)
-            + candidate_feature_values[:, None] * active_feature_values[None, :]
-        )
+        if self._candidate_score_trace_decay == 0.0:
+            new_correlation_trace = correlation_increment
+        else:
+            trace_decay = jnp.asarray(
+                self._candidate_score_trace_decay, dtype=jnp.float32
+            )
+            new_correlation_trace = (
+                trace_decay * candidate_active_correlation_trace
+                + correlation_increment
+            )
         denom = jnp.sqrt(
             candidate_energy_trace[:, None] * active_energy_trace[None, :]
             + self._candidate_score_energy_epsilon
@@ -2563,12 +2562,14 @@ class CompositionalFeatureLearner:
         active_mask = ~jnp.isnan(targets)
         safe_targets = jnp.where(active_mask, targets, 0.0)
         active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
-        activity_decay = jnp.asarray(
-            self._future_utility_task_activity_decay, dtype=jnp.float32
-        )
-        task_activity_ema = _skip_zero_scale(
-            activity_decay, state.task_activity_ema
-        ) + (1.0 - activity_decay) * active_mask.astype(jnp.float32)
+        if self._future_utility_task_activity_decay == 0.0:
+            task_activity_ema = active_mask.astype(jnp.float32)
+        else:
+            task_activity_ema = (
+                self._future_utility_task_activity_decay * state.task_activity_ema
+                + (1.0 - self._future_utility_task_activity_decay)
+                * active_mask.astype(jnp.float32)
+            )
 
         feature_values = _compute_feature_values(
             state.ops,
@@ -2661,10 +2662,13 @@ class CompositionalFeatureLearner:
                 state.feature_score_residual_trace,
                 state.feature_score_energy_trace,
             )
-        utility_decay = jnp.asarray(self._utility_decay, dtype=jnp.float32)
-        new_utilities = _skip_zero_scale(utility_decay, state.utilities) + (
-            1.0 - utility_decay
-        ) * utility_signal
+        if self._utility_decay == 0.0:
+            new_utilities = utility_signal
+        else:
+            new_utilities = (
+                self._utility_decay * state.utilities
+                + (1.0 - self._utility_decay) * utility_signal
+            )
         retention_slow_utilities = self._retention_slow_utility(
             state.retention_slow_utilities,
             utility_signal,
@@ -2781,9 +2785,13 @@ class CompositionalFeatureLearner:
                     )
                 )
                 candidate_signal = candidate_signal * novelty_gate
-            new_candidate_utilities = _skip_zero_scale(
-                utility_decay, state.candidate_utilities
-            ) + (1.0 - utility_decay) * candidate_signal
+            if self._utility_decay == 0.0:
+                new_candidate_utilities = candidate_signal
+            else:
+                new_candidate_utilities = (
+                    self._utility_decay * state.candidate_utilities
+                    + (1.0 - self._utility_decay) * candidate_signal
+                )
         candidate_retention_slow_utilities = self._retention_slow_utility(
             state.candidate_retention_slow_utilities,
             candidate_signal if self._candidate_count > 0 else new_candidate_utilities,

--- a/tests/test_compositional_features.py
+++ b/tests/test_compositional_features.py
@@ -275,6 +275,33 @@ class TestCompositionalFeatureLearner:
         assert float(result.state.utilities[0]) == 1.5
         assert float(result.state.candidate_utilities[0]) == 1.5
 
+    def test_zero_utility_decay_does_not_multiply_inf_utilities(self) -> None:
+        """utility_decay=0 times an infinite tracker is NaN and would freeze."""
+        learner = CompositionalFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            candidate_count=1,
+            utility_decay=0.0,
+            replacement_interval=0,
+            use_obgd=False,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(17))
+        state = state.replace(  # type: ignore[attr-defined]
+            utilities=jnp.full_like(state.utilities, jnp.inf),
+            candidate_utilities=jnp.full_like(state.candidate_utilities, jnp.inf),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.array([1.0, -0.5], dtype=jnp.float32),
+            jnp.array([0.25], dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.state.utilities)))
+        assert bool(jnp.all(jnp.isfinite(result.state.candidate_utilities)))
+
     def test_energy_novelty_scoring_normalizes_candidate_scale(self) -> None:
         learner = CompositionalFeatureLearner(
             n_features=2,

--- a/tests/test_compositional_features.py
+++ b/tests/test_compositional_features.py
@@ -302,6 +302,66 @@ class TestCompositionalFeatureLearner:
         assert bool(jnp.all(jnp.isfinite(result.state.utilities)))
         assert bool(jnp.all(jnp.isfinite(result.state.candidate_utilities)))
 
+    def test_zero_task_activity_decay_recovers_inf_activity(self) -> None:
+        learner = CompositionalFeatureLearner(
+            n_features=2,
+            n_tasks=2,
+            candidate_count=0,
+            future_utility_task_activity_decay=0.0,
+            replacement_interval=0,
+            use_obgd=False,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(18)).replace(  # type: ignore[attr-defined]
+            task_activity_ema=jnp.full((2,), jnp.inf, dtype=jnp.float32)
+        )
+
+        result = learner.update(
+            state,
+            jnp.array([1.0, -0.5], dtype=jnp.float32),
+            jnp.array([0.25, jnp.nan], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(
+            result.state.task_activity_ema,
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+        )
+
+    def test_zero_score_decay_recovers_every_inf_score_trace(self) -> None:
+        learner = CompositionalFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            candidate_count=1,
+            utility_decay=0.0,
+            replacement_interval=0,
+            candidate_scoring_mode="energy_novelty",
+            candidate_score_trace_decay=0.0,
+            use_obgd=False,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(19)).replace(  # type: ignore[attr-defined]
+            feature_score_residual_trace=jnp.full((1, 2), jnp.inf),
+            feature_score_energy_trace=jnp.full((2,), jnp.inf),
+            candidate_score_residual_trace=jnp.full((1, 1), jnp.inf),
+            candidate_score_energy_trace=jnp.full((1,), jnp.inf),
+            candidate_active_correlation_trace=jnp.full((1, 2), jnp.inf),
+        )
+
+        result = learner.update(
+            state,
+            jnp.array([1.0, -0.5], dtype=jnp.float32),
+            jnp.array([0.25], dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        for trace in (
+            result.state.feature_score_residual_trace,
+            result.state.feature_score_energy_trace,
+            result.state.candidate_score_residual_trace,
+            result.state.candidate_score_energy_trace,
+            result.state.candidate_active_correlation_trace,
+        ):
+            assert bool(jnp.all(jnp.isfinite(trace)))
+
     def test_energy_novelty_scoring_normalizes_candidate_scale(self) -> None:
         learner = CompositionalFeatureLearner(
             n_features=2,


### PR DESCRIPTION
## Summary

Compositional feature discovery has several decay paths where a legitimate zero decay must not form IEEE `0 * inf`. This repair specializes only the exact zero-decay configurations, preserving the original arithmetic graph for every nonzero decay. That distinction is load-bearing: the earlier generic `where` helper changed finite default-path last bits and failed the repository's pinned bitwise digest.

The zero-decay paths now recover safely for utilities, candidate utilities, task activity, residual/energy traces, and novelty traces. Nonzero paths retain their historical equations exactly.

## Verification

Validated at `51ec2fd9f11ea522c53973bb5cde2e6ae0a8901f`, rebased on current `main` after PR #268:

- `tests/test_compositional_features.py` + `tests/test_optimizer_nonfinite_transactions.py`: **111 passed**;
- the pinned finite one-step digest regression passes;
- targeted Ruff: clean;
- strict mypy on `compositional_features.py`: clean;
- `git diff --check`: clean.

No `outputs/**` artifact or evidence protocol changed.

## Contribution provenance

Original report and fix: Kayvan-Zahiri. Additional adversarial finite-path diagnosis, static zero-decay specialization, rebase, and verification: lalalune/Codex.