### PR TITLE
fix(step7): reject illegal planning facade config

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -33,6 +33,10 @@ deltas are scaled by a clipped target/behavior probability ratio.  Planning
 output is discarded until the world model has absorbed
 ``planning_warmup_steps`` real transitions.
 
+The facade rejects illegal planning dimensions and scientific scalars
+before constructing the Step 6/8 components. Accepted numbers are
+canonicalized to builtin ints and floats; legal endpoints stay valid.
+
 References:
     Sutton (1990). "Integrated Architectures for Learning, Planning, and
         Reacting Based on Approximating Dynamic Programming."  (Dyna)
@@ -43,7 +47,9 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass, field
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
@@ -104,35 +110,8 @@ class Step7DynaConfig:
     planning_utility_step_size: float = 0.2
 
     def __post_init__(self) -> None:
-        """Validate planning hyperparameters and component compatibility."""
-        if self.planning_steps < 0:
-            raise ValueError("planning_steps must be non-negative")
-        if self.planning_rollout_depth < 1:
-            raise ValueError("planning_rollout_depth must be positive")
-        if self.planning_warmup_steps < 0:
-            raise ValueError("planning_warmup_steps must be non-negative")
-        if self.planning_memory_size < 1:
-            raise ValueError("planning_memory_size must be positive")
-        if self.planning_importance_ratio_clip <= 0.0:
-            raise ValueError("planning_importance_ratio_clip must be positive")
-        if self.planning_priority_propagation < 0.0:
-            raise ValueError("planning_priority_propagation must be non-negative")
-        if not 0.0 <= self.planning_utility_step_size <= 1.0:
-            raise ValueError("planning_utility_step_size must be in [0, 1]")
-        if self.planning_strategy not in (
-            "random",
-            "reward",
-            "surprise",
-            "predecessor",
-            "prioritized",
-            "learned",
-        ):
-            raise ValueError(
-                "planning_strategy must be random, reward, surprise, predecessor, "
-                "prioritized, or learned"
-            )
-        if self.world_model.n_actions != self.control.n_actions:
-            raise ValueError("world_model.n_actions must equal control.n_actions")
+        """Reject illegal planning dimensions and scalars, then canonicalize."""
+        _validate_planning_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -152,6 +131,95 @@ class Step7DynaConfig:
             cast(dict[str, object], data["world_model"])
         )
         return cls(**cast(Any, data))
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    return number
+
+
+def _validate_planning_config(config: Step7DynaConfig) -> None:
+    planning_steps = _require_int("planning_steps", config.planning_steps, minimum=0)
+    planning_rollout_depth = _require_int(
+        "planning_rollout_depth",
+        config.planning_rollout_depth,
+        minimum=1,
+    )
+    planning_warmup_steps = _require_int(
+        "planning_warmup_steps",
+        config.planning_warmup_steps,
+        minimum=0,
+    )
+    planning_memory_size = _require_int(
+        "planning_memory_size",
+        config.planning_memory_size,
+        minimum=1,
+    )
+    importance_clip = _require_real(
+        "planning_importance_ratio_clip",
+        config.planning_importance_ratio_clip,
+    )
+    if importance_clip <= 0.0:
+        raise ValueError(
+            f"planning_importance_ratio_clip must be positive, got "
+            f"{config.planning_importance_ratio_clip!r}"
+        )
+    propagation = _require_real(
+        "planning_priority_propagation",
+        config.planning_priority_propagation,
+    )
+    if propagation < 0.0:
+        raise ValueError(
+            f"planning_priority_propagation must be non-negative, got "
+            f"{config.planning_priority_propagation!r}"
+        )
+    utility_step = _require_real(
+        "planning_utility_step_size",
+        config.planning_utility_step_size,
+    )
+    if not 0.0 <= utility_step <= 1.0:
+        raise ValueError(
+            f"planning_utility_step_size must be in [0, 1], got "
+            f"{config.planning_utility_step_size!r}"
+        )
+    if config.planning_strategy not in (
+        "random",
+        "reward",
+        "surprise",
+        "predecessor",
+        "prioritized",
+        "learned",
+    ):
+        raise ValueError(
+            "planning_strategy must be random, reward, surprise, predecessor, "
+            "prioritized, or learned"
+        )
+    if config.world_model.n_actions != config.control.n_actions:
+        raise ValueError("world_model.n_actions must equal control.n_actions")
+    object.__setattr__(config, "planning_steps", planning_steps)
+    object.__setattr__(config, "planning_rollout_depth", planning_rollout_depth)
+    object.__setattr__(config, "planning_warmup_steps", planning_warmup_steps)
+    object.__setattr__(config, "planning_memory_size", planning_memory_size)
+    object.__setattr__(config, "planning_importance_ratio_clip", importance_clip)
+    object.__setattr__(config, "planning_priority_propagation", propagation)
+    object.__setattr__(config, "planning_utility_step_size", utility_step)
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -1,10 +1,20 @@
-"""Tests for the Step 7 Dyna planning production facade."""
+"""Production-facing Step 7 Dyna planning facade tests.
+
+Covers the bounded planning facade on real constructors. Invalid dimension
+and scientific-scalar cases are written to fail on current main (bool,
+non-real, non-integral, non-finite, and out-of-domain values accepted) and
+pass after the facade rejects them. Legal endpoints stay constructible.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
@@ -29,6 +39,61 @@ from alberta_framework.steps.step8 import Step8WorldModelConfig
 
 OBS_DIM = 4
 N_ACTIONS = 2
+
+_INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("planning_steps", True),
+    ("planning_steps", False),
+    ("planning_steps", -1),
+    ("planning_steps", 1.5),
+    ("planning_steps", "1"),
+    ("planning_steps", None),
+    ("planning_rollout_depth", True),
+    ("planning_rollout_depth", False),
+    ("planning_rollout_depth", 0),
+    ("planning_rollout_depth", -1),
+    ("planning_rollout_depth", 1.5),
+    ("planning_rollout_depth", "1"),
+    ("planning_rollout_depth", None),
+    ("planning_warmup_steps", True),
+    ("planning_warmup_steps", False),
+    ("planning_warmup_steps", -1),
+    ("planning_warmup_steps", 1.5),
+    ("planning_warmup_steps", "1"),
+    ("planning_warmup_steps", None),
+    ("planning_memory_size", True),
+    ("planning_memory_size", False),
+    ("planning_memory_size", 0),
+    ("planning_memory_size", -1),
+    ("planning_memory_size", 1.5),
+    ("planning_memory_size", "1"),
+    ("planning_memory_size", None),
+    ("planning_importance_ratio_clip", float("nan")),
+    ("planning_importance_ratio_clip", float("inf")),
+    ("planning_importance_ratio_clip", float("-inf")),
+    ("planning_importance_ratio_clip", True),
+    ("planning_importance_ratio_clip", False),
+    ("planning_importance_ratio_clip", 0.0),
+    ("planning_importance_ratio_clip", -1.0),
+    ("planning_importance_ratio_clip", "10"),
+    ("planning_importance_ratio_clip", None),
+    ("planning_priority_propagation", float("nan")),
+    ("planning_priority_propagation", float("inf")),
+    ("planning_priority_propagation", float("-inf")),
+    ("planning_priority_propagation", True),
+    ("planning_priority_propagation", False),
+    ("planning_priority_propagation", -0.1),
+    ("planning_priority_propagation", "1"),
+    ("planning_priority_propagation", None),
+    ("planning_utility_step_size", float("nan")),
+    ("planning_utility_step_size", float("inf")),
+    ("planning_utility_step_size", float("-inf")),
+    ("planning_utility_step_size", True),
+    ("planning_utility_step_size", False),
+    ("planning_utility_step_size", -0.1),
+    ("planning_utility_step_size", 1.1),
+    ("planning_utility_step_size", "0.2"),
+    ("planning_utility_step_size", None),
+)
 
 
 def _cfg(
@@ -101,6 +166,101 @@ class TestStep7ConfigValidation:
                 world_model=Step8WorldModelConfig(observation_dim=OBS_DIM, n_actions=N_ACTIONS),
                 planning_strategy="bogus",  # type: ignore[arg-type]
             )
+
+
+def _config_with(**overrides: Any) -> Step7DynaConfig:
+    payload: dict[str, Any] = {
+        "control": Step6DifferentialSARSAConfig(n_actions=N_ACTIONS),
+        "world_model": Step8WorldModelConfig(observation_dim=OBS_DIM, n_actions=N_ACTIONS),
+    }
+    payload.update(overrides)
+    return Step7DynaConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP7_FIELDS)
+def test_step7_planning_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step7_planning_fields_preserve_legal_endpoints() -> None:
+    config = Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=N_ACTIONS),
+        world_model=Step8WorldModelConfig(observation_dim=OBS_DIM, n_actions=N_ACTIONS),
+        planning_steps=0,
+        planning_rollout_depth=1,
+        planning_warmup_steps=0,
+        planning_memory_size=1,
+        planning_importance_ratio_clip=1e-6,
+        planning_priority_propagation=0.0,
+        planning_utility_step_size=0.0,
+    )
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step7DynaConfig.from_dict(payload)
+    assert restored.planning_steps == 0
+    assert restored.planning_rollout_depth == 1
+    assert restored.planning_warmup_steps == 0
+    assert restored.planning_memory_size == 1
+    assert restored.planning_importance_ratio_clip == 1e-6
+    assert restored.planning_priority_propagation == 0.0
+    assert restored.planning_utility_step_size == 0.0
+    assert payload["planning_priority_propagation"] == 0.0
+    assert payload["planning_utility_step_size"] == 0.0
+
+    upper = Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=N_ACTIONS),
+        world_model=Step8WorldModelConfig(observation_dim=OBS_DIM, n_actions=N_ACTIONS),
+        planning_steps=3,
+        planning_rollout_depth=2,
+        planning_warmup_steps=4,
+        planning_memory_size=8,
+        planning_importance_ratio_clip=10.0,
+        planning_priority_propagation=1.0,
+        planning_utility_step_size=1.0,
+    )
+    make_step7_components(upper)
+    assert upper.planning_importance_ratio_clip == 10.0
+    assert upper.planning_priority_propagation == 1.0
+    assert upper.planning_utility_step_size == 1.0
+
+    smoke = run_step7_smoke(config, steps=4, seed=0)
+    assert smoke.finite
+    assert smoke.planning_td_errors_shape == (4, 0)
+
+
+def test_step7_planning_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.5)
+    config = Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=N_ACTIONS),
+        world_model=Step8WorldModelConfig(observation_dim=OBS_DIM, n_actions=N_ACTIONS),
+        planning_steps=np.int64(2),
+        planning_rollout_depth=np.int64(3),
+        planning_warmup_steps=np.int64(4),
+        planning_memory_size=np.int64(8),
+        planning_importance_ratio_clip=np.float64(5.0),
+        planning_priority_propagation=value,
+        planning_utility_step_size=value,
+    )
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.planning_steps == 2
+    assert config.planning_rollout_depth == 3
+    assert config.planning_warmup_steps == 4
+    assert config.planning_memory_size == 8
+    assert config.planning_importance_ratio_clip == 5.0
+    assert config.planning_priority_propagation == 0.5
+    assert config.planning_utility_step_size == 0.5
+    assert type(payload["planning_steps"]) is int
+    assert type(payload["planning_rollout_depth"]) is int
+    assert type(payload["planning_warmup_steps"]) is int
+    assert type(payload["planning_memory_size"]) is int
+    assert type(payload["planning_importance_ratio_clip"]) is float
+    assert type(payload["planning_priority_propagation"]) is float
+    assert type(payload["planning_utility_step_size"]) is float
+    restored = Step7DynaConfig.from_dict(payload)
+    assert restored.planning_steps == 2
+    assert restored.planning_utility_step_size == 0.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #243.

## What

The production Step 7 Dyna facade now validates its planning-specific dimensions and scientific scalars before constructing the existing Step 6 and Step 8 components:

- `planning_steps` and `planning_warmup_steps` must be non-negative integers;
- `planning_rollout_depth` and `planning_memory_size` must be positive integers;
- `planning_importance_ratio_clip` must be a finite positive real;
- `planning_priority_propagation` must be a finite non-negative real;
- `planning_utility_step_size` must be a finite real in `[0, 1]`;
- booleans and non-real/non-integral coercive inputs are rejected;
- accepted `Integral`/`Real` values, including NumPy scalars, are canonicalized to built-in ints/floats for stable serialization.

Existing legal endpoints, planning-strategy validation, and Step 6/Step 8 action-count compatibility remain intact.

## Verification

Exact local head before publication: `86a6e1c575ec336b6a6e2d0fe9a832d9c2aa31e3`.

- Focused Step 7 production suite — **91 passed**.
- Baseline/fail-proof against the unmodified facade — **34 failed, 20 passed** for the newly rejected malformed classes; restoring the fix returned **91/91** green.
- Ruff on both changed files and the full repository — clean.
- Project mypy — **163 source files clean**.
- `git diff --check origin/main...HEAD` — clean.
- Fresh complete open-PR ownership scan immediately before publication found no PR touching either changed path.

## Scientific-integrity scope

This is ordinary planning-facade configuration validation. It does not edit Step 6, Step 8, any core learner/model module, registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no scientific-performance or promotion claim.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Build
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"xAI","model":"grok-4.6","client":"Grok Build","attribution":"self-reported"} -->
