### PR TITLE
fix(memory): normalize tiny positive neighbor scores

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -840,7 +840,8 @@ class ExperientialMemory:
         neighbor_mask = jnp.isfinite(top_scores) & (top_scores > 0.0)
         positive_scores = jnp.where(neighbor_mask, top_scores, 0.0)
         score_sum = jnp.sum(positive_scores)
-        neighbor_weights = positive_scores / jnp.maximum(score_sum, 1.0e-12)
+        weight_denominator = jnp.where(score_sum > 0.0, score_sum, 1.0)
+        neighbor_weights = positive_scores / weight_denominator
 
         neighbor_similarities = similarities[indices]
         neighbor_reliabilities = effective_reliabilities[indices]

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -135,6 +135,31 @@ def test_config_json_roundtrip_and_memory_roundtrip() -> None:
     assert reconstructed.persistent_bytes == memory.persistent_bytes
 
 
+def test_single_tiny_positive_neighbor_score_still_has_unit_weight() -> None:
+    memory = ExperientialMemory(
+        _config(
+            distance_scale=1.0,
+            min_similarity=0.0,
+            min_effective_reliability=1.0e-6,
+        )
+    )
+    entry = _entry(8, key=(6.0, 6.0), action=(2.0, 4.0))
+    state = _write(memory, memory.init(), entry)
+
+    retrieval = memory.query(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(1, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(True, dtype=jnp.bool_),
+    )
+
+    assert bool(retrieval.accepted)
+    np.testing.assert_array_equal(retrieval.neighbor_mask, [True, False])
+    np.testing.assert_allclose(retrieval.neighbor_weights, [1.0, 0.0])
+    np.testing.assert_allclose(retrieval.action, entry.action)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
Closes #253.

## What changed

`ExperientialMemory.query` normalized neighbor scores with `positive_scores / jnp.maximum(score_sum, 1.0e-12)`. The `1e-12` floor is meant to guard the zero-score case (no accepted neighbors → avoid dividing by zero), but it applied unconditionally rather than only when `score_sum` is exactly zero. Empirically, for a genuinely small-but-nonzero `score_sum` (a single accepted neighbor whose true similarity is exp(-36) ≈ 2.32e-16), the denominator floor produced a weight of approximately `2.32e-4` rather than `1.0` — the weights no longer summed to one for that neighbor, corrupting the weighted average over recovered actions.

confirmed via a real mutation-resistance transcript before shipping:

```text
red (source fix reverted, regression test kept):
Mismatch at index [0]: 0.00023195227549877018 (ACTUAL), 1.0 (DESIRED)

green (fix restored):
47 passed
```

fix: use the real `score_sum` as the denominator whenever it's positive, falling back to `1.0` only when it's exactly zero (`jnp.where(score_sum > 0.0, score_sum, 1.0)`) instead of an unconditional epsilon floor via `jnp.maximum`.

## Reachability

`ExperientialMemory` is genuinely package-root exported (`alberta_framework/__init__.py` and `alberta_framework/core/__init__.py`, both import and `__all__`). `ExperientialMemory.query` is called by `ExperientialMemoryPolicy.propose`, which the public `PrototypeAgent`'s opt-in experiential-memory transaction calls via `policy.propose` — reachable through exported APIs with ordinary, configuration-valid inputs.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_experiential_memory.py -q -o addopts=""
47 passed in 5.34s

$ .venv/bin/python -m ruff check alberta_framework/core/experiential_memory.py tests/test_experiential_memory.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_single_tiny_positive_neighbor_score_still_has_unit_weight`, constructing a real query at a configuration-valid distance that produces a genuinely small-but-positive similarity score, asserting acceptance, unit weight, and exact recovery of the sole neighbor's stored action.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/core/experiential_memory.py`, kept the test), reran — failed with the exact mismatch shown above (weight `0.000232` instead of `1.0`). Restored the fix, 47/47 green again.

## Evidence

<!-- evidence-head -->
4f75cc83583cedcb518e88a4684021267afed959

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_experiential_memory.py -q -o addopts="" -k test_single_tiny_positive_neighbor_score_still_has_unit_weight
AssertionError: Not equal to tolerance rtol=1e-07, atol=0
Mismatch at index [0]: 0.00023195227549877018 (ACTUAL), 1.0 (DESIRED)
1 failed, 46 deselected in 0.99s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_experiential_memory.py -q -o addopts=""
47 passed in 5.43s
```

<!-- evidence-row:domain-artifact -->
```text
$ grep -n "ExperientialMemory" alberta_framework/__init__.py alberta_framework/core/__init__.py
alberta_framework/__init__.py:227:    ExperientialMemory,
alberta_framework/__init__.py:1058:    "ExperientialMemory",
alberta_framework/core/__init__.py:155:    ExperientialMemory,
alberta_framework/core/__init__.py:812:    "ExperientialMemory",
$ grep -n "\.propose(" alberta_framework/core/prototype_agent.py
4821:        proposal = policy.propose(
```
independently confirmed the package-root export and the real `policy.propose` caller chain, and independently reran the exact mutation-resistance revert/restore cycle myself against a clean checkout rather than trusting the report's transcript alone.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the exact red/green transcript from a clean checkout, verified the package-root export and real caller chain directly, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported

