### PR TITLE
fix(statistics): reject non-finite bootstrap samples

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -674,9 +674,9 @@ def bootstrap_ci(
         Tuple of (point_estimate, ci_lower, ci_upper)
 
     Raises:
-        ValueError: If ``values`` is empty, ``statistic`` is not ``"mean"`` or
-            ``"median"``, ``confidence_level`` is not strictly between 0 and 1,
-            or ``n_bootstrap`` is not positive.
+        ValueError: If ``values`` is empty or contains a non-finite sample,
+            ``statistic`` is not ``"mean"`` or ``"median"``, ``confidence_level``
+            is not strictly between 0 and 1, or ``n_bootstrap`` is not positive.
     """
     arr = np.asarray(values)
     if len(arr) == 0:
@@ -684,6 +684,7 @@ def bootstrap_ci(
             "bootstrap_ci requires at least one value; got an empty array "
             "(a NaN interval would be indistinguishable from a real CI)"
         )
+    _require_finite_values(arr, name="values")
     if statistic not in ("mean", "median"):
         raise ValueError(
             f"statistic must be either 'mean' or 'median' (got {statistic!r})"

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -244,6 +244,14 @@ class TestBootstrapCI:
             with pytest.raises(ValueError, match="empty"):
                 bootstrap_ci(empty)
 
+    @pytest.mark.parametrize("poison", [float("nan"), float("inf"), float("-inf")])
+    def test_nonfinite_values_rejected_without_warnings(self, poison: float) -> None:
+        """A poisoned seed must not become a non-finite bootstrap estimate or CI."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^values must be finite$"):
+                bootstrap_ci([1.0, poison, 2.0], n_bootstrap=20, seed=0)
+
     @pytest.mark.parametrize("statistic", ["typo", "Mean", ""])
     def test_unknown_statistic_rejected_without_warnings(self, statistic: str) -> None:
         with warnings.catch_warnings():


### PR DESCRIPTION
Closes #291.

## What changed

`bootstrap_ci` accepted `NaN`, positive infinity, and negative infinity in its sample. It then returned non-finite publication statistics (point estimate and/or confidence interval), or raised NumPy runtime warnings from percentile interpolation deep inside the resampling loop.

The neighboring `compute_statistics` and `compute_timeseries_statistics` functions in the same module already enforce the module's finite-sample invariant via a shared `_require_finite_values` helper (`"Reject NaN/inf samples so summaries cannot gold-plate a poisoned seed."`); `bootstrap_ci` was the one function in this module that omitted it.

confirmed directly before touching the source:

```text
/Users/.../numpy/lib/_function_base_impl.py:4608: RuntimeWarning: invalid value encountered in scalar subtract
  diff_b_a = b - a
nan (nan, nan, nan)
inf (inf, 1.0, nan)
-inf (-inf, nan, 1.6666666666666667)
```

fix: call the existing `_require_finite_values(arr, name="values")` after the existing empty-input guard and before computing the point estimate or resamples — matching the pattern already used by the two neighboring functions.

## Reachability (honest)

`bootstrap_ci` is genuinely exported from `alberta_framework/utils/__init__.py` (both import and `__all__`), a public subpackage entry point accepting real caller data. It is **not** re-exported from the top-level `alberta_framework/__init__.py`, and a repository search found no production callers beyond its own definition and tests. The practical impact is direct library consumers of `alberta_framework.utils`, not an internally exercised benchmark CLI.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""
110 passed, 2 warnings in 2.17s

$ .venv/bin/python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

The 2 warnings are pre-existing scipy precision-loss notices from unrelated `TestPairedTests`/`TestPairwiseComparisons` cases, unchanged by this fix.

New test: `test_nonfinite_values_rejected_without_warnings`, parameterized over `NaN`, `+inf`, `-inf`, wrapping the call in `warnings.simplefilter("error")` — confirming rejection happens before any NumPy warning can fire, matching the file's existing convention for this class of test.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/utils/statistics.py`, kept the test), reran — all 3 parameterized cases failed, one with `Failed: DID NOT RAISE ValueError` and two with the real NumPy `RuntimeWarning: invalid value encountered in scalar subtract` (promoted to an error by the test's own warning filter). Restored the fix, 110/110 green again.

## Evidence

<!-- evidence-head -->
6b24c355662fe1c53b0921971d711906a4de2b2a

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts="" -k test_nonfinite_values_rejected_without_warnings
FAILED tests/test_statistics_validation.py::TestBootstrapCI::test_nonfinite_values_rejected_without_warnings[nan] - Failed: DID NOT RAISE ValueError
FAILED tests/test_statistics_validation.py::TestBootstrapCI::test_nonfinite_values_rejected_without_warnings[inf] - RuntimeWarning: invalid value encountered in scalar subtract
FAILED tests/test_statistics_validation.py::TestBootstrapCI::test_nonfinite_values_rejected_without_warnings[-inf] - RuntimeWarning: invalid value encountered in scalar subtract
3 failed, 3 passed, 104 deselected in 0.70s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""
110 passed, 2 warnings in 2.47s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import warnings
from alberta_framework.utils.statistics import bootstrap_ci
for poison in (float('nan'), float('inf'), float('-inf')):
    with warnings.catch_warnings():
        warnings.simplefilter('error')
        try:
            bootstrap_ci([1.0, poison, 2.0], n_bootstrap=20, seed=0)
            print(f'poison={poison}: accepted (BUG if this prints)')
        except ValueError as e:
            print(f'poison={poison}: rejected -> {e}')
"
poison=nan: rejected -> values must be finite
poison=inf: rejected -> values must be finite
poison=-inf: rejected -> values must be finite
```
independently confirmed `_require_finite_values` is a pre-existing, already-tested helper (not new logic) used identically by two neighboring functions in the same file before shipping this, and independently confirmed the honest non-top-level-re-exported reachability status via `grep`.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting all three invalid inputs before any warning fires, confirmed `_require_finite_values`'s pre-existing usage pattern and the honest reachability status directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
