### PR TITLE
fix(streams): narrow original reals directly to float32

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -1,0 +1,117 @@
+"""Exact host-scalar conversion helpers for float32 JAX sinks."""
+
+from __future__ import annotations
+
+import math
+import struct
+from numbers import Integral, Real
+
+
+def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
+    quotient, remainder = divmod(numerator, denominator)
+    doubled_remainder = remainder * 2
+    if doubled_remainder > denominator or (
+        doubled_remainder == denominator and quotient % 2 == 1
+    ):
+        return quotient + 1
+    return quotient
+
+
+def _float32_from_ratio(
+    numerator: int,
+    denominator: int,
+    *,
+    negative_zero: bool,
+) -> float:
+    """Round an exact ratio to IEEE 754 binary32 with ties-to-even."""
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+
+    negative = numerator < 0 or (numerator == 0 and negative_zero)
+    magnitude = abs(numerator)
+    sign_bits = int(negative) << 31
+    if magnitude == 0:
+        bits = sign_bits
+    else:
+        exponent = magnitude.bit_length() - denominator.bit_length()
+        if exponent >= 0:
+            if magnitude < denominator << exponent:
+                exponent -= 1
+        elif magnitude << -exponent < denominator:
+            exponent -= 1
+
+        if exponent > 127:
+            bits = sign_bits | 0x7F800000
+        elif exponent >= -126:
+            shift = 23 - exponent
+            if shift >= 0:
+                significand = _round_quotient_ties_to_even(
+                    magnitude << shift,
+                    denominator,
+                )
+            else:
+                significand = _round_quotient_ties_to_even(
+                    magnitude,
+                    denominator << -shift,
+                )
+            if significand == 1 << 24:
+                significand >>= 1
+                exponent += 1
+            if exponent > 127:
+                bits = sign_bits | 0x7F800000
+            else:
+                bits = (
+                    sign_bits
+                    | ((exponent + 127) << 23)
+                    | (significand - (1 << 23))
+                )
+        else:
+            significand = _round_quotient_ties_to_even(
+                magnitude << 149,
+                denominator,
+            )
+            bits = sign_bits | significand
+    return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
+
+
+def round_real_to_float32(value: Real) -> float:
+    """Round a standard exact-ratio real directly to IEEE binary32.
+
+    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
+    round-to-nearest, ties-to-even semantics without an intermediate binary64
+    conversion. Real implementations that cannot expose an exact ratio are
+    rejected instead of being silently double-rounded.
+    """
+    if isinstance(value, Integral):
+        ratio: object = (int(value), 1)
+    else:
+        ratio_method = getattr(value, "as_integer_ratio", None)
+        if not callable(ratio_method):
+            raise TypeError("real value must expose as_integer_ratio")
+        ratio = ratio_method()
+    if not isinstance(ratio, tuple) or len(ratio) != 2:
+        raise TypeError("as_integer_ratio must return an integer pair")
+    numerator_raw, denominator_raw = ratio
+    if (
+        isinstance(numerator_raw, bool)
+        or not isinstance(numerator_raw, Integral)
+        or isinstance(denominator_raw, bool)
+        or not isinstance(denominator_raw, Integral)
+    ):
+        raise TypeError("as_integer_ratio must return an integer pair")
+    numerator = int(numerator_raw)
+    denominator = int(denominator_raw)
+    negative_zero = (
+        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    )
+    return _float32_from_ratio(
+        numerator,
+        denominator,
+        negative_zero=negative_zero,
+    )
+
+
+__all__ = ["round_real_to_float32"]

--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -85,6 +85,8 @@ def round_real_to_float32(value: Real) -> float:
     conversion. Real implementations that cannot expose an exact ratio are
     rejected instead of being silently double-rounded.
     """
+    if isinstance(value, bool):
+        raise TypeError("real value must not be a bool")
     if isinstance(value, Integral):
         ratio: object = (int(value), 1)
     else:

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -39,6 +39,7 @@ from alberta_framework._fixed_count_selection import (
     require_positive_builtin_int,
     stable_smallest_mask,
 )
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.types import TimeStep
 
 
@@ -47,15 +48,14 @@ def _require_positive_float32(value: object, name: str) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a positive finite float32 value")
     try:
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            converted = np.asarray(value, dtype=np.float32).reshape(())
-    except (OverflowError, TypeError, ValueError) as error:
+        converted = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(
             f"{name} must be a positive finite float32 value"
         ) from error
     if not np.isfinite(converted) or converted <= np.float32(0.0):
         raise ValueError(f"{name} must be a positive finite float32 value")
-    return float(converted)
+    return converted
 
 # =============================================================================
 # OutOfClassPolynomialStream -- degree-3 polynomial targets

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -26,7 +26,6 @@ or tanh feature bank:
   compositional DAG that builds features-of-features can.
 """
 
-import math
 from numbers import Real
 
 import chex
@@ -47,11 +46,13 @@ def _require_positive_float32(value: object, name: str) -> float:
     """Return a positive finite value representable in the stream execution dtype."""
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a positive finite float32 value")
-    number = float(value)
-    if not math.isfinite(number) or number <= 0.0:
-        raise ValueError(f"{name} must be a positive finite float32 value")
-    with np.errstate(over="ignore", under="ignore"):
-        converted = np.float32(number)
+    try:
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            converted = np.asarray(value, dtype=np.float32).reshape(())
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"{name} must be a positive finite float32 value"
+        ) from error
     if not np.isfinite(converted) or converted <= np.float32(0.0):
         raise ValueError(f"{name} must be a positive finite float32 value")
     return float(converted)

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -50,6 +50,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Int, PRNGKeyArray
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
@@ -88,9 +89,8 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     if value < 0:
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
     try:
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32).reshape(())
-    except (OverflowError, TypeError, ValueError) as error:
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
         ) from error
@@ -98,7 +98,7 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
         )
-    return float(narrowed)
+    return narrowed
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -40,13 +40,13 @@ References
 from __future__ import annotations
 
 import math
-import struct
 from numbers import Real
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Int, PRNGKeyArray
 
@@ -83,18 +83,22 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     below the float32 subnormal range are accepted as exact zero, matching the
     noise-free trajectory they produce in the stream's float32 arithmetic.
     """
-    number = _require_finite_real(value, name=name, nonnegative=True)
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+    if value < 0:
+        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
     try:
-        narrowed = float(struct.unpack("!f", struct.pack("!f", number))[0])
-    except OverflowError as error:
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            narrowed = np.asarray(value, dtype=np.float32).reshape(())
+    except (OverflowError, TypeError, ValueError) as error:
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
         ) from error
-    if not math.isfinite(narrowed):
+    if not bool(np.isfinite(narrowed)):
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
         )
-    return narrowed
+    return float(narrowed)
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:

--- a/tests/test_float32.py
+++ b/tests/test_float32.py
@@ -1,0 +1,62 @@
+"""Exact boundary tests for host-real to IEEE binary32 narrowing."""
+
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from alberta_framework._float32 import round_real_to_float32
+
+
+def _raw_float32(value: float) -> int:
+    return int(np.asarray(value, dtype=np.float32).view(np.uint32).item())
+
+
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (-Fraction(1, 2**60), np.float32(1.0)),
+        (Fraction(0), np.float32(1.0)),
+        (
+            Fraction(1, 2**60),
+            np.nextafter(np.float32(1.0), np.float32(2.0)),
+        ),
+    ],
+    ids=("below", "tie-to-even", "above"),
+)
+def test_rounds_fraction_midpoint_exactly(offset: Fraction, expected: np.float32) -> None:
+    midpoint = Fraction(1) + Fraction(1, 2**24)
+    assert _raw_float32(round_real_to_float32(midpoint + offset)) == _raw_float32(
+        float(expected)
+    )
+
+
+def test_rounds_overflow_midpoint_outward() -> None:
+    float32_max = (2**24 - 1) * 2**104
+    midpoint = Fraction(float32_max + 2**103)
+
+    assert round_real_to_float32(midpoint - 1) == float(np.finfo(np.float32).max)
+    assert round_real_to_float32(midpoint) == float("inf")
+    assert round_real_to_float32(midpoint + 1) == float("inf")
+
+
+def test_rounds_subnormal_midpoint_to_even_zero() -> None:
+    midpoint = Fraction(1, 2**150)
+    minimum_subnormal = np.nextafter(np.float32(0.0), np.float32(1.0))
+
+    assert _raw_float32(round_real_to_float32(midpoint - Fraction(1, 2**200))) == 0
+    assert _raw_float32(round_real_to_float32(midpoint)) == 0
+    assert _raw_float32(round_real_to_float32(midpoint + Fraction(1, 2**200))) == (
+        _raw_float32(float(minimum_subnormal))
+    )
+
+
+@pytest.mark.parametrize("value", [-0.0, np.float32(-0.0), np.longdouble(-0.0)])
+def test_preserves_signed_zero(value: float) -> None:
+    assert _raw_float32(round_real_to_float32(value)) == 0x80000000
+
+
+@pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+def test_rejects_bool_aliases(value: object) -> None:
+    with pytest.raises(TypeError):
+        round_real_to_float32(value)  # type: ignore[arg-type]

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -336,6 +336,38 @@ class TestFrequencyMismatchStream:
         stream = FrequencyMismatchStream(omega_min=1.0, omega_max=omega_max)
         assert stream._omega_max == expected  # noqa: SLF001
 
+    def test_frequency_bounds_apply_exact_float32_overflow_midpoint(self) -> None:
+        float32_max = (2**24 - 1) * 2**104
+        overflow_midpoint = float32_max + 2**103
+
+        stream = FrequencyMismatchStream(
+            omega_min=1.0,
+            omega_max=Fraction(overflow_midpoint - 1),
+        )
+        assert stream._omega_max == float(np.finfo(np.float32).max)  # noqa: SLF001
+        with pytest.raises(ValueError, match="omega_max"):
+            FrequencyMismatchStream(
+                omega_min=1.0,
+                omega_max=Fraction(overflow_midpoint),
+            )
+
+    def test_frequency_bounds_apply_exact_subnormal_midpoint(self) -> None:
+        subnormal_midpoint = Fraction(1, 2**150)
+
+        with pytest.raises(ValueError, match="omega_min"):
+            FrequencyMismatchStream(omega_min=subnormal_midpoint, omega_max=1.0)
+        stream = FrequencyMismatchStream(
+            omega_min=subnormal_midpoint + Fraction(1, 2**200),
+            omega_max=1.0,
+        )
+        assert stream._omega_min == float(  # noqa: SLF001
+            np.nextafter(np.float32(0.0), np.float32(1.0))
+        )
+
+    def test_frequency_bounds_reject_negative_zero(self) -> None:
+        with pytest.raises(ValueError, match="omega_min"):
+            FrequencyMismatchStream(omega_min=-0.0, omega_max=1.0)
+
     def test_step_shapes(self):
         stream = FrequencyMismatchStream(
             feature_dim=4,

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -7,6 +7,8 @@ shape correctness, JIT compatibility via ``jax.lax.scan``, and the
 out-of-class structural properties that motivate each stream.
 """
 
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -305,6 +307,34 @@ class TestFrequencyMismatchStream:
 
         stream = FrequencyMismatchStream(omega_min=1.0, omega_max=midpoint_plus)
         assert stream._omega_max == float(np.float32(midpoint_plus))  # noqa: SLF001
+
+    @pytest.mark.parametrize(
+        ("omega_max", "expected"),
+        [
+            (
+                Fraction(1, 1) + Fraction(1, 2**24) - Fraction(1, 2**60),
+                None,
+            ),
+            (Fraction(1, 1) + Fraction(1, 2**24), None),
+            (
+                Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60),
+                float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+            ),
+        ],
+        ids=("below", "tie-to-even", "above"),
+    )
+    def test_frequency_bounds_round_fraction_midpoints_once(
+        self,
+        omega_max: Fraction,
+        expected: float | None,
+    ) -> None:
+        if expected is None:
+            with pytest.raises(ValueError, match="omega_max must exceed"):
+                FrequencyMismatchStream(omega_min=1.0, omega_max=omega_max)
+            return
+
+        stream = FrequencyMismatchStream(omega_min=1.0, omega_max=omega_max)
+        assert stream._omega_max == expected  # noqa: SLF001
 
     def test_step_shapes(self):
         stream = FrequencyMismatchStream(

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -295,6 +295,17 @@ class TestFrequencyMismatchStream:
         assert bool(jnp.all(state.omegas >= expected_min))
         assert bool(jnp.all(state.omegas < expected_max))
 
+    def test_frequency_bounds_narrow_the_original_real_once(self) -> None:
+        midpoint_plus = (
+            np.longdouble(1.0)
+            + np.longdouble(2.0) ** -24
+            + np.longdouble(2.0) ** -60
+        )
+        assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+
+        stream = FrequencyMismatchStream(omega_min=1.0, omega_max=midpoint_plus)
+        assert stream._omega_max == float(np.float32(midpoint_plus))  # noqa: SLF001
+
     def test_step_shapes(self):
         stream = FrequencyMismatchStream(
             feature_dim=4,

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -11,6 +11,8 @@ Covers:
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -505,6 +507,32 @@ def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     assert float(below_zero) == 0.0
     with pytest.raises(ValueError, match="noise_std"):
         ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=below_zero)
+
+
+@pytest.mark.parametrize(
+    ("noise_std", "expected"),
+    [
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) - Fraction(1, 2**60),
+            1.0,
+        ),
+        (Fraction(1, 1) + Fraction(1, 2**24), 1.0),
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60),
+            float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+        ),
+    ],
+    ids=("below", "tie-to-even", "above"),
+)
+def test_construct_rounds_fraction_noise_midpoints_once(
+    noise_std: Fraction,
+    expected: float,
+) -> None:
+    stream = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=noise_std,
+    )
+    assert stream._noise_std == expected  # noqa: SLF001
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True])

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,28 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+def test_construct_narrows_original_noise_real_once() -> None:
+    midpoint_plus = (
+        np.longdouble(1.0)
+        + np.longdouble(2.0) ** -24
+        + np.longdouble(2.0) ** -60
+    )
+    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+
+    stream = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=midpoint_plus,
+    )
+    assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
+
+
+def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
+    below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
+    assert float(below_zero) == 0.0
+    with pytest.raises(ValueError, match="noise_std"):
+        ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=below_zero)
+
+
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True])
 def test_construct_rejects_illegal_distractor_prob(value: object) -> None:
     """Distractor probability must be a finite real in ``[0, 1]``."""

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -535,6 +535,44 @@ def test_construct_rounds_fraction_noise_midpoints_once(
     assert stream._noise_std == expected  # noqa: SLF001
 
 
+def test_construct_applies_exact_float32_overflow_midpoint() -> None:
+    float32_max = (2**24 - 1) * 2**104
+    overflow_midpoint = float32_max + 2**103
+
+    stream = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=Fraction(overflow_midpoint - 1),
+    )
+    assert stream._noise_std == float(np.finfo(np.float32).max)  # noqa: SLF001
+    with pytest.raises(ValueError, match="noise_std"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            noise_std=Fraction(overflow_midpoint),
+        )
+
+
+def test_construct_applies_exact_subnormal_midpoint_and_signed_zero() -> None:
+    subnormal_midpoint = Fraction(1, 2**150)
+    tie = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=subnormal_midpoint,
+    )
+    above = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=subnormal_midpoint + Fraction(1, 2**200),
+    )
+    negative_zero = ClassicalConditioningStream(
+        phases=(_valid_phase(),),
+        noise_std=-0.0,
+    )
+
+    assert tie._noise_std == 0.0  # noqa: SLF001
+    assert above._noise_std == float(  # noqa: SLF001
+        np.nextafter(np.float32(0.0), np.float32(1.0))
+    )
+    assert np.signbit(negative_zero._noise_std)  # noqa: SLF001
+
+
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True])
 def test_construct_rejects_illegal_distractor_prob(value: object) -> None:
     """Distractor probability must be a finite real in ``[0, 1]``."""


### PR DESCRIPTION
Closes #288

This fail-closed follow-up removes both extended-precision and exact-Rational double rounding left by merged PR #268. A shared host-scalar converter now rounds exact integer ratios directly to IEEE-754 binary32 with ties-to-even, including normal, subnormal, signed-zero, and overflow boundaries. Frequency-mismatch and Pavlovian validators consume that exact sink value while preserving their distinct domains.

Retained coverage includes:
- Fraction values immediately below, exactly at, and immediately above a normal midpoint
- the float32 overflow midpoint, including the finite value immediately below it
- the half-minimum-subnormal tie and the value immediately above it
- signed zero in Python, NumPy float32, and NumPy long-double forms
- strict rejection of bool aliases by the shared converter
- strict-positive frequency bounds versus non-negative Pavlovian noise semantics

Validation on rebased exact head `529fe0d`:
- focused affected panel: 148 passed
- independent integer-rounding oracle: 30,006 randomized/extreme exact ratios plus signed-zero variants, bit-identical
- Ruff: clean
- strict mypy: 164 source files clean
- git diff --check: clean
- no output artifacts changed
- changed stream sources and the new internal helper are not registered by the five-claim evidence manifest; inherited registry status is unchanged (pre-existing invalid)
