### PR TITLE
Harden persisted micro configs and float32 stream bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validated frequency-mismatch bounds and Pavlovian noise in their actual
   float32 execution domain, rejecting overflowed or collapsed frequency
   intervals and overflowed noise scales before stream state can become invalid.
+- Preserved non-finite sentinels on rejected recurring-multiagent transition
+  payloads because the compatibility `step()` surface does not return the
+  separate transaction-validity bit; invalid events cannot masquerade as
+  ordinary finite zero-reward samples.
 - Rejected SIGReg samples, embeddings, directions, and derived projections that are
   non-finite in float32 arithmetic before they can become silent NaN losses, including
   under compiled and vectorized JAX calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Required persisted micro-stream scalar fields to be concrete real values and
+  canonicalized them to built-in floats, preventing numeric strings or custom
+  conversion objects from crossing the strict development-artifact boundary.
+- Validated frequency-mismatch bounds and Pavlovian noise in their actual
+  float32 execution domain, rejecting overflowed or collapsed frequency
+  intervals and overflowed noise scales before stream state can become invalid.
 - Rejected SIGReg samples, embeddings, directions, and derived projections that are
   non-finite in float32 arithmetic before they can become silent NaN losses, including
   under compiled and vectorized JAX calls.

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -71,6 +71,7 @@ import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, fields
 from functools import lru_cache
+from numbers import Real
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -146,15 +147,10 @@ _BAYES_DOMAIN = 404
 
 
 def _require_finite_real(value: object, name: str) -> float:
-    """Reject bools and non-finite values while accepting every other real."""
-    if isinstance(value, bool):
+    """Return one canonical float after rejecting non-real and non-finite values."""
+    if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a finite real number, got {value!r}")
-    try:
-        number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"{name} must be a finite real number, got {value!r}"
-        ) from exc
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number, got {value!r}")
     return number
@@ -239,21 +235,37 @@ class MicroStreamConfig:
             raise ValueError(
                 f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})"
             )
-        class_sparsity = _require_finite_real(self.class_sparsity, "class_sparsity")
+        real_fields = (
+            "spectrum_decades",
+            "mean_separation",
+            "component_scale",
+            "class_sparsity",
+            "noise_scale",
+            "offset_scale",
+            "scale_shift_min",
+            "scale_shift_max",
+        )
+        normalized_reals = {
+            name: _require_finite_real(getattr(self, name), name) for name in real_fields
+        }
+        for name, number in normalized_reals.items():
+            object.__setattr__(self, name, number)
+
+        class_sparsity = normalized_reals["class_sparsity"]
         if not 0.0 < class_sparsity <= 1.0:
             raise ValueError(
                 f"class_sparsity must be in (0, 1], got {self.class_sparsity!r}"
             )
         for name in ("mean_separation", "noise_scale"):
-            if not _require_finite_real(getattr(self, name), name) > 0.0:
+            if not normalized_reals[name] > 0.0:
                 raise ValueError(f"{name} must be positive, got {getattr(self, name)!r}")
         for name in ("offset_scale", "spectrum_decades", "component_scale"):
-            if _require_finite_real(getattr(self, name), name) < 0.0:
+            if normalized_reals[name] < 0.0:
                 raise ValueError(
                     f"{name} must be non-negative, got {getattr(self, name)!r}"
                 )
-        scale_min = _require_finite_real(self.scale_shift_min, "scale_shift_min")
-        scale_max = _require_finite_real(self.scale_shift_max, "scale_shift_max")
+        scale_min = normalized_reals["scale_shift_min"]
+        scale_max = normalized_reals["scale_shift_max"]
         if not 0.0 < scale_min < scale_max:
             raise ValueError(
                 "scale_shift bounds must satisfy 0 < scale_shift_min < "

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -27,10 +27,12 @@ or tanh feature bank:
 """
 
 import math
+from numbers import Real
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
@@ -39,6 +41,20 @@ from alberta_framework._fixed_count_selection import (
     stable_smallest_mask,
 )
 from alberta_framework.core.types import TimeStep
+
+
+def _require_positive_float32(value: object, name: str) -> float:
+    """Return a positive finite value representable in the stream execution dtype."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a positive finite float32 value")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{name} must be a positive finite float32 value")
+    with np.errstate(over="ignore", under="ignore"):
+        converted = np.float32(number)
+    if not np.isfinite(converted) or converted <= np.float32(0.0):
+        raise ValueError(f"{name} must be a positive finite float32 value")
+    return float(converted)
 
 # =============================================================================
 # OutOfClassPolynomialStream -- degree-3 polynomial targets
