### PR TITLE
Skip baseline-optimizer 0*inf moment EMAs

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -53,6 +53,17 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled EMA decay does not poison the next moment."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def _zero_if_disabled(scale: Array, value: Array) -> Array:
+    """Treat a zero-decay tracker as skippable in the finite-state check."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+
+
 # =============================================================================
 # State dataclasses
 # =============================================================================
@@ -496,8 +507,8 @@ class Adam(Optimizer[Any]):
             g = gradient
 
         new_t = state.t + 1.0
-        new_m = state.beta1 * state.m + (1.0 - state.beta1) * g
-        new_v = state.beta2 * state.v + (1.0 - state.beta2) * g**2
+        new_m = _skip_zero_scale(state.beta1, state.m) + (1.0 - state.beta1) * g
+        new_v = _skip_zero_scale(state.beta2, state.v) + (1.0 - state.beta2) * g**2
 
         m_hat = new_m / (1.0 - state.beta1**new_t)
         v_hat = new_v / (1.0 - state.beta2**new_t)
@@ -525,8 +536,12 @@ class Adam(Optimizer[Any]):
             if param is None
             else jnp.all(jnp.isfinite(param))
         )
+        checked_state = state.replace(
+            m=_zero_if_disabled(state.beta1, state.m),
+            v=_zero_if_disabled(state.beta2, state.v),
+        )
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(checked_state)
             & jnp.all(jnp.isfinite(gradient))
             & error_is_finite
             & param_is_finite
@@ -568,10 +583,14 @@ class Adam(Optimizer[Any]):
         g_b = -error_scalar
 
         new_t = state.t + 1.0
-        new_m = state.beta1 * state.m + (1.0 - state.beta1) * g
-        new_v = state.beta2 * state.v + (1.0 - state.beta2) * g**2
-        new_bias_m = state.beta1 * state.bias_m + (1.0 - state.beta1) * g_b
-        new_bias_v = state.beta2 * state.bias_v + (1.0 - state.beta2) * g_b**2
+        new_m = _skip_zero_scale(state.beta1, state.m) + (1.0 - state.beta1) * g
+        new_v = _skip_zero_scale(state.beta2, state.v) + (1.0 - state.beta2) * g**2
+        new_bias_m = (
+            _skip_zero_scale(state.beta1, state.bias_m) + (1.0 - state.beta1) * g_b
+        )
+        new_bias_v = (
+            _skip_zero_scale(state.beta2, state.bias_v) + (1.0 - state.beta2) * g_b**2
+        )
 
         m_hat = new_m / (1.0 - state.beta1**new_t)
         v_hat = new_v / (1.0 - state.beta2**new_t)
@@ -602,8 +621,14 @@ class Adam(Optimizer[Any]):
             "t": new_t,
         }
 
+        checked_state = state.replace(
+            m=_zero_if_disabled(state.beta1, state.m),
+            v=_zero_if_disabled(state.beta2, state.v),
+            bias_m=_zero_if_disabled(state.beta1, state.bias_m),
+            bias_v=_zero_if_disabled(state.beta2, state.bias_v),
+        )
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(checked_state)
             & jnp.isfinite(error_scalar)
             & jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(weight_delta))
@@ -740,7 +765,7 @@ class RMSprop(Optimizer[Any]):
         else:
             g = gradient
 
-        new_v = state.decay * state.v + (1.0 - state.decay) * g**2
+        new_v = _skip_zero_scale(state.decay, state.v) + (1.0 - state.decay) * g**2
         step = state.step_size * g / (jnp.sqrt(new_v) + state.eps)
 
         candidate_state = RMSpropParamState(
@@ -754,8 +779,9 @@ class RMSprop(Optimizer[Any]):
             if error is None
             else jnp.all(jnp.isfinite(error))
         )
+        checked_state = state.replace(v=_zero_if_disabled(state.decay, state.v))
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(checked_state)
             & jnp.all(jnp.isfinite(gradient))
             & error_is_finite
             & jnp.all(jnp.isfinite(step))
@@ -793,8 +819,10 @@ class RMSprop(Optimizer[Any]):
         g = -error_scalar * observation
         g_b = -error_scalar
 
-        new_v = state.decay * state.v + (1.0 - state.decay) * g**2
-        new_bias_v = state.decay * state.bias_v + (1.0 - state.decay) * g_b**2
+        new_v = _skip_zero_scale(state.decay, state.v) + (1.0 - state.decay) * g**2
+        new_bias_v = (
+            _skip_zero_scale(state.decay, state.bias_v) + (1.0 - state.decay) * g_b**2
+        )
 
         weight_delta = -state.step_size * g / (jnp.sqrt(new_v) + state.eps)
         bias_delta = -state.step_size * g_b / (jnp.sqrt(new_bias_v) + state.eps)
@@ -811,8 +839,12 @@ class RMSprop(Optimizer[Any]):
             "mean_v": jnp.mean(new_v),
         }
 
+        checked_state = state.replace(
+            v=_zero_if_disabled(state.decay, state.v),
+            bias_v=_zero_if_disabled(state.decay, state.bias_v),
+        )
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(checked_state)
             & jnp.isfinite(error_scalar)
             & jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(weight_delta))
@@ -920,7 +952,7 @@ class NADALINE(Optimizer[Any]):
         """
         error_scalar = jnp.squeeze(error)
         new_second_moment = (
-            state.decay * state.feature_second_moment
+            _skip_zero_scale(state.decay, state.feature_second_moment)
             + (1.0 - state.decay) * observation**2
         )
 
