### PR TITLE
fix(streams): reject illegal Pavlovian constructor scalars

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -52,6 +52,8 @@ from jaxtyping import Int, PRNGKeyArray
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
+_INT32_MAX = 2**31 - 1
+
 
 def _require_finite_real(
     value: object,
@@ -80,12 +82,20 @@ def _require_unit_interval(value: object, *, name: str) -> float:
     return number
 
 
-def _require_builtin_int(value: object, *, name: str, minimum: int) -> int:
+def _require_builtin_int(
+    value: object,
+    *,
+    name: str,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
     """Return a built-in int at or above ``minimum``; reject bool and numpy ints."""
     if type(value) is not int:
         raise ValueError(f"{name} must be a built-in integer, got {value!r}")
     if value < minimum:
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     return value
 
 # =============================================================================
@@ -253,8 +263,18 @@ class ClassicalConditioningStream:
         )
         cs_us_delay = _require_builtin_int(cs_us_delay, name="cs_us_delay", minimum=1)
         cs_duration = _require_builtin_int(cs_duration, name="cs_duration", minimum=1)
-        iti_min = _require_builtin_int(iti_min, name="iti_min", minimum=0)
-        iti_max = _require_builtin_int(iti_max, name="iti_max", minimum=0)
+        iti_min = _require_builtin_int(
+            iti_min,
+            name="iti_min",
+            minimum=0,
+            maximum=_INT32_MAX - 1,
+        )
+        iti_max = _require_builtin_int(
+            iti_max,
+            name="iti_max",
+            minimum=0,
+            maximum=_INT32_MAX - 1,
+        )
         if iti_max < iti_min:
             raise ValueError(f"need 0 <= iti_min <= iti_max, got {iti_min}, {iti_max}")
         noise_std = _require_finite_real(noise_std, name="noise_std", nonnegative=True)

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -39,6 +39,9 @@ References
 
 from __future__ import annotations
 
+import math
+from numbers import Real
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -48,6 +51,42 @@ from jaxtyping import Int, PRNGKeyArray
 
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
+
+
+def _require_finite_real(
+    value: object,
+    *,
+    name: str,
+    nonnegative: bool = False,
+) -> float:
+    """Return a finite real, rejecting bools, NaN, and infinities."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real, got {value!r}")
+    if nonnegative and number < 0.0:
+        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+    return number
+
+
+def _require_unit_interval(value: object, *, name: str) -> float:
+    """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    number = float(value)
+    if not math.isfinite(number) or not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_builtin_int(value: object, *, name: str, minimum: int) -> int:
+    """Return a built-in int at or above ``minimum``; reject bool and numpy ints."""
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    return value
 
 # =============================================================================
 # State and phase descriptors
@@ -199,42 +238,60 @@ class ClassicalConditioningStream:
                 distractor turns on.
 
         Raises:
-            ValueError: if ``phases`` is empty, ``n_cs <= 0``, the
-                ITI range is malformed, or any phase references a CS
-                index that does not exist.
+            ValueError: if ``phases`` is empty, an integer knob is not a
+                built-in int in its domain, the ITI range is malformed,
+                any phase references a CS index that does not exist, a
+                phase contingency is not a finite real in ``[0, 1]``, or
+                ``noise_std`` / ``distractor_prob`` is not a legal
+                scientific scalar.
         """
         if not phases:
             raise ValueError("phases must be non-empty")
-        if n_cs <= 0:
-            raise ValueError(f"n_cs must be positive, got {n_cs}")
-        if n_distractors < 0:
-            raise ValueError(f"n_distractors must be >= 0, got {n_distractors}")
-        if cs_us_delay <= 0:
-            raise ValueError(f"cs_us_delay must be positive, got {cs_us_delay}")
-        if cs_duration <= 0:
-            raise ValueError(f"cs_duration must be positive, got {cs_duration}")
-        if iti_min < 0 or iti_max < iti_min:
+        n_cs = _require_builtin_int(n_cs, name="n_cs", minimum=1)
+        n_distractors = _require_builtin_int(
+            n_distractors, name="n_distractors", minimum=0
+        )
+        cs_us_delay = _require_builtin_int(cs_us_delay, name="cs_us_delay", minimum=1)
+        cs_duration = _require_builtin_int(cs_duration, name="cs_duration", minimum=1)
+        iti_min = _require_builtin_int(iti_min, name="iti_min", minimum=0)
+        iti_max = _require_builtin_int(iti_max, name="iti_max", minimum=0)
+        if iti_max < iti_min:
             raise ValueError(f"need 0 <= iti_min <= iti_max, got {iti_min}, {iti_max}")
+        noise_std = _require_finite_real(noise_std, name="noise_std", nonnegative=True)
+        distractor_prob = _require_unit_interval(
+            distractor_prob, name="distractor_prob"
+        )
 
         for phase in phases:
-            if not 0.0 <= phase.cs_us_contingency <= 1.0:
+            try:
+                _require_unit_interval(
+                    phase.cs_us_contingency, name="cs_us_contingency"
+                )
+            except ValueError as error:
                 raise ValueError(
                     f"phase {phase.name!r} cs_us_contingency must be in [0, 1], "
                     f"got {phase.cs_us_contingency}"
-                )
+                ) from error
+            _require_builtin_int(phase.n_steps, name="n_steps", minimum=1)
+            compound_index = _require_builtin_int(
+                phase.compound_index, name="compound_index", minimum=-1
+            )
             for cs_idx in phase.cs_active:
+                if type(cs_idx) is not int:
+                    raise ValueError(
+                        f"phase {phase.name!r} cs_active index must be a "
+                        f"built-in integer, got {cs_idx!r}"
+                    )
                 if not (0 <= cs_idx < n_cs):
                     raise ValueError(
                         f"phase {phase.name!r} references cs_active index {cs_idx}, "
                         f"but n_cs={n_cs}"
                     )
-            if phase.compound_index >= n_cs:
+            if compound_index >= n_cs:
                 raise ValueError(
                     f"phase {phase.name!r} has compound_index={phase.compound_index} "
                     f"but n_cs={n_cs}"
                 )
-            if phase.n_steps <= 0:
-                raise ValueError(f"phase {phase.name!r} must have n_steps > 0")
 
         self._phases = tuple(phases)
         self._n_cs = int(n_cs)
@@ -732,10 +789,12 @@ def partial_reinforcement_scenario(
         ``ClassicalConditioningStream`` with one phase.
 
     Raises:
-        ValueError: if ``p`` is outside ``[0, 1]``.
+        ValueError: if ``p`` is not a finite real in ``[0, 1]``.
     """
-    if not (0.0 <= p <= 1.0):
-        raise ValueError(f"p must be in [0, 1], got {p}")
+    try:
+        p = _require_unit_interval(p, name="p")
+    except ValueError as error:
+        raise ValueError(f"p must be in [0, 1], got {p}") from error
     phases = (
         PavlovianPhase(
             name="partial_reinforcement",

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -556,6 +556,47 @@ def test_phase_compound_index_requires_builtin_int(value: object) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("n_distractors", 2**31),
+        ("cs_us_delay", 2**31),
+        ("cs_duration", 2**31),
+        ("iti_max", 2**31 - 1),
+    ],
+)
+def test_schedule_fields_reject_values_outside_jax_int32(
+    field: str,
+    value: int,
+) -> None:
+    """Accepted configuration must remain representable in JAX state."""
+    kwargs: dict[str, object] = {field: value}
+    with pytest.raises(ValueError, match=field):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+
+def test_phase_n_steps_rejects_values_outside_jax_int32() -> None:
+    """Phase validation must run before materializing the int32 phase array."""
+    with pytest.raises(ValueError, match="n_steps"):
+        ClassicalConditioningStream(phases=(_valid_phase(n_steps=2**31),))
+
+
+def test_schedule_fields_accept_jax_int32_upper_endpoints() -> None:
+    stream = ClassicalConditioningStream(
+        phases=(_valid_phase(n_steps=2**31 - 1),),
+        cs_us_delay=2**31 - 1,
+        cs_duration=2**31 - 1,
+        iti_min=2**31 - 2,
+        iti_max=2**31 - 2,
+    )
+    state = stream.init(jr.key(99))
+    stream.step(state, jnp.array(0))
+    assert int(state.iti_steps_remaining) == 2**31 - 2
+
+
 def test_reacquisition_runs_three_phases():
     """Reacquisition scenario has three distinct contingency periods."""
     n_acq = 200

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -15,6 +15,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.streams.pavlovian import (
@@ -428,6 +429,131 @@ def test_partial_reinforcement_rejects_invalid_p():
         except ValueError:
             continue
         raise AssertionError(f"expected ValueError for p={bad_p}")
+
+
+def _valid_phase(**overrides: object) -> PavlovianPhase:
+    payload = {
+        "name": "acq",
+        "n_steps": 10,
+        "cs_us_contingency": 1.0,
+        "cs_active": (0,),
+    }
+    payload.update(overrides)
+    return PavlovianPhase(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), True, -1.0])
+def test_construct_rejects_illegal_noise_std(value: object) -> None:
+    """Observation noise is a non-negative finite real, not a bool or NaN."""
+    with pytest.raises(ValueError, match="noise_std"):
+        ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True])
+def test_construct_rejects_illegal_distractor_prob(value: object) -> None:
+    """Distractor probability must be a finite real in ``[0, 1]``."""
+    with pytest.raises(ValueError, match="distractor_prob"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            distractor_prob=value,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_construct_rejects_bool_phase_contingency(value: bool) -> None:
+    """A bool is not a scientific contingency, even though ``True == 1``."""
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        ClassicalConditioningStream(phases=(_valid_phase(cs_us_contingency=value),))
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), True])
+def test_partial_reinforcement_rejects_illegal_p(value: object) -> None:
+    """Scenario ``p`` must be a finite real in ``[0, 1]``, not a bool or NaN."""
+    with pytest.raises(ValueError, match=r"\bp\b"):
+        partial_reinforcement_scenario(p=value)  # type: ignore[arg-type]
+
+
+def test_construct_accepts_zero_noise_and_zero_distractor_prob() -> None:
+    stream = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=0.0,
+        distractor_prob=0.0,
+    )
+    assert stream.feature_dim == 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 1.0, 1.5, np.int64(5), -1, float("nan"), "5", None],
+)
+def test_iti_min_rejects_bool_nonintegral_and_out_of_domain(value: object) -> None:
+    """``iti_min`` is a built-in int in ``[0, iti_max]``."""
+    with pytest.raises(ValueError, match="iti_min"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            iti_min=value,  # type: ignore[arg-type]
+            iti_max=20,
+        )
+
+
+@pytest.mark.parametrize("value", [True, False, 20.0, np.int64(20), -1])
+def test_iti_max_rejects_bool_nonintegral_and_out_of_domain(value: object) -> None:
+    with pytest.raises(ValueError, match="iti_max"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            iti_min=0,
+            iti_max=value,  # type: ignore[arg-type]
+        )
+
+
+def test_iti_min_accepts_zero_and_equal_max_endpoints() -> None:
+    zero = ClassicalConditioningStream(phases=(_valid_phase(),), iti_min=0, iti_max=20)
+    equal = ClassicalConditioningStream(phases=(_valid_phase(),), iti_min=0, iti_max=0)
+    matched = ClassicalConditioningStream(phases=(_valid_phase(),), iti_min=5, iti_max=5)
+    assert zero.feature_dim == 1
+    assert equal.feature_dim == 1
+    assert matched.feature_dim == 1
+
+
+def test_iti_min_rejects_greater_than_iti_max() -> None:
+    with pytest.raises(ValueError, match="iti_min <= iti_max"):
+        ClassicalConditioningStream(phases=(_valid_phase(),), iti_min=6, iti_max=5)
+
+
+@pytest.mark.parametrize(
+    ("field", "minimum"),
+    [
+        ("n_cs", 1),
+        ("n_distractors", 0),
+        ("cs_us_delay", 1),
+        ("cs_duration", 1),
+    ],
+)
+@pytest.mark.parametrize("value", [True, False, 1.0, np.int64(1)])
+def test_pavlovian_integer_fields_reject_bool_and_nonintegral(
+    field: str, minimum: int, value: object
+) -> None:
+    del minimum
+    with pytest.raises(ValueError, match=field):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            **{field: value},  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("value", [True, False, 1.0, np.int64(10), 0])
+def test_phase_n_steps_requires_positive_builtin_int(value: object) -> None:
+    with pytest.raises(ValueError, match="n_steps"):
+        ClassicalConditioningStream(phases=(_valid_phase(n_steps=value),))
+
+
+@pytest.mark.parametrize("value", [True, False, 1.0, np.int64(-1)])
+def test_phase_compound_index_requires_builtin_int(value: object) -> None:
+    with pytest.raises(ValueError, match="compound_index"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(compound_index=value),),
+            n_cs=2,
+        )
 
 
 def test_reacquisition_runs_three_phases():


### PR DESCRIPTION
Closes #251.

## What changed

The Pavlovian/classical-conditioning stream now validates its numeric constructor boundary before constructing JAX arrays or generating a trajectory:

- schedule and dimension fields require built-in integers in their documented domains;
- Python booleans, floating aliases, NumPy integer aliases, and other coercive values are rejected for integer fields;
- `iti_min=0` and `iti_min == iti_max` remain legal, while inverted ITI ranges fail immediately;
- observation noise must be finite and non-negative;
- distractor probability, phase contingencies, and partial-reinforcement `p` must be finite reals in `[0, 1]` and cannot be booleans;
- phase step counts, active CS indices, and compound indices are validated before materializing phase arrays;
- accepted constructor real values are stored as built-in floats.

Valid defaults, zero-noise runs, zero/equal ITI endpoints, and probability endpoints `0` and `1` retain their existing behavior.

## Why

Several malformed values previously crossed the public constructor because Python booleans alias integers and ordered comparisons do not reject `NaN`, NumPy integer aliases, or all non-integral inputs. Those values could become a silent but invalid scientific stream or fail later inside JAX with less actionable errors.

## Scope

- `alberta_framework/streams/pavlovian.py`
- `tests/test_pavlovian_stream.py`

This was split from a broader local stream-constructor repair after live ownership refresh found PR #250 already owned the out-of-class stream paths. This PR contains only the still-unowned Pavlovian half.

## Verification

Exact published head: `4cf8a38d5cbdc81264eab482f6ff0b8b7305d4de`

- Pavlovian stream + learning suites: **79 passed**;
- full Ruff: **all checks passed**;
- full mypy: **no issues in 163 source files**;
- `git diff --check`: clean;
- live ownership refresh immediately before publication: neither changed path was owned by another open PR;
- active evidence-source search: no registered reference to `streams/pavlovian.py`;
- `origin/main` remained `58b6780840e1ba3fd6fdaea4d49c906d6c3b55cb` at publication.

## Scientific integrity

This is ordinary constructor input validation. It does not change frozen protocols, seeds, registered evidence sources, benchmark outputs, `CHANGELOG.md`, or any `outputs/**` artifact, and it makes no performance or promotion claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code CLI Proxy
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"xAI","model":"grok-4.6","client":"Grok Build","attribution":"self-reported"} -->
