### PR TITLE
fix(ipmnist): bind partial manifest to one byte snapshot

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -1198,7 +1198,7 @@ def partial_payload(result: IPMNISTRunResult) -> dict[str, Any]:
     }
 
 
-def _strict_json_object(path: Path) -> dict[str, Any]:
+def _decode_strict_json_object(raw: bytes, *, path: Path) -> dict[str, Any]:
     def pairs_hook(pairs: list[tuple[str, object]]) -> dict[str, object]:
         parsed: dict[str, object] = {}
         for key, value in pairs:
@@ -1217,7 +1217,7 @@ def _strict_json_object(path: Path) -> dict[str, Any]:
         return parsed
 
     payload = json.loads(
-        Path(path).read_text(encoding="utf-8"),
+        raw.decode("utf-8"),
         object_pairs_hook=pairs_hook,
         parse_constant=reject_constant,
         parse_float=parse_float,
@@ -1225,6 +1225,11 @@ def _strict_json_object(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"{path}: payload must be one JSON object")
     return payload
+
+
+def _strict_json_object(path: Path) -> dict[str, Any]:
+    resolved = Path(path)
+    return _decode_strict_json_object(resolved.read_bytes(), path=resolved)
 
 
 def _v2_partial_manifest(paths: Sequence[Path]) -> list[dict[str, object]]:
@@ -1242,7 +1247,7 @@ def _v2_partial_manifest(paths: Sequence[Path]) -> list[dict[str, object]]:
     for path_value in paths:
         path = Path(path_value)
         raw = path.read_bytes()
-        payload = _strict_json_object(path)
+        payload = _decode_strict_json_object(raw, path=path)
         if payload.get("schema") != PARTIAL_SCHEMA:
             raise ValueError(f"{path}: partial manifest accepts only strict v2 shards")
         learner = payload.get("learner")

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -4,7 +4,9 @@ CI-cheap: everything runs on tiny synthetic data. Real-MNIST benchmark runs
 happen only through ``python -m alberta_framework.benchmarks.upgd_ipmnist``.
 """
 
+import hashlib
 import json
+from pathlib import Path
 
 import jax.numpy as jnp
 import jax.random as jr
@@ -659,6 +661,39 @@ class TestNoisePoolMode:
 
 
 class TestPartialMerge:
+    def test_v2_partial_manifest_binds_identity_and_digest_to_one_read(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "partial.json"
+        original = json.dumps(
+            {"schema": PARTIAL_SCHEMA, "learner": "adamw", "seed_id": 7}
+        ).encode("utf-8")
+        replacement = json.dumps(
+            {"schema": PARTIAL_SCHEMA, "learner": "upgd_w", "seed_id": 11}
+        )
+        path.write_bytes(original)
+
+        original_read_bytes = Path.read_bytes
+
+        def replace_after_read(target: Path) -> bytes:
+            snapshot = original_read_bytes(target)
+            target.write_text(replacement, encoding="utf-8")
+            return snapshot
+
+        monkeypatch.setattr(Path, "read_bytes", replace_after_read)
+
+        manifest = upgd_ipmnist._v2_partial_manifest([path])
+
+        assert manifest == [
+            {
+                "learner": "adamw",
+                "seed_id": 7,
+                "path": path.as_posix(),
+                "size_bytes": len(original),
+                "sha256": hashlib.sha256(original).hexdigest(),
+            }
+        ]
+
     def test_partial_roundtrip_and_merge(self, tmp_path):
         data_x, data_y = _synthetic_dataset(6, N_TRAIN, TINY.input_dim, TINY.n_classes)
         shard_a = run_ipmnist(data_x, data_y, "upgd_w", seeds=(1,), config=TINY)


### PR DESCRIPTION
Closes #208.

## Summary

- Decode each UPGD-IPMNIST v2 shard from the same byte snapshot used for `size_bytes` and `sha256`.
- Preserve the existing strict duplicate-key and finite-number validation.
- Add a regression test that replaces the path immediately after its first byte read and proves the manifest identity and digest remain bound to that original snapshot.

## Measurement-integrity effect

Lane: permanently nonpromoting UPGD-IPMNIST v2 artifact assembly.

Before this change, `_v2_partial_manifest` hashed one read but decoded `learner` and `seed_id` from a second read. The failing-test-first reproduction bound replacement identity `upgd_w`/`11` to the original `adamw`/`7` shard digest. After the change, that test passes because identity, size, and digest all derive from one immutable byte read.

This is an artifact-integrity fix, not a benchmark-performance claim. It consumes no benchmark compute or seeds, changes no protocol, and modifies no pinned artifact or `outputs/` path.

## Verification

Commit: `97ec38229fbd3191bb951be3485fccf1c72407e0`

- `.venv/bin/python -m pytest tests/test_upgd_ipmnist.py -q -o addopts="" --basetemp=/tmp/asi-pr208-pytest` — 49 passed.
- `.venv/bin/python -m ruff check .` — passed.
- `.venv/bin/python -m mypy` — no issues in 163 source files.
- `git diff --check origin/main...HEAD` — passed.

Provider/model/client: `openai` / `gpt-5.6-sol` / `codex`.

<!-- evidence-head:97ec38229fbd3191bb951be3485fccf1c72407e0 -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.github.com/techforky/01dd31f4ca773cbb66fb0ad1dedb8740/2daffb6039a728237979decfceb8493998bd6020
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/techforky/asi/blob/97ec38229fbd3191bb951be3485fccf1c72407e0/tests/test_upgd_ipmnist.py#L664-L697

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: elizaOS/slopdotcash@a99f2e649ecadc35896c9d65c8d5136e947333ce:skills/contribute-to-asi
Attribution status: self-reported
— [ipmnist-fix-codex]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"elizaOS/slopdotcash@a99f2e649ecadc35896c9d65c8d5136e947333ce:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M03W6HWS61DKQ48T6JWD5TXR","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-15T23:30:33.497Z","completed_at":"2026-08-16T02:24:49.389Z","skill_sha256":"7a906f03de69cf246f41ef475f44f5a8e151a047751f843b834cba0e310e742c","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cec5edcdbb8c8916ac0d6f017f3ade20fe6fbcf49d45e87a07f00913bc9f163a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"57b542ee-f52b-4994-9301-f4008de813d5","object_id":"sha256:cec5edcdbb8c8916ac0d6f017f3ade20fe6fbcf49d45e87a07f00913bc9f163a","sha256":"cec5edcdbb8c8916ac0d6f017f3ade20fe6fbcf49d45e87a07f00913bc9f163a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3aceg4QgMsc0ZP53MJ3M0V3eCnPq1NI7RTfZopU8XDQ","device_key_id":"f49fedd315360d799d914e11dd88eb8940b9d1c0045b8ab2a84dd77f70df8564","device_signature":"8j7JDHAMwTmIWMLXbUoC4fcGF8LCM2CL6XPzyT7LrTNcj8YVd2KKyee4gQB_1AlL9brkyxJoTrpBDpFJD2hoDA"}} -->
