### PR TITLE
Skip normalizer 0*inf when decay or momentum is disabled

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -36,6 +36,12 @@ from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next moment."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 NORMALIZER_STATE_SCHEMA = "alberta.normalizer-state.v2"
 WELFORD_ESTIMATOR_SCHEMA = "alberta.welford-cumulative-float32-fail-stop-at-2p24.v2"
 BOUNDED_RECENCY_ESTIMATOR_SEMANTICS = "bounded-recency"
@@ -485,7 +491,15 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
         """
         status = self.counter_status(state)
         observation_valid = jnp.all(jnp.isfinite(observation))
-        source_state_finite = _floating_tree_is_finite(state)
+        checked_state = (
+            state.replace(
+                mean=jnp.zeros_like(state.mean),
+                var=jnp.ones_like(state.var),
+            )
+            if self._decay == 0.0
+            else state
+        )
+        source_state_finite = _floating_tree_is_finite(checked_state)
         update_available = (
             status.update_available & observation_valid & source_state_finite
         )
@@ -501,9 +515,17 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
                 1.0 - 1.0 / (new_count_float + 1.0),
             )
             delta = observation - state.mean
-            new_mean = state.mean + (1.0 - effective_decay) * delta
+            new_mean = jnp.where(
+                effective_decay == 0.0,
+                observation,
+                state.mean + (1.0 - effective_decay) * delta,
+            )
             delta2 = observation - new_mean
-            new_var = effective_decay * state.var + (1.0 - effective_decay) * delta * delta2
+            new_var = jnp.where(
+                effective_decay == 0.0,
+                delta2 * delta2,
+                effective_decay * state.var + (1.0 - effective_decay) * delta * delta2,
+            )
             new_var = jnp.maximum(new_var, self._epsilon)
             normalized = (observation - new_mean) / (jnp.sqrt(new_var) + self._epsilon)
             return normalized, EMANormalizerState(
@@ -737,7 +759,15 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
         """Normalize and conditionally commit BatchNorm-style moments."""
         status = self.counter_status(state)
         observation_valid = jnp.all(jnp.isfinite(observation))
-        source_state_finite = _floating_tree_is_finite(state)
+        checked_state = (
+            state.replace(
+                mean=jnp.zeros_like(state.mean),
+                var=jnp.ones_like(state.var),
+            )
+            if self._momentum == 0.0
+            else state
+        )
+        source_state_finite = _floating_tree_is_finite(checked_state)
         update_available = (
             status.update_available & observation_valid & source_state_finite
         )
@@ -749,10 +779,19 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
             del ignored_capacity
             is_first = _lifetime_words_are_zero(state.sample_count_words)
             one_minus_m = 1.0 - state.momentum
-            candidate_mean = state.momentum * state.mean + one_minus_m * observation
+            candidate_mean = (
+                _skip_zero_scale(state.momentum, state.mean) + one_minus_m * observation
+            )
             new_mean = jnp.where(is_first, observation, candidate_mean)
-            centered = observation - state.mean
-            candidate_var = state.momentum * state.var + one_minus_m * (centered * centered)
+            centered = jnp.where(
+                state.momentum == 0.0,
+                observation - new_mean,
+                observation - state.mean,
+            )
+            candidate_var = (
+                _skip_zero_scale(state.momentum, state.var)
+                + one_minus_m * (centered * centered)
+            )
             new_var = jnp.where(
                 is_first,
                 jnp.ones_like(state.var),

--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -36,12 +36,6 @@ from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
 
-
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
-    """Skip ``0 * inf`` so a disabled decay does not poison the next moment."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
-
-
 NORMALIZER_STATE_SCHEMA = "alberta.normalizer-state.v2"
 WELFORD_ESTIMATOR_SCHEMA = "alberta.welford-cumulative-float32-fail-stop-at-2p24.v2"
 BOUNDED_RECENCY_ESTIMATOR_SEMANTICS = "bounded-recency"
