### PR TITLE
Skip reward-model 0*inf when error EMA decay is disabled

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -24,6 +24,11 @@ from jax import Array
 from jaxtyping import Bool, Float
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled error EMA does not poison the diagnostic."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 @dataclass(frozen=True)
 class RLSRewardModelConfig:
     """Configuration for a linear recursive-least-squares reward model.
@@ -176,7 +181,8 @@ class RLSRewardModel:
         next_abs_error_ema = jnp.where(
             state.step_count == 0,
             abs_error,
-            error_decay * state.abs_error_ema + (1.0 - error_decay) * abs_error,
+            _skip_zero_scale(error_decay, state.abs_error_ema)
+            + (1.0 - error_decay) * abs_error,
         )
         next_state = RLSRewardModelState(
             weights=next_weights,
@@ -186,10 +192,15 @@ class RLSRewardModel:
         )
         # Inf reward * a silent feature's zero gain is 0*inf = NaN, and
         # that channel stays poisoned. Hold the previous finite state.
+        checked_error_ema = (
+            jnp.zeros_like(state.abs_error_ema)
+            if self._config.error_decay == 0.0
+            else state.abs_error_ema
+        )
         source_finite = (
             jnp.all(jnp.isfinite(state.weights))
             & jnp.all(jnp.isfinite(state.covariance))
-            & jnp.isfinite(state.abs_error_ema)
+            & jnp.isfinite(checked_error_ema)
         )
         inputs_valid = jnp.all(jnp.isfinite(x)) & jnp.isfinite(jnp.squeeze(target))
         proposed_finite = (

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -92,3 +92,21 @@ def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.covariance)
     assert bool(recovered.update_applied)
+
+
+def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
+    """error_decay=0 times an infinite abs-error EMA is NaN."""
+    model = RLSRewardModel(
+        RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0, error_decay=0.0)
+    )
+    features = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    state = model.update(
+        model.init(), features, jnp.array(1.0, dtype=jnp.float32)
+    ).state
+    state = state.replace(abs_error_ema=jnp.asarray(jnp.inf, dtype=jnp.float32))
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = model.update(state, features, jnp.array(0.5, dtype=jnp.float32))
+    assert bool(result.update_applied)
+    assert bool(jnp.isfinite(result.state.abs_error_ema))


### PR DESCRIPTION
## Summary
- RLS reward-model abs-error EMA allows error_decay=0. IEEE 0*inf is NaN, and the fail-closed guard would freeze that diagnostic.
- Skip the product before mixing in the current absolute error. When decay is 0, also treat the previous EMA as skippable so a later finite reward can recover.

## Test plan
- [x] `test_zero_error_decay_does_not_multiply_inf_ema`
- [x] `tests/test_reward_model.py` (5 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)