### PR TITLE
fix(step12): reject illegal IA facade config

### DIFF
--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -30,10 +30,12 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.intelligence_amplification import (
@@ -86,6 +88,10 @@ class Step12IAConfig:
     epsilon_base: float = 0.1
     utility_ema_decay: float = 0.99
 
+    def __post_init__(self) -> None:
+        """Reject illegal dimensions and scientific scalars, then canonicalize."""
+        _validate_ia_facade_config(self)
+
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-serializable representation."""
         return {
@@ -136,6 +142,158 @@ class Step12IAConfig:
             step_size=self.cerebellum_step_size,
         )
         return IAConfig(cerebellum=cerebellum, cortex=cortex)
+
+
+_INT32_MAX = 2**31 - 1
+
+
+def _require_real(name: str, value: object) -> float:
+    """Return a concrete real scalar after direct float32 sink validation."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    try:
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            narrowed = np.asarray(value, dtype=np.float32).reshape(())
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be finite in float32, got {value!r}") from exc
+    if not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must be finite in float32, got {value!r}")
+    return float(narrowed)
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    original: Any = value
+    if original < 0.0 or original > 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return _require_real(name, value)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    original: Any = value
+    if original < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return _require_real(name, value)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    original: Any = value
+    if original <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    narrowed = _require_real(name, value)
+    if narrowed <= 0.0:
+        raise ValueError(f"{name} must remain positive in float32, got {value!r}")
+    return narrowed
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    exclusive_maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if exclusive_maximum is not None and number >= exclusive_maximum:
+        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    return number
+
+
+def _validate_ia_facade_config(config: Step12IAConfig) -> None:
+    n_demons = _require_int("n_demons", config.n_demons, minimum=1)
+    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    n_primitive_actions = _require_int(
+        "n_primitive_actions",
+        config.n_primitive_actions,
+        minimum=1,
+    )
+    option_planning_backups_per_step = _require_int(
+        "option_planning_backups_per_step",
+        config.option_planning_backups_per_step,
+        minimum=0,
+        exclusive_maximum=_INT32_MAX,
+    )
+    if not isinstance(config.subtask_specs, tuple):
+        raise ValueError(
+            f"subtask_specs must be a tuple of SubtaskSpec, got {config.subtask_specs!r}"
+        )
+    canonical_specs: list[SubtaskSpec] = []
+    for spec in config.subtask_specs:
+        if not isinstance(spec, SubtaskSpec):
+            raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
+        feature_index = _require_int("feature_index", spec.feature_index, minimum=0)
+        if feature_index >= observation_dim:
+            raise ValueError(
+                f"feature_index must be < observation_dim, got {spec.feature_index!r}"
+            )
+        threshold = _require_positive_real("threshold", spec.threshold)
+        pseudo_reward_scale = _require_real(
+            "pseudo_reward_scale",
+            spec.pseudo_reward_scale,
+        )
+        max_option_steps = _require_int(
+            "max_option_steps",
+            spec.max_option_steps,
+            minimum=1,
+        )
+        if max_option_steps > _INT32_MAX:
+            raise ValueError("max_option_steps must fit int32 telemetry")
+        canonical_specs.append(
+            SubtaskSpec(
+                feature_index=feature_index,
+                threshold=threshold,
+                pseudo_reward_scale=pseudo_reward_scale,
+                max_option_steps=max_option_steps,
+            )
+        )
+    cerebellum_step_size = _require_positive_real(
+        "cerebellum_step_size",
+        config.cerebellum_step_size,
+    )
+    base_step_size = _require_nonnegative_real("base_step_size", config.base_step_size)
+    base_avg_reward_step_size = _require_nonnegative_real(
+        "base_avg_reward_step_size",
+        config.base_avg_reward_step_size,
+    )
+    option_step_size = _require_nonnegative_real(
+        "option_step_size",
+        config.option_step_size,
+    )
+    option_gamma = _require_unit_interval("option_gamma", config.option_gamma)
+    epsilon_base = _require_unit_interval("epsilon_base", config.epsilon_base)
+    utility_ema_decay = _require_unit_interval(
+        "utility_ema_decay",
+        config.utility_ema_decay,
+    )
+    object.__setattr__(config, "n_demons", n_demons)
+    object.__setattr__(config, "subtask_specs", tuple(canonical_specs))
+    object.__setattr__(config, "observation_dim", observation_dim)
+    object.__setattr__(config, "n_primitive_actions", n_primitive_actions)
+    object.__setattr__(config, "cerebellum_step_size", cerebellum_step_size)
+    object.__setattr__(config, "base_step_size", base_step_size)
+    object.__setattr__(config, "base_avg_reward_step_size", base_avg_reward_step_size)
+    object.__setattr__(config, "option_step_size", option_step_size)
+    object.__setattr__(config, "option_gamma", option_gamma)
+    object.__setattr__(
+        config,
+        "option_planning_backups_per_step",
+        option_planning_backups_per_step,
+    )
+    object.__setattr__(config, "epsilon_base", epsilon_base)
+    object.__setattr__(config, "utility_ema_decay", utility_ema_decay)
 
 
 @dataclass(frozen=True)
@@ -296,6 +454,7 @@ def run_step12_smoke(
         & jnp.all(jnp.isfinite(result.augmented_obs))
         & jnp.all(result.recommendations >= 0)
         & jnp.all(result.recommendations < cfg.n_primitive_actions)
+        & jnp.all(result.updates_applied)
     )
 
     return Step12SmokeResult(

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -38,6 +38,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.intelligence_amplification import (
     ExoCerebellumConfig,
     IAAgent,
@@ -152,13 +153,12 @@ def _require_real(name: str, value: object) -> float:
     if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
     try:
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32).reshape(())
+        narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be finite in float32, got {value!r}") from exc
     if not bool(np.isfinite(narrowed)):
         raise ValueError(f"{name} must be finite in float32, got {value!r}")
-    return float(narrowed)
+    return narrowed
 
 
 def _require_unit_interval(name: str, value: object) -> float:

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from fractions import Fraction
+from typing import Any
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.intelligence_amplification import (
@@ -20,6 +25,7 @@ from alberta_framework.core.intelligence_amplification import (
 )
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.steps import step12 as step12_module
 from alberta_framework.steps.step12 import (
     Step12IAConfig,
     Step12SmokeResult,
@@ -36,6 +42,11 @@ from alberta_framework.steps.step12 import (
 
 _SPEC0 = SubtaskSpec(feature_index=0, threshold=0.5, pseudo_reward_scale=1.0, max_option_steps=8)
 _SPEC1 = SubtaskSpec(feature_index=1, threshold=0.3, pseudo_reward_scale=2.0, max_option_steps=4)
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
+_FLOAT32_MIN_SUBNORMAL = float(
+    np.nextafter(np.float32(0.0), np.float32(1.0), dtype=np.float32)
+)
+_INT32_MAX = 2**31 - 1
 
 
 def _make_step12_cfg(
@@ -170,6 +181,490 @@ def test_step12_config_to_ia_config_dims_match() -> None:
     assert ia_cfg.cortex.observation_dim == 5
     assert ia_cfg.cortex.n_primitive_actions == 3
     assert ia_cfg.cerebellum.n_demons == 4
+
+
+_INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("n_demons", 0),
+    ("n_demons", -1),
+    ("n_demons", True),
+    ("n_demons", False),
+    ("n_demons", "4"),
+    ("n_demons", 4.5),
+    ("n_demons", float("nan")),
+    ("n_demons", float("inf")),
+    ("n_demons", None),
+    ("observation_dim", 0),
+    ("observation_dim", -1),
+    ("observation_dim", True),
+    ("observation_dim", False),
+    ("observation_dim", "4"),
+    ("observation_dim", 4.5),
+    ("observation_dim", float("nan")),
+    ("observation_dim", float("inf")),
+    ("observation_dim", None),
+    ("n_primitive_actions", 0),
+    ("n_primitive_actions", -1),
+    ("n_primitive_actions", True),
+    ("n_primitive_actions", False),
+    ("n_primitive_actions", "2"),
+    ("n_primitive_actions", 2.5),
+    ("n_primitive_actions", float("nan")),
+    ("n_primitive_actions", float("inf")),
+    ("n_primitive_actions", None),
+    ("cerebellum_step_size", float("nan")),
+    ("cerebellum_step_size", float("inf")),
+    ("cerebellum_step_size", float("-inf")),
+    ("cerebellum_step_size", True),
+    ("cerebellum_step_size", False),
+    ("cerebellum_step_size", 0.0),
+    ("cerebellum_step_size", -1.0),
+    ("cerebellum_step_size", "0.05"),
+    ("cerebellum_step_size", None),
+    ("base_step_size", float("nan")),
+    ("base_step_size", float("inf")),
+    ("base_step_size", float("-inf")),
+    ("base_step_size", True),
+    ("base_step_size", False),
+    ("base_step_size", -1.0),
+    ("base_step_size", "0.05"),
+    ("base_step_size", None),
+    ("base_avg_reward_step_size", float("nan")),
+    ("base_avg_reward_step_size", float("inf")),
+    ("base_avg_reward_step_size", True),
+    ("base_avg_reward_step_size", False),
+    ("base_avg_reward_step_size", -0.01),
+    ("base_avg_reward_step_size", "0.01"),
+    ("option_step_size", float("nan")),
+    ("option_step_size", float("inf")),
+    ("option_step_size", True),
+    ("option_step_size", False),
+    ("option_step_size", -1.0),
+    ("option_step_size", "0.05"),
+    ("option_gamma", float("nan")),
+    ("option_gamma", float("inf")),
+    ("option_gamma", float("-inf")),
+    ("option_gamma", True),
+    ("option_gamma", False),
+    ("option_gamma", -0.1),
+    ("option_gamma", 1.1),
+    ("option_gamma", "0.99"),
+    ("option_planning_backups_per_step", -1),
+    ("option_planning_backups_per_step", 2**31 - 1),
+    ("option_planning_backups_per_step", 2**31),
+    ("option_planning_backups_per_step", True),
+    ("option_planning_backups_per_step", False),
+    ("option_planning_backups_per_step", "0"),
+    ("option_planning_backups_per_step", 1.5),
+    ("option_planning_backups_per_step", float("nan")),
+    ("option_planning_backups_per_step", float("inf")),
+    ("option_planning_backups_per_step", None),
+    ("epsilon_base", float("nan")),
+    ("epsilon_base", float("inf")),
+    ("epsilon_base", True),
+    ("epsilon_base", False),
+    ("epsilon_base", -0.1),
+    ("epsilon_base", 1.1),
+    ("epsilon_base", "0.1"),
+    ("utility_ema_decay", float("nan")),
+    ("utility_ema_decay", float("inf")),
+    ("utility_ema_decay", float("-inf")),
+    ("utility_ema_decay", True),
+    ("utility_ema_decay", False),
+    ("utility_ema_decay", -0.1),
+    ("utility_ema_decay", 1.1),
+    ("utility_ema_decay", "0.99"),
+)
+
+
+def _config_with(**overrides: Any) -> Step12IAConfig:
+    payload: dict[str, Any] = {
+        "subtask_specs": (_SPEC0,),
+        "observation_dim": 4,
+        "n_primitive_actions": 2,
+        "n_demons": 3,
+    }
+    payload.update(overrides)
+    return Step12IAConfig(**payload)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP12_FIELDS)
+def test_step12_ia_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step12_config_feature_index_out_of_bounds_raises() -> None:
+    bad_spec = SubtaskSpec(feature_index=10)
+    with pytest.raises(ValueError, match="feature_index"):
+        Step12IAConfig(subtask_specs=(bad_spec,), observation_dim=4)
+
+
+def test_step12_ia_rejects_non_tuple_subtask_specs() -> None:
+    with pytest.raises(ValueError, match="subtask_specs"):
+        Step12IAConfig(subtask_specs=[_SPEC0])  # type: ignore[arg-type]
+
+
+def test_step12_ia_rejects_bool_and_nonfinite_spec_scalars() -> None:
+    with pytest.raises(ValueError, match="feature_index"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=float("nan")),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, threshold=float("inf")),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, pseudo_reward_scale=True),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step12IAConfig(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, pseudo_reward_scale=float("nan")),
+            ),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="max_option_steps"):
+        Step12IAConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0, max_option_steps=True),),
+            observation_dim=4,
+        )
+
+
+def test_step12_ia_fields_preserve_legal_endpoints() -> None:
+    config = Step12IAConfig(
+        n_demons=1,
+        cerebellum_step_size=1e-12,
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=1e-12,
+                pseudo_reward_scale=0.0,
+                max_option_steps=1,
+            ),
+        ),
+        observation_dim=1,
+        n_primitive_actions=1,
+        base_step_size=0.0,
+        base_avg_reward_step_size=0.0,
+        option_step_size=0.0,
+        option_gamma=0.0,
+        option_planning_backups_per_step=0,
+        epsilon_base=0.0,
+        utility_ema_decay=0.0,
+    )
+    agent = make_step12_ia_agent(config)
+    payload = config.to_config()
+    json.dumps(payload, allow_nan=False)
+    restored = Step12IAConfig.from_config(payload)
+    assert restored.n_demons == 1
+    assert restored.cerebellum_step_size == float(np.float32(1e-12))
+    assert restored.observation_dim == 1
+    assert restored.n_primitive_actions == 1
+    assert restored.base_step_size == 0.0
+    assert restored.base_avg_reward_step_size == 0.0
+    assert restored.option_step_size == 0.0
+    assert restored.option_gamma == 0.0
+    assert restored.option_planning_backups_per_step == 0
+    assert restored.epsilon_base == 0.0
+    assert restored.utility_ema_decay == 0.0
+    assert restored.subtask_specs[0].feature_index == 0
+    assert restored.subtask_specs[0].threshold == float(np.float32(1e-12))
+    assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert restored.subtask_specs[0].max_option_steps == 1
+    assert agent.config.cortex.stomp.option_gamma == 0.0
+
+    upper = Step12IAConfig(
+        n_demons=10,
+        cerebellum_step_size=1.0,
+        subtask_specs=(_SPEC0,),
+        observation_dim=4,
+        n_primitive_actions=2,
+        option_gamma=1.0,
+        epsilon_base=1.0,
+        utility_ema_decay=1.0,
+        option_planning_backups_per_step=2**31 - 2,
+    )
+    make_step12_ia_agent(upper)
+    assert upper.option_gamma == 1.0
+    assert upper.epsilon_base == 1.0
+    assert upper.utility_ema_decay == 1.0
+    assert upper.option_planning_backups_per_step == 2**31 - 2
+
+
+def test_step12_ia_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.5)
+    spec = SubtaskSpec(
+        feature_index=np.int64(1),
+        threshold=value,
+        pseudo_reward_scale=value,
+        max_option_steps=np.int64(4),
+    )
+    config = Step12IAConfig(
+        n_demons=np.int64(3),
+        cerebellum_step_size=value,
+        subtask_specs=(spec,),
+        observation_dim=np.int64(3),
+        n_primitive_actions=np.int64(2),
+        base_step_size=value,
+        base_avg_reward_step_size=value,
+        option_step_size=value,
+        option_gamma=value,
+        option_planning_backups_per_step=np.int64(1),
+        epsilon_base=value,
+        utility_ema_decay=value,
+    )
+    agent = make_step12_ia_agent(config)
+    payload = config.to_config()
+    json.dumps(payload, allow_nan=False)
+    assert config.n_demons == 3
+    assert config.observation_dim == 3
+    assert config.n_primitive_actions == 2
+    assert config.option_planning_backups_per_step == 1
+    assert config.option_gamma == 0.5
+    assert config.utility_ema_decay == 0.5
+    assert config.subtask_specs[0].feature_index == 1
+    assert config.subtask_specs[0].threshold == 0.5
+    assert config.subtask_specs[0].max_option_steps == 4
+    assert type(payload["n_demons"]) is int
+    assert type(payload["observation_dim"]) is int
+    assert type(payload["n_primitive_actions"]) is int
+    assert type(payload["option_planning_backups_per_step"]) is int
+    assert type(payload["cerebellum_step_size"]) is float
+    assert type(payload["base_step_size"]) is float
+    assert type(payload["base_avg_reward_step_size"]) is float
+    assert type(payload["option_step_size"]) is float
+    assert type(payload["option_gamma"]) is float
+    assert type(payload["epsilon_base"]) is float
+    assert type(payload["utility_ema_decay"]) is float
+    assert type(payload["subtask_specs"][0]["feature_index"]) is int
+    assert type(payload["subtask_specs"][0]["threshold"]) is float
+    assert type(payload["subtask_specs"][0]["pseudo_reward_scale"]) is float
+    assert type(payload["subtask_specs"][0]["max_option_steps"]) is int
+    assert agent.config.cortex.stomp.option_gamma == 0.5
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "cerebellum_step_size",
+        "base_step_size",
+        "base_avg_reward_step_size",
+        "option_step_size",
+    ],
+)
+def test_step12_rejects_values_that_overflow_float32(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: 1.0e100})
+
+
+@pytest.mark.parametrize("value", [1.0e100, -1.0e100])
+def test_step12_rejects_pseudo_reward_scale_that_overflows_float32(value: float) -> None:
+    spec = SubtaskSpec(feature_index=0, pseudo_reward_scale=value)
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        _config_with(subtask_specs=(spec,))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("cerebellum_step_size", 1.0e-50),
+        (
+            "subtask_specs",
+            (SubtaskSpec(feature_index=0, threshold=1.0e-50),),
+        ),
+    ],
+)
+def test_step12_strict_positive_fields_reject_float32_zero_collapse(
+    field: str,
+    value: object,
+) -> None:
+    expected = "threshold" if field == "subtask_specs" else field
+    with pytest.raises(ValueError, match=expected):
+        _config_with(**{field: value})
+
+
+def test_step12_float32_underflow_and_finite_boundaries_are_canonical() -> None:
+    spec = SubtaskSpec(
+        feature_index=0,
+        threshold=_FLOAT32_MIN_SUBNORMAL,
+        pseudo_reward_scale=-1.0e-50,
+    )
+    config = _config_with(
+        subtask_specs=(spec,),
+        cerebellum_step_size=_FLOAT32_MIN_SUBNORMAL,
+        base_step_size=1.0e-50,
+        base_avg_reward_step_size=1.0e-50,
+        option_step_size=1.0e-50,
+    )
+    assert config.cerebellum_step_size == _FLOAT32_MIN_SUBNORMAL
+    assert config.base_step_size == 0.0
+    assert config.base_avg_reward_step_size == 0.0
+    assert config.option_step_size == 0.0
+    assert config.subtask_specs[0].threshold == _FLOAT32_MIN_SUBNORMAL
+    assert config.subtask_specs[0].pseudo_reward_scale == 0.0
+
+    maximum = _config_with(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=_FLOAT32_MAX,
+                pseudo_reward_scale=-_FLOAT32_MAX,
+            ),
+        ),
+        cerebellum_step_size=_FLOAT32_MAX,
+        base_step_size=_FLOAT32_MAX,
+        base_avg_reward_step_size=_FLOAT32_MAX,
+        option_step_size=_FLOAT32_MAX,
+    )
+    assert maximum.cerebellum_step_size == _FLOAT32_MAX
+    assert maximum.base_step_size == _FLOAT32_MAX
+    assert maximum.subtask_specs[0].threshold == _FLOAT32_MAX
+    assert maximum.subtask_specs[0].pseudo_reward_scale == -_FLOAT32_MAX
+
+
+def test_step12_int32_counter_boundaries_match_core_sinks() -> None:
+    config = _config_with(
+        subtask_specs=(SubtaskSpec(feature_index=0, max_option_steps=_INT32_MAX),),
+        option_planning_backups_per_step=_INT32_MAX - 1,
+    )
+    make_step12_ia_agent(config)
+    assert config.subtask_specs[0].max_option_steps == _INT32_MAX
+    assert config.option_planning_backups_per_step == _INT32_MAX - 1
+
+    with pytest.raises(ValueError, match="max_option_steps"):
+        _config_with(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, max_option_steps=_INT32_MAX + 1),
+            )
+        )
+    with pytest.raises(ValueError, match="option_planning_backups_per_step"):
+        _config_with(option_planning_backups_per_step=_INT32_MAX)
+
+
+def test_step12_builtin_json_roundtrip_preserves_canonical_config() -> None:
+    config = _config_with(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=0.2,
+                pseudo_reward_scale=0.3,
+                max_option_steps=17,
+            ),
+        ),
+        cerebellum_step_size=0.02,
+        base_step_size=0.03,
+        option_gamma=0.875,
+        epsilon_base=0.125,
+    )
+
+    payload = json.loads(json.dumps(config.to_config(), allow_nan=False))
+    assert Step12IAConfig.from_config(payload) == config
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("base_step_size", Fraction(-1, 10**400)),
+        ("base_avg_reward_step_size", Fraction(-1, 10**400)),
+        ("option_step_size", Fraction(-1, 10**400)),
+        ("option_gamma", Fraction(-1, 10**400)),
+        ("option_gamma", Fraction(10**400 + 1, 10**400)),
+        ("epsilon_base", Fraction(-1, 10**400)),
+        ("epsilon_base", Fraction(10**400 + 1, 10**400)),
+        ("utility_ema_decay", Fraction(-1, 10**400)),
+        ("utility_ema_decay", Fraction(10**400 + 1, 10**400)),
+    ],
+)
+def test_step12_fields_check_exact_domains_before_float_conversion(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
+def test_step12_wraps_real_conversion_overflow_as_config_error() -> None:
+    with pytest.raises(ValueError, match="cerebellum_step_size"):
+        _config_with(cerebellum_step_size=Fraction(10**400, 1))
+
+
+def test_step12_narrows_original_real_directly_without_double_rounding() -> None:
+    midpoint_plus = (
+        np.longdouble(1.0)
+        + np.longdouble(2.0) ** -24
+        + np.longdouble(2.0) ** -60
+    )
+    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+
+    config = _config_with(
+        subtask_specs=(
+            SubtaskSpec(feature_index=0, pseudo_reward_scale=midpoint_plus),
+        )
+    )
+
+    assert config.subtask_specs[0].pseudo_reward_scale == float(
+        np.float32(midpoint_plus)
+    )
+
+
+def test_step12_smoke_health_gate_reports_any_refused_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_scan = step12_module.run_step12_scan
+
+    def _refuse_update(*args: Any, **kwargs: Any) -> Any:
+        result = original_scan(*args, **kwargs)
+        return result.replace(updates_applied=result.updates_applied.at[0].set(False))
+
+    monkeypatch.setattr(step12_module, "run_step12_scan", _refuse_update)
+
+    assert not run_step12_smoke(steps=2).finite
+
+
+def test_step12_smallest_positive_float32_values_execute_healthy_update() -> None:
+    config = _config_with(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=_FLOAT32_MIN_SUBNORMAL,
+                pseudo_reward_scale=_FLOAT32_MIN_SUBNORMAL,
+                max_option_steps=4,
+            ),
+        ),
+        cerebellum_step_size=_FLOAT32_MIN_SUBNORMAL,
+    )
+    agent, state = _setup(config, seed=43)
+    obs = jnp.full((4,), 0.1, dtype=jnp.float32)
+
+    result = step12_update(
+        agent,
+        state,
+        obs,
+        jnp.asarray(0.25, dtype=jnp.float32),
+        obs * jnp.asarray(1.5, dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert bool(result.cerebellum_update_applied)
+    assert bool(result.cortex_update_applied)
+    chex.assert_tree_all_finite(result.state.cerebellum_state.weights)
+    chex.assert_tree_all_finite(
+        result.state.cortex_state.stomp_state.base_learner_state
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -621,6 +621,59 @@ def test_step12_narrows_original_real_directly_without_double_rounding() -> None
     )
 
 
+@pytest.mark.parametrize(
+    ("pseudo_reward_scale", "expected"),
+    [
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) - Fraction(1, 2**60),
+            1.0,
+        ),
+        (Fraction(1, 1) + Fraction(1, 2**24), 1.0),
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60),
+            float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+        ),
+    ],
+    ids=("below", "tie-to-even", "above"),
+)
+def test_step12_rounds_fraction_midpoints_once(
+    pseudo_reward_scale: Fraction,
+    expected: float,
+) -> None:
+    config = _config_with(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                pseudo_reward_scale=pseudo_reward_scale,
+            ),
+        )
+    )
+    assert config.subtask_specs[0].pseudo_reward_scale == expected
+
+
+def test_step12_fraction_float32_overflow_midpoint_is_exact() -> None:
+    maximum = Fraction((2**24 - 1) * 2**104)
+    overflow_midpoint = maximum + 2**103
+
+    just_below = _config_with(cerebellum_step_size=overflow_midpoint - 1)
+    assert just_below.cerebellum_step_size == _FLOAT32_MAX
+    with pytest.raises(ValueError, match="cerebellum_step_size"):
+        _config_with(cerebellum_step_size=overflow_midpoint)
+
+
+def test_step12_fraction_subnormal_midpoint_obeys_ties_to_even() -> None:
+    half_min_subnormal = Fraction(1, 2**150)
+
+    collapsed = _config_with(base_step_size=half_min_subnormal)
+    assert collapsed.base_step_size == 0.0
+    with pytest.raises(ValueError, match="cerebellum_step_size"):
+        _config_with(cerebellum_step_size=half_min_subnormal)
+    accepted = _config_with(
+        cerebellum_step_size=half_min_subnormal + Fraction(1, 2**200)
+    )
+    assert accepted.cerebellum_step_size == _FLOAT32_MIN_SUBNORMAL
+
+
 def test_step12_smoke_health_gate_reports_any_refused_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #272.