@@ -942,8 +974,13 @@ class NADALINE(Optimizer[Any]):
             "mean_denom": jnp.mean(denom),
         }
 
+        checked_state = state.replace(
+            feature_second_moment=_zero_if_disabled(
+                state.decay, state.feature_second_moment
+            ),
+        )
         update_applied = (
-            floating_tree_is_finite(state)
+            floating_tree_is_finite(checked_state)
             & jnp.isfinite(error_scalar)
             & jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(weight_delta))

--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -54,14 +54,20 @@ from alberta_framework.core.update_safety import (
 )
 
 
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
-    """Skip ``0 * inf`` so a disabled EMA decay does not poison the next moment."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+def _skip_zero_scale(configured_scale: float, scale: Array, value: Array) -> Array:
+    """Skip a disabled EMA without changing enabled optimizer graphs."""
+    if configured_scale == 0.0:
+        # Preserve the persisted-state contract if a caller supplies a
+        # nonzero state scale to a zero-configured optimizer.
+        return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+    return scale * value
 
 
-def _zero_if_disabled(scale: Array, value: Array) -> Array:
-    """Treat a zero-decay tracker as skippable in the finite-state check."""
-    return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+def _zero_if_disabled(configured_scale: float, scale: Array, value: Array) -> Array:
+    """Relax only a statically enabled zero-decay recovery path."""
+    if configured_scale == 0.0:
+        return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+    return value
 
 
 # =============================================================================
@@ -507,8 +513,12 @@ class Adam(Optimizer[Any]):
             g = gradient
 
         new_t = state.t + 1.0
-        new_m = _skip_zero_scale(state.beta1, state.m) + (1.0 - state.beta1) * g
-        new_v = _skip_zero_scale(state.beta2, state.v) + (1.0 - state.beta2) * g**2
+        new_m = _skip_zero_scale(self._beta1, state.beta1, state.m) + (
+            1.0 - state.beta1
+        ) * g
+        new_v = _skip_zero_scale(self._beta2, state.beta2, state.v) + (
+            1.0 - state.beta2
+        ) * g**2
 
         m_hat = new_m / (1.0 - state.beta1**new_t)
         v_hat = new_v / (1.0 - state.beta2**new_t)
@@ -536,9 +546,9 @@ class Adam(Optimizer[Any]):
             if param is None
             else jnp.all(jnp.isfinite(param))
         )
-        checked_state = state.replace(
-            m=_zero_if_disabled(state.beta1, state.m),
-            v=_zero_if_disabled(state.beta2, state.v),
+        checked_state = state.replace(  # type: ignore[attr-defined]
+            m=_zero_if_disabled(self._beta1, state.beta1, state.m),
+            v=_zero_if_disabled(self._beta2, state.beta2, state.v),
         )
         update_applied = (
             floating_tree_is_finite(checked_state)
@@ -583,13 +593,19 @@ class Adam(Optimizer[Any]):
         g_b = -error_scalar
 
         new_t = state.t + 1.0
-        new_m = _skip_zero_scale(state.beta1, state.m) + (1.0 - state.beta1) * g
-        new_v = _skip_zero_scale(state.beta2, state.v) + (1.0 - state.beta2) * g**2
+        new_m = _skip_zero_scale(self._beta1, state.beta1, state.m) + (
+            1.0 - state.beta1
+        ) * g
+        new_v = _skip_zero_scale(self._beta2, state.beta2, state.v) + (
+            1.0 - state.beta2
+        ) * g**2
         new_bias_m = (
-            _skip_zero_scale(state.beta1, state.bias_m) + (1.0 - state.beta1) * g_b
+            _skip_zero_scale(self._beta1, state.beta1, state.bias_m)
+            + (1.0 - state.beta1) * g_b
         )
         new_bias_v = (
-            _skip_zero_scale(state.beta2, state.bias_v) + (1.0 - state.beta2) * g_b**2
+            _skip_zero_scale(self._beta2, state.beta2, state.bias_v)
+            + (1.0 - state.beta2) * g_b**2
         )
 
         m_hat = new_m / (1.0 - state.beta1**new_t)
@@ -621,11 +637,11 @@ class Adam(Optimizer[Any]):
             "t": new_t,
         }
 
-        checked_state = state.replace(
-            m=_zero_if_disabled(state.beta1, state.m),
-            v=_zero_if_disabled(state.beta2, state.v),
-            bias_m=_zero_if_disabled(state.beta1, state.bias_m),
-            bias_v=_zero_if_disabled(state.beta2, state.bias_v),
+        checked_state = state.replace(  # type: ignore[attr-defined]
+            m=_zero_if_disabled(self._beta1, state.beta1, state.m),
+            v=_zero_if_disabled(self._beta2, state.beta2, state.v),
+            bias_m=_zero_if_disabled(self._beta1, state.beta1, state.bias_m),
+            bias_v=_zero_if_disabled(self._beta2, state.beta2, state.bias_v),
         )
         update_applied = (
             floating_tree_is_finite(checked_state)
@@ -765,7 +781,9 @@ class RMSprop(Optimizer[Any]):
         else:
             g = gradient
 
-        new_v = _skip_zero_scale(state.decay, state.v) + (1.0 - state.decay) * g**2
+        new_v = _skip_zero_scale(self._decay, state.decay, state.v) + (
+            1.0 - state.decay
+        ) * g**2
         step = state.step_size * g / (jnp.sqrt(new_v) + state.eps)
 
         candidate_state = RMSpropParamState(
@@ -779,7 +797,9 @@ class RMSprop(Optimizer[Any]):
             if error is None
             else jnp.all(jnp.isfinite(error))
         )
-        checked_state = state.replace(v=_zero_if_disabled(state.decay, state.v))
+        checked_state = state.replace(  # type: ignore[attr-defined]
+            v=_zero_if_disabled(self._decay, state.decay, state.v)
+        )
         update_applied = (
             floating_tree_is_finite(checked_state)
             & jnp.all(jnp.isfinite(gradient))
@@ -819,9 +839,12 @@ class RMSprop(Optimizer[Any]):
         g = -error_scalar * observation
         g_b = -error_scalar
 
-        new_v = _skip_zero_scale(state.decay, state.v) + (1.0 - state.decay) * g**2
+        new_v = _skip_zero_scale(self._decay, state.decay, state.v) + (
+            1.0 - state.decay
+        ) * g**2
         new_bias_v = (
-            _skip_zero_scale(state.decay, state.bias_v) + (1.0 - state.decay) * g_b**2
+            _skip_zero_scale(self._decay, state.decay, state.bias_v)
+            + (1.0 - state.decay) * g_b**2
         )
 
         weight_delta = -state.step_size * g / (jnp.sqrt(new_v) + state.eps)
@@ -839,9 +862,9 @@ class RMSprop(Optimizer[Any]):
             "mean_v": jnp.mean(new_v),
         }
 
-        checked_state = state.replace(
-            v=_zero_if_disabled(state.decay, state.v),
-            bias_v=_zero_if_disabled(state.decay, state.bias_v),
+        checked_state = state.replace(  # type: ignore[attr-defined]
+            v=_zero_if_disabled(self._decay, state.decay, state.v),
+            bias_v=_zero_if_disabled(self._decay, state.decay, state.bias_v),
         )
         update_applied = (
             floating_tree_is_finite(checked_state)
@@ -952,7 +975,7 @@ class NADALINE(Optimizer[Any]):
         """
         error_scalar = jnp.squeeze(error)
         new_second_moment = (
-            _skip_zero_scale(state.decay, state.feature_second_moment)
+            _skip_zero_scale(self._decay, state.decay, state.feature_second_moment)
             + (1.0 - state.decay) * observation**2
         )
 