@@ -491,13 +485,13 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
         """
         status = self.counter_status(state)
         observation_valid = jnp.all(jnp.isfinite(observation))
-        checked_state = (
-            state.replace(
-                mean=jnp.zeros_like(state.mean),
-                var=jnp.ones_like(state.var),
-            )
-            if self._decay == 0.0
-            else state
+        zero_decay = state.decay == jnp.asarray(0.0, dtype=jnp.float32)
+        checked_state = EMANormalizerState(
+            mean=jnp.where(zero_decay, jnp.zeros_like(state.mean), state.mean),
+            var=jnp.where(zero_decay, jnp.ones_like(state.var), state.var),
+            sample_count=state.sample_count,
+            sample_count_words=state.sample_count_words,
+            decay=state.decay,
         )
         source_state_finite = _floating_tree_is_finite(checked_state)
         update_available = (
@@ -514,17 +508,22 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
                 state.decay,
                 1.0 - 1.0 / (new_count_float + 1.0),
             )
-            delta = observation - state.mean
-            new_mean = jnp.where(
-                effective_decay == 0.0,
+            mean_for_update = jnp.where(
+                zero_decay & ~jnp.isfinite(state.mean),
                 observation,
-                state.mean + (1.0 - effective_decay) * delta,
+                state.mean,
             )
+            delta = observation - mean_for_update
+            new_mean = mean_for_update + (1.0 - effective_decay) * delta
             delta2 = observation - new_mean
-            new_var = jnp.where(
-                effective_decay == 0.0,
-                delta2 * delta2,
-                effective_decay * state.var + (1.0 - effective_decay) * delta * delta2,
+            var_for_update = jnp.where(
+                zero_decay & ~jnp.isfinite(state.var),
+                jnp.zeros_like(state.var),
+                state.var,
+            )
+            new_var = (
+                effective_decay * var_for_update
+                + (1.0 - effective_decay) * delta * delta2
             )
             new_var = jnp.maximum(new_var, self._epsilon)
             normalized = (observation - new_mean) / (jnp.sqrt(new_var) + self._epsilon)
@@ -759,13 +758,13 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
         """Normalize and conditionally commit BatchNorm-style moments."""
         status = self.counter_status(state)
         observation_valid = jnp.all(jnp.isfinite(observation))
-        checked_state = (
-            state.replace(
-                mean=jnp.zeros_like(state.mean),
-                var=jnp.ones_like(state.var),
-            )
-            if self._momentum == 0.0
-            else state
+        zero_momentum = state.momentum == jnp.asarray(0.0, dtype=jnp.float32)
+        checked_state = StreamingBatchNormalizerState(
+            mean=state.mean,
+            var=jnp.where(zero_momentum, jnp.ones_like(state.var), state.var),
+            sample_count=state.sample_count,
+            sample_count_words=state.sample_count_words,
+            momentum=state.momentum,
         )
         source_state_finite = _floating_tree_is_finite(checked_state)
         update_available = (
@@ -779,17 +778,16 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
             del ignored_capacity
             is_first = _lifetime_words_are_zero(state.sample_count_words)
             one_minus_m = 1.0 - state.momentum
-            candidate_mean = (
-                _skip_zero_scale(state.momentum, state.mean) + one_minus_m * observation
-            )
+            candidate_mean = state.momentum * state.mean + one_minus_m * observation
             new_mean = jnp.where(is_first, observation, candidate_mean)
-            centered = jnp.where(
-                state.momentum == 0.0,
-                observation - new_mean,
-                observation - state.mean,
+            centered = observation - state.mean
+            var_for_update = jnp.where(
+                zero_momentum & ~jnp.isfinite(state.var),
+                jnp.zeros_like(state.var),
+                state.var,
             )
             candidate_var = (
-                _skip_zero_scale(state.momentum, state.var)
+                state.momentum * var_for_update
                 + one_minus_m * (centered * centered)
             )
             new_var = jnp.where(

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -91,6 +91,25 @@ class TestEMANormalizer:
         # (not exact due to decay and numerical issues)
         chex.assert_trees_all_close(state.mean, sample_observation, atol=0.5)
 
+    def test_zero_decay_does_not_multiply_inf_moments(self):
+        """decay=0 times an infinite mean or variance is NaN."""
+        normalizer = EMANormalizer(decay=0.0)
+        obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
+        state = normalizer.normalize(normalizer.init(2), obs)[1]
+        state = state.replace(
+            mean=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            var=jnp.full(2, jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = normalizer.normalize_with_diagnostics(state, obs)
+        assert bool(result.update_applied)
+        chex.assert_trees_all_close(result.state.mean, obs)
+        chex.assert_tree_all_finite(result.state.var)
+        chex.assert_tree_all_finite(result.normalized)
+
+
 class TestWelfordNormalizer:
     """Tests for the WelfordNormalizer class."""
 
@@ -214,6 +233,25 @@ class TestStreamingBatchNormalizer:
         assert isinstance(restored, StreamingBatchNormalizer)
         assert restored._momentum == 0.75
         assert restored._epsilon == 1e-4
+
+
+    def test_zero_momentum_does_not_multiply_inf_moments(self):
+        """momentum=0 times an infinite mean or variance is NaN."""
+        normalizer = StreamingBatchNormalizer(momentum=0.0)
+        obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
+        state = normalizer.normalize(normalizer.init(2), obs)[1]
+        state = state.replace(
+            mean=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            var=jnp.full(2, jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = normalizer.normalize_with_diagnostics(state, obs)
+        assert bool(result.update_applied)
+        chex.assert_trees_all_close(result.state.mean, obs)
+        chex.assert_tree_all_finite(result.state.var)
+        chex.assert_tree_all_finite(result.normalized)
 
 
 class TestNormalizerABC:

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -91,8 +91,8 @@ class TestEMANormalizer:
         # (not exact due to decay and numerical issues)
         chex.assert_trees_all_close(state.mean, sample_observation, atol=0.5)
 
-    def test_zero_decay_does_not_multiply_inf_moments(self):
-        """decay=0 times an infinite mean or variance is NaN."""
+    def test_zero_decay_recovers_from_nonfinite_unused_moments(self) -> None:
+        """A zero-decay update does not consume either previous moment."""
         normalizer = EMANormalizer(decay=0.0)
         obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
         state = normalizer.normalize(normalizer.init(2), obs)[1]
@@ -100,14 +100,62 @@ class TestEMANormalizer:
             mean=jnp.full(2, jnp.inf, dtype=jnp.float32),
             var=jnp.full(2, jnp.inf, dtype=jnp.float32),
         )
-        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
-        assert not bool(jnp.isfinite(raw))
-
         result = normalizer.normalize_with_diagnostics(state, obs)
+        assert isinstance(result.state, EMANormalizerState)
         assert bool(result.update_applied)
         chex.assert_trees_all_close(result.state.mean, obs)
-        chex.assert_tree_all_finite(result.state.var)
-        chex.assert_tree_all_finite(result.normalized)
+        chex.assert_trees_all_close(
+            result.state.var,
+            jnp.full_like(obs, normalizer._epsilon),
+        )
+        chex.assert_trees_all_close(result.normalized, jnp.zeros_like(obs))
+
+    def test_zero_decay_preserves_finite_update_arithmetic(self) -> None:
+        """Finite zero-decay updates retain the established rounding path."""
+        normalizer = EMANormalizer(decay=0.0)
+        state = normalizer.normalize(
+            normalizer.init(1),
+            jnp.array([0.0], dtype=jnp.float32),
+        )[1]
+        state = state.replace(
+            mean=jnp.array([1.0e20], dtype=jnp.float32),
+            var=jnp.array([7.0], dtype=jnp.float32),
+        )
+        obs = jnp.array([1.0], dtype=jnp.float32)
+        delta = obs - state.mean
+        expected_mean = state.mean + delta
+        delta2 = obs - expected_mean
+        expected_var = jnp.maximum(
+            jnp.asarray(0.0, dtype=jnp.float32) * state.var + delta * delta2,
+            normalizer._epsilon,
+        )
+
+        result = normalizer.normalize_with_diagnostics(state, obs)
+        assert isinstance(result.state, EMANormalizerState)
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state.mean, expected_mean)
+        chex.assert_trees_all_equal(result.state.var, expected_var)
+        assert not bool(jnp.array_equal(result.state.mean, obs))
+
+    def test_zero_decay_config_does_not_relax_nonzero_persisted_decay(self) -> None:
+        """A host/state decay mismatch remains fail-closed with poisoned moments."""
+        normalizer = EMANormalizer(decay=0.0)
+        state = normalizer.init(1).replace(
+            mean=jnp.array([jnp.inf], dtype=jnp.float32),
+            var=jnp.array([jnp.inf], dtype=jnp.float32),
+            decay=jnp.asarray(0.5, dtype=jnp.float32),
+        )
+
+        result = normalizer.normalize_with_diagnostics(
+            state,
+            jnp.array([2.0], dtype=jnp.float32),
+        )
+        assert isinstance(result.state, EMANormalizerState)
+        assert not bool(result.counter_valid)
+        assert not bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.normalized)))
+        chex.assert_trees_all_equal(result.normalized, jnp.zeros(1, dtype=jnp.float32))
+        chex.assert_trees_all_equal(result.state.sample_count_words, state.sample_count_words)
 
 
 class TestWelfordNormalizer:
@@ -234,24 +282,95 @@ class TestStreamingBatchNormalizer:
         assert restored._momentum == 0.75
         assert restored._epsilon == 1e-4
 
-
-    def test_zero_momentum_does_not_multiply_inf_moments(self):
-        """momentum=0 times an infinite mean or variance is NaN."""
+    def test_zero_momentum_preserves_finite_variance_update(self) -> None:
+        """The previous mean still defines variance when momentum is zero."""
         normalizer = StreamingBatchNormalizer(momentum=0.0)
-        obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
-        state = normalizer.normalize(normalizer.init(2), obs)[1]
+        state = normalizer.normalize(
+            normalizer.init(2),
+            jnp.array([0.0, 0.0], dtype=jnp.float32),
+        )[1]
         state = state.replace(
-            mean=jnp.full(2, jnp.inf, dtype=jnp.float32),
-            var=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            mean=jnp.array([4.0, -5.0], dtype=jnp.float32),
+            var=jnp.array([2.0, 3.0], dtype=jnp.float32),
         )
-        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
-        assert not bool(jnp.isfinite(raw))
+        obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
+        expected_mean = state.momentum * state.mean + (1.0 - state.momentum) * obs
+        centered = obs - state.mean
+        expected_var = jnp.maximum(
+            state.momentum * state.var
+            + (1.0 - state.momentum) * (centered * centered),
+            normalizer._epsilon,
+        )
 
         result = normalizer.normalize_with_diagnostics(state, obs)
+        assert isinstance(result.state, StreamingBatchNormalizerState)
         assert bool(result.update_applied)
-        chex.assert_trees_all_close(result.state.mean, obs)
-        chex.assert_tree_all_finite(result.state.var)
+        chex.assert_trees_all_equal(result.state.mean, expected_mean)
+        chex.assert_trees_all_equal(result.state.var, expected_var)
+        assert bool(jnp.all(result.state.var > normalizer._epsilon))
+
+    def test_zero_momentum_recovers_from_nonfinite_unused_variance(self) -> None:
+        """Only the zero-scaled previous variance may be nonfinite."""
+        normalizer = StreamingBatchNormalizer(momentum=0.0)
+        state = normalizer.normalize(
+            normalizer.init(2),
+            jnp.array([0.0, 0.0], dtype=jnp.float32),
+        )[1]
+        state = state.replace(
+            mean=jnp.array([4.0, -5.0], dtype=jnp.float32),
+            var=jnp.full(2, jnp.inf, dtype=jnp.float32),
+        )
+        obs = jnp.array([1.0, -2.0], dtype=jnp.float32)
+
+        result = normalizer.normalize_with_diagnostics(state, obs)
+        assert isinstance(result.state, StreamingBatchNormalizerState)
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state.mean, obs)
+        chex.assert_trees_all_equal(result.state.var, (obs - state.mean) ** 2)
         chex.assert_tree_all_finite(result.normalized)
+
+    def test_zero_momentum_rejects_nonfinite_consumed_mean(self) -> None:
+        """The previous mean cannot be ignored because variance consumes it."""
+        normalizer = StreamingBatchNormalizer(momentum=0.0)
+        state = normalizer.normalize(
+            normalizer.init(1),
+            jnp.array([0.0], dtype=jnp.float32),
+        )[1]
+        state = state.replace(
+            mean=jnp.array([jnp.inf], dtype=jnp.float32),
+            var=jnp.array([jnp.inf], dtype=jnp.float32),
+        )
+
+        result = normalizer.normalize_with_diagnostics(
+            state,
+            jnp.array([2.0], dtype=jnp.float32),
+        )
+        assert isinstance(result.state, StreamingBatchNormalizerState)
+        assert bool(result.counter_valid)
+        assert not bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.normalized)))
+        chex.assert_trees_all_equal(result.normalized, jnp.zeros(1, dtype=jnp.float32))
+        chex.assert_trees_all_equal(result.state.sample_count_words, state.sample_count_words)
+
+    def test_zero_momentum_config_does_not_relax_nonzero_persisted_value(self) -> None:
+        """A host/state momentum mismatch remains fail-closed with poisoned moments."""
+        normalizer = StreamingBatchNormalizer(momentum=0.0)
+        state = normalizer.init(1).replace(
+            mean=jnp.array([jnp.inf], dtype=jnp.float32),
+            var=jnp.array([jnp.inf], dtype=jnp.float32),
+            momentum=jnp.asarray(0.5, dtype=jnp.float32),
+        )
+
+        result = normalizer.normalize_with_diagnostics(
+            state,
+            jnp.array([2.0], dtype=jnp.float32),
+        )
+        assert isinstance(result.state, StreamingBatchNormalizerState)
+        assert not bool(result.counter_valid)
+        assert not bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.normalized)))
+        chex.assert_trees_all_equal(result.normalized, jnp.zeros(1, dtype=jnp.float32))
+        chex.assert_trees_all_equal(result.state.sample_count_words, state.sample_count_words)
 
 
 class TestNormalizerABC:


### PR DESCRIPTION
## Summary
- Let `EMANormalizer(decay=0)` recover when its previous mean or variance is nonfinite without evaluating the disabled `0 * inf` terms.
- Let `StreamingBatchNormalizer(momentum=0)` ignore only a nonfinite previous variance. Its previous mean remains required because the established update uses `(observation - old_mean)^2`; a poisoned mean still fails closed.
- Preserve the prior arithmetic exactly for finite states, and key zero-scale validity from the persisted state scalar so host/state configuration mismatches remain invalid.

## Test plan
- [x] `tests/test_normalizers.py` (44 passed)
- [x] `tests/test_checkpoints.py tests/test_config_serialization.py tests/test_single_step_api.py` (59 passed)
- [x] `ruff check .`
- [x] strict `mypy` (163 source files)

No evidence artifacts or `outputs/` paths were changed.

Original contribution made with Cursor; maintainer repair performed with Codex. No Slop measured-run receipt was attached.