### PR TITLE
fix(step4): reject illegal SARSA scientific scalar config

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -21,7 +21,9 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
@@ -71,10 +73,8 @@ class Step4SARSAConfig:
     trace_mode: Literal["accumulating", "replacing"] = "accumulating"
 
     def __post_init__(self) -> None:
-        """Validate action count."""
-        if self.n_actions < 1:
-            msg = f"n_actions must be positive, got {self.n_actions}"
-            raise ValueError(msg)
+        """Reject illegal SARSA scientific scalars and canonicalize reals."""
+        _validate_sarsa_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -132,6 +132,73 @@ class Step4OneStepResult:
     q_values: Array
     td_error: Array
     reward: Array
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    number = int(value)
+    if number < 1:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return number
+
+
+def _require_nonneg_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    number = int(value)
+    if number < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    return number
+
+
+def _validate_sarsa_config(config: Step4SARSAConfig) -> None:
+    n_actions = _require_positive_int("n_actions", config.n_actions)
+    hidden_sizes = tuple(
+        _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
+    )
+    gamma = _require_unit_interval("gamma", config.gamma)
+    epsilon_start = _require_unit_interval("epsilon_start", config.epsilon_start)
+    epsilon_end = _require_unit_interval("epsilon_end", config.epsilon_end)
+    epsilon_decay_steps = _require_nonneg_int("epsilon_decay_steps", config.epsilon_decay_steps)
+    lamda = _require_unit_interval("lamda", config.lamda)
+    step_size = _require_real("step_size", config.step_size)
+    if step_size < 0.0:
+        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
+    meta_step_size = _require_real("meta_step_size", config.meta_step_size)
+    if meta_step_size < 0.0:
+        raise ValueError(f"meta_step_size must be non-negative, got {config.meta_step_size!r}")
+    bounder_kappa = _require_real("bounder_kappa", config.bounder_kappa)
+    if bounder_kappa <= 0.0:
+        raise ValueError(f"bounder_kappa must be positive, got {config.bounder_kappa!r}")
+    sparsity = _require_unit_interval("sparsity", config.sparsity)
+    object.__setattr__(config, "n_actions", n_actions)
+    object.__setattr__(config, "hidden_sizes", hidden_sizes)
+    object.__setattr__(config, "gamma", gamma)
+    object.__setattr__(config, "epsilon_start", epsilon_start)
+    object.__setattr__(config, "epsilon_end", epsilon_end)
+    object.__setattr__(config, "epsilon_decay_steps", epsilon_decay_steps)
+    object.__setattr__(config, "lamda", lamda)
+    object.__setattr__(config, "step_size", step_size)
+    object.__setattr__(config, "meta_step_size", meta_step_size)
+    object.__setattr__(config, "bounder_kappa", bounder_kappa)
+    object.__setattr__(config, "sparsity", sparsity)
 
 
 def make_step4_optimizer(config: Step4SARSAConfig) -> Any:

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -1,8 +1,17 @@
-"""Production-facing Step 4 SARSA facade tests (mirrors test_step3_production.py)."""
+"""Production-facing Step 4 SARSA facade tests (mirrors test_step3_production.py).
+
+Invalid scientific-scalar cases are written to fail on current main (bool,
+non-real, non-finite, and out-of-domain values accepted) and pass after
+the facade rejects them. Legal endpoints stay constructible.
+"""
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.optimizers import IDBD, LMS, Autostep, ObGDBounding
@@ -15,6 +24,54 @@ from alberta_framework.steps import (
     run_step4_scan,
     run_step4_smoke,
     step4_update,
+)
+
+_INVALID_STEP4_SCALARS: tuple[tuple[str, Any], ...] = (
+    ("gamma", float("nan")),
+    ("gamma", float("inf")),
+    ("gamma", float("-inf")),
+    ("gamma", True),
+    ("gamma", False),
+    ("gamma", "0.99"),
+    ("gamma", -0.1),
+    ("gamma", 1.1),
+    ("epsilon_start", float("nan")),
+    ("epsilon_start", True),
+    ("epsilon_start", -0.1),
+    ("epsilon_start", 1.1),
+    ("epsilon_end", float("nan")),
+    ("epsilon_end", True),
+    ("epsilon_end", -0.1),
+    ("epsilon_end", 1.1),
+    ("lamda", float("nan")),
+    ("lamda", True),
+    ("lamda", -0.1),
+    ("lamda", 1.1),
+    ("step_size", float("nan")),
+    ("step_size", float("inf")),
+    ("step_size", True),
+    ("step_size", False),
+    ("step_size", -1.0),
+    ("meta_step_size", float("nan")),
+    ("meta_step_size", float("inf")),
+    ("meta_step_size", True),
+    ("meta_step_size", -1.0),
+    ("bounder_kappa", float("nan")),
+    ("bounder_kappa", float("inf")),
+    ("bounder_kappa", True),
+    ("bounder_kappa", 0.0),
+    ("bounder_kappa", -1.0),
+    ("sparsity", float("nan")),
+    ("sparsity", True),
+    ("sparsity", -0.1),
+    ("sparsity", 1.1),
+    ("epsilon_decay_steps", True),
+    ("epsilon_decay_steps", False),
+    ("epsilon_decay_steps", -1),
+    ("epsilon_decay_steps", 1.5),
+    ("n_actions", True),
+    ("hidden_sizes", (0,)),
+    ("hidden_sizes", (True,)),
 )
 
 
