### PR TITLE
fix(nexting): prevent running RMSE overflow

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -32,6 +32,8 @@ References:
 
 from __future__ import annotations
 
+from functools import partial
+
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -174,6 +176,67 @@ def _finite_rmse_jvp(
     return rmse, rmse_dot
 
 
+def _sliding_sum(values: Array, window_size: int) -> Array:
+    prefix = jnp.cumsum(
+        jnp.concatenate(
+            [jnp.zeros((1, values.shape[1]), dtype=values.dtype), values],
+            axis=0,
+        ),
+        axis=0,
+    )
+    return prefix[window_size:] - prefix[:-window_size]
+
+
+def _pad_running_window(values: Array, window_size: int) -> Array:
+    pad = jnp.broadcast_to(values[0], (window_size - 1, values.shape[1]))
+    return jnp.concatenate([pad, values], axis=0)
+
+
+def _scaled_running_rmse_terms(
+    errors: Array, window_size: int
+) -> tuple[Array, Array, Array]:
+    """Return one global power-of-two scale and stable sliding RMS terms."""
+    scale = jnp.max(jnp.abs(errors), axis=0)
+    _, exponent = jnp.frexp(scale)
+    scaled_errors = jnp.ldexp(errors, -exponent)
+    scaled_window = _sliding_sum(scaled_errors**2, window_size)
+    scaled_running = jnp.sqrt(scaled_window / window_size)
+    return exponent, scaled_errors, scaled_running
+
+
+@partial(jax.custom_jvp, nondiff_argnums=(1,))
+def _finite_running_rmse(errors: Array, window_size: int) -> Array:
+    """Compute a finite sliding RMSE with a scale-free derivative."""
+    exponent, _, scaled_running = _scaled_running_rmse_terms(errors, window_size)
+    return _pad_running_window(jnp.ldexp(scaled_running, exponent), window_size)
+
+
+@_finite_running_rmse.defjvp
+def _finite_running_rmse_jvp(
+    window_size: int,
+    primals: tuple[Array],
+    tangents: tuple[Array],
+) -> tuple[Array, Array]:
+    (errors,), (errors_dot,) = primals, tangents
+    exponent, scaled_errors, scaled_running = _scaled_running_rmse_terms(
+        errors, window_size
+    )
+    running = _pad_running_window(
+        jnp.ldexp(scaled_running, exponent), window_size
+    )
+    safe_scaled_running = jnp.where(
+        scaled_running > 0.0,
+        scaled_running,
+        jnp.ones_like(scaled_running),
+    )
+    numerator = _sliding_sum(scaled_errors * errors_dot, window_size) / window_size
+    running_dot = _pad_running_window(
+        numerator / safe_scaled_running,
+        window_size,
+    )
+    return running, running_dot
+
+
 def per_horizon_rmse(
     predictions: Float[Array, "T H"],
     forward_returns: Float[Array, "T H"],
@@ -263,15 +326,11 @@ def per_horizon_running_rmse(
             f"(got window_size={window_size}, n_steps={n_steps})"
         )
     errors = predictions - forward_returns
-    scale = jnp.max(jnp.abs(errors), axis=0)
-    _, exponent = jnp.frexp(scale)
-    scaled_errors = jnp.ldexp(errors, -exponent)
-    sq_err = scaled_errors**2  # (T, H)
-    cumsum = jnp.cumsum(
-        jnp.concatenate([jnp.zeros((1, sq_err.shape[1]), dtype=sq_err.dtype), sq_err]),
-        axis=0,
+    finite_columns = jnp.all(jnp.isfinite(errors), axis=0)
+    safe_errors = jnp.where(finite_columns[None, :], errors, jnp.zeros_like(errors))
+    stable_running = _finite_running_rmse(safe_errors, window_size)
+    nonfinite = jnp.broadcast_to(
+        jnp.max(jnp.abs(errors), axis=0),
+        stable_running.shape,
     )
-    window = cumsum[window_size:] - cumsum[:-window_size]
-    running = jnp.ldexp(jnp.sqrt(window / window_size), exponent)
-    pad = jnp.broadcast_to(running[0], (window_size - 1, sq_err.shape[1]))
-    return jnp.concatenate([pad, running], axis=0)
+    return jnp.where(finite_columns[None, :], stable_running, nonfinite)

--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -262,9 +262,16 @@ def per_horizon_running_rmse(
             f"window_size must satisfy 1 <= window_size <= n_steps "
             f"(got window_size={window_size}, n_steps={n_steps})"
         )
-    sq_err = (predictions - forward_returns) ** 2  # (T, H)
-    cumsum = jnp.cumsum(jnp.concatenate([jnp.zeros((1, sq_err.shape[1])), sq_err]), axis=0)
+    errors = predictions - forward_returns
+    scale = jnp.max(jnp.abs(errors), axis=0)
+    _, exponent = jnp.frexp(scale)
+    scaled_errors = jnp.ldexp(errors, -exponent)
+    sq_err = scaled_errors**2  # (T, H)
+    cumsum = jnp.cumsum(
+        jnp.concatenate([jnp.zeros((1, sq_err.shape[1]), dtype=sq_err.dtype), sq_err]),
+        axis=0,
+    )
     window = cumsum[window_size:] - cumsum[:-window_size]
-    running = jnp.sqrt(window / window_size)
+    running = jnp.ldexp(jnp.sqrt(window / window_size), exponent)
     pad = jnp.broadcast_to(running[0], (window_size - 1, sq_err.shape[1]))
     return jnp.concatenate([pad, running], axis=0)

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -369,6 +369,51 @@ class TestRunningRMSE:
             np.full((2, 1), 2.0e20, dtype=np.float32),
         )
 
+    @pytest.mark.parametrize("magnitude", [2.0e20, 1.0e38, 3.0e38])
+    def test_large_finite_running_rmse_has_stable_eager_jit_and_jvp_gradients(
+        self, magnitude: float
+    ) -> None:
+        predictions = jnp.full((2, 1), magnitude, dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        def loss(values: jax.Array) -> jax.Array:
+            return per_horizon_running_rmse(values, returns, window_size=2)[1, 0]
+
+        expected = jnp.full_like(predictions, 0.5)
+        eager = jax.grad(loss)(predictions)
+        compiled = jax.jit(jax.grad(loss))(predictions)
+        _primal, tangent = jax.jvp(
+            lambda values: per_horizon_running_rmse(values, returns, window_size=2),
+            (predictions,),
+            (jnp.ones_like(predictions),),
+        )
+
+        chex.assert_trees_all_close(eager, expected, rtol=5e-6, atol=0.0)
+        chex.assert_trees_all_close(compiled, expected, rtol=5e-6, atol=0.0)
+        chex.assert_trees_all_close(tangent, jnp.ones_like(tangent), rtol=5e-6, atol=0.0)
+
+    def test_zero_running_rmse_uses_zero_eager_jit_and_jvp_gradient_convention(
+        self,
+    ) -> None:
+        predictions = jnp.zeros((3, 2), dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        def loss(values: jax.Array) -> jax.Array:
+            return jnp.sum(per_horizon_running_rmse(values, returns, window_size=2))
+
+        expected = jnp.zeros_like(predictions)
+        eager = jax.grad(loss)(predictions)
+        compiled = jax.jit(jax.grad(loss))(predictions)
+        _primal, tangent = jax.jvp(
+            lambda values: per_horizon_running_rmse(values, returns, window_size=2),
+            (predictions,),
+            (jnp.ones_like(predictions),),
+        )
+
+        chex.assert_trees_all_equal(eager, expected)
+        chex.assert_trees_all_equal(compiled, expected)
+        chex.assert_trees_all_equal(tangent, jnp.zeros_like(tangent))
+
     def test_shape(self) -> None:
         t, h = 50, 3
         preds = jnp.zeros((t, h))

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -356,6 +356,19 @@ class TestRMSE:
 
 
 class TestRunningRMSE:
+    def test_large_finite_errors_do_not_overflow(self) -> None:
+        predictions = jnp.asarray([[2.0e20], [2.0e20]], dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        with jax.debug_infs(True):
+            running = per_horizon_running_rmse(predictions, returns, window_size=2)
+
+        assert bool(jnp.all(jnp.isfinite(running)))
+        np.testing.assert_allclose(
+            np.asarray(running),
+            np.full((2, 1), 2.0e20, dtype=np.float32),
+        )
+
     def test_shape(self) -> None:
         t, h = 50, 3
         preds = jnp.zeros((t, h))


### PR DESCRIPTION
Closes #296.

## What changed

`per_horizon_running_rmse` previously squared large finite float32 errors before accumulating each sliding window. Values such as `2e20` therefore overflowed even though the true RMSE is finite.

This revision now:

- uses exact power-of-two scaling before squaring and restores the exponent after each sliding RMS;
- masks nonfinite columns before arithmetic while preserving NaN/Inf diagnostics in the returned column;
- defines a custom JVP whose scale-free derivative remains finite at `2e20`, `1e38`, and `3e38`;
- uses an explicit zero tangent/subgradient for all-zero windows.

The custom JVP is necessary because differentiating the stable primal naively still produced zero or NaN gradients at extreme finite magnitudes.

## Red-first evidence

Against the original head `ff5ea03ff0d2cbd572b9a1290a3d9a601e6b7269`:

- the value-only `2e20` regression passed after the original scaling patch;
- reverse/JVP gradients failed at `1e38` and `3e38`;
- the all-zero reverse/JVP convention returned NaNs.

The added tests cover eager reverse-mode, JIT reverse-mode, and forward JVP at `2e20`, `1e38`, `3e38`, plus all-zero windows.

## Verification

Exact repaired head: `378680fc31da3846372ac651d56328e7ea10e9b5`

```text
tests/test_nexting.py: 66 passed
ruff (changed source and tests): clean
mypy alberta_framework/utils/nexting.py: clean
git diff --check: clean
```

The existing shape/domain, ordinary-magnitude, NaN/Inf diagnostic, eager/JIT, and checkify/debug regressions remain green.

## Reachability and scope

The function remains directly callable from `alberta_framework.utils.nexting`; it is not re-exported at the package root. This is a numerical correctness repair only and does not alter evidence artifacts or claim status.

## Provenance

AI provider/model: OpenAI GPT-5.6 (repair, adversarial numerical review, tests)
Client/tooling: Codex
Attribution status: self-reported
