### PR TITLE
fix(ftl-world-model): round exact reals once

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -41,11 +41,12 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
-_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+from alberta_framework._float32 import round_real_to_float32
+
+_FLOAT32_TINY = 2.0**-126
 
 
 def _finite_positive_normal_float32(name: str, value: object) -> float:
@@ -54,16 +55,12 @@ def _finite_positive_normal_float32(name: str, value: object) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(message)
     try:
-        concrete = float(value)
+        narrowed = round_real_to_float32(value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if not math.isfinite(concrete) or concrete <= 0.0:
-        raise ValueError(message)
-    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-        narrowed = float(np.float32(concrete))
     if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY:
         raise ValueError(message)
-    return concrete
+    return narrowed
 
 
 @dataclasses.dataclass(frozen=True)

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -35,7 +35,7 @@ import dataclasses
 import functools
 import math
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax
@@ -52,6 +52,7 @@ _FLOAT32_TINY = 2.0**-126
 def _finite_positive_normal_float32(name: str, value: object) -> float:
     """Return a concrete real after validation in the model's execution dtype."""
     message = f"{name} must be a finite positive normal float32"
+    preserve_builtin_payload = type(value) is int or type(value) is float
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(message)
     try:
@@ -60,6 +61,10 @@ def _finite_positive_normal_float32(name: str, value: object) -> float:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY:
         raise ValueError(message)
+    if preserve_builtin_payload:
+        concrete = float(value)
+        if round_real_to_float32(cast(Real, concrete)) == narrowed:
+            return concrete
     return narrowed
 
 

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -196,6 +196,20 @@ def test_config_canonicalizes_numpy_scalars_for_strict_json_roundtrip() -> None:
     assert type(restored.prediction_clip) is float
 
 
+def test_config_preserves_existing_ordinary_serialization_payloads() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=2,
+        action_dim=1,
+        ridge=0.01,
+        prediction_clip=10.1,
+    )
+
+    assert config.ridge == 0.01
+    assert config.prediction_clip == 10.1
+    assert config.to_config()["ridge"] == 0.01
+    assert config.to_config()["prediction_clip"] == 10.1
+
+
 def test_underflowing_ridge_is_rejected_before_update_poisoning() -> None:
     ridge = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
 

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from fractions import Fraction
 
 import chex
 import jax
@@ -134,6 +135,48 @@ def test_config_rejects_values_outside_normal_float32_execution_domain(
 
     with pytest.raises(ValueError, match=rf"{field} must be a finite positive normal float32"):
         SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", ["ridge", "prediction_clip"])
+def test_config_rounds_exact_normal_boundary_before_validation(field: str) -> None:
+    minimum_normal = Fraction(1, 2**126)
+    normal_midpoint = minimum_normal - Fraction(1, 2**150)
+    below_midpoint = normal_midpoint - Fraction(1, 2**210)
+    kwargs: dict[str, object] = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        field: below_midpoint,
+    }
+
+    with pytest.raises(ValueError, match=rf"{field} must be a finite positive normal float32"):
+        SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+
+    for accepted in (normal_midpoint, normal_midpoint + Fraction(1, 2**210)):
+        kwargs[field] = accepted
+        config = SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+        assert getattr(config, field) == float(np.finfo(np.float32).tiny)
+
+
+@pytest.mark.parametrize("field", ["ridge", "prediction_clip"])
+def test_config_rounds_exact_overflow_midpoint_before_validation(field: str) -> None:
+    float32_max = (2**24 - 1) * 2**104
+    overflow_midpoint = Fraction(float32_max + 2**103)
+    kwargs: dict[str, object] = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        field: overflow_midpoint - 1,
+    }
+
+    config = SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
+    assert getattr(config, field) == float(np.finfo(np.float32).max)
+
+    for rejected in (overflow_midpoint, overflow_midpoint + 1):
+        kwargs[field] = rejected
+        with pytest.raises(
+            ValueError,
+            match=rf"{field} must be a finite positive normal float32",
+        ):
+            SparseFTLWorldModelConfig(**kwargs)  # type: ignore[arg-type]
 
 
 def test_config_canonicalizes_numpy_scalars_for_strict_json_roundtrip() -> None:


### PR DESCRIPTION
## Summary

`SparseFTLWorldModelConfig` still converted supported exact `Real` inputs through binary64 before validating the float32 execution sink. Values close enough to a binary32 midpoint could therefore be classified from the wrong side of the normal-domain or overflow boundary.

This follow-up uses the exact-ratio, round-to-nearest-ties-to-even `round_real_to_float32` helper merged in #289. Validation is always performed against that exact float32 result. Exact and non-built-in `Real` inputs are canonicalized to the sink value; ordinary built-in `int`/`float` payloads retain their existing JSON-facing value only when independently narrowing that concrete payload produces the identical sink. This preserves prior configuration serialization without weakening the execution-domain decision.

## Boundary behavior

- A `Fraction` immediately below the max-subnormal/min-normal midpoint now rounds to max subnormal and is rejected.
- The exact midpoint and a value immediately above it round to the even minimum-normal value and are accepted.
- A `Fraction` immediately below the max-finite/infinity midpoint now rounds to max finite and is accepted.
- The exact overflow midpoint and a value immediately above it round outward to infinity and are rejected.
- Both policies are retained for `ridge` and `prediction_clip`.
- NumPy scalar payloads remain canonical strict-JSON floats, while ordinary built-in payloads such as `0.01` and `10.1` preserve their prior serialized spelling/value when sink-equivalent.

## Validation

Validated on exact head `9d58c96749b9fb66d95831dffb477907468b5728`, based on main at `a18d250ba07ee708936fb41afc8c50cbcba2f67b` (which contains merged #289):

- red before the exact-conversion source change: 4 failed exact-boundary cases
- focused FTL world-model and decision-fidelity panel: 68 passed
- Ruff: clean
- strict mypy: 164 source files clean
- `git diff --check`: clean
- exact diff remains two files; no `outputs/**` files changed

## Evidence status

`alberta_framework/core/ftl_world_model.py` is a registered source. The live evidence registry remains fail-closed at exit 2 (`overall_status=invalid`; `ftl_world_model_decision_fidelity=invalid`) because current source bytes do not match the pinned historical artifacts. That is expected source drift, not a validator defect or evidence promotion. No pinned artifact, threshold, seed, result, or evidence record is modified.
