### PR TITLE
Skip SwiftTD 0*inf trace decay and allow inf next obs at gamma 0

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -56,6 +56,11 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
 # Paper default for the step-size floor: eta_min = e^-15.
 _DEFAULT_ETA_MIN = math.exp(-15.0)
 
@@ -336,10 +341,14 @@ class SwiftTD:
         new_h_temp = new_h
 
         # Decay eligibility-side traces for the next transition.
-        decay_factor = gamma_scalar * state.trace_decay
-        new_z = decay_factor * z_ext
-        new_p = decay_factor * p_ext
-        new_z_bar = decay_factor * z_bar_ext
+        decay_factor = jnp.where(
+            (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
+            jnp.zeros_like(gamma_scalar),
+            gamma_scalar * state.trace_decay,
+        )
+        new_z = _skip_zero_scale(decay_factor, z_ext)
+        new_p = _skip_zero_scale(decay_factor, p_ext)
+        new_z_bar = _skip_zero_scale(decay_factor, z_bar_ext)
 
         candidate_state = SwiftTDState(
             log_step_sizes=new_log_step_sizes,
@@ -369,11 +378,33 @@ class SwiftTD:
         inputs_valid = (
             jnp.all(jnp.isfinite(td_error))
             & jnp.all(jnp.isfinite(observation))
-            & next_observation_finite
+            & (next_observation_finite | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
         )
+        previous_checked = state.replace(
+            eligibility_traces=jnp.where(
+                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
+                jnp.zeros_like(state.eligibility_traces),
+                state.eligibility_traces,
+            ),
+            z_bar_traces=jnp.where(
+                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
+                jnp.zeros_like(state.z_bar_traces),
+                state.z_bar_traces,
+            ),
+            p_traces=jnp.where(
+                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
+                jnp.zeros_like(state.p_traces),
+                state.p_traces,
+            ),
+            trace_decay=jnp.where(
+                gamma_scalar == 0.0,
+                jnp.zeros_like(state.trace_decay),
+                state.trace_decay,
+            ),
+        )
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(previous_checked)
             & inputs_valid
             & jnp.all(jnp.isfinite(meta_delta))
             & jnp.all(jnp.isfinite(delta_w))

--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -381,30 +381,8 @@ class SwiftTD:
             & (next_observation_finite | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
         )
-        previous_checked = state.replace(
-            eligibility_traces=jnp.where(
-                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
-                jnp.zeros_like(state.eligibility_traces),
-                state.eligibility_traces,
-            ),
-            z_bar_traces=jnp.where(
-                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
-                jnp.zeros_like(state.z_bar_traces),
-                state.z_bar_traces,
-            ),
-            p_traces=jnp.where(
-                (gamma_scalar == 0.0) | (state.trace_decay == 0.0),
-                jnp.zeros_like(state.p_traces),
-                state.p_traces,
-            ),
-            trace_decay=jnp.where(
-                gamma_scalar == 0.0,
-                jnp.zeros_like(state.trace_decay),
-                state.trace_decay,
-            ),
-        )
         update_applied = (
-            floating_tree_is_finite(previous_checked)
+            floating_tree_is_finite(state)
             & inputs_valid
             & jnp.all(jnp.isfinite(meta_delta))
             & jnp.all(jnp.isfinite(delta_w))

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -379,6 +379,23 @@ class TestSwiftTDBehavior:
             result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7
         )
 
+    def test_zero_gamma_does_not_disguise_consumed_inf_trace_state(self) -> None:
+        optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.0)
+        state = optimizer.init(2).replace(  # type: ignore[attr-defined]
+            eligibility_traces=jnp.full((3,), jnp.inf, dtype=jnp.float32)
+        )
+
+        result = optimizer.update(
+            state,
+            jnp.asarray(1.0, dtype=jnp.float32),
+            jnp.asarray([0.5, -0.25], dtype=jnp.float32),
+            jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.new_state, state)
+
     def test_integrates_with_td_linear_learner(self):
         """SwiftTD follows the TDOptimizer interface and drives TDLinearLearner."""
         learner = TDLinearLearner(optimizer=SwiftTD(initial_step_size=0.01))

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -361,6 +361,24 @@ class TestSwiftTDBehavior:
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.9))
         assert float(jnp.max(jnp.abs(result.new_state.eligibility_traces))) > 0.0
 
+    def test_zero_gamma_does_not_require_finite_next_observation(self) -> None:
+        """gamma=0 still required a finite next obs even though V(s') is unused."""
+        optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.9)
+        state = optimizer.init(2)
+        obs = jnp.asarray([0.5, -0.25], dtype=jnp.float32)
+        result = optimizer.update(
+            state,
+            jnp.asarray(1.0, dtype=jnp.float32),
+            obs,
+            jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
+        chex.assert_trees_all_close(
+            result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7
+        )
+
     def test_integrates_with_td_linear_learner(self):
         """SwiftTD follows the TDOptimizer interface and drives TDLinearLearner."""
         learner = TDLinearLearner(optimizer=SwiftTD(initial_step_size=0.01))


### PR DESCRIPTION
## Summary
- SwiftTD decays eligibility traces with `gamma * lambda`. IEEE 0*inf is NaN in those traces and in the published eligibility metric.
- The public next observation is unused in the update (V(s') is already in the TD error), but a non-finite next observation still froze a terminal `gamma=0` step.
- Skip the decay product when the scale is 0. A next observation may be non-finite only when gamma is already 0.

## Test plan
- [x] `test_zero_gamma_does_not_require_finite_next_observation`
- [x] `TestSwiftTDBehavior` and the rest of `tests/test_swift_td.py -m "not slow"` (15 passed)
- [x] SwiftTD cases in `test_optimizer_nonfinite_transactions.py`
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)