@@ -974,9 +997,9 @@ class NADALINE(Optimizer[Any]):
             "mean_denom": jnp.mean(denom),
         }
 
-        checked_state = state.replace(
+        checked_state = state.replace(  # type: ignore[attr-defined]
             feature_second_moment=_zero_if_disabled(
-                state.decay, state.feature_second_moment
+                self._decay, state.decay, state.feature_second_moment
             ),
         )
         update_applied = (

--- a/tests/test_baseline_optimizers.py
+++ b/tests/test_baseline_optimizers.py
@@ -263,6 +263,28 @@ class TestAdam:
         assert isinstance(recreated, Adam)
         assert recreated.to_config()["weight_decay"] == pytest.approx(0.0)
 
+    def test_zero_beta_does_not_multiply_inf_moments(self):
+        """beta1=beta2=0 times an infinite moment EMA is NaN."""
+        optimizer = Adam(step_size=0.01, beta1=0.0, beta2=0.0)
+        state = optimizer.init(feature_dim=3).replace(
+            m=jnp.full(3, jnp.inf, dtype=jnp.float32),
+            v=jnp.full(3, jnp.inf, dtype=jnp.float32),
+            bias_m=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            bias_v=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = optimizer.update(
+            state,
+            jnp.asarray(0.5, dtype=jnp.float32),
+            jnp.ones(3, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.new_state)
+        chex.assert_tree_all_finite(result.weight_delta)
+        chex.assert_tree_all_finite(result.bias_delta)
+
 
 # =============================================================================
 # RMSprop
@@ -330,6 +352,26 @@ class TestRMSprop:
         assert isinstance(state, RMSpropParamState)
         chex.assert_shape(state.v, (3, 4))
         chex.assert_trees_all_close(state.v, jnp.zeros((3, 4)))
+
+    def test_zero_decay_does_not_multiply_inf_second_moment(self):
+        """decay=0 times an infinite squared-gradient EMA is NaN."""
+        optimizer = RMSprop(step_size=0.01, decay=0.0)
+        state = optimizer.init(feature_dim=3).replace(
+            v=jnp.full(3, jnp.inf, dtype=jnp.float32),
+            bias_v=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = optimizer.update(
+            state,
+            jnp.asarray(0.5, dtype=jnp.float32),
+            jnp.ones(3, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.new_state)
+        chex.assert_tree_all_finite(result.weight_delta)
+        chex.assert_tree_all_finite(result.bias_delta)
 
 
 # =============================================================================
@@ -427,3 +469,22 @@ class TestNADALINE:
         result = optimizer.update(state, error, observation)
         # bias_delta = alpha * error
         assert float(result.bias_delta) == pytest.approx(0.05 * 0.7, abs=1e-6)
+
+    def test_zero_decay_does_not_multiply_inf_second_moment(self):
+        """decay=0 times an infinite feature second-moment EMA is NaN."""
+        optimizer = NADALINE(step_size=0.01, decay=0.0)
+        state = optimizer.init(feature_dim=3).replace(
+            feature_second_moment=jnp.full(3, jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = optimizer.update(
+            state,
+            jnp.asarray(0.5, dtype=jnp.float32),
+            jnp.ones(3, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.new_state)
+        chex.assert_tree_all_finite(result.weight_delta)
+        chex.assert_tree_all_finite(result.bias_delta)

--- a/tests/test_baseline_optimizers.py
+++ b/tests/test_baseline_optimizers.py
@@ -285,6 +285,40 @@ class TestAdam:
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.bias_delta)
 
+    def test_zero_beta_recovers_poisoned_per_parameter_moments(self):
+        """The checked MLP path has the same zero-decay recovery contract."""
+        optimizer = Adam(step_size=0.01, beta1=0.0, beta2=0.0)
+        state = optimizer.init_for_shape((2, 3)).replace(
+            m=jnp.full((2, 3), jnp.inf, dtype=jnp.float32),
+            v=jnp.full((2, 3), jnp.inf, dtype=jnp.float32),
+        )
+
+        result = optimizer.update_from_gradient_checked(
+            state,
+            jnp.full((2, 3), 0.25, dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.step)
+        chex.assert_tree_all_finite(result.new_state)
+
+    def test_zero_config_does_not_relax_a_nonzero_persisted_beta(self):
+        """Recovery requires the persisted tracker decay itself to be disabled."""
+        optimizer = Adam(step_size=0.01, beta1=0.0, beta2=0.0)
+        state = optimizer.init_for_shape((3,)).replace(
+            beta1=jnp.asarray(0.5, dtype=jnp.float32),
+            m=jnp.full(3, jnp.inf, dtype=jnp.float32),
+        )
+
+        result = optimizer.update_from_gradient_checked(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+        )
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.new_state, state)
+        chex.assert_trees_all_equal(result.step, jnp.zeros(3, dtype=jnp.float32))
+
 
 # =============================================================================
 # RMSprop
@@ -372,6 +406,39 @@ class TestRMSprop:
         chex.assert_tree_all_finite(result.new_state)
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.bias_delta)
+
+    def test_zero_decay_recovers_poisoned_per_parameter_moment(self):
+        """The checked MLP path skips a disabled poisoned second moment."""
+        optimizer = RMSprop(step_size=0.01, decay=0.0)
+        state = optimizer.init_for_shape((2, 3)).replace(
+            v=jnp.full((2, 3), jnp.inf, dtype=jnp.float32)
+        )
+
+        result = optimizer.update_from_gradient_checked(
+            state,
+            jnp.full((2, 3), 0.25, dtype=jnp.float32),
+        )
+
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.step)
+        chex.assert_tree_all_finite(result.new_state)
+
+    def test_zero_config_does_not_relax_a_nonzero_persisted_decay(self):
+        """A nonzero persisted decay still consumes and validates its history."""
+        optimizer = RMSprop(step_size=0.01, decay=0.0)
+        state = optimizer.init_for_shape((3,)).replace(
+            decay=jnp.asarray(0.5, dtype=jnp.float32),
+            v=jnp.full(3, jnp.inf, dtype=jnp.float32),
+        )
+
+        result = optimizer.update_from_gradient_checked(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+        )
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.new_state, state)
+        chex.assert_trees_all_equal(result.step, jnp.zeros(3, dtype=jnp.float32))
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Skip IEEE `0 * inf` only for genuinely disabled Adam, RMSprop, and NADALINE moment trackers.
- Statically specialize the configured nonzero path so the ordinary Adam/RMSprop benchmark graphs retain their direct legacy multiplication.
- Require the persisted state decay itself to be zero before poisoned history is relaxed; mismatched nonzero persisted decay remains fail-closed.
- Cover both linear optimizer updates and the per-parameter checked paths used by the IPMNIST AdamW baseline.

## Validation
- [x] `tests/test_baseline_optimizers.py tests/test_upgd_ipmnist.py` — 81 passed
- [x] focused Ruff
- [x] strict mypy on `baseline_optimizers.py`
- [x] `git diff --check`
- [x] no `outputs/**` changes

The added regressions exercise linear and arbitrary-shape recovery, persisted-decay mismatch rejection, atomic rollback, and neutral rejected steps.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).