@@ -342,18 +358,18 @@ class FrequencyMismatchStream:
             raise ValueError("n_contexts must be positive")
         if context_length < 1:
             raise ValueError("context_length must be positive")
-        if not math.isfinite(omega_min) or omega_min <= 0:
-            raise ValueError("omega_min must be finite and positive")
-        if not math.isfinite(omega_max) or omega_max <= omega_min:
-            raise ValueError("omega_max must exceed omega_min")
+        omega_min_float32 = _require_positive_float32(omega_min, "omega_min")
+        omega_max_float32 = _require_positive_float32(omega_max, "omega_max")
+        if omega_max_float32 <= omega_min_float32:
+            raise ValueError("omega_max must exceed omega_min in float32")
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks
         self._n_components_per_task = n_components_per_task
         self._n_contexts = n_contexts
         self._context_length = context_length
-        self._omega_min = omega_min
-        self._omega_max = omega_max
+        self._omega_min = omega_min_float32
+        self._omega_max = omega_max_float32
         self._amplitude_scale = amplitude_scale
         self._noise_std = noise_std
 

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -40,6 +40,7 @@ References
 from __future__ import annotations
 
 import math
+import struct
 from numbers import Real
 
 import chex
@@ -64,12 +65,36 @@ def _require_finite_real(
     """Return a finite real, rejecting bools, NaN, and infinities."""
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a finite real, got {value!r}")
-    number = float(value)
+    try:
+        number = float(value)
+    except (OverflowError, ValueError) as error:
+        raise ValueError(f"{name} must be a finite real, got {value!r}") from error
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real, got {value!r}")
     if nonnegative and number < 0.0:
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
     return number
+
+
+def _require_nonnegative_float32(value: object, *, name: str) -> float:
+    """Return the value rounded to the stream's non-negative float32 domain.
+
+    Host-finite values that overflow float32 are rejected. Positive values
+    below the float32 subnormal range are accepted as exact zero, matching the
+    noise-free trajectory they produce in the stream's float32 arithmetic.
+    """
+    number = _require_finite_real(value, name=name, nonnegative=True)
+    try:
+        narrowed = float(struct.unpack("!f", struct.pack("!f", number))[0])
+    except OverflowError as error:
+        raise ValueError(
+            f"{name} must remain finite when rounded to float32, got {value!r}"
+        ) from error
+    if not math.isfinite(narrowed):
+        raise ValueError(
+            f"{name} must remain finite when rounded to float32, got {value!r}"
+        )
+    return narrowed
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:
@@ -208,7 +233,9 @@ class ClassicalConditioningStream:
         cs_duration: How many steps a CS stays active.
         iti_min: Minimum ITI (steps).
         iti_max: Maximum ITI (steps, inclusive).
-        noise_std: Std of Gaussian observation noise.
+        noise_std: Std of Gaussian observation noise, canonicalized to
+            float32. Positive values below the float32 subnormal range
+            become exact zero.
         distractor_prob: Per-step probability that an idle distractor
             fires.
         phases: Tuple of ``PavlovianPhase``.
@@ -244,6 +271,8 @@ class ClassicalConditioningStream:
             iti_min: Minimum inter-trial interval (steps).
             iti_max: Maximum inter-trial interval (steps, inclusive).
             noise_std: Gaussian noise added to the observation features.
+                Accepted values are rounded to float32; positive values below
+                its subnormal range become exact zero.
             distractor_prob: Per-step probability that an idle
                 distractor turns on.
 
@@ -253,7 +282,8 @@ class ClassicalConditioningStream:
                 any phase references a CS index that does not exist, a
                 phase contingency is not a finite real in ``[0, 1]``, or
                 ``noise_std`` / ``distractor_prob`` is not a legal
-                scientific scalar.
+                scientific scalar, or ``noise_std`` becomes non-finite when
+                rounded to the stream's float32 execution dtype.
         """
         if not phases:
             raise ValueError("phases must be non-empty")
@@ -277,7 +307,7 @@ class ClassicalConditioningStream:
         )
         if iti_max < iti_min:
             raise ValueError(f"need 0 <= iti_min <= iti_max, got {iti_min}, {iti_max}")
-        noise_std = _require_finite_real(noise_std, name="noise_std", nonnegative=True)
+        noise_std = _require_nonnegative_float32(noise_std, name="noise_std")
         distractor_prob = _require_unit_interval(
             distractor_prob, name="distractor_prob"
         )

--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -824,8 +824,8 @@ class RecurringTwoAgentWorld:
                     update_applied,
                     value,
                     (
-                        jnp.zeros_like(value)
-                        if jnp.issubdtype(value.dtype, jnp.inexact)
+                        jnp.full_like(value, jnp.nan)
+                        if jnp.issubdtype(value.dtype, jnp.floating)
                         else (
                             jnp.zeros_like(value)
                             if jnp.issubdtype(value.dtype, jnp.bool_)

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -186,6 +186,50 @@ class TestConfig:
         assert rebuilt == TINY
         assert MicroStreamConfig.from_mapping(TINY.to_config()) == TINY
 
+    def test_real_fields_roundtrip_as_canonical_floats(self):
+        fields = (
+            "spectrum_decades",
+            "mean_separation",
+            "component_scale",
+            "class_sparsity",
+            "noise_scale",
+            "offset_scale",
+            "scale_shift_min",
+            "scale_shift_max",
+        )
+        config = MicroStreamConfig.from_mapping(TINY.to_config())
+
+        assert all(type(getattr(config, name)) is float for name in fields)
+        assert all(type(config.to_config()[name]) is float for name in fields)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "spectrum_decades",
+            "mean_separation",
+            "component_scale",
+            "class_sparsity",
+            "noise_scale",
+            "offset_scale",
+            "scale_shift_min",
+            "scale_shift_max",
+        ],
+    )
+    def test_from_mapping_rejects_numeric_strings(self, field: str):
+        payload = TINY.to_config()
+        payload[field] = str(payload[field])
+
+        with pytest.raises(ValueError, match=field):
+            MicroStreamConfig.from_mapping(payload)
+
+    def test_constructor_rejects_arbitrary_float_protocol_objects(self):
+        class FloatLike:
+            def __float__(self) -> float:
+                return 0.2
+
+        with pytest.raises(ValueError, match="class_sparsity"):
+            tiny("input_permutation", class_sparsity=FloatLike())
+
     def test_from_mapping_rejects_missing_and_empty_keys(self):
         complete = TINY.to_config()
         missing = dict(complete)

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -267,6 +267,34 @@ class TestFrequencyMismatchStream:
         with pytest.raises(ValueError):
             FrequencyMismatchStream(omega_min=omega_min, omega_max=omega_max)
 
+    @pytest.mark.parametrize(
+        ("omega_min", "omega_max"),
+        [(1e-50, 1.0), (1.0, 1e100), (1.0, 1.0 + 1e-12)],
+    )
+    def test_frequency_bounds_must_define_a_positive_float32_interval(
+        self, omega_min: float, omega_max: float
+    ) -> None:
+        with pytest.raises(ValueError, match="float32"):
+            FrequencyMismatchStream(omega_min=omega_min, omega_max=omega_max)
+
+    @pytest.mark.parametrize("value", [True, "0.5", object()])
+    def test_frequency_bounds_reject_non_real_values(self, value: object) -> None:
+        with pytest.raises(ValueError, match="float32"):
+            FrequencyMismatchStream(omega_min=value)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match="float32"):
+            FrequencyMismatchStream(omega_max=value)  # type: ignore[arg-type]
+
+    def test_frequency_bounds_are_canonicalized_to_float32(self) -> None:
+        stream = FrequencyMismatchStream(omega_min=0.7, omega_max=2.3)
+        state = stream.init(jr.key(23))
+
+        expected_min = jnp.asarray(0.7, dtype=jnp.float32)
+        expected_max = jnp.asarray(2.3, dtype=jnp.float32)
+        assert bool(jnp.all(jnp.isfinite(state.omegas)))
+        assert bool(jnp.all(state.omegas >= expected_min))
+        assert bool(jnp.all(state.omegas < expected_max))
+
     def test_step_shapes(self):
         stream = FrequencyMismatchStream(
             feature_dim=4,

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -442,11 +442,47 @@ def _valid_phase(**overrides: object) -> PavlovianPhase:
     return PavlovianPhase(**payload)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), True, -1.0])
+@pytest.mark.parametrize(
+    "value",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        -1.0,
+        1e100,
+        10**400,
+    ],
+)
 def test_construct_rejects_illegal_noise_std(value: object) -> None:
-    """Observation noise is a non-negative finite real, not a bool or NaN."""
+    """Noise must remain non-negative and finite in float32 execution."""
     with pytest.raises(ValueError, match="noise_std"):
         ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        float(np.finfo(np.float32).max),
+        float(np.nextafter(np.float32(0.0), np.float32(1.0))),
+    ],
+)
+def test_construct_accepts_float32_noise_std_boundaries(value: float) -> None:
+    """Finite float32 endpoints survive constructor canonicalization."""
+    stream = ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=value)
+    assert stream._noise_std == value  # noqa: SLF001 - normalization is under test
+
+
+def test_construct_canonicalizes_underflowing_noise_std_to_zero() -> None:
+    """A positive host float below float32 range has exact zero-noise semantics."""
+    stream = ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=1e-50)
+    assert stream._noise_std == 0.0  # noqa: SLF001 - normalization is under test
+
+
+def test_construct_canonicalizes_noise_std_to_float32() -> None:
+    """Stored noise matches the scalar used by the float32 trajectory."""
+    stream = ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=0.1)
+    assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True])

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -405,21 +405,30 @@ def test_state_is_an_immutable_chex_pytree() -> None:
     chex.assert_trees_all_equal(rebuilt, state)
 
 
-def test_rejected_nonfinite_action_returns_finite_terminal_transition() -> None:
+def test_public_step_keeps_rejected_nonfinite_action_unaggregatable() -> None:
     world = RecurringTwoAgentWorld(nuisance_dim=0)
     state = world.init(jr.key(13)).replace(
         velocities=jnp.array([0.2, -0.1], dtype=jnp.float32),
     )
 
-    result = world.step_result(
+    transition, next_state = world.step(
         state,
         jnp.array([jnp.nan, 0.0], dtype=jnp.float32),
     )
 
-    assert bool(result.update_rejected)
-    assert bool(result.transition.terminated)
-    chex.assert_tree_all_finite(result.transition)
-    chex.assert_trees_all_equal(result.state, state)
+    assert bool(transition.terminated)
+    assert float(transition.discount) == 0.0
+    for payload in (
+        transition.observation,
+        transition.action,
+        transition.reward,
+        transition.next_observation,
+    ):
+        assert bool(jnp.all(jnp.isnan(payload)))
+    for leaf in jax.tree.leaves(transition.oracle):
+        if jnp.issubdtype(leaf.dtype, jnp.floating):
+            assert bool(jnp.all(jnp.isnan(leaf)))
+    chex.assert_trees_all_equal(next_state, state)
 
 
 def test_jitted_scan_runs_continually_and_remains_bounded() -> None:


### PR DESCRIPTION
## Summary
This production follow-up closes strict-boundary gaps that remained after #234, #250, #252, and #259 were merged:

- require persisted micro-stream real fields to be concrete `numbers.Real` values excluding booleans, then canonicalize every accepted field to a built-in float;
- validate FrequencyMismatchStream bounds after float32 narrowing, rejecting overflow, underflow to zero, and intervals that collapse at execution precision;
- validate and canonicalize Pavlovian `noise_std` through its actual float32 execution dtype, rejecting overflow before a stream can emit non-finite observations;
- restore non-finite rejection sentinels for recurring-multiagent payloads, since public `step()` omits the separate validity bit and finite zero payloads can silently enter metrics as ordinary zero-reward events.

Accepted ordinary values preserve their execution semantics. Pavlovian subnormal underflow is explicitly normalized to exact zero; frequency endpoints must remain strictly positive and ordered because they define a logarithmic interval.

## Validation
- [x] combined stream/config/release suites — 344 passed
- [x] full Ruff
- [x] strict mypy — 163 source files
- [x] `git diff --check`
- [x] release metadata tests included
- [x] no `outputs/**` changes

The regressions cover persisted-string and custom-conversion rejection, roundtrip canonical types, float32 boundaries, overflow and interval-collapse rejection, finite valid stream state, rejected-event aggregation safety, exact state rollback, and existing stream/learning integration surfaces.