### PR TITLE
Skip learning-signal 0*inf when an EMA decay is disabled

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -53,6 +53,11 @@ from jaxtyping import Bool, Float, Int
 _INT32_MAX = 2_147_483_647
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled EMA decay does not poison the next value."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _saturating_increment(value: Array) -> Array:
     """Increment a non-negative int32 counter without lifetime wraparound."""
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
@@ -357,6 +362,21 @@ class LearningSignalEstimator:
         )
         loss = self._floating_array(jnp.asarray(observed_loss), (), name="observed_loss")
 
+        checked_fast_loss = (
+            jnp.zeros_like(state.fast_loss_ema)
+            if self._config.fast_loss_decay == 0.0
+            else state.fast_loss_ema
+        )
+        checked_slow_loss = (
+            jnp.zeros_like(state.slow_loss_ema)
+            if self._config.slow_loss_decay == 0.0
+            else state.slow_loss_ema
+        )
+        checked_change = (
+            jnp.zeros_like(state.sustained_change_probability)
+            if self._config.change_decay == 0.0
+            else state.sustained_change_probability
+        )
         state_valid = (
             (state.step_count >= 0)
             & (state.valid_count >= 0)
@@ -376,15 +396,15 @@ class LearningSignalEstimator:
             & (state.calibration_mean <= self._config.max_normalized_residual)
             & jnp.isfinite(state.calibration_m2)
             & (state.calibration_m2 >= 0.0)
-            & jnp.isfinite(state.fast_loss_ema)
-            & (state.fast_loss_ema >= 0.0)
-            & (state.fast_loss_ema <= self._config.max_observed_loss)
-            & jnp.isfinite(state.slow_loss_ema)
-            & (state.slow_loss_ema >= 0.0)
-            & (state.slow_loss_ema <= self._config.max_observed_loss)
-            & jnp.isfinite(state.sustained_change_probability)
-            & (state.sustained_change_probability >= 0.0)
-            & (state.sustained_change_probability <= 1.0)
+            & jnp.isfinite(checked_fast_loss)
+            & (checked_fast_loss >= 0.0)
+            & (checked_fast_loss <= self._config.max_observed_loss)
+            & jnp.isfinite(checked_slow_loss)
+            & (checked_slow_loss >= 0.0)
+            & (checked_slow_loss <= self._config.max_observed_loss)
+            & jnp.isfinite(checked_change)
+            & (checked_change >= 0.0)
+            & (checked_change <= 1.0)
         )
         input_valid = (
             jnp.all(jnp.isfinite(means))
@@ -470,17 +490,20 @@ class LearningSignalEstimator:
         )
 
         first_valid_event = state.valid_count == 0
+        fast_decay = jnp.asarray(self._config.fast_loss_decay, dtype=jnp.float32)
+        slow_decay = jnp.asarray(self._config.slow_loss_decay, dtype=jnp.float32)
+        change_decay = jnp.asarray(self._config.change_decay, dtype=jnp.float32)
         fast_loss = jnp.where(
             first_valid_event,
             safe_loss,
-            self._config.fast_loss_decay * state.fast_loss_ema
-            + (1.0 - self._config.fast_loss_decay) * safe_loss,
+            _skip_zero_scale(fast_decay, state.fast_loss_ema)
+            + (1.0 - fast_decay) * safe_loss,
         )
         slow_loss = jnp.where(
             first_valid_event,
             safe_loss,
-            self._config.slow_loss_decay * state.slow_loss_ema
-            + (1.0 - self._config.slow_loss_decay) * safe_loss,
+            _skip_zero_scale(slow_decay, state.slow_loss_ema)
+            + (1.0 - slow_decay) * safe_loss,
         )
         learning_progress = slow_loss - fast_loss
         next_valid_count = _saturating_increment(state.valid_count)
@@ -519,8 +542,8 @@ class LearningSignalEstimator:
             / self._config.change_temperature
         )
         sustained_change_probability = (
-            self._config.change_decay * state.sustained_change_probability
-            + (1.0 - self._config.change_decay) * instantaneous_change_probability
+            _skip_zero_scale(change_decay, state.sustained_change_probability)
+            + (1.0 - change_decay) * instantaneous_change_probability
         )
         change_available = event_valid & calibration_ready
 

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -435,3 +435,24 @@ def test_checkpoint_resume_matches_uninterrupted_scan(tmp_path) -> None:
         jax.tree_util.tree_structure(expected_state),
         jax.tree_util.tree_structure(actual_state),
     )
+
+
+def test_zero_ema_decay_does_not_multiply_inf_trackers() -> None:
+    """A disabled EMA decay times an infinite tracker is NaN."""
+    estimator = _estimator(fast_loss_decay=0.0, change_decay=0.0)
+    state, _ = _observe_scalar(estimator, estimator.init())
+    state = state.replace(fast_loss_ema=jnp.asarray(jnp.inf, dtype=jnp.float32))
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    next_state, _ = _observe_scalar(estimator, state, loss=0.25)
+    chex.assert_trees_all_close(
+        next_state.fast_loss_ema,
+        jnp.asarray(0.25, dtype=jnp.float32),
+    )
+
+    calibrated = _calibrated_state(estimator).replace(
+        sustained_change_probability=jnp.asarray(jnp.inf, dtype=jnp.float32),
+    )
+    next_calibrated, _ = _observe_scalar(estimator, calibrated)
+    assert bool(jnp.isfinite(next_calibrated.sustained_change_probability))


### PR DESCRIPTION
## Summary
- Learning-signal loss and change EMAs allow decay 0. IEEE 0*inf is NaN, and the finite-state guard would freeze the infinite tracker.
- Skip those products before mixing in the current observation. When a decay is 0, also treat the previous tracker as skippable so a later finite observation can recover.

## Test plan
- [x] `test_zero_ema_decay_does_not_multiply_inf_trackers`
- [x] `tests/test_learning_signals.py` (12 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)