### PR TITLE
fix(streams): reject invalid logarithmic scale bounds

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -7,6 +7,7 @@ track and adapt.
 All streams use JAX-compatible pure functions that work with jax.lax.scan.
 """
 
+import math
 from typing import Any
 
 import chex
@@ -851,6 +852,13 @@ def make_scale_range(
     ```
     """
     if log_spaced:
+        if (
+            not math.isfinite(min_scale)
+            or not math.isfinite(max_scale)
+            or min_scale <= 0.0
+            or max_scale <= 0.0
+        ):
+            raise ValueError("log-spaced scale bounds must be finite and positive")
         return jnp.logspace(
             jnp.log10(min_scale),
             jnp.log10(max_scale),

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -13,6 +13,7 @@ from typing import Any
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
@@ -20,6 +21,8 @@ from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
 _INT32_MAX = 2**31 - 1
+_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
 
 
 def _require_positive_int(name: str, value: object) -> int:
@@ -34,6 +37,25 @@ def _require_positive_int(name: str, value: object) -> int:
             f"{name} must be a positive integer in [1, {_INT32_MAX}], got {value!r}"
         )
     return value
+
+
+def _require_normal_float32_scale(name: str, value: float) -> float:
+    """Return a positive bound with stable JAX float32 logarithm semantics."""
+    message = f"{name} must be finite, positive, and representable as a normal float32 value"
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if (
+        not math.isfinite(normalized)
+        or normalized < _FLOAT32_TINY
+        or normalized > _FLOAT32_MAX
+    ):
+        raise ValueError(message)
+    narrowed = float(np.float32(normalized))
+    if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
+        raise ValueError(message)
+    return narrowed
 
 
 @chex.dataclass(frozen=True)
