### PR TITLE
Skip UPGD-memory 0*inf when reliability decay is disabled

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -43,6 +43,11 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 
 
+def _finite_or_zero(value: Array) -> Array:
+    """Replace only poisoned disabled-EMA history, retaining finite history exactly."""
+    return jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value))
+
+
 UPGDMemoryReadoutMode = Literal["linear_mse", "softmax_ce"]
 
 
@@ -369,16 +374,15 @@ class UPGDMemoryLearner:
     ) -> Array:
         active_memory = (jnp.sum(state.memory_state.counts > 0.0) > 0).astype(jnp.float32)
         confidence_delta = jnp.max(memory_prediction) - jnp.max(upgd_prediction)
-        upgd_loss_ema = (
-            jnp.zeros_like(state.upgd_loss_ema)
-            if self._config.reliability_decay == 0.0
-            else state.upgd_loss_ema
-        )
-        memory_loss_ema = (
-            jnp.zeros_like(state.memory_loss_ema)
-            if self._config.reliability_decay == 0.0
-            else state.memory_loss_ema
-        )
+        if self._config.reliability_decay == 0.0:
+            # These prior losses still determine the prediction gate before
+            # the zero-decay EMAs are overwritten.  Preserve every finite
+            # value; only a poisoned historical value is recoverable here.
+            upgd_loss_ema = _finite_or_zero(state.upgd_loss_ema)
+            memory_loss_ema = _finite_or_zero(state.memory_loss_ema)
+        else:
+            upgd_loss_ema = state.upgd_loss_ema
+            memory_loss_ema = state.memory_loss_ema
         reliability_delta = upgd_loss_ema - memory_loss_ema
         logit = (
             state.memory_logit
@@ -548,10 +552,10 @@ class UPGDMemoryLearner:
         )
         checked_state = (
             state.replace(  # type: ignore[attr-defined]
-                allocation_ema=jnp.zeros_like(state.allocation_ema),
-                upgd_loss_ema=jnp.zeros_like(state.upgd_loss_ema),
-                memory_loss_ema=jnp.zeros_like(state.memory_loss_ema),
-                blended_loss_ema=jnp.zeros_like(state.blended_loss_ema),
+                allocation_ema=_finite_or_zero(state.allocation_ema),
+                upgd_loss_ema=_finite_or_zero(state.upgd_loss_ema),
+                memory_loss_ema=_finite_or_zero(state.memory_loss_ema),
+                blended_loss_ema=_finite_or_zero(state.blended_loss_ema),
             )
             if self._config.reliability_decay == 0.0
             else state

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -37,6 +37,12 @@ from alberta_framework.core.update_safety import (
 )
 from alberta_framework.core.upgd import UPGDLearner, UPGDState
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled reliability EMA does not poison trackers."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 UPGDMemoryReadoutMode = Literal["linear_mse", "softmax_ce"]
 
 
@@ -363,7 +369,17 @@ class UPGDMemoryLearner:
     ) -> Array:
         active_memory = (jnp.sum(state.memory_state.counts > 0.0) > 0).astype(jnp.float32)
         confidence_delta = jnp.max(memory_prediction) - jnp.max(upgd_prediction)
-        reliability_delta = state.upgd_loss_ema - state.memory_loss_ema
+        upgd_loss_ema = (
+            jnp.zeros_like(state.upgd_loss_ema)
+            if self._config.reliability_decay == 0.0
+            else state.upgd_loss_ema
+        )
+        memory_loss_ema = (
+            jnp.zeros_like(state.memory_loss_ema)
+            if self._config.reliability_decay == 0.0
+            else state.memory_loss_ema
+        )
+        reliability_delta = upgd_loss_ema - memory_loss_ema
         logit = (
             state.memory_logit
             + self._config.confidence_logit_scale * confidence_delta
@@ -483,7 +499,9 @@ class UPGDMemoryLearner:
         allocated = memory_result.metrics[5]
         decay = jnp.asarray(self._config.reliability_decay, dtype=jnp.float32)
         one_minus_decay = 1.0 - decay
-        next_allocation_ema = decay * state.allocation_ema + one_minus_decay * allocated
+        next_allocation_ema = (
+            _skip_zero_scale(decay, state.allocation_ema) + one_minus_decay * allocated
+        )
         allocation_error = next_allocation_ema - jnp.asarray(
             self._config.target_allocation_rate,
             dtype=jnp.float32,
@@ -502,9 +520,14 @@ class UPGDMemoryLearner:
             memory_state=memory_result.state,
             memory_logit=next_memory_logit,
             novelty_log_threshold=next_log_threshold,
-            upgd_loss_ema=decay * state.upgd_loss_ema + one_minus_decay * upgd_loss,
-            memory_loss_ema=decay * state.memory_loss_ema + one_minus_decay * memory_loss,
-            blended_loss_ema=(decay * state.blended_loss_ema + one_minus_decay * blended_loss),
+            upgd_loss_ema=_skip_zero_scale(decay, state.upgd_loss_ema)
+            + one_minus_decay * upgd_loss,
+            memory_loss_ema=_skip_zero_scale(decay, state.memory_loss_ema)
+            + one_minus_decay * memory_loss,
+            blended_loss_ema=(
+                _skip_zero_scale(decay, state.blended_loss_ema)
+                + one_minus_decay * blended_loss
+            ),
             allocation_ema=next_allocation_ema,
             step_count=state.step_count + 1,
         )
@@ -523,11 +546,21 @@ class UPGDMemoryLearner:
             ],
             dtype=jnp.float32,
         )