@@ -131,3 +188,99 @@ def test_step4_smoke_validation() -> None:
         run_step4_smoke(steps=0)
     with pytest.raises(ValueError, match="feature_dim"):
         run_step4_smoke(feature_dim=0)
+
+
+def _config_with(**overrides: Any) -> Step4SARSAConfig:
+    payload: dict[str, Any] = {"n_actions": 2}
+    payload.update(overrides)
+    return Step4SARSAConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP4_SCALARS)
+def test_step4_sarsa_scalars_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step4_sarsa_scalars_preserve_legal_boundaries() -> None:
+    config = Step4SARSAConfig(
+        n_actions=1,
+        hidden_sizes=(),
+        gamma=0.0,
+        epsilon_start=0.0,
+        epsilon_end=1.0,
+        epsilon_decay_steps=0,
+        lamda=1.0,
+        step_size=0.0,
+        meta_step_size=0.0,
+        bounder_kappa=0.5,
+        sparsity=1.0,
+        use_layer_norm=False,
+    )
+    agent = make_step4_sarsa_agent(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step4SARSAConfig.from_dict(payload)
+    assert restored.gamma == 0.0
+    assert restored.epsilon_start == 0.0
+    assert restored.epsilon_end == 1.0
+    assert restored.lamda == 1.0
+    assert restored.step_size == 0.0
+    assert restored.meta_step_size == 0.0
+    assert restored.bounder_kappa == 0.5
+    assert restored.sparsity == 1.0
+    assert restored.epsilon_decay_steps == 0
+    assert restored.n_actions == 1
+    assert restored.hidden_sizes == ()
+    assert agent.to_config()["type"] == "SARSAAgent"
+
+    upper = Step4SARSAConfig(
+        n_actions=2,
+        gamma=1.0,
+        epsilon_start=1.0,
+        epsilon_end=0.0,
+        lamda=0.0,
+        sparsity=0.0,
+    )
+    make_step4_sarsa_agent(upper)
+    assert upper.gamma == 1.0
+    assert upper.epsilon_start == 1.0
+    assert upper.epsilon_end == 0.0
+    assert upper.lamda == 0.0
+    assert upper.sparsity == 0.0
+
+
+def test_step4_sarsa_scalars_canonicalize_nonbuiltin_reals() -> None:
+    value = np.float64(0.5)
+    config = Step4SARSAConfig(
+        n_actions=np.int64(3),
+        hidden_sizes=(np.int64(8),),
+        gamma=value,
+        epsilon_start=value,
+        epsilon_end=np.float64(0.0),
+        epsilon_decay_steps=np.int64(4),
+        lamda=value,
+        step_size=value,
+        meta_step_size=value,
+        bounder_kappa=np.float64(2.0),
+        sparsity=value,
+    )
+    agent = make_step4_sarsa_agent(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.gamma == 0.5
+    assert config.epsilon_start == 0.5
+    assert config.epsilon_end == 0.0
+    assert config.lamda == 0.5
+    assert type(payload["gamma"]) is float
+    assert type(payload["epsilon_start"]) is float
+    assert type(payload["epsilon_end"]) is float
+    assert type(payload["lamda"]) is float
+    assert type(payload["step_size"]) is float
+    assert type(payload["meta_step_size"]) is float
+    assert type(payload["bounder_kappa"]) is float
+    assert type(payload["sparsity"]) is float
+    assert type(payload["n_actions"]) is int
+    assert type(payload["epsilon_decay_steps"]) is int
+    assert type(payload["hidden_sizes"][0]) is int
+    assert agent.to_config()["type"] == "SARSAAgent"


### PR DESCRIPTION
Fixes #239.

## What

The packaged Step 4 SARSA facade now validates every dimension and scientific scalar at `Step4SARSAConfig` construction:

- `gamma`, `epsilon_start`, `epsilon_end`, `lamda`, and `sparsity` must be finite real values in `[0, 1]`;
- `step_size` and `meta_step_size` must be finite and non-negative;
- `bounder_kappa` must be finite and positive;
- `n_actions` and every hidden width must be positive integers;
- `epsilon_decay_steps` must be a non-negative integer;
- booleans and non-real/non-integral coercive inputs are rejected;
- accepted `Integral`/`Real` values, including NumPy scalars, are canonicalized to built-in ints/floats for stable serialization.

Legal endpoints remain valid. The repair is confined to the Step 4 facade and does not edit PR #209's `alberta_framework/core/sarsa.py` paths.

## Verification

Exact local head before publication: `0ff70e6c7852b7fd83e2651f1a82b7c4ce699f44`.

- Focused Step 4 production suite — **53 passed**.
- Pipeline consumer suite — **16 passed**.
- Combined exact-head proof — **69 passed**.
- Baseline red proof with the new tests against unmodified production — **46 failed, 1 passed**.
- Ruff on both changed files — clean and formatted.
- Project mypy — **163 source files clean**.
- `git diff --check origin/main...HEAD` — clean.
- Fresh complete ownership scan immediately before issue publication found no open PR touching either changed file; PR #209 remains confined to `core/sarsa.py` and `tests/test_sarsa.py`.

## Scientific-integrity scope

This is ordinary facade configuration validation. It does not edit core SARSA, registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Build
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"xAI","model":"grok-4.6","client":"Grok Build","attribution":"self-reported"} -->
