### PR TITLE
fix(option-value-duration): saturate lifetime counters instead of wrapping

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -40,6 +40,13 @@ from jaxtyping import Bool, Float, Int
 REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
+_INT32_MAX = 2_147_483_647
+
+
+def _saturating_increment(value: Array) -> Array:
+    """Increment an int32 counter without wrapping at its lifetime limit."""
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -322,8 +329,10 @@ class OptionValueDurationLearner:
         update_applied = jnp.any(head_updates_applied)
         proposed_state = state.replace(
             weights=state.weights.at[safe_option_index].set(updated_option_weights),
-            option_update_counts=state.option_update_counts.at[safe_option_index].add(1),
-            step_count=state.step_count + 1,
+            option_update_counts=state.option_update_counts.at[safe_option_index].set(
+                _saturating_increment(state.option_update_counts[safe_option_index])
+            ),
+            step_count=_saturating_increment(state.step_count),
         )
         new_state = jax.lax.cond(
             update_applied,

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -107,6 +107,29 @@ def test_two_head_td_targets_and_updates_match_exact_analytic_values() -> None:
     assert int(result.state.step_count) == 1
 
 
+def test_applied_update_saturates_lifetime_counters_without_wrapping() -> None:
+    learner = OptionValueDurationLearner(1)
+    int32_max = jnp.iinfo(jnp.int32).max
+    state = learner.init(1).replace(  # type: ignore[attr-defined]
+        option_update_counts=jnp.array([int32_max], dtype=jnp.int32),
+        step_count=jnp.array(int32_max, dtype=jnp.int32),
+    )
+
+    result = learner.update(
+        state,
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array(0.0, dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert not bool(jnp.array_equal(result.state.weights, state.weights))
+    assert int(result.state.option_update_counts[0]) == int32_max
+    assert int(result.state.step_count) == int32_max
+
+
 def test_termination_discount_zeros_bootstrap_and_no_average_reward_is_subtracted() -> None:
     learner = OptionValueDurationLearner(
         1,


### PR DESCRIPTION
Closes #283.

## What changed

`OptionValueDurationLearner.update` stored lifetime accounting counters (`option_update_counts`, `step_count`) as `int32`, but incremented them with ordinary addition. A valid update at `INT32_MAX` wrapped both counters to `INT32_MIN`, corrupting the lifetime measurement while the weight update itself was still applied normally — the wrap is silent, not a crash.

confirmed directly before touching the source:

```text
update_applied=True
option_update_count_before=2147483647
option_update_count_after=-2147483648
step_count_before=2147483647
step_count_after=-2147483648
```

fix: both counters now saturate at `INT32_MAX` via a JAX-compatible `_saturating_increment` helper, matching the existing saturating-increment pattern already used elsewhere in this codebase (`alberta_framework/core/average_reward.py`'s `_saturating_int32_increment`).

## Reachability

`OptionValueDurationLearner`, its state/result types, and `run_option_value_duration_from_arrays` are imported and listed in `alberta_framework/core/__init__.py`. The package root `alberta_framework/__init__.py` does not re-export this symbol. The public array runner accepts real observation, option-index, reward, next-observation, and continuation-discount arrays and invokes `learner.update` inside `jax.lax.scan`; direct calls to the exported learner are also supported.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_option_value_duration.py -q -o addopts=""
7 passed in 0.94s

$ .venv/bin/python -m ruff check alberta_framework/core/option_value_duration.py tests/test_option_value_duration.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_applied_update_saturates_lifetime_counters_without_wrapping`, seeding both counters at `INT32_MAX`, applying a real update, and asserting the counters stay pinned at `INT32_MAX` **and** the learning weights genuinely change — proving saturation doesn't silently suppress a valid update.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/core/option_value_duration.py`, kept the test), reran — failed with `assert -2147483648 == 2147483647`, the exact wraparound. Restored the fix, 7/7 green again.

## Evidence

<!-- evidence-head -->
a88672eea9da9be6fdf293934394649a7923d29c

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_option_value_duration.py -q -o addopts="" -k test_applied_update_saturates_lifetime_counters_without_wrapping
assert -2147483648 == 2147483647
1 failed, 6 deselected in 0.57s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_option_value_duration.py -q -o addopts=""
7 passed in 1.00s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp
from alberta_framework.core.option_value_duration import OptionValueDurationLearner
learner = OptionValueDurationLearner(1)
int32_max = jnp.iinfo(jnp.int32).max
state = learner.init(1).replace(option_update_counts=jnp.array([int32_max], dtype=jnp.int32), step_count=jnp.array(int32_max, dtype=jnp.int32))
result = learner.update(state, jnp.array([1.0], dtype=jnp.float32), jnp.array(0, dtype=jnp.int32), jnp.array(1.0, dtype=jnp.float32), jnp.array([1.0], dtype=jnp.float32), jnp.array(0.0, dtype=jnp.float32))
print('update_applied:', bool(result.update_applied))
print('weights_changed:', not bool(jnp.array_equal(result.state.weights, state.weights)))
print('option_update_count after:', int(result.state.option_update_counts[0]))
print('step_count after:', int(result.state.step_count))
"
update_applied: True
weights_changed: True
option_update_count after: 2147483647
step_count after: 2147483647
```
independently reproduced against the fixed head, and independently confirmed the reachability claim (`core/__init__.py` export, no top-level re-export) via `grep` before writing it up.

## Note on report integrity

The original Codex run's report claimed a commit SHA (`2abcc487855f080f46b05d1d8e419fe362fe8c19`) that does not actually exist in this repository (`git log` on that SHA returns `fatal: bad object`) — the same `.git` read-only restriction that blocks every other round's commit attempt applied here too, the report's claimed SHA was fabricated. Caught and discarded during independent re-verification; the SHA in this PR (`a88672eea9da9be6fdf293934394649a7923d29c`) is the real commit I made myself after independently reproducing, testing, and mutation-checking the diff from scratch.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the saturation behavior and the weight-still-changes invariant, verified the reachability claim directly, caught and discarded a fabricated commit SHA in the original report, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
