### PR TITLE
fix(step8): reject illegal world-model facade config

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -6,7 +6,9 @@ learn a one-step model — expected reward and next observation (or observation
 delta, with ``predict_delta=True``) given the current observation and action —
 online, from the same stream the control learner sees.  Step 7's Dyna backups
 and Step 9's guarded dreaming both consume this model.  The implementation
-lives in :mod:`alberta_framework.core.world_model`.
+lives in :mod:`alberta_framework.core.world_model`. The facade rejects illegal
+dimensions and decay/step-size/sparsity/leaky-ReLU scalars before constructing
+that core model; accepted numbers are canonicalized to builtin ints and floats.
 
 Network defaults follow the streaming stability recipe used across the
 package (Elsayed et al. 2024, "Streaming Deep Reinforcement Learning Finally
@@ -23,8 +25,10 @@ via Disagreement."
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -56,6 +60,10 @@ class Step8WorldModelConfig:
     predict_delta: bool = False
     utility_decay: float = 0.99
 
+    def __post_init__(self) -> None:
+        """Reject illegal dimensions and scientific scalars, then canonicalize."""
+        _validate_world_model_config(self)
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
@@ -68,7 +76,7 @@ class Step8WorldModelConfig:
         data = dict(payload)
         hidden_sizes = data.get("hidden_sizes", (64,))
         if isinstance(hidden_sizes, list):
-            data["hidden_sizes"] = tuple(int(v) for v in hidden_sizes)
+            data["hidden_sizes"] = tuple(hidden_sizes)
         return cls(**cast(Any, data))
 
     def to_core_config(self) -> WorldModelConfig:
@@ -85,6 +93,73 @@ class Step8WorldModelConfig:
             predict_delta=self.predict_delta,
             utility_decay=self.utility_decay,
         )
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number < 1.0:
+        raise ValueError(f"{name} must be in [0, 1), got {value!r}")
+    return number
+
+
+def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    return number
+
+
+def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
+    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    n_actions = (
+        None if config.n_actions is None else _require_int("n_actions", config.n_actions, minimum=1)
+    )
+    action_dim = _require_int(
+        "action_dim",
+        config.action_dim,
+        minimum=1 if n_actions is None else None,
+    )
+    if not isinstance(config.hidden_sizes, tuple):
+        raise ValueError(f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}")
+    hidden_sizes = tuple(
+        _require_int("hidden_sizes", size, minimum=1) for size in config.hidden_sizes
+    )
+    step_size = _require_real("step_size", config.step_size)
+    if step_size < 0.0:
+        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
+    sparsity = _require_unit_interval("sparsity", config.sparsity)
+    leaky_relu_slope = _require_real("leaky_relu_slope", config.leaky_relu_slope)
+    if leaky_relu_slope < 0.0:
+        raise ValueError(f"leaky_relu_slope must be non-negative, got {config.leaky_relu_slope!r}")
+    utility_decay = _require_half_open_unit_interval("utility_decay", config.utility_decay)
+    object.__setattr__(config, "observation_dim", observation_dim)
+    object.__setattr__(config, "n_actions", n_actions)
+    object.__setattr__(config, "action_dim", action_dim)
+    object.__setattr__(config, "hidden_sizes", hidden_sizes)
+    object.__setattr__(config, "step_size", step_size)
+    object.__setattr__(config, "sparsity", sparsity)
+    object.__setattr__(config, "leaky_relu_slope", leaky_relu_slope)
+    object.__setattr__(config, "utility_decay", utility_decay)
 
 
 @dataclass(frozen=True)
