### PR TITLE
Skip future-utility 0*inf when trace decay is disabled

### DIFF
--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -14,6 +14,11 @@ from jax import Array
 from jaxtyping import Bool, Float
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next trace."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 class FutureUtilityEstimate(NamedTuple):
     """One-step utility estimate with an explicit transaction verdict."""
 
@@ -165,7 +170,7 @@ def contribution_trace_output_loss_reduction_with_diagnostics(
     count = jnp.asarray(active_count, dtype=jnp.float32)
 
     active_errors = jnp.where(active_mask, errors, 0.0)
-    decayed_contribution = decay * contribution_trace
+    decayed_contribution = _skip_zero_scale(decay, contribution_trace)
     new_contribution_trace = (
         decayed_contribution + active_errors[:, None] * feature_values[None, :]
     )
@@ -174,7 +179,9 @@ def contribution_trace_output_loss_reduction_with_diagnostics(
         new_contribution_trace,
         decayed_contribution,
     )
-    new_feature_energy_trace = decay * feature_energy_trace + feature_values**2
+    new_feature_energy_trace = (
+        _skip_zero_scale(decay, feature_energy_trace) + feature_values**2
+    )
 
     delta_weight = (
         step_size
@@ -191,8 +198,11 @@ def contribution_trace_output_loss_reduction_with_diagnostics(
     inputs_valid = (
         jnp.all(jnp.where(active_mask, jnp.isfinite(errors), True))
         & jnp.all(jnp.isfinite(feature_values))
-        & jnp.all(jnp.isfinite(contribution_trace))
-        & jnp.all(jnp.isfinite(feature_energy_trace))
+        & jnp.logical_or(
+            decay == 0.0,
+            jnp.all(jnp.isfinite(contribution_trace))
+            & jnp.all(jnp.isfinite(feature_energy_trace)),
+        )
         & jnp.isfinite(decay)
         & (decay >= 0.0)
         & (decay <= 1.0)
@@ -297,10 +307,13 @@ def trace_output_loss_reduction_with_diagnostics(
     count = jnp.asarray(active_count, dtype=jnp.float32)
 
     active_errors = jnp.where(active_mask, errors, 0.0)
-    new_error_trace = decay * error_trace + active_errors
-    new_error_trace = jnp.where(active_mask, new_error_trace, decay * error_trace)
-    new_feature_trace = decay * feature_trace + feature_values
-    new_feature_energy_trace = decay * feature_energy_trace + feature_values**2
+    decayed_error = _skip_zero_scale(decay, error_trace)
+    new_error_trace = decayed_error + active_errors
+    new_error_trace = jnp.where(active_mask, new_error_trace, decayed_error)
+    new_feature_trace = _skip_zero_scale(decay, feature_trace) + feature_values
+    new_feature_energy_trace = (
+        _skip_zero_scale(decay, feature_energy_trace) + feature_values**2
+    )
 
     delta_weight = (
         step_size
@@ -319,9 +332,12 @@ def trace_output_loss_reduction_with_diagnostics(
     inputs_valid = (
         jnp.all(jnp.where(active_mask, jnp.isfinite(errors), True))
         & jnp.all(jnp.isfinite(feature_values))
-        & jnp.all(jnp.isfinite(error_trace))
-        & jnp.all(jnp.isfinite(feature_trace))
-        & jnp.all(jnp.isfinite(feature_energy_trace))
+        & jnp.logical_or(
+            decay == 0.0,
+            jnp.all(jnp.isfinite(error_trace))
+            & jnp.all(jnp.isfinite(feature_trace))
+            & jnp.all(jnp.isfinite(feature_energy_trace)),
+        )
         & jnp.isfinite(decay)
         & (decay >= 0.0)
         & (decay <= 1.0)
@@ -404,7 +420,9 @@ def normalize_future_utility_signal(
     """
     decay = jnp.asarray(moment_decay, dtype=jnp.float32)
     utility_decay_arr = jnp.asarray(utility_decay, dtype=jnp.float32)
-    new_second_moment = decay * second_moment + (1.0 - decay) * signal**2
+    new_second_moment = (
+        _skip_zero_scale(decay, second_moment) + (1.0 - decay) * signal**2
+    )
     normalized = signal
 
     if mode in {"age", "uncertainty_age"}:

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -12,6 +12,7 @@ from alberta_framework.core.future_utility import (
     normalize_future_utility_signal,
     one_step_output_loss_reduction_with_diagnostics,
     trace_decay_from_half_life,
+    trace_output_loss_reduction_with_diagnostics,
 )
 
 
@@ -45,6 +46,60 @@ def test_contribution_trace_matches_one_step_at_zero_decay() -> None:
         jnp.array([[2.0, 4.0], [0.0, 0.0]], dtype=jnp.float32),
     )
     chex.assert_trees_all_close(energy_trace, features**2)
+
+
+def test_zero_trace_decay_does_not_multiply_inf_traces() -> None:
+    """trace_decay=0 times an infinite previous trace is NaN and would be held."""
+    errors = jnp.array([2.0], dtype=jnp.float32)
+    features = jnp.array([1.0], dtype=jnp.float32)
+    active_mask = jnp.array([True])
+    inf_trace = jnp.array([[jnp.inf]], dtype=jnp.float32)
+    inf_energy = jnp.array([jnp.inf], dtype=jnp.float32)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    contribution = contribution_trace_output_loss_reduction_with_diagnostics(
+        errors=errors,
+        feature_values=features,
+        active_mask=active_mask,
+        step_size_output=0.5,
+        active_count=1.0,
+        contribution_trace=inf_trace,
+        feature_energy_trace=inf_energy,
+        trace_decay=0.0,
+    )
+    assert bool(contribution.update_applied)
+    chex.assert_tree_all_finite(contribution.reductions)
+    chex.assert_tree_all_finite(contribution.contribution_trace)
+    chex.assert_tree_all_finite(contribution.feature_energy_trace)
+
+    factored = trace_output_loss_reduction_with_diagnostics(
+        errors=errors,
+        feature_values=features,
+        active_mask=active_mask,
+        step_size_output=0.5,
+        active_count=1.0,
+        error_trace=jnp.array([jnp.inf], dtype=jnp.float32),
+        feature_trace=jnp.array([jnp.inf], dtype=jnp.float32),
+        feature_energy_trace=inf_energy,
+        trace_decay=0.0,
+    )
+    assert bool(factored.update_applied)
+    chex.assert_tree_all_finite(factored.reductions)
+    chex.assert_tree_all_finite(factored.error_trace)
+    chex.assert_tree_all_finite(factored.feature_trace)
+    chex.assert_tree_all_finite(factored.feature_energy_trace)
+
+    normalized, second_moment = normalize_future_utility_signal(
+        signal=jnp.array([1.0], dtype=jnp.float32),
+        ages=jnp.array([1], dtype=jnp.int32),
+        second_moment=jnp.array([jnp.inf], dtype=jnp.float32),
+        moment_decay=0.0,
+        utility_decay=0.0,
+        mode="none",
+    )
+    chex.assert_tree_all_finite(normalized)
+    chex.assert_tree_all_finite(second_moment)
 
 
 def test_contribution_trace_has_no_future_label_leakage() -> None:


### PR DESCRIPTION
## Summary
- Contribution traces, factored traces, and the optional second-moment normalizer all multiply a previous tracker by a decay that can be 0. IEEE 0*inf is NaN, and the fail-closed guard would keep the infinite previous trace forever.
- Skip those products before adding the current sample. When decay is 0, also skip the finite-previous check so a disabled trace can recover from an already-infinite tracker.

## Test plan
- [x] `test_zero_trace_decay_does_not_multiply_inf_traces`
- [x] `tests/test_future_utility.py` (9 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)