### PR TITLE
Skip historical UPGD 0*inf utility and diagnostic EMAs

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -50,6 +50,12 @@ from alberta_framework.core.optimizers import Bounder, ObGDBounding
 from alberta_framework.core.types import MLPParams
 from alberta_framework.core.update_safety import zero_if_collapsed_infinity
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next EMA."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 # =============================================================================
 # Types
 # =============================================================================
@@ -2242,13 +2248,15 @@ class UPGDLearner:
 
         sq_for_metric = (predictions - safe_targets) ** 2
         step_mse = jnp.sum(jnp.where(active_mask, sq_for_metric, 0.0)) / n_active
+        fast_decay = jnp.asarray(self._loss_fast_decay, dtype=jnp.float32)
+        slow_decay = jnp.asarray(self._loss_slow_decay, dtype=jnp.float32)
         new_loss_fast_ema = (
-            jnp.asarray(self._loss_fast_decay, dtype=jnp.float32) * state.loss_fast_ema
-            + (1.0 - jnp.asarray(self._loss_fast_decay, dtype=jnp.float32)) * step_mse
+            _skip_zero_scale(fast_decay, state.loss_fast_ema)
+            + (1.0 - fast_decay) * step_mse
         )
         new_loss_slow_ema = (
-            jnp.asarray(self._loss_slow_decay, dtype=jnp.float32) * state.loss_slow_ema
-            + (1.0 - jnp.asarray(self._loss_slow_decay, dtype=jnp.float32)) * step_mse
+            _skip_zero_scale(slow_decay, state.loss_slow_ema)
+            + (1.0 - slow_decay) * step_mse
         )
         loss_pressure = jnp.array(1.0, dtype=jnp.float32)
         if self._unit_replacement_loss_gate_ratio > 0.0:
@@ -2292,23 +2300,14 @@ class UPGDLearner:
             self._head_repetition_delta_threshold,
             dtype=jnp.float32,
         )
+        repetition_decay = jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
         new_target_repeat_ema = (
-            jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
-            * state.target_repeat_ema
-            + (
-                1.0
-                - jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
-            )
-            * repeat_now.astype(jnp.float32)
+            _skip_zero_scale(repetition_decay, state.target_repeat_ema)
+            + (1.0 - repetition_decay) * repeat_now.astype(jnp.float32)
         )
         new_target_simplex_ema = (
-            jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
-            * state.target_simplex_ema
-            + (
-                1.0
-                - jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
-            )
-            * simplex_like_target.astype(jnp.float32)
+            _skip_zero_scale(repetition_decay, state.target_simplex_ema)
+            + (1.0 - repetition_decay) * simplex_like_target.astype(jnp.float32)
         )
         repetition_warm = state.step_count >= jnp.asarray(
             self._head_repetition_warmup_steps,
@@ -2740,7 +2739,10 @@ class UPGDLearner:
         new_unit_ages: list[Array] = []
         for i in range(n_trunk):
             instantaneous = jnp.abs(state.trunk_params.weights[i] * trunk_w_grads[i])
-            u_new = decay * state.utilities[i] + (1.0 - decay) * instantaneous
+            u_new = (
+                _skip_zero_scale(decay, state.utilities[i])
+                + (1.0 - decay) * instantaneous
+            )
             new_utilities.append(u_new)
 
             if track_unit_utilities:
@@ -2778,16 +2780,16 @@ class UPGDLearner:
                         * outgoing_signal
                     )
                 new_unit_utilities.append(
-                    unit_decay * state.unit_utilities[i]
+                    _skip_zero_scale(unit_decay, state.unit_utilities[i])
                     + (1.0 - unit_decay) * unit_signal
                 )
                 new_unit_long_utilities.append(
-                    unit_long_decay * state.unit_long_utilities[i]
+                    _skip_zero_scale(unit_long_decay, state.unit_long_utilities[i])
                     + (1.0 - unit_long_decay) * unit_signal
                 )
                 unit_gradient_signal = jnp.mean(jnp.abs(trunk_w_grads[i]), axis=1)
                 new_unit_gradient_emas.append(
-                    unit_gradient_decay * state.unit_gradient_emas[i]
+                    _skip_zero_scale(unit_gradient_decay, state.unit_gradient_emas[i])
                     + (1.0 - unit_gradient_decay) * unit_gradient_signal
                 )
                 new_unit_ages.append(state.unit_ages[i] + 1)

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -1422,6 +1422,50 @@ class TestUtilityTracking:
             jnp.ones_like(result.state.unit_ages[0]),
         )
 
+    def test_zero_utility_decay_does_not_multiply_inf_ema(self):
+        """utility_decay=0 times an infinite EMA is NaN and would be committed."""
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            step_size=0.0,
+            perturbation_sigma=0.0,
+            utility_decay=0.0,
+            unit_utility_decay=0.0,
+            unit_long_utility_decay=0.0,
+            unit_gradient_decay=0.0,
+            loss_fast_decay=0.0,
+            loss_slow_decay=0.0,
+            head_repetition_decay=0.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        state = state.replace(  # type: ignore[attr-defined]
+            utilities=tuple(jnp.full_like(u, jnp.inf) for u in state.utilities),
+            unit_utilities=tuple(jnp.full_like(u, jnp.inf) for u in state.unit_utilities),
+            unit_long_utilities=tuple(
+                jnp.full_like(u, jnp.inf) for u in state.unit_long_utilities
+            ),
+            unit_gradient_emas=tuple(
+                jnp.full_like(u, jnp.inf) for u in state.unit_gradient_emas
+            ),
+            loss_fast_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            loss_slow_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            target_repeat_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            target_simplex_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(state, jnp.ones(3), jnp.array([1.0]))
+        chex.assert_tree_all_finite(result.state.utilities)
+        chex.assert_tree_all_finite(result.state.unit_utilities)
+        chex.assert_tree_all_finite(result.state.unit_long_utilities)
+        chex.assert_tree_all_finite(result.state.unit_gradient_emas)
+        assert bool(jnp.isfinite(result.state.loss_fast_ema))
+        assert bool(jnp.isfinite(result.state.loss_slow_ema))
+        assert bool(jnp.isfinite(result.state.target_repeat_ema))
+        assert bool(jnp.isfinite(result.state.target_simplex_ema))
+
     def test_unit_recycling_reinitializes_lowest_mature_unit(self):
         learner = UPGDLearner(
             n_heads=2,


### PR DESCRIPTION
## Summary
- Historical UPGDLearner allows utility, unit-utility, loss, and repetition decays of 0. IEEE 0*inf is NaN, and this learner commits the tracker with no fail-closed transaction.
- Skip those products before adding the current signal so a zero-decay step recovers from an already-infinite EMA.

## Test plan
- [x] `TestUtilityTracking.test_zero_utility_decay_does_not_multiply_inf_ema`
- [x] `TestUtilityTracking` (12 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)