## What changed

`Step12IAConfig` now validates every facade-owned dimension, subtask,
counter, and scientific scalar before constructing IA. Float32 execution
values use the shared exact-ratio `round_real_to_float32` helper, preventing
binary64 double rounding for `Fraction` and extended-precision inputs.

Exact float32 overflow is rejected; legal zero/one endpoints remain valid; and
strictly positive cerebellum step sizes and thresholds that collapse to zero
are rejected. The planning budget remains strictly below signed-int32 max,
while `max_option_steps` may use its inclusive int32 telemetry endpoint. The
smoke health result also requires every IA update to have applied.

## Scope

- `alberta_framework/steps/step12.py`
- `tests/test_step12_production.py`

The shared converter comes from main; this PR does not modify it. No
registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence
artifact changed.

## Exact-head verification

Verified head: `fd35fbd4886ff003ac28c5460adf24da7cad8271`  
Base: `bfd79627c752b3bdcfaf3688bb7872e440b10faa`

- focused Step 12 production suite: **165 passed**;
- affected IA/OaK adoption panel: **31 passed**;
- exact-head Fraction/underflow/overflow/health subset after the final
  disjoint main rebase: **8 passed**;
- full Ruff: **passed**;
- strict mypy: **no issues in 164 source files**;
- `git diff --check`: clean;
- exact-head CI run `31942540092`: **20/20 passed**.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance
claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: google / gemini-3.7-flash
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported