### PR TITLE
fix(option-value-duration): validate config in float32 domain

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -27,20 +27,58 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
 import time
+from numbers import Real
 from typing import Any
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
+
+from alberta_framework._float32 import round_real_to_float32
 
 REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
 _INT32_MAX = 2_147_483_647
+
+
+def _require_float32_real(
+    name: str,
+    value: object,
+    *,
+    strictly_positive: bool,
+) -> float:
+    """Validate one host scalar in its exact domain and float32 sink."""
+    domain = "positive" if strictly_positive else "non-negative"
+    preserve_builtin_payload = type(value) is int or type(value) is float
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be finite and {domain}")
+    try:
+        if strictly_positive:
+            if value <= 0:
+                raise ValueError
+        elif value < 0:
+            raise ValueError
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite and {domain}") from error
+    if not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must narrow to a finite float32")
+    if value != 0 and narrowed == 0.0:
+        raise ValueError(f"{name} must not underflow to zero in float32")
+
+    # Preserve already-valid built-in payloads for serialization compatibility.
+    # Non-built-in Real scalars are canonicalized to the exact execution value.
+    if not preserve_builtin_payload:
+        return narrowed
+    number = float(value)
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = float(np.float32(number))
+    return number if narrowed == renarrowed else narrowed
 
 
 def _saturating_increment(value: Array) -> Array:
@@ -65,13 +103,34 @@ class OptionValueDurationConfig:
     duration_floor: float = 1e-6
 
     def __post_init__(self) -> None:
