### PR TITLE
fix(step9): reject malformed dreaming facade config

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -16,12 +16,18 @@ anchored multi-step dreaming.  Key additions over Step 7:
 
 The control learner is the same :class:`DifferentialSARSAAgent` from Step 6,
 preserving the continuing / average-reward formulation.
+
+The facade rejects illegal dimensions and scientific scalars before any core
+object is constructed. Accepted numbers are canonicalized to builtin ints and
+floats; legal endpoints stay valid.
 """
 
 from __future__ import annotations
 
 import functools
+import math
 from dataclasses import asdict, dataclass, field
+from numbers import Integral, Real
 from typing import Any, cast
 
 import chex
@@ -131,26 +137,8 @@ class Step9DreamingConfig:
     dreams_update_average_reward: bool = False
 
     def __post_init__(self) -> None:
-        """Validate hyperparameters."""
-        if self.control.n_actions != self.n_actions:
-            raise ValueError(
-                f"control.n_actions ({self.control.n_actions}) must equal "
-                f"n_actions ({self.n_actions})"
-            )
-        if self.planning_budget < 0:
-            raise ValueError("planning_budget must be non-negative")
-        if self.dreaming_warmup_steps < 0:
-            raise ValueError("dreaming_warmup_steps must be non-negative")
-        if self.dreaming_max_model_error < 0.0:
-            raise ValueError("dreaming_max_model_error must be non-negative")
-        if self.buffer_capacity < 1:
-            raise ValueError("buffer_capacity must be positive")
-        if self.behavior_model_step_size < 0.0:
-            raise ValueError("behavior_model_step_size must be non-negative")
-        if self.dream_rollout_horizon < 1:
-            raise ValueError("dream_rollout_horizon must be positive")
-        if self.dream_candidate_count < 1:
-            raise ValueError("dream_candidate_count must be positive")
+        """Reject illegal dimensions and scientific scalars, then canonicalize."""
+        _validate_dreaming_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -168,7 +156,7 @@ class Step9DreamingConfig:
         )
         hs = data.get("model_hidden_sizes", (64,))
         if isinstance(hs, list):
-            data["model_hidden_sizes"] = tuple(int(v) for v in hs)
+            data["model_hidden_sizes"] = tuple(hs)
         return cls(**cast(Any, data))
 
     def to_world_model_config(self) -> ActionConditionedWorldModelConfig:
@@ -184,6 +172,149 @@ class Step9DreamingConfig:
             error_decay=self.model_error_decay,
             include_action_interactions=self.model_include_action_interactions,
         )
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_nonneg_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number < 1.0:
+        raise ValueError(f"{name} must be in [0, 1), got {value!r}")
+    return number
+
+
+def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    return number
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a bool, got {value!r}")
+    return value
+
+
+def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
+    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    n_actions = _require_int("n_actions", config.n_actions, minimum=1)
+    if config.control.n_actions != n_actions:
+        raise ValueError(
+            f"control.n_actions ({config.control.n_actions}) must equal "
+            f"n_actions ({n_actions})"
+        )
+    if not isinstance(config.model_hidden_sizes, tuple):
+        raise ValueError(
+            f"model_hidden_sizes must be a tuple of integers, got "
+            f"{config.model_hidden_sizes!r}"
+        )
+    model_hidden_sizes = tuple(
+        _require_int("model_hidden_sizes", size, minimum=1)
+        for size in config.model_hidden_sizes
+    )
+    model_step_size = _require_nonneg_real("model_step_size", config.model_step_size)
+    model_sparsity = _require_unit_interval("model_sparsity", config.model_sparsity)
+    model_include_action_interactions = _require_bool(
+        "model_include_action_interactions",
+        config.model_include_action_interactions,
+    )
+    model_use_layer_norm = _require_bool(
+        "model_use_layer_norm",
+        config.model_use_layer_norm,
+    )
+    model_gamma = _require_unit_interval("model_gamma", config.model_gamma)
+    dreaming_warmup_steps = _require_int(
+        "dreaming_warmup_steps",
+        config.dreaming_warmup_steps,
+        minimum=0,
+    )
+    dreaming_max_model_error = _require_nonneg_real(
+        "dreaming_max_model_error",
+        config.dreaming_max_model_error,
+    )
+    model_error_decay = _require_half_open_unit_interval(
+        "model_error_decay",
+        config.model_error_decay,
+    )
+    behavior_model_step_size = _require_nonneg_real(
+        "behavior_model_step_size",
+        config.behavior_model_step_size,
+    )
+    planning_budget = _require_int("planning_budget", config.planning_budget, minimum=0)
+    dream_rollout_horizon = _require_int(
+        "dream_rollout_horizon",
+        config.dream_rollout_horizon,
+        minimum=1,
+    )
+    dream_candidate_count = _require_int(
+        "dream_candidate_count",
+        config.dream_candidate_count,
+        minimum=1,
+    )
+    dream_surprise_weight = _require_real(
+        "dream_surprise_weight",
+        config.dream_surprise_weight,
+    )
+    dream_utility_weight = _require_real(
+        "dream_utility_weight",
+        config.dream_utility_weight,
+    )
+    buffer_capacity = _require_int("buffer_capacity", config.buffer_capacity, minimum=1)
+    dreams_update_average_reward = _require_bool(
+        "dreams_update_average_reward",
+        config.dreams_update_average_reward,
+    )
+    object.__setattr__(config, "observation_dim", observation_dim)
+    object.__setattr__(config, "n_actions", n_actions)
+    object.__setattr__(config, "model_hidden_sizes", model_hidden_sizes)
+    object.__setattr__(config, "model_step_size", model_step_size)
+    object.__setattr__(config, "model_sparsity", model_sparsity)
+    object.__setattr__(
+        config,
+        "model_include_action_interactions",
+        model_include_action_interactions,
+    )
+    object.__setattr__(config, "model_use_layer_norm", model_use_layer_norm)
+    object.__setattr__(config, "model_gamma", model_gamma)
+    object.__setattr__(config, "dreaming_warmup_steps", dreaming_warmup_steps)
+    object.__setattr__(config, "dreaming_max_model_error", dreaming_max_model_error)
+    object.__setattr__(config, "model_error_decay", model_error_decay)
+    object.__setattr__(config, "behavior_model_step_size", behavior_model_step_size)
+    object.__setattr__(config, "planning_budget", planning_budget)
+    object.__setattr__(config, "dream_rollout_horizon", dream_rollout_horizon)
+    object.__setattr__(config, "dream_candidate_count", dream_candidate_count)
+    object.__setattr__(config, "dream_surprise_weight", dream_surprise_weight)
+    object.__setattr__(config, "dream_utility_weight", dream_utility_weight)
+    object.__setattr__(config, "buffer_capacity", buffer_capacity)
+    object.__setattr__(config, "dreams_update_average_reward", dreams_update_average_reward)
 
 
 @chex.dataclass(frozen=True)

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -63,6 +63,8 @@ from alberta_framework.steps.step6 import (
     make_step6_differential_sarsa_agent,
 )
 
+_INT32_MAX = 2**31 - 1
+
 
 @dataclass(frozen=True)
 class Step9DreamingConfig:
@@ -204,7 +206,13 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
     return number
 
 
-def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
     number = int(value)
@@ -214,6 +222,8 @@ def _require_int(name: str, value: object, *, minimum: int | None = None) -> int
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     return number
 
 
@@ -251,10 +261,12 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.model_use_layer_norm,
     )
     model_gamma = _require_unit_interval("model_gamma", config.model_gamma)
+    # The world-model warmup clock is stored as a signed int32 scalar.
     dreaming_warmup_steps = _require_int(
         "dreaming_warmup_steps",
         config.dreaming_warmup_steps,
         minimum=0,
+        maximum=_INT32_MAX,
     )
     dreaming_max_model_error = _require_nonneg_real(
         "dreaming_max_model_error",
@@ -274,10 +286,12 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.dream_rollout_horizon,
         minimum=1,
     )
+    # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",
@@ -287,7 +301,14 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         "dream_utility_weight",
         config.dream_utility_weight,
     )
-    buffer_capacity = _require_int("buffer_capacity", config.buffer_capacity, minimum=1)
+    # Buffer ``size`` and ``index`` are int32. Leaving one count below the
+    # maximum keeps repeated full-buffer increments and modulo updates in range.
+    buffer_capacity = _require_int(
+        "buffer_capacity",
+        config.buffer_capacity,
+        minimum=1,
+        maximum=_INT32_MAX - 1,
+    )
     dreams_update_average_reward = _require_bool(
         "dreams_update_average_reward",
         config.dreams_update_average_reward,

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -397,6 +397,34 @@ def test_step9_dreaming_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert restored.model_error_decay == 0.5
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("dreaming_warmup_steps", 2**31),
+        ("dream_candidate_count", 2**31),
+        ("buffer_capacity", 2**31 - 1),
+    ],
+)
+def test_step9_count_fields_reject_values_outside_int32_contract(
+    field: str,
+    value: int,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step9_count_fields_preserve_int32_upper_endpoints() -> None:
+    config = _config_with(
+        dreaming_warmup_steps=2**31 - 1,
+        dream_candidate_count=2**31 - 1,
+        buffer_capacity=2**31 - 2,
+    )
+    assert config.dreaming_warmup_steps == 2**31 - 1
+    assert config.dream_candidate_count == 2**31 - 1
+    assert config.buffer_capacity == 2**31 - 2
+    json.dumps(config.to_dict(), allow_nan=False)
+
+
 # ---------------------------------------------------------------------------
 # Factory and init tests
 # ---------------------------------------------------------------------------

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -1,10 +1,20 @@
-"""Tests for the Step 9 guarded-dreaming facade."""
+"""Tests for the Step 9 guarded-dreaming facade.
+
+Invalid dimension and scientific-scalar cases are written to fail on current
+main (bool, non-real, non-integral, non-finite, and out-of-domain values
+accepted) and pass after the facade rejects them. Legal endpoints stay
+constructible.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
@@ -16,6 +26,141 @@ from alberta_framework.steps.step9 import (
     run_step9_scan,
     run_step9_smoke,
     step9_update,
+)
+
+_INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("observation_dim", True),
+    ("observation_dim", False),
+    ("observation_dim", 0),
+    ("observation_dim", -1),
+    ("observation_dim", 1.5),
+    ("observation_dim", "4"),
+    ("observation_dim", None),
+    ("n_actions", True),
+    ("n_actions", False),
+    ("n_actions", 0),
+    ("n_actions", -1),
+    ("n_actions", 1.5),
+    ("n_actions", "2"),
+    ("n_actions", None),
+    ("model_hidden_sizes", (True,)),
+    ("model_hidden_sizes", (False,)),
+    ("model_hidden_sizes", (0,)),
+    ("model_hidden_sizes", (-1,)),
+    ("model_hidden_sizes", (1.5,)),
+    ("model_hidden_sizes", ("64",)),
+    ("model_hidden_sizes", [64]),
+    ("model_hidden_sizes", 64),
+    ("model_step_size", float("nan")),
+    ("model_step_size", float("inf")),
+    ("model_step_size", float("-inf")),
+    ("model_step_size", True),
+    ("model_step_size", False),
+    ("model_step_size", -1.0),
+    ("model_step_size", "0.03"),
+    ("model_step_size", None),
+    ("model_sparsity", float("nan")),
+    ("model_sparsity", float("inf")),
+    ("model_sparsity", float("-inf")),
+    ("model_sparsity", True),
+    ("model_sparsity", False),
+    ("model_sparsity", -0.1),
+    ("model_sparsity", 1.1),
+    ("model_sparsity", "0.9"),
+    ("model_sparsity", None),
+    ("model_gamma", float("nan")),
+    ("model_gamma", float("inf")),
+    ("model_gamma", float("-inf")),
+    ("model_gamma", True),
+    ("model_gamma", False),
+    ("model_gamma", -0.1),
+    ("model_gamma", 1.1),
+    ("model_gamma", "0.99"),
+    ("model_gamma", None),
+    ("model_error_decay", float("nan")),
+    ("model_error_decay", float("inf")),
+    ("model_error_decay", float("-inf")),
+    ("model_error_decay", True),
+    ("model_error_decay", False),
+    ("model_error_decay", -0.1),
+    ("model_error_decay", 1.0),
+    ("model_error_decay", "0.99"),
+    ("model_error_decay", None),
+    ("dreaming_warmup_steps", True),
+    ("dreaming_warmup_steps", False),
+    ("dreaming_warmup_steps", -1),
+    ("dreaming_warmup_steps", 1.5),
+    ("dreaming_warmup_steps", "100"),
+    ("dreaming_warmup_steps", None),
+    ("dreaming_max_model_error", float("nan")),
+    ("dreaming_max_model_error", float("inf")),
+    ("dreaming_max_model_error", float("-inf")),
+    ("dreaming_max_model_error", True),
+    ("dreaming_max_model_error", False),
+    ("dreaming_max_model_error", -0.1),
+    ("dreaming_max_model_error", "1.0"),
+    ("dreaming_max_model_error", None),
+    ("behavior_model_step_size", float("nan")),
+    ("behavior_model_step_size", float("inf")),
+    ("behavior_model_step_size", float("-inf")),
+    ("behavior_model_step_size", True),
+    ("behavior_model_step_size", False),
+    ("behavior_model_step_size", -0.1),
+    ("behavior_model_step_size", "0.05"),
+    ("behavior_model_step_size", None),
+    ("planning_budget", True),
+    ("planning_budget", False),
+    ("planning_budget", -1),
+    ("planning_budget", 1.5),
+    ("planning_budget", "1"),
+    ("planning_budget", None),
+    ("buffer_capacity", True),
+    ("buffer_capacity", False),
+    ("buffer_capacity", 0),
+    ("buffer_capacity", -1),
+    ("buffer_capacity", 1.5),
+    ("buffer_capacity", "64"),
+    ("buffer_capacity", None),
+    ("dream_rollout_horizon", True),
+    ("dream_rollout_horizon", False),
+    ("dream_rollout_horizon", 0),
+    ("dream_rollout_horizon", -1),
+    ("dream_rollout_horizon", 1.5),
+    ("dream_rollout_horizon", "1"),
+    ("dream_rollout_horizon", None),
+    ("dream_candidate_count", True),
+    ("dream_candidate_count", False),
+    ("dream_candidate_count", 0),
+    ("dream_candidate_count", -1),
+    ("dream_candidate_count", 1.5),
+    ("dream_candidate_count", "1"),
+    ("dream_candidate_count", None),
+    ("dream_surprise_weight", float("nan")),
+    ("dream_surprise_weight", float("inf")),
+    ("dream_surprise_weight", float("-inf")),
+    ("dream_surprise_weight", True),
+    ("dream_surprise_weight", False),
+    ("dream_surprise_weight", "1.0"),
+    ("dream_surprise_weight", None),
+    ("dream_utility_weight", float("nan")),
+    ("dream_utility_weight", float("inf")),
+    ("dream_utility_weight", float("-inf")),
+    ("dream_utility_weight", True),
+    ("dream_utility_weight", False),
+    ("dream_utility_weight", "1.0"),
+    ("dream_utility_weight", None),
+    ("model_include_action_interactions", 0),
+    ("model_include_action_interactions", 1),
+    ("model_include_action_interactions", "true"),
+    ("model_include_action_interactions", None),
+    ("model_use_layer_norm", 0),
+    ("model_use_layer_norm", 1),
+    ("model_use_layer_norm", "true"),
+    ("model_use_layer_norm", None),
+    ("dreams_update_average_reward", 0),
+    ("dreams_update_average_reward", 1),
+    ("dreams_update_average_reward", "true"),
+    ("dreams_update_average_reward", None),
 )
 
 # ---------------------------------------------------------------------------
