### PR TITLE
fix(step11): reject illegal OaK facade config

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -37,6 +37,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.oak import (
     KeyboardChordLearnerConfig,
     KeyboardChordLearnerState,
@@ -169,13 +170,12 @@ def _require_real(name: str, value: object) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
     try:
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            execution_value = np.asarray(value, dtype=np.float32).reshape(())
-    except (OverflowError, TypeError, ValueError) as error:
+        execution_value = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(f"{name} must be finite in float32, got {value!r}") from error
     if not bool(np.isfinite(execution_value)):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    return float(execution_value)
+    return execution_value
 
 
 def _require_unit_interval(name: str, value: object) -> float:

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -15,6 +15,11 @@ additional mechanisms:
 This facade exposes a minimal, stable surface over the core
 :class:`~alberta_framework.core.oak.OaKAgent` implementation.
 
+The facade rejects illegal dimensions and scientific scalars — epsilons,
+gamma, decays, step sizes, and curation thresholds — before constructing the
+core agent. Accepted numbers are canonicalized to builtin ints and floats;
+legal endpoints stay valid.
+
 References:
     Sutton, Bowling, & Pilarski (2022). "The Alberta Plan for AI Research."
     Sutton (RLC 2025). "The OaK Architecture: A Vision of SuperIntelligence."
@@ -23,7 +28,9 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any
 
 import jax.numpy as jnp
@@ -93,6 +100,10 @@ class Step11OaKConfig:
     utility_ema_decay: float = 0.99
     curation_threshold: float = 0.0
 
+    def __post_init__(self) -> None:
+        """Reject illegal dimensions and scientific scalars, then canonicalize."""
+        _validate_oak_facade_config(self)
+
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
         return {
@@ -149,6 +160,166 @@ class Step11OaKConfig:
             utility_ema_decay=self.utility_ema_decay,
             curation_threshold=self.curation_threshold,
         )
+
+
+_INT32_MAX = 2**31 - 1
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return number
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return number
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    exclusive_maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if exclusive_maximum is not None and number >= exclusive_maximum:
+        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    return number
+
+
+def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
+    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    n_primitive_actions = _require_int(
+        "n_primitive_actions",
+        config.n_primitive_actions,
+        minimum=1,
+    )
+    option_planning_backups_per_step = _require_int(
+        "option_planning_backups_per_step",
+        config.option_planning_backups_per_step,
+        minimum=0,
+        exclusive_maximum=_INT32_MAX,
+    )
+    if not isinstance(config.subtask_specs, tuple):
+        raise ValueError(
+            f"subtask_specs must be a tuple of SubtaskSpec, got {config.subtask_specs!r}"
+        )
+    canonical_specs: list[SubtaskSpec] = []
+    for spec in config.subtask_specs:
+        if not isinstance(spec, SubtaskSpec):
+            raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
+        feature_index = _require_int("feature_index", spec.feature_index, minimum=0)
+        if feature_index >= observation_dim:
+            raise ValueError(
+                f"feature_index must be < observation_dim, got {spec.feature_index!r}"
+            )
+        threshold = _require_positive_real("threshold", spec.threshold)
+        pseudo_reward_scale = _require_real(
+            "pseudo_reward_scale",
+            spec.pseudo_reward_scale,
+        )
+        max_option_steps = _require_int(
+            "max_option_steps",
+            spec.max_option_steps,
+            minimum=1,
+        )
+        if max_option_steps > _INT32_MAX:
+            raise ValueError("max_option_steps must fit int32 telemetry")
+        canonical_specs.append(
+            SubtaskSpec(
+                feature_index=feature_index,
+                threshold=threshold,
+                pseudo_reward_scale=pseudo_reward_scale,
+                max_option_steps=max_option_steps,
+            )
+        )
+    base_step_size = _require_nonnegative_real("base_step_size", config.base_step_size)
+    base_avg_reward_step_size = _require_nonnegative_real(
+        "base_avg_reward_step_size",
+        config.base_avg_reward_step_size,
+    )
+    base_trace_decay = _require_unit_interval("base_trace_decay", config.base_trace_decay)
+    option_step_size = _require_nonnegative_real(
+        "option_step_size",
+        config.option_step_size,
+    )
+    option_avg_reward_step_size = _require_nonnegative_real(
+        "option_avg_reward_step_size",
+        config.option_avg_reward_step_size,
+    )
+    option_trace_decay = _require_unit_interval(
+        "option_trace_decay",
+        config.option_trace_decay,
+    )
+    option_gamma = _require_unit_interval("option_gamma", config.option_gamma)
+    option_model_decay = _require_unit_interval(
+        "option_model_decay",
+        config.option_model_decay,
+    )
+    option_model_step_size = _require_nonnegative_real(
+        "option_model_step_size",
+        config.option_model_step_size,
+    )
+    epsilon_base = _require_unit_interval("epsilon_base", config.epsilon_base)
+    epsilon_option = _require_unit_interval("epsilon_option", config.epsilon_option)
+    utility_ema_decay = _require_unit_interval(
+        "utility_ema_decay",
+        config.utility_ema_decay,
+    )
+    curation_threshold = _require_nonnegative_real(
+        "curation_threshold",
+        config.curation_threshold,
+    )
+    object.__setattr__(config, "subtask_specs", tuple(canonical_specs))
+    object.__setattr__(config, "observation_dim", observation_dim)
+    object.__setattr__(config, "n_primitive_actions", n_primitive_actions)
+    object.__setattr__(config, "base_step_size", base_step_size)
+    object.__setattr__(config, "base_avg_reward_step_size", base_avg_reward_step_size)
+    object.__setattr__(config, "base_trace_decay", base_trace_decay)
+    object.__setattr__(config, "option_step_size", option_step_size)
+    object.__setattr__(config, "option_avg_reward_step_size", option_avg_reward_step_size)
+    object.__setattr__(config, "option_trace_decay", option_trace_decay)
+    object.__setattr__(config, "option_gamma", option_gamma)
+    object.__setattr__(config, "option_model_decay", option_model_decay)
+    object.__setattr__(config, "option_model_step_size", option_model_step_size)
+    object.__setattr__(
+        config,
+        "option_planning_backups_per_step",
+        option_planning_backups_per_step,
+    )
+    object.__setattr__(config, "epsilon_base", epsilon_base)
+    object.__setattr__(config, "epsilon_option", epsilon_option)
+    object.__setattr__(config, "utility_ema_decay", utility_ema_decay)
+    object.__setattr__(config, "curation_threshold", curation_threshold)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -35,6 +35,7 @@ from typing import Any
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.oak import (
@@ -163,6 +164,8 @@ class Step11OaKConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
+_FLOAT32_MIN = -_FLOAT32_MAX
 
 
 def _require_real(name: str, value: object) -> float:
@@ -171,7 +174,9 @@ def _require_real(name: str, value: object) -> float:
     number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+    if not _FLOAT32_MIN <= number <= _FLOAT32_MAX:
+        raise ValueError(f"{name} overflows float32 execution sink, got {value!r}")
+    return float(np.float32(number))
 
 
 def _require_unit_interval(name: str, value: object) -> float:
@@ -191,7 +196,9 @@ def _require_nonnegative_real(name: str, value: object) -> float:
 def _require_positive_real(name: str, value: object) -> float:
     number = _require_real(name, value)
     if number <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
+        raise ValueError(
+            f"{name} must be positive in float32 execution sink, got {value!r}"
+        )
     return number
 
 

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -28,7 +28,6 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
 from numbers import Integral, Real
 from typing import Any
@@ -164,22 +163,29 @@ class Step11OaKConfig:
 
 
 _INT32_MAX = 2**31 - 1
-_FLOAT32_MAX = float(np.finfo(np.float32).max)
-_FLOAT32_MIN = -_FLOAT32_MAX
 
 
 def _require_real(name: str, value: object) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
+    try:
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            execution_value = np.asarray(value, dtype=np.float32).reshape(())
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite in float32, got {value!r}") from error
+    if not bool(np.isfinite(execution_value)):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    if not _FLOAT32_MIN <= number <= _FLOAT32_MAX:
-        raise ValueError(f"{name} overflows float32 execution sink, got {value!r}")
-    return float(np.float32(number))
+    return float(execution_value)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
+    original_value: Any = value
+    if (
+        not isinstance(value, bool)
+        and isinstance(value, Real)
+        and (original_value < 0 or original_value > 1)
+    ):
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     number = _require_real(name, value)
     if not 0.0 <= number <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
@@ -187,6 +193,8 @@ def _require_unit_interval(name: str, value: object) -> float:
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
+    if not isinstance(value, bool) and isinstance(value, Real) and value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
     number = _require_real(name, value)
     if number < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
@@ -194,6 +202,8 @@ def _require_nonnegative_real(name: str, value: object) -> float:
 
 
 def _require_positive_real(name: str, value: object) -> float:
+    if not isinstance(value, bool) and isinstance(value, Real) and value <= 0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
     number = _require_real(name, value)
     if number <= 0.0:
         raise ValueError(

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -376,7 +376,7 @@ def test_step11_oak_fields_preserve_legal_endpoints() -> None:
     assert restored.utility_ema_decay == 0.0
     assert restored.curation_threshold == 0.0
     assert restored.subtask_specs[0].feature_index == 0
-    assert restored.subtask_specs[0].threshold == 1e-12
+    assert restored.subtask_specs[0].threshold == float(np.float32(1e-12))
     assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
     assert restored.subtask_specs[0].max_option_steps == 1
     assert agent.config.stomp.option_gamma == 0.0
@@ -405,6 +405,70 @@ def test_step11_oak_fields_preserve_legal_endpoints() -> None:
     assert upper.utility_ema_decay == 1.0
     assert upper.curation_threshold == 10.0
     assert upper.option_planning_backups_per_step == 2**31 - 2
+
+
+def test_step11_oak_rejects_float32_underflow_for_positive_fields() -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=1e-50),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=1e-46),),
+            observation_dim=4,
+        )
+
+
+def test_step11_oak_rejects_float32_overflow() -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=1e100),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step11OaKConfig(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, pseudo_reward_scale=1e100),
+            ),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step11OaKConfig(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, pseudo_reward_scale=-1e100),
+            ),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="base_step_size"):
+        Step11OaKConfig(base_step_size=1e100)
+    with pytest.raises(ValueError, match="curation_threshold"):
+        Step11OaKConfig(curation_threshold=1e100)
+    with pytest.raises(ValueError, match="option_model_step_size"):
+        Step11OaKConfig(option_model_step_size=1e100)
+
+
+def test_step11_oak_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    f32_min = float(np.finfo(np.float32).min)
+    config = Step11OaKConfig(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=f32_max,
+                pseudo_reward_scale=f32_min,
+                max_option_steps=10,
+            ),
+        ),
+        observation_dim=2,
+        curation_threshold=f32_max,
+        base_step_size=f32_max,
+    )
+    agent = make_step11_oak_agent(config)
+    assert agent.config.stomp.subtask_specs[0].threshold == f32_max
+    assert agent.config.stomp.subtask_specs[0].pseudo_reward_scale == f32_min
+    assert config.curation_threshold == f32_max
+    assert config.base_step_size == f32_max
 
 
 def test_step11_oak_fields_canonicalize_nonbuiltin_numbers() -> None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1,10 +1,20 @@