@@ -178,9 +253,7 @@ def step8_ensemble_predict(
     mean_reward = jnp.mean(reward_predictions, axis=0)
     mean_next_observation = jnp.mean(next_observation_predictions, axis=0)
     reward_disagreement = jnp.var(reward_predictions, axis=0)
-    next_observation_disagreement = jnp.mean(
-        jnp.var(next_observation_predictions, axis=0)
-    )
+    next_observation_disagreement = jnp.mean(jnp.var(next_observation_predictions, axis=0))
     total_disagreement = reward_disagreement + next_observation_disagreement
     return Step8EnsemblePrediction(
         reward_predictions=reward_predictions,

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -134,11 +134,7 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     n_actions = (
         None if config.n_actions is None else _require_int("n_actions", config.n_actions, minimum=1)
     )
-    action_dim = _require_int(
-        "action_dim",
-        config.action_dim,
-        minimum=1 if n_actions is None else None,
-    )
+    action_dim = _require_int("action_dim", config.action_dim, minimum=1)
     if not isinstance(config.hidden_sizes, tuple):
         raise ValueError(f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}")
     hidden_sizes = tuple(

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -1,10 +1,21 @@
-"""Tests for the Step 8 world-model facade."""
+"""Production-facing Step 8 world-model facade tests.
+
+Covers the one-step environment-model facade on real constructors. Invalid
+dimension and scientific-scalar cases are written to fail on current main
+(bool, non-real, non-finite, and out-of-domain values accepted) and pass
+after the facade rejects them. Legal endpoints stay constructible.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
+import pytest
 
 from alberta_framework.steps.step8 import (
     Step8WorldModelConfig,
@@ -14,6 +25,53 @@ from alberta_framework.steps.step8 import (
     run_step8_smoke,
     step8_ensemble_predict,
     step8_update,
+)
+
+_INVALID_WORLD_MODEL_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("observation_dim", True),
+    ("observation_dim", False),
+    ("observation_dim", 0),
+    ("observation_dim", -1),
+    ("observation_dim", 1.5),
+    ("observation_dim", "4"),
+    ("n_actions", True),
+    ("n_actions", False),
+    ("n_actions", 0),
+    ("n_actions", -1),
+    ("n_actions", 1.5),
+    ("n_actions", "2"),
+    ("action_dim", True),
+    ("action_dim", False),
+    ("action_dim", 1.5),
+    ("action_dim", "1"),
+    ("hidden_sizes", (True,)),
+    ("hidden_sizes", (False,)),
+    ("hidden_sizes", (0,)),
+    ("hidden_sizes", (-1,)),
+    ("hidden_sizes", (1.5,)),
+    ("hidden_sizes", ("64",)),
+    ("step_size", float("nan")),
+    ("step_size", float("inf")),
+    ("step_size", True),
+    ("step_size", False),
+    ("step_size", -1.0),
+    ("sparsity", float("nan")),
+    ("sparsity", True),
+    ("sparsity", -0.1),
+    ("sparsity", 1.1),
+    ("utility_decay", float("nan")),
+    ("utility_decay", float("inf")),
+    ("utility_decay", True),
+    ("utility_decay", False),
+    ("utility_decay", -0.1),
+    ("utility_decay", 1.0),
+    ("leaky_relu_slope", float("nan")),
+    ("leaky_relu_slope", float("inf")),
+    ("leaky_relu_slope", float("-inf")),
+    ("leaky_relu_slope", True),
+    ("leaky_relu_slope", False),
+    ("leaky_relu_slope", "0.01"),
+    ("leaky_relu_slope", -0.01),
 )
 
 
@@ -110,3 +168,95 @@ def test_step8_ensemble_prediction_rejects_empty_state_list() -> None:
         assert "states must contain" in str(exc)
     else:
         raise AssertionError("empty Step 8 ensemble state list should fail")
+
+
+def _config_with(**overrides: Any) -> Step8WorldModelConfig:
+    payload: dict[str, Any] = {
+        "observation_dim": 2,
+        "n_actions": 2,
+        "hidden_sizes": (),
+    }
+    payload.update(overrides)
+    if overrides.get("n_actions") is None and "action_dim" not in overrides:
+        payload["action_dim"] = 1
+    return Step8WorldModelConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_WORLD_MODEL_FIELDS)
+def test_step8_world_model_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_step8_world_model(_config_with(**{field: value}))
+
+
+def test_step8_world_model_rejects_nonpositive_vector_action_dim() -> None:
+    with pytest.raises(ValueError, match="action_dim"):
+        make_step8_world_model(_config_with(n_actions=None, action_dim=0))
+
+
+def test_step8_world_model_fields_preserve_legal_boundaries() -> None:
+    config = Step8WorldModelConfig(
+        observation_dim=1,
+        n_actions=None,
+        action_dim=1,
+        hidden_sizes=(),
+        step_size=0.0,
+        sparsity=1.0,
+        leaky_relu_slope=0.0,
+        utility_decay=0.0,
+    )
+    model = make_step8_world_model(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step8WorldModelConfig.from_dict(payload)
+    assert restored.observation_dim == 1
+    assert restored.n_actions is None
+    assert restored.action_dim == 1
+    assert restored.hidden_sizes == ()
+    assert restored.step_size == 0.0
+    assert restored.sparsity == 1.0
+    assert restored.leaky_relu_slope == 0.0
+    assert restored.utility_decay == 0.0
+    assert payload["sparsity"] == 1.0
+    assert payload["leaky_relu_slope"] == 0.0
+    assert model.to_config()["type"] == "OneStepWorldModel"
+
+    positive = Step8WorldModelConfig(
+        observation_dim=1,
+        n_actions=1,
+        hidden_sizes=(),
+        leaky_relu_slope=0.01,
+    )
+    make_step8_world_model(positive)
+    assert positive.leaky_relu_slope == 0.01
+
+
+def test_step8_world_model_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.5)
+    config = Step8WorldModelConfig(
+        observation_dim=np.int64(3),
+        n_actions=np.int64(2),
+        action_dim=np.int64(1),
+        hidden_sizes=(np.int64(4),),
+        step_size=value,
+        sparsity=value,
+        leaky_relu_slope=value,
+        utility_decay=value,
+    )
+    model = make_step8_world_model(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.observation_dim == 3
+    assert config.n_actions == 2
+    assert config.action_dim == 1
+    assert config.hidden_sizes == (4,)
+    assert config.leaky_relu_slope == 0.5
+    assert type(payload["observation_dim"]) is int
+    assert type(payload["n_actions"]) is int
+    assert type(payload["action_dim"]) is int
+    assert type(payload["hidden_sizes"][0]) is int
+    assert type(payload["step_size"]) is float
+    assert type(payload["sparsity"]) is float
+    assert type(payload["leaky_relu_slope"]) is float
+    assert type(payload["utility_decay"]) is float
+    assert model.to_config()["config"]["utility_decay"] == 0.5
+    assert model.to_config()["config"]["leaky_relu_slope"] == 0.5

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -42,6 +42,8 @@ _INVALID_WORLD_MODEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_actions", "2"),
     ("action_dim", True),
     ("action_dim", False),
+    ("action_dim", 0),
+    ("action_dim", -1),
     ("action_dim", 1.5),
     ("action_dim", "1"),
     ("hidden_sizes", (True,)),


### PR DESCRIPTION
Fixes #241.

## What

The production Step 8 world-model facade now validates every dimension and scientific scalar before constructing the core one-step model:

- `observation_dim` must be a positive integer;
- `n_actions` must be `None` or a positive integer;
- `action_dim` must always be a positive integer, including discrete-action configurations where the core currently ignores it;
- `hidden_sizes` must be a tuple of positive integers, with an empty tuple remaining legal;
- `step_size` and `leaky_relu_slope` must be finite and non-negative;
- `sparsity` must be a finite real in `[0, 1]`;
- `utility_decay` must be a finite real in `[0, 1)`;
- booleans and non-real/non-integral coercive inputs are rejected;
- accepted `Integral`/`Real` values, including NumPy scalars, are canonicalized to built-in ints/floats for stable serialization.

Legal endpoints remain valid. The repair is confined to the Step 8 facade and does not edit any core world-model file.

## Verification

Exact published head: `c5084cc54c3ad3d4e7e57c79c253a2896ed97ca4`.

- Focused Step 8 production suite — **53 passed**.
- Initial baseline red proof against unmodified production — **24 failed, 20 passed** before the complete scalar set was added.
- Independent pre-publication review caught missing `leaky_relu_slope` coverage; focused fail-proof against that intermediate facade produced **8 failed, 38 passed, 5 deselected**.
- Reviewer regression proof against the prior published head — **2 failed, 51 passed**: discrete-action configs still accepted `action_dim=0` and `action_dim=-1`.
- Exact-head correction — **53/53** green.
- Ruff on both changed files and the full repository — clean.
- Project mypy — **163 source files clean**.
- `git diff --check` — clean.
- Fresh complete ownership scan before the correction push found no open PR touching either changed path except this PR.

## Scientific-integrity scope

This is ordinary facade configuration validation. It does not edit core world-model modules, registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
Client / agent tooling: Grok Build; Claude Code CLI Proxy
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"xAI","model":"grok-4.6","client":"Grok Build","attribution":"self-reported"} -->
