### PR TITLE
fix(step3): reject illegal Horde scientific scalar config

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import asdict, dataclass
-from numbers import Real
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
@@ -186,6 +186,15 @@ def _require_unit_interval(name: str, value: object) -> float:
     return number
 
 
+def _require_positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    number = int(value)
+    if number < 1:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return number
+
+
 def _validate_horde_config(config: Step3HordeConfig) -> None:
     if len(config.gammas) == 0:
         raise ValueError("Step 3 Horde must have at least one demon")
@@ -204,11 +213,12 @@ def _validate_horde_config(config: Step3HordeConfig) -> None:
     obgd_kappa = _require_real("obgd_kappa", config.obgd_kappa)
     if obgd_kappa <= 0.0:
         raise ValueError(f"obgd_kappa must be positive, got {config.obgd_kappa!r}")
-    if any(size < 1 for size in config.hidden_sizes):
-        msg = f"hidden_sizes must contain positive sizes, got {config.hidden_sizes!r}"
-        raise ValueError(msg)
+    hidden_sizes = tuple(
+        _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
+    )
     object.__setattr__(config, "gammas", gammas)
     object.__setattr__(config, "lamdas", lamdas)
+    object.__setattr__(config, "hidden_sizes", hidden_sizes)
     object.__setattr__(config, "step_size", step_size)
     object.__setattr__(config, "sparsity", sparsity)
     object.__setattr__(config, "obgd_kappa", obgd_kappa)

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -14,7 +14,9 @@ Research-scale evidence and open boundaries for Step 3 are tracked in
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Real
 from typing import Any, Literal, cast
 
 import chex
@@ -65,6 +67,10 @@ class Step3HordeConfig:
     use_layer_norm: bool = True
     trace_mode: Step3TraceModeName = "accumulating"
     routing: Step3RoutingName = "shared"
+
+    def __post_init__(self) -> None:
+        """Reject illegal Horde scientific scalars and canonicalize reals."""
+        _validate_horde_config(self)
 
     @property
     def n_demons(self) -> int:
@@ -164,6 +170,22 @@ class Step3OneStepResult:
     per_demon_metrics: Array
 
 
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
 def _validate_horde_config(config: Step3HordeConfig) -> None:
     if len(config.gammas) == 0:
         raise ValueError("Step 3 Horde must have at least one demon")
@@ -173,16 +195,23 @@ def _validate_horde_config(config: Step3HordeConfig) -> None:
             f"got {len(config.gammas)} and {len(config.lamdas)}"
         )
         raise ValueError(msg)
-    for name, values in (("gammas", config.gammas), ("lamdas", config.lamdas)):
-        invalid = [value for value in values if value < 0.0 or value > 1.0]
-        if invalid:
-            msg = f"{name} must all be in [0, 1], got {invalid!r}"
-            raise ValueError(msg)
-    if config.step_size < 0.0:
-        raise ValueError(f"step_size must be non-negative, got {config.step_size}")
+    gammas = tuple(_require_unit_interval("gammas", value) for value in config.gammas)
+    lamdas = tuple(_require_unit_interval("lamdas", value) for value in config.lamdas)
+    step_size = _require_real("step_size", config.step_size)
+    if step_size < 0.0:
+        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
+    sparsity = _require_unit_interval("sparsity", config.sparsity)
+    obgd_kappa = _require_real("obgd_kappa", config.obgd_kappa)
+    if obgd_kappa <= 0.0:
+        raise ValueError(f"obgd_kappa must be positive, got {config.obgd_kappa!r}")
     if any(size < 1 for size in config.hidden_sizes):
         msg = f"hidden_sizes must contain positive sizes, got {config.hidden_sizes!r}"
         raise ValueError(msg)
