### PR TITLE
fix(interaction-features): exclude inactive tasks from top-k utility

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -1385,10 +1385,16 @@ class FixedBudgetInteractionLearner:
                 return jnp.mean(jnp.sort(weighted_activity, axis=0)[-k:, :], axis=0)
             scores = jnp.where(active_mask[:, None], weighted_activity, -jnp.inf)
             selected, _ = jax.lax.top_k(jnp.swapaxes(scores, 0, 1), k)
-            selected_mask = jnp.isfinite(selected)
-            selected_count = jnp.sum(selected_mask, axis=1)
-            selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
-            safe_count = jnp.maximum(selected_count, 1.0)
+            selected_count = jnp.minimum(
+                jnp.sum(active_mask.astype(jnp.int32)),
+                k,
+            )
+            selected_mask = jnp.arange(k) < selected_count
+            selected_sum = jnp.sum(
+                jnp.where(selected_mask[None, :], selected, 0.0),
+                axis=1,
+            )
+            safe_count = jnp.maximum(selected_count, 1)
             return jnp.where(selected_count > 0, selected_sum / safe_count, 0.0)
 
         if self._utility_task_balancing == "active":
@@ -1480,10 +1486,16 @@ class FixedBudgetInteractionLearner:
                 return jnp.mean(jnp.sort(weighted_signal, axis=0)[-k:, :], axis=0)
             scores = jnp.where(active_mask[:, None], weighted_signal, -jnp.inf)
             selected, _ = jax.lax.top_k(jnp.swapaxes(scores, 0, 1), k)
-            selected_mask = jnp.isfinite(selected)
-            selected_count = jnp.sum(selected_mask, axis=1)
-            selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
-            safe_count = jnp.maximum(selected_count, 1.0)
+            selected_count = jnp.minimum(
+                jnp.sum(active_mask.astype(jnp.int32)),
+                k,
+            )
+            selected_mask = jnp.arange(k) < selected_count
+            selected_sum = jnp.sum(
+                jnp.where(selected_mask[None, :], selected, 0.0),
+                axis=1,
+            )
+            safe_count = jnp.maximum(selected_count, 1)
             return jnp.where(selected_count > 0, selected_sum / safe_count, 0.0)
         if self._utility_task_balancing in {"active", "active_inverse_frequency"}:
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)

--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -1388,7 +1388,8 @@ class FixedBudgetInteractionLearner:
             selected_mask = jnp.isfinite(selected)
             selected_count = jnp.sum(selected_mask, axis=1)
             selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
-            return jnp.where(selected_count > 0, selected_sum / selected_count, 0.0)
+            safe_count = jnp.maximum(selected_count, 1.0)
+            return jnp.where(selected_count > 0, selected_sum / safe_count, 0.0)
 
         if self._utility_task_balancing == "active":
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
@@ -1482,7 +1483,8 @@ class FixedBudgetInteractionLearner:
             selected_mask = jnp.isfinite(selected)
             selected_count = jnp.sum(selected_mask, axis=1)
             selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
-            return jnp.where(selected_count > 0, selected_sum / selected_count, 0.0)
+            safe_count = jnp.maximum(selected_count, 1.0)
+            return jnp.where(selected_count > 0, selected_sum / safe_count, 0.0)
         if self._utility_task_balancing in {"active", "active_inverse_frequency"}:
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
             return jnp.sum(weighted_signal, axis=0) / active_count

--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -1381,7 +1381,14 @@ class FixedBudgetInteractionLearner:
             return jnp.max(weighted_activity, axis=0)
         if self._utility_aggregation == "topk":
             k = min(self._utility_top_k, self._n_tasks)
