### PR TITLE
fix(step1): reject illegal kernel facade config

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -24,6 +24,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, RMSprop
 from alberta_framework.core.learners import LinearLearner, run_learning_loop
 from alberta_framework.core.normalizers import (
@@ -65,16 +66,16 @@ _VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
 
 def _require_real(name: str, value: object) -> tuple[float, float]:
     """Return a JSON scalar and the value consumed by float32 JAX sinks."""
-
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
     try:
-        with np.errstate(invalid="ignore", over="ignore", under="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32)
+        narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+    if not math.isfinite(narrowed):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed, narrowed
     try:
         number = float(value)
     except (OverflowError, TypeError, ValueError):

--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -21,6 +21,7 @@ from typing import Any, Literal, cast
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, RMSprop
@@ -62,33 +63,62 @@ _VALID_NORMALIZERS: frozenset[str] = frozenset({"none", "ema", "welford", "strea
 _VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
 
 
-def _require_real(name: str, value: object) -> float:
+def _require_real(name: str, value: object) -> tuple[float, float]:
+    """Return a JSON scalar and the value consumed by float32 JAX sinks."""
+
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
+    try:
+        with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+            narrowed = np.asarray(value, dtype=np.float32)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must be a finite real number, got {value!r}") from None
     if not math.isfinite(number):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+
+    # Preserve ordinary built-in/NumPy-float serialization when it narrows to
+    # exactly the checked sink value.  Extended-precision inputs at a rounding
+    # boundary must instead retain the direct float32 value: routing them
+    # through binary64 can double-round a finite float32 to infinity.
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number, float(narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    if value < 0.0 or not value <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    number, _ = _require_real(name, value)
     return number
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    if value < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
+    number, _ = _require_real(name, value)
     return number
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number <= 0.0:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    if value <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
+    number, narrowed = _require_real(name, value)
+    if narrowed <= 0.0:
+        raise ValueError(f"{name} must remain positive in float32, got {value!r}")
     return number
 
 
@@ -151,6 +181,9 @@ def _validate_step1_config(config: Step1KernelConfig) -> None:
     )
     object.__setattr__(config, "feature_dim", feature_dim)
     object.__setattr__(config, "num_relevant", num_relevant)
+    object.__setattr__(config, "optimizer", config.optimizer.lower())
+    object.__setattr__(config, "normalizer", config.normalizer.lower())
+    object.__setattr__(config, "stream", config.stream.lower())
     object.__setattr__(config, "step_size", step_size)
     object.__setattr__(config, "meta_step_size", meta_step_size)
     object.__setattr__(config, "drift_rate_w", drift_rate_w)

--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -14,7 +14,9 @@ paper-scale Step 1 claims require multi-seed optimizer/normalizer grid sweeps
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import jax.numpy as jnp
@@ -53,6 +55,111 @@ Step1OptimizerName = Literal[
 Step1NormalizerName = Literal["none", "ema", "welford", "streaming_batch"]
 Step1StreamName = Literal["alberta", "xdist_shift"]
 
+_VALID_OPTIMIZERS: frozenset[str] = frozenset(
+    {"lms", "idbd", "autostep", "autostep_gtd", "adagain", "adam", "rmsprop", "nadaline"}
+)
+_VALID_NORMALIZERS: frozenset[str] = frozenset({"none", "ema", "welford", "streaming_batch"})
+_VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return number
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return number
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    exclusive_maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if exclusive_maximum is not None and number >= exclusive_maximum:
+        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    return number
+
+
+def _validate_step1_config(config: Step1KernelConfig) -> None:
+    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
+    num_relevant = _require_int("num_relevant", config.num_relevant, minimum=1)
+    if num_relevant > feature_dim:
+        raise ValueError(
+            f"num_relevant ({num_relevant}) must be <= feature_dim ({feature_dim})"
+        )
+    if not isinstance(config.optimizer, str) or config.optimizer.lower() not in _VALID_OPTIMIZERS:
+        raise ValueError(
+            f"unknown Step 1 optimizer {config.optimizer!r}; "
+            f"expected one of {sorted(_VALID_OPTIMIZERS)}"
+        )
+    if (
+        not isinstance(config.normalizer, str)
+        or config.normalizer.lower() not in _VALID_NORMALIZERS
+    ):
+        raise ValueError(
+            f"unknown Step 1 normalizer {config.normalizer!r}; "
+            f"expected one of {sorted(_VALID_NORMALIZERS)}"
+        )
+    if not isinstance(config.stream, str) or config.stream.lower() not in _VALID_STREAMS:
+        raise ValueError(
+            f"unknown Step 1 stream {config.stream!r}; "
+            f"expected one of {sorted(_VALID_STREAMS)}"
+        )
+    step_size = _require_nonnegative_real("step_size", config.step_size)
+    meta_step_size = _require_nonnegative_real("meta_step_size", config.meta_step_size)
+    drift_rate_w = _require_nonnegative_real("drift_rate_w", config.drift_rate_w)
+    drift_rate_b = _require_nonnegative_real("drift_rate_b", config.drift_rate_b)
+    noise_std = _require_nonnegative_real("noise_std", config.noise_std)
+    feature_std = _require_positive_real("feature_std", config.feature_std)
+    ema_decay = _require_unit_interval("ema_decay", config.ema_decay)
+    streaming_batch_momentum = _require_unit_interval(
+        "streaming_batch_momentum",
+        config.streaming_batch_momentum,
+    )
+    object.__setattr__(config, "feature_dim", feature_dim)
+    object.__setattr__(config, "num_relevant", num_relevant)
+    object.__setattr__(config, "step_size", step_size)
+    object.__setattr__(config, "meta_step_size", meta_step_size)
+    object.__setattr__(config, "drift_rate_w", drift_rate_w)
+    object.__setattr__(config, "drift_rate_b", drift_rate_b)
+    object.__setattr__(config, "noise_std", noise_std)
+    object.__setattr__(config, "feature_std", feature_std)
+    object.__setattr__(config, "ema_decay", ema_decay)
+    object.__setattr__(config, "streaming_batch_momentum", streaming_batch_momentum)
+
 
 @dataclass(frozen=True)
 class Step1KernelConfig:
@@ -77,6 +184,10 @@ class Step1KernelConfig:
     feature_std: float = 1.0
     ema_decay: float = 0.99
     streaming_batch_momentum: float = 0.99
+
+    def __post_init__(self) -> None:
+        """Reject invalid hyperparameters and canonicalize scalars."""
+        _validate_step1_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -21,6 +21,7 @@ from alberta_framework.steps import (
     Step2StrictDigitReadoutConfig,
     Step2TemporalContextConfig,
     make_step1_learner,
+    make_step1_optimizer,
     make_step1_stream,
     make_step2_hybrid_learner,
     make_step2_learner,
@@ -89,6 +90,26 @@ def test_step1_kernel_rejects_unpublished_auto_alias() -> None:
 def test_step1_kernel_rejects_misspelled_adagain_alias() -> None:
     with pytest.raises(ValueError, match="optimizer"):
         Step1KernelConfig(optimizer="adagiven")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("optimizer", "LMS", "lms"),
+        ("normalizer", "EMA", "ema"),
+        ("stream", "ALBERTA", "alberta"),
+    ],
+)
+def test_step1_kernel_canonicalizes_supported_enum_spellings(
+    field: str,
+    value: object,
+    expected: str,
+) -> None:
+    config = Step1KernelConfig(**{field: value})
+
+    assert getattr(config, field) == expected
+    make_step1_learner(config)
+    make_step1_stream(config)
 
 
 _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
@@ -224,8 +245,6 @@ def test_step1_fields_preserve_legal_endpoints() -> None:
 
 
 def test_step1_fields_canonicalize_nonbuiltin_numbers() -> None:
-    import numpy as np
-
     value = np.float64(0.05)
     config = Step1KernelConfig(
         feature_dim=np.int64(10),
@@ -254,6 +273,75 @@ def test_step1_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert type(payload["feature_std"]) is float
     assert type(payload["ema_decay"]) is float
     assert type(payload["streaming_batch_momentum"]) is float
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "step_size",
+        "meta_step_size",
+        "drift_rate_w",
+        "drift_rate_b",
+        "noise_std",
+        "feature_std",
+    ],
+)
+def test_step1_float32_consumed_fields_reject_finite_wide_overflow(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step1KernelConfig(**{field: 1e100})
+
+
+def test_step1_positive_float32_field_rejects_positive_to_zero_collapse() -> None:
+    with pytest.raises(ValueError, match="feature_std"):
+        Step1KernelConfig(feature_std=1e-50)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("step_size", Fraction(-1, 10**1000)),
+        ("meta_step_size", Fraction(-1, 10**1000)),
+        ("drift_rate_w", Fraction(-1, 10**1000)),
+        ("drift_rate_b", Fraction(-1, 10**1000)),
+        ("noise_std", Fraction(-1, 10**1000)),
+        ("feature_std", Fraction(1, 10**1000)),
+        ("ema_decay", Fraction(-1, 10**1000)),
+        ("ema_decay", Fraction(10**1000 + 1, 10**1000)),
+        ("streaming_batch_momentum", Fraction(-1, 10**1000)),
+        (
+            "streaming_batch_momentum",
+            Fraction(10**1000 + 1, 10**1000),
+        ),
+    ],
+)
+def test_step1_fields_check_exact_domains_before_float_conversion(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step1KernelConfig(**{field: value})
+
+
+def test_step1_fields_wrap_real_conversion_overflow_as_config_error() -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        Step1KernelConfig(step_size=Fraction(10**1000, 1))
+
+
+def test_step1_field_uses_direct_float32_narrowing_at_overflow_boundary() -> None:
+    overflow_midpoint = np.ldexp(
+        np.longdouble(2) - np.ldexp(np.longdouble(1), -24),
+        127,
+    )
+    largest_finite_input = np.nextafter(
+        overflow_midpoint,
+        np.longdouble("-inf"),
+    )
+
+    config = Step1KernelConfig(optimizer="lms", step_size=largest_finite_input)
+    optimizer = make_step1_optimizer(config)
+
+    assert bool(np.isfinite(np.asarray(config.step_size, dtype=np.float32)))
+    assert optimizer.to_config()["step_size"] == config.step_size
 
 
 def test_step2_kernel_factory_and_smoke_are_finite() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -82,19 +82,178 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
 
 
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:
-    config = Step1KernelConfig(optimizer="auto")  # type: ignore[arg-type]
-    try:
-        make_step1_learner(config)
-    except ValueError as exc:
-        assert "unknown Step 1 optimizer" in str(exc)
-    else:
-        raise AssertionError("expected unpublished Auto alias to be rejected")
+    with pytest.raises(ValueError, match="optimizer"):
+        Step1KernelConfig(optimizer="auto")  # type: ignore[arg-type]
 
 
 def test_step1_kernel_rejects_misspelled_adagain_alias() -> None:
-    config = Step1KernelConfig(optimizer="adagiven")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="unknown Step 1 optimizer"):
-        make_step1_learner(config)
+    with pytest.raises(ValueError, match="optimizer"):
+        Step1KernelConfig(optimizer="adagiven")  # type: ignore[arg-type]
+
+
+_INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("feature_dim", 0),
+    ("feature_dim", -1),
+    ("feature_dim", True),
+    ("feature_dim", False),
+    ("feature_dim", "20"),
+    ("feature_dim", 20.5),
+    ("feature_dim", float("nan")),
+    ("feature_dim", float("inf")),
+    ("feature_dim", None),
+    ("num_relevant", 0),
+    ("num_relevant", -1),
+    ("num_relevant", True),
+    ("num_relevant", False),
+    ("num_relevant", "5"),
+    ("num_relevant", 5.5),
+    ("num_relevant", float("nan")),
+    ("num_relevant", float("inf")),
+    ("num_relevant", None),
+    ("optimizer", "unknown_opt"),
+    ("optimizer", 123),
+    ("optimizer", None),
+    ("normalizer", "unknown_norm"),
+    ("normalizer", 123),
+    ("normalizer", None),
+    ("stream", "unknown_stream"),
+    ("stream", 123),
+    ("stream", None),
+    ("step_size", float("nan")),
+    ("step_size", float("inf")),
+    ("step_size", float("-inf")),
+    ("step_size", True),
+    ("step_size", False),
+    ("step_size", -1.0),
+    ("step_size", "0.01"),
+    ("step_size", None),
+    ("meta_step_size", float("nan")),
+    ("meta_step_size", float("inf")),
+    ("meta_step_size", True),
+    ("meta_step_size", False),
+    ("meta_step_size", -0.01),
+    ("drift_rate_w", float("nan")),
+    ("drift_rate_w", float("inf")),
+    ("drift_rate_w", True),
+    ("drift_rate_w", False),
+    ("drift_rate_w", -0.001),
+    ("drift_rate_b", float("nan")),
+    ("drift_rate_b", float("inf")),
+    ("drift_rate_b", True),
+    ("drift_rate_b", False),
+    ("drift_rate_b", -0.001),
+    ("noise_std", float("nan")),
+    ("noise_std", float("inf")),
+    ("noise_std", True),
+    ("noise_std", False),
+    ("noise_std", -1.0),
+    ("feature_std", float("nan")),
+    ("feature_std", float("inf")),
+    ("feature_std", True),
+    ("feature_std", False),
+    ("feature_std", 0.0),
+    ("feature_std", -1.0),
+    ("feature_std", "1.0"),
+    ("feature_std", None),
+    ("ema_decay", float("nan")),
+    ("ema_decay", float("inf")),
+    ("ema_decay", True),
+    ("ema_decay", False),
+    ("ema_decay", -0.1),
+    ("ema_decay", 1.1),
+    ("ema_decay", "0.99"),
+    ("streaming_batch_momentum", float("nan")),
+    ("streaming_batch_momentum", float("inf")),
+    ("streaming_batch_momentum", True),
+    ("streaming_batch_momentum", False),
+    ("streaming_batch_momentum", -0.1),
+    ("streaming_batch_momentum", 1.1),
+    ("streaming_batch_momentum", "0.99"),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP1_FIELDS)
+def test_step1_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step1KernelConfig(**{field: value})
+
+
+def test_step1_num_relevant_exceeding_feature_dim_raises() -> None:
+    with pytest.raises(ValueError, match="num_relevant"):
+        Step1KernelConfig(feature_dim=4, num_relevant=5)
+
+
+def test_step1_fields_preserve_legal_endpoints() -> None:
+    config = Step1KernelConfig(
+        feature_dim=1,
+        num_relevant=1,
+        optimizer="lms",
+        normalizer="none",
+        stream="alberta",
+        step_size=0.0,
+        meta_step_size=0.0,
+        drift_rate_w=0.0,
+        drift_rate_b=0.0,
+        noise_std=0.0,
+        feature_std=1e-12,
+        ema_decay=0.0,
+        streaming_batch_momentum=0.0,
+    )
+    make_step1_learner(config)
+    stream = make_step1_stream(config)
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step1KernelConfig.from_dict(payload)
+    assert restored.feature_dim == 1
+    assert restored.num_relevant == 1
+    assert restored.step_size == 0.0
+    assert restored.feature_std == 1e-12
+    assert restored.ema_decay == 0.0
+    assert restored.streaming_batch_momentum == 0.0
+    assert stream.feature_dim == 1
+
+    upper = Step1KernelConfig(
+        feature_dim=10,
+        num_relevant=10,
+        ema_decay=1.0,
+        streaming_batch_momentum=1.0,
+    )
+    make_step1_learner(upper)
+    assert upper.ema_decay == 1.0
+    assert upper.streaming_batch_momentum == 1.0
+
+
+def test_step1_fields_canonicalize_nonbuiltin_numbers() -> None:
+    import numpy as np
+
+    value = np.float64(0.05)
+    config = Step1KernelConfig(
+        feature_dim=np.int64(10),
+        num_relevant=np.int64(3),
+        step_size=value,
+        meta_step_size=value,
+        drift_rate_w=value,
+        drift_rate_b=value,
+        noise_std=value,
+        feature_std=np.float64(1.0),
+        ema_decay=value,
+        streaming_batch_momentum=value,
+    )
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert config.feature_dim == 10
+    assert config.num_relevant == 3
+    assert config.step_size == 0.05
+    assert type(payload["feature_dim"]) is int
+    assert type(payload["num_relevant"]) is int
+    assert type(payload["step_size"]) is float
+    assert type(payload["meta_step_size"]) is float
+    assert type(payload["drift_rate_w"]) is float
+    assert type(payload["drift_rate_b"]) is float
+    assert type(payload["noise_std"]) is float
+    assert type(payload["feature_std"]) is float
+    assert type(payload["ema_decay"]) is float
+    assert type(payload["streaming_batch_momentum"]) is float
 
 
 def test_step2_kernel_factory_and_smoke_are_finite() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -344,6 +344,37 @@ def test_step1_field_uses_direct_float32_narrowing_at_overflow_boundary() -> Non
     assert optimizer.to_config()["step_size"] == config.step_size
 
 
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (-Fraction(1, 2**80), 1.0),
+        (Fraction(0), 1.0),
+        (
+            Fraction(1, 2**80),
+            float(np.nextafter(np.float32(1.0), np.float32(np.inf))),
+        ),
+    ],
+)
+def test_step1_fraction_midpoint_rounds_once_to_nearest_even(
+    offset: Fraction,
+    expected: float,
+) -> None:
+    midpoint = Fraction(1) + Fraction(1, 2**24)
+    config = Step1KernelConfig(optimizer="lms", step_size=midpoint + offset)
+
+    assert config.step_size == expected
+
+
+def test_step1_fraction_float32_overflow_midpoint_is_exact() -> None:
+    maximum = Fraction((2**24 - 1) * 2**104)
+    overflow_midpoint = maximum + 2**103
+
+    just_below = Step1KernelConfig(optimizer="lms", step_size=overflow_midpoint - 1)
+    assert just_below.step_size == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match="step_size"):
+        Step1KernelConfig(optimizer="lms", step_size=overflow_midpoint)
+
+
 def test_step2_kernel_factory_and_smoke_are_finite() -> None:
     config = Step2KernelConfig(feature_dim=4, n_heads=2, hidden_sizes=(8,))
     learner = make_step2_learner(config)


### PR DESCRIPTION
Closes #280.

## What changed

`Step1KernelConfig` now validates dimensions, public enum names, and every
scientific scalar before constructing learners and streams. Float32 execution
values use the shared exact-ratio `round_real_to_float32` helper, rejecting
overflow and coercive/non-real values without binary64 double rounding.

Legal zero/one endpoints and built-in/NumPy JSON behavior remain intact.
Accepted non-built-in reals such as `Fraction` are canonicalized to their
exact float32 execution value, and strictly positive `feature_std` values
that collapse to zero are rejected.

## Scope

- `alberta_framework/steps/step1.py`
- `tests/test_production_steps.py`

The shared converter comes from main; core optimizers, normalizers, streams,
frozen evidence sources, and artifacts are unchanged.

## Exact-head verification

Verified head: `0ed413a6f7a72eb2cc397a1904e8f3602fd315e9`  
Base: `bfd79627c752b3bdcfaf3688bb7872e440b10faa`

- exact-head focused Step 1/2 production suite: **300 passed**;
- affected learner/optimizer/normalizer/stream panel: **209 passed**;
- exact-head Fraction/overflow/execution subset: **5 passed**;
- full Ruff: **passed**;
- strict mypy: **no issues in 164 source files**;
- `git diff --check`: clean;
- exact-head CI run `31942541121`: **20/20 passed**.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance
claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: google / gemini-3.7-flash
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported