### PR TITLE
fix(ftl-world-model): reject non-finite ridge and prediction_clip

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -34,14 +34,36 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+from numbers import Real
 from typing import Any
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
+
+_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+
+
+def _finite_positive_normal_float32(name: str, value: object) -> float:
+    """Return a concrete real after validation in the model's execution dtype."""
+    message = f"{name} must be a finite positive normal float32"
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        concrete = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(concrete) or concrete <= 0.0:
+        raise ValueError(message)
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        narrowed = float(np.float32(concrete))
+    if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY:
+        raise ValueError(message)
+    return concrete
 
 
 @dataclasses.dataclass(frozen=True)
@@ -81,14 +103,17 @@ class SparseFTLWorldModelConfig:
             raise ValueError("projection_dim must be positive")
         if self.bins < 2:
             raise ValueError("bins must be at least 2")
-        if not math.isfinite(self.ridge) or self.ridge <= 0.0:
-            raise ValueError("ridge must be finite and positive")
+        ridge = _finite_positive_normal_float32("ridge", self.ridge)
         if not 0.0 < self.statistics_decay <= 1.0:
             raise ValueError("statistics_decay must be in (0, 1]")
-        if not math.isfinite(self.prediction_clip) or self.prediction_clip <= 0.0:
-            raise ValueError("prediction_clip must be finite and positive")
+        prediction_clip = _finite_positive_normal_float32(
+            "prediction_clip",
+            self.prediction_clip,
+        )
         if not 0.0 <= self.error_decay < 1.0:
             raise ValueError("error_decay must be in [0, 1)")
+        object.__setattr__(self, "ridge", ridge)
+        object.__setattr__(self, "prediction_clip", prediction_clip)
 
     @property
     def input_dim(self) -> int:

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Any
 
 import chex
@@ -80,12 +81,12 @@ class SparseFTLWorldModelConfig:
             raise ValueError("projection_dim must be positive")
         if self.bins < 2:
             raise ValueError("bins must be at least 2")
-        if self.ridge <= 0.0:
-            raise ValueError("ridge must be positive")
+        if not math.isfinite(self.ridge) or self.ridge <= 0.0:
+            raise ValueError("ridge must be finite and positive")
         if not 0.0 < self.statistics_decay <= 1.0:
             raise ValueError("statistics_decay must be in (0, 1]")