-            return jnp.mean(jnp.sort(weighted_activity, axis=0)[-k:, :], axis=0)
+            if self._utility_task_balancing == "none":
+                return jnp.mean(jnp.sort(weighted_activity, axis=0)[-k:, :], axis=0)
+            scores = jnp.where(active_mask[:, None], weighted_activity, -jnp.inf)
+            selected, _ = jax.lax.top_k(jnp.swapaxes(scores, 0, 1), k)
+            selected_mask = jnp.isfinite(selected)
+            selected_count = jnp.sum(selected_mask, axis=1)
+            selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
+            return jnp.where(selected_count > 0, selected_sum / selected_count, 0.0)
 
         if self._utility_task_balancing == "active":
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
@@ -1468,7 +1475,14 @@ class FixedBudgetInteractionLearner:
             return jnp.max(weighted_signal, axis=0)
         if self._utility_aggregation == "topk":
             k = min(self._utility_top_k, self._n_tasks)
-            return jnp.mean(jnp.sort(weighted_signal, axis=0)[-k:, :], axis=0)
+            if self._utility_task_balancing == "none":
+                return jnp.mean(jnp.sort(weighted_signal, axis=0)[-k:, :], axis=0)
+            scores = jnp.where(active_mask[:, None], weighted_signal, -jnp.inf)
+            selected, _ = jax.lax.top_k(jnp.swapaxes(scores, 0, 1), k)
+            selected_mask = jnp.isfinite(selected)
+            selected_count = jnp.sum(selected_mask, axis=1)
+            selected_sum = jnp.sum(jnp.where(selected_mask, selected, 0.0), axis=1)
+            return jnp.where(selected_count > 0, selected_sum / selected_count, 0.0)
         if self._utility_task_balancing in {"active", "active_inverse_frequency"}:
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
             return jnp.sum(weighted_signal, axis=0) / active_count

