### PR TITLE
fix(streams): reject non-finite compositional weight scale

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -473,28 +473,27 @@ class FrequencyMismatchStream:
 def _require_compositional_weight_scale_float32(value: object) -> float:
     """Return a signed scale in the stream's safe float32 execution domain.
 
-    The scale is canonicalized to a built-in float carrying the exact rounded
-    float32 value.  Values below the float32 subnormal range become signed
-    zero.  A finite float32 square is required because the scale controls
-    initialization variance and is multiplied before fan-in normalization;
-    that conservative headroom prevents eager/XLA reassociation from turning
-    an accepted scale into non-finite oracle weights.
+    The scale is canonicalized from its exact integer ratio to a built-in float
+    carrying the nearest-even float32 value.  Magnitudes at or below half the
+    smallest float32 subnormal become signed zero.  A finite float32 square is
+    required because the scale controls initialization variance and is
+    multiplied before fan-in normalization; that conservative headroom
+    prevents eager/XLA reassociation from turning an accepted scale into
+    non-finite oracle weights.
     """
     message = "weight_scale must be finite in float32 with finite float32 squared magnitude"
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise ValueError(message)
     try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError) as error:
+        rounded = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(message) from error
-    if not math.isfinite(number):
-        raise ValueError(message)
     with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-        narrowed = np.float32(number)
+        narrowed = np.float32(rounded)
         squared = np.float32(narrowed * narrowed)
-    if not np.isfinite(narrowed) or not np.isfinite(squared):
+    if not bool(np.isfinite(narrowed)) or not bool(np.isfinite(squared)):
         raise ValueError(message)
-    return float(narrowed)
+    return rounded
 
 
 @chex.dataclass(frozen=True)
@@ -568,11 +567,12 @@ class CompositionalStream:
             context_length: Steps before switching context.
             feature_std: Standard deviation of raw observations.
             weight_scale: Scale of per-layer weights (divided by sqrt(fan-in)
-                for unit-variance pre-activations). Real values are rounded to
-                float32 at construction. Values below the float32 subnormal
-                range become signed zero; zero and negative scales remain
-                valid. Values whose float32 square overflows are rejected so
-                eager and compiled initialization stay finite.
+                for unit-variance pre-activations). Real values are rounded
+                once from their exact integer ratio to nearest-even float32 at
+                construction. Magnitudes at or below half the smallest
+                float32 subnormal become signed zero; zero and negative scales
+                remain valid. Values whose float32 square overflows are
+                rejected so eager and compiled initialization stay finite.
             amplitude_scale: Scale of per-component output amplitudes.
             noise_std: Standard deviation of target noise.
         """

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -470,6 +470,33 @@ class FrequencyMismatchStream:
 # =============================================================================
 
 
+def _require_compositional_weight_scale_float32(value: object) -> float:
+    """Return a signed scale in the stream's safe float32 execution domain.
+
+    The scale is canonicalized to a built-in float carrying the exact rounded
+    float32 value.  Values below the float32 subnormal range become signed
+    zero.  A finite float32 square is required because the scale controls
+    initialization variance and is multiplied before fan-in normalization;
+    that conservative headroom prevents eager/XLA reassociation from turning
+    an accepted scale into non-finite oracle weights.
+    """
+    message = "weight_scale must be finite in float32 with finite float32 squared magnitude"
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(message) from error
+    if not math.isfinite(number):
+        raise ValueError(message)
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        narrowed = np.float32(number)
+        squared = np.float32(narrowed * narrowed)
+    if not np.isfinite(narrowed) or not np.isfinite(squared):
+        raise ValueError(message)
+    return float(narrowed)
+
+
 @chex.dataclass(frozen=True)
 class CompositionalState:
     """State for ``CompositionalStream``.
@@ -541,7 +568,11 @@ class CompositionalStream:
             context_length: Steps before switching context.
             feature_std: Standard deviation of raw observations.
             weight_scale: Scale of per-layer weights (divided by sqrt(fan-in)
-                for unit-variance pre-activations).
+                for unit-variance pre-activations). Real values are rounded to
+                float32 at construction. Values below the float32 subnormal
+                range become signed zero; zero and negative scales remain
+                valid. Values whose float32 square overflows are rejected so
+                eager and compiled initialization stay finite.
             amplitude_scale: Scale of per-component output amplitudes.
             noise_std: Standard deviation of target noise.
         """
@@ -557,6 +588,7 @@ class CompositionalStream:
             raise ValueError("n_contexts must be positive")
         if context_length < 1:
             raise ValueError("context_length must be positive")
+        weight_scale_float32 = _require_compositional_weight_scale_float32(weight_scale)
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks
@@ -565,7 +597,7 @@ class CompositionalStream:
         self._n_contexts = n_contexts
         self._context_length = context_length
         self._feature_std = feature_std
-        self._weight_scale = weight_scale
+        self._weight_scale = weight_scale_float32
         self._amplitude_scale = amplitude_scale
         self._noise_std = noise_std
 

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -514,6 +514,47 @@ class TestCompositionalStream:
         assert state.inner_w.dtype == jnp.float32
         assert state.outer_w.dtype == jnp.float32
 
+    def test_weight_scale_narrows_the_original_real_once(self) -> None:
+        midpoint_plus = (
+            np.longdouble(1.0)
+            + np.longdouble(2.0) ** -24
+            + np.longdouble(2.0) ** -60
+        )
+        assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+
+        stream = CompositionalStream(weight_scale=midpoint_plus)
+        assert stream._weight_scale == float(np.float32(midpoint_plus))
+
+    @pytest.mark.parametrize(
+        ("offset", "expected"),
+        [
+            (Fraction(-1, 1 << 60), 1.0),
+            (Fraction(0), 1.0),
+            (
+                Fraction(1, 1 << 60),
+                float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+            ),
+        ],
+        ids=["below", "tie", "above"],
+    )
+    def test_weight_scale_rounds_exact_fraction_midpoints_once(
+        self, offset: Fraction, expected: float
+    ) -> None:
+        midpoint = Fraction(1) + Fraction(1, 1 << 24)
+        stream = CompositionalStream(weight_scale=midpoint + offset)
+
+        assert stream._weight_scale == expected
+
+    def test_weight_scale_fraction_midpoint_uses_ties_to_even(self) -> None:
+        lower = np.nextafter(np.float32(1.0), np.float32(2.0))
+        upper = np.nextafter(lower, np.float32(2.0))
+        lower_ratio = Fraction(*lower.as_integer_ratio())
+        upper_ratio = Fraction(*upper.as_integer_ratio())
+        midpoint = (lower_ratio + upper_ratio) / 2
+
+        stream = CompositionalStream(weight_scale=midpoint)
+        assert stream._weight_scale == float(upper)
+
     @pytest.mark.parametrize("weight_scale", [1e39, -1e39, 2e38, -2e38])
     def test_weight_scale_rejects_float32_conversion_or_initialization_overflow(
         self, weight_scale: float
@@ -571,6 +612,27 @@ class TestCompositionalStream:
         chex.assert_trees_all_equal(
             stream.init(jr.key(95)), zero_stream.init(jr.key(95))
         )
+
+    @pytest.mark.parametrize("sign", [1, -1])
+    @pytest.mark.parametrize(
+        ("offset", "expected_magnitude"),
+        [
+            (Fraction(-1, 1 << 200), 0.0),
+            (Fraction(0), 0.0),
+            (Fraction(1, 1 << 200), float(np.nextafter(np.float32(0.0), 1.0))),
+        ],
+        ids=["below", "tie", "above"],
+    )
+    def test_weight_scale_rounds_half_minimum_subnormal_to_even_signed_zero(
+        self, sign: int, offset: Fraction, expected_magnitude: float
+    ) -> None:
+        half_minimum_subnormal = Fraction(1, 1 << 150)
+        weight_scale = sign * (half_minimum_subnormal + offset)
+
+        stream = CompositionalStream(weight_scale=weight_scale)
+
+        assert abs(stream._weight_scale) == expected_magnitude
+        assert math.copysign(1.0, stream._weight_scale) == float(sign)
 
     def test_weight_scale_boundary_stays_finite_eager_and_jit_across_seeds(
         self,

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -7,6 +7,9 @@ shape correctness, JIT compatibility via ``jax.lax.scan``, and the
 out-of-class structural properties that motivate each stream.
 """
 
+import json
+import math
+from decimal import Decimal
 from fractions import Fraction
 
 import chex
@@ -21,6 +24,13 @@ from alberta_framework.streams.out_of_class import (
     FrequencyMismatchStream,
     OutOfClassPolynomialStream,
 )