+        checked_state = (
+            state.replace(  # type: ignore[attr-defined]
+                allocation_ema=jnp.zeros_like(state.allocation_ema),
+                upgd_loss_ema=jnp.zeros_like(state.upgd_loss_ema),
+                memory_loss_ema=jnp.zeros_like(state.memory_loss_ema),
+                blended_loss_ema=jnp.zeros_like(state.blended_loss_ema),
+            )
+            if self._config.reliability_decay == 0.0
+            else state
+        )
         update_applied = (
             observation_valid
             & target_valid
             & memory_result.update_applied
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(checked_state)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(prediction))
             & jnp.all(jnp.isfinite(errors))

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -211,3 +211,68 @@ def test_zero_reliability_decay_does_not_multiply_inf_ema() -> None:
     assert bool(jnp.isfinite(result.state.upgd_loss_ema))
     assert bool(jnp.isfinite(result.state.memory_loss_ema))
     assert bool(jnp.isfinite(result.state.blended_loss_ema))
+
+
+def test_zero_reliability_decay_retains_finite_loss_history_in_gate() -> None:
+    """A zero EMA decay must not discard finite losses used by the current gate."""
+    config = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=2,
+        hidden_sizes=(4,),
+        slots_per_class=2,
+        reliability_decay=0.0,
+        confidence_logit_scale=0.0,
+        reliability_logit_scale=2.0,
+    )
+    learner = UPGDMemoryLearner(config)
+    initial = learner.init(jr.key(4))
+    active_memory = initial.memory_state.replace(  # type: ignore[attr-defined]
+        counts=jnp.ones_like(initial.memory_state.counts)
+    )
+    state = initial.replace(  # type: ignore[attr-defined]
+        memory_state=active_memory,
+        memory_logit=jnp.asarray(0.25, dtype=jnp.float32),
+        upgd_loss_ema=jnp.asarray(1.5, dtype=jnp.float32),
+        memory_loss_ema=jnp.asarray(0.5, dtype=jnp.float32),
+    )
+
+    gate = learner._blend_gate(
+        state,
+        jnp.asarray([0.0, 0.0], dtype=jnp.float32),
+        jnp.asarray([0.0, 0.0], dtype=jnp.float32),
+    )
+
+    expected = jax.nn.sigmoid(jnp.asarray(2.25, dtype=jnp.float32))
+    chex.assert_trees_all_close(gate, expected)
+
+
+def test_zero_reliability_decay_does_not_relax_consumed_non_ema_state() -> None:
+    """Only disabled EMA history is recoverable; a poisoned gate logit remains fatal."""
+    config = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=2,
+        hidden_sizes=(4,),
+        slots_per_class=2,
+        reliability_decay=0.0,
+    )
+    learner = UPGDMemoryLearner(config)
+    state = learner.init(jr.key(5)).replace(  # type: ignore[attr-defined]
+        memory_logit=jnp.asarray(jnp.inf, dtype=jnp.float32)
+    )
+
+    result = learner.update(
+        state,
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+
+    assert not bool(result.update_applied)
+    # The wall-clock diagnostic is materialized through JIT at float32
+    # precision; normalize it before asserting transactional rollback.
+    expected = state.replace(  # type: ignore[attr-defined]
+        upgd_state=state.upgd_state.replace(  # type: ignore[attr-defined]
+            birth_timestamp=result.state.upgd_state.birth_timestamp
+        )
+    )
+    chex.assert_trees_all_equal(result.state, expected)
+    chex.assert_trees_all_equal(result.predictions, jnp.zeros((2,), dtype=jnp.float32))

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -180,3 +180,34 @@ def test_upgd_memory_novelty_threshold_adapts() -> None:
         ).state
 
     assert float(jnp.exp(state.novelty_log_threshold)) > config.initial_novelty_threshold
+
+
+def test_zero_reliability_decay_does_not_multiply_inf_ema() -> None:
+    """reliability_decay=0 times an infinite EMA is NaN and would be held."""
+    config = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=2,
+        hidden_sizes=(4,),
+        slots_per_class=2,
+        reliability_decay=0.0,
+    )
+    learner = UPGDMemoryLearner(config)
+    state = learner.init(jr.key(0)).replace(  # type: ignore[attr-defined]
+        allocation_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        upgd_loss_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        memory_loss_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        blended_loss_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = learner.update(
+        state,
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert bool(jnp.isfinite(result.state.allocation_ema))
+    assert bool(jnp.isfinite(result.state.upgd_loss_ema))
+    assert bool(jnp.isfinite(result.state.memory_loss_ema))
+    assert bool(jnp.isfinite(result.state.blended_loss_ema))


### PR DESCRIPTION
## Summary
- Avoid IEEE `0 * inf` contamination when `reliability_decay=0` by skipping only the disabled EMA products.
- Recover poisoned disabled-EMA history without weakening the rest of the transaction guard.
- Preserve finite prior loss EMAs exactly because they still determine the current blend gate before the zero-decay update overwrites them.
- Keep poisoned consumed state such as `memory_logit` fail-closed with atomic rollback and neutral outputs.

## Validation
- [x] `tests/test_upgd_memory.py tests/test_upgd_memory_grad.py tests/test_production_steps.py` — 41 passed
- [x] focused Ruff
- [x] strict mypy on `upgd_memory.py`
- [x] `git diff --check`
- [x] no `outputs/**` changes

The new regressions cover poisoned EMA recovery, exact finite-history gate semantics, and rejection of a poisoned non-EMA gate input.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).