-"""Tests for the Step 11 OaK production facade."""
+"""Tests for the Step 11 OaK production facade.
+
+Invalid dimension and scientific-scalar cases are written to fail on current
+main (bool, non-real, non-integral, non-finite, and out-of-domain values
+accepted) and pass after the facade rejects them. Legal endpoints stay
+constructible and accepted numbers canonicalize to builtin ints and floats.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.oak import (
@@ -129,6 +139,334 @@ def test_step11_config_to_oak_config_fields_match() -> None:
     assert oak_cfg.observation_dim == 5
     assert oak_cfg.n_primitive_actions == 3
     assert oak_cfg.stomp.subtask_specs == cfg.subtask_specs
+
+
+_INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("observation_dim", 0),
+    ("observation_dim", -1),
+    ("observation_dim", True),
+    ("observation_dim", False),
+    ("observation_dim", "4"),
+    ("observation_dim", 4.5),
+    ("observation_dim", float("nan")),
+    ("observation_dim", float("inf")),
+    ("observation_dim", None),
+    ("n_primitive_actions", 0),
+    ("n_primitive_actions", -1),
+    ("n_primitive_actions", True),
+    ("n_primitive_actions", False),
+    ("n_primitive_actions", "2"),
+    ("n_primitive_actions", 2.5),
+    ("n_primitive_actions", float("nan")),
+    ("n_primitive_actions", float("inf")),
+    ("n_primitive_actions", None),
+    ("option_planning_backups_per_step", -1),
+    ("option_planning_backups_per_step", 2**31 - 1),
+    ("option_planning_backups_per_step", 2**31),
+    ("option_planning_backups_per_step", True),
+    ("option_planning_backups_per_step", False),
+    ("option_planning_backups_per_step", "0"),
+    ("option_planning_backups_per_step", 1.5),
+    ("option_planning_backups_per_step", float("nan")),
+    ("option_planning_backups_per_step", float("inf")),
+    ("option_planning_backups_per_step", None),
+    ("base_step_size", float("nan")),
+    ("base_step_size", float("inf")),
+    ("base_step_size", float("-inf")),
+    ("base_step_size", True),
+    ("base_step_size", False),
+    ("base_step_size", -1.0),
+    ("base_step_size", "0.05"),
+    ("base_step_size", None),
+    ("base_avg_reward_step_size", float("nan")),
+    ("base_avg_reward_step_size", float("inf")),
+    ("base_avg_reward_step_size", True),
+    ("base_avg_reward_step_size", False),
+    ("base_avg_reward_step_size", -0.01),
+    ("base_avg_reward_step_size", "0.01"),
+    ("base_trace_decay", float("nan")),
+    ("base_trace_decay", float("inf")),
+    ("base_trace_decay", True),
+    ("base_trace_decay", False),
+    ("base_trace_decay", -0.1),
+    ("base_trace_decay", 1.1),
+    ("base_trace_decay", "0.0"),
+    ("option_step_size", float("nan")),
+    ("option_step_size", float("inf")),
+    ("option_step_size", True),
+    ("option_step_size", False),
+    ("option_step_size", -1.0),
+    ("option_step_size", "0.05"),
+    ("option_avg_reward_step_size", float("nan")),
+    ("option_avg_reward_step_size", float("inf")),
+    ("option_avg_reward_step_size", True),
+    ("option_avg_reward_step_size", False),
+    ("option_avg_reward_step_size", -0.01),
+    ("option_trace_decay", float("nan")),
+    ("option_trace_decay", float("inf")),
+    ("option_trace_decay", True),
+    ("option_trace_decay", False),
+    ("option_trace_decay", -0.1),
+    ("option_trace_decay", 1.1),
+    ("option_gamma", float("nan")),
+    ("option_gamma", float("inf")),
+    ("option_gamma", float("-inf")),
+    ("option_gamma", True),
+    ("option_gamma", False),
+    ("option_gamma", -0.1),
+    ("option_gamma", 1.1),
+    ("option_gamma", "0.99"),
+    ("option_model_decay", float("nan")),
+    ("option_model_decay", float("inf")),
+    ("option_model_decay", True),
+    ("option_model_decay", False),
+    ("option_model_decay", -0.1),
+    ("option_model_decay", 1.1),
+    ("option_model_decay", "0.95"),
+    ("option_model_step_size", float("nan")),
+    ("option_model_step_size", float("inf")),
+    ("option_model_step_size", True),
+    ("option_model_step_size", False),
+    ("option_model_step_size", -0.1),
+    ("option_model_step_size", "0.1"),
+    ("epsilon_base", float("nan")),
+    ("epsilon_base", float("inf")),
+    ("epsilon_base", True),
+    ("epsilon_base", False),
+    ("epsilon_base", -0.1),
+    ("epsilon_base", 1.1),
+    ("epsilon_base", "0.1"),
+    ("epsilon_option", float("nan")),
+    ("epsilon_option", float("inf")),
+    ("epsilon_option", True),
+    ("epsilon_option", False),
+    ("epsilon_option", -0.1),
+    ("epsilon_option", 1.1),
+    ("utility_ema_decay", float("nan")),
+    ("utility_ema_decay", float("inf")),
+    ("utility_ema_decay", float("-inf")),
+    ("utility_ema_decay", True),
+    ("utility_ema_decay", False),
+    ("utility_ema_decay", -0.1),
+    ("utility_ema_decay", 1.1),
+    ("utility_ema_decay", "0.99"),
+    ("curation_threshold", float("nan")),
+    ("curation_threshold", float("inf")),
+    ("curation_threshold", float("-inf")),
+    ("curation_threshold", True),
+    ("curation_threshold", False),
+    ("curation_threshold", -0.1),
+    ("curation_threshold", "0.0"),
+    ("curation_threshold", None),
+)
+
+
+def _config_with(**overrides: Any) -> Step11OaKConfig:
+    payload: dict[str, Any] = {
+        "subtask_specs": (_SPEC0,),
+        "observation_dim": 4,
+        "n_primitive_actions": 2,
+    }
+    payload.update(overrides)
+    return Step11OaKConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP11_FIELDS)
+def test_step11_oak_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step11_config_feature_index_out_of_bounds_raises() -> None:
+    bad_spec = SubtaskSpec(feature_index=10)
+    with pytest.raises(ValueError, match="feature_index"):
+        Step11OaKConfig(subtask_specs=(bad_spec,), observation_dim=4)
+
+
+def test_step11_oak_rejects_non_tuple_subtask_specs() -> None:
+    with pytest.raises(ValueError, match="subtask_specs"):
+        Step11OaKConfig(subtask_specs=[_SPEC0])  # type: ignore[arg-type]
+
+
+def test_step11_oak_rejects_bool_and_nonfinite_spec_scalars() -> None:
+    with pytest.raises(ValueError, match="feature_index"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=float("nan")),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=float("inf")),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, pseudo_reward_scale=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step11OaKConfig(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, pseudo_reward_scale=float("nan")),
+            ),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="max_option_steps"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, max_option_steps=True),),
+            observation_dim=4,
+        )
+
+
+def test_step11_oak_fields_preserve_legal_endpoints() -> None:
+    config = Step11OaKConfig(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=1e-12,
+                pseudo_reward_scale=0.0,
+                max_option_steps=1,
+            ),
+        ),
+        observation_dim=1,
+        n_primitive_actions=1,
+        base_step_size=0.0,
+        base_avg_reward_step_size=0.0,
+        base_trace_decay=0.0,
+        option_step_size=0.0,
+        option_avg_reward_step_size=0.0,
+        option_trace_decay=0.0,
+        option_gamma=0.0,
+        option_model_decay=0.0,
+        option_model_step_size=0.0,
+        option_planning_backups_per_step=0,
+        epsilon_base=0.0,
+        epsilon_option=0.0,
+        utility_ema_decay=0.0,
+        curation_threshold=0.0,
+    )
+    agent = make_step11_oak_agent(config)
+    payload = config.to_config()
+    json.dumps(payload, allow_nan=False)
+    restored = Step11OaKConfig.from_config(payload)
+    assert restored.observation_dim == 1
+    assert restored.n_primitive_actions == 1
+    assert restored.base_step_size == 0.0
+    assert restored.base_avg_reward_step_size == 0.0
+    assert restored.base_trace_decay == 0.0
+    assert restored.option_step_size == 0.0
+    assert restored.option_avg_reward_step_size == 0.0
+    assert restored.option_trace_decay == 0.0
+    assert restored.option_gamma == 0.0
+    assert restored.option_model_decay == 0.0
+    assert restored.option_model_step_size == 0.0
+    assert restored.option_planning_backups_per_step == 0
+    assert restored.epsilon_base == 0.0
+    assert restored.epsilon_option == 0.0
+    assert restored.utility_ema_decay == 0.0
+    assert restored.curation_threshold == 0.0
+    assert restored.subtask_specs[0].feature_index == 0
+    assert restored.subtask_specs[0].threshold == 1e-12
+    assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert restored.subtask_specs[0].max_option_steps == 1
+    assert agent.config.stomp.option_gamma == 0.0
+
+    upper = Step11OaKConfig(
+        subtask_specs=(_SPEC0,),
+        observation_dim=4,
+        n_primitive_actions=2,
+        base_trace_decay=1.0,
+        option_trace_decay=1.0,
+        option_gamma=1.0,
+        option_model_decay=1.0,
+        epsilon_base=1.0,
+        epsilon_option=1.0,
+        utility_ema_decay=1.0,
+        curation_threshold=10.0,
+        option_planning_backups_per_step=2**31 - 2,
+    )
+    make_step11_oak_agent(upper)
+    assert upper.base_trace_decay == 1.0
+    assert upper.option_trace_decay == 1.0
+    assert upper.option_gamma == 1.0
+    assert upper.option_model_decay == 1.0
+    assert upper.epsilon_base == 1.0
+    assert upper.epsilon_option == 1.0
+    assert upper.utility_ema_decay == 1.0
+    assert upper.curation_threshold == 10.0
+    assert upper.option_planning_backups_per_step == 2**31 - 2
+
+
+def test_step11_oak_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.5)
+    spec = SubtaskSpec(
+        feature_index=np.int64(1),
+        threshold=value,
+        pseudo_reward_scale=value,
+        max_option_steps=np.int64(4),
+    )
+    config = Step11OaKConfig(
+        subtask_specs=(spec,),
+        observation_dim=np.int64(3),
+        n_primitive_actions=np.int64(2),
+        base_step_size=value,
+        base_avg_reward_step_size=value,
+        base_trace_decay=value,
+        option_step_size=value,
+        option_avg_reward_step_size=value,
+        option_trace_decay=value,
+        option_gamma=value,
+        option_model_decay=value,
+        option_model_step_size=value,
+        option_planning_backups_per_step=np.int64(1),
+        epsilon_base=value,
+        epsilon_option=value,
+        utility_ema_decay=value,
+        curation_threshold=np.float64(0.0),
+    )
+    agent = make_step11_oak_agent(config)
+    payload = config.to_config()
+    json.dumps(payload, allow_nan=False)
+    assert config.observation_dim == 3
+    assert config.n_primitive_actions == 2
+    assert config.option_planning_backups_per_step == 1
+    assert config.option_gamma == 0.5
+    assert config.utility_ema_decay == 0.5
+    assert config.curation_threshold == 0.0
+    assert config.subtask_specs[0].feature_index == 1
+    assert config.subtask_specs[0].threshold == 0.5
+    assert config.subtask_specs[0].max_option_steps == 4
+    assert type(payload["observation_dim"]) is int
+    assert type(payload["n_primitive_actions"]) is int
+    assert type(payload["option_planning_backups_per_step"]) is int
+    assert type(payload["base_step_size"]) is float
+    assert type(payload["base_avg_reward_step_size"]) is float
+    assert type(payload["base_trace_decay"]) is float
+    assert type(payload["option_step_size"]) is float
+    assert type(payload["option_avg_reward_step_size"]) is float
+    assert type(payload["option_trace_decay"]) is float
+    assert type(payload["option_gamma"]) is float
+    assert type(payload["option_model_decay"]) is float
+    assert type(payload["option_model_step_size"]) is float
+    assert type(payload["epsilon_base"]) is float
+    assert type(payload["epsilon_option"]) is float
+    assert type(payload["utility_ema_decay"]) is float
+    assert type(payload["curation_threshold"]) is float
+    assert type(payload["subtask_specs"][0]["feature_index"]) is int
+    assert type(payload["subtask_specs"][0]["threshold"]) is float
+    assert type(payload["subtask_specs"][0]["pseudo_reward_scale"]) is float
+    assert type(payload["subtask_specs"][0]["max_option_steps"]) is int
+    assert agent.config.stomp.option_gamma == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -9,6 +9,7 @@ constructible and accepted numbers canonicalize to builtin ints and floats.
 from __future__ import annotations
 
 import json
+from fractions import Fraction
 from typing import Any
 
 import chex
@@ -446,6 +447,40 @@ def test_step11_oak_rejects_float32_overflow() -> None:
         Step11OaKConfig(curation_threshold=1e100)
     with pytest.raises(ValueError, match="option_model_step_size"):
         Step11OaKConfig(option_model_step_size=1e100)
+
+
+def test_step11_oak_validates_original_real_domain_before_narrowing() -> None:
+    above_one = np.longdouble(1.0) + np.finfo(np.longdouble).eps
+    below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
+    assert float(above_one) == 1.0
+    assert float(below_zero) == 0.0
+
+    with pytest.raises(ValueError, match="epsilon_base"):
+        Step11OaKConfig(epsilon_base=above_one)
+    with pytest.raises(ValueError, match="base_step_size"):
+        Step11OaKConfig(base_step_size=below_zero)
+
+
+def test_step11_oak_wraps_real_conversion_overflow() -> None:
+    with pytest.raises(ValueError, match="base_step_size"):
+        Step11OaKConfig(base_step_size=Fraction(10**400, 1))
+
+
+def test_step11_oak_narrows_the_original_real_once() -> None:
+    midpoint_plus = (
+        np.longdouble(1.0)
+        + np.longdouble(2.0) ** -24
+        + np.longdouble(2.0) ** -60
+    )
+    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+    config = Step11OaKConfig(
+        subtask_specs=(
+            SubtaskSpec(feature_index=0, pseudo_reward_scale=midpoint_plus),
+        ),
+    )
+    assert config.subtask_specs[0].pseudo_reward_scale == float(
+        np.float32(midpoint_plus)
+    )
 
 
 def test_step11_oak_preserves_float32_boundaries() -> None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -483,6 +483,46 @@ def test_step11_oak_narrows_the_original_real_once() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("pseudo_reward_scale", "expected"),
+    [
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) - Fraction(1, 2**60),
+            1.0,
+        ),
+        (Fraction(1, 1) + Fraction(1, 2**24), 1.0),
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60),
+            float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+        ),
+    ],
+    ids=("below", "tie-to-even", "above"),
+)
+def test_step11_oak_rounds_fraction_midpoints_once(
+    pseudo_reward_scale: Fraction,
+    expected: float,
+) -> None:
+    config = Step11OaKConfig(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                pseudo_reward_scale=pseudo_reward_scale,
+            ),
+        ),
+    )
+    assert config.subtask_specs[0].pseudo_reward_scale == expected
+
+
+def test_step11_fraction_float32_overflow_midpoint_is_exact() -> None:
+    maximum = Fraction((2**24 - 1) * 2**104)
+    overflow_midpoint = maximum + 2**103
+
+    just_below = Step11OaKConfig(base_step_size=overflow_midpoint - 1)
+    assert just_below.base_step_size == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match="base_step_size"):
+        Step11OaKConfig(base_step_size=overflow_midpoint)
+
+
 def test_step11_oak_preserves_float32_boundaries() -> None:
     f32_max = float(np.finfo(np.float32).max)
     f32_min = float(np.finfo(np.float32).min)


### PR DESCRIPTION
Closes #267.

## What changed

`Step11OaKConfig` now rejects malformed facade dimensions, subtasks,
counters, and scientific scalars before constructing OaK/STOMP. Float32
execution values use the shared exact-ratio `round_real_to_float32` helper,
so `Fraction`, NumPy, extended-precision, and built-in reals round once with
IEEE ties-to-even semantics instead of passing through binary64.

Overflow at the exact float32 midpoint is rejected, legal zero/one endpoints
remain valid, and strictly positive thresholds that collapse to zero are
rejected. The planning budget remains strictly below signed-int32 max, while
`max_option_steps` may use its inclusive int32 telemetry endpoint.

## Scope

- `alberta_framework/steps/step11.py`
- `tests/test_step11_production.py`

The shared converter comes from main; this PR does not modify it. No
registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence
artifact changed.

## Exact-head verification

Verified head: `8153a34e0080507b4cec7e40045fcd7dbe29045e`  
Base: `bfd79627c752b3bdcfaf3688bb7872e440b10faa`

- focused Step 11 production suite: **172 passed**;
- affected OaK/STOMP panel: **106 passed**;
- exact-head Fraction/underflow/overflow subset after the final disjoint main
  rebase: **5 passed**;
- full Ruff: **passed**;
- strict mypy: **no issues in 164 source files**;
- `git diff --check`: clean;
- exact-head CI run `31942540523`: **20/20 passed**.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance
claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: google / gemini-3.7-flash
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported