### PR TITLE
fix(ci): close merged IPMNIST preregistration launch gaps

### DIFF
--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -166,20 +166,58 @@ def _github_pages(path: str, *, token: str) -> list[Any]:
     raise RuntimeError(f"GitHub API pagination exceeded 10,000 records for {path}")
 
 
-def _workflow_runs(repository: str, *, token: str) -> list[dict[str, Any]]:
+def _workflow_runs(repository: str, *, source: str, token: str) -> list[dict[str, Any]]:
+    source = _lower_hex(source, 40, name="source")
     encoded = urllib.parse.quote(Path(WORKFLOW_PATH).name, safe="")
-    path = f"/repos/{repository}/actions/workflows/{encoded}/runs?event=workflow_dispatch"
+    query = urllib.parse.urlencode(
+        {"event": "workflow_dispatch", "head_sha": source, "per_page": 100}
+    )
+    path = f"/repos/{repository}/actions/workflows/{encoded}/runs?{query}"
     runs: list[dict[str, Any]] = []
-    for page in range(1, 101):
-        payload = _github_json(f"{path}&per_page=100&page={page}", token=token)
-        if isinstance(payload, dict) and isinstance(payload.get("workflow_runs"), list):
-            page_runs = [cast(dict[str, Any], value) for value in payload["workflow_runs"]]
-            runs.extend(page_runs)
-            if len(page_runs) < 100:
-                return runs
-            continue
-        raise RuntimeError("GitHub Actions API returned an invalid workflow-runs payload")
-    raise RuntimeError("GitHub Actions pagination exceeded 10,000 workflow runs")
+    seen_ids: set[int] = set()
+    expected_total: int | None = None
+    for page in range(1, 11):
+        payload = _github_json(f"{path}&page={page}", token=token)
+        if not isinstance(payload, dict):
+            raise RuntimeError("GitHub Actions run search returned a non-object payload")
+        total_count = payload.get("total_count")
+        raw_runs = payload.get("workflow_runs")
+        if type(total_count) is not int or total_count < 0 or not isinstance(raw_runs, list):
+            raise RuntimeError("GitHub Actions run search returned malformed pagination data")
+        if total_count > 1_000:
+            raise RuntimeError(
+                "source-filtered workflow run search exceeds GitHub's 1,000-result API cap"
+            )
+        if expected_total is None:
+            expected_total = total_count
+        elif total_count != expected_total:
+            raise RuntimeError("GitHub Actions run total changed during pagination")
+        if len(raw_runs) > 100 or any(not isinstance(value, dict) for value in raw_runs):
+            raise RuntimeError("GitHub Actions run search returned a malformed result page")
+        page_runs = cast(list[dict[str, Any]], raw_runs)
+        for run in page_runs:
+            run_id = run.get("id")
+            if (
+                type(run_id) is not int
+                or run_id <= 0
+                or run.get("event") != "workflow_dispatch"
+                or run.get("head_sha") != source
+                or run.get("path") != WORKFLOW_PATH
+                or not isinstance(run.get("display_title"), str)
+                or not run["display_title"]
+            ):
+                raise RuntimeError("GitHub Actions run search returned a malformed result page")
+            if run_id in seen_ids:
+                raise RuntimeError("GitHub Actions run search repeated a workflow run ID")
+            seen_ids.add(run_id)
+        runs.extend(page_runs)
+        if len(runs) > total_count:
+            raise RuntimeError("GitHub Actions run search returned more runs than total_count")
+        if len(runs) == total_count:
+            return runs
+        if len(raw_runs) < 100:
+            raise RuntimeError("GitHub Actions run search ended before total_count")
+    raise RuntimeError("GitHub Actions run search did not complete within the 1,000-result cap")
 
 
 def verify_launch_authorization(
@@ -231,7 +269,7 @@ def verify_launch_authorization(
 
     matching_runs = [
         run
-        for run in _workflow_runs(repository, token=token)
+        for run in _workflow_runs(repository, source=source, token=token)
         if run.get("event") == "workflow_dispatch"
         and run.get("head_sha") == source
         and run.get("display_title") == expected_title
@@ -358,12 +396,10 @@ def _validate_summary_reconstruction(
         raise ValueError("summary created_unix must be a finite non-negative float")
     if _canonical_json(summary.get("shard_manifest")) != _canonical_json(expected_manifest):
         raise ValueError("summary shard manifest does not bind the exact shard bytes and paths")
-    operational_fields = {"created_unix", "shard_manifest"}
-    stored_derivation = {
-        key: value for key, value in summary.items() if key not in operational_fields
-    }
+    normalized_recomputed = {**recomputed, "shard_manifest": expected_manifest}
+    stored_derivation = {key: value for key, value in summary.items() if key != "created_unix"}
     fresh_derivation = {
-        key: value for key, value in recomputed.items() if key not in operational_fields
+        key: value for key, value in normalized_recomputed.items() if key != "created_unix"
     }
     if _canonical_json(stored_derivation) != _canonical_json(fresh_derivation):
         raise ValueError("summary derivation does not match an exact reconstruction from shards")
@@ -491,6 +527,13 @@ def validate_result_bundle(
         )
     sorted_paths = sorted(expected_paths)
     shards = [load_shard(path) for path in sorted_paths]
+    for path, shard in zip(sorted_paths, shards, strict=True):
+        expected_name = f"{shard['config_name']}_seed{shard['seed']}.json"
+        if path.name != expected_name:
+            raise ValueError(
+                "shard filename/payload identity mismatch; "
+                f"{path.name!r} contains {expected_name!r}"
+            )
     observed_pairs = {(shard["config_name"], shard["seed"]) for shard in shards}
     if observed_pairs != expected_pairs or len(shards) != len(expected_pairs):
         raise ValueError("shard payload arm/seed coverage is not exact")

--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -132,7 +132,13 @@ def classify_outcome(
 
 
 def _parse_utc(value: str) -> dt.datetime:
-    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError("authorization timestamp is not valid ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != dt.timedelta(0):
+        raise RuntimeError("authorization timestamp must identify UTC")
+    return parsed
 
 
 def _github_json(path: str, *, token: str) -> Any:
@@ -301,10 +307,11 @@ def verify_launch_authorization(
     run_created_at = current.get("created_at")
     comment_created_at = comment.get("created_at")
     comment_updated_at = comment.get("updated_at")
-    if not all(
-        isinstance(value, str) and value
-        for value in (run_created_at, comment_created_at, comment_updated_at)
-    ):
+    if not isinstance(run_created_at, str) or not run_created_at:
+        raise RuntimeError("authorization timestamps are missing or invalid")
+    if not isinstance(comment_created_at, str) or not comment_created_at:
+        raise RuntimeError("authorization timestamps are missing or invalid")
+    if not isinstance(comment_updated_at, str) or not comment_updated_at:
         raise RuntimeError("authorization timestamps are missing or invalid")
     if comment_updated_at != comment_created_at:
         raise RuntimeError("authorization comment must be exact and never edited")
@@ -625,11 +632,10 @@ def validate_result_bundle(
     results = recomputed["results"]
     if not isinstance(results, list) or len(results) != 2:
         raise ValueError("summary must contain exactly the control and candidate")
-    by_name = {
-        result.get("config_name"): result
-        for result in results
-        if isinstance(result, dict) and isinstance(result.get("config_name"), str)
-    }
+    by_name: dict[str, dict[str, Any]] = {}
+    for result in results:
+        if isinstance(result, dict) and isinstance(result.get("config_name"), str):
+            by_name[cast(str, result["config_name"])] = result
     if set(by_name) != {protocol.control, protocol.candidate}:
         raise ValueError(f"summary arm set mismatch: {sorted(by_name)}")
     for name, result in by_name.items():

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -51,10 +51,12 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.launch_sha }}
 
-      - name: Set up exact Python 3.12.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - name: Set up exact uv 0.9.24
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
-          python-version: 3.12.12
+          version: 0.9.24
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Bind source, tag, workflow, and lock identities
         id: identity
@@ -116,6 +118,25 @@ jobs:
             exit 1
           fi
 
+      - name: Install exact uv-managed CPython 3.12.12
+        id: python
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$(uv --version)" != "uv 0.9.24" ]]; then
+            echo "setup-uv did not install exact uv 0.9.24" >&2
+            exit 1
+          fi
+          uv python install --managed-python 3.12.12
+          python_path="$(uv python find --managed-python --no-project 3.12.12)"
+          identity="$("$python_path" -c \
+            'import platform; print(platform.python_implementation(), platform.python_version(), platform.machine())')"
+          if [[ "$identity" != "CPython 3.12.12 arm64" ]]; then
+            echo "uv-managed Python identity mismatch: $identity" >&2
+            exit 1
+          fi
+          echo "path=$python_path" >> "$GITHUB_OUTPUT"
+
       - name: Require one pre-data project-owner authorization and one dispatch
         shell: bash
         env:
@@ -126,10 +147,11 @@ jobs:
           UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
           WORKFLOW_BLOB_SHA1: ${{ steps.identity.outputs.workflow_blob_sha1 }}
           DRIVER_BLOB_SHA1: ${{ steps.identity.outputs.driver_blob_sha1 }}
+          PYTHON_PATH: ${{ steps.python.outputs.path }}
         run: |
           set -euo pipefail
           metadata="$RUNNER_TEMP/prereg-metadata/launch-preflight.json"
-          python .github/scripts/ipmnist_prereg.py preflight \
+          "$PYTHON_PATH" .github/scripts/ipmnist_prereg.py preflight \
             --protocol "$PROTOCOL" \
             --repository "$GITHUB_REPOSITORY" \
             --source "$SOURCE" \
@@ -142,15 +164,10 @@ jobs:
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --output "$metadata"
 
-      - name: Set up exact uv 0.9.24
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: 0.9.24
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-
       - name: Synchronize the committed environment
         shell: bash
+        env:
+          PYTHON_PATH: ${{ steps.python.outputs.path }}
         run: |
           set -euo pipefail
           cpu_brand="$(sysctl -n machdep.cpu.brand_string)"
@@ -160,7 +177,7 @@ jobs:
           fi
           uv sync \
             --locked \
-            --python "$(command -v python)" \
+            --python "$PYTHON_PATH" \
             --extra research
           uv run --no-sync python - "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
           import importlib.metadata
@@ -341,7 +358,7 @@ jobs:
             echo
             echo "- Protocol: $PROTOCOL"
             echo "- Source: $SOURCE"
-            echo "- Outcome: $(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["outcome"])' "$result")"
+            echo "- Outcome: $(uv run --no-sync python -c 'import json,sys; print(json.load(open(sys.argv[1]))["outcome"])' "$result")"
             echo "- Validation metadata: result-validation.json"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -17,8 +17,10 @@ _strict_json = cast(Any, _DRIVER["_strict_json"])
 _validate_summary_reconstruction = cast(Any, _DRIVER["_validate_summary_reconstruction"])
 _validate_result_bundle = cast(Any, _DRIVER["validate_result_bundle"])
 _verify_launch_authorization = cast(Any, _DRIVER["verify_launch_authorization"])
+_workflow_runs = cast(Any, _DRIVER["_workflow_runs"])
 _write_json = cast(Any, _DRIVER["_write_json"])
 _DRIVER_GLOBALS = cast(dict[str, Any], _verify_launch_authorization.__globals__)
+_WORKFLOW_RUN_GLOBALS = cast(dict[str, Any], _workflow_runs.__globals__)
 
 
 def test_prereg_protocols_pin_exact_arms_and_seeds() -> None:
@@ -190,6 +192,138 @@ def test_launch_authorization_rejects_wrong_identity_or_edited_comment(
 ) -> None:
     with pytest.raises(RuntimeError, match="authorization"):
         _verify_with_comment(monkeypatch, _authorization_comment(**overrides))
+
+
+def test_launch_authorization_requires_strictly_pre_dispatch_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(RuntimeError, match="before workflow dispatch"):
+        _verify_with_comment(
+            monkeypatch,
+            _authorization_comment(
+                created_at="2026-08-16T10:00:00Z",
+                updated_at="2026-08-16T10:00:00Z",
+            ),
+        )
+
+
+def _searched_workflow_run(run_id: int) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "event": "workflow_dispatch",
+        "head_sha": "1" * 40,
+        "display_title": f"unrelated-run-{run_id}",
+        "path": ".github/workflows/ipmnist-prereg.yml",
+    }
+
+
+def test_workflow_run_search_binds_source_and_paginates_exact_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    responses = [
+        {
+            "total_count": 101,
+            "workflow_runs": [_searched_workflow_run(value) for value in range(1, 101)],
+        },
+        {"total_count": 101, "workflow_runs": [_searched_workflow_run(101)]},
+    ]
+
+    def fake_github_json(path: str, *, token: str) -> dict[str, Any]:
+        assert token == "token"
+        calls.append(path)
+        return responses.pop(0)
+
+    monkeypatch.setitem(_WORKFLOW_RUN_GLOBALS, "_github_json", fake_github_json)
+    runs = _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+
+    assert [run["id"] for run in runs] == list(range(1, 102))
+    assert len(calls) == 2
+    assert all("event=workflow_dispatch" in path for path in calls)
+    assert all(f"head_sha={'1' * 40}" in path for path in calls)
+
+
+def test_workflow_run_search_rejects_unsearchable_or_changing_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        _WORKFLOW_RUN_GLOBALS,
+        "_github_json",
+        lambda *_args, **_kwargs: {"total_count": 1001, "workflow_runs": []},
+    )
+    with pytest.raises(RuntimeError, match="1,000"):
+        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+
+    responses = [
+        {
+            "total_count": 101,
+            "workflow_runs": [_searched_workflow_run(value) for value in range(1, 101)],
+        },
+        {"total_count": 100, "workflow_runs": []},
+    ]
+    monkeypatch.setitem(
+        _WORKFLOW_RUN_GLOBALS,
+        "_github_json",
+        lambda *_args, **_kwargs: responses.pop(0),
+    )
+    with pytest.raises(RuntimeError, match="changed during pagination"):
+        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+
+
+def test_workflow_run_search_never_skips_a_malformed_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    responses = [
+        {
+            "total_count": 101,
+            "workflow_runs": [_searched_workflow_run(value) for value in range(1, 101)],
+        },
+        {"total_count": 101, "workflow_runs": ["not-a-workflow-run"]},
+        {"total_count": 101, "workflow_runs": [_searched_workflow_run(101)]},
+    ]
+
+    def fake_github_json(path: str, *, token: str) -> dict[str, Any]:
+        assert token == "token"
+        calls.append(path)
+        return responses.pop(0)
+
+    monkeypatch.setitem(_WORKFLOW_RUN_GLOBALS, "_github_json", fake_github_json)
+    with pytest.raises(RuntimeError, match="malformed result page"):
+        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+
+    assert len(calls) == 2
+    assert calls[-1].endswith("page=2")
+
+
+def test_workflow_run_search_rejects_duplicate_ids_across_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [
+        {
+            "total_count": 101,
+            "workflow_runs": [_searched_workflow_run(value) for value in range(1, 101)],
+        },
+        {"total_count": 101, "workflow_runs": [_searched_workflow_run(100)]},
+    ]
+    monkeypatch.setitem(
+        _WORKFLOW_RUN_GLOBALS,
+        "_github_json",
+        lambda *_args, **_kwargs: responses.pop(0),
+    )
+    with pytest.raises(RuntimeError, match="repeated a workflow run ID"):
+        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+
+
+def test_workflow_installs_exact_uv_managed_python() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "ipmnist-prereg.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "actions/setup-python@" not in workflow
+    assert "uv python install --managed-python 3.12.12" in workflow
+    assert 'uv python find --managed-python --no-project 3.12.12' in workflow
+    assert "CPython 3.12.12 arm64" in workflow
+    assert '--python "$PYTHON_PATH"' in workflow
 
 
 def test_summary_reconstruction_rejects_resigned_derived_metrics_and_manifest() -> None:
@@ -437,6 +571,71 @@ def test_result_bundle_rejects_resigned_summary_metric(
     candidate["paired_vs_control"]["mean_diff"] = 0.5
     summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
     with pytest.raises(ValueError, match="reconstruction"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("path", "outputs/ipmnist_screening/replication_r1/shards/forged.json"),
+        ("size_bytes", 1),
+        ("sha256", "f" * 64),
+    ],
+)
+def test_result_bundle_rejects_summary_manifest_tamper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+) -> None:
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["shard_manifest"][0][field] = value
+    summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_shard_filename_payload_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from alberta_framework.benchmarks.ipmnist_screening import merge_shards
+
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    shards_dir = summary_path.parent / "shards"
+    control = shards_dir / "sigma0_shiftnorm_d099_seed0.json"
+    candidate = shards_dir / "rls_head_resid_l1_preset005_seed1.json"
+    control_raw = control.read_bytes()
+    candidate_raw = candidate.read_bytes()
+    control.write_bytes(candidate_raw)
+    candidate.write_bytes(control_raw)
+    paths = sorted(path.relative_to(tmp_path) for path in shards_dir.glob("*.json"))
+    summary_path.write_text(
+        json.dumps(
+            merge_shards(paths, control_name="sigma0_shiftnorm_d099", slope_window=15),
+            allow_nan=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="filename/payload"):
         _validate_result_bundle(
             protocol_key="issue51",
             root=tmp_path,

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -207,6 +207,21 @@ def test_launch_authorization_requires_strictly_pre_dispatch_timestamp(
         )
 
 
+@pytest.mark.parametrize(
+    "timestamp",
+    ["not-a-timestamp", "2026-08-16T09:00:00", "2026-08-16T10:00:00+01:00"],
+)
+def test_launch_authorization_requires_valid_utc_timestamps(
+    monkeypatch: pytest.MonkeyPatch,
+    timestamp: str,
+) -> None:
+    with pytest.raises(RuntimeError, match="timestamp"):
+        _verify_with_comment(
+            monkeypatch,
+            _authorization_comment(created_at=timestamp, updated_at=timestamp),
+        )
+
+
 def _searched_workflow_run(run_id: int) -> dict[str, Any]:
     return {
         "id": run_id,


### PR DESCRIPTION
Closes #302.

PR #290 merged before its final independent launch audit completed. This code-only follow-up closes the remaining fail-closed gaps. No benchmark ran, no seed was consumed, and no preregistration artifact was created.

## Hardened launch contract

- Provisions exact uv-managed CPython 3.12.12 on macOS arm64 because the setup-python manifest has no Darwin 3.12.12 asset.
- Binds one-shot workflow-run enumeration to `head_sha`, enforces the filtered 1,000-result API cap, requires stable `total_count`, and rejects malformed, duplicate, or incomplete pages.
- Requires the exact unedited owner authorization to predate dispatch and rejects malformed, naive, or non-UTC timestamps.
- Binds shard filenames to payload arm/seed identities.
- Recomputes strict-v2 summaries from exact shard bytes and compares every derived field except operational `created_unix`, including normalized manifest path, size, and SHA-256.
- Adds adversarial regressions for authorization edits/timestamps, pagination drift/caps, unavailable Python setup, swapped shard payloads, manifest tampering, and resigned metrics.

## Exact-head verification

Head: `056e4821f4d0628366f522a8ef9546150d14066f`

```text
driver tests: 33 passed
focused IPMNIST panel on the same workflow repair before the timestamp/type-only follow-up:
  144 passed, 192 deselected
Ruff (driver/tests): clean
direct strict mypy of workflow driver: clean
actionlint 1.7.10: clean
git diff --check: clean
```

The direct mypy check is intentional: the workflow driver lives under `.github/scripts` and is not part of the package-only default mypy target.

## Scientific boundary

Launch remains blocked until this follow-up merges and the applicable issue contains exact pre-dispatch authorization. For #188, the explicit source, runner, seeds/n, and compute amendment must precede the final authorization comment. This workflow remains permanently nonpromoting and produces only a 90-day result/recovery bundle; it does not authenticate execution or create scientific evidence.