@@ -83,6 +228,173 @@ def test_step9_config_zero_dream_rollout_horizon_raises() -> None:
 def test_step9_config_zero_dream_candidate_count_raises() -> None:
     with pytest.raises(ValueError, match="dream_candidate_count"):
         Step9DreamingConfig(dream_candidate_count=0)
+
+
+def _config_with(**overrides: Any) -> Step9DreamingConfig:
+    n_actions = overrides.get("n_actions", 2)
+    payload: dict[str, Any] = {
+        "control": Step6DifferentialSARSAConfig(n_actions=n_actions),
+        "observation_dim": 2,
+        "n_actions": 2,
+        "model_hidden_sizes": (),
+    }
+    payload.update(overrides)
+    if "n_actions" in overrides and "control" not in overrides:
+        payload["control"] = Step6DifferentialSARSAConfig(n_actions=n_actions)
+    return Step9DreamingConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP9_FIELDS)
+def test_step9_dreaming_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step9_dreaming_fields_preserve_legal_endpoints() -> None:
+    config = Step9DreamingConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=1),
+        observation_dim=1,
+        n_actions=1,
+        model_hidden_sizes=(),
+        model_step_size=0.0,
+        model_sparsity=0.0,
+        model_include_action_interactions=False,
+        model_use_layer_norm=False,
+        model_gamma=0.0,
+        dreaming_warmup_steps=0,
+        dreaming_max_model_error=0.0,
+        model_error_decay=0.0,
+        behavior_model_step_size=0.0,
+        planning_budget=0,
+        dream_rollout_horizon=1,
+        dream_candidate_count=1,
+        dream_surprise_weight=-2.5,
+        dream_utility_weight=0.0,
+        buffer_capacity=1,
+        dreams_update_average_reward=False,
+    )
+    make_step9_components(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step9DreamingConfig.from_dict(payload)
+    assert restored.observation_dim == 1
+    assert restored.n_actions == 1
+    assert restored.model_hidden_sizes == ()
+    assert restored.model_step_size == 0.0
+    assert restored.model_sparsity == 0.0
+    assert restored.model_include_action_interactions is False
+    assert restored.model_use_layer_norm is False
+    assert restored.model_gamma == 0.0
+    assert restored.dreaming_warmup_steps == 0
+    assert restored.dreaming_max_model_error == 0.0
+    assert restored.model_error_decay == 0.0
+    assert restored.behavior_model_step_size == 0.0
+    assert restored.planning_budget == 0
+    assert restored.dream_rollout_horizon == 1
+    assert restored.dream_candidate_count == 1
+    assert restored.dream_surprise_weight == -2.5
+    assert restored.dream_utility_weight == 0.0
+    assert restored.buffer_capacity == 1
+    assert restored.dreams_update_average_reward is False
+    assert payload["model_sparsity"] == 0.0
+    assert payload["model_error_decay"] == 0.0
+    assert payload["dream_surprise_weight"] == -2.5
+
+    upper = Step9DreamingConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=2),
+        observation_dim=1,
+        n_actions=2,
+        model_hidden_sizes=(),
+        model_sparsity=1.0,
+        model_include_action_interactions=True,
+        model_use_layer_norm=True,
+        model_gamma=1.0,
+        dreaming_max_model_error=1e30,
+        model_error_decay=0.999,
+        dream_surprise_weight=2.0,
+        dream_utility_weight=-0.5,
+        dreams_update_average_reward=True,
+    )
+    make_step9_components(upper)
+    json.dumps(upper.to_dict(), allow_nan=False)
+    assert upper.model_sparsity == 1.0
+    assert upper.model_gamma == 1.0
+    assert upper.dreaming_max_model_error == 1e30
+    assert upper.model_include_action_interactions is True
+    assert upper.dreams_update_average_reward is True
+
+    defaults = Step9DreamingConfig()
+    make_step9_components(defaults)
+    assert defaults.observation_dim == 4
+    assert defaults.n_actions == 2
+    assert defaults.model_hidden_sizes == (64,)
+    assert defaults.model_step_size == 0.03
+    assert defaults.model_sparsity == 0.9
+    assert defaults.model_gamma == 0.99
+    assert defaults.model_error_decay == 0.99
+
+
+def test_step9_dreaming_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.5)
+    config = Step9DreamingConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=2),
+        observation_dim=np.int64(3),
+        n_actions=np.int64(2),
+        model_hidden_sizes=(np.int64(4),),
+        model_step_size=value,
+        model_sparsity=value,
+        model_gamma=value,
+        dreaming_warmup_steps=np.int64(0),
+        dreaming_max_model_error=value,
+        model_error_decay=value,
+        behavior_model_step_size=value,
+        planning_budget=np.int64(2),
+        dream_rollout_horizon=np.int64(3),
+        dream_candidate_count=np.int64(4),
+        dream_surprise_weight=np.float64(-1.5),
+        dream_utility_weight=value,
+        buffer_capacity=np.int64(8),
+    )
+    make_step9_components(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.observation_dim == 3
+    assert config.n_actions == 2
+    assert config.model_hidden_sizes == (4,)
+    assert config.model_step_size == 0.5
+    assert config.model_sparsity == 0.5
+    assert config.model_gamma == 0.5
+    assert config.dreaming_warmup_steps == 0
+    assert config.dreaming_max_model_error == 0.5
+    assert config.model_error_decay == 0.5
+    assert config.behavior_model_step_size == 0.5
+    assert config.planning_budget == 2
+    assert config.dream_rollout_horizon == 3
+    assert config.dream_candidate_count == 4
+    assert config.dream_surprise_weight == -1.5
+    assert config.dream_utility_weight == 0.5
+    assert config.buffer_capacity == 8
+    assert type(payload["observation_dim"]) is int
+    assert type(payload["n_actions"]) is int
+    assert type(payload["model_hidden_sizes"][0]) is int
+    assert type(payload["model_step_size"]) is float
+    assert type(payload["model_sparsity"]) is float
+    assert type(payload["model_gamma"]) is float
+    assert type(payload["dreaming_warmup_steps"]) is int
+    assert type(payload["dreaming_max_model_error"]) is float
+    assert type(payload["model_error_decay"]) is float
+    assert type(payload["behavior_model_step_size"]) is float
+    assert type(payload["planning_budget"]) is int
+    assert type(payload["dream_rollout_horizon"]) is int
+    assert type(payload["dream_candidate_count"]) is int
+    assert type(payload["dream_surprise_weight"]) is float
+    assert type(payload["dream_utility_weight"]) is float
+    assert type(payload["buffer_capacity"]) is int
+    restored = Step9DreamingConfig.from_dict(payload)
+    assert restored.observation_dim == 3
+    assert restored.model_hidden_sizes == (4,)
+    assert restored.dream_surprise_weight == -1.5
+    assert restored.model_error_decay == 0.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #247.

## What changed

The production Step 9 guarded-dreaming facade now validates every facade-owned dimension and scientific scalar before constructing core world-model, behavior-model, or dream-selection objects:

- `observation_dim` and `n_actions` must be positive integers, and `n_actions` must still equal `control.n_actions`;
- `model_hidden_sizes` must be a tuple of positive integers, with an empty tuple remaining legal;
- model/behavior step sizes and maximum model error must be finite and non-negative;
- model sparsity and gamma must be finite reals in `[0, 1]`;
- model error decay must be a finite real in `[0, 1)`;
- warmup and planning budget must be non-negative integers;
- buffer capacity, rollout horizon, and candidate count must be positive integers;
- surprise and utility weights must be finite reals, without inventing a sign constraint;
- boolean fields remain strict booleans;
- accepted `Integral` / `Real` values, including NumPy scalars, are canonicalized to built-in integers/floats for stable strict-JSON serialization.

Legal endpoints and existing defaults remain valid. The repair does not edit core world-model, dreaming, or behavior-model code.

## Why

Malformed configuration could cross the Step 9 public facade and fail later during JAX array construction or silently alter scientific behavior. Python booleans also alias integers, and non-built-in numeric scalars could leak into serialized configuration. This patch rejects those cases at construction and leaves downstream code with canonical values.

## Scope

- `alberta_framework/steps/step9.py`
- `tests/test_step9_production.py`

## Verification

Exact published head: `105f79a3664478201c6d546c01d4dc91b55093a3`

- tests-first baseline against unmodified production: **118 failed, 44 passed**;
- focused Step 9 production suite with the repair: **162 passed**;
- full Ruff: **all checks passed**;
- full mypy: **no issues in 163 source files**;
- `git diff --check`: clean;
- live ownership refresh immediately before publication: neither target path was owned by another open PR;
- `origin/main` remained `58b6780840e1ba3fd6fdaea4d49c906d6c3b55cb` at publication.

## Scientific integrity

This is ordinary facade input validation. It does not edit core scientific modules, registered evidence sources, frozen protocols, seeds, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no performance or promotion claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code CLI Proxy
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"xAI","model":"grok-4.6","client":"Grok Build","attribution":"self-reported"} -->