-        """Validate scalar hyperparameters."""
-        if not math.isfinite(self.reward_step_size) or self.reward_step_size < 0.0:
-            raise ValueError("reward_step_size must be finite and non-negative")
-        if not math.isfinite(self.duration_step_size) or self.duration_step_size < 0.0:
-            raise ValueError("duration_step_size must be finite and non-negative")
-        if not math.isfinite(self.duration_floor) or self.duration_floor <= 0.0:
-            raise ValueError("duration_floor must be finite and positive")
+        """Validate float32 execution values and canonicalize host scalars."""
+        object.__setattr__(
+            self,
+            "reward_step_size",
+            _require_float32_real(
+                "reward_step_size",
+                self.reward_step_size,
+                strictly_positive=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "duration_step_size",
+            _require_float32_real(
+                "duration_step_size",
+                self.duration_step_size,
+                strictly_positive=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "duration_floor",
+            _require_float32_real(
+                "duration_floor",
+                self.duration_floor,
+                strictly_positive=True,
+            ),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-serializable configuration."""

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -4,9 +4,15 @@ These are analytic and deterministic development tests, not held-out evidence
 that Alberta Plan Step 5 is complete.
 """
 
+import json
+import math
+from decimal import Decimal
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.option_value_duration import (
@@ -48,6 +54,152 @@ def test_config_roundtrip_validation_and_fixed_parameter_count() -> None:
             OptionValueDurationConfig(duration_step_size=invalid)
         with pytest.raises(ValueError, match="duration_floor"):
             OptionValueDurationConfig(duration_floor=invalid)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("reward_step_size", "duration_step_size", "duration_floor"),
+)
+@pytest.mark.parametrize(
+    "invalid",
+    (
+        True,
+        np.bool_(True),
+        "0.1",
+        1.0 + 0.0j,
+        Decimal("0.1"),
+        jnp.asarray(0.1, dtype=jnp.float32),
+    ),
+)
+def test_config_rejects_boolean_and_non_real_scalar_inputs(
+    field: str,
+    invalid: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        OptionValueDurationConfig(**{field: invalid})
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    (
+        ("reward_step_size", Fraction(-1, 10**400)),
+        ("duration_step_size", Fraction(-1, 10**400)),
+        ("duration_floor", Fraction(-1, 10**400)),
+        ("reward_step_size", Fraction(1, 10**400)),
+        ("duration_step_size", Fraction(1, 10**400)),
+        ("duration_floor", Fraction(1, 10**400)),
+        ("reward_step_size", 3.5e38),
+        ("duration_step_size", 3.5e38),
+        ("duration_floor", 3.5e38),
+    ),
+)
+def test_config_enforces_exact_domain_and_float32_sink_bounds(
+    field: str,
+    invalid: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        OptionValueDurationConfig(**{field: invalid})
+
+
+def test_config_uses_direct_float32_narrowing_without_double_rounding() -> None:
+    overflow_midpoint = np.ldexp(
+        np.longdouble(2) - np.ldexp(np.longdouble(1), -24),
+        127,
+    )
+    largest_finite_input = np.nextafter(
+        overflow_midpoint,
+        np.longdouble("-inf"),
+    )
+
+    reward = OptionValueDurationConfig(reward_step_size=largest_finite_input)
+    duration = OptionValueDurationConfig(duration_step_size=largest_finite_input)
+    floor = OptionValueDurationConfig(duration_floor=largest_finite_input)
+
+    for value in (
+        reward.reward_step_size,
+        duration.duration_step_size,
+        floor.duration_floor,
+    ):
+        assert type(value) is float
+        assert bool(np.isfinite(np.asarray(value, dtype=np.float32)))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("reward_step_size", "duration_step_size", "duration_floor"),
+)
+def test_config_rounds_exact_rationals_to_float32_with_ties_to_even(field: str) -> None:
+    midpoint = Fraction(1, 1) + Fraction(1, 2**24)
+    offset = Fraction(1, 2**60)
+    next_float32 = np.nextafter(
+        np.float32(1.0),
+        np.float32(2.0),
+        dtype=np.float32,
+    )
+
+    below = OptionValueDurationConfig(**{field: midpoint - offset})
+    tie = OptionValueDurationConfig(**{field: midpoint})
+    above = OptionValueDurationConfig(**{field: midpoint + offset})
+
+    assert getattr(below, field) == 1.0
+    assert getattr(tie, field) == 1.0
+    assert getattr(above, field) == float(next_float32)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("reward_step_size", "duration_step_size", "duration_floor"),
+)
+def test_config_enforces_exact_float32_underflow_and_overflow_midpoints(field: str) -> None:
+    minimum_subnormal = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+    underflow_midpoint = Fraction(1, 2**150)
+    overflow_midpoint = Fraction(((2**24 - 1) * 2**104) + 2**103)
+
+    with pytest.raises(ValueError, match=field):
+        OptionValueDurationConfig(**{field: underflow_midpoint})
+    above_underflow = OptionValueDurationConfig(
+        **{field: underflow_midpoint + Fraction(1, 2**200)}
+    )
+    assert getattr(above_underflow, field) == minimum_subnormal
+
+    below_overflow = OptionValueDurationConfig(**{field: overflow_midpoint - 1})
+    assert getattr(below_overflow, field) == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match=field):
+        OptionValueDurationConfig(**{field: overflow_midpoint})
+
+
+def test_config_canonicalizes_real_scalars_and_preserves_builtin_float_payload() -> None:
+    builtin = OptionValueDurationConfig(
+        reward_step_size=0.1,
+        duration_step_size=0.2,
+        duration_floor=1.0e-4,
+    )
+    assert builtin.to_config() == {
+        "type": "OptionValueDurationConfig",
+        "reward_step_size": 0.1,
+        "duration_step_size": 0.2,
+        "duration_floor": 1.0e-4,
+    }
+
+    config = OptionValueDurationConfig(
+        reward_step_size=np.float64(0.25),
+        duration_step_size=np.int64(1),
+        duration_floor=Fraction(1, 4),
+    )
+    payload = config.to_config()
+
+    assert type(config.reward_step_size) is float
+    assert type(config.duration_step_size) is float
+    assert type(config.duration_floor) is float
+    json.dumps(payload, allow_nan=False)
+    assert OptionValueDurationConfig.from_config(payload) == config
+
+    signed_zero = OptionValueDurationConfig(
+        reward_step_size=-0.0,
+        duration_step_size=-0.0,
+    )
+    assert math.copysign(1.0, signed_zero.reward_step_size) < 0.0
+    assert math.copysign(1.0, signed_zero.duration_step_size) < 0.0
 
 
 def test_two_head_td_targets_and_updates_match_exact_analytic_values() -> None:


### PR DESCRIPTION
Closes #287

OptionValueDurationConfig now validates every scalar in both its exact host domain and its float32 execution sink. It rejects bool aliases and non-Real values, exact negative values, nonzero values that round to zero, and values at or above the finite-overflow midpoint. Accepted non-built-in Real values are canonical built-in floats; already-valid built-in float payloads and signed zero remain serialization-compatible.

The implementation reuses the shared exact IEEE binary32 ties-to-even converter merged in #289. No duplicate rounding implementation is introduced.

Validation:
- failing-test-first original-source matrix: 26 failed / 4 passed before the repair
- exact Fraction midpoint discriminator exposed the earlier double-rounding attempt before the shared-helper composition
- final option-duration suite: 42 passed
- exact normal/subnormal/overflow midpoint endpoints retained for all three fields
- Ruff: clean
- strict mypy: 164 source files clean
- git diff --check: clean
- only the option-duration source and its unit test change; neither is a five-claim registered evidence source, and no output/artifact changes

This is a library contract fix, not evidence or a promotion claim.