### PR TITLE
fix(benchmarks): validate micro-continual persisted config

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -69,7 +69,7 @@ import platform
 import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
@@ -82,6 +82,7 @@ import numpy as np
 from jax import Array
 
 from alberta_framework._fixed_count_selection import stable_smallest_mask
+from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
 from alberta_framework._strict_json import load_strict_json_object
 from alberta_framework.benchmarks.ipmnist_screening import (
     ScreeningStepFn,
@@ -142,6 +143,21 @@ _STREAM_DOMAIN = 101
 _INIT_DOMAIN = 202
 _STEP_DOMAIN = 303
 _BAYES_DOMAIN = 404
+
+
+def _require_finite_real(value: object, name: str) -> float:
+    """Reject bools and non-finite values while accepting every other real."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+    try:
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a finite real number, got {value!r}"
+        ) from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+    return number
 
 
 # =============================================================================
@@ -223,19 +239,22 @@ class MicroStreamConfig:
             raise ValueError(
                 f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})"
             )
-        if not 0.0 < float(self.class_sparsity) <= 1.0:
+        class_sparsity = _require_finite_real(self.class_sparsity, "class_sparsity")
+        if not 0.0 < class_sparsity <= 1.0:
             raise ValueError(
                 f"class_sparsity must be in (0, 1], got {self.class_sparsity!r}"
             )
         for name in ("mean_separation", "noise_scale"):
-            if not float(getattr(self, name)) > 0.0:
+            if not _require_finite_real(getattr(self, name), name) > 0.0:
                 raise ValueError(f"{name} must be positive, got {getattr(self, name)!r}")
         for name in ("offset_scale", "spectrum_decades", "component_scale"):
-            if float(getattr(self, name)) < 0.0:
+            if _require_finite_real(getattr(self, name), name) < 0.0:
                 raise ValueError(
                     f"{name} must be non-negative, got {getattr(self, name)!r}"
                 )
-        if not 0.0 < self.scale_shift_min < self.scale_shift_max:
+        scale_min = _require_finite_real(self.scale_shift_min, "scale_shift_min")
+        scale_max = _require_finite_real(self.scale_shift_max, "scale_shift_max")
+        if not 0.0 < scale_min < scale_max:
             raise ValueError(
                 "scale_shift bounds must satisfy 0 < scale_shift_min < "
                 f"scale_shift_max, got [{self.scale_shift_min}, {self.scale_shift_max}]"
@@ -275,6 +294,34 @@ class MicroStreamConfig:
             "scale_shift_max": self.scale_shift_max,
             "recurrence_pool": self.recurrence_pool,
         }
+
+    @classmethod
+    def from_mapping(
+        cls, mapping: object, *, source: str = "stream_config"
+    ) -> MicroStreamConfig:
+        """Reconstruct a stream config from a serialized object.
+
+        The mapping must contain exactly the :meth:`to_config` key set.
+        Omitted fields must not be filled from dataclass defaults: a truncated
+        shard would otherwise reconstruct a different stream identity.
+        """
+        if not isinstance(mapping, Mapping):
+            raise ValueError(f"{source} must be an object")
+        expected = {field.name for field in fields(cls)}
+        actual = set(mapping)
+        if actual != expected:
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            details: list[str] = []
+            if missing:
+                details.append(f"missing {missing}")
+            if extra:
+                details.append(f"unexpected {extra}")
+            raise ValueError(
+                f"{source} must contain exactly the serialized key set; "
+                + "; ".join(details)
+            )
+        return cls(**dict(mapping))
 
 
 # =============================================================================
@@ -741,6 +788,7 @@ def run_micro_arm(
     per-regime value is the mean over the regime's steps.
     """
     spec = arm if isinstance(arm, MicroArmSpec) else micro_arm_spec(arm)
+    seed = require_jax_seed(seed, name="seed")
     stream = generate_stream(config, seed)
     net = IPMNISTConfig(
         n_tasks=config.n_regimes,
@@ -876,7 +924,9 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         raise ValueError(
             f"{path}: environment must record non-empty jax, numpy, python, and platform strings"
         )
-    config = MicroStreamConfig(**payload["stream_config"])
+    config = MicroStreamConfig.from_mapping(
+        payload.get("stream_config"), source=f"{path}: stream_config"
+    )
     if payload.get("family") != config.family:
         raise ValueError(
             f"{path}: family {payload.get('family')!r} does not match "
@@ -891,8 +941,7 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
     payload["wall_clock_seconds"] = _validated_wall_clock_seconds(
         payload.get("wall_clock_seconds"), path
     )
-    if type(payload.get("seed")) is not int or payload["seed"] < 0:
-        raise ValueError(f"{path}: seed must be a non-negative integer")
+    payload["seed"] = require_jax_seed(payload.get("seed"), name=f"{path}: seed")
     for fieldname in ("hidden1", "hidden2"):
         value = payload.get(fieldname)
         if type(value) is not int or value <= 0:
@@ -935,7 +984,9 @@ def _micro_shard_batch_contract(
             f"separately (mismatched: {environment_mismatches})"
         )
     return (
-        MicroStreamConfig(**shards[0]["stream_config"]),
+        MicroStreamConfig.from_mapping(
+            shards[0]["stream_config"], source="stream_config"
+        ),
         dict(reference_environment),
     )
 
@@ -1443,15 +1494,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = _config_from_args(args)
 
     if args.command == "run":
+        seed = require_jax_seed(args.seed, name="seed")
         _run_or_skip_shard(
-            config, args.arm, args.seed, args.out, args.hidden1, args.hidden2
+            config, args.arm, seed, args.out, args.hidden1, args.hidden2
         )
         return 0
 
     # ladder
+    seeds = require_unique_jax_seeds(args.seeds, name="seeds")
     paths: list[Path] = []
     for arm_name in args.arms:
-        for seed in args.seeds:
+        for seed in seeds:
             paths.append(
                 _run_or_skip_shard(
                     config, arm_name, seed, args.out, args.hidden1, args.hidden2

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -26,6 +26,7 @@ import jax.random as jr
 import numpy as np
 import pytest
 
+from alberta_framework._seed_validation import JAX_KEY_SEED_MAX
 from alberta_framework.benchmarks.ipmnist_screening import (
     SCREENING_REGISTRY,
     screening_spec,
@@ -183,6 +184,71 @@ class TestConfig:
     def test_to_config_roundtrip(self):
         rebuilt = MicroStreamConfig(**TINY.to_config())
         assert rebuilt == TINY
+        assert MicroStreamConfig.from_mapping(TINY.to_config()) == TINY
+
+    def test_from_mapping_rejects_missing_and_empty_keys(self):
+        complete = TINY.to_config()
+        missing = dict(complete)
+        del missing["mean_separation"]
+        with pytest.raises(ValueError, match="mean_separation"):
+            MicroStreamConfig.from_mapping(missing)
+        missing_dim = dict(complete)
+        del missing_dim["dim"]
+        with pytest.raises(ValueError, match="dim"):
+            MicroStreamConfig.from_mapping(missing_dim)
+        with pytest.raises(ValueError, match="stream_config"):
+            MicroStreamConfig.from_mapping({})
+
+    def test_from_mapping_rejects_extra_keys_and_non_objects(self):
+        extra = dict(TINY.to_config())
+        extra["unknown_field"] = 1
+        with pytest.raises(ValueError, match="unknown_field"):
+            MicroStreamConfig.from_mapping(extra)
+        with pytest.raises(ValueError, match="stream_config"):
+            MicroStreamConfig.from_mapping(["not", "an", "object"])
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "class_sparsity",
+            "mean_separation",
+            "noise_scale",
+            "spectrum_decades",
+            "component_scale",
+            "offset_scale",
+            "scale_shift_min",
+            "scale_shift_max",
+        ],
+    )
+    def test_bool_is_not_a_valid_float(self, field: str):
+        with pytest.raises(ValueError, match=field):
+            tiny("input_permutation", **{field: True})
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "class_sparsity",
+            "mean_separation",
+            "noise_scale",
+            "spectrum_decades",
+            "component_scale",
+            "offset_scale",
+            "scale_shift_min",
+            "scale_shift_max",
+        ],
+    )
+    @pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+    def test_nonfinite_floats_rejected(self, field: str, value: float):
+        with pytest.raises(ValueError, match=field):
+            tiny("input_permutation", **{field: value})
+
+    def test_legal_float_reals_and_range_edges_preserved(self):
+        tiny("input_permutation", class_sparsity=1)
+        tiny("input_permutation", class_sparsity=1.0)
+        tiny("input_permutation", spectrum_decades=0.0)
+        tiny("input_permutation", offset_scale=0.0)
+        tiny("input_permutation", component_scale=0.0)
+        tiny("input_permutation", mean_separation=0.4, noise_scale=1)
 
 
 # =============================================================================
@@ -693,6 +759,45 @@ class TestShards:
             atol=1e-8,
         )
 
+    def _write_payload(self, tmp_path: Path, payload: dict, name: str = "shard.json"):
+        path = tmp_path / name
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_load_rejects_incomplete_and_empty_stream_config(self, tmp_path: Path):
+        payload = micro_shard_payload(self._result())
+        missing = dict(payload["stream_config"])
+        del missing["mean_separation"]
+        payload["stream_config"] = missing
+        with pytest.raises(ValueError, match="mean_separation"):
+            load_micro_shard(self._write_payload(tmp_path, payload, "missing.json"))
+
+        payload["stream_config"] = {}
+        with pytest.raises(ValueError, match="stream_config"):
+            load_micro_shard(self._write_payload(tmp_path, payload, "empty.json"))
+
+    def test_load_rejects_seed_outside_jax_domain(self, tmp_path: Path):
+        payload = micro_shard_payload(self._result())
+        payload["seed"] = JAX_KEY_SEED_MAX + 1
+        with pytest.raises(ValueError, match="seed"):
+            load_micro_shard(self._write_payload(tmp_path, payload, "seed-hi.json"))
+
+    @pytest.mark.parametrize("seed", [0, JAX_KEY_SEED_MAX])
+    def test_load_accepts_jax_seed_domain_edges(self, tmp_path: Path, seed: int):
+        payload = micro_shard_payload(self._result())
+        payload["seed"] = seed
+        loaded = load_micro_shard(self._write_payload(tmp_path, payload, f"seed-{seed}.json"))
+        assert loaded["seed"] == seed
+
+    def test_run_rejects_seed_outside_jax_domain(self):
+        with pytest.raises(ValueError, match="seed"):
+            run_micro_arm(TINY, "naive_bayes", seed=JAX_KEY_SEED_MAX + 1, hidden1=8, hidden2=6)
+
+    @pytest.mark.parametrize("seed", [0, JAX_KEY_SEED_MAX])
+    def test_run_accepts_jax_seed_domain_edges(self, seed: int):
+        result = run_micro_arm(TINY, "naive_bayes", seed=seed, hidden1=8, hidden2=6)
+        assert result.seed == seed
+
     @pytest.mark.parametrize("location", ["top-level", "nested"])
     def test_load_rejects_duplicate_top_level_and_nested_keys(
         self, tmp_path: Path, location: str
@@ -1145,6 +1250,22 @@ class TestCLI:
         assert report["schema"] == MICRO_VALIDATION_SCHEMA
         # exit code mirrors the verdict: 0 = ordering reproduced, 2 = not
         assert code == (0 if report["transfer_valid"] else 2)
+
+    def test_run_rejects_seed_outside_jax_domain(self, tmp_path: Path):
+        argv = [
+            "run", "--family", "input_permutation", "--arm", "sgd_raw",
+            "--seed", str(JAX_KEY_SEED_MAX + 1), "--out", str(tmp_path), *self.ARGS,
+        ]
+        with pytest.raises(ValueError, match="seed"):
+            main(argv)
+
+    def test_ladder_rejects_seed_outside_jax_domain(self, tmp_path: Path):
+        argv = [
+            "ladder", "--family", "input_permutation", "--seeds", str(JAX_KEY_SEED_MAX + 1),
+            "--arms", "sgd_raw", "--out", str(tmp_path), *self.ARGS,
+        ]
+        with pytest.raises(ValueError, match="seeds"):
+            main(argv)
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #231.

## What

The development-only micro-continual benchmark now fails closed at its persisted-config and JAX seed identity boundaries:

- serialized `stream_config` objects must contain exactly the complete key set emitted by `MicroStreamConfig.to_config()` instead of silently receiving dataclass defaults;
- float-valued stream fields reject booleans and every non-finite value before preserving the existing legal range checks;
- shard loading, `run_micro_arm`, and both CLI modes enforce the canonical scalar JAX seed domain `[0, 2**32 - 1]`, with ladder seeds also required to be non-empty and unique.

Complete config round-trips, legal finite boundary values, and seed endpoints remain valid. Lower-level geometry helpers are intentionally unchanged; the repair is confined to the required load, run, and CLI boundaries.

## Verification

Exact local head before publication: `db3bd2a361b3bc78c11c42442189df7af38c6604`.

- `tests/test_micro_continual.py` — **150 passed**.
- `tests/test_rule_discovery.py` — **37 passed**.
- Red proof against baseline production — **24 expected failures** for the new malformed-input contracts; fixed production restored the filtered set to **43/43 passed**.
- Ruff on both changed files — clean.
- Project mypy — **163 source files clean**.
- `git diff --check origin/main...HEAD` — clean.
- Fresh ownership scan immediately before issue publication found no open PR touching either changed file; duplicate issue search returned none.

## Scientific-integrity scope

This is validation for an explicitly nonpromoting development diagnostic. It does not edit registered evidence sources, frozen protocols, seed schedules, benchmark results, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
