### PR TITLE
fix(streams): reject non-finite FrequencyMismatchStream bounds

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -26,6 +26,8 @@ or tanh feature bank:
   compositional DAG that builds features-of-features can.
 """
 
+import math
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
@@ -340,9 +342,9 @@ class FrequencyMismatchStream:
             raise ValueError("n_contexts must be positive")
         if context_length < 1:
             raise ValueError("context_length must be positive")
-        if omega_min <= 0:
-            raise ValueError("omega_min must be positive")
-        if omega_max <= omega_min:
+        if not math.isfinite(omega_min) or omega_min <= 0:
+            raise ValueError("omega_min must be finite and positive")
+        if not math.isfinite(omega_max) or omega_max <= omega_min:
             raise ValueError("omega_max must exceed omega_min")
 
         self._feature_dim = feature_dim

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -257,6 +257,16 @@ class TestOutOfClassPolynomialStream:
 class TestFrequencyMismatchStream:
     """Tests for the trigonometric out-of-class stream."""
 
+    @pytest.mark.parametrize(
+        ("omega_min", "omega_max"),
+        [(float("nan"), 3.0), (0.5, float("inf")), (float("inf"), float("inf"))],
+    )
+    def test_frequency_bounds_must_be_finite(
+        self, omega_min: float, omega_max: float
+    ) -> None:
+        with pytest.raises(ValueError):
+            FrequencyMismatchStream(omega_min=omega_min, omega_max=omega_max)
+
     def test_step_shapes(self):
         stream = FrequencyMismatchStream(
             feature_dim=4,


### PR DESCRIPTION
Closes #249.

## What changed

`FrequencyMismatchStream.__init__` checked `omega_min <= 0` and `omega_max <= omega_min` but never checked finiteness. Every ordered comparison with `NaN` is `false`, so `omega_min=float("nan")` slipped past the positivity check; `omega_max=float("inf")` also slipped past the exceeds-omega_min check (since `inf > any_finite_number`). `init()` then generated non-finite frequencies internally, and the public `step()` returned non-finite targets, corrupting benchmark measurement.

confirmed directly before touching the source:

```text
accepted_nan_bound: True
all_omegas_finite: False
target: [nan nan]
all_targets_finite: False
```

fix: both `omega_min` and `omega_max` now require `math.isfinite(...)` in addition to the existing positivity/ordering checks. Both checks must come first since `NaN`/`inf` also silently pass ordered comparisons in the original checks.

## Reachability

`FrequencyMismatchStream` is defined in `alberta_framework.streams.out_of_class`, imported and listed in `__all__` by the top-level `alberta_framework/__init__.py` — genuinely package-root exported. A real caller constructs it with caller-supplied frequency bounds and reaches `init()`/`step()` directly, not a hardcoded-safe-only path.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_out_of_class_streams.py -q -o addopts=""
26 passed in 12.85s

$ .venv/bin/python -m ruff check alberta_framework/streams/out_of_class.py tests/test_out_of_class_streams.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_frequency_bounds_must_be_finite`, parameterized over `(NaN, 3.0)`, `(0.5, inf)`, `(inf, inf)`, in `tests/test_out_of_class_streams.py`.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/out_of_class.py`, kept the test), reran — 2/3 parameterized cases failed with `Failed: DID NOT RAISE ValueError` (the third, `inf/inf`, is still caught by the pre-existing `omega_max <= omega_min` check since `inf <= inf` is true, so it wasn't expected to flip). Restored the fix, 26/26 green again.

## Evidence

<!-- evidence-head -->
bbc8019540bba2f141b51fadb32da3a3ed4c4df9

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_out_of_class_streams.py -q -o addopts="" -k test_frequency_bounds_must_be_finite
FAILED tests/test_out_of_class_streams.py::TestFrequencyMismatchStream::test_frequency_bounds_must_be_finite[nan-3.0]
FAILED tests/test_out_of_class_streams.py::TestFrequencyMismatchStream::test_frequency_bounds_must_be_finite[0.5-inf]
2 failed, 1 passed, 23 deselected in 0.46s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_out_of_class_streams.py -q -o addopts=""
26 passed in 13.80s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework import FrequencyMismatchStream
for omega_min, omega_max in [(float('nan'), 3.0), (0.5, float('inf')), (float('inf'), float('inf'))]:
    try:
        FrequencyMismatchStream(omega_min=omega_min, omega_max=omega_max)
        print(f'omega_min={omega_min}, omega_max={omega_max}: accepted (BUG if this prints)')
    except ValueError as e:
        print(f'omega_min={omega_min}, omega_max={omega_max}: rejected -> {e}')
"
omega_min=nan, omega_max=3.0: rejected -> omega_min must be finite and positive
omega_min=0.5, omega_max=inf: rejected -> omega_max must exceed omega_min
omega_min=inf, omega_max=inf: rejected -> omega_min must be finite and positive
```
independently reproduced against the fixed head, confirming the guard rejects all three invalid inputs, and independently confirmed the package-root export via `grep` before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting all three invalid inputs, verified the package-root export directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
