### PR TITLE
fix(security): refuse non-finite JSON from to_dict mappings

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -9,10 +9,19 @@ requiring either sibling repository at import time.
 from __future__ import annotations
 
 import dataclasses
+import json
 import time
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
 from typing import Any
+
+
+def _require_rfc_json_mapping(payload: Mapping[str, Any], *, name: str) -> None:
+    """Raise ``ValueError`` unless ``payload`` serializes as RFC-compliant JSON."""
+    try:
+        json.dumps(payload, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be RFC-compliant JSON") from exc
 
 
 class SecurityAction(IntEnum):
@@ -86,7 +95,9 @@ class SecurityRewardWeights:
 
     def to_dict(self) -> dict[str, float]:
         """Return a JSON-serializable weight mapping."""
-        return dataclasses.asdict(self)
+        payload = dataclasses.asdict(self)
+        _require_rfc_json_mapping(payload, name="security reward weights")
+        return payload
 
 
 def security_reward(
@@ -135,12 +146,14 @@ class SecurityFeatureSchema:
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable schema mapping."""
-        return {
+        payload = {
             "version": self.version,
             "dtype": self.dtype,
             "names": list(self.names),
             "feature_dim": self.feature_dim,
         }
+        _require_rfc_json_mapping(payload, name="security feature schema")
+        return payload
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> SecurityFeatureSchema:
@@ -166,7 +179,7 @@ class SecurityRolloutStep:
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable transition mapping."""
-        return {
+        payload = {
             "state": list(self.state),
             "action": int(self.action),
             "action_name": self.action.name.lower(),
@@ -176,6 +189,8 @@ class SecurityRolloutStep:
             "truncated": self.truncated,
             "policy_metadata": dict(self.policy_metadata),
         }
+        _require_rfc_json_mapping(payload, name="security rollout step")
+        return payload
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> SecurityRolloutStep:
@@ -204,7 +219,7 @@ class SecurityOracleExperience:
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
-        return {
+        payload = {
             "schema": self.schema,
             "state": list(self.state),
             "action": int(self.action),
@@ -213,6 +228,8 @@ class SecurityOracleExperience:
             "outcome": dict(self.outcome),
             "policy_metadata": dict(self.policy_metadata),
         }
+        _require_rfc_json_mapping(payload, name="security oracle experience")
+        return payload
 
 
 def security_rollout_step_to_oracle_experience(
@@ -336,11 +353,13 @@ class ThroughputMeasurement:
 
     def to_dict(self) -> dict[str, float | int]:
         """Return a JSON-serializable measurement mapping."""
-        return {
+        payload = {
             "n_events": self.n_events,
             "elapsed_s": self.elapsed_s,
             "events_per_second": self.events_per_second,
         }
+        _require_rfc_json_mapping(payload, name="throughput measurement")
+        return payload
 
 
 class ThroughputMeter:

--- a/tests/test_security_integration.py
+++ b/tests/test_security_integration.py
@@ -1,5 +1,8 @@
 """Tests for security-gym / rlsecd integration contracts."""
 
+import json
+import math
+
 import pytest
 
 from alberta_framework import (
@@ -17,6 +20,10 @@ from alberta_framework import (
     security_reward,
     to_security_gym_action,
     validate_security_rollout,
+)
+from alberta_framework.security import (
+    SecurityOracleExperience,
+    ThroughputMeasurement,
 )
 
 
@@ -127,3 +134,71 @@ def test_throughput_meter_records_events() -> None:
     assert measurement.elapsed_s >= 0.0
     assert measurement.events_per_second > 0.0
     assert measurement.to_dict()["n_events"] == 3
+
+
+@pytest.mark.parametrize("elapsed_s", [0.0, -1.0, float("-inf")])
+def test_throughput_measurement_to_dict_rejects_nonpositive_elapsed(
+    elapsed_s: float,
+) -> None:
+    measurement = ThroughputMeasurement(n_events=3, elapsed_s=elapsed_s)
+    assert measurement.events_per_second == float("inf")
+    leaked = json.dumps(
+        {
+            "n_events": measurement.n_events,
+            "elapsed_s": measurement.elapsed_s,
+            "events_per_second": measurement.events_per_second,
+        }
+    )
+    assert "Infinity" in leaked
+    with pytest.raises(ValueError, match="RFC-compliant JSON"):
+        measurement.to_dict()
+
+
+def test_throughput_measurement_to_dict_rejects_nan_elapsed() -> None:
+    measurement = ThroughputMeasurement(n_events=3, elapsed_s=float("nan"))
+    assert math.isnan(measurement.events_per_second)
+    leaked = json.dumps(
+        {
+            "n_events": measurement.n_events,
+            "elapsed_s": measurement.elapsed_s,
+            "events_per_second": measurement.events_per_second,
+        }
+    )
+    assert "NaN" in leaked
+    with pytest.raises(ValueError, match="RFC-compliant JSON"):
+        measurement.to_dict()
+
+
+def test_throughput_measurement_to_dict_is_strict_json() -> None:
+    payload = ThroughputMeasurement(n_events=4, elapsed_s=2.0).to_dict()
+    encoded = json.dumps(payload, allow_nan=False, sort_keys=True)
+    assert json.loads(encoded) == {
+        "elapsed_s": 2.0,
+        "events_per_second": 2.0,
+        "n_events": 4,
+    }
+    assert "Infinity" not in encoded
+    assert "NaN" not in encoded
+
+
+def test_security_to_dict_rejects_nonfinite_numbers() -> None:
+    weights = SecurityRewardWeights(threat_blocked=float("inf"))
+    step = SecurityRolloutStep(
+        state=(0.0, 1.0),
+        action=SecurityAction.PASS,
+        reward=float("nan"),
+        next_state=(0.0, 1.0),
+        terminated=False,
+    )
+    experience = SecurityOracleExperience(
+        state=(0.0, 1.0),
+        action=SecurityAction.PASS,
+        reward=0.0,
+        outcome={"label": "true_negative", "score": float("nan")},
+    )
+    with pytest.raises(ValueError, match="RFC-compliant JSON"):
+        weights.to_dict()
+    with pytest.raises(ValueError, match="RFC-compliant JSON"):
+        step.to_dict()
+    with pytest.raises(ValueError, match="RFC-compliant JSON"):
+        experience.to_dict()


### PR DESCRIPTION
Fixes #235.

## What

The documented security serialization boundaries now fail closed when a mapping contains IEEE non-finite numbers:

- `ThroughputMeasurement.to_dict()` rejects the `Infinity` synthesized from nonpositive elapsed time and rejects NaN elapsed time;
- `SecurityRewardWeights`, `SecurityFeatureSchema`, `SecurityRolloutStep`, and `SecurityOracleExperience` apply the same RFC-compliant JSON contract to caller-supplied nested data;
- legal finite mappings remain byte-for-byte equivalent, and the in-memory `events_per_second` property retains its existing behavior.

The implementation uses `json.dumps(..., allow_nan=False)` only as a validation gate and returns the original mapping.

## Verification

Exact local head before publication: `58200140aee42aa3805a1a107d7d35c08504d150`.

- Focused security integration suite — **12 passed**.
- Baseline red proof with the new tests against unmodified production — **5 failed, 7 passed**, all five malformed classes did not raise.
- Fail-proof after temporarily restoring `origin/main` production — the same **5 expected failures**.
- Ruff on both changed files — clean.
- Project mypy — **163 source files clean**.
- `git diff --check origin/main...HEAD` — clean.
- Fresh complete ownership scan immediately before issue publication found no open PR touching either changed file.

## Scientific-integrity scope

This is ordinary machine-readable serialization validation. It does not edit registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