@@ -852,19 +874,36 @@ def make_scale_range(
     ```
     """
     if log_spaced:
-        if (
-            not math.isfinite(min_scale)
-            or not math.isfinite(max_scale)
-            or min_scale <= 0.0
-            or max_scale <= 0.0
-        ):
-            raise ValueError("log-spaced scale bounds must be finite and positive")
-        return jnp.logspace(
-            jnp.log10(min_scale),
-            jnp.log10(max_scale),
-            feature_dim,
-            dtype=jnp.float32,
-        )
+        min_bound = _require_normal_float32_scale("min_scale", min_scale)
+        max_bound = _require_normal_float32_scale("max_scale", max_scale)
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            values = np.geomspace(
+                np.float32(min_bound),
+                np.float32(max_bound),
+                feature_dim,
+                dtype=np.float32,
+            )
+        if values.size:
+            lower_bound = min(min_bound, max_bound)
+            upper_bound = max(min_bound, max_bound)
+            ordered = (
+                np.all(values[:-1] <= values[1:])
+                if min_bound <= max_bound
+                else np.all(values[:-1] >= values[1:])
+            )
+            valid = (
+                np.all(np.isfinite(values))
+                and np.all(values > 0.0)
+                and ordered
+                and np.all(values >= lower_bound)
+                and np.all(values <= upper_bound)
+            )
+            if not valid:
+                raise ValueError(
+                    "generated log-spaced scales must be finite, positive, ordered, "
+                    "and within the canonical float32 bounds"
+                )
+        return jnp.asarray(values, dtype=jnp.float32)
     else:
         return jnp.linspace(min_scale, max_scale, feature_dim, dtype=jnp.float32)
 

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -878,8 +878,8 @@ def make_scale_range(
         max_bound = _require_normal_float32_scale("max_scale", max_scale)
         with np.errstate(over="ignore", under="ignore", invalid="ignore"):
             values = np.geomspace(
-                np.float32(min_bound),
-                np.float32(max_bound),
+                min_bound,
+                max_bound,
                 feature_dim,
                 dtype=np.float32,
             )

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -3,6 +3,7 @@
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -409,6 +410,10 @@ class TestMakeScaleRange:
             pytest.param(0.01, float("inf"), id="max-positive-infinity"),
             pytest.param(float("-inf"), 100.0, id="min-negative-infinity"),
             pytest.param(0.01, float("-inf"), id="max-negative-infinity"),
+            pytest.param(1e-50, 1.0, id="min-below-float32-range"),
+            pytest.param(1.0, 1e-50, id="max-below-float32-range"),
+            pytest.param(1e100, 1.0, id="min-above-float32-range"),
+            pytest.param(1.0, 1e100, id="max-above-float32-range"),
         ],
     )
     def test_log_spaced_range_rejects_invalid_bounds(
@@ -416,12 +421,75 @@ class TestMakeScaleRange:
         min_scale,
         max_scale,
     ):
-        """Log-spaced scales require endpoints in the real logarithm domain."""
-        with pytest.raises(ValueError, match="finite and positive"):
+        """Log-spaced scales require bounds in JAX's normal float32 domain."""
+        with pytest.raises(ValueError, match="normal float32"):
             make_scale_range(
                 5,
                 min_scale=min_scale,
                 max_scale=max_scale,
+                log_spaced=True,
+            )
+
+    @pytest.mark.parametrize(
+        ("min_scale", "max_scale"),
+        [
+            pytest.param(0.01, 100.0, id="ascending"),
+            pytest.param(100.0, 0.01, id="descending"),
+            pytest.param(
+                float(np.finfo(np.float32).tiny),
+                float(np.finfo(np.float32).max),
+                id="float32-boundaries",
+            ),
+        ],
+    )
+    def test_log_spaced_range_has_valid_float32_postconditions(
+        self,
+        min_scale,
+        max_scale,
+    ):
+        """Generated ranges preserve canonical endpoints and ordering."""
+        scales = make_scale_range(
+            5,
+            min_scale=min_scale,
+            max_scale=max_scale,
+            log_spaced=True,
+        )
+        values = np.asarray(scales)
+        lower_bound = np.float32(min(min_scale, max_scale))
+        upper_bound = np.float32(max(min_scale, max_scale))
+
+        assert values.dtype == np.dtype(np.float32)
+        assert values[0] == np.float32(min_scale)
+        assert values[-1] == np.float32(max_scale)
+        assert np.all(np.isfinite(values))
+        assert np.all(values > 0.0)
+        assert np.all(values >= lower_bound)
+        assert np.all(values <= upper_bound)
+        if min_scale <= max_scale:
+            assert np.all(values[:-1] <= values[1:])
+        else:
+            assert np.all(values[:-1] >= values[1:])
+
+    @pytest.mark.parametrize(
+        "generated",
+        [
+            pytest.param(jnp.array([1.0, jnp.nan, 10.0]), id="non-finite"),
+            pytest.param(jnp.array([1.0, 0.0, 10.0]), id="non-positive"),
+            pytest.param(jnp.array([1.0, 9.0, 8.0, 10.0]), id="unordered"),
+        ],
+    )
+    def test_log_spaced_range_rejects_invalid_generated_values(self, monkeypatch, generated):
+        """Backend numerical failures must fail closed before scales escape."""
+        monkeypatch.setattr(
+            "alberta_framework.streams.synthetic.np.geomspace",
+            lambda *args, **kwargs: generated,
+        )
+
+        with pytest.raises(ValueError, match="generated log-spaced scales"):
+            make_scale_range(
+                generated.size,
+                min_scale=1.0,
+                max_scale=10.0,
                 log_spaced=True,
             )
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -435,10 +435,31 @@ class TestMakeScaleRange:
         [
             pytest.param(0.01, 100.0, id="ascending"),
             pytest.param(100.0, 0.01, id="descending"),
+            pytest.param(np.float32(0.123), np.float32(0.123), id="equal"),
+            pytest.param(
+                np.float32(3.0),
+                np.nextafter(np.float32(3.0), np.float32("inf")),
+                id="adjacent-ascending",
+            ),
+            pytest.param(
+                np.nextafter(np.float32(3.0), np.float32("inf")),
+                np.float32(3.0),
+                id="adjacent-descending",
+            ),
             pytest.param(
                 float(np.finfo(np.float32).tiny),
                 float(np.finfo(np.float32).max),
                 id="float32-boundaries",
+            ),
+            pytest.param(
+                float(np.finfo(np.float32).tiny),
+                float(np.finfo(np.float32).tiny),
+                id="equal-float32-tiny",
+            ),
+            pytest.param(
+                float(np.finfo(np.float32).max),
+                float(np.finfo(np.float32).max),
+                id="equal-float32-max",
             ),
         ],
     )

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -398,9 +398,20 @@ class TestMakeScaleRange:
 
     @pytest.mark.parametrize(
         ("min_scale", "max_scale"),
-        [(-1.0, 100.0), (0.01, -100.0)],
+        [
+            pytest.param(-1.0, 100.0, id="min-negative"),
+            pytest.param(0.01, -100.0, id="max-negative"),
+            pytest.param(0.0, 100.0, id="min-zero"),
+            pytest.param(0.01, 0.0, id="max-zero"),
+            pytest.param(float("nan"), 100.0, id="min-nan"),
+            pytest.param(0.01, float("nan"), id="max-nan"),
+            pytest.param(float("inf"), 100.0, id="min-positive-infinity"),
+            pytest.param(0.01, float("inf"), id="max-positive-infinity"),
+            pytest.param(float("-inf"), 100.0, id="min-negative-infinity"),
+            pytest.param(0.01, float("-inf"), id="max-negative-infinity"),
+        ],
     )
-    def test_log_spaced_range_rejects_nonpositive_bounds(
+    def test_log_spaced_range_rejects_invalid_bounds(
         self,
         min_scale,
         max_scale,

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -396,6 +396,24 @@ class TestMakeScaleRange:
         # Middle value should be geometric mean ≈ 1.0
         chex.assert_trees_all_close(scales[2], jnp.array(1.0), rtol=0.1)
 
+    @pytest.mark.parametrize(
+        ("min_scale", "max_scale"),
+        [(-1.0, 100.0), (0.01, -100.0)],
+    )
+    def test_log_spaced_range_rejects_nonpositive_bounds(
+        self,
+        min_scale,
+        max_scale,
+    ):
+        """Log-spaced scales require endpoints in the real logarithm domain."""
+        with pytest.raises(ValueError, match="finite and positive"):
+            make_scale_range(
+                5,
+                min_scale=min_scale,
+                max_scale=max_scale,
+                log_spaced=True,
+            )
+
     def test_linear_spaced_range(self):
         """Linear-spaced scales should span min to max linearly."""
         scales = make_scale_range(5, min_scale=0.0, max_scale=100.0, log_spaced=False)


### PR DESCRIPTION
Closes #256.

## What changed

`make_scale_range(..., log_spaced=True)` previously sent unchecked host values into a
float32 logarithmic calculation. The failure modes differ by input:

- a zero endpoint makes `log10(0)` negative infinity, and JAX returns finite zero scales
  (not NaNs);
- a negative endpoint produces NaNs;
- a host-finite positive endpoint can still narrow outside float32: `1e-50` becomes zero,
  while `1e100` becomes positive infinity and produces NaN/infinite scales.

The logarithmic branch now:

- requires each endpoint to be finite, positive, and representable as a normal float32
  value, matching JAX's effective logarithm domain;
- canonicalizes accepted endpoints to float32 before range construction;
- constructs an exact-endpoint float32 geometric range; and
- fails closed unless every generated scale is finite, positive, monotone in the requested
  direction, and within the canonical endpoint interval.

The `log_spaced=False` branch is unchanged and still permits a zero endpoint.

## Reachability and scope

`make_scale_range` is exported from both `alberta_framework.streams` and the package root.
Its output is intended for `ScaledStreamWrapper`, where invalid scales directly corrupt
observations. There are no internal runtime callers beyond the implementation's docstring
example, so this repairs a public utility contract rather than claiming an active benchmark
failure or scientific result. No evidence artifacts are changed.

## Regression coverage

The retained matrix exercises zero, negative, NaN, positive infinity, negative infinity,
below-float32, and above-float32 inputs in both endpoint positions. Positive controls cover
ascending and descending ranges, the normal float32 endpoints, exact canonical endpoints,
finite/positive/ordered/in-range postconditions, linear zero behavior, and fail-closed
handling of invalid generated values.

## Verification

Validated at `a21a799d5a04d61750a16c5e3468ac87f2d2227e`:

```text
$ python -m pytest tests/test_streams.py -q -o addopts=""
130 passed in 12.06s

$ python -m ruff check alberta_framework/streams/synthetic.py tests/test_streams.py
All checks passed!

$ python -m mypy
Success: no issues found in 163 source files
```

The repair is rebased on current `main` (`8b49cec714c97c58864f4b6c93cc799455c4c077`).

## Provenance

Original fix and tests: Svector-anu, with self-reported AI assistance in the initial PR.
Float32-domain hardening, generated-range postconditions, regression expansion, and
re-verification: lalalune/Codex.