-        if self.prediction_clip <= 0.0:
-            raise ValueError("prediction_clip must be positive")
+        if not math.isfinite(self.prediction_clip) or self.prediction_clip <= 0.0:
+            raise ValueError("prediction_clip must be finite and positive")
         if not 0.0 <= self.error_decay < 1.0:
             raise ValueError("error_decay must be in [0, 1)")
 

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -58,9 +58,11 @@ def _shared_dynamics_mse(
         ("projection_dim", 0),
         ("bins", 1),
         ("ridge", 0.0),
+        ("ridge", float("nan")),
         ("statistics_decay", 0.0),
         ("statistics_decay", 1.01),
         ("prediction_clip", 0.0),
+        ("prediction_clip", float("nan")),
         ("error_decay", 1.0),
     ],
 )

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -8,6 +8,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.ftl_world_model import (
@@ -81,6 +82,127 @@ def test_config_rejects_invalid_parameters(field: str, value: int | float) -> No
 
     with pytest.raises(ValueError):
         SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["ridge", "prediction_clip"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(True, id="bool"),
+        pytest.param(np.bool_(True), id="numpy-bool"),
+        pytest.param("0.01", id="string"),
+        pytest.param(1.0 + 0.0j, id="complex"),
+        pytest.param(object(), id="object"),
+    ],
+)
+def test_config_rejects_non_real_or_boolean_execution_scalars(
+    field: str,
+    value: object,
+) -> None:
+    kwargs: dict[str, object] = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        field: value,
+    }
+
+    with pytest.raises(ValueError, match=rf"{field} must be a finite positive normal float32"):
+        SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["ridge", "prediction_clip"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(
+            float(np.nextafter(np.float32(0.0), np.float32(1.0))),
+            id="float32-subnormal",
+        ),
+        pytest.param(np.nextafter(0.0, 1.0), id="underflows-to-zero"),
+        pytest.param(float(np.finfo(np.float32).max) * 2.0, id="overflows-to-infinity"),
+    ],
+)
+def test_config_rejects_values_outside_normal_float32_execution_domain(
+    field: str,
+    value: float,
+) -> None:
+    assert np.isfinite(value) and value > 0.0
+    kwargs: dict[str, object] = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        field: value,
+    }
+
+    with pytest.raises(ValueError, match=rf"{field} must be a finite positive normal float32"):
+        SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_config_canonicalizes_numpy_scalars_for_strict_json_roundtrip() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=2,
+        action_dim=1,
+        ridge=np.float32(0.125),  # type: ignore[arg-type]
+        prediction_clip=np.int64(4),  # type: ignore[arg-type]
+    )
+
+    assert type(config.ridge) is float
+    assert type(config.prediction_clip) is float
+    encoded = json.dumps(config.to_config(), allow_nan=False)
+    restored = SparseFTLWorldModelConfig.from_config(json.loads(encoded))
+    assert restored == config
+    assert type(restored.ridge) is float
+    assert type(restored.prediction_clip) is float
+
+
+def test_underflowing_ridge_is_rejected_before_update_poisoning() -> None:
+    ridge = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+
+    with pytest.raises(ValueError, match="ridge must be a finite positive normal float32"):
+        config = SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=2,
+            bins=3,
+            ridge=ridge,
+        )
+        model = SparseFTLWorldModel(config)
+        state = model.init(jr.key(100))
+        result = model.update(
+            state,
+            jnp.array([0.0], dtype=jnp.float32),
+            jnp.array([0.0], dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        assert not bool(jnp.all(jnp.isfinite(result.state.weights)))
+
+
+def test_overflowing_prediction_clip_is_rejected_before_prediction_poisoning() -> None:
+    prediction_clip = float(np.finfo(np.float32).max) * 2.0
+
+    with pytest.raises(
+        ValueError,
+        match="prediction_clip must be a finite positive normal float32",
+    ):
+        config = SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=2,
+            bins=3,
+            prediction_clip=prediction_clip,
+        )
+        model = SparseFTLWorldModel(config)
+        state = model.init(jr.key(101)).replace(  # type: ignore[attr-defined]
+            weights=jnp.full(
+                (config.feature_dim, config.observation_dim),
+                jnp.finfo(jnp.float32).max,
+                dtype=jnp.float32,
+            )
+        )
+        prediction = model.predict(
+            state,
+            jnp.array([0.0], dtype=jnp.float32),
+            jnp.array([0.0], dtype=jnp.float32),
+        )
+        assert not bool(jnp.all(jnp.isfinite(prediction.delta)))
 
 
 def test_soft_bin_features_are_bounded_local_and_boundary_safe() -> None:


### PR DESCRIPTION
Closes #265.

## Summary

`SparseFTLWorldModelConfig` now validates `ridge` and `prediction_clip` in the float32 domain used by the model, instead of only checking the host scalar:

- rejects booleans and non-`numbers.Real` inputs with a stable `ValueError`;
- rejects NaN, infinities, non-positive values, float32 subnormals/underflow-to-zero, and finite host values that overflow to float32 infinity;
- canonicalizes accepted NumPy/integer real scalars to built-in `float`, so `to_config()` is strict-JSON-safe and roundtrips through `json.dumps(..., allow_nan=False)`;
- preserves ordinary accepted values while failing before invalid values reach the JAX ridge solve or clipping bound.

The original NaN fix is retained as rebased commit `349ed60`; the complete execution-domain hardening is commit `64afa79`. The contributor branch was rebased onto `origin/main` at `9f53ba0` before verification and push.

## Downstream reachability

Both fields feed float32 execution directly:

- `ridge` is added to the active Gram block before `jnp.linalg.solve`. A subnormal admitted by the old host-only guard is ineffective in the solve and the regression test demonstrates non-finite learned weights.
- `prediction_clip` is the `jnp.clip` bound. A finite host value above the float32 range narrows to infinity, allowing an overflowed raw prediction to escape as infinity.

The config remains reachable through the direct module API (`alberta_framework.core.ftl_world_model`); it is not newly re-exported from package roots.

## Red-first regression evidence

Before the implementation change, the new focused cases produced:

```text
19 failed, 20 deselected in 2.63s
```

Failures covered built-in/NumPy booleans, strings/complex/object inputs, float32 subnormal and underflow-to-zero values, finite host overflow, NumPy scalar canonicalization/JSON roundtrip, and both live execution sinks. The two execution-level tests reached the poisoned ridge-update and prediction paths when the constructor failed to reject their values.

## Verification on final rebased tree

```text
$ .venv/bin/python -m pytest tests/test_ftl_world_model.py tests/test_ftl_decision_fidelity.py -q -o addopts=""
63 passed in 20.48s

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files

$ git diff --check origin/main...HEAD
# clean
```

## Evidence and artifact status

No `outputs/**` file was edited. `alberta_framework/core/ftl_world_model.py` is a registered source, so the evidence registry correctly returns exit 2 / `invalid`; this is expected source drift and is not evidence promotion. The frozen artifact records source SHA-256 `10de4526e967c400c6f2732f04dca63c0f0f7e22d44324fad85d064245e9f976`; this head has `2da0894e089ea903fbe4dee5dc57ed0e50e8714d62d4022df7e204bacfd76c00`. Existing pinned artifacts were left immutable and no scientific protocol was rerun.

<!-- evidence-head -->
64afa796dd6bcd2f15693bc00befb75529e2c9a9

<!-- evidence-row:logs -->
```text
red: 19 failed, 20 deselected
final focused: 63 passed
full Ruff: clean
strict mypy: 163 source files clean
```

## Provenance

The contributor's original change is preserved in the rebased commit stack. Float32-domain hardening, regression expansion, rebase, and verification were performed by OpenAI Codex in this maintenance pass. Attribution is self-reported.
