### PR TITLE
fix(export): reject inconsistent metric surfaces

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -70,7 +70,11 @@ def _preflight_export_results(
                 f"AggregatedResults {name!r} must contain requested metric {metric!r} "
                 "in both metric_arrays and summary"
             )
-
+        if set(aggregate.metric_arrays) != set(aggregate.summary):
+            raise ValueError(
+                f"AggregatedResults {name!r} metric_arrays and summary must contain "
+                "the same metric names"
+            )
         for metric_name, values in aggregate.metric_arrays.items():
             qualified_name = f"AggregatedResults {name!r} metric {metric_name!r}"
             if values.ndim != 2:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -378,6 +378,23 @@ def test_csv_preflight_requires_requested_metric_in_every_aggregate(
     assert not absent.parent.exists()
 
 
+@pytest.mark.parametrize("mode", ["json", "csv"])
+def test_preflight_rejects_metric_surface_mismatch(mode: str, tmp_path: Path) -> None:
+    valid = _constant_result("mismatch")
+    mismatched = valid._replace(
+        metric_arrays={**valid.metric_arrays, "extra": valid.metric_arrays[_METRIC]}
+    )
+    destination = tmp_path / f"mismatch.{mode}"
+
+    with pytest.raises(ValueError, match="same metric names"):
+        if mode == "json":
+            export_to_json({"mismatch": mismatched}, destination, include_timeseries=True)
+        else:
+            export_to_csv({"mismatch": mismatched}, destination, metric=_METRIC)
+
+    assert not destination.exists()
+
+
 @pytest.mark.parametrize("case", ["empty_results", "zero_step_axis", "missing_metric"])
 def test_report_preflight_rejects_before_output_directory_mutation(
     case: str,


### PR DESCRIPTION
Closes #261.

## What changed

`_preflight_export_results` validated `metric_arrays` and `summary` independently — each checked non-empty, and a *specific requested* metric (when `metric` is passed) was checked present in both — but never required the full sets of metric names in `metric_arrays` and `summary` to match each other.

`export_to_json(..., include_timeseries=True)` writes both a summary section and a timeseries section from the same `AggregatedResults`. If those two dicts have different metric name sets, the export silently writes a summary describing one set of metrics and timeseries describing a different set — the two sections of the same export file disagree about what was measured, with no error.

confirmed directly before touching the source:

```text
summary metrics: ['accuracy']
timeseries metrics: ['loss']
sets match: False
```

fix: the preflight now rejects unequal metric-name sets between `metric_arrays` and `summary` before any filesystem mutation, matching the existing fail-closed pattern the rest of the preflight already uses.

## Reachability

`export_to_csv`, `export_to_json`, and `save_experiment_report` are all publicly re-exported by `alberta_framework/utils/__init__.py`. The shared `_preflight_export_results` is called by both export functions and by the report workflow — reachable through the public utility surface with ordinary `AggregatedResults` inputs.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_export.py -q -o addopts=""
92 passed in 0.48s

$ .venv/bin/python -m ruff check alberta_framework/utils/export.py tests/test_export.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_preflight_rejects_metric_surface_mismatch`, parameterized over `json` and `csv` export modes, asserting both the rejection and that no destination file is created (matching the sibling `test_csv_preflight_requires_requested_metric_in_every_aggregate` right above it).

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/utils/export.py`, kept the test), reran — both parameterized cases failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 92/92 green again.

## Evidence

<!-- evidence-head -->
8346a37e4225e1be866b7b0c803a5638607f71d9

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_export.py -q -o addopts="" -k test_preflight_rejects_metric_surface_mismatch
FAILED tests/test_export.py::test_preflight_rejects_metric_surface_mismatch[json]
FAILED tests/test_export.py::test_preflight_rejects_metric_surface_mismatch[csv]
2 failed, 90 deselected in 0.46s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_export.py -q -o addopts=""
92 passed in 0.48s
```

<!-- evidence-row:domain-artifact -->
```text
$ grep -n "export_to_json\|export_to_csv\|save_experiment_report" alberta_framework/utils/__init__.py
    export_to_csv,
    export_to_json,
    save_experiment_report,
    "export_to_csv",
    "export_to_json",
    "save_experiment_report",
```
independently confirmed all three functions are genuinely package-root re-exported before writing up the reachability claim, and independently confirmed the existing `metric is not None` branch only checks a single requested metric's presence in both dicts, not the full-set equality this fix adds.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, verified the public re-export chain directly, confirmed the existing check's narrower scope vs. this fix's broader one, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
