### PR TITLE
fix(streams): require ScaledStreamWrapper feature_scales to be 1-D

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -790,9 +790,12 @@ class ScaledStreamWrapper:
         self._inner_stream: ScanStream[Any] = inner_stream
         self._feature_scales = jnp.asarray(feature_scales, dtype=jnp.float32)
 
-        if self._feature_scales.shape[0] != inner_stream.feature_dim:
+        if (
+            self._feature_scales.ndim != 1
+            or self._feature_scales.shape[0] != inner_stream.feature_dim
+        ):
             raise ValueError(
-                f"feature_scales length ({self._feature_scales.shape[0]}) "
+                f"feature_scales shape ({self._feature_scales.shape}) "
                 f"must match inner stream's feature_dim ({inner_stream.feature_dim})"
             )
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -801,3 +801,9 @@ class TestScheduleModuliRejectInvalid:
         """The representable boundary is valid even when allocation would be impractical."""
         stream = CyclicStream(feature_dim=3, num_configurations=_INT32_MAX)
         assert stream.feature_dim == 3
+
+
+def test_scaled_stream_wrapper_rejects_non_vector_feature_scales():
+    """Per-feature scales must stay one-dimensional to preserve observation shape."""
+    with pytest.raises(ValueError, match=r"feature_scales shape \(\(3, 1\)\)"):
+        ScaledStreamWrapper(RandomWalkStream(feature_dim=3), jnp.ones((3, 1)))


### PR DESCRIPTION
Closes #298.

## What changed

`ScaledStreamWrapper` documents `feature_scales` as a per-feature vector with shape `(feature_dim,)`, but the constructor only checked `feature_scales.shape[0]` against `inner_stream.feature_dim`, never `.ndim`. A `(3, 1)` array for a stream with `feature_dim=3` passed the length check (`shape[0] == 3`) and then silently broadcast a 1-D observation `(3,)` into shape `(3, 3)` during elementwise multiplication, corrupting the stream's public timestep shape instead of rejecting the malformed input.

confirmed directly before touching the source:

```text
scales_shape (3, 1)
observation_shape (3, 3)
```

fix: the constructor now requires `feature_scales.ndim == 1` in addition to the existing feature-dimension length check.

## Reachability

`ScaledStreamWrapper` is re-exported by both `alberta_framework.streams.__init__` and `alberta_framework.__init__` — genuinely package-root exported. The regression test uses a real `RandomWalkStream` and a real JAX key/input shape; the failure is observable at the emitted `TimeStep.observation` boundary, not an internal-only path.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_streams.py -q -o addopts=""
136 passed in 7.98s

$ .venv/bin/python -m ruff check alberta_framework/streams/synthetic.py tests/test_streams.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 163 source files
```

New test: `test_scaled_stream_wrapper_rejects_non_vector_feature_scales`, using a real `RandomWalkStream` instance, matching the file's existing convention of testing with real streams rather than mocks.

mutation-resistance verified independently: reverted just the source fix (`git checkout -- alberta_framework/streams/synthetic.py`, kept the test), reran — failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 136/136 green again.

## Evidence

<!-- evidence-head -->
0b2814525215fbc27c46526d3835bc733744e0c1

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_streams.py -q -o addopts="" -k test_scaled_stream_wrapper_rejects_non_vector_feature_scales
FAILED tests/test_streams.py::test_scaled_stream_wrapper_rejects_non_vector_feature_scales - Failed: DID NOT RAISE ValueError
1 failed, 135 deselected in 0.69s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_streams.py -q -o addopts=""
136 passed in 6.56s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp
from alberta_framework.streams.synthetic import ScaledStreamWrapper, RandomWalkStream
try:
    w = ScaledStreamWrapper(RandomWalkStream(feature_dim=3), jnp.ones((3, 1)))
    print('accepted (BUG if this prints)')
except ValueError as e:
    print('rejected ->', e)
w2 = ScaledStreamWrapper(RandomWalkStream(feature_dim=3), jnp.ones((3,)))
print('valid 1D vector accepted:', w2._feature_scales.shape)
"
rejected -> feature_scales shape ((3, 1)) must match inner stream's feature_dim (3)
valid 1D vector accepted: (3,)
```
independently confirmed the fixed constructor rejects the malformed 2-D shape while still accepting a genuinely valid 1-D vector, and independently confirmed the package-root export before writing up the reachability claim.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the guard rejecting the invalid shape while confirming the valid case is unaffected, verified the package-root export directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
