### PR TITLE
fix(nexting): scale before squaring to avoid float32 RMSE overflow

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -139,6 +139,41 @@ def _validate_rmse_inputs(
     return predictions.shape[0]
 
 
+def _scaled_rmse_terms(errors: Array) -> tuple[Array, Array, Array]:
+    """Return power-of-two scale, scaled errors, and their RMS."""
+    scale = jnp.max(jnp.abs(errors), axis=0)
+    _, exponent = jnp.frexp(scale)
+    scaled_errors = jnp.ldexp(errors, -exponent)
+    scaled_rmse = jnp.sqrt(jnp.mean(scaled_errors**2, axis=0))
+    return exponent, scaled_errors, scaled_rmse
+
+
+@jax.custom_jvp
+def _finite_rmse(errors: Array) -> Array:
+    """Compute finite-column RMSE without overflow or reciprocal underflow."""
+    exponent, _, scaled_rmse = _scaled_rmse_terms(errors)
+    return jnp.ldexp(scaled_rmse, exponent)
+
+
+@_finite_rmse.defjvp
+def _finite_rmse_jvp(
+    primals: tuple[Array],
+    tangents: tuple[Array],
+) -> tuple[Array, Array]:
+    """Differentiate in the scaled domain so huge finite gradients stay valid."""
+    (errors,), (errors_dot,) = primals, tangents
+    exponent, scaled_errors, scaled_rmse = _scaled_rmse_terms(errors)
+    rmse = jnp.ldexp(scaled_rmse, exponent)
+    # Zero is a valid subgradient for an all-zero column and avoids a 0 / 0.
+    safe_scaled_rmse = jnp.where(
+        scaled_rmse > 0.0,
+        scaled_rmse,
+        jnp.ones_like(scaled_rmse),
+    )
+    rmse_dot = jnp.mean(scaled_errors * errors_dot, axis=0) / safe_scaled_rmse
+    return rmse, rmse_dot
+
+
 def per_horizon_rmse(
     predictions: Float[Array, "T H"],
     forward_returns: Float[Array, "T H"],
@@ -182,16 +217,10 @@ def per_horizon_rmse(
     # in the final result.
     finite_columns = jnp.all(jnp.isfinite(errors), axis=0)
     safe_errors = jnp.where(finite_columns[None, :], errors, jnp.zeros_like(errors))
-    scale = jnp.max(jnp.abs(safe_errors), axis=0)
-    _mantissa, exponent = jnp.frexp(scale)
     # Arbitrary division by a near-max float32 scale can lower to a reciprocal
     # that underflows to zero.  ldexp performs exact power-of-two scaling and
     # keeps the normalized magnitudes in range without that reciprocal.
-    normalized = jnp.ldexp(safe_errors, -exponent[None, :])
-    stable_rmse = jnp.ldexp(
-        jnp.sqrt(jnp.mean(normalized**2, axis=0)),
-        exponent,
-    )
+    stable_rmse = _finite_rmse(safe_errors)
     # A maximum absolute error carries the desired diagnostic: NaN if any
     # error is NaN, otherwise Inf if any error is infinite.  Deriving it from
     # the input avoids constructing discarded NaN/Inf literals on finite calls.

--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -173,8 +173,18 @@ def per_horizon_rmse(
     if burn_in:
         predictions = predictions[burn_in:]
         forward_returns = forward_returns[burn_in:]
-    sq_err = (predictions - forward_returns) ** 2
-    return jnp.sqrt(jnp.mean(sq_err, axis=0))
+    errors = predictions - forward_returns
+    sq_err = errors**2
+    raw_rmse = jnp.sqrt(jnp.mean(sq_err, axis=0))
+
+    # Scale before squaring so large, finite float32 errors do not overflow.
+    # Keep the direct result for non-finite inputs so NaN/Inf diagnostics remain
+    # visible to callers instead of being hidden by the stable path.
+    scale = jnp.max(jnp.abs(errors), axis=0)
+    normalized = jnp.where(scale > 0.0, errors / scale, jnp.zeros_like(errors))
+    stable_rmse = scale * jnp.sqrt(jnp.mean(normalized**2, axis=0))
+    finite_columns = jnp.all(jnp.isfinite(errors), axis=0)
+    return jnp.where(finite_columns, stable_rmse, raw_rmse)
 
 
 def per_horizon_running_rmse(

--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -174,17 +174,29 @@ def per_horizon_rmse(
         predictions = predictions[burn_in:]
         forward_returns = forward_returns[burn_in:]
     errors = predictions - forward_returns
-    sq_err = errors**2
-    raw_rmse = jnp.sqrt(jnp.mean(sq_err, axis=0))
 
     # Scale before squaring so large, finite float32 errors do not overflow.
-    # Keep the direct result for non-finite inputs so NaN/Inf diagnostics remain
-    # visible to callers instead of being hidden by the stable path.
-    scale = jnp.max(jnp.abs(errors), axis=0)
-    normalized = jnp.where(scale > 0.0, errors / scale, jnp.zeros_like(errors))
-    stable_rmse = scale * jnp.sqrt(jnp.mean(normalized**2, axis=0))
+    # Mask non-finite columns before every arithmetic operation, and divide by
+    # one for all-zero columns.  This keeps debug/checkify modes free of
+    # discarded overflow and 0/0 operations while retaining NaN/Inf diagnostics
+    # in the final result.
     finite_columns = jnp.all(jnp.isfinite(errors), axis=0)
-    return jnp.where(finite_columns, stable_rmse, raw_rmse)
+    safe_errors = jnp.where(finite_columns[None, :], errors, jnp.zeros_like(errors))
+    scale = jnp.max(jnp.abs(safe_errors), axis=0)
+    _mantissa, exponent = jnp.frexp(scale)
+    # Arbitrary division by a near-max float32 scale can lower to a reciprocal
+    # that underflows to zero.  ldexp performs exact power-of-two scaling and
+    # keeps the normalized magnitudes in range without that reciprocal.
+    normalized = jnp.ldexp(safe_errors, -exponent[None, :])
+    stable_rmse = jnp.ldexp(
+        jnp.sqrt(jnp.mean(normalized**2, axis=0)),
+        exponent,
+    )
+    # A maximum absolute error carries the desired diagnostic: NaN if any
+    # error is NaN, otherwise Inf if any error is infinite.  Deriving it from
+    # the input avoids constructing discarded NaN/Inf literals on finite calls.
+    nonfinite_rmse = jnp.max(jnp.abs(errors), axis=0)
+    return jnp.where(finite_columns, stable_rmse, nonfinite_rmse)
 
 
 def per_horizon_running_rmse(

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -165,6 +165,25 @@ class TestRMSE:
             error.throw()
             chex.assert_tree_all_finite(rmse)
 
+    def test_huge_finite_error_gradient_is_correct_eager_and_jit(self) -> None:
+        predictions = jnp.asarray([[3.0e38], [-1.0e38]], dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        def scalar_rmse(values: jax.Array) -> jax.Array:
+            return per_horizon_rmse(values, returns)[0]
+
+        reference_values = np.asarray(predictions, dtype=np.float64)
+        reference_rmse = np.sqrt(np.mean(reference_values**2, axis=0))[0]
+        expected = reference_values / (predictions.shape[0] * reference_rmse)
+
+        eager = jax.grad(scalar_rmse)(predictions)
+        compiled = jax.jit(jax.grad(scalar_rmse))(predictions)
+
+        assert bool(jnp.all(jnp.isfinite(eager)))
+        assert bool(jnp.all(jnp.isfinite(compiled)))
+        np.testing.assert_allclose(np.asarray(eager), expected, rtol=2e-6, atol=0.0)
+        np.testing.assert_allclose(np.asarray(compiled), expected, rtol=2e-6, atol=0.0)
+
     def test_zero_error_when_predictions_match(self) -> None:
         t, h = 50, 4
         truths = jnp.ones((t, h))

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -9,6 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax.experimental import checkify
 
 from alberta_framework.utils.nexting import (
     forward_view_returns,
@@ -124,10 +125,45 @@ class TestRMSE:
         predictions = jnp.asarray([[2.0e20], [2.0e20]], dtype=jnp.float32)
         returns = jnp.zeros_like(predictions)
 
-        rmse = per_horizon_rmse(predictions, returns)
+        with jax.debug_infs(True):
+            rmse = per_horizon_rmse(predictions, returns)
 
         assert bool(jnp.isfinite(rmse[0]))
         np.testing.assert_allclose(np.asarray(rmse), np.asarray([2.0e20], dtype=np.float32))
+
+    def test_zero_error_does_not_form_a_discarded_zero_division(self) -> None:
+        predictions = jnp.zeros((3, 2), dtype=jnp.float32)
+
+        with jax.debug_nans(True):
+            rmse = per_horizon_rmse(predictions, predictions)
+
+        np.testing.assert_array_equal(np.asarray(rmse), np.zeros(2, dtype=np.float32))
+
+    def test_near_max_finite_errors_do_not_underflow_during_scaling(self) -> None:
+        values = np.linspace(-1.0e38, 1.0e38, 257, dtype=np.float32)[:, None]
+        predictions = jnp.asarray(values)
+        returns = jnp.zeros_like(predictions)
+        reference = np.sqrt(np.mean(np.square(values.astype(np.float64)), axis=0))
+
+        with jax.debug_infs(True):
+            rmse = per_horizon_rmse(predictions, returns)
+
+        assert bool(jnp.isfinite(rmse[0]))
+        np.testing.assert_allclose(np.asarray(rmse), reference, rtol=2e-6)
+        compiled = jax.jit(per_horizon_rmse)(predictions, returns)
+        np.testing.assert_allclose(np.asarray(compiled), reference, rtol=2e-6)
+
+    def test_finite_stable_rmse_has_no_checkify_float_errors(self) -> None:
+        checked = checkify.checkify(per_horizon_rmse, errors=checkify.float_checks)
+
+        for predictions in (
+            jnp.zeros((3, 1), dtype=jnp.float32),
+            jnp.full((3, 1), 2.0e20, dtype=jnp.float32),
+            jnp.linspace(-1.0e38, 1.0e38, 257, dtype=jnp.float32)[:, None],
+        ):
+            error, rmse = checked(predictions, jnp.zeros_like(predictions))
+            error.throw()
+            chex.assert_tree_all_finite(rmse)
 
     def test_zero_error_when_predictions_match(self) -> None:
         t, h = 50, 4

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -184,6 +184,44 @@ class TestRMSE:
         np.testing.assert_allclose(np.asarray(eager), expected, rtol=2e-6, atol=0.0)
         np.testing.assert_allclose(np.asarray(compiled), expected, rtol=2e-6, atol=0.0)
 
+    @pytest.mark.parametrize("magnitude", [2.0e20, 1.0e38, 3.0e38])
+    def test_large_finite_rmse_has_stable_eager_and_jit_gradients(
+        self,
+        magnitude: float,
+    ) -> None:
+        predictions = jnp.full((2, 1), magnitude, dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        def loss(values: jax.Array) -> jax.Array:
+            return jnp.sum(per_horizon_rmse(values, returns))
+
+        expected = jnp.full_like(predictions, 0.5)
+        eager = jax.grad(loss)(predictions)
+        compiled = jax.jit(jax.grad(loss))(predictions)
+
+        chex.assert_trees_all_close(eager, expected, rtol=5e-6, atol=0.0)
+        chex.assert_trees_all_close(compiled, expected, rtol=5e-6, atol=0.0)
+
+    def test_zero_rmse_uses_zero_eager_jit_and_forward_gradient_convention(self) -> None:
+        predictions = jnp.zeros((3, 2), dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        def loss(values: jax.Array) -> jax.Array:
+            return jnp.sum(per_horizon_rmse(values, returns))
+
+        expected = jnp.zeros_like(predictions)
+        eager = jax.grad(loss)(predictions)
+        compiled = jax.jit(jax.grad(loss))(predictions)
+        _primal, tangent = jax.jvp(
+            lambda values: per_horizon_rmse(values, returns),
+            (predictions,),
+            (jnp.ones_like(predictions),),
+        )
+
+        chex.assert_trees_all_equal(eager, expected)
+        chex.assert_trees_all_equal(compiled, expected)
+        chex.assert_trees_all_equal(tangent, jnp.zeros((2,), dtype=jnp.float32))
+
     def test_zero_error_when_predictions_match(self) -> None:
         t, h = 50, 4
         truths = jnp.ones((t, h))

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -120,6 +120,15 @@ class TestMultiChannel:
 
 
 class TestRMSE:
+    def test_large_finite_errors_do_not_overflow(self) -> None:
+        predictions = jnp.asarray([[2.0e20], [2.0e20]], dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        rmse = per_horizon_rmse(predictions, returns)
+
+        assert bool(jnp.isfinite(rmse[0]))
+        np.testing.assert_allclose(np.asarray(rmse), np.asarray([2.0e20], dtype=np.float32))
+
     def test_zero_error_when_predictions_match(self) -> None:
         t, h = 50, 4
         truths = jnp.ones((t, h))


### PR DESCRIPTION
Closes #263.

## Summary
`per_horizon_rmse` previously squared float32 errors directly, so finite errors such as `2e20` overflowed the intermediate square even though the correct RMSE remained representable.

The initial max-division repair was also incomplete: on XLA, dividing by a near-max float32 scale can lower through a reciprocal that underflows to zero, causing errors around `1e38` to report RMSE `0.0`. It also formed discarded overflow and zero-division operations that fail under JAX debug/checkify modes.

The corrected implementation:

- masks non-finite columns before arithmetic while retaining NaN/Inf diagnostics in the returned metric;
- uses `frexp` plus `ldexp` for exact power-of-two scaling instead of an arbitrary reciprocal;
- never squares unscaled large errors and never divides an all-zero column;
- supplies a scaled-domain custom JVP so eager and JIT reverse/forward autodiff remain finite and correct at extreme finite magnitudes;
- defines the RMSE derivative at an all-zero error column as zero;
- preserves ordinary eager/JIT results and the existing input/burn-in contract.

## Validation
- [x] `tests/test_nexting.py` — 61 passed
- [x] eager/JIT gradient regressions at `2e20`, `1e38`, and `3e38`
- [x] mixed-sign `3e38`/`-1e38` gradient against a float64 analytic reference
- [x] explicit all-zero eager/JIT reverse-mode and forward-mode zero convention
- [x] full Ruff
- [x] strict mypy — 163 source files
- [x] `git diff --check`
- [x] no `outputs/**` changes

Regressions also cover 257 values spanning `[-1e38, 1e38]` against a float64 reference, all-zero columns, eager/JIT agreement, JAX debug modes, checkify float checks, and retained NaN/Inf visibility.

Backend caveat: on the tested JAX CPU backend, the smallest float32 subnormal error is flushed to zero before the stable RMSE scaling stage. The smallest normal float32 value is preserved. This PR does not claim subnormal preservation and does not alter that pre-existing backend behavior.

The protocol and forward-view equations are unchanged; this is a numerically stable evaluation and derivative of the same RMSE definition.