+
+
+class _FloatCoercible:
+    """Non-real object that would be accepted by ``math.isfinite``."""
+
+    def __float__(self) -> float:
+        return 0.5
 
 
 def _scan_collect(stream, num_steps: int, key) -> tuple[jnp.ndarray, jnp.ndarray]:
@@ -462,6 +472,159 @@ class TestFrequencyMismatchStream:
 
 class TestCompositionalStream:
     """Tests for the 2-hidden-layer compositional out-of-class stream."""
+
+    @pytest.mark.parametrize("weight_scale", [float("nan"), float("inf"), float("-inf")])
+    def test_weight_scale_must_be_finite(self, weight_scale: float) -> None:
+        with pytest.raises(ValueError, match="weight_scale must be finite"):
+            CompositionalStream(weight_scale=weight_scale)
+
+    @pytest.mark.parametrize(
+        "weight_scale",
+        [
+            True,
+            False,
+            np.bool_(True),
+            "0.5",
+            Decimal("0.5"),
+            _FloatCoercible(),
+            object(),
+        ],
+    )
+    def test_weight_scale_rejects_bool_non_real_and_coercive_inputs(
+        self, weight_scale: object
+    ) -> None:
+        with pytest.raises(ValueError, match="weight_scale must be finite in float32"):
+            CompositionalStream(weight_scale=weight_scale)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "weight_scale",
+        [Fraction(1, 2), np.float32(0.5), np.float64(0.5), np.int64(2)],
+    )
+    def test_weight_scale_is_stored_as_a_json_safe_canonical_float32_float(
+        self, weight_scale: object
+    ) -> None:
+        stream = CompositionalStream(weight_scale=weight_scale)  # type: ignore[arg-type]
+        expected = float(np.float32(float(weight_scale)))
+
+        assert type(stream._weight_scale) is float
+        assert stream._weight_scale == expected
+        encoded = json.dumps({"weight_scale": stream._weight_scale}, allow_nan=False)
+        assert json.loads(encoded) == {"weight_scale": expected}
+        state = stream.init(jr.key(93))
+        assert state.inner_w.dtype == jnp.float32
+        assert state.outer_w.dtype == jnp.float32
+
+    @pytest.mark.parametrize("weight_scale", [1e39, -1e39, 2e38, -2e38])
+    def test_weight_scale_rejects_float32_conversion_or_initialization_overflow(
+        self, weight_scale: float
+    ) -> None:
+        with pytest.raises(ValueError, match="weight_scale must be finite in float32"):
+            CompositionalStream(weight_scale=weight_scale)
+
+    def test_weight_scale_safe_float32_boundary(self) -> None:
+        safe = np.sqrt(np.finfo(np.float32).max, dtype=np.float32)
+        unsafe = np.nextafter(safe, np.float32(np.inf), dtype=np.float32)
+
+        stream = CompositionalStream(weight_scale=float(safe))
+        assert stream._weight_scale == float(safe)
+        with pytest.raises(ValueError, match="weight_scale must be finite in float32"):
+            CompositionalStream(weight_scale=float(unsafe))
+
+    @pytest.mark.parametrize("weight_scale", [0.0, -0.0, -2.5])
+    def test_weight_scale_preserves_valid_zero_and_negative_semantics(
+        self, weight_scale: float
+    ) -> None:
+        stream = CompositionalStream(weight_scale=weight_scale)
+
+        assert stream._weight_scale == weight_scale
+        assert math.copysign(1.0, stream._weight_scale) == math.copysign(
+            1.0, weight_scale
+        )
+        eager_state = stream.init(jr.key(94))
+        eager_timestep, _ = stream.step(eager_state, jnp.array(0, dtype=jnp.int32))
+        jit_state = jax.jit(stream.init)(jr.key(94))
+        jit_timestep, _ = jax.jit(stream.step)(jit_state, jnp.array(0, dtype=jnp.int32))
+        chex.assert_tree_all_finite(
+            (
+                eager_state.inner_w,
+                eager_state.outer_w,
+                eager_timestep.observation,
+                eager_timestep.target,
+                jit_state.inner_w,
+                jit_state.outer_w,
+                jit_timestep.observation,
+                jit_timestep.target,
+            )
+        )
+
+    @pytest.mark.parametrize("weight_scale", [1e-50, -1e-50])
+    def test_weight_scale_float32_underflow_is_canonical_signed_zero(
+        self, weight_scale: float
+    ) -> None:
+        stream = CompositionalStream(weight_scale=weight_scale)
+        zero_stream = CompositionalStream(weight_scale=math.copysign(0.0, weight_scale))
+
+        assert stream._weight_scale == 0.0
+        assert math.copysign(1.0, stream._weight_scale) == math.copysign(
+            1.0, weight_scale
+        )
+        chex.assert_trees_all_equal(
+            stream.init(jr.key(95)), zero_stream.init(jr.key(95))
+        )
+
+    def test_weight_scale_boundary_stays_finite_eager_and_jit_across_seeds(
+        self,
+    ) -> None:
+        safe = float(np.sqrt(np.finfo(np.float32).max, dtype=np.float32))
+        stream = CompositionalStream(weight_scale=safe)
+        jit_init = jax.jit(stream.init)
+        jit_step = jax.jit(stream.step)
+
+        for seed in range(16):
+            key = jr.key(seed)
+            eager_state = stream.init(key)
+            eager_timestep, _ = stream.step(
+                eager_state, jnp.array(0, dtype=jnp.int32)
+            )
+            jit_state = jit_init(key)
+            jit_timestep, _ = jit_step(jit_state, jnp.array(0, dtype=jnp.int32))
+            chex.assert_tree_all_finite(
+                (
+                    eager_state.inner_w,
+                    eager_state.outer_w,
+                    eager_timestep.target,
+                    jit_state.inner_w,
+                    jit_state.outer_w,
+                    jit_timestep.target,
+                )
+            )
+            np.testing.assert_allclose(
+                np.asarray(eager_timestep.target),
+                np.asarray(jit_timestep.target),
+                rtol=1e-5,
+                atol=1e-6,
+            )
+
+    @pytest.mark.parametrize("use_jit", [False, True])
+    def test_numpy_weight_scale_is_x64_invariant(self, use_jit: bool) -> None:
+        def run(x64_enabled: bool):
+            with jax.enable_x64(x64_enabled):
+                stream = CompositionalStream(weight_scale=np.float64(0.7))
+                init = jax.jit(stream.init) if use_jit else stream.init
+                step = jax.jit(stream.step) if use_jit else stream.step
+                state = init(jr.key(96))
+                timestep, _ = step(state, jnp.array(0, dtype=jnp.int32))
+                return stream, state, timestep
+
+        stream32, state32, timestep32 = run(False)
+        stream64, state64, timestep64 = run(True)
+
+        assert type(stream32._weight_scale) is float
+        assert type(stream64._weight_scale) is float
+        assert state32.inner_w.dtype == jnp.float32
+        assert state64.inner_w.dtype == jnp.float32
+        chex.assert_trees_all_equal(state32, state64)
+        chex.assert_trees_all_equal(timestep32, timestep64)
 
     def test_step_shapes(self):
         stream = CompositionalStream(


### PR DESCRIPTION
Closes #269.

## What changed

`CompositionalStream` previously kept `weight_scale` in its caller-provided host type and checked only `math.isfinite`. That rejected explicit NaN/Infinity, but still allowed values and types that changed meaning in the stream's actual float32 execution domain:

- host-finite `1e39` narrowed to Infinity and produced non-finite oracle weights and NaN targets in eager and JIT execution;
- `2e38` produced non-finite weights/NaN targets eagerly while seed 0 happened to stay finite under JIT reassociation (and 256 compiled seeds still produced 11 non-finite inner states and 50 non-finite outer states);
- booleans and coercive non-`Real` values were accepted, with `Decimal`/`Fraction` then failing late in `init`;
- NumPy scalars were stored without canonicalization, so `np.float64` promoted the supposedly float32 weights to float64 when JAX x64 was enabled.

The constructor now applies one explicit signed-float32 contract:

- reject booleans, non-`Real`/coercive inputs, NaN, Infinity, float32 overflow, and magnitudes whose rounded float32 square overflows;
- accept in-range `Real` inputs, including NumPy real scalars and `Fraction`, and store the nearest-even float32 value as a JSON-safe built-in `float`;
- preserve valid positive, zero, signed-zero, and negative scale semantics;
- round exact magnitudes at or below half the smallest float32 subnormal to signed zero, with values just above that tie rounding to the signed minimum subnormal.

The constructor reuses the shared `alberta_framework._float32.round_real_to_float32` integer IEEE-754 converter merged in #289. It therefore rounds exact integer ratios directly to binary32 with round-to-nearest, ties-to-even semantics and exact subnormal/overflow boundaries, without a Python-float or NumPy-coercion double-rounding step. The compositional wrapper adds its distinct signed/zero-valid policy and finite-square headroom. That conservative square gate prevents eager/XLA operation reassociation from turning an accepted scale into non-finite oracle weights. Ordinary finite scales keep their existing float32 execution behavior.

## Reachability

`CompositionalStream` remains exported from the package root and from `alberta_framework.streams`. `alberta_framework.steps.step2` also imports it for the compositional Step 2 stream. The packaged Step 2 factory uses the safe default and does not forward a caller scale, while direct public construction exposes this boundary:

```python
import alberta_framework as alberta

stream = alberta.CompositionalStream(weight_scale=0.7)
state = stream.init(key)
timestep, state = stream.step(state, index)
```

## Interaction with PRs #268 and #289

PR #268 introduced the positive-only float32 frequency-bound policy in this module. Merged PR #289 moved exact real-to-binary32 conversion into the shared internal helper used by frequency and Pavlovian consumers. This repair calls that same helper and retains only the compositional-specific signed/zero-valid and finite-square checks; no duplicate converter remains. A randomized compatibility audit matched the shared integer converter bit-for-bit against the prior adjacent-float exact oracle on 38,527 finite `Fraction` ratios plus signed-zero, subnormal, midpoint, and overflow cases.

## Evidence impact

`alberta_framework/streams/out_of_class.py` and the shared helper are not registered sources for any of the five evidence-manifest claims. No `outputs/**` artifact changed, and this development hardening does not promote or alter a scientific claim.

## Verification

Red-first against the original host-domain guard:

```text
20 failed, 7 passed, 26 deselected
```

Red-first against the direct NumPy-narrowing follow-up, for exact Fraction midpoint behavior:

```text
1 failed, 3 passed, 61 deselected
failing value: Fraction(1) + 2^-24 + 2^-60
observed: 1.0
required: nextafter(float32(1), float32(2))
```

Final exact head `b003ecbef00cbb8cd9091811a650c55f42e5a697`, rebased onto `a18d250ba07ee708936fb41afc8c50cbcba2f67b`:

```text
$ .venv/bin/python -m pytest tests/test_out_of_class_streams.py tests/test_float32.py -q -o addopts='' -k 'weight_scale or test_round'
43 passed, 47 deselected

$ .venv/bin/python -m pytest tests/test_step2_theory_invariants.py tests/test_production_steps.py -q -o addopts=''
29 passed

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 164 source files

$ git diff --check origin/main...HEAD
(clean)

$ git merge-tree --write-tree origin/main HEAD
6ee6d6297fd22d14892b1881eef03423b8103018
```

The regression panel covers explicit non-finites; bool/non-real/coercive rejection; accepted `Real`, `Fraction`, and NumPy scalar canonicalization; exact below/tie/above midpoint rounding; ties-to-even; exact half-minimum-subnormal signed-zero behavior; JSON-safe stored type; conversion and initialization-overflow boundaries; valid signed-zero/negative behavior; eager/JIT multi-seed finiteness; and x64-on/off output parity.

## Evidence

<!-- evidence-head -->
b003ecbef00cbb8cd9091811a650c55f42e5a697

<!-- evidence-row:logs -->
```text
original red: 20 failed, 7 passed, 26 deselected
exact Fraction red: 1 failed, 3 passed, 61 deselected
focused exact/JIT/x64 green: 43 passed, 47 deselected
relevant Step 2 green: 29 passed
shared-helper compatibility oracle: 38,527 finite exact ratios matched bit-for-bit
Ruff: All checks passed!
mypy: Success: no issues found in 164 source files
diff-check: clean
merge-tree: clean
```

<!-- evidence-row:domain-artifact -->
```text
Fraction(1) + 2^-24 +/- 2^-60: correctly rounds below/tie/above the float32 midpoint
exact midpoint between odd/even adjacent float32 values: rounds to the even candidate
exact +/- 2^-150: stores +/- 0.0; just above in magnitude stores the signed minimum subnormal
host-finite 1e39 and reassociation case 2e38: rejected at construction
0.0 / -0.0 / -2.5: accepted with finite eager and JIT trajectories
np.float64(0.7): built-in-float storage, float32 state, identical x64-off/on output
```

## Provenance

Original report and patch: Svector-anu. Maintainer audit, expanded red-first panel, exact float32-domain repair, shared-helper reconciliation, rebase, and independent verification: lalalune using OpenAI Codex. Attribution status: self-reported.