+    object.__setattr__(config, "gammas", gammas)
+    object.__setattr__(config, "lamdas", lamdas)
+    object.__setattr__(config, "step_size", step_size)
+    object.__setattr__(config, "sparsity", sparsity)
+    object.__setattr__(config, "obgd_kappa", obgd_kappa)
 
 
 def make_step3_normalizer(

--- a/tests/test_step3_production.py
+++ b/tests/test_step3_production.py
@@ -49,6 +49,12 @@ _INVALID_HORDE_SCALARS: tuple[tuple[str, Any], ...] = (
     ("obgd_kappa", True),
     ("obgd_kappa", 0.0),
     ("obgd_kappa", -1.0),
+    ("hidden_sizes", (True,)),
+    ("hidden_sizes", (False,)),
+    ("hidden_sizes", (0,)),
+    ("hidden_sizes", (-1,)),
+    ("hidden_sizes", (1.5,)),
+    ("hidden_sizes", ("64",)),
 )
 
 
@@ -214,6 +220,7 @@ def test_step3_horde_scalars_canonicalize_nonbuiltin_reals() -> None:
     config = Step3HordeConfig(
         gammas=(value,),
         lamdas=(value,),
+        hidden_sizes=(np.int64(4),),
         step_size=value,
         sparsity=value,
         obgd_kappa=np.float64(2.0),
@@ -223,8 +230,10 @@ def test_step3_horde_scalars_canonicalize_nonbuiltin_reals() -> None:
     json.dumps(payload, allow_nan=False)
     assert config.gammas == (0.5,)
     assert config.lamdas == (0.5,)
+    assert config.hidden_sizes == (4,)
     assert type(payload["gammas"][0]) is float
     assert type(payload["lamdas"][0]) is float
+    assert type(payload["hidden_sizes"][0]) is int
     assert type(payload["step_size"]) is float
     assert type(payload["sparsity"]) is float
     assert type(payload["obgd_kappa"]) is float

--- a/tests/test_step3_production.py
+++ b/tests/test_step3_production.py
@@ -1,8 +1,18 @@
-"""Production-facing Step 3 Horde helper tests."""
+"""Production-facing Step 3 Horde helper tests.
+
+Covers the given-feature Horde facade on real constructors. Invalid
+scientific-scalar cases are written to fail on current main (bool,
+non-real, non-finite, and out-of-domain values accepted) and pass after
+the facade rejects them. Legal endpoints stay constructible.
+"""
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.horde import run_horde_learning_loop
@@ -11,6 +21,34 @@ from alberta_framework.steps import (
     build_step2_to_step3_arrays,
     make_step3_horde,
     run_step3_smoke,
+)
+
+_INVALID_HORDE_SCALARS: tuple[tuple[str, Any], ...] = (
+    ("gammas", (float("nan"),)),
+    ("gammas", (float("inf"),)),
+    ("gammas", (float("-inf"),)),
+    ("gammas", (True,)),
+    ("gammas", (False,)),
+    ("gammas", ("0.5",)),
+    ("gammas", (-0.1,)),
+    ("gammas", (1.1,)),
+    ("lamdas", (float("nan"),)),
+    ("lamdas", (True,)),
+    ("lamdas", (1.1,)),
+    ("step_size", float("nan")),
+    ("step_size", float("inf")),
+    ("step_size", True),
+    ("step_size", False),
+    ("step_size", -1.0),
+    ("sparsity", float("nan")),
+    ("sparsity", True),
+    ("sparsity", -0.1),
+    ("sparsity", 1.1),
+    ("obgd_kappa", float("nan")),
+    ("obgd_kappa", float("inf")),
+    ("obgd_kappa", True),
+    ("obgd_kappa", 0.0),
+    ("obgd_kappa", -1.0),
 )
 
 
@@ -130,3 +168,64 @@ def test_step3_config_validation() -> None:
 
     with pytest.raises(ValueError, match="final_window"):
         run_step3_smoke(steps=4, final_window=8)
+
+
+def _config_with(**overrides: Any) -> Step3HordeConfig:
+    payload: dict[str, Any] = {
+        "gammas": (0.0,),
+        "lamdas": (0.0,),
+    }
+    payload.update(overrides)
+    return Step3HordeConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_HORDE_SCALARS)
+def test_step3_horde_scalars_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_step3_horde(_config_with(**{field: value}))
+
+
+def test_step3_horde_scalars_preserve_legal_boundaries() -> None:
+    config = Step3HordeConfig(
+        gammas=(0.0, 1.0),
+        lamdas=(0.0, 1.0),
+        step_size=0.0,
+        sparsity=1.0,
+        obgd_kappa=2.0,
+        use_obgd=False,
+    )
+    horde = make_step3_horde(config)
+    assert horde.horde_spec.demons[0].gamma == 0.0
+    assert horde.horde_spec.demons[1].gamma == 1.0
+    assert horde.horde_spec.demons[0].lamda == 0.0
+    assert horde.horde_spec.demons[1].lamda == 1.0
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step3HordeConfig.from_dict(payload)
+    assert restored.gammas == (0.0, 1.0)
+    assert restored.lamdas == (0.0, 1.0)
+    assert restored.step_size == 0.0
+    assert restored.sparsity == 1.0
+    assert restored.obgd_kappa == 2.0
+
+
+def test_step3_horde_scalars_canonicalize_nonbuiltin_reals() -> None:
+    value = np.float64(0.5)
+    config = Step3HordeConfig(
+        gammas=(value,),
+        lamdas=(value,),
+        step_size=value,
+        sparsity=value,
+        obgd_kappa=np.float64(2.0),
+    )
+    horde = make_step3_horde(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.gammas == (0.5,)
+    assert config.lamdas == (0.5,)
+    assert type(payload["gammas"][0]) is float
+    assert type(payload["lamdas"][0]) is float
+    assert type(payload["step_size"]) is float
+    assert type(payload["sparsity"]) is float
+    assert type(payload["obgd_kappa"]) is float
+    assert horde.horde_spec.demons[0].gamma == 0.5


### PR DESCRIPTION
Fixes #237.

## What

The production Step 3 Horde facade now rejects malformed scientific scalar configuration before it reaches the underlying learner:

- `gammas`, `lamdas`, and `sparsity` must be finite real values in `[0, 1]`;
- `step_size` must be finite and non-negative;
- `obgd_kappa` must be finite and positive;
- every `hidden_sizes` width must be a positive integer;
- booleans and non-real/non-integral coercive inputs are rejected;
- accepted `numbers.Real` and `numbers.Integral` values, including NumPy scalars, are canonicalized to built-in floats and ints for stable serialization.

Legal endpoints remain valid. The repair is confined to the Step 3 facade and does not edit `MultiHead` or any #211-owned core file.

## Verification

Exact published head: `84b06b56969a7338ac1379ebf888f910efaccf3f`.

- Focused Step 3 production suite — **37 passed**.
- Original baseline red proof with the initial tests against unmodified production — **20 failed, 11 passed**.
- Reviewer regression proof against the prior published head — **3 failed, 34 passed**: `True` and `1.5` widths were accepted, while a string width leaked a `TypeError` instead of the facade's `ValueError` contract.
- Exact-head correction — **37/37** green, including boolean, non-integral, non-positive, string, and NumPy integer width cases.
- Ruff on both changed files and the full repository — clean.
- Project mypy — **163 source files clean**.
- `git diff --check` — clean.
- Fresh complete ownership scan before the correction push found no open PR touching either changed path except this PR.

## Scientific-integrity scope

This is ordinary facade configuration validation. It does not edit `MultiHead`, registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
