### PR TITLE
fix(streams): keep rejected transitions finite

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -824,8 +824,8 @@ class RecurringTwoAgentWorld:
                     update_applied,
                     value,
                     (
-                        jnp.full_like(value, jnp.nan)
-                        if jnp.issubdtype(value.dtype, jnp.floating)
+                        jnp.zeros_like(value)
+                        if jnp.issubdtype(value.dtype, jnp.inexact)
                         else (
                             jnp.zeros_like(value)
                             if jnp.issubdtype(value.dtype, jnp.bool_)

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -405,6 +405,23 @@ def test_state_is_an_immutable_chex_pytree() -> None:
     chex.assert_trees_all_equal(rebuilt, state)
 
 
+def test_rejected_nonfinite_action_returns_finite_terminal_transition() -> None:
+    world = RecurringTwoAgentWorld(nuisance_dim=0)
+    state = world.init(jr.key(13)).replace(
+        velocities=jnp.array([0.2, -0.1], dtype=jnp.float32),
+    )
+
+    result = world.step_result(
+        state,
+        jnp.array([jnp.nan, 0.0], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_rejected)
+    assert bool(result.transition.terminated)
+    chex.assert_tree_all_finite(result.transition)
+    chex.assert_trees_all_equal(result.state, state)
+
+
 def test_jitted_scan_runs_continually_and_remains_bounded() -> None:
     world = RecurringTwoAgentWorld(
         context_length=3,


### PR DESCRIPTION
Closes #258.

## What changed

`RecurringTwoAgentWorld._advance_result` correctly rejects invalid actions and keeps the environment state unchanged, but replaced every floating leaf in the returned terminal transition with `NaN`:

```python
jnp.full_like(value, jnp.nan) if jnp.issubdtype(value.dtype, jnp.floating) else ...
```

A caller that records the rejected terminal transition — not just checks `update_rejected` — therefore received non-finite observations, rewards, actions, and oracle measurements, poisoning any downstream aggregate metric even though the environment transaction itself is an atomic no-op.

confirmed directly before touching the source:

```text
applied False terminated True
state_unchanged True
observation_finite False
next_observation_finite False
reward_finite False
next_observation [[nan nan nan nan nan nan]
 [nan nan nan nan nan nan]]
```

fix: rejected transition leaves now use finite zeros for inexact (floating/complex) arrays instead of `NaN`, widened from `jnp.floating` to `jnp.inexact` to also cover complex dtypes defensively. Boolean and integer rejection sentinels retain their existing behavior (`False` / `-1` respectively) — only the poisoned NaN leaves are replaced. The committed state remains unchanged and the transition remains correctly marked terminal with zero discount.

## Reachability

`RecurringTwoAgentWorld` is exported from `alberta_framework.streams` and included in that subpackage's `__all__`. Its public `step`/`step_result` and `step_with_partner`/`step_with_partner_result` methods both delegate to the affected transactional path (`_advance_result`) with caller-supplied actions — non-finite/out-of-range real inputs reach the corrected rejection behavior through public entry points.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_recurring_multiagent_stream.py -q -o addopts=""
21 passed in 6.76s

$ .venv/bin/python -m ruff check alberta_framework/streams/recurring_multiagent.py tests/test_recurring_multiagent_stream.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_rejected_nonfinite_action_returns_finite_terminal_transition` — passes a non-finite action from a valid state with nonzero velocity, then asserts rejection, terminal status, full transition finiteness (`chex.assert_tree_all_finite`), and an exact no-op state.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/recurring_multiagent.py`, kept the test), reran — failed with a chex finiteness assertion listing every observation/reward/action/oracle leaf as `'Nonfinite'`. Restored the fix, 21/21 green again.

## Evidence

<!-- evidence-head -->
0e528d847fbba09438a40c1c7d0668c6d42550b5

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_recurring_multiagent_stream.py -q -o addopts="" -k test_rejected_nonfinite_action_returns_finite_terminal_transition
AssertionError: [Chex] Assertion assert_tree_all_finite failed: Tree contains non-finite value:
RecurringTwoAgentTransition(observation='Nonfinite', action='Nonfinite', reward='Nonfinite', ...)
1 failed, 20 deselected in 1.66s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_recurring_multiagent_stream.py -q -o addopts=""
21 passed in 6.82s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp, jax.random as jr, chex
from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentWorld
world = RecurringTwoAgentWorld(nuisance_dim=0)
state = world.init(jr.key(13)).replace(velocities=jnp.array([0.2, -0.1], dtype=jnp.float32))
result = world.step_result(state, jnp.array([jnp.nan, 0.0], dtype=jnp.float32))
print('applied:', not bool(result.update_rejected))
print('terminated:', bool(result.transition.terminated))
chex.assert_tree_all_finite(result.transition)
print('all finite: True')
print('state unchanged:', bool(jnp.array_equal(result.state.velocities, state.velocities)))
"
applied: False
terminated: True
all finite: True
state unchanged: True
```
independently reproduced against the fixed head, confirming the full rejected-transition contract (rejected, terminal, finite, exact no-op state), and independently confirmed the package-root export and both public step-method callers before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the fixed rejection contract, verified the public export and both real step-method callers directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
