### PR TITLE
fix(memory): reject non-finite decay and gate config

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -11,6 +11,7 @@ updates.
 from __future__ import annotations
 
 import functools
+import math
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from typing import Any, cast
@@ -181,8 +182,8 @@ class WorkingMemoryArrayResult:
 
 
 def _validate_decay_rates(name: str, rates: tuple[float, ...]) -> None:
-    if any(rate < 0.0 or rate >= 1.0 for rate in rates):
-        raise ValueError(f"{name} must lie in [0, 1); got {rates}")
+    if any(not math.isfinite(rate) or rate < 0.0 or rate >= 1.0 for rate in rates):
+        raise ValueError(f"{name} must contain finite values in [0, 1); got {rates}")
 
 
 def _validate_config(config: WorkingMemoryConfig) -> None:
@@ -195,10 +196,10 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     _validate_decay_rates("observation_decay_rates", config.observation_decay_rates)
     _validate_decay_rates("action_decay_rates", config.action_decay_rates)
     _validate_decay_rates("reward_decay_rates", config.reward_decay_rates)
-    if config.gate_temperature <= 0.0:
-        raise ValueError("gate_temperature must be positive")
-    if config.gate_threshold < 0.0:
-        raise ValueError("gate_threshold must be non-negative")
+    if not math.isfinite(config.gate_temperature) or config.gate_temperature <= 0.0:
+        raise ValueError("gate_temperature must be finite and positive")
+    if not math.isfinite(config.gate_threshold) or config.gate_threshold < 0.0:
+        raise ValueError("gate_threshold must be finite and non-negative")
     if config.feature_dim() < 1:
         raise ValueError("configuration must produce at least one feature")
 

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import chex
 import jax
 import jax.numpy as jnp
+import pytest
 
 from alberta_framework.core.working_memory import (
     WorkingMemoryConfig,
@@ -375,3 +376,78 @@ def test_working_memory_delayed_action_positive_control() -> None:
 
     chex.assert_trees_all_close(memory_mse, 0.0)
     assert float(memory_mse) < float(raw_mse)
+
+
+def _minimal_config(**overrides: object) -> WorkingMemoryConfig:
+    payload: dict[str, object] = {
+        "observation_dim": 2,
+        "action_dim": 0,
+        "reward_dim": 0,
+        "observation_decay_rates": (0.5,),
+        "action_decay_rates": (),
+        "reward_decay_rates": (),
+        "include_current_action": False,
+        "include_current_reward": False,
+    }
+    payload.update(overrides)
+    return WorkingMemoryConfig(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", [
+    "observation_decay_rates",
+    "action_decay_rates",
+    "reward_decay_rates",
+])
+@pytest.mark.parametrize(
+    "rates",
+    [
+        (float("nan"),),
+        (0.5, float("nan")),
+        (float("inf"),),
+        (float("-inf"),),
+        (1.0,),
+        (-0.1,),
+    ],
+)
+def test_decay_rates_must_be_finite_and_in_unit_half_open_interval(
+    field: str, rates: tuple[float, ...]
+) -> None:
+    extras: dict[str, object] = {field: rates}
+    if field != "observation_decay_rates":
+        extras["observation_decay_rates"] = (0.5,)
+    with pytest.raises(ValueError, match=field):
+        WorkingMemoryFeaturizer(_minimal_config(**extras))
+
+
+@pytest.mark.parametrize("temperature", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
+def test_gate_temperature_must_be_finite_and_positive(temperature: float) -> None:
+    with pytest.raises(ValueError, match="gate_temperature"):
+        WorkingMemoryFeaturizer(
+            _minimal_config(gated_update=True, gate_temperature=temperature)
+        )
+
+
+@pytest.mark.parametrize("threshold", [float("nan"), float("inf"), float("-inf"), -1.0])
+def test_gate_threshold_must_be_finite_and_nonnegative(threshold: float) -> None:
+    with pytest.raises(ValueError, match="gate_threshold"):
+        WorkingMemoryFeaturizer(
+            _minimal_config(gated_update=True, gate_threshold=threshold)
+        )
+
+
+def test_legal_finite_decay_endpoints_still_construct_and_update() -> None:
+    memory = WorkingMemoryFeaturizer(
+        _minimal_config(
+            observation_decay_rates=(0.0, 0.5, 0.99),
+            gate_temperature=1.0,
+            gate_threshold=0.0,
+        )
+    )
+    checked = memory.update_checked(
+        memory.init(),
+        jnp.asarray([1.0, 2.0], dtype=jnp.float32),
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    assert bool(checked.update_applied)
+    chex.assert_tree_all_finite(checked.state)


### PR DESCRIPTION
Fixes #230.

## What

`WorkingMemoryFeaturizer` now rejects IEEE non-finite decay and gate configuration at construction:

- observation, action, and reward decay rates must be finite and in `[0, 1)`;
- `gate_temperature` must be finite and strictly positive;
- `gate_threshold` must be finite and non-negative.

The validation remains at the existing featurizer construction boundary. The config dataclass and unrelated numeric type policy are unchanged, and legal finite endpoints still construct and complete a checked JAX update.

## Verification

Exact local head before publication: `1b42b00e93f194981431b88edff5a0a45940c5bb`.

- Focused WorkingMemory suite — **40 passed**.
- Broader relevant suite — **128 passed**.
- Red proof against baseline production — **10 failed, 18 passed** as expected for the newly rejected malformed classes; restoring the fix returned the focused suite to green.
- Ruff — clean.
- Project mypy — **163 source files clean**.
- Fresh ownership scan immediately before issue publication found no open PR touching either changed file.

## Scientific-integrity scope

This is ordinary configuration validation. It does not edit registered evidence sources, frozen protocols, seeds, benchmark results, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
