### PR TITLE
fix(step6): reject illegal differential SARSA facade config

### DIFF
--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -27,6 +27,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAArrayResult,
@@ -48,15 +49,14 @@ def _require_real(name: str, value: object) -> Any:
 def _narrow_float32(name: str, value: Any) -> float:
     """Narrow exactly as the JAX core does, without an intermediate float64."""
     try:
-        with np.errstate(invalid="ignore", over="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32)
+        narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+    if not bool(np.isfinite(narrowed)):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
     if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
         return float(value)
-    return float(narrowed)
+    return narrowed
 
 
 def _require_unit_interval(name: str, value: object) -> float:

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -18,7 +18,9 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -34,6 +36,77 @@ from alberta_framework.core.average_reward import (
     run_differential_sarsa_from_arrays,
 )
 
+_INT32_MAX = 2**31 - 1
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return number
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    exclusive_maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if exclusive_maximum is not None and number >= exclusive_maximum:
+        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    return number
+
+
+def _validate_step6_config(config: Step6DifferentialSARSAConfig) -> None:
+    n_actions = _require_int("n_actions", config.n_actions, minimum=1)
+    q_step_size = _require_nonnegative_real("q_step_size", config.q_step_size)
+    average_reward_step_size = _require_nonnegative_real(
+        "average_reward_step_size",
+        config.average_reward_step_size,
+    )
+    trace_decay = _require_unit_interval("trace_decay", config.trace_decay)
+    epsilon_start = _require_unit_interval("epsilon_start", config.epsilon_start)
+    epsilon_end = _require_unit_interval("epsilon_end", config.epsilon_end)
+    epsilon_decay_steps = _require_int(
+        "epsilon_decay_steps",
+        config.epsilon_decay_steps,
+        minimum=0,
+        exclusive_maximum=_INT32_MAX,
+    )
+    object.__setattr__(config, "n_actions", n_actions)
+    object.__setattr__(config, "q_step_size", q_step_size)
+    object.__setattr__(config, "average_reward_step_size", average_reward_step_size)
+    object.__setattr__(config, "trace_decay", trace_decay)
+    object.__setattr__(config, "epsilon_start", epsilon_start)
+    object.__setattr__(config, "epsilon_end", epsilon_end)
+    object.__setattr__(config, "epsilon_decay_steps", epsilon_decay_steps)
+
 
 @dataclass(frozen=True)
 class Step6DifferentialSARSAConfig:
@@ -46,6 +119,10 @@ class Step6DifferentialSARSAConfig:
     epsilon_start: float = 0.1
     epsilon_end: float = 0.01
     epsilon_decay_steps: int = 0
+
+    def __post_init__(self) -> None:
+        """Reject illegal parameters and canonicalize scalars."""
+        _validate_step6_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -18,13 +18,13 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
 from numbers import Integral, Real
 from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.average_reward import (
@@ -39,27 +39,38 @@ from alberta_framework.core.average_reward import (
 _INT32_MAX = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> float:
+def _require_real(name: str, value: object) -> Any:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+    return value
+
+
+def _narrow_float32(name: str, value: Any) -> float:
+    """Narrow exactly as the JAX core does, without an intermediate float64."""
+    try:
+        with np.errstate(invalid="ignore", over="ignore"):
+            narrowed = np.asarray(value, dtype=np.float32)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
+        return float(value)
+    return float(narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    original = _require_real(name, value)
+    if not 0.0 <= original <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    original = _require_real(name, value)
+    if original < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_int(
@@ -67,7 +78,7 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
-    exclusive_maximum: int | None = None,
+    maximum: int | None = None,
 ) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
@@ -78,13 +89,18 @@ def _require_int(
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_step6_config(config: Step6DifferentialSARSAConfig) -> None:
-    n_actions = _require_int("n_actions", config.n_actions, minimum=1)
+    n_actions = _require_int(
+        "n_actions",
+        config.n_actions,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     q_step_size = _require_nonnegative_real("q_step_size", config.q_step_size)
     average_reward_step_size = _require_nonnegative_real(
         "average_reward_step_size",
@@ -97,7 +113,7 @@ def _validate_step6_config(config: Step6DifferentialSARSAConfig) -> None:
         "epsilon_decay_steps",
         config.epsilon_decay_steps,
         minimum=0,
-        exclusive_maximum=_INT32_MAX,
+        maximum=_INT32_MAX,
     )
     object.__setattr__(config, "n_actions", n_actions)
     object.__setattr__(config, "q_step_size", q_step_size)
@@ -249,6 +265,7 @@ def run_step6_smoke(
         & jnp.all(jnp.isfinite(result.average_rewards))
         & jnp.all(result.actions >= 0)
         & jnp.all(result.actions < cfg.n_actions)
+        & jnp.all(result.updates_applied)
     )
     return Step6SmokeResult(
         config=cfg,

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -1,5 +1,7 @@
 """Production facade tests for Alberta Plan Steps 5, 6, and 7."""
 
+from __future__ import annotations
+
 import json
 from fractions import Fraction
 from typing import Any
@@ -255,6 +257,140 @@ def test_step6_facade_config_roundtrip_one_step_and_smoke() -> None:
     assert smoke.average_rewards_shape == (12,)
     assert smoke.actions_shape == (12,)
     assert smoke.agent_config["type"] == "DifferentialSARSAAgent"
+
+
+_INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("n_actions", 0),
+    ("n_actions", -1),
+    ("n_actions", True),
+    ("n_actions", False),
+    ("n_actions", "2"),
+    ("n_actions", 2.5),
+    ("n_actions", float("nan")),
+    ("n_actions", float("inf")),
+    ("n_actions", None),
+    ("q_step_size", float("nan")),
+    ("q_step_size", float("inf")),
+    ("q_step_size", float("-inf")),
+    ("q_step_size", True),
+    ("q_step_size", False),
+    ("q_step_size", -1.0),
+    ("q_step_size", "0.05"),
+    ("q_step_size", None),
+    ("average_reward_step_size", float("nan")),
+    ("average_reward_step_size", float("inf")),
+    ("average_reward_step_size", True),
+    ("average_reward_step_size", False),
+    ("average_reward_step_size", -0.01),
+    ("average_reward_step_size", "0.01"),
+    ("average_reward_step_size", None),
+    ("trace_decay", float("nan")),
+    ("trace_decay", float("inf")),
+    ("trace_decay", True),
+    ("trace_decay", False),
+    ("trace_decay", -0.1),
+    ("trace_decay", 1.1),
+    ("trace_decay", "0.0"),
+    ("trace_decay", None),
+    ("epsilon_start", float("nan")),
+    ("epsilon_start", float("inf")),
+    ("epsilon_start", True),
+    ("epsilon_start", False),
+    ("epsilon_start", -0.1),
+    ("epsilon_start", 1.1),
+    ("epsilon_start", "0.1"),
+    ("epsilon_start", None),
+    ("epsilon_end", float("nan")),
+    ("epsilon_end", float("inf")),
+    ("epsilon_end", True),
+    ("epsilon_end", False),
+    ("epsilon_end", -0.1),
+    ("epsilon_end", 1.1),
+    ("epsilon_end", "0.01"),
+    ("epsilon_end", None),
+    ("epsilon_decay_steps", -1),
+    ("epsilon_decay_steps", 2**31 - 1),
+    ("epsilon_decay_steps", 2**31),
+    ("epsilon_decay_steps", True),
+    ("epsilon_decay_steps", False),
+    ("epsilon_decay_steps", "0"),
+    ("epsilon_decay_steps", 1.5),
+    ("epsilon_decay_steps", float("nan")),
+    ("epsilon_decay_steps", float("inf")),
+    ("epsilon_decay_steps", None),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP6_FIELDS)
+def test_step6_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step6DifferentialSARSAConfig(**{field: value})
+
+
+def test_step6_fields_preserve_legal_endpoints() -> None:
+    config = Step6DifferentialSARSAConfig(
+        n_actions=1,
+        q_step_size=0.0,
+        average_reward_step_size=0.0,
+        trace_decay=0.0,
+        epsilon_start=0.0,
+        epsilon_end=0.0,
+        epsilon_decay_steps=0,
+    )
+    agent = make_step6_differential_sarsa_agent(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step6DifferentialSARSAConfig.from_dict(payload)
+    assert restored.n_actions == 1
+    assert restored.q_step_size == 0.0
+    assert restored.average_reward_step_size == 0.0
+    assert restored.trace_decay == 0.0
+    assert restored.epsilon_start == 0.0
+    assert restored.epsilon_end == 0.0
+    assert restored.epsilon_decay_steps == 0
+    assert agent.config.n_actions == 1
+
+    upper = Step6DifferentialSARSAConfig(
+        n_actions=10,
+        q_step_size=1.0,
+        average_reward_step_size=1.0,
+        trace_decay=1.0,
+        epsilon_start=1.0,
+        epsilon_end=1.0,
+        epsilon_decay_steps=2**31 - 2,
+    )
+    make_step6_differential_sarsa_agent(upper)
+    assert upper.trace_decay == 1.0
+    assert upper.epsilon_start == 1.0
+    assert upper.epsilon_end == 1.0
+    assert upper.epsilon_decay_steps == 2**31 - 2
+
+
+def test_step6_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.05)
+    config = Step6DifferentialSARSAConfig(
+        n_actions=np.int64(3),
+        q_step_size=value,
+        average_reward_step_size=value,
+        trace_decay=value,
+        epsilon_start=value,
+        epsilon_end=value,
+        epsilon_decay_steps=np.int64(100),
+    )
+    agent = make_step6_differential_sarsa_agent(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.n_actions == 3
+    assert config.q_step_size == 0.05
+    assert config.epsilon_decay_steps == 100
+    assert type(payload["n_actions"]) is int
+    assert type(payload["epsilon_decay_steps"]) is int
+    assert type(payload["q_step_size"]) is float
+    assert type(payload["average_reward_step_size"]) is float
+    assert type(payload["trace_decay"]) is float
+    assert type(payload["epsilon_start"]) is float
+    assert type(payload["epsilon_end"]) is float
+    assert agent.config.n_actions == 3
 
 
 def test_step7_dyna_facade_roundtrip_one_step_and_smoke() -> None:

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -434,6 +434,37 @@ def test_step6_float32_narrowing_avoids_longdouble_double_rounding() -> None:
     assert agent.config.q_step_size == config.q_step_size
 
 
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (-Fraction(1, 2**80), 1.0),
+        (Fraction(0), 1.0),
+        (
+            Fraction(1, 2**80),
+            float(np.nextafter(np.float32(1.0), np.float32(np.inf))),
+        ),
+    ],
+)
+def test_step6_fraction_midpoint_rounds_once_to_nearest_even(
+    offset: Fraction,
+    expected: float,
+) -> None:
+    midpoint = Fraction(1) + Fraction(1, 2**24)
+    config = Step6DifferentialSARSAConfig(q_step_size=midpoint + offset)
+
+    assert config.q_step_size == expected
+
+
+def test_step6_fraction_float32_overflow_midpoint_is_exact() -> None:
+    maximum = Fraction((2**24 - 1) * 2**104)
+    overflow_midpoint = maximum + 2**103
+
+    just_below = Step6DifferentialSARSAConfig(q_step_size=overflow_midpoint - 1)
+    assert just_below.q_step_size == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match="q_step_size"):
+        Step6DifferentialSARSAConfig(q_step_size=overflow_midpoint)
+
+
 def test_step6_float32_underflow_canonicalizes_to_legal_zero_endpoint() -> None:
     config = Step6DifferentialSARSAConfig(
         q_step_size=1e-50,

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -31,6 +31,7 @@ from alberta_framework.steps import (
     step7_update,
 )
 from alberta_framework.steps import step5 as step5_module
+from alberta_framework.steps import step6 as step6_module
 from alberta_framework.steps.step7 import (
     _apply_planning_importance_correction,
     _pop_prioritized_planning_anchor,
@@ -269,12 +270,14 @@ _INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_actions", float("nan")),
     ("n_actions", float("inf")),
     ("n_actions", None),
+    ("n_actions", 2**31),
     ("q_step_size", float("nan")),
     ("q_step_size", float("inf")),
     ("q_step_size", float("-inf")),
     ("q_step_size", True),
     ("q_step_size", False),
     ("q_step_size", -1.0),
+    ("q_step_size", 3.5e38),
     ("q_step_size", "0.05"),
     ("q_step_size", None),
     ("average_reward_step_size", float("nan")),
@@ -282,6 +285,7 @@ _INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
     ("average_reward_step_size", True),
     ("average_reward_step_size", False),
     ("average_reward_step_size", -0.01),
+    ("average_reward_step_size", 3.5e38),
     ("average_reward_step_size", "0.01"),
     ("average_reward_step_size", None),
     ("trace_decay", float("nan")),
@@ -309,7 +313,6 @@ _INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
     ("epsilon_end", "0.01"),
     ("epsilon_end", None),
     ("epsilon_decay_steps", -1),
-    ("epsilon_decay_steps", 2**31 - 1),
     ("epsilon_decay_steps", 2**31),
     ("epsilon_decay_steps", True),
     ("epsilon_decay_steps", False),
@@ -357,13 +360,13 @@ def test_step6_fields_preserve_legal_endpoints() -> None:
         trace_decay=1.0,
         epsilon_start=1.0,
         epsilon_end=1.0,
-        epsilon_decay_steps=2**31 - 2,
+        epsilon_decay_steps=2**31 - 1,
     )
     make_step6_differential_sarsa_agent(upper)
     assert upper.trace_decay == 1.0
     assert upper.epsilon_start == 1.0
     assert upper.epsilon_end == 1.0
-    assert upper.epsilon_decay_steps == 2**31 - 2
+    assert upper.epsilon_decay_steps == 2**31 - 1
 
 
 def test_step6_fields_canonicalize_nonbuiltin_numbers() -> None:
@@ -381,7 +384,7 @@ def test_step6_fields_canonicalize_nonbuiltin_numbers() -> None:
     payload = config.to_dict()
     json.dumps(payload, allow_nan=False)
     assert config.n_actions == 3
-    assert config.q_step_size == 0.05
+    assert config.q_step_size == float(np.float32(0.05))
     assert config.epsilon_decay_steps == 100
     assert type(payload["n_actions"]) is int
     assert type(payload["epsilon_decay_steps"]) is int
@@ -391,6 +394,81 @@ def test_step6_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert type(payload["epsilon_start"]) is float
     assert type(payload["epsilon_end"]) is float
     assert agent.config.n_actions == 3
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("q_step_size", Fraction(-1, 10**400)),
+        ("average_reward_step_size", Fraction(-1, 10**400)),
+        ("trace_decay", Fraction(-1, 10**400)),
+        ("trace_decay", Fraction(10**400 + 1, 10**400)),
+        ("epsilon_start", Fraction(-1, 10**400)),
+        ("epsilon_start", Fraction(10**400 + 1, 10**400)),
+        ("epsilon_end", Fraction(-1, 10**400)),
+        ("epsilon_end", Fraction(10**400 + 1, 10**400)),
+    ],
+)
+def test_step6_fields_enforce_exact_scientific_domains(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step6DifferentialSARSAConfig(**{field: value})
+
+
+def test_step6_float32_narrowing_avoids_longdouble_double_rounding() -> None:
+    overflow_midpoint = np.ldexp(
+        np.longdouble(2) - np.ldexp(np.longdouble(1), -24),
+        127,
+    )
+    largest_finite_input = np.nextafter(
+        overflow_midpoint,
+        np.longdouble("-inf"),
+    )
+
+    config = Step6DifferentialSARSAConfig(q_step_size=largest_finite_input)
+    agent = make_step6_differential_sarsa_agent(config)
+
+    assert bool(np.isfinite(np.asarray(config.q_step_size, dtype=np.float32)))
+    assert agent.config.q_step_size == config.q_step_size
+
+
+def test_step6_float32_underflow_canonicalizes_to_legal_zero_endpoint() -> None:
+    config = Step6DifferentialSARSAConfig(
+        q_step_size=1e-50,
+        average_reward_step_size=np.longdouble("1e-50"),
+        epsilon_start=1e-50,
+        epsilon_end=np.longdouble("1e-50"),
+    )
+
+    assert config.q_step_size == 0.0
+    assert config.average_reward_step_size == 0.0
+    assert config.epsilon_start == 0.0
+    assert config.epsilon_end == 0.0
+    assert run_step6_smoke(config, steps=3, feature_dim=2).finite
+
+
+def test_step6_smoke_health_gate_reports_any_refused_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_run = step6_module.run_differential_sarsa_from_arrays
+
+    def _refuse_updates(*args: Any, **kwargs: Any) -> Any:
+        result = original_run(*args, **kwargs)
+        return result.replace(
+            updates_applied=result.updates_applied.at[0].set(False)
+        )
+
+    monkeypatch.setattr(
+        step6_module,
+        "run_differential_sarsa_from_arrays",
+        _refuse_updates,
+    )
+
+    result = run_step6_smoke(steps=3, feature_dim=2)
+
+    assert not result.finite
 
 
 def test_step7_dyna_facade_roundtrip_one_step_and_smoke() -> None:


### PR DESCRIPTION
Closes #278.

## What changed

`Step6DifferentialSARSAConfig` now validates dimensions, counters, and
scientific scalars in their actual execution domains. Float32 values use the
shared exact-ratio `round_real_to_float32` helper, so exact `Fraction`
midpoints cannot double-round through binary64. Overflow is rejected, exact
host-side ranges are checked before narrowing, and legal non-negative
underflow is canonicalized to zero.

Built-in JSON scalars retain stable roundtrips while non-built-in reals are
canonicalized to the execution value. `n_actions` and
`epsilon_decay_steps` accept the inclusive signed-int32 endpoint used by
their sinks. Smoke health requires every update to have applied.

## Scope

- `alberta_framework/steps/step6.py`
- `tests/test_step5_step6_production.py`

The prior main conflict was resolved by preserving both Step 5 and Step 6
coverage, then rebasing onto current main. The shared converter comes from
main; core differential SARSA and frozen evidence sources are unchanged.

## Exact-head verification

Verified head: `b8035bf64d5ad88939b739260f0f0bdc7287c37b`  
Base: `bfd79627c752b3bdcfaf3688bb7872e440b10faa`

- focused Step 5/6 production suite: **141 passed**;
- affected differential-SARSA and Step 7–9 consumer panel: **423 passed**;
- exact-head Fraction/underflow/double-rounding/health subset after the final
  disjoint main rebase: **8 passed**;
- full Ruff: **passed**;
- strict mypy: **no issues in 164 source files**;
- `git diff --check`: clean;
- exact-head CI run `31942540695`: **20/20 passed**.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance
claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: google / gemini-3.7-flash
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported