### PR TITLE
ci: add fail-closed IPMNIST preregistration launches

### DIFF
--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Fail-closed orchestration checks for manual IPMNIST preregistration runs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Final, cast
+
+WORKFLOW_PATH: Final = ".github/workflows/ipmnist-prereg.yml"
+DRIVER_PATH: Final = ".github/scripts/ipmnist_prereg.py"
+OWNER_LOGIN: Final = "lalalune"
+EXPECTED_CONFIG: Final = {
+    "n_tasks": 60,
+    "task_length": 5000,
+    "input_dim": 784,
+    "hidden1": 300,
+    "hidden2": 150,
+    "n_classes": 10,
+}
+EXPECTED_POLICY: Final = {
+    "evidence_class": "development_screening_diagnostic",
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+}
+
+
+@dataclass(frozen=True)
+class Protocol:
+    key: str
+    issue: int
+    namespace: str
+    control: str
+    candidate: str
+    seeds: tuple[int, ...]
+
+
+PROTOCOLS: Final = {
+    "issue51": Protocol(
+        key="issue51",
+        issue=51,
+        namespace="replication_r1",
+        control="sigma0_shiftnorm_d099",
+        candidate="rls_head_resid_l1_preset005",
+        seeds=(0, 1, 2),
+    ),
+    "issue188": Protocol(
+        key="issue188",
+        issue=188,
+        namespace="gate_ablation_r3",
+        control="rls_head_resid_l1_preset005",
+        candidate="rls_head_resid_l1_preset005_nogate",
+        seeds=tuple(range(3, 13)),
+    ),
+}
+
+
+def protocol_for(key: str) -> Protocol:
+    try:
+        return PROTOCOLS[key]
+    except KeyError as exc:
+        raise ValueError(f"unsupported preregistration protocol: {key!r}") from exc
+
+
+def _lower_hex(value: str, length: int, *, name: str) -> str:
+    if len(value) != length or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{name} must be exactly {length} lowercase hexadecimal characters")
+    return value
+
+
+def authorization_line(
+    protocol: Protocol,
+    *,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
+    workflow_blob_sha1: str,
+    driver_blob_sha1: str,
+    ref_name: str,
+) -> str:
+    source = _lower_hex(source, 40, name="source")
+    tree = _lower_hex(tree, 40, name="tree")
+    uv_lock_sha256 = _lower_hex(uv_lock_sha256, 64, name="uv_lock_sha256")
+    workflow_blob_sha1 = _lower_hex(workflow_blob_sha1, 40, name="workflow_blob_sha1")
+    driver_blob_sha1 = _lower_hex(driver_blob_sha1, 40, name="driver_blob_sha1")
+    if not ref_name or any(char.isspace() for char in ref_name):
+        raise ValueError("ref_name must be a non-empty tag name without whitespace")
+    seeds = ",".join(str(seed) for seed in protocol.seeds)
+    return (
+        f"ASI_PREREG_LAUNCH_V1 issue={protocol.issue} protocol={protocol.key} "
+        f"source={source} tree={tree} uv_lock_sha256={uv_lock_sha256} "
+        f"workflow_blob_sha1={workflow_blob_sha1} driver_blob_sha1={driver_blob_sha1} "
+        f"ref={ref_name} runner=macos-14-arm64 seeds={seeds} "
+        "protocol_approval=approved seed_budget=approved "
+        "compute=authorized-uncompensated"
+    )
+
+
+def classify_outcome(
+    protocol_key: str, *, mean_diff: float, stderr_diff: float, per_seed_diff: tuple[float, ...]
+) -> str:
+    if not math.isfinite(mean_diff) or not math.isfinite(stderr_diff) or stderr_diff < 0.0:
+        raise ValueError("paired summary statistics must be finite and stderr non-negative")
+    if not per_seed_diff or not all(math.isfinite(value) for value in per_seed_diff):
+        raise ValueError("paired per-seed differences must be non-empty and finite")
+    if protocol_key == "issue51":
+        if any(value <= 0.0 for value in per_seed_diff):
+            return "not_replicated"
+        if 0.004882 <= mean_diff <= 0.005950:
+            return "replicated"
+        return "directionally_replicated"
+    if protocol_key == "issue188":
+        margin = 0.0015
+        if mean_diff - 2.0 * stderr_diff > -margin:
+            return "not_load_bearing"
+        if mean_diff + 2.0 * stderr_diff < -margin:
+            return "load_bearing"
+        return "inconclusive"
+    raise ValueError(f"unsupported preregistration protocol: {protocol_key!r}")
+
+
+def _parse_utc(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _github_json(path: str, *, token: str) -> Any:
+    url = f"https://api.github.com{path}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "asi-ipmnist-prereg-v1",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, urllib.error.HTTPError) as exc:
+        raise RuntimeError(f"GitHub API request failed for {path}: {exc}") from exc
+
+
+def _github_pages(path: str, *, token: str) -> list[Any]:
+    separator = "&" if "?" in path else "?"
+    values: list[Any] = []
+    for page in range(1, 101):
+        payload = _github_json(f"{path}{separator}per_page=100&page={page}", token=token)
+        if not isinstance(payload, list):
+            raise RuntimeError(f"GitHub API pagination expected a list for {path}")
+        values.extend(payload)
+        if len(payload) < 100:
+            return values
+    raise RuntimeError(f"GitHub API pagination exceeded 10,000 records for {path}")
+
+
+def _workflow_runs(repository: str, *, token: str) -> list[dict[str, Any]]:
+    encoded = urllib.parse.quote(Path(WORKFLOW_PATH).name, safe="")
+    path = f"/repos/{repository}/actions/workflows/{encoded}/runs?event=workflow_dispatch"
+    runs: list[dict[str, Any]] = []
+    for page in range(1, 101):
+        payload = _github_json(f"{path}&per_page=100&page={page}", token=token)
+        if isinstance(payload, dict) and isinstance(payload.get("workflow_runs"), list):
+            page_runs = [cast(dict[str, Any], value) for value in payload["workflow_runs"]]
+            runs.extend(page_runs)
+            if len(page_runs) < 100:
+                return runs
+            continue
+        time.sleep(2.0)
+    raise RuntimeError("GitHub Actions pagination exceeded 10,000 workflow runs")
+
+
+def verify_launch_authorization(
+    *,
+    protocol_key: str,
+    repository: str,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
+    workflow_blob_sha1: str,
+    driver_blob_sha1: str,
+    ref_name: str,
+    run_id: int,
+    run_attempt: int,
+    token: str,
+) -> dict[str, Any]:
+    protocol = protocol_for(protocol_key)
+    expected_line = authorization_line(
+        protocol,
+        source=source,
+        tree=tree,
+        uv_lock_sha256=uv_lock_sha256,
+        workflow_blob_sha1=workflow_blob_sha1,
+        driver_blob_sha1=driver_blob_sha1,
+        ref_name=ref_name,
+    )
+    if run_attempt != 1:
+        raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
+
+    current = _github_json(f"/repos/{repository}/actions/runs/{run_id}", token=token)
+    if not isinstance(current, dict):
+        raise RuntimeError("current workflow run metadata is unavailable")
+    expected_title = f"ipmnist-{protocol.key}-{source}"
+    required_current = {
+        "id": run_id,
+        "event": "workflow_dispatch",
+        "head_sha": source,
+        "display_title": expected_title,
+        "run_attempt": 1,
+        "path": WORKFLOW_PATH,
+    }
+    mismatched = {
+        key: (current.get(key), expected)
+        for key, expected in required_current.items()
+        if current.get(key) != expected
+    }
+    if mismatched:
+        raise RuntimeError(f"current workflow run binding mismatch: {mismatched}")
+
+    matching_runs = [
+        run
+        for run in _workflow_runs(repository, token=token)
+        if run.get("event") == "workflow_dispatch"
+        and run.get("head_sha") == source
+        and run.get("display_title") == expected_title
+    ]
+    matching_ids = sorted(int(run["id"]) for run in matching_runs)
+    if matching_ids != [run_id]:
+        raise RuntimeError(
+            "this protocol/source must have exactly one dispatch; "
+            f"observed matching run IDs {matching_ids}"
+        )
+
+    comments = _github_pages(f"/repos/{repository}/issues/{protocol.issue}/comments", token=token)
+    matches = [
+        cast(dict[str, Any], comment)
+        for comment in comments
+        if isinstance(comment, dict)
+        and comment.get("body") == expected_line
+        and isinstance(comment.get("user"), dict)
+        and comment["user"].get("login") == OWNER_LOGIN
+        and comment.get("author_association") == "OWNER"
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected exactly one standalone owner authorization comment; found {len(matches)}"
+        )
+    comment = matches[0]
+    created_at = cast(str, current.get("created_at"))
+    if _parse_utc(cast(str, comment["created_at"])) >= _parse_utc(created_at):
+        raise RuntimeError("owner authorization must be durable before workflow dispatch")
+    return {
+        "schema": "asi.ipmnist_prereg.launch_preflight.v1",
+        "protocol": asdict(protocol),
+        "source": source,
+        "tree": tree,
+        "uv_lock_sha256": uv_lock_sha256,
+        "workflow_blob_sha1": workflow_blob_sha1,
+        "driver_blob_sha1": driver_blob_sha1,
+        "ref_name": ref_name,
+        "runner": "macos-14-arm64",
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "run_url": current.get("html_url"),
+        "authorization_comment_id": comment.get("id"),
+        "authorization_comment_url": comment.get("html_url"),
+        "authorization_created_at": comment.get("created_at"),
+        "authorization_line": expected_line,
+        "authorization_sha256": hashlib.sha256(expected_line.encode()).hexdigest(),
+    }
+
+
+def _strict_json(path: Path) -> dict[str, Any]:
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"{path}: duplicate JSON key {key!r}")
+            value[key] = item
+        return value
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"{path}: non-finite JSON constant {value!r}")
+
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=pairs_hook,
+        parse_constant=reject_constant,
+    )
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected one JSON object")
+    return payload
+
+
+def _require_exact_keys(value: dict[str, Any], expected: set[str], *, context: str) -> None:
+    if set(value) != expected:
+        raise ValueError(
+            f"{context}: key mismatch; missing={sorted(expected - set(value))}, "
+            f"unexpected={sorted(set(value) - expected)}"
+        )
+
+
+def _validate_runtime(environment: dict[str, Any]) -> None:
+    python = cast(dict[str, Any], environment["python"])
+    host = cast(dict[str, Any], environment["platform"])
+    packages = cast(dict[str, Any], environment["packages"])
+    jax = cast(dict[str, Any], environment["jax"])
+    process = cast(dict[str, Any], environment["process_environment"])
+    if python != {"implementation": "CPython", "version": "3.12.12"}:
+        raise ValueError(f"unexpected Python receipt: {python}")
+    if host.get("system") != "Darwin" or host.get("machine") != "arm64":
+        raise ValueError(f"runner must be Darwin arm64, got {host}")
+    expected_packages = {
+        "jax": "0.11.0",
+        "jaxlib": "0.11.0",
+        "numpy": "2.5.1",
+        "scikit-learn": "1.9.0",
+    }
+    if any(packages.get(name) != version for name, version in expected_packages.items()):
+        raise ValueError(f"unexpected locked package receipt: {packages}")
+    devices = jax.get("devices")
+    if jax.get("backend") != "cpu" or not isinstance(devices, list) or len(devices) != 1:
+        raise ValueError(f"expected exactly one JAX CPU device, got {jax}")
+    device = cast(dict[str, Any], devices[0])
+    if device.get("platform") != "cpu":
+        raise ValueError(f"expected a CPU JAX device, got {device}")
+    expected_process = {
+        "CUDA_VISIBLE_DEVICES": "",
+        "JAX_DEFAULT_MATMUL_PRECISION": None,
+        "JAX_ENABLE_X64": "false",
+        "JAX_PLATFORM_NAME": "cpu",
+        "JAX_PLATFORMS": "cpu",
+        "OMP_NUM_THREADS": "1",
+        "XLA_FLAGS": "--xla_force_host_platform_device_count=1",
+    }
+    if process != expected_process:
+        raise ValueError(f"unexpected process-environment receipt: {process}")
+
+
+def validate_result_bundle(
+    *, protocol_key: str, root: Path, source: str, tree: str, uv_lock_sha256: str
+) -> dict[str, Any]:
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        SHARD_SCHEMA,
+        SUMMARY_SCHEMA,
+        load_shard,
+    )
+
+    protocol = protocol_for(protocol_key)
+    source = _lower_hex(source, 40, name="source")
+    tree = _lower_hex(tree, 40, name="tree")
+    uv_lock_sha256 = _lower_hex(uv_lock_sha256, 64, name="uv_lock_sha256")
+    namespace = root / "outputs" / "ipmnist_screening" / protocol.namespace
+    shards_dir = namespace / "shards"
+    expected_pairs = {
+        (arm, seed) for arm in (protocol.control, protocol.candidate) for seed in protocol.seeds
+    }
+    expected_paths = {shards_dir / f"{arm}_seed{seed}.json" for arm, seed in expected_pairs}
+    observed_paths = set(shards_dir.glob("*.json"))
+    if observed_paths != expected_paths:
+        raise ValueError(
+            "shard filename coverage mismatch; "
+            f"missing={sorted(str(path) for path in expected_paths - observed_paths)}, "
+            f"unexpected={sorted(str(path) for path in observed_paths - expected_paths)}"
+        )
+    shards = [load_shard(path) for path in sorted(expected_paths)]
+    observed_pairs = {(shard["config_name"], shard["seed"]) for shard in shards}
+    if observed_pairs != expected_pairs or len(shards) != len(expected_pairs):
+        raise ValueError("shard payload arm/seed coverage is not exact")
+    first = shards[0]
+    for shard in shards:
+        if shard["schema"] != SHARD_SCHEMA:
+            raise ValueError("all shards must use the strict v2 schema")
+        if shard["config"] != EXPECTED_CONFIG:
+            raise ValueError(f"unexpected protocol config in shard: {shard['config']}")
+        if shard["noise_mode"] != "step" or shard["noise_pool_steps"] is not None:
+            raise ValueError("all shards must use exact step noise")
+        provenance = cast(dict[str, Any], shard["source_provenance"])
+        if (
+            provenance.get("git_commit") != source
+            or provenance.get("git_tree") != tree
+            or provenance.get("uv_lock_sha256") != uv_lock_sha256
+            or provenance.get("worktree_clean") is not True
+        ):
+            raise ValueError(f"shard source provenance mismatch: {provenance}")
+        if shard["source_provenance"] != first["source_provenance"]:
+            raise ValueError("shards do not share exact source provenance")
+        if shard["dataset_provenance"] != first["dataset_provenance"]:
+            raise ValueError("shards do not share exact dataset provenance")
+        if shard["environment"] != first["environment"]:
+            raise ValueError("shards do not share exact runtime provenance")
+    _validate_runtime(cast(dict[str, Any], first["environment"]))
+
+    summary_path = namespace / (
+        "summary.json" if protocol.key == "issue51" else "summary_resid_gate_ablation_r3.json"
+    )
+    summary = _strict_json(summary_path)
+    expected_summary_keys = {
+        "schema",
+        "evidence_policy",
+        "created_unix",
+        "protocol_config",
+        "environment",
+        "noise_mode",
+        "noise_pool_steps",
+        "control_name",
+        "confirmation_threshold",
+        "slope_window",
+        "n_shards",
+        "results",
+        "source_provenance",
+        "dataset_provenance",
+        "shard_manifest",
+    }
+    _require_exact_keys(summary, expected_summary_keys, context=str(summary_path))
+    if summary["schema"] != SUMMARY_SCHEMA or summary["evidence_policy"] != EXPECTED_POLICY:
+        raise ValueError("summary must be a strict-v2 permanently nonpromoting artifact")
+    if (
+        summary["protocol_config"] != EXPECTED_CONFIG
+        or summary["noise_mode"] != "step"
+        or summary["noise_pool_steps"] is not None
+        or summary["control_name"] != protocol.control
+        or summary["n_shards"] != len(expected_pairs)
+        or summary["source_provenance"] != first["source_provenance"]
+        or summary["dataset_provenance"] != first["dataset_provenance"]
+        or summary["environment"] != first["environment"]
+    ):
+        raise ValueError("summary protocol or provenance binding mismatch")
+    results = summary["results"]
+    if not isinstance(results, list) or len(results) != 2:
+        raise ValueError("summary must contain exactly the control and candidate")
+    by_name = {
+        result.get("config_name"): result
+        for result in results
+        if isinstance(result, dict) and isinstance(result.get("config_name"), str)
+    }
+    if set(by_name) != {protocol.control, protocol.candidate}:
+        raise ValueError(f"summary arm set mismatch: {sorted(by_name)}")
+    for name, result in by_name.items():
+        if result.get("seeds") != list(protocol.seeds) or result.get("n_seeds") != len(
+            protocol.seeds
+        ):
+            raise ValueError(f"summary seed coverage mismatch for {name}")
+    candidate = by_name[protocol.candidate]
+    paired = candidate.get("paired_vs_control")
+    if not isinstance(paired, dict):
+        raise ValueError("candidate summary is missing its paired comparison")
+    if paired.get("control") != protocol.control or paired.get("seeds") != list(protocol.seeds):
+        raise ValueError("paired comparison does not bind the frozen control/seeds")
+    raw_diffs = paired.get("per_seed_diff")
+    if not isinstance(raw_diffs, list) or len(raw_diffs) != len(protocol.seeds):
+        raise ValueError("paired per-seed difference coverage mismatch")
+    diffs = tuple(float(value) for value in raw_diffs)
+    mean_diff = float(paired["mean_diff"])
+    stderr_diff = float(paired["stderr_diff"])
+    outcome = classify_outcome(
+        protocol.key,
+        mean_diff=mean_diff,
+        stderr_diff=stderr_diff,
+        per_seed_diff=diffs,
+    )
+    manifest = summary["shard_manifest"]
+    if not isinstance(manifest, list) or len(manifest) != len(expected_pairs):
+        raise ValueError("summary shard manifest coverage mismatch")
+    manifest_pairs = {(entry.get("config_name"), entry.get("seed")) for entry in manifest}
+    if manifest_pairs != expected_pairs:
+        raise ValueError("summary shard manifest arm/seed identities mismatch")
+    return {
+        "schema": "asi.ipmnist_prereg.result_validation.v1",
+        "protocol": asdict(protocol),
+        "source": source,
+        "tree": tree,
+        "uv_lock_sha256": uv_lock_sha256,
+        "summary": summary_path.relative_to(root).as_posix(),
+        "summary_sha256": hashlib.sha256(summary_path.read_bytes()).hexdigest(),
+        "mean_diff": mean_diff,
+        "stderr_diff": stderr_diff,
+        "per_seed_diff": list(diffs),
+        "outcome": outcome,
+        "runtime": first["environment"],
+        "dataset_provenance": first["dataset_provenance"],
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _preflight_command(args: argparse.Namespace) -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    payload = verify_launch_authorization(
+        protocol_key=args.protocol,
+        repository=args.repository,
+        source=args.source,
+        tree=args.tree,
+        uv_lock_sha256=args.uv_lock_sha256,
+        workflow_blob_sha1=args.workflow_blob_sha1,
+        driver_blob_sha1=args.driver_blob_sha1,
+        ref_name=args.ref_name,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        token=token,
+    )
+    _write_json(args.output, payload)
+    print(json.dumps(payload, allow_nan=False, sort_keys=True))
+    return 0
+
+
+def _validate_command(args: argparse.Namespace) -> int:
+    payload = validate_result_bundle(
+        protocol_key=args.protocol,
+        root=args.root.resolve(strict=True),
+        source=args.source,
+        tree=args.tree,
+        uv_lock_sha256=args.uv_lock_sha256,
+    )
+    _write_json(args.output, payload)
+    print(json.dumps(payload, allow_nan=False, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    preflight = subparsers.add_parser("preflight")
+    preflight.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
+    preflight.add_argument("--repository", required=True)
+    preflight.add_argument("--source", required=True)
+    preflight.add_argument("--tree", required=True)
+    preflight.add_argument("--uv-lock-sha256", required=True)
+    preflight.add_argument("--workflow-blob-sha1", required=True)
+    preflight.add_argument("--driver-blob-sha1", required=True)
+    preflight.add_argument("--ref-name", required=True)
+    preflight.add_argument("--run-id", type=int, required=True)
+    preflight.add_argument("--run-attempt", type=int, required=True)
+    preflight.add_argument("--output", type=Path, required=True)
+    preflight.set_defaults(handler=_preflight_command)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
+    validate.add_argument("--root", type=Path, required=True)
+    validate.add_argument("--source", required=True)
+    validate.add_argument("--tree", required=True)
+    validate.add_argument("--uv-lock-sha256", required=True)
+    validate.add_argument("--output", type=Path, required=True)
+    validate.set_defaults(handler=_validate_command)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    handler = cast(Any, args.handler)
+    return int(handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -9,7 +9,6 @@ import hashlib
 import json
 import math
 import os
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -19,7 +18,9 @@ from typing import Any, Final, cast
 
 WORKFLOW_PATH: Final = ".github/workflows/ipmnist-prereg.yml"
 DRIVER_PATH: Final = ".github/scripts/ipmnist_prereg.py"
-OWNER_LOGIN: Final = "lalalune"
+AUTHORIZED_LOGIN: Final = "lalalune"
+AUTHORIZED_USER_ID: Final = 18_633_264
+AUTHORIZED_ASSOCIATION: Final = "MEMBER"
 EXPECTED_CONFIG: Final = {
     "n_tasks": 60,
     "task_length": 5000,
@@ -101,6 +102,7 @@ def authorization_line(
         f"source={source} tree={tree} uv_lock_sha256={uv_lock_sha256} "
         f"workflow_blob_sha1={workflow_blob_sha1} driver_blob_sha1={driver_blob_sha1} "
         f"ref={ref_name} runner=macos-14-arm64 seeds={seeds} "
+        "registration_amendment=source-and-runner-as-bound "
         "protocol_approval=approved seed_budget=approved "
         "compute=authorized-uncompensated"
     )
@@ -176,7 +178,7 @@ def _workflow_runs(repository: str, *, token: str) -> list[dict[str, Any]]:
             if len(page_runs) < 100:
                 return runs
             continue
-        time.sleep(2.0)
+        raise RuntimeError("GitHub Actions API returned an invalid workflow-runs payload")
     raise RuntimeError("GitHub Actions pagination exceeded 10,000 workflow runs")
 
 
@@ -248,17 +250,28 @@ def verify_launch_authorization(
         if isinstance(comment, dict)
         and comment.get("body") == expected_line
         and isinstance(comment.get("user"), dict)
-        and comment["user"].get("login") == OWNER_LOGIN
-        and comment.get("author_association") == "OWNER"
+        and comment["user"].get("login") == AUTHORIZED_LOGIN
+        and comment["user"].get("id") == AUTHORIZED_USER_ID
+        and comment.get("author_association") == AUTHORIZED_ASSOCIATION
     ]
     if len(matches) != 1:
         raise RuntimeError(
-            f"expected exactly one standalone owner authorization comment; found {len(matches)}"
+            "expected exactly one standalone project-owner authorization comment; "
+            f"found {len(matches)}"
         )
     comment = matches[0]
-    created_at = cast(str, current.get("created_at"))
-    if _parse_utc(cast(str, comment["created_at"])) >= _parse_utc(created_at):
-        raise RuntimeError("owner authorization must be durable before workflow dispatch")
+    run_created_at = current.get("created_at")
+    comment_created_at = comment.get("created_at")
+    comment_updated_at = comment.get("updated_at")
+    if not all(
+        isinstance(value, str) and value
+        for value in (run_created_at, comment_created_at, comment_updated_at)
+    ):
+        raise RuntimeError("authorization timestamps are missing or invalid")
+    if comment_updated_at != comment_created_at:
+        raise RuntimeError("authorization comment must be exact and never edited")
+    if _parse_utc(comment_updated_at) >= _parse_utc(run_created_at):
+        raise RuntimeError("project-owner authorization must be durable before workflow dispatch")
     return {
         "schema": "asi.ipmnist_prereg.launch_preflight.v1",
         "protocol": asdict(protocol),
@@ -275,12 +288,13 @@ def verify_launch_authorization(
         "authorization_comment_id": comment.get("id"),
         "authorization_comment_url": comment.get("html_url"),
         "authorization_created_at": comment.get("created_at"),
+        "authorization_updated_at": comment.get("updated_at"),
         "authorization_line": expected_line,
         "authorization_sha256": hashlib.sha256(expected_line.encode()).hexdigest(),
     }
 
 
-def _strict_json(path: Path) -> dict[str, Any]:
+def _strict_json_bytes(path: Path) -> tuple[dict[str, Any], bytes]:
     def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         value: dict[str, Any] = {}
         for key, item in pairs:
@@ -292,14 +306,67 @@ def _strict_json(path: Path) -> dict[str, Any]:
     def reject_constant(value: str) -> Any:
         raise ValueError(f"{path}: non-finite JSON constant {value!r}")
 
+    def finite_float(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            raise ValueError(f"{path}: non-finite JSON number {value!r}")
+        return parsed
+
+    try:
+        raw = path.read_bytes()
+        text = raw.decode("utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(f"{path}: could not read one UTF-8 JSON artifact") from exc
     payload = json.loads(
-        path.read_text(encoding="utf-8"),
+        text,
         object_pairs_hook=pairs_hook,
         parse_constant=reject_constant,
+        parse_float=finite_float,
     )
     if not isinstance(payload, dict):
         raise ValueError(f"{path}: expected one JSON object")
+    return payload, raw
+
+
+def _strict_json(path: Path) -> dict[str, Any]:
+    payload, _raw = _strict_json_bytes(path)
     return payload
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("artifact contains a noncanonical JSON value") from exc
+
+
+def _validate_summary_reconstruction(
+    *,
+    summary: dict[str, Any],
+    recomputed: dict[str, Any],
+    expected_manifest: list[dict[str, Any]],
+) -> None:
+    """Require stored derived fields and input bindings to match a fresh merge exactly."""
+
+    created_unix = summary.get("created_unix")
+    if type(created_unix) is not float or not math.isfinite(created_unix) or created_unix < 0.0:
+        raise ValueError("summary created_unix must be a finite non-negative float")
+    if _canonical_json(summary.get("shard_manifest")) != _canonical_json(expected_manifest):
+        raise ValueError("summary shard manifest does not bind the exact shard bytes and paths")
+    operational_fields = {"created_unix", "shard_manifest"}
+    stored_derivation = {
+        key: value for key, value in summary.items() if key not in operational_fields
+    }
+    fresh_derivation = {
+        key: value for key, value in recomputed.items() if key not in operational_fields
+    }
+    if _canonical_json(stored_derivation) != _canonical_json(fresh_derivation):
+        raise ValueError("summary derivation does not match an exact reconstruction from shards")
 
 
 def _require_exact_keys(value: dict[str, Any], expected: set[str], *, context: str) -> None:
@@ -347,13 +414,62 @@ def _validate_runtime(environment: dict[str, Any]) -> None:
         raise ValueError(f"unexpected process-environment receipt: {process}")
 
 
+def _validate_runner_receipt(
+    payload: dict[str, Any], *, environment: dict[str, Any]
+) -> None:
+    _require_exact_keys(
+        payload,
+        {
+            "schema",
+            "runner_label",
+            "cpu_brand",
+            "platform",
+            "machine",
+            "python",
+            "packages",
+            "jax_backend",
+            "jax_devices",
+        },
+        context="runner receipt",
+    )
+    cpu_brand = payload["cpu_brand"]
+    if (
+        payload["schema"] != "asi.ipmnist_prereg.runner.v1"
+        or payload["runner_label"] != "macos-14"
+        or not isinstance(cpu_brand, str)
+        or "Apple M1" not in cpu_brand
+        or not isinstance(payload["platform"], str)
+        or not payload["platform"]
+        or payload["machine"] != "arm64"
+        or payload["python"] != "3.12.12"
+        or payload["jax_backend"] != "cpu"
+    ):
+        raise ValueError(f"unexpected macos-14 arm64 runner receipt: {payload}")
+    packages = cast(dict[str, Any], environment["packages"])
+    expected_packages = {
+        name: packages[name] for name in ("jax", "jaxlib", "numpy", "scikit-learn")
+    }
+    if payload["packages"] != expected_packages:
+        raise ValueError("runner receipt package versions differ from shard provenance")
+    jax_binding = cast(dict[str, Any], environment["jax"])
+    if payload["jax_devices"] != jax_binding["devices"]:
+        raise ValueError("runner receipt JAX devices differ from shard provenance")
+
+
 def validate_result_bundle(
-    *, protocol_key: str, root: Path, source: str, tree: str, uv_lock_sha256: str
+    *,
+    protocol_key: str,
+    root: Path,
+    runner_receipt: Path,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
 ) -> dict[str, Any]:
     from alberta_framework.benchmarks.ipmnist_screening import (
         SHARD_SCHEMA,
         SUMMARY_SCHEMA,
         load_shard,
+        merge_shards,
     )
 
     protocol = protocol_for(protocol_key)
@@ -373,7 +489,8 @@ def validate_result_bundle(
             f"missing={sorted(str(path) for path in expected_paths - observed_paths)}, "
             f"unexpected={sorted(str(path) for path in observed_paths - expected_paths)}"
         )
-    shards = [load_shard(path) for path in sorted(expected_paths)]
+    sorted_paths = sorted(expected_paths)
+    shards = [load_shard(path) for path in sorted_paths]
     observed_pairs = {(shard["config_name"], shard["seed"]) for shard in shards}
     if observed_pairs != expected_pairs or len(shards) != len(expected_pairs):
         raise ValueError("shard payload arm/seed coverage is not exact")
@@ -399,12 +516,15 @@ def validate_result_bundle(
             raise ValueError("shards do not share exact dataset provenance")
         if shard["environment"] != first["environment"]:
             raise ValueError("shards do not share exact runtime provenance")
-    _validate_runtime(cast(dict[str, Any], first["environment"]))
+    environment = cast(dict[str, Any], first["environment"])
+    _validate_runtime(environment)
+    runner, runner_raw = _strict_json_bytes(runner_receipt)
+    _validate_runner_receipt(runner, environment=environment)
 
     summary_path = namespace / (
         "summary.json" if protocol.key == "issue51" else "summary_resid_gate_ablation_r3.json"
     )
-    summary = _strict_json(summary_path)
+    summary, summary_raw = _strict_json_bytes(summary_path)
     expected_summary_keys = {
         "schema",
         "evidence_policy",
@@ -423,6 +543,29 @@ def validate_result_bundle(
         "shard_manifest",
     }
     _require_exact_keys(summary, expected_summary_keys, context=str(summary_path))
+    recomputed = merge_shards(sorted_paths, control_name=protocol.control, slope_window=15)
+    recomputed_manifest = recomputed.get("shard_manifest")
+    if not isinstance(recomputed_manifest, list):
+        raise ValueError("fresh strict-v2 merge did not produce a shard manifest")
+    expected_manifest: list[dict[str, Any]] = []
+    for raw_entry in recomputed_manifest:
+        if not isinstance(raw_entry, dict):
+            raise ValueError("fresh strict-v2 merge produced an invalid shard manifest")
+        entry = dict(raw_entry)
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError("fresh strict-v2 merge produced an invalid shard path")
+        try:
+            canonical_path = Path(raw_path).resolve(strict=True)
+            entry["path"] = canonical_path.relative_to(root).as_posix()
+        except (OSError, ValueError) as exc:
+            raise ValueError("fresh strict-v2 merge input escaped the repository root") from exc
+        expected_manifest.append(entry)
+    _validate_summary_reconstruction(
+        summary=summary,
+        recomputed=recomputed,
+        expected_manifest=expected_manifest,
+    )
     if summary["schema"] != SUMMARY_SCHEMA or summary["evidence_policy"] != EXPECTED_POLICY:
         raise ValueError("summary must be a strict-v2 permanently nonpromoting artifact")
     if (
@@ -436,7 +579,7 @@ def validate_result_bundle(
         or summary["environment"] != first["environment"]
     ):
         raise ValueError("summary protocol or provenance binding mismatch")
-    results = summary["results"]
+    results = recomputed["results"]
     if not isinstance(results, list) or len(results) != 2:
         raise ValueError("summary must contain exactly the control and candidate")
     by_name = {
@@ -482,22 +625,22 @@ def validate_result_bundle(
         "tree": tree,
         "uv_lock_sha256": uv_lock_sha256,
         "summary": summary_path.relative_to(root).as_posix(),
-        "summary_sha256": hashlib.sha256(summary_path.read_bytes()).hexdigest(),
+        "summary_sha256": hashlib.sha256(summary_raw).hexdigest(),
         "mean_diff": mean_diff,
         "stderr_diff": stderr_diff,
         "per_seed_diff": list(diffs),
         "outcome": outcome,
-        "runtime": first["environment"],
+        "runtime": environment,
+        "runner": runner,
+        "runner_receipt_sha256": hashlib.sha256(runner_raw).hexdigest(),
         "dataset_provenance": first["dataset_provenance"],
     }
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    with path.open("x", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n")
 
 
 def _preflight_command(args: argparse.Namespace) -> int:
@@ -526,6 +669,7 @@ def _validate_command(args: argparse.Namespace) -> int:
     payload = validate_result_bundle(
         protocol_key=args.protocol,
         root=args.root.resolve(strict=True),
+        runner_receipt=args.runner_receipt.resolve(strict=True),
         source=args.source,
         tree=args.tree,
         uv_lock_sha256=args.uv_lock_sha256,
@@ -555,6 +699,7 @@ def build_parser() -> argparse.ArgumentParser:
     validate = subparsers.add_parser("validate")
     validate.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
     validate.add_argument("--root", type=Path, required=True)
+    validate.add_argument("--runner-receipt", type=Path, required=True)
     validate.add_argument("--source", required=True)
     validate.add_argument("--tree", required=True)
     validate.add_argument("--uv-lock-sha256", required=True)

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -1,0 +1,356 @@
+---
+name: IPMNIST preregistration
+run-name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}
+
+# This workflow is deliberately manual-only. It is launch infrastructure for
+# two permanently nonpromoting development protocols, not a CI benchmark lane.
+"on":
+  workflow_dispatch:
+    inputs:
+      protocol:
+        description: Exact preregistration to execute
+        required: true
+        type: choice
+        options:
+          - issue51
+          - issue188
+      launch_sha:
+        description: Full 40-character commit SHA of the immutable launch tag
+        required: true
+        type: string
+
+concurrency:
+  group: ipmnist-prereg-${{ inputs.protocol }}-${{ inputs.launch_sha }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+
+env:
+  CUDA_VISIBLE_DEVICES: ""
+  JAX_ENABLE_X64: "false"
+  JAX_PLATFORM_NAME: cpu
+  JAX_PLATFORMS: cpu
+  OMP_NUM_THREADS: "1"
+  PYTHONHASHSEED: "0"
+  XLA_FLAGS: --xla_force_host_platform_device_count=1
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+
+jobs:
+  run:
+    if: github.repository == 'elizaOS/asi'
+    runs-on: macos-14
+    timeout-minutes: 360
+    steps:
+      - name: Check out the exact launch object
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.launch_sha }}
+
+      - name: Set up exact Python 3.12.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: 3.12.12
+
+      - name: Bind source, tag, workflow, and lock identities
+        id: identity
+        shell: bash
+        env:
+          LAUNCH_SHA: ${{ inputs.launch_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$LAUNCH_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "launch_sha must be a full lowercase SHA-1" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+            echo "dispatch ref must be an immutable reviewed tag" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_SHA" != "$LAUNCH_SHA" || "$WORKFLOW_SHA" != "$LAUNCH_SHA" ]]; then
+            echo "dispatch, input, and workflow source identities differ" >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse --verify HEAD)" != "$LAUNCH_SHA" ]]; then
+            echo "checkout HEAD differs from the authorized source" >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse --verify "$GITHUB_REF^{commit}")" != "$LAUNCH_SHA" ]]; then
+            echo "launch tag does not peel to the authorized source" >&2
+            exit 1
+          fi
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "tracked checkout is dirty before launch" >&2
+            exit 1
+          fi
+          tree="$(git rev-parse --verify 'HEAD^{tree}')"
+          uv_lock_sha256="$(shasum -a 256 uv.lock | awk '{print $1}')"
+          workflow_blob_sha1="$(git rev-parse "HEAD:.github/workflows/ipmnist-prereg.yml")"
+          driver_blob_sha1="$(git rev-parse "HEAD:.github/scripts/ipmnist_prereg.py")"
+          {
+            echo "tree=$tree"
+            echo "uv_lock_sha256=$uv_lock_sha256"
+            echo "workflow_blob_sha1=$workflow_blob_sha1"
+            echo "driver_blob_sha1=$driver_blob_sha1"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Refuse occupied output namespaces
+        shell: bash
+        env:
+          PROTOCOL: ${{ inputs.protocol }}
+        run: |
+          set -euo pipefail
+          case "$PROTOCOL" in
+            issue51) namespace="replication_r1" ;;
+            issue188) namespace="gate_ablation_r3" ;;
+            *) echo "unsupported protocol" >&2; exit 1 ;;
+          esac
+          target="outputs/ipmnist_screening/$namespace"
+          if [[ -e "$target" ]]; then
+            echo "append-only namespace is already occupied: $target" >&2
+            exit 1
+          fi
+
+      - name: Require one pre-data owner authorization and one dispatch
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROTOCOL: ${{ inputs.protocol }}
+          SOURCE: ${{ inputs.launch_sha }}
+          TREE: ${{ steps.identity.outputs.tree }}
+          UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
+          WORKFLOW_BLOB_SHA1: ${{ steps.identity.outputs.workflow_blob_sha1 }}
+          DRIVER_BLOB_SHA1: ${{ steps.identity.outputs.driver_blob_sha1 }}
+        run: |
+          set -euo pipefail
+          metadata="$RUNNER_TEMP/prereg-metadata/launch-preflight.json"
+          python .github/scripts/ipmnist_prereg.py preflight \
+            --protocol "$PROTOCOL" \
+            --repository "$GITHUB_REPOSITORY" \
+            --source "$SOURCE" \
+            --tree "$TREE" \
+            --uv-lock-sha256 "$UV_LOCK_SHA256" \
+            --workflow-blob-sha1 "$WORKFLOW_BLOB_SHA1" \
+            --driver-blob-sha1 "$DRIVER_BLOB_SHA1" \
+            --ref-name "$GITHUB_REF_NAME" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$metadata"
+
+      - name: Set up exact uv 0.9.24
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: 0.9.24
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Synchronize the committed environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          cpu_brand="$(sysctl -n machdep.cpu.brand_string)"
+          if [[ "$cpu_brand" != *"Apple M1"* ]]; then
+            echo "macos-14 runner is not an Apple M1 family host: $cpu_brand" >&2
+            exit 1
+          fi
+          uv sync \
+            --locked \
+            --python "$(command -v python)" \
+            --extra research
+          uv run --no-sync python - "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
+          import importlib.metadata
+          import json
+          import platform
+          import sys
+          from pathlib import Path
+
+          import jax
+
+          expected = {
+              "jax": "0.11.0",
+              "jaxlib": "0.11.0",
+              "numpy": "2.5.1",
+              "scikit-learn": "1.9.0",
+          }
+          assert platform.python_implementation() == "CPython"
+          assert platform.python_version() == "3.12.12"
+          assert platform.system() == "Darwin"
+          assert platform.machine() == "arm64"
+          assert {name: importlib.metadata.version(name) for name in expected} == expected
+          devices = jax.devices()
+          assert jax.default_backend() == "cpu"
+          assert len(devices) == 1
+          assert devices[0].platform == "cpu"
+          destination = Path(sys.argv[2])
+          destination.parent.mkdir(parents=True, exist_ok=True)
+          destination.write_text(
+              json.dumps(
+                  {
+                      "schema": "asi.ipmnist_prereg.runner.v1",
+                      "runner_label": "macos-14",
+                      "cpu_brand": sys.argv[1],
+                      "platform": platform.platform(),
+                      "machine": platform.machine(),
+                      "python": platform.python_version(),
+                      "packages": expected,
+                      "jax_backend": jax.default_backend(),
+                      "jax_devices": [
+                          {
+                              "id": int(device.id),
+                              "platform": device.platform,
+                              "device_kind": device.device_kind,
+                              "process_index": int(device.process_index),
+                          }
+                          for device in devices
+                      ],
+                  },
+                  allow_nan=False,
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Run code-only preregistration preflight tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync python -m pytest \
+            tests/test_ipmnist_prereg_workflow.py \
+            tests/test_ipmnist_screening.py \
+            -q \
+            -o addopts="" \
+            --strict-config \
+            --strict-markers \
+            -k "ipmnist_prereg or TestRLSHead or TestShiftNorm or TestShardsAndMerge"
+
+      - name: Materialize and hash the canonical MNIST cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          data_home="$RUNNER_TEMP/openml-cache"
+          uv run --no-sync python - "$data_home" <<'PY'
+          import hashlib
+          import sys
+          from pathlib import Path
+
+          from alberta_framework.benchmarks.upgd_ipmnist import load_mnist_train
+          from alberta_framework.evaluation.upgd_ipmnist_nonpromoting import (
+              MNIST_CACHE_RELATIVE_PATH,
+              MNIST_CACHE_SHA256,
+          )
+
+          data_home = Path(sys.argv[1])
+          x, y = load_mnist_train(data_home)
+          assert x.shape == (60_000, 784)
+          assert y.shape == (60_000,)
+          cache = data_home / MNIST_CACHE_RELATIVE_PATH
+          raw = cache.read_bytes()
+          assert len(raw) == 15_469_256
+          assert hashlib.sha256(raw).hexdigest() == MNIST_CACHE_SHA256
+          PY
+
+      - name: Run the frozen arms sequentially and merge once
+        id: measurement
+        shell: bash
+        env:
+          PROTOCOL: ${{ inputs.protocol }}
+        run: |
+          set -euo pipefail
+          case "$PROTOCOL" in
+            issue51)
+              namespace="replication_r1"
+              control="sigma0_shiftnorm_d099"
+              candidate="rls_head_resid_l1_preset005"
+              seeds=(0 1 2)
+              summary="summary.json"
+              ;;
+            issue188)
+              namespace="gate_ablation_r3"
+              control="rls_head_resid_l1_preset005"
+              candidate="rls_head_resid_l1_preset005_nogate"
+              seeds=(3 4 5 6 7 8 9 10 11 12)
+              summary="summary_resid_gate_ablation_r3.json"
+              ;;
+            *) echo "unsupported protocol" >&2; exit 1 ;;
+          esac
+          data_home="$RUNNER_TEMP/openml-cache"
+          output_root="outputs/ipmnist_screening/$namespace"
+          shards_dir="$output_root/shards"
+          logs_dir="$RUNNER_TEMP/prereg-metadata/logs"
+          mkdir -p "$shards_dir" "$logs_dir"
+          shard_args=()
+          for seed in "${seeds[@]}"; do
+            for arm in "$control" "$candidate"; do
+              shard="$shards_dir/${arm}_seed${seed}.json"
+              log="$logs_dir/${arm}_seed${seed}.log"
+              uv run --no-sync python -m \
+                alberta_framework.benchmarks.ipmnist_screening run \
+                --config-name "$arm" \
+                --seed "$seed" \
+                --n-tasks 60 \
+                --task-length 5000 \
+                --data-home "$data_home" \
+                --noise-mode step \
+                --progress-every 10 \
+                --out "$shard" \
+                2>&1 | tee "$log"
+              shard_args+=("$shard")
+            done
+          done
+          uv run --no-sync python -m \
+            alberta_framework.benchmarks.ipmnist_screening merge \
+            --shards "${shard_args[@]}" \
+            --control-name "$control" \
+            --slope-window 15 \
+            --output "$output_root/$summary" \
+            2>&1 | tee "$logs_dir/merge.log"
+          {
+            echo "namespace=$namespace"
+            echo "summary=$summary"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Independently validate exact coverage, provenance, and frozen outcome
+        shell: bash
+        env:
+          PROTOCOL: ${{ inputs.protocol }}
+          SOURCE: ${{ inputs.launch_sha }}
+          TREE: ${{ steps.identity.outputs.tree }}
+          UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/prereg-metadata/result-validation.json"
+          uv run --no-sync python .github/scripts/ipmnist_prereg.py validate \
+            --protocol "$PROTOCOL" \
+            --root "$GITHUB_WORKSPACE" \
+            --source "$SOURCE" \
+            --tree "$TREE" \
+            --uv-lock-sha256 "$UV_LOCK_SHA256" \
+            --output "$result"
+          {
+            echo "## Permanently nonpromoting IPMNIST result"
+            echo
+            echo "- Protocol: $PROTOCOL"
+            echo "- Source: $SOURCE"
+            echo "- Outcome: $(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["outcome"])' "$result")"
+            echo "- Validation metadata: result-validation.json"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable result or partial recovery bundle
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}-${{ github.run_id }}
+          path: |
+            outputs/ipmnist_screening/replication_r1
+            outputs/ipmnist_screening/gate_ablation_r3
+            ${{ runner.temp }}/prereg-metadata
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -15,7 +15,7 @@ run-name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}
           - issue51
           - issue188
       launch_sha:
-        description: Full 40-character commit SHA of the immutable launch tag
+        description: Full 40-character commit SHA of the reviewed launch tag
         required: true
         type: string
 
@@ -69,7 +69,7 @@ jobs:
             exit 1
           fi
           if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
-            echo "dispatch ref must be an immutable reviewed tag" >&2
+            echo "dispatch ref must be a reviewed tag" >&2
             exit 1
           fi
           if [[ "$GITHUB_SHA" != "$LAUNCH_SHA" || "$WORKFLOW_SHA" != "$LAUNCH_SHA" ]]; then
@@ -116,7 +116,7 @@ jobs:
             exit 1
           fi
 
-      - name: Require one pre-data owner authorization and one dispatch
+      - name: Require one pre-data project-owner authorization and one dispatch
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
           assert devices[0].platform == "cpu"
           destination = Path(sys.argv[2])
           destination.parent.mkdir(parents=True, exist_ok=True)
-          destination.write_text(
+          encoded = (
               json.dumps(
                   {
                       "schema": "asi.ipmnist_prereg.runner.v1",
@@ -213,9 +213,10 @@ jobs:
                   indent=2,
                   sort_keys=True,
               )
-              + "\n",
-              encoding="utf-8",
+              + "\n"
           )
+          with destination.open("x", encoding="utf-8") as stream:
+              stream.write(encoded)
           PY
 
       - name: Run code-only preregistration preflight tests
@@ -330,6 +331,7 @@ jobs:
           uv run --no-sync python .github/scripts/ipmnist_prereg.py validate \
             --protocol "$PROTOCOL" \
             --root "$GITHUB_WORKSPACE" \
+            --runner-receipt "$RUNNER_TEMP/prereg-metadata/runner.json" \
             --source "$SOURCE" \
             --tree "$TREE" \
             --uv-lock-sha256 "$UV_LOCK_SHA256" \
@@ -343,7 +345,7 @@ jobs:
             echo "- Validation metadata: result-validation.json"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload immutable result or partial recovery bundle
+      - name: Upload 90-day result or partial recovery bundle
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DRIVER = runpy.run_path(_ROOT / ".github" / "scripts" / "ipmnist_prereg.py")
+_PROTOCOLS = cast(dict[str, Any], _DRIVER["PROTOCOLS"])
+_authorization_line = cast(Any, _DRIVER["authorization_line"])
+_classify_outcome = cast(Any, _DRIVER["classify_outcome"])
+
+
+def test_prereg_protocols_pin_exact_arms_and_seeds() -> None:
+    issue51 = _PROTOCOLS["issue51"]
+    assert issue51.issue == 51
+    assert issue51.namespace == "replication_r1"
+    assert issue51.control == "sigma0_shiftnorm_d099"
+    assert issue51.candidate == "rls_head_resid_l1_preset005"
+    assert issue51.seeds == (0, 1, 2)
+
+    issue188 = _PROTOCOLS["issue188"]
+    assert issue188.issue == 188
+    assert issue188.namespace == "gate_ablation_r3"
+    assert issue188.control == "rls_head_resid_l1_preset005"
+    assert issue188.candidate == "rls_head_resid_l1_preset005_nogate"
+    assert issue188.seeds == tuple(range(3, 13))
+
+
+def test_authorization_line_binds_every_launch_identity() -> None:
+    line = _authorization_line(
+        _PROTOCOLS["issue51"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    assert line == (
+        "ASI_PREREG_LAUNCH_V1 issue=51 protocol=issue51 "
+        f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
+        f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
+        "ref=ipmnist-prereg-example runner=macos-14-arm64 seeds=0,1,2 "
+        "protocol_approval=approved seed_budget=approved compute=authorized-uncompensated"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mean_diff", "diffs", "expected"),
+    [
+        (0.004882, (0.004, 0.005, 0.006), "replicated"),
+        (0.005950, (0.004, 0.005, 0.006), "replicated"),
+        (0.006, (0.004, 0.005, 0.006), "directionally_replicated"),
+        (0.005, (0.004, 0.0, 0.006), "not_replicated"),
+    ],
+)
+def test_issue51_outcomes_are_frozen(
+    mean_diff: float, diffs: tuple[float, ...], expected: str
+) -> None:
+    assert (
+        _classify_outcome("issue51", mean_diff=mean_diff, stderr_diff=0.0001, per_seed_diff=diffs)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("mean_diff", "stderr_diff", "expected"),
+    [
+        (-0.001, 0.0001, "not_load_bearing"),
+        (-0.002, 0.0001, "load_bearing"),
+        (-0.0015, 0.0001, "inconclusive"),
+        (-0.0013, 0.0001, "inconclusive"),
+    ],
+)
+def test_issue188_outcomes_are_frozen(mean_diff: float, stderr_diff: float, expected: str) -> None:
+    assert (
+        _classify_outcome(
+            "issue188",
+            mean_diff=mean_diff,
+            stderr_diff=stderr_diff,
+            per_seed_diff=(mean_diff,) * 10,
+        )
+        == expected
+    )
+
+
+def test_outcome_validation_rejects_nonfinite_values() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        _classify_outcome(
+            "issue188",
+            mean_diff=float("nan"),
+            stderr_diff=0.0,
+            per_seed_diff=(0.0,) * 10,
+        )

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import runpy
 from pathlib import Path
 from typing import Any, cast
 
+import numpy as np
 import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -11,6 +13,12 @@ _DRIVER = runpy.run_path(_ROOT / ".github" / "scripts" / "ipmnist_prereg.py")
 _PROTOCOLS = cast(dict[str, Any], _DRIVER["PROTOCOLS"])
 _authorization_line = cast(Any, _DRIVER["authorization_line"])
 _classify_outcome = cast(Any, _DRIVER["classify_outcome"])
+_strict_json = cast(Any, _DRIVER["_strict_json"])
+_validate_summary_reconstruction = cast(Any, _DRIVER["_validate_summary_reconstruction"])
+_validate_result_bundle = cast(Any, _DRIVER["validate_result_bundle"])
+_verify_launch_authorization = cast(Any, _DRIVER["verify_launch_authorization"])
+_write_json = cast(Any, _DRIVER["_write_json"])
+_DRIVER_GLOBALS = cast(dict[str, Any], _verify_launch_authorization.__globals__)
 
 
 def test_prereg_protocols_pin_exact_arms_and_seeds() -> None:
@@ -44,6 +52,7 @@ def test_authorization_line_binds_every_launch_identity() -> None:
         f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
         f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
         "ref=ipmnist-prereg-example runner=macos-14-arm64 seeds=0,1,2 "
+        "registration_amendment=source-and-runner-as-bound "
         "protocol_approval=approved seed_budget=approved compute=authorized-uncompensated"
     )
 
@@ -94,4 +103,345 @@ def test_outcome_validation_rejects_nonfinite_values() -> None:
             mean_diff=float("nan"),
             stderr_diff=0.0,
             per_seed_diff=(0.0,) * 10,
+        )
+
+
+def _launch_api_payloads(comment: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    current = {
+        "id": 123,
+        "event": "workflow_dispatch",
+        "head_sha": "1" * 40,
+        "display_title": f"ipmnist-issue51-{'1' * 40}",
+        "run_attempt": 1,
+        "path": ".github/workflows/ipmnist-prereg.yml",
+        "created_at": "2026-08-16T10:00:00Z",
+        "html_url": "https://example.invalid/run/123",
+    }
+    return current, [comment]
+
+
+def _verify_with_comment(
+    monkeypatch: pytest.MonkeyPatch, comment: dict[str, Any]
+) -> dict[str, Any]:
+    current, comments = _launch_api_payloads(comment)
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_pages", lambda *_args, **_kwargs: comments)
+    return cast(
+        dict[str, Any],
+        _verify_launch_authorization(
+            protocol_key="issue51",
+            repository="elizaOS/asi",
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="3" * 64,
+            workflow_blob_sha1="4" * 40,
+            driver_blob_sha1="5" * 40,
+            ref_name="ipmnist-prereg-example",
+            run_id=123,
+            run_attempt=1,
+            token="token",
+        ),
+    )
+
+
+def _authorization_comment(**overrides: Any) -> dict[str, Any]:
+    body = _authorization_line(
+        _PROTOCOLS["issue51"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    comment: dict[str, Any] = {
+        "id": 456,
+        "body": body,
+        "user": {"id": 18_633_264, "login": "lalalune"},
+        "author_association": "MEMBER",
+        "created_at": "2026-08-16T09:00:00Z",
+        "updated_at": "2026-08-16T09:00:00Z",
+        "html_url": "https://example.invalid/comment/456",
+    }
+    comment.update(overrides)
+    return comment
+
+
+def test_launch_authorization_accepts_exact_unedited_project_owner_comment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _verify_with_comment(monkeypatch, _authorization_comment())
+    assert payload["authorization_comment_id"] == 456
+    assert payload["authorization_created_at"] == "2026-08-16T09:00:00Z"
+    assert payload["authorization_updated_at"] == "2026-08-16T09:00:00Z"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"author_association": "OWNER"},
+        {"user": {"id": 1, "login": "lalalune"}},
+        {"updated_at": "2026-08-16T09:30:00Z"},
+    ],
+)
+def test_launch_authorization_rejects_wrong_identity_or_edited_comment(
+    monkeypatch: pytest.MonkeyPatch, overrides: dict[str, Any]
+) -> None:
+    with pytest.raises(RuntimeError, match="authorization"):
+        _verify_with_comment(monkeypatch, _authorization_comment(**overrides))
+
+
+def test_summary_reconstruction_rejects_resigned_derived_metrics_and_manifest() -> None:
+    expected_manifest = [
+        {
+            "path": "outputs/ipmnist_screening/example/shards/control_seed0.json",
+            "size_bytes": 10,
+            "sha256": "a" * 64,
+            "config_name": "control",
+            "seed": 0,
+        }
+    ]
+    summary = {
+        "schema": "summary.v2",
+        "created_unix": 1.0,
+        "results": [{"config_name": "candidate", "mean_diff": 0.25}],
+        "shard_manifest": expected_manifest,
+    }
+    recomputed = {
+        **summary,
+        "created_unix": 2.0,
+        "shard_manifest": [{**expected_manifest[0], "path": "/absolute/input.json"}],
+    }
+    _validate_summary_reconstruction(
+        summary=summary,
+        recomputed=recomputed,
+        expected_manifest=expected_manifest,
+    )
+
+    forged = {**summary, "results": [{"config_name": "candidate", "mean_diff": 0.5}]}
+    with pytest.raises(ValueError, match="reconstruction"):
+        _validate_summary_reconstruction(
+            summary=forged,
+            recomputed=recomputed,
+            expected_manifest=expected_manifest,
+        )
+
+    forged_manifest = [{**expected_manifest[0], "sha256": "b" * 64}]
+    with pytest.raises(ValueError, match="manifest"):
+        _validate_summary_reconstruction(
+            summary={**summary, "shard_manifest": forged_manifest},
+            recomputed=recomputed,
+            expected_manifest=expected_manifest,
+        )
+
+
+def test_strict_json_rejects_exponent_overflow(tmp_path: Path) -> None:
+    path = tmp_path / "payload.json"
+    path.write_text('{"value": 1e999}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="finite"):
+        _strict_json(path)
+
+
+def test_metadata_writer_refuses_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "metadata.json"
+    _write_json(path, {"value": 1})
+    with pytest.raises(FileExistsError):
+        _write_json(path, {"value": 2})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"value": 1}
+
+
+def _source_provenance() -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.source_provenance.v1",
+        "git_commit": "1" * 40,
+        "git_tree": "2" * 40,
+        "git_object_format": "sha1",
+        "relevant_source_scope": "tracked:alberta_framework/**,pyproject.toml,uv.lock",
+        "relevant_source_file_count": 3,
+        "relevant_source_sha256": "3" * 64,
+        "uv_lock_sha256": "4" * 64,
+        "worktree_clean": True,
+    }
+
+
+def _dataset_provenance() -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+        "source": {
+            "provider": "openml",
+            "name": "mnist_784",
+            "version": 1,
+            "row_start": 0,
+            "row_stop_exclusive": 60_000,
+        },
+        "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+        "x": {"dtype": "<f4", "shape": [60_000, 784], "sha256": "5" * 64},
+        "y": {"dtype": "<i4", "shape": [60_000], "sha256": "6" * 64},
+    }
+
+
+def _runtime_environment() -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.runtime.v1",
+        "python": {"implementation": "CPython", "version": "3.12.12"},
+        "platform": {"system": "Darwin", "release": "24.0", "machine": "arm64"},
+        "packages": {
+            "chex": "0.1.91",
+            "jax": "0.11.0",
+            "jaxlib": "0.11.0",
+            "numpy": "2.5.1",
+            "scikit-learn": "1.9.0",
+        },
+        "jax": {
+            "backend": "cpu",
+            "devices": [
+                {"id": 0, "platform": "cpu", "device_kind": "Apple M1", "process_index": 0}
+            ],
+            "config": {
+                "jax_enable_x64": False,
+                "jax_default_matmul_precision": None,
+                "jax_disable_jit": False,
+                "jax_numpy_dtype_promotion": "standard",
+                "jax_numpy_rank_promotion": "allow",
+                "jax_random_seed_offset": 0,
+                "jax_threefry_partitionable": True,
+                "jax_default_prng_impl": "threefry2x32",
+            },
+        },
+        "process_environment": {
+            "CUDA_VISIBLE_DEVICES": "",
+            "JAX_DEFAULT_MATMUL_PRECISION": None,
+            "JAX_ENABLE_X64": "false",
+            "JAX_PLATFORM_NAME": "cpu",
+            "JAX_PLATFORMS": "cpu",
+            "OMP_NUM_THREADS": "1",
+            "XLA_FLAGS": "--xla_force_host_platform_device_count=1",
+        },
+    }
+
+
+def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        ScreeningRunResult,
+        merge_shards,
+        screening_spec,
+        shard_payload,
+    )
+    from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+    namespace = root / "outputs" / "ipmnist_screening" / "replication_r1"
+    shards_dir = namespace / "shards"
+    shards_dir.mkdir(parents=True)
+    config = IPMNISTConfig(
+        n_tasks=60,
+        task_length=5_000,
+        input_dim=784,
+        hidden1=300,
+        hidden2=150,
+        n_classes=10,
+    )
+    relative_paths: list[Path] = []
+    for seed in (0, 1, 2):
+        for arm, accuracy in (
+            ("sigma0_shiftnorm_d099", 0.5),
+            ("rls_head_resid_l1_preset005", 0.505),
+        ):
+            spec = screening_spec(arm)
+            result = ScreeningRunResult(
+                config_name=arm,
+                base_learner=spec.base_learner,
+                hyperparameters=dict(spec.hyperparameters),
+                seed=seed,
+                config=config,
+                per_task_accuracy=np.full(60, accuracy, dtype=np.float64),
+                per_task_loss=np.full(60, 0.5, dtype=np.float64),
+                per_task_plasticity=np.full(60, 0.5, dtype=np.float64),
+                wall_clock_seconds=1.0,
+            )
+            path = shards_dir / f"{arm}_seed{seed}.json"
+            path.write_text(
+                json.dumps(
+                    shard_payload(
+                        result,
+                        source_provenance=_source_provenance(),
+                        dataset_provenance=_dataset_provenance(),
+                        environment=_runtime_environment(),
+                    ),
+                    allow_nan=False,
+                ),
+                encoding="utf-8",
+            )
+            relative_paths.append(path.relative_to(root))
+    monkeypatch.chdir(root)
+    summary = merge_shards(
+        relative_paths,
+        control_name="sigma0_shiftnorm_d099",
+        slope_window=15,
+    )
+    summary_path = namespace / "summary.json"
+    summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
+    return summary_path
+
+
+def _write_runner_receipt(root: Path) -> Path:
+    environment = _runtime_environment()
+    jax_binding = cast(dict[str, Any], environment["jax"])
+    receipt = {
+        "schema": "asi.ipmnist_prereg.runner.v1",
+        "runner_label": "macos-14",
+        "cpu_brand": "Apple M1 (Virtual)",
+        "platform": "macOS-14-arm64",
+        "machine": "arm64",
+        "python": "3.12.12",
+        "packages": {
+            name: cast(dict[str, Any], environment["packages"])[name]
+            for name in ("jax", "jaxlib", "numpy", "scikit-learn")
+        },
+        "jax_backend": "cpu",
+        "jax_devices": jax_binding["devices"],
+    }
+    path = root / "runner.json"
+    path.write_text(json.dumps(receipt, allow_nan=False), encoding="utf-8")
+    return path
+
+
+def test_result_bundle_recomputes_summary_from_exact_shards(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    result = _validate_result_bundle(
+        protocol_key="issue51",
+        root=tmp_path,
+        runner_receipt=runner_receipt,
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="4" * 64,
+    )
+    assert result["outcome"] == "replicated"
+    assert result["mean_diff"] == pytest.approx(0.005)
+
+
+def test_result_bundle_rejects_resigned_summary_metric(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    candidate = next(
+        entry
+        for entry in summary["results"]
+        if entry["config_name"] == "rls_head_resid_l1_preset005"
+    )
+    candidate["paired_vs_control"]["mean_diff"] = 0.5
+    summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
+    with pytest.raises(ValueError, match="reconstruction"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
         )


### PR DESCRIPTION
Adds the manual-only launch surface required to finish preregistrations #51 and #188 after the code sweep freezes a final source.\n\nThe workflow is deliberately non-CI and permanently nonpromoting. It requires a reviewed tag plus exact SHA/tree/uv/workflow/driver bindings, one exact unedited pre-dispatch project-owner authorization comment bound to the elizaOS organization MEMBER identity and numeric GitHub user ID, an explicit source/runner registration amendment, a first-attempt one-shot run, standard macos-14 arm64 Apple M1 hardware, Python 3.12.12/JAX 0.11.0, OMP_NUM_THREADS=1, the canonical MNIST cache hash, sequential fixed arms/seeds, strict-v2 source/runtime/dataset receipts, exact external arm/seed coverage, and one merge.\n\nPost-run validation reloads every strict shard, reconstructs the summary from those exact bytes, compares all derived fields canonically, verifies the complete shard hash/path manifest, and binds the independently captured M1 runner receipt. Metadata publication is exclusive-create. The always-uploaded GitHub artifact is accurately described as a 90-day result/recovery bundle, not immutable or durable evidence. The workflow never commits artifacts, posts issue results, authorizes compute, or launches itself.\n\nRepair validation on head d602736644f0f56030b6da55f150a728932ef9fe:\n- preregistration driver tests: 20 passed, including authorization-edit/identity, exponent overflow, overwrite, exact reconstruction, manifest, runner, and resigned-metric regressions\n- focused driver + RLS/shift/strict-shard panel: 134 passed, 192 deselected\n- repository Ruff: clean\n- strict mypy: 163 source files clean\n- actionlint: clean\n- git diff --check: clean\n- outputs unchanged\n\nThis PR is launch infrastructure only. It does not approve, dispatch, execute, authenticate, promote, or durably preserve either scientific protocol.