### PR TITLE
fix(metrics): stop backdating a future window's mean onto earlier steps

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -365,27 +365,34 @@ def compute_running_mean(
     values: NDArray[np.float64] | list[float],
     window_size: int = 100,
 ) -> NDArray[np.float64]:
-    """Compute running mean of values.
+    """Compute the trailing (causal) running mean of values.
 
-    The output has the same length as the input: the first ``window_size - 1``
-    entries are padded with the first fully-windowed mean (they are not
-    partial-window means). If the input is shorter than ``window_size``, the
-    input is returned unchanged.
+    The output has the same length as the input. Position ``i`` holds the
+    mean of ``values[i - window_size + 1 : i + 1]`` -- the window ending at
+    and including step ``i`` -- so no returned value is ever computed from
+    observations that had not yet occurred at that step. The first
+    ``window_size - 1`` entries therefore have no complete trailing window
+    and are ``NaN`` (not yet computable; see the module docstring's
+    NaN-for-"not evaluated" convention), rather than being backdated with a
+    later window's mean. If the input is shorter than ``window_size``, no
+    window is ever complete and the input is returned unchanged.
 
     Args:
         values: Array of values
         window_size: Size of the moving average window
 
     Returns:
-        Array of running mean values (same length as input, padded at start)
+        Array of running mean values (same length as input), with ``NaN``
+        wherever a complete trailing window is not yet available.
     """
     values_arr = np.asarray(values)
     cumsum = np.cumsum(np.insert(values_arr, 0, 0))
     running_mean = (cumsum[window_size:] - cumsum[:-window_size]) / window_size
 
-    # Pad the beginning with the first computed mean
+    # The first `window_size - 1` steps have no complete trailing window yet;
+    # mark them NaN instead of backdating the first complete window's mean.
     if len(running_mean) > 0:
-        padding = np.full(window_size - 1, running_mean[0])
+        padding = np.full(window_size - 1, np.nan)
         return np.concatenate([padding, running_mean])
     return values_arr
 
@@ -394,10 +401,13 @@ def compute_tracking_error(
     metrics_history: list[dict[str, float]],
     window_size: int = 100,
 ) -> NDArray[np.float64]:
-    """Compute tracking error (running mean of squared error).
+    """Compute tracking error (trailing running mean of squared error).
 
     This is the key metric for evaluating continual learners:
-    how well can the learner track the non-stationary target?
+    how well can the learner track the non-stationary target? See
+    ``compute_running_mean`` for the causal windowing contract: the first
+    ``window_size - 1`` entries are ``NaN`` (no complete trailing window
+    yet), not a value borrowed from later time steps.
 
     Args:
         metrics_history: List of metric dictionaries from learning loop

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -375,7 +375,7 @@ def compute_running_mean(
     and are ``NaN`` (not yet computable; see the module docstring's
     NaN-for-"not evaluated" convention), rather than being backdated with a
     later window's mean. If the input is shorter than ``window_size``, no
-    window is ever complete and the input is returned unchanged.
+    window is ever complete and every returned position is ``NaN``.
 
     Args:
         values: Array of values
@@ -385,7 +385,15 @@ def compute_running_mean(
         Array of running mean values (same length as input), with ``NaN``
         wherever a complete trailing window is not yet available.
     """
-    values_arr = np.asarray(values)
+    if type(window_size) is not int:
+        raise ValueError("window_size must be a built-in int")
+    if window_size < 1:
+        raise ValueError("window_size must be positive")
+
+    values_arr = np.asarray(values, dtype=np.float64)
+    if len(values_arr) < window_size:
+        return np.full(values_arr.shape, np.nan, dtype=np.float64)
+
     cumsum = np.cumsum(np.insert(values_arr, 0, 0))
     running_mean = (cumsum[window_size:] - cumsum[:-window_size]) / window_size
 
