### PR TITLE
fix(utils): carry rounded duration across unit boundaries

### DIFF
--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -43,15 +43,16 @@ def format_duration(seconds: float) -> str:
     format_duration(3665)  # Returns: '1h 1m 5.00s'
     ```
     """
-    if seconds < 60:
-        return f"{seconds:.2f}s"
-    elif seconds < 3600:
-        minutes = int(seconds // 60)
-        secs = seconds % 60
+    rounded_seconds = round(seconds, 2)
+    if rounded_seconds < 60:
+        return f"{rounded_seconds:.2f}s"
+    elif rounded_seconds < 3600:
+        minutes = int(rounded_seconds // 60)
+        secs = rounded_seconds % 60
         return f"{minutes}m {secs:.2f}s"
     else:
-        hours = int(seconds // 3600)
-        remaining = seconds % 3600
+        hours = int(rounded_seconds // 3600)
+        remaining = rounded_seconds % 3600
         minutes = int(remaining // 60)
         secs = remaining % 60
         return f"{hours}h {minutes}m {secs:.2f}s"

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -41,6 +41,8 @@ def test_format_duration_branches() -> None:
     assert format_duration(0.5) == "0.50s"
     assert format_duration(90.5) == "1m 30.50s"
     assert format_duration(3665) == "1h 1m 5.00s"
+    assert format_duration(59.999) == "1m 0.00s"
+    assert format_duration(3599.999) == "1h 0m 0.00s"
 
 
 def test_timer_monotonic_accumulation() -> None:


### PR DESCRIPTION
Closes #293.

## What changed

`format_duration` selected the displayed unit (seconds/minutes/hours) and decomposed the value **before** rounding to its own documented two-decimal display precision. A duration immediately below a unit boundary — where rounding to two decimals crosses that boundary — produced an impossible or misleading display: a seconds component of `60.00` without carrying into minutes, or `59m 60.00s` without carrying into hours.

confirmed directly before touching the source:

```text
59.999 -> 60.00s          (should be 1m 0.00s)
3599.999 -> 59m 60.00s    (should be 1h 0m 0.00s)
86399.999 -> 23h 59m 60.00s   (should be 24h 0m 0.00s)
```

fix: round the duration to the formatter's own two-decimal output precision **before** selecting the unit branch and decomposing into hours/minutes/seconds, so the carry propagates correctly through all three levels.

## Reachability

`format_duration` is genuinely package-root exported — `alberta_framework/__init__.py` imports it from `alberta_framework.utils.timing`, callers reach it as `alberta_framework.format_duration`. `Timer.__exit__` (same module) calls `format_duration(self.duration)`, where `self.duration` is the real difference between two `time.perf_counter()` readings — arbitrary measured durations can legitimately fall on these rounding boundaries in real timing output.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""
15 passed in 1.55s

$ .venv/bin/python -m ruff check alberta_framework/utils/timing.py tests/test_utils_smoke.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

Regression assertions added to the existing `test_format_duration_branches`, covering both the seconds-to-minutes boundary (`59.999` → `1m 0.00s`) and the minutes-to-hours boundary (`3599.999` → `1h 0m 0.00s`).

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/utils/timing.py`, kept the test), reran — failed with `assert '60.00s' == '1m 0.00s'`. Restored the fix, 15/15 green again.

## Evidence

<!-- evidence-head -->
ffff6422a755819f1a8a6308f0df9bf01309b4e1

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts="" -k test_format_duration_branches
AssertionError: assert '60.00s' == '1m 0.00s'
1 failed, 14 deselected in 0.67s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_utils_smoke.py -q -o addopts=""
15 passed in 1.47s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework.utils.timing import format_duration
print(format_duration(59.999), '(expect 1m 0.00s)')
print(format_duration(3599.999), '(expect 1h 0m 0.00s)')
print(format_duration(86399.999), '(expect 24h 0m 0.00s)')
print(format_duration(0.5), '(expect 0.50s, unchanged)')
print(format_duration(90.5), '(expect 1m 30.50s, unchanged)')
print(format_duration(3665), '(expect 1h 1m 5.00s, unchanged)')
"
1m 0.00s (expect 1m 0.00s)
1h 0m 0.00s (expect 1h 0m 0.00s)
24h 0m 0.00s (expect 24h 0m 0.00s)
0.50s (expect 0.50s, unchanged)
1m 30.50s (expect 1m 30.50s, unchanged)
1h 1m 5.00s (expect 1h 1m 5.00s, unchanged)
```
independently confirmed a third boundary case (24h edge) beyond the two in the committed test, and confirmed all pre-existing normal-case outputs are unchanged, before writing this up. Also independently confirmed the package-root export and the real `Timer.__exit__` caller.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced both committed boundary cases plus an additional untested 24h boundary and all pre-existing normal cases, verified the package-root export and real caller directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
