### PR TITLE
Skip canonical UPGD 0*inf utility and moment decay

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -98,9 +98,11 @@ _RAW_GLOBAL_PROFILES = frozenset(
 )
 
 
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
-    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+def _static_zero_scale(scale: float, value: Array) -> Array:
+    """Skip a statically disabled EMA without changing enabled JAX graphs."""
+    if scale == 0.0:
+        return jnp.zeros_like(value)
+    return scale * value
 
 
 @dataclass(frozen=True)
@@ -430,7 +432,7 @@ class CanonicalUPGD:
             instantaneous = -clean_gradient * param
             next_utility = jnp.where(
                 active,
-                _skip_zero_scale(jnp.asarray(beta, dtype=param.dtype), utility)
+                _static_zero_scale(beta, utility)
                 + (1.0 - beta) * instantaneous,
                 utility,
             )
@@ -1086,17 +1088,27 @@ class AlbertaAdaUPGD:
         state_is_valid = self.state_valid(state, params)
         if self._config.utility_decay == 0.0 or self._config.second_moment_decay == 0.0:
             checked_utility = (
-                jax.tree.map(jnp.zeros_like, state.utility_ema)
+                jax.tree.map(
+                    lambda value: jnp.where(
+                        jnp.isfinite(value), value, jnp.zeros_like(value)
+                    ),
+                    state.utility_ema,
+                )
                 if self._config.utility_decay == 0.0
                 else state.utility_ema
             )
             checked_moment = (
-                jax.tree.map(jnp.zeros_like, state.gradient_second_moment)
+                jax.tree.map(
+                    lambda value: jnp.where(
+                        jnp.isfinite(value), value, jnp.zeros_like(value)
+                    ),
+                    state.gradient_second_moment,
+                )
                 if self._config.second_moment_decay == 0.0
                 else state.gradient_second_moment
             )
             state_is_valid = self.state_valid(
-                state.replace(
+                state.replace(  # type: ignore[attr-defined]
                     utility_ema=checked_utility,
                     gradient_second_moment=checked_moment,
                 ),
@@ -1183,7 +1195,7 @@ class AlbertaAdaUPGD:
             instantaneous_utility = -gradient * param
             proposed_utility = jnp.where(
                 eligible,
-                _skip_zero_scale(jnp.asarray(beta_utility, dtype=param.dtype), utility)
+                _static_zero_scale(beta_utility, utility)
                 + (1.0 - beta_utility) * instantaneous_utility,
                 utility,
             )
@@ -1200,9 +1212,9 @@ class AlbertaAdaUPGD:
                 0.0,
             )
 
-            proposed_moment = _skip_zero_scale(
-                jnp.asarray(beta_second, dtype=param.dtype), moment
-            ) + (1.0 - beta_second) * jnp.square(gradient)
+            proposed_moment = _static_zero_scale(beta_second, moment) + (
+                1.0 - beta_second
+            ) * jnp.square(gradient)
             moment_clock = jnp.maximum(proposed_step, 1).astype(param.dtype)
             moment_correction = 1.0 - jnp.power(beta_second, moment_clock)
             corrected_moment = proposed_moment / jnp.maximum(
@@ -1810,19 +1822,16 @@ class OfficialAdaUPGD:
             second_leaves,
             strict=True,
         ):
-            utility_scale = jnp.asarray(self._config.utility_decay, dtype=param.dtype)
-            first_scale = jnp.asarray(self._config.beta1, dtype=param.dtype)
-            second_scale = jnp.asarray(self._config.beta2, dtype=param.dtype)
             proposed_utility_leaves.append(
-                _skip_zero_scale(utility_scale, utility)
+                _static_zero_scale(self._config.utility_decay, utility)
                 + (1.0 - self._config.utility_decay) * (-gradient * param)
             )
             proposed_first_leaves.append(
-                _skip_zero_scale(first_scale, first)
+                _static_zero_scale(self._config.beta1, first)
                 + (1.0 - self._config.beta1) * gradient
             )
             proposed_second_leaves.append(
-                _skip_zero_scale(second_scale, second)
+                _static_zero_scale(self._config.beta2, second)
                 + (1.0 - self._config.beta2) * jnp.square(gradient)
             )
 

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -98,6 +98,11 @@ _RAW_GLOBAL_PROFILES = frozenset(
 )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 @dataclass(frozen=True)
 class CanonicalUPGDConfig:
     """Configuration for canonical first-order UPGD.
@@ -425,7 +430,8 @@ class CanonicalUPGD:
             instantaneous = -clean_gradient * param
             next_utility = jnp.where(
                 active,
-                beta * utility + (1.0 - beta) * instantaneous,
+                _skip_zero_scale(jnp.asarray(beta, dtype=param.dtype), utility)
+                + (1.0 - beta) * instantaneous,
                 utility,
             )
             if self._config.uses_global_clock:
@@ -1078,6 +1084,24 @@ class AlbertaAdaUPGD:
         proposed_next_key = split_keys[0]
         noise_keys = split_keys[1:]
         state_is_valid = self.state_valid(state, params)
+        if self._config.utility_decay == 0.0 or self._config.second_moment_decay == 0.0:
+            checked_utility = (
+                jax.tree.map(jnp.zeros_like, state.utility_ema)
+                if self._config.utility_decay == 0.0
+                else state.utility_ema
+            )
+            checked_moment = (
+                jax.tree.map(jnp.zeros_like, state.gradient_second_moment)
+                if self._config.second_moment_decay == 0.0
+                else state.gradient_second_moment
+            )
+            state_is_valid = self.state_valid(
+                state.replace(
+                    utility_ema=checked_utility,
+                    gradient_second_moment=checked_moment,
+                ),
+                params,
+            )
         capacity_available = state.step < jnp.asarray(_INT32_MAX, dtype=jnp.int32)
         proposed_step = jnp.where(capacity_available, state.step + 1, state.step)
         input_is_valid = jnp.asarray(True, dtype=jnp.bool_)
@@ -1159,7 +1183,7 @@ class AlbertaAdaUPGD:
             instantaneous_utility = -gradient * param
             proposed_utility = jnp.where(
                 eligible,
-                beta_utility * utility
+                _skip_zero_scale(jnp.asarray(beta_utility, dtype=param.dtype), utility)
                 + (1.0 - beta_utility) * instantaneous_utility,
                 utility,
             )
@@ -1176,9 +1200,9 @@ class AlbertaAdaUPGD:
                 0.0,
             )
 
-            proposed_moment = (
-                beta_second * moment + (1.0 - beta_second) * jnp.square(gradient)
-            )
+            proposed_moment = _skip_zero_scale(
+                jnp.asarray(beta_second, dtype=param.dtype), moment
+            ) + (1.0 - beta_second) * jnp.square(gradient)
             moment_clock = jnp.maximum(proposed_step, 1).astype(param.dtype)
             moment_correction = 1.0 - jnp.power(beta_second, moment_clock)
             corrected_moment = proposed_moment / jnp.maximum(
@@ -1786,16 +1810,19 @@ class OfficialAdaUPGD:
             second_leaves,
             strict=True,
         ):
+            utility_scale = jnp.asarray(self._config.utility_decay, dtype=param.dtype)
+            first_scale = jnp.asarray(self._config.beta1, dtype=param.dtype)
+            second_scale = jnp.asarray(self._config.beta2, dtype=param.dtype)
             proposed_utility_leaves.append(
-                self._config.utility_decay * utility
+                _skip_zero_scale(utility_scale, utility)
                 + (1.0 - self._config.utility_decay) * (-gradient * param)
             )
             proposed_first_leaves.append(
-                self._config.beta1 * first
+                _skip_zero_scale(first_scale, first)
                 + (1.0 - self._config.beta1) * gradient
             )
             proposed_second_leaves.append(
-                self._config.beta2 * second
+                _skip_zero_scale(second_scale, second)
                 + (1.0 - self._config.beta2) * jnp.square(gradient)
             )
 

--- a/tests/test_canonical_adaupgd.py
+++ b/tests/test_canonical_adaupgd.py
@@ -35,6 +35,63 @@ def _assert_key_equal(left, right) -> None:
     chex.assert_trees_all_equal(jr.key_data(left), jr.key_data(right))
 
 
+def test_alberta_zero_decays_recover_unused_inf_trackers() -> None:
+    params = {"w": jnp.ones(2, dtype=jnp.float32)}
+    optimizer = AlbertaAdaUPGD(
+        AlbertaAdaUPGDConfig(
+            utility_decay=0.0,
+            second_moment_decay=0.0,
+            noise_std=0.0,
+        )
+    )
+    state = optimizer.init(params).replace(  # type: ignore[attr-defined]
+        utility_ema={"w": jnp.full(2, jnp.inf, dtype=jnp.float32)},
+        gradient_second_moment={
+            "w": jnp.full(2, jnp.inf, dtype=jnp.float32)
+        },
+    )
+
+    result = optimizer.update(
+        state,
+        params,
+        {"w": jnp.asarray([-1.0, -0.5], dtype=jnp.float32)},
+        jr.key(101),
+        noise=_zero_noise(params),
+    )
+
+    assert bool(result.accepted)
+    chex.assert_tree_all_finite(result.state)
+    chex.assert_tree_all_finite(result.params)
+
+
+def test_official_zero_decays_do_not_multiply_inf_trackers() -> None:
+    params = {"w": jnp.ones(2, dtype=jnp.float32)}
+    optimizer = OfficialAdaUPGD(
+        OfficialAdaUPGDConfig(
+            utility_decay=0.0,
+            beta1=0.0,
+            beta2=0.0,
+            noise_std=0.0,
+        )
+    )
+    state = optimizer.init(params).replace(  # type: ignore[attr-defined]
+        utility_ema={"w": jnp.full(2, jnp.inf, dtype=jnp.float32)},
+        first_moment={"w": jnp.full(2, jnp.inf, dtype=jnp.float32)},
+        second_moment={"w": jnp.full(2, jnp.inf, dtype=jnp.float32)},
+    )
+
+    result = optimizer.update(
+        state,
+        params,
+        {"w": jnp.asarray([-1.0, -0.5], dtype=jnp.float32)},
+        jr.key(102),
+        noise=_zero_noise(params),
+    )
+
+    chex.assert_tree_all_finite(result.state)
+    chex.assert_tree_all_finite(result.params)
+
+
 def test_config_is_explicitly_derived_strict_and_roundtrips() -> None:
     config = AlbertaAdaUPGDConfig(
         step_size=0.02,

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -11,6 +11,7 @@ import pytest
 from alberta_framework.core.canonical_upgd import (
     CanonicalUPGD,
     CanonicalUPGDConfig,
+    _static_zero_scale,
 )
 from alberta_framework.core.checkpoints import load_checkpoint, save_checkpoint
 
@@ -383,6 +384,26 @@ def test_zero_utility_decay_does_not_multiply_inf_ema() -> None:
     result = optimizer.update(state, params, gradients, jr.key(0))
     chex.assert_tree_all_finite(result.state.utility_ema)
     chex.assert_tree_all_finite(result.params)
+
+
+def test_nonzero_static_decay_preserves_legacy_hlo() -> None:
+    value = jnp.ones((4,), dtype=jnp.float32)
+    decay = 0.999
+
+    legacy_hlo = (
+        jax.jit(lambda leaf: decay * leaf)
+        .lower(value)
+        .compiler_ir(dialect="hlo")
+        .as_hlo_text()
+    )
+    guarded_hlo = (
+        jax.jit(lambda leaf: _static_zero_scale(decay, leaf))
+        .lower(value)
+        .compiler_ir(dialect="hlo")
+        .as_hlo_text()
+    )
+
+    assert legacy_hlo.splitlines()[1:] == guarded_hlo.splitlines()[1:]
 
 
 def test_paper_global_all_negative_uses_signed_maximum_and_reverses_order() -> None:

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -369,6 +369,22 @@ def test_global_normalization_spans_all_pytree_leaves() -> None:
     assert float(result.metrics["global_maximum_utility"]) == pytest.approx(2.0)
 
 
+def test_zero_utility_decay_does_not_multiply_inf_ema() -> None:
+    """utility_decay=0 times an infinite EMA is NaN and would be committed."""
+    params = {"w": jnp.ones(2, dtype=jnp.float32)}
+    gradients = {"w": jnp.array([-1.0, -0.5], dtype=jnp.float32)}
+    optimizer = CanonicalUPGD(CanonicalUPGDConfig(utility_decay=0.0, noise_std=0.0))
+    state = optimizer.init(params).replace(
+        utility_ema={"w": jnp.full(2, jnp.inf, dtype=jnp.float32)}
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = optimizer.update(state, params, gradients, jr.key(0))
+    chex.assert_tree_all_finite(result.state.utility_ema)
+    chex.assert_tree_all_finite(result.params)
+
+
 def test_paper_global_all_negative_uses_signed_maximum_and_reverses_order() -> None:
     """Pin the literal, potentially undesirable all-negative source equation."""
 


### PR DESCRIPTION
## Summary
- First-order CanonicalUPGD, Alberta AdaUPGD, and official AdaUPGD all decay utility (and Adam-style moments) with a scale that may be 0. IEEE 0*inf is NaN. CanonicalUPGD would commit that NaN EMA.
- Skip those products before writing the new tracker. On a zero-decay path, Alberta AdaUPGD also treats already-infinite EMAs as skippable so the finite-state guard can recover.

## Test plan
- [x] `test_zero_utility_decay_does_not_multiply_inf_ema`
- [x] `tests/test_canonical_upgd.py` (37 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)