@@ -394,7 +402,7 @@ def compute_running_mean(
     if len(running_mean) > 0:
         padding = np.full(window_size - 1, np.nan)
         return np.concatenate([padding, running_mean])
-    return values_arr
+    return np.full(values_arr.shape, np.nan, dtype=np.float64)
 
 
 def compute_tracking_error(

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -153,9 +153,9 @@ def plot_learning_curves(
             ]
         )
 
-        # ``compute_running_mean`` preserves length by padding the leading
-        # positions with the first complete trailing-window mean. Do not plot
-        # those future-informed padding values at earlier time steps.
+        # ``compute_running_mean`` preserves length by marking the leading
+        # positions NaN until a full trailing window exists. Drop that prefix
+        # rather than plotting or feeding NaN into the CI statistics below.
         first_complete_window = (
             window_size - 1 if metric_array.shape[1] >= window_size else 0
         )

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -153,13 +153,16 @@ def plot_learning_curves(
             ]
         )
 
-        # ``compute_running_mean`` preserves length by marking the leading
-        # positions NaN until a full trailing window exists. Drop that prefix
-        # rather than plotting or feeding NaN into the CI statistics below.
-        first_complete_window = (
-            window_size - 1 if metric_array.shape[1] >= window_size else 0
-        )
-        smoothed = smoothed[:, first_complete_window:]
+        # ``compute_running_mean`` marks every position NaN when the trace is
+        # shorter than the requested window. Preserve this plotting API's
+        # established raw short-trace fallback; otherwise drop the leading
+        # NaN prefix before plotting or computing confidence intervals.
+        if metric_array.shape[1] < window_size:
+            smoothed = np.asarray(metric_array, dtype=np.float64)
+            first_complete_window = 0
+        else:
+            first_complete_window = window_size - 1
+            smoothed = smoothed[:, first_complete_window:]
 
         mean, ci_lower, ci_upper = compute_timeseries_statistics(smoothed)
 

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -227,12 +227,12 @@ def test_running_mean_exact_window_length_has_one_valid_entry() -> None:
     np.testing.assert_allclose(result[2:], [2.0])
 
 
-def test_running_mean_shorter_than_window_is_returned_unchanged() -> None:
-    """Documented short-input fallback is unaffected by the padding fix."""
+def test_running_mean_shorter_than_window_has_no_computable_values() -> None:
+    result = compute_running_mean([2, 4], window_size=3)
 
-    result = compute_running_mean([2.0, 4.0], window_size=3)
-
-    np.testing.assert_array_equal(result, [2.0, 4.0])
+    assert result.shape == (2,)
+    assert result.dtype == np.float64
+    assert np.all(np.isnan(result))
 
 
 def test_tracking_error_inherits_the_causal_running_mean_fix() -> None:
@@ -242,3 +242,19 @@ def test_tracking_error_inherits_the_causal_running_mean_fix() -> None:
 
     assert np.all(np.isnan(result[:2]))
     np.testing.assert_allclose(result[2:], [1.0, 2.0, 3.0, 4.0])
+
+
+def test_tracking_error_shorter_than_window_has_no_computable_values() -> None:
+    result = compute_tracking_error(
+        [{"squared_error": 2.0}, {"squared_error": 4.0}],
+        window_size=3,
+    )
+
+    assert result.shape == (2,)
+    assert np.all(np.isnan(result))
+
+
+@pytest.mark.parametrize("window_size", [True, False, np.int64(3), 3.0, 0, -1])
+def test_running_mean_rejects_invalid_window_size(window_size: object) -> None:
+    with pytest.raises(ValueError, match="window_size"):
+        compute_running_mean([1.0, 2.0, 3.0], window_size=window_size)  # type: ignore[arg-type]

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -12,7 +12,9 @@ from alberta_framework.utils.metrics import (
     compute_per_task_forgetting,
     compute_prequential_performance,
     compute_recovery_lengths,
+    compute_running_mean,
     compute_stability_gap,
+    compute_tracking_error,
     summarize_continual_learning,
 )
 
@@ -195,3 +197,48 @@ def test_task_metrics_reject_infinite_post_exposure_evaluations(value: float) ->
 
     with pytest.raises(ValueError, match="infinite evaluation"):
         compute_per_task_forgetting([[0.8], [value], [0.6]], [0])