--- a/tests/test_interaction_task_utility_weights.py
+++ b/tests/test_interaction_task_utility_weights.py
@@ -323,6 +323,22 @@ def test_unweighted_active_topk_all_inactive_avoids_zero_division(
     np.testing.assert_array_equal(checkified_result, expected)
 
 
+@pytest.mark.parametrize("invalid", [jnp.nan, jnp.inf, -jnp.inf])
+def test_unweighted_active_topk_does_not_hide_invalid_active_signal(invalid: float) -> None:
+    learner = _learner(
+        utility_aggregation="topk",
+        utility_top_k=2,
+        utility_task_balancing="active",
+    )
+    active_mask = jnp.asarray((True, False, False, False, False), dtype=jnp.bool_)
+    activity = jnp.ones((5,), dtype=jnp.float32)
+    signal = jnp.asarray(((invalid,), (0.0,), (0.0,), (0.0,), (0.0,)), dtype=jnp.float32)
+
+    value = learner._aggregate_task_feature_signal(signal, active_mask, activity)
+
+    assert not bool(jnp.all(jnp.isfinite(value)))
+
+
 def test_weighted_update_is_eager_jit_and_scan_compatible() -> None:
     learner = _learner(
         task_utility_weights=_GROUP_WEIGHTS,

--- a/tests/test_interaction_task_utility_weights.py
+++ b/tests/test_interaction_task_utility_weights.py
@@ -251,6 +251,28 @@ def test_weighted_topk_normalizes_only_selected_positive_weight_mass() -> None:
     )
 
 
+def test_unweighted_active_topk_excludes_inactive_zero_placeholders() -> None:
+    learner = _learner(
+        utility_aggregation="topk",
+        utility_top_k=2,
+        utility_task_balancing="active",
+    )
+    active_mask = jnp.asarray((True, False, False, False, False), dtype=jnp.bool_)
+    activity = jnp.ones((5,), dtype=jnp.float32)
+    signed_signal = jnp.asarray(
+        ((-4.0,), (99.0,), (99.0,), (99.0,), (99.0,)),
+        dtype=jnp.float32,
+    )
+
+    utility = learner._aggregate_task_feature_signal(
+        signed_signal,
+        active_mask,
+        activity,
+    )
+
+    np.testing.assert_array_equal(utility, np.asarray((-4.0,), dtype=np.float32))
+
+
 def test_weighted_update_is_eager_jit_and_scan_compatible() -> None:
     learner = _learner(
         task_utility_weights=_GROUP_WEIGHTS,

--- a/tests/test_interaction_task_utility_weights.py
+++ b/tests/test_interaction_task_utility_weights.py
@@ -13,6 +13,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import pytest
+from jax.experimental import checkify
 
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
@@ -271,6 +272,55 @@ def test_unweighted_active_topk_excludes_inactive_zero_placeholders() -> None:
     )
 
     np.testing.assert_array_equal(utility, np.asarray((-4.0,), dtype=np.float32))
+
+
+@pytest.mark.parametrize(
+    "reducer_name",
+    ["_aggregate_task_feature_signal", "_utility_signal"],
+)
+def test_unweighted_active_topk_all_inactive_avoids_zero_division(
+    reducer_name: str,
+) -> None:
+    """An all-inactive mask must not form 0 / 0 inside jnp.where.
+
+    jnp.where evaluates both branches eagerly, so a denominator that can hit
+    zero must be guarded even though the outer where discards the result:
+    JAX_DEBUG_NANS and checkify both observe the invalid intermediate.
+    """
+    learner = _learner(
+        utility_aggregation="topk",
+        utility_top_k=2,
+        utility_task_balancing="active",
+    )
+    active_mask = jnp.zeros((5,), dtype=jnp.bool_)
+    activity = jnp.ones((5,), dtype=jnp.float32)
+    reducer = getattr(learner, reducer_name)
+    if reducer_name == "_aggregate_task_feature_signal":
+        signal = jnp.asarray(((1.0,), (2.0,), (3.0,), (4.0,), (5.0,)), dtype=jnp.float32)
+        args = (signal, active_mask, activity)
+    else:
+        output_weights = jnp.asarray(
+            ((1.0,), (2.0,), (3.0,), (4.0,), (5.0,)), dtype=jnp.float32
+        )
+        features = jnp.asarray((1.0,), dtype=jnp.float32)
+        args = (output_weights, features, active_mask, activity)
+
+    expected = np.zeros((1,), dtype=np.float32)
+
+    eager = reducer(*args)
+    np.testing.assert_array_equal(eager, expected)
+
+    compiled = jax.jit(reducer)(*args)
+    np.testing.assert_array_equal(compiled, expected)
+
+    with jax.debug_nans(True):
+        debug_nans_result = reducer(*args)
+    np.testing.assert_array_equal(debug_nans_result, expected)
+
+    checked_reducer = checkify.checkify(reducer, errors=checkify.float_checks)
+    err, checkified_result = checked_reducer(*args)
+    err.throw()
+    np.testing.assert_array_equal(checkified_result, expected)
 
 
 def test_weighted_update_is_eager_jit_and_scan_compatible() -> None:


### PR DESCRIPTION
Closes #275.

## What changed

The unweighted active-task `topk` reducers no longer let zero placeholders from inactive tasks outrank a real negative active signal or dilute a sparse active mean. Inactive rows are ranked as `-inf`, and the denominator is the exact `min(active_count, k)`.

The corrected implementation also preserves two fail-closed invariants:

- an all-inactive task set uses a safe denominator and returns exact zero without forming `0 / 0` under eager, JIT, `JAX_DEBUG_NANS`, or checkify execution;
- non-finite values from an active task remain non-finite and cannot be mistaken for an inactive placeholder.

The historical `utility_task_balancing="none"` algebra remains unchanged.

## Reachability

`FixedBudgetInteractionLearner` is exported from the package root and is constructed by the recurring-feature and Prototype feature-lifecycle paths. The affected reducers run inside its public update path.

## Verification

Validated at `477ccf4bc990591ec40c01049c40d7ab46f7c44f`, rebased on current `main`:

- interaction top-k, horizon, retirement, Prototype lifecycle, and recurring-feature panels: **71 passed**;
- targeted Ruff: clean;
- strict mypy: clean;
- `git diff --check`: clean.

Regression coverage includes negative active signals, sparse positive means, all-inactive eager/JIT/debug/checkify execution, and NaN/positive-infinity/negative-infinity fail visibility.

No `outputs/**` artifact or evidence protocol changed.

## Contribution provenance

Original report and fix: Svector-anu. Additional adversarial review, safe-denominator correction, active-count semantics, fail-visible invalid-signal coverage, rebase, and verification: lalalune/Codex.