### PR TITLE
fix(step2): reject illegal kernel and memory facade configs

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -101,6 +101,7 @@ _STEP2_MEMORY_CONFIG_KEYS = frozenset(
         "bandwidth",
     }
 )
+_INT32_MAX = int(np.iinfo(np.int32).max)
 
 
 def _require_exact_keys(
@@ -165,32 +166,43 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
-    exclusive_maximum: int | None = None,
+    maximum: int | None = None,
 ) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    try:
+        number = int(value)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must be an integer, got {value!r}") from None
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     return number
 
 
 def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
-    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
-    n_heads = _require_int("n_heads", config.n_heads, minimum=1)
+    feature_dim = _require_int(
+        "feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX
+    )
+    n_heads = _require_int(
+        "n_heads", config.n_heads, minimum=1, maximum=_INT32_MAX
+    )
     if not isinstance(config.hidden_sizes, tuple):
         raise ValueError(
             f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}"
         )
     canonical_hidden: list[int] = []
     for h in config.hidden_sizes:
-        canonical_hidden.append(_require_int("hidden_sizes element", h, minimum=1))
+        canonical_hidden.append(
+            _require_int(
+                "hidden_sizes element", h, minimum=1, maximum=_INT32_MAX
+            )
+        )
     if not isinstance(config.stream, str) or config.stream not in _VALID_STEP2_STREAMS:
         raise ValueError(
             f"unknown Step 2 stream field {config.stream!r}; "
@@ -215,7 +227,12 @@ def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
             f"expected one of {sorted(_VALID_STEP2_LOSS_NORMALIZATIONS)}"
         )
     step_size = _require_nonnegative_real("step_size", config.step_size)
-    context_length = _require_int("context_length", config.context_length, minimum=1)
+    context_length = _require_int(
+        "context_length",
+        config.context_length,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     noise_std = _require_nonnegative_real("noise_std", config.noise_std)
     object.__setattr__(config, "feature_dim", feature_dim)
     object.__setattr__(config, "n_heads", n_heads)
@@ -226,14 +243,20 @@ def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
 
 
 def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -> None:
-    n_heads = _require_int("n_heads", config.n_heads, minimum=1)
+    n_heads = _require_int(
+        "n_heads", config.n_heads, minimum=1, maximum=_INT32_MAX
+    )
     if not isinstance(config.hidden_sizes, tuple):
         raise ValueError(
             f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}"
         )
     canonical_hidden: list[int] = []
     for h in config.hidden_sizes:
-        canonical_hidden.append(_require_int("hidden_sizes element", h, minimum=1))
+        canonical_hidden.append(
+            _require_int(
+                "hidden_sizes element", h, minimum=1, maximum=_INT32_MAX
+            )
+        )
     step_size = _require_nonnegative_real("step_size", config.step_size)
     object.__setattr__(config, "n_heads", n_heads)
     object.__setattr__(config, "hidden_sizes", tuple(canonical_hidden))
@@ -253,9 +276,18 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
 
 
 def _validate_step2_memory_config(config: Step2MemoryConfig) -> None:
-    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
-    n_classes = _require_int("n_classes", config.n_classes, minimum=2)
-    slots_per_class = _require_int("slots_per_class", config.slots_per_class, minimum=1)
+    feature_dim = _require_int(
+        "feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX
+    )
+    n_classes = _require_int(
+        "n_classes", config.n_classes, minimum=2, maximum=_INT32_MAX
+    )
+    slots_per_class = _require_int(
+        "slots_per_class",
+        config.slots_per_class,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     update_rate = _require_half_open_unit_interval("update_rate", config.update_rate)
     novelty_threshold = _require_nonnegative_real(
         "novelty_threshold",

--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -26,6 +26,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.associative_memory import (
     AssociativeFeatureFamily,
     AssociativeMemoryConfig,
@@ -124,11 +125,10 @@ def _require_real(name: str, value: object) -> Any:
 def _narrow_float32(name: str, value: Any) -> float:
     """Narrow exactly as the downstream JAX kernels do."""
     try:
-        with np.errstate(invalid="ignore", over="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32)
+        narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+    if not bool(np.isfinite(narrowed)):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
     if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
         return float(value)

--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -17,11 +17,14 @@ contracts are exercised in ``tests/test_prototype_memory.py`` and
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.associative_memory import (
@@ -57,6 +60,163 @@ Step2ReadoutMode = Literal[
 ]
 Step2HybridReadoutMode = Literal["linear_mse", "softmax_ce"]
 
+_VALID_STEP2_STREAMS: frozenset[str] = frozenset(
+    {"polynomial", "frequency", "compositional"}
+)
+_VALID_STEP2_READOUT_MODES: frozenset[str] = frozenset(
+    {
+        "linear_mse",
+        "softmax_ce",
+        "adaptive_simplex",
+        "factorized_simplex",
+        "adaptive_factorized_simplex",
+        "two_timescale_simplex",
+    }
+)
+_VALID_STEP2_LOSS_NORMALIZATIONS: frozenset[str] = frozenset(
+    {"target_structure", "target_density"}
+)
+
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
+_FLOAT32_MIN = -_FLOAT32_MAX
+
+
+def _require_real(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    if not _FLOAT32_MIN <= number <= _FLOAT32_MAX:
+        raise ValueError(f"{name} overflows float32 execution sink, got {value!r}")
+    return float(np.float32(number))
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 <= number <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return number
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if number <= 0.0:
+        raise ValueError(
+            f"{name} must be positive in float32 execution sink, got {value!r}"
+        )
+    return number
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    exclusive_maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if exclusive_maximum is not None and number >= exclusive_maximum:
+        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    return number
+
+
+def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
+    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
+    n_heads = _require_int("n_heads", config.n_heads, minimum=1)
+    if not isinstance(config.hidden_sizes, tuple):
+        raise ValueError(
+            f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}"
+        )
+    canonical_hidden: list[int] = []
+    for h in config.hidden_sizes:
+        canonical_hidden.append(_require_int("hidden_sizes element", h, minimum=1))
+    if not isinstance(config.stream, str) or config.stream.lower() not in _VALID_STEP2_STREAMS:
+        raise ValueError(
+            f"unknown Step 2 stream {config.stream!r}; "
+            f"expected one of {sorted(_VALID_STEP2_STREAMS)}"
+        )
+    if (
+        not isinstance(config.readout_mode, str)
+        or config.readout_mode.lower() not in _VALID_STEP2_READOUT_MODES
+    ):
+        raise ValueError(
+            f"unknown Step 2 readout_mode {config.readout_mode!r}; "
+            f"expected one of {sorted(_VALID_STEP2_READOUT_MODES)}"
+        )
+    if (
+        not isinstance(config.loss_normalization, str)
+        or config.loss_normalization.lower() not in _VALID_STEP2_LOSS_NORMALIZATIONS
+    ):
+        raise ValueError(
+            f"unknown Step 2 loss_normalization {config.loss_normalization!r}; "
+            f"expected one of {sorted(_VALID_STEP2_LOSS_NORMALIZATIONS)}"
+        )
+    step_size = _require_nonnegative_real("step_size", config.step_size)
+    context_length = _require_int("context_length", config.context_length, minimum=1)
+    noise_std = _require_nonnegative_real("noise_std", config.noise_std)
+    object.__setattr__(config, "feature_dim", feature_dim)
+    object.__setattr__(config, "n_heads", n_heads)
+    object.__setattr__(config, "hidden_sizes", tuple(canonical_hidden))
+    object.__setattr__(config, "step_size", step_size)
+    object.__setattr__(config, "context_length", context_length)
+    object.__setattr__(config, "noise_std", noise_std)
+
+
+def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -> None:
+    n_heads = _require_int("n_heads", config.n_heads, minimum=1)
+    if not isinstance(config.hidden_sizes, tuple):
+        raise ValueError(
+            f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}"
+        )
+    canonical_hidden: list[int] = []
+    for h in config.hidden_sizes:
+        canonical_hidden.append(_require_int("hidden_sizes element", h, minimum=1))
+    step_size = _require_nonnegative_real("step_size", config.step_size)
+    object.__setattr__(config, "n_heads", n_heads)
+    object.__setattr__(config, "hidden_sizes", tuple(canonical_hidden))
+    object.__setattr__(config, "step_size", step_size)
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    number = _require_real(name, value)
+    if not 0.0 < number <= 1.0:
+        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+    return number
+
+
+def _validate_step2_memory_config(config: Step2MemoryConfig) -> None:
+    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
+    n_classes = _require_int("n_classes", config.n_classes, minimum=2)
+    slots_per_class = _require_int("slots_per_class", config.slots_per_class, minimum=1)
+    update_rate = _require_half_open_unit_interval("update_rate", config.update_rate)
+    novelty_threshold = _require_nonnegative_real(
+        "novelty_threshold",
+        config.novelty_threshold,
+    )
+    bandwidth = _require_positive_real("bandwidth", config.bandwidth)
+    object.__setattr__(config, "feature_dim", feature_dim)
+    object.__setattr__(config, "n_classes", n_classes)
+    object.__setattr__(config, "slots_per_class", slots_per_class)
+    object.__setattr__(config, "update_rate", update_rate)
+    object.__setattr__(config, "novelty_threshold", novelty_threshold)
+    object.__setattr__(config, "bandwidth", bandwidth)
+
 
 @dataclass(frozen=True)
 class Step2KernelConfig:
@@ -73,6 +233,10 @@ class Step2KernelConfig:
     )
     context_length: int = 128
     noise_std: float = 0.05
+
+    def __post_init__(self) -> None:
+        """Reject invalid parameters and canonicalize scalars."""
+        _validate_step2_kernel_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -102,6 +266,10 @@ class Step2StrictDigitReadoutConfig:
     hidden_sizes: tuple[int, ...] = (64, 64)
     step_size: float = 0.018
 
+    def __post_init__(self) -> None:
+        """Reject invalid parameters and canonicalize scalars."""
+        _validate_step2_strict_digit_config(self)
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
@@ -129,6 +297,10 @@ class Step2MemoryConfig:
     update_rate: float = 0.3
     novelty_threshold: float = 0.08
     bandwidth: float = 0.01
+
+    def __post_init__(self) -> None:
+        """Reject invalid parameters and canonicalize scalars."""
+        _validate_step2_memory_config(self)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -17,7 +17,6 @@ contracts are exercised in ``tests/test_prototype_memory.py`` and
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
 from numbers import Integral, Real
 from typing import Any, Literal, cast
@@ -76,38 +75,84 @@ _VALID_STEP2_READOUT_MODES: frozenset[str] = frozenset(
 _VALID_STEP2_LOSS_NORMALIZATIONS: frozenset[str] = frozenset(
     {"target_structure", "target_density"}
 )
+_STEP2_KERNEL_CONFIG_KEYS = frozenset(
+    {
+        "feature_dim",
+        "n_heads",
+        "hidden_sizes",
+        "stream",
+        "readout_mode",
+        "step_size",
+        "loss_normalization",
+        "context_length",
+        "noise_std",
+    }
+)
+_STEP2_STRICT_DIGIT_CONFIG_KEYS = frozenset(
+    {"n_heads", "hidden_sizes", "step_size"}
+)
+_STEP2_MEMORY_CONFIG_KEYS = frozenset(
+    {
+        "feature_dim",
+        "n_classes",
+        "slots_per_class",
+        "update_rate",
+        "novelty_threshold",
+        "bandwidth",
+    }
+)
 
-_FLOAT32_MAX = float(np.finfo(np.float32).max)
-_FLOAT32_MIN = -_FLOAT32_MAX
+
+def _require_exact_keys(
+    config_name: str,
+    payload: dict[str, object],
+    expected: frozenset[str],
+) -> None:
+    if set(payload) != expected:
+        raise ValueError(
+            f"{config_name} payload keys must be exactly {sorted(expected)!r}"
+        )
 
 
-def _require_real(name: str, value: object) -> float:
+def _require_real(name: str, value: object) -> Any:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    if not _FLOAT32_MIN <= number <= _FLOAT32_MAX:
-        raise ValueError(f"{name} overflows float32 execution sink, got {value!r}")
-    return float(np.float32(number))
+    return value
+
+
+def _narrow_float32(name: str, value: Any) -> float:
+    """Narrow exactly as the downstream JAX kernels do."""
+    try:
+        with np.errstate(invalid="ignore", over="ignore"):
+            narrowed = np.asarray(value, dtype=np.float32)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
+        return float(value)
+    return float(narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    original = _require_real(name, value)
+    if not 0.0 <= original <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    original = _require_real(name, value)
+    if original < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
+    original = _require_real(name, value)
+    if original <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    number = _narrow_float32(name, original)
     if number <= 0.0:
         raise ValueError(
             f"{name} must be positive in float32 execution sink, got {value!r}"
@@ -146,25 +191,27 @@ def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
     canonical_hidden: list[int] = []
     for h in config.hidden_sizes:
         canonical_hidden.append(_require_int("hidden_sizes element", h, minimum=1))
-    if not isinstance(config.stream, str) or config.stream.lower() not in _VALID_STEP2_STREAMS:
+    if not isinstance(config.stream, str) or config.stream not in _VALID_STEP2_STREAMS:
         raise ValueError(
-            f"unknown Step 2 stream {config.stream!r}; "
+            f"unknown Step 2 stream field {config.stream!r}; "
             f"expected one of {sorted(_VALID_STEP2_STREAMS)}"
         )
+    if config.stream == "polynomial" and feature_dim < 3:
+        raise ValueError("feature_dim must be at least 3 for the polynomial stream")
     if (
         not isinstance(config.readout_mode, str)
-        or config.readout_mode.lower() not in _VALID_STEP2_READOUT_MODES
+        or config.readout_mode not in _VALID_STEP2_READOUT_MODES
     ):
         raise ValueError(
-            f"unknown Step 2 readout_mode {config.readout_mode!r}; "
+            f"unknown Step 2 readout_mode field {config.readout_mode!r}; "
             f"expected one of {sorted(_VALID_STEP2_READOUT_MODES)}"
         )
     if (
         not isinstance(config.loss_normalization, str)
-        or config.loss_normalization.lower() not in _VALID_STEP2_LOSS_NORMALIZATIONS
+        or config.loss_normalization not in _VALID_STEP2_LOSS_NORMALIZATIONS
     ):
         raise ValueError(
-            f"unknown Step 2 loss_normalization {config.loss_normalization!r}; "
+            f"unknown Step 2 loss_normalization field {config.loss_normalization!r}; "
             f"expected one of {sorted(_VALID_STEP2_LOSS_NORMALIZATIONS)}"
         )
     step_size = _require_nonnegative_real("step_size", config.step_size)
@@ -194,9 +241,14 @@ def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 < number <= 1.0:
+    original = _require_real(name, value)
+    if not 0.0 < original <= 1.0:
         raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+    number = _narrow_float32(name, original)
+    if number <= 0.0:
+        raise ValueError(
+            f"{name} must remain positive in float32 execution sink, got {value!r}"
+        )
     return number
 
 
@@ -247,8 +299,10 @@ class Step2KernelConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step2KernelConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        _require_exact_keys(cls.__name__, payload, _STEP2_KERNEL_CONFIG_KEYS)
         config = dict(payload)
-        config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
+        if isinstance(config["hidden_sizes"], list):
+            config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         return cls(**cast(Any, config))
 
 
@@ -282,8 +336,10 @@ class Step2StrictDigitReadoutConfig:
         payload: dict[str, object],
     ) -> Step2StrictDigitReadoutConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        _require_exact_keys(cls.__name__, payload, _STEP2_STRICT_DIGIT_CONFIG_KEYS)
         config = dict(payload)
-        config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
+        if isinstance(config["hidden_sizes"], list):
+            config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         return cls(**cast(Any, config))
 
 
@@ -309,6 +365,7 @@ class Step2MemoryConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step2MemoryConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        _require_exact_keys(cls.__name__, payload, _STEP2_MEMORY_CONFIG_KEYS)
         return cls(**cast(Any, payload))
 
 

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -25,6 +25,7 @@ from alberta_framework.steps import (
     make_step2_hybrid_learner,
     make_step2_learner,
     make_step2_memory_learner,
+    make_step2_stream,
     make_step2_strict_digit_readout_learner,
     make_step2_temporal_context,
     make_step2_temporal_learner,
@@ -34,6 +35,8 @@ from alberta_framework.steps import (
 
 # The module is ~40 seconds serial on the supported development environment.
 pytestmark = pytest.mark.slow
+
+_INT32_MAX = int(np.iinfo(np.int32).max)
 
 
 def test_step1_kernel_factory_and_smoke_are_finite() -> None:
@@ -151,17 +154,20 @@ _INVALID_STEP2_KERNEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("feature_dim", float("nan")),
     ("feature_dim", float("inf")),
     ("feature_dim", None),
+    ("feature_dim", _INT32_MAX + 1),
     ("n_heads", 0),
     ("n_heads", -1),
     ("n_heads", True),
     ("n_heads", False),
     ("n_heads", "3"),
     ("n_heads", None),
+    ("n_heads", _INT32_MAX + 1),
     ("hidden_sizes", [32]),
     ("hidden_sizes", (0,)),
     ("hidden_sizes", (-1,)),
     ("hidden_sizes", (True,)),
     ("hidden_sizes", (32.5,)),
+    ("hidden_sizes", (_INT32_MAX + 1,)),
     ("stream", "unknown_stream"),
     ("readout_mode", "unknown_mode"),
     ("step_size", float("nan")),
@@ -179,6 +185,7 @@ _INVALID_STEP2_KERNEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("context_length", False),
     ("context_length", "128"),
     ("context_length", None),
+    ("context_length", _INT32_MAX + 1),
     ("noise_std", float("nan")),
     ("noise_std", float("inf")),
     ("noise_std", True),
@@ -200,6 +207,7 @@ _INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
     ("feature_dim", False),
     ("feature_dim", "784"),
     ("feature_dim", None),
+    ("feature_dim", _INT32_MAX + 1),
     ("n_classes", 1),
     ("n_classes", 0),
     ("n_classes", -1),
@@ -207,12 +215,14 @@ _INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_classes", False),
     ("n_classes", "10"),
     ("n_classes", None),
+    ("n_classes", _INT32_MAX + 1),
     ("slots_per_class", 0),
     ("slots_per_class", -1),
     ("slots_per_class", True),
     ("slots_per_class", False),
     ("slots_per_class", "20"),
     ("slots_per_class", None),
+    ("slots_per_class", _INT32_MAX + 1),
     ("update_rate", float("nan")),
     ("update_rate", float("inf")),
     ("update_rate", True),
@@ -359,12 +369,28 @@ def test_step2_configs_use_direct_float32_narrowing_without_double_rounding() ->
     ("field", "value"),
     [
         ("n_heads", 0),
+        ("n_heads", -1),
         ("n_heads", True),
+        ("n_heads", False),
+        ("n_heads", "10"),
+        ("n_heads", 10.5),
+        ("n_heads", None),
+        ("n_heads", _INT32_MAX + 1),
         ("hidden_sizes", [8]),
         ("hidden_sizes", (0,)),
+        ("hidden_sizes", (-1,)),
         ("hidden_sizes", (False,)),
+        ("hidden_sizes", (8.5,)),
+        ("hidden_sizes", (_INT32_MAX + 1,)),
         ("step_size", float("nan")),
+        ("step_size", float("inf")),
+        ("step_size", float("-inf")),
+        ("step_size", True),
+        ("step_size", False),
+        ("step_size", -1.0),
         ("step_size", 3.5e38),
+        ("step_size", "0.018"),
+        ("step_size", None),
         ("step_size", jnp.asarray(0.25)),
     ],
 )
@@ -374,6 +400,85 @@ def test_step2_strict_digit_config_rejects_malformed_fields(
 ) -> None:
     with pytest.raises(ValueError, match=field):
         Step2StrictDigitReadoutConfig(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        (Step2KernelConfig, "step_size"),
+        (Step2KernelConfig, "noise_std"),
+        (Step2StrictDigitReadoutConfig, "step_size"),
+        (Step2MemoryConfig, "update_rate"),
+        (Step2MemoryConfig, "novelty_threshold"),
+        (Step2MemoryConfig, "bandwidth"),
+    ],
+)
+def test_step2_real_conversion_overflow_is_a_value_error(
+    config_type: type[Any],
+    field: str,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        config_type(**{field: Fraction(10**1000, 1)})
+
+
+def test_step2_integer_fields_accept_int32_maximum() -> None:
+    kernel = Step2KernelConfig(
+        feature_dim=_INT32_MAX,
+        n_heads=_INT32_MAX,
+        hidden_sizes=(_INT32_MAX,),
+        stream="frequency",
+        context_length=_INT32_MAX,
+    )
+    strict = Step2StrictDigitReadoutConfig(
+        n_heads=_INT32_MAX,
+        hidden_sizes=(_INT32_MAX,),
+    )
+    memory = Step2MemoryConfig(
+        feature_dim=_INT32_MAX,
+        n_classes=_INT32_MAX,
+        slots_per_class=_INT32_MAX,
+    )
+
+    assert kernel.feature_dim == _INT32_MAX
+    assert kernel.n_heads == _INT32_MAX
+    assert kernel.hidden_sizes == (_INT32_MAX,)
+    assert kernel.context_length == _INT32_MAX
+    assert strict.n_heads == _INT32_MAX
+    assert strict.hidden_sizes == (_INT32_MAX,)
+    assert memory.feature_dim == _INT32_MAX
+    assert memory.n_classes == _INT32_MAX
+    assert memory.slots_per_class == _INT32_MAX
+
+
+def test_step2_context_length_int32_maximum_reaches_stream_step() -> None:
+    stream = make_step2_stream(Step2KernelConfig(context_length=_INT32_MAX))
+    state = stream.init(jr.key(0))
+
+    timestep, next_state = stream.step(state, jnp.asarray(0, dtype=jnp.int32))
+
+    assert timestep.observation.shape == (8,)
+    assert int(next_state.step_count) == 1
+
+
+def test_step2_strict_digit_config_canonical_json_roundtrip() -> None:
+    config = Step2StrictDigitReadoutConfig(
+        n_heads=np.int64(3),
+        hidden_sizes=(np.int64(8), np.int64(16)),
+        step_size=np.float64(0.018),
+    )
+
+    payload = json.loads(json.dumps(config.to_dict(), allow_nan=False))
+    restored = Step2StrictDigitReadoutConfig.from_dict(payload)
+
+    assert type(config.n_heads) is int
+    assert all(type(size) is int for size in config.hidden_sizes)
+    assert type(config.step_size) is float
+    assert payload == {
+        "n_heads": 3,
+        "hidden_sizes": [8, 16],
+        "step_size": float(np.float32(0.018)),
+    }
+    assert restored == config
 
 
 @pytest.mark.parametrize(

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -4,9 +4,11 @@
 import json
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.cli import step1_smoke_main, step2_smoke_main
@@ -136,6 +138,179 @@ def test_step2_memory_factory_updates_fixed_budget_memory() -> None:
     assert int(jnp.sum(result.state.counts > 0.0)) == 1
     assert learner.config.to_config()["slots_per_class"] == 2
     assert config.to_dict()["n_classes"] == 3
+
+
+_INVALID_STEP2_KERNEL_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("feature_dim", 0),
+    ("feature_dim", -1),
+    ("feature_dim", True),
+    ("feature_dim", False),
+    ("feature_dim", "8"),
+    ("feature_dim", 8.5),
+    ("feature_dim", float("nan")),
+    ("feature_dim", float("inf")),
+    ("feature_dim", None),
+    ("n_heads", 0),
+    ("n_heads", -1),
+    ("n_heads", True),
+    ("n_heads", False),
+    ("n_heads", "3"),
+    ("n_heads", None),
+    ("hidden_sizes", [32]),
+    ("hidden_sizes", (0,)),
+    ("hidden_sizes", (-1,)),
+    ("hidden_sizes", (True,)),
+    ("hidden_sizes", (32.5,)),
+    ("stream", "unknown_stream"),
+    ("readout_mode", "unknown_mode"),
+    ("step_size", float("nan")),
+    ("step_size", float("inf")),
+    ("step_size", float("-inf")),
+    ("step_size", True),
+    ("step_size", False),
+    ("step_size", -1.0),
+    ("step_size", "0.03"),
+    ("step_size", None),
+    ("loss_normalization", "invalid_norm"),
+    ("context_length", 0),
+    ("context_length", -1),
+    ("context_length", True),
+    ("context_length", False),
+    ("context_length", "128"),
+    ("context_length", None),
+    ("noise_std", float("nan")),
+    ("noise_std", float("inf")),
+    ("noise_std", True),
+    ("noise_std", False),
+    ("noise_std", -1.0),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP2_KERNEL_FIELDS)
+def test_step2_kernel_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step2KernelConfig(**{field: value})
+
+
+_INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
+    ("feature_dim", 0),
+    ("feature_dim", -1),
+    ("feature_dim", True),
+    ("feature_dim", False),
+    ("feature_dim", "784"),
+    ("feature_dim", None),
+    ("n_classes", 1),
+    ("n_classes", 0),
+    ("n_classes", -1),
+    ("n_classes", True),
+    ("n_classes", False),
+    ("n_classes", "10"),
+    ("n_classes", None),
+    ("slots_per_class", 0),
+    ("slots_per_class", -1),
+    ("slots_per_class", True),
+    ("slots_per_class", False),
+    ("slots_per_class", "20"),
+    ("slots_per_class", None),
+    ("update_rate", float("nan")),
+    ("update_rate", float("inf")),
+    ("update_rate", True),
+    ("update_rate", False),
+    ("update_rate", 0.0),
+    ("update_rate", -0.1),
+    ("update_rate", 1.1),
+    ("novelty_threshold", float("nan")),
+    ("novelty_threshold", float("inf")),
+    ("novelty_threshold", True),
+    ("novelty_threshold", False),
+    ("novelty_threshold", -0.01),
+    ("bandwidth", float("nan")),
+    ("bandwidth", float("inf")),
+    ("bandwidth", True),
+    ("bandwidth", False),
+    ("bandwidth", 0.0),
+    ("bandwidth", -0.01),
+    ("bandwidth", None),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_STEP2_MEMORY_FIELDS)
+def test_step2_memory_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step2MemoryConfig(**{field: value})
+
+
+def test_step2_fields_preserve_legal_endpoints() -> None:
+    k_cfg = Step2KernelConfig(
+        feature_dim=1,
+        n_heads=1,
+        hidden_sizes=(),
+        step_size=0.0,
+        context_length=1,
+        noise_std=0.0,
+    )
+    make_step2_learner(k_cfg)
+    payload = k_cfg.to_dict()
+    json.dumps(payload, allow_nan=False)
+    restored = Step2KernelConfig.from_dict(payload)
+    assert restored.feature_dim == 1
+    assert restored.n_heads == 1
+    assert restored.step_size == 0.0
+    assert restored.noise_std == 0.0
+
+    m_cfg = Step2MemoryConfig(
+        feature_dim=1,
+        n_classes=2,
+        slots_per_class=1,
+        update_rate=float(np.float32(1e-6)),
+        novelty_threshold=0.0,
+        bandwidth=float(np.float32(1e-12)),
+    )
+    make_step2_memory_learner(m_cfg)
+    m_payload = m_cfg.to_dict()
+    json.dumps(m_payload, allow_nan=False)
+    m_restored = Step2MemoryConfig.from_dict(m_payload)
+    assert m_restored.update_rate == float(np.float32(1e-6))
+    assert m_restored.novelty_threshold == 0.0
+    assert m_restored.bandwidth == float(np.float32(1e-12))
+
+    m_upper = Step2MemoryConfig(
+        update_rate=1.0,
+    )
+    assert m_upper.update_rate == 1.0
+
+
+def test_step2_rejects_float32_overflow_and_underflow() -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        Step2KernelConfig(step_size=1e100)
+    with pytest.raises(ValueError, match="bandwidth"):
+        Step2MemoryConfig(bandwidth=1e100)
+    with pytest.raises(ValueError, match="bandwidth"):
+        Step2MemoryConfig(bandwidth=1e-50)
+
+
+def test_step2_fields_canonicalize_nonbuiltin_numbers() -> None:
+    value = np.float64(0.03)
+    k_cfg = Step2KernelConfig(
+        feature_dim=np.int64(8),
+        n_heads=np.int64(3),
+        hidden_sizes=(np.int64(16),),
+        step_size=value,
+        context_length=np.int64(64),
+        noise_std=value,
+    )
+    payload = k_cfg.to_dict()
+    json.dumps(payload, allow_nan=False)
+    assert k_cfg.feature_dim == 8
+    assert k_cfg.n_heads == 3
+    assert k_cfg.hidden_sizes == (16,)
+    assert k_cfg.step_size == float(np.float32(0.03))
+    assert type(payload["feature_dim"]) is int
+    assert type(payload["n_heads"]) is int
+    assert type(payload["hidden_sizes"][0]) is int
+    assert type(payload["step_size"]) is float
+    assert type(payload["context_length"]) is int
+    assert type(payload["noise_std"]) is float
 
 
 def test_step2_hybrid_factory_updates_upgd_and_memory() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -3,6 +3,7 @@
 
 import json
 import tomllib
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -245,6 +246,7 @@ def test_step2_fields_preserve_legal_endpoints() -> None:
         feature_dim=1,
         n_heads=1,
         hidden_sizes=(),
+        stream="frequency",
         step_size=0.0,
         context_length=1,
         noise_std=0.0,
@@ -311,6 +313,130 @@ def test_step2_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert type(payload["step_size"]) is float
     assert type(payload["context_length"]) is int
     assert type(payload["noise_std"]) is float
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field", "value"),
+    [
+        (Step2KernelConfig, "step_size", Fraction(-1, 10**400)),
+        (Step2KernelConfig, "noise_std", Fraction(-1, 10**400)),
+        (Step2StrictDigitReadoutConfig, "step_size", Fraction(-1, 10**400)),
+        (Step2MemoryConfig, "update_rate", Fraction(1, 10**400)),
+        (Step2MemoryConfig, "update_rate", Fraction(10**400 + 1, 10**400)),
+        (Step2MemoryConfig, "novelty_threshold", Fraction(-1, 10**400)),
+        (Step2MemoryConfig, "bandwidth", Fraction(1, 10**400)),
+    ],
+)
+def test_step2_configs_enforce_exact_scientific_domains(
+    config_type: type[Any],
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        config_type(**{field: value})
+
+
+def test_step2_configs_use_direct_float32_narrowing_without_double_rounding() -> None:
+    overflow_midpoint = np.ldexp(
+        np.longdouble(2) - np.ldexp(np.longdouble(1), -24),
+        127,
+    )
+    largest_finite_input = np.nextafter(
+        overflow_midpoint,
+        np.longdouble("-inf"),
+    )
+
+    kernel = Step2KernelConfig(step_size=largest_finite_input)
+    strict = Step2StrictDigitReadoutConfig(step_size=largest_finite_input)
+    memory = Step2MemoryConfig(novelty_threshold=largest_finite_input)
+
+    for value in (kernel.step_size, strict.step_size, memory.novelty_threshold):
+        assert type(value) is float
+        assert bool(np.isfinite(np.asarray(value, dtype=np.float32)))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("n_heads", 0),
+        ("n_heads", True),
+        ("hidden_sizes", [8]),
+        ("hidden_sizes", (0,)),
+        ("hidden_sizes", (False,)),
+        ("step_size", float("nan")),
+        ("step_size", 3.5e38),
+        ("step_size", jnp.asarray(0.25)),
+    ],
+)
+def test_step2_strict_digit_config_rejects_malformed_fields(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step2StrictDigitReadoutConfig(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("stream", "POLYNOMIAL"),
+        ("readout_mode", "LINEAR_MSE"),
+        ("loss_normalization", "TARGET_STRUCTURE"),
+    ],
+)
+def test_step2_kernel_rejects_case_mismatched_names(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        Step2KernelConfig(**{field: value})
+
+
+def test_step2_kernel_rejects_polynomial_dimensions_without_a_triple() -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        Step2KernelConfig(feature_dim=2, stream="polynomial")
+
+
+def test_step2_builtin_float_defaults_remain_serialization_compatible() -> None:
+    assert Step2KernelConfig().to_dict() == {
+        "feature_dim": 8,
+        "n_heads": 3,
+        "hidden_sizes": [32],
+        "stream": "polynomial",
+        "readout_mode": "linear_mse",
+        "step_size": 0.03,
+        "loss_normalization": "target_structure",
+        "context_length": 128,
+        "noise_std": 0.05,
+    }
+    assert Step2StrictDigitReadoutConfig().to_dict()["step_size"] == 0.018
+    assert Step2MemoryConfig().to_dict() == {
+        "feature_dim": 784,
+        "n_classes": 10,
+        "slots_per_class": 20,
+        "update_rate": 0.3,
+        "novelty_threshold": 0.08,
+        "bandwidth": 0.01,
+    }
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        Step2KernelConfig(),
+        Step2StrictDigitReadoutConfig(),
+        Step2MemoryConfig(),
+    ],
+)
+def test_step2_config_from_dict_requires_exact_keys(config: Any) -> None:
+    payload = config.to_dict()
+    missing = dict(payload)
+    missing.pop(next(iter(missing)))
+    extra = {**payload, "unexpected": 1}
+
+    for malformed in (missing, extra):
+        with pytest.raises(ValueError, match=type(config).__name__):
+            type(config).from_dict(malformed)
 
 
 def test_step2_hybrid_factory_updates_upgd_and_memory() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -366,6 +366,117 @@ def test_step2_configs_use_direct_float32_narrowing_without_double_rounding() ->
 
 
 @pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        (Step2KernelConfig, "step_size"),
+        (Step2KernelConfig, "noise_std"),
+        (Step2StrictDigitReadoutConfig, "step_size"),
+        (Step2MemoryConfig, "update_rate"),
+        (Step2MemoryConfig, "novelty_threshold"),
+        (Step2MemoryConfig, "bandwidth"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (-Fraction(1, 2**61), 0.5),
+        (Fraction(0), 0.5),
+        (
+            Fraction(1, 2**61),
+            float(np.nextafter(np.float32(0.5), np.float32(1.0))),
+        ),
+    ],
+    ids=("below", "tie-to-even", "above"),
+)
+def test_step2_configs_round_fraction_midpoints_once(
+    config_type: type[Any],
+    field: str,
+    offset: Fraction,
+    expected: float,
+) -> None:
+    midpoint = Fraction(1, 2) + Fraction(1, 2**25)
+    config = config_type(**{field: midpoint + offset})
+    assert getattr(config, field) == expected
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        (Step2KernelConfig, "step_size"),
+        (Step2KernelConfig, "noise_std"),
+        (Step2StrictDigitReadoutConfig, "step_size"),
+        (Step2MemoryConfig, "novelty_threshold"),
+        (Step2MemoryConfig, "bandwidth"),
+    ],
+)
+def test_step2_configs_apply_exact_float32_overflow_midpoint(
+    config_type: type[Any],
+    field: str,
+) -> None:
+    float32_max = (2**24 - 1) * 2**104
+    overflow_midpoint = Fraction(float32_max + 2**103)
+
+    config = config_type(**{field: overflow_midpoint - 1})
+    assert getattr(config, field) == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match=field):
+        config_type(**{field: overflow_midpoint})
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field", "allows_zero"),
+    [
+        (Step2KernelConfig, "step_size", True),
+        (Step2KernelConfig, "noise_std", True),
+        (Step2StrictDigitReadoutConfig, "step_size", True),
+        (Step2MemoryConfig, "update_rate", False),
+        (Step2MemoryConfig, "novelty_threshold", True),
+        (Step2MemoryConfig, "bandwidth", False),
+    ],
+)
+def test_step2_configs_apply_exact_subnormal_midpoint(
+    config_type: type[Any],
+    field: str,
+    allows_zero: bool,
+) -> None:
+    subnormal_midpoint = Fraction(1, 2**150)
+    if allows_zero:
+        config = config_type(**{field: subnormal_midpoint})
+        assert getattr(config, field) == 0.0
+    else:
+        with pytest.raises(ValueError, match=field):
+            config_type(**{field: subnormal_midpoint})
+
+    above = config_type(**{field: subnormal_midpoint + Fraction(1, 2**200)})
+    assert getattr(above, field) == float(
+        np.nextafter(np.float32(0.0), np.float32(1.0))
+    )
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field", "allows_zero"),
+    [
+        (Step2KernelConfig, "step_size", True),
+        (Step2KernelConfig, "noise_std", True),
+        (Step2StrictDigitReadoutConfig, "step_size", True),
+        (Step2MemoryConfig, "update_rate", False),
+        (Step2MemoryConfig, "novelty_threshold", True),
+        (Step2MemoryConfig, "bandwidth", False),
+    ],
+)
+def test_step2_configs_preserve_signed_zero_domain_policy(
+    config_type: type[Any],
+    field: str,
+    allows_zero: bool,
+) -> None:
+    if allows_zero:
+        config = config_type(**{field: -0.0})
+        assert np.signbit(getattr(config, field))
+    else:
+        with pytest.raises(ValueError, match=field):
+            config_type(**{field: -0.0})
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     [
         ("n_heads", 0),


### PR DESCRIPTION
Closes #282.

## What changed

`Step2KernelConfig`, `Step2StrictDigitReadoutConfig`, and `Step2MemoryConfig` now validate and canonicalize their public parameters before constructing Step 2 components:

- enum fields require exact canonical literals, so case-mismatched values cannot construct and fail later;
- `feature_dim`, `n_heads`, every hidden width, `context_length`, `n_classes`, and `slots_per_class` are built-in integers in `[minimum, 2147483647]`, matching downstream signed-int32 JAX sinks;
- `context_length=2147483647` reaches a real stream step, while `2147483648` and corresponding oversized dimension/capacity values fail at construction;
- scientific reals are checked in their exact host domain and narrowed through the shared exact-ratio IEEE binary32 converter from #289;
- exact Fraction values below, at, and above a normal midpoint round once with ties-to-even across all six public real fields;
- overflow midpoint, half-minimum-subnormal, signed-zero, strict-positive, non-negative, and interval policies are retained at the actual float32 sink;
- conversion failures, including `Fraction(10**1000, 1)`, are normalized to field-specific `ValueError`;
- polynomial streams reject dimensions too small to form a triple;
- JSON reconstruction requires exact schema keys while built-in default spellings remain serialization-compatible.

The strict digit/readout facade has its own invalid-field matrix and canonical JSON round-trip coverage, including non-built-in numeric canonicalization.

## Scope

- `alberta_framework/steps/step2.py`
- `tests/test_production_steps.py`

Core learners, registered/frozen evidence sources, protocols, seeds, changelog, and `outputs/**` remain untouched.

## Live-head reconciliation

- original contribution and prior repairs are preserved as the first three rebased commits;
- reviewed contributor head before this pass: `a816250d9fa457657e3e4b52ada81cc237303491`;
- no newer contributor changes appeared during repair;
- rebased base: `origin/main@79d2432cf2a2bd55bef4c0b53998760e2007251d`;
- final pushed head: `7c7e923a3f7558ba4f7f972673ebeae361926962`.

## Verification

Red-first on the reviewed live implementation:

- exact Fraction normal-midpoint panel: **6 failed, 12 passed** (the above-midpoint case failed for every public real field).

After repair, on exact final head:

- exact rounding/domain boundary panel: **35 passed**;
- `tests/test_production_steps.py tests/test_step2_theory_invariants.py tests/test_pipeline.py`: **219 passed**;
- full Ruff: clean;
- strict mypy: no issues in 164 source files;
- `git diff --check`: clean;
- changed paths are exactly the two files listed above; `outputs/**` is untouched.

## Scientific integrity

This is facade input validation and serialization hardening. It does not alter scientific artifacts, benchmark evidence, frozen protocols, thresholds, seeds, or performance claims.

## Contribution provenance

Original contribution:

- AI assistance: yes
- AI provider/model: google / gemini-3.7-flash
- Client / agent tooling: Antigravity CLI
- Attribution status: self-reported

Maintainer repair:

- AI assistance: yes
- Provider/tooling: OpenAI Codex
