### PR TITLE
Skip CBP 0*inf utility EMA decay

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -287,7 +287,12 @@ def update_utility(
         # previous finite utility so replacement does not treat NaN as
         # the lowest-utility unit.
         contribution_finite = jnp.isfinite(contribution)
-        u_new = decay * cbp_state.utilities[i] + (1.0 - decay) * contribution
+        decayed = jnp.where(
+            decay == 0.0,
+            jnp.zeros_like(cbp_state.utilities[i]),
+            decay * cbp_state.utilities[i],
+        )
+        u_new = decayed + (1.0 - decay) * contribution
         u_new = jnp.where(contribution_finite, u_new, cbp_state.utilities[i])
         new_utilities.append(u_new)
         new_ages.append(cbp_state.ages[i] + 1)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -151,6 +151,24 @@ class TestUtilityUpdate:
         assert bool(has)
         assert int(idx) == 1
 
+    def test_zero_decay_does_not_multiply_inf_utility(self) -> None:
+        """decay=0 times an infinite utility EMA is NaN and would be committed."""
+        cbp_state = ContinualBackpropState(  # type: ignore[call-arg]
+            utilities=(jnp.array([jnp.inf, jnp.inf], dtype=jnp.float32),),
+            ages=(jnp.array([5, 5], dtype=jnp.int32),),
+            replacement_accumulators=jnp.zeros(1, dtype=jnp.float32),
+            rng_key=jr.key(0),
+        )
+        activations = (jnp.array([1.0, 0.5], dtype=jnp.float32),)
+        grads = (jnp.array([0.2, -0.4], dtype=jnp.float32),)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        new = update_utility(cbp_state, activations, grads, 0.0)
+        assert bool(jnp.all(jnp.isfinite(new.utilities[0])))
+        expected = jnp.abs(activations[0] * grads[0])
+        chex.assert_trees_all_close(new.utilities[0], expected)
+
 
 class TestWrapperUtilityGradients:
     """The CBP wrapper should track utility in every hidden layer."""


### PR DESCRIPTION
## Summary
- Continual Backprop already holds a previous utility when the contribution is non-finite. It still formed `decay * utility` when decay is 0, so an infinite stored EMA became NaN and was committed.
- Skip the product when decay is 0 so the tracker becomes the current finite contribution.

## Test plan
- [x] `test_zero_decay_does_not_multiply_inf_utility`
- [x] `test_inf_activation_silent_grad_holds_finite_utility`
- [x] `tests/test_continual_backprop.py` (21 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)