+
+
+def test_running_mean_does_not_backdate_a_future_informed_value() -> None:
+    """The leading positions must not be filled with a later window's mean.
+
+    Before this fix, ``compute_running_mean`` padded the first
+    ``window_size - 1`` entries with the mean of the *first complete*
+    trailing window -- a value that depends on observations from steps that
+    had not yet occurred at those earlier positions. #175/#176 documented
+    and worked around exactly this defect at one call site
+    (``plot_learning_curves``) without fixing the underlying function, so
+    every other caller of the public, top-level-exported
+    ``compute_running_mean``/``compute_tracking_error`` still received the
+    corrupted, future-informed trace directly.
+    """
+
+    result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
+
+    assert result.shape == (6,)
+    assert np.all(np.isnan(result[:2]))
+    np.testing.assert_allclose(result[2:], [1.0, 2.0, 3.0, 4.0])
+
+
+def test_running_mean_exact_window_length_has_one_valid_entry() -> None:
+    result = compute_running_mean([1.0, 2.0, 3.0], window_size=3)
+
+    assert np.all(np.isnan(result[:2]))
+    np.testing.assert_allclose(result[2:], [2.0])
+
+
+def test_running_mean_shorter_than_window_is_returned_unchanged() -> None:
+    """Documented short-input fallback is unaffected by the padding fix."""
+
+    result = compute_running_mean([2.0, 4.0], window_size=3)
+
+    np.testing.assert_array_equal(result, [2.0, 4.0])
+
+
+def test_tracking_error_inherits_the_causal_running_mean_fix() -> None:
+    history = [{"squared_error": float(v)} for v in range(6)]
+
+    result = compute_tracking_error(history, window_size=3)
+
+    assert np.all(np.isnan(result[:2]))
+    np.testing.assert_allclose(result[2:], [1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
## Outcome: Fix

Closes #303.

`compute_running_mean` and `compute_tracking_error` no longer backdate the first complete trailing-window mean onto earlier time steps. Every position without a complete window is now `NaN`, including an entire trace shorter than `window_size`; integer inputs are returned in a float64 array capable of representing that state. The public boundary rejects bool, non-built-in, zero, and negative window sizes deterministically.

`plot_learning_curves` keeps its established visualization compatibility: it drops the unavailable prefix for a complete-window trace and explicitly plots raw observations when the whole trace is shorter than the requested smoothing window.

## Failing-test-first and review evidence

The contributor regression reproduced the original future-information leak. Maintainer boundary review then reproduced eight additional failures on the prior PR head: short inputs returned scientifically invalid raw values through both public metrics, malformed windows leaked incidental slicing errors, and integer short inputs could not represent `NaN`.

Exact head `78b5dc42b2ddfd92c9c00a87467afc8046cff2c1` passes:

- 39 metric and visualization tests
- 12,120 independent length/window comparisons against a causal trailing-window oracle
- repository Ruff
- full strict mypy
- `git diff --check`

No benchmark run or output artifact is produced. `alberta_framework/utils/metrics.py` is a registered source for the recurring-multiagent claim; that claim was already invalid on the base, this merge adds source drift, and nothing here revalidates or rewrites frozen evidence.


---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M053G7PRFRWK3Q95JP3VGEXV","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T10:57:25.209Z","completed_at":"2026-08-16T10:59:04.941Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3f107f6ef01b947c061ecfabaf1117e555cfab20807310a7a43909f628fdc6fa","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6f57b679-44ff-4b6a-889e-1ea3c4b0b0a3","object_id":"sha256:3f107f6ef01b947c061ecfabaf1117e555cfab20807310a7a43909f628fdc6fa","sha256":"3f107f6ef01b947c061ecfabaf1117e555cfab20807310a7a43909f628fdc6fa"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"IyZTe190HW_aIVOPQ_l3ZVA0lTM6VtD6_NLNu8gzyJfVTCwqxiaoAW9tcIa1AxnvkaByoUu-NEXM5ohxs7lpAA"}} -->
