### PR TITLE
fix(steps): round exact Real inputs once

### DIFF
--- a/alberta_framework/steps/_float32_validation.py
+++ b/alberta_framework/steps/_float32_validation.py
@@ -1,0 +1,38 @@
+"""Shared validation policy for Step facade scalars consumed as float32."""
+
+from __future__ import annotations
+
+import math
+from numbers import Real
+from typing import cast
+
+from alberta_framework._float32 import round_real_to_float32
+
+
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, float]:
+    """Return the original real and its exact finite binary32 rounding."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    try:
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must be finite, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return value, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
+    """Canonicalize non-builtins while preserving builtin JSON float values.
+
+    A builtin float is already an exact binary64 input, so the eventual JAX
+    conversion performs the same single binary32 rounding validated here.
+    Exact and third-party ``Real`` implementations are stored as the already
+    rounded builtin float, avoiding both double rounding and non-JSON scalars.
+    """
+    if type(cast(object, value)) is float:
+        return float(value)
+    return narrowed
+
+
+__all__ = ["canonical_float32_storage", "finite_real_and_float32"]

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -36,9 +36,8 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -53,6 +52,10 @@ from alberta_framework.core.options import (
     STOMPState,
     STOMPUpdateResult,
     SubtaskSpec,
+)
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
 )
 
 
@@ -170,33 +173,29 @@ _INT32_MAX = 2**31 - 1
 
 
 def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+    real, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number <= 0.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or narrowed == 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -179,21 +179,21 @@ def _require_real(name: str, value: object) -> float:
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed == 0.0:
+    if real <= 0.0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -46,6 +46,7 @@ from alberta_framework.steps._float32_validation import (
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 Step3RoutingName = Literal["shared", "independent", "mixed"]
 
 
@@ -175,21 +176,30 @@ class Step3OneStepResult:
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_gvf_probability(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    if narrowed < _FLOAT32_MIN_NORMAL and (real != 0.0 or narrowed != 0.0):
+        raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed == 0.0:
+    if real <= 0.0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
@@ -212,8 +222,8 @@ def _validate_horde_config(config: Step3HordeConfig) -> None:
             f"got {len(config.gammas)} and {len(config.lamdas)}"
         )
         raise ValueError(msg)
-    gammas = tuple(_require_unit_interval("gammas", value) for value in config.gammas)
-    lamdas = tuple(_require_unit_interval("lamdas", value) for value in config.lamdas)
+    gammas = tuple(_require_gvf_probability("gammas", value) for value in config.gammas)
+    lamdas = tuple(_require_gvf_probability("lamdas", value) for value in config.lamdas)
     step_size = _require_nonnegative_real("step_size", config.step_size)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
     obgd_kappa = _require_positive_real("obgd_kappa", config.obgd_kappa)

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -185,7 +185,9 @@ def _require_gvf_probability(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    if narrowed < _FLOAT32_MIN_NORMAL and (real != 0.0 or narrowed != 0.0):
+    if (real != 0.0 and real < _FLOAT32_MIN_NORMAL) or (
+        narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL
+    ):
         raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -14,9 +14,8 @@ Research-scale evidence and open boundaries for Step 3 are tracked in
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, Literal, cast
 
 import chex
@@ -40,6 +39,10 @@ from alberta_framework.core.multi_head_learner import MultiHeadMLPState
 from alberta_framework.core.normalizers import EMANormalizer, Normalizer
 from alberta_framework.core.optimizers import ObGDBounding
 from alberta_framework.core.types import DemonType, GVFSpec, TraceMode, create_horde_spec
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
+)
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
@@ -170,20 +173,25 @@ class Step3OneStepResult:
     per_demon_metrics: Array
 
 
-def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
-
-
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or narrowed == 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_int(name: str, value: object) -> int:
@@ -206,13 +214,9 @@ def _validate_horde_config(config: Step3HordeConfig) -> None:
         raise ValueError(msg)
     gammas = tuple(_require_unit_interval("gammas", value) for value in config.gammas)
     lamdas = tuple(_require_unit_interval("lamdas", value) for value in config.lamdas)
-    step_size = _require_real("step_size", config.step_size)
-    if step_size < 0.0:
-        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
+    step_size = _require_nonnegative_real("step_size", config.step_size)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
-    obgd_kappa = _require_real("obgd_kappa", config.obgd_kappa)
-    if obgd_kappa <= 0.0:
-        raise ValueError(f"obgd_kappa must be positive, got {config.obgd_kappa!r}")
+    obgd_kappa = _require_positive_real("obgd_kappa", config.obgd_kappa)
     hidden_sizes = tuple(
         _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
     )

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -149,7 +149,9 @@ def _require_gvf_probability(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    if narrowed < _FLOAT32_MIN_NORMAL and (real != 0.0 or narrowed != 0.0):
+    if (real != 0.0 and real < _FLOAT32_MIN_NORMAL) or (
+        narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL
+    ):
         raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -53,6 +53,7 @@ from alberta_framework.steps._float32_validation import (
 
 Step4OptimizerName = Literal["lms", "idbd", "autostep"]
 Step4BounderName = Literal["none", "obgd"]
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 
 
 @dataclass(frozen=True)
@@ -139,21 +140,30 @@ class Step4OneStepResult:
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_gvf_probability(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    if narrowed < _FLOAT32_MIN_NORMAL and (real != 0.0 or narrowed != 0.0):
+        raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed == 0.0:
+    if real <= 0.0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
@@ -181,11 +191,11 @@ def _validate_sarsa_config(config: Step4SARSAConfig) -> None:
     hidden_sizes = tuple(
         _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
     )
-    gamma = _require_unit_interval("gamma", config.gamma)
+    gamma = _require_gvf_probability("gamma", config.gamma)
     epsilon_start = _require_unit_interval("epsilon_start", config.epsilon_start)
     epsilon_end = _require_unit_interval("epsilon_end", config.epsilon_end)
     epsilon_decay_steps = _require_nonneg_int("epsilon_decay_steps", config.epsilon_decay_steps)
-    lamda = _require_unit_interval("lamda", config.lamda)
+    lamda = _require_gvf_probability("lamda", config.lamda)
     step_size = _require_nonnegative_real("step_size", config.step_size)
     meta_step_size = _require_nonnegative_real("meta_step_size", config.meta_step_size)
     bounder_kappa = _require_positive_real("bounder_kappa", config.bounder_kappa)

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -21,9 +21,8 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, Literal, cast
 
 import chex
@@ -47,6 +46,10 @@ from alberta_framework.core.sarsa import (
     SARSAUpdateResult,
 )
 from alberta_framework.core.types import GVFSpec, TraceMode
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
+)
 
 Step4OptimizerName = Literal["lms", "idbd", "autostep"]
 Step4BounderName = Literal["none", "obgd"]
@@ -134,20 +137,25 @@ class Step4OneStepResult:
     reward: Array
 
 
-def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
-
-
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or narrowed == 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_int(name: str, value: object) -> int:
@@ -178,15 +186,9 @@ def _validate_sarsa_config(config: Step4SARSAConfig) -> None:
     epsilon_end = _require_unit_interval("epsilon_end", config.epsilon_end)
     epsilon_decay_steps = _require_nonneg_int("epsilon_decay_steps", config.epsilon_decay_steps)
     lamda = _require_unit_interval("lamda", config.lamda)
-    step_size = _require_real("step_size", config.step_size)
-    if step_size < 0.0:
-        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
-    meta_step_size = _require_real("meta_step_size", config.meta_step_size)
-    if meta_step_size < 0.0:
-        raise ValueError(f"meta_step_size must be non-negative, got {config.meta_step_size!r}")
-    bounder_kappa = _require_real("bounder_kappa", config.bounder_kappa)
-    if bounder_kappa <= 0.0:
-        raise ValueError(f"bounder_kappa must be positive, got {config.bounder_kappa!r}")
+    step_size = _require_nonnegative_real("step_size", config.step_size)
+    meta_step_size = _require_nonnegative_real("meta_step_size", config.meta_step_size)
+    bounder_kappa = _require_positive_real("bounder_kappa", config.bounder_kappa)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
     object.__setattr__(config, "n_actions", n_actions)
     object.__setattr__(config, "hidden_sizes", hidden_sizes)

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -52,6 +52,15 @@ def _finite_float32_scalar(name: str, value: object) -> float:
     return narrowed
 
 
+def _compatible_float32_storage(value: object, narrowed: float) -> float:
+    """Preserve a builtin payload only when its eventual sink is proved equal."""
+    if type(value) is float:
+        return value
+    if type(value) is int and value == narrowed:
+        return value
+    return narrowed
+
+
 @dataclass(frozen=True)
 class Step5AverageRewardTDConfig:
     """Config for the production Step 5 differential TD facade."""
@@ -73,20 +82,26 @@ class Step5AverageRewardTDConfig:
             raise ValueError("average_reward_step_size must be non-negative")
         if not 0.0 <= self.trace_decay <= 1.0 or not 0.0 <= trace_decay <= 1.0:
             raise ValueError("trace_decay must be in [0, 1]")
-        # Preserve the exact built-in JSON scalar values accepted by the
-        # existing facade. Non-built-in Real scalars need canonicalization so
-        # persistence remains JSON-safe and the stored value exactly matches
-        # the float32 value validated above.
-        if type(self.step_size) not in (int, float):
-            object.__setattr__(self, "step_size", step_size)
-        if type(self.average_reward_step_size) not in (int, float):
-            object.__setattr__(
-                self,
-                "average_reward_step_size",
+        # Preserve builtin floats and sink-exact builtin integers. Other Reals
+        # need the already-rounded value so the JAX sink cannot double-round.
+        object.__setattr__(
+            self,
+            "step_size",
+            _compatible_float32_storage(self.step_size, step_size),
+        )
+        object.__setattr__(
+            self,
+            "average_reward_step_size",
+            _compatible_float32_storage(
+                self.average_reward_step_size,
                 average_reward_step_size,
-            )
-        if type(self.trace_decay) not in (int, float):
-            object.__setattr__(self, "trace_decay", trace_decay)
+            ),
+        )
+        object.__setattr__(
+            self,
+            "trace_decay",
+            _compatible_float32_storage(self.trace_decay, trace_decay),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -24,12 +24,10 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from numbers import Real
 from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 
 from alberta_framework.core.average_reward import (
     DifferentialTDArrayResult,
@@ -37,6 +35,7 @@ from alberta_framework.core.average_reward import (
     DifferentialTDLearner,
     run_differential_td_from_arrays,
 )
+from alberta_framework.steps._float32_validation import finite_real_and_float32
 
 _STEP5_CONFIG_KEYS = frozenset(
     {"step_size", "average_reward_step_size", "trace_decay"}
@@ -49,16 +48,8 @@ _STEP5_CONFIG_KEYS_ERROR = (
 
 def _finite_float32_scalar(name: str, value: object) -> float:
     """Validate a real scalar before the core narrows it to float32."""
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real scalar")
-    try:
-        with np.errstate(invalid="ignore", over="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32") from None
-    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
-        raise ValueError(f"{name} must narrow to a finite float32")
-    return float(narrowed)
+    _, narrowed = finite_real_and_float32(name, value)
+    return narrowed
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -67,11 +67,11 @@ class Step5AverageRewardTDConfig:
             "average_reward_step_size", self.average_reward_step_size
         )
         trace_decay = _finite_float32_scalar("trace_decay", self.trace_decay)
-        if self.step_size < 0.0:
+        if self.step_size < 0.0 or step_size < 0.0:
             raise ValueError("step_size must be non-negative")
-        if self.average_reward_step_size < 0.0:
+        if self.average_reward_step_size < 0.0 or average_reward_step_size < 0.0:
             raise ValueError("average_reward_step_size must be non-negative")
-        if not 0.0 <= self.trace_decay <= 1.0:
+        if not 0.0 <= self.trace_decay <= 1.0 or not 0.0 <= trace_decay <= 1.0:
             raise ValueError("trace_decay must be in [0, 1]")
         # Preserve the exact built-in JSON scalar values accepted by the
         # existing facade. Non-built-in Real scalars need canonicalization so

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -47,9 +47,8 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import asdict, dataclass, field
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, Literal, cast
 
 import chex
@@ -67,6 +66,10 @@ from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelState,
     WorldModelUpdateResult,
+)
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
 )
 from alberta_framework.steps.step6 import (
     Step6DifferentialSARSAConfig,
@@ -133,13 +136,25 @@ class Step7DynaConfig:
         return cls(**cast(Any, data))
 
 
-def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or narrowed == 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
@@ -172,33 +187,18 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         config.planning_memory_size,
         minimum=1,
     )
-    importance_clip = _require_real(
+    importance_clip = _require_positive_real(
         "planning_importance_ratio_clip",
         config.planning_importance_ratio_clip,
     )
-    if importance_clip <= 0.0:
-        raise ValueError(
-            f"planning_importance_ratio_clip must be positive, got "
-            f"{config.planning_importance_ratio_clip!r}"
-        )
-    propagation = _require_real(
+    propagation = _require_nonnegative_real(
         "planning_priority_propagation",
         config.planning_priority_propagation,
     )
-    if propagation < 0.0:
-        raise ValueError(
-            f"planning_priority_propagation must be non-negative, got "
-            f"{config.planning_priority_propagation!r}"
-        )
-    utility_step = _require_real(
+    utility_step = _require_unit_interval(
         "planning_utility_step_size",
         config.planning_utility_step_size,
     )
-    if not 0.0 <= utility_step <= 1.0:
-        raise ValueError(
-            f"planning_utility_step_size must be in [0, 1], got "
-            f"{config.planning_utility_step_size!r}"
-        )
     if config.planning_strategy not in (
         "random",
         "reward",

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -138,21 +138,21 @@ class Step7DynaConfig:
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed == 0.0:
+    if real <= 0.0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -107,7 +107,7 @@ def _require_unit_interval(name: str, value: object) -> float:
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0:
+    if real < 0.0 or not real < 1.0 or not narrowed < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -100,21 +100,21 @@ class Step8WorldModelConfig:
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0 or not narrowed < 1.0:
+    if real < 0.0 or not real < 1.0 or narrowed < 0.0 or not narrowed < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -25,10 +25,9 @@ via Disagreement."
 
 from __future__ import annotations
 
-import math
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -42,6 +41,10 @@ from alberta_framework.core.world_model import (
     WorldModelState,
     WorldModelUpdateResult,
     run_world_model_learning_loop,
+)
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
 )
 
 
@@ -95,27 +98,25 @@ class Step8WorldModelConfig:
         )
 
 
-def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
-
-
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number < 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
@@ -140,13 +141,12 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     hidden_sizes = tuple(
         _require_int("hidden_sizes", size, minimum=1) for size in config.hidden_sizes
     )
-    step_size = _require_real("step_size", config.step_size)
-    if step_size < 0.0:
-        raise ValueError(f"step_size must be non-negative, got {config.step_size!r}")
+    step_size = _require_nonnegative_real("step_size", config.step_size)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
-    leaky_relu_slope = _require_real("leaky_relu_slope", config.leaky_relu_slope)
-    if leaky_relu_slope < 0.0:
-        raise ValueError(f"leaky_relu_slope must be non-negative, got {config.leaky_relu_slope!r}")
+    leaky_relu_slope = _require_nonnegative_real(
+        "leaky_relu_slope",
+        config.leaky_relu_slope,
+    )
     utility_decay = _require_half_open_unit_interval("utility_decay", config.utility_decay)
     object.__setattr__(config, "observation_dim", observation_dim)
     object.__setattr__(config, "n_actions", n_actions)

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -200,7 +200,7 @@ def _require_unit_interval(name: str, value: object) -> float:
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0:
+    if real < 0.0 or not real < 1.0 or not narrowed < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -186,21 +186,21 @@ def _require_real(name: str, value: object) -> float:
 
 def _require_nonneg_real(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0:
+    if real < 0.0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0:
+    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
     real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0 or not narrowed < 1.0:
+    if real < 0.0 or not real < 1.0 or narrowed < 0.0 or not narrowed < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -25,9 +25,8 @@ floats; legal endpoints stay valid.
 from __future__ import annotations
 
 import functools
-import math
 from dataclasses import asdict, dataclass, field
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, cast
 
 import chex
@@ -57,6 +56,10 @@ from alberta_framework.core.world_model import (
     ActionConditionedWorldModelConfig,
     ActionConditionedWorldModelState,
     WorldModelUpdateResult,
+)
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
 )
 from alberta_framework.steps.step6 import (
     Step6DifferentialSARSAConfig,
@@ -177,33 +180,29 @@ class Step9DreamingConfig:
 
 
 def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+    real, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonneg_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number < 1.0:
+    real, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or not real < 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -450,6 +450,68 @@ def test_large_integral_midpoint_uses_binary32_ties_to_even() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "average_reward_step_size"],
+)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            2**64 + 2**40 + 1,
+            float.fromhex("0x1.000002p+64"),
+            id="above-large-midpoint",
+        ),
+        pytest.param(
+            (2**25 - 1) * 2**103 - 1,
+            float.fromhex("0x1.fffffep+127"),
+            id="below-overflow-midpoint",
+        ),
+    ],
+)
+def test_step5_builtin_int_storage_matches_validated_float32_sink(
+    field: str,
+    value: int,
+    expected: float,
+) -> None:
+    config = Step5AverageRewardTDConfig(**{field: cast(Any, value)})
+    stored = cast(float, getattr(config, field))
+
+    assert float(jnp.asarray(stored, dtype=jnp.float32)) == expected
+    assert type(stored) is float
+    assert stored == expected
+
+
+def test_step5_preserves_only_sink_exact_builtin_int_payloads() -> None:
+    exact = 2**64
+    config = Step5AverageRewardTDConfig(
+        step_size=cast(Any, exact),
+        average_reward_step_size=cast(Any, 0),
+        trace_decay=cast(Any, 1),
+    )
+    payload = config.to_dict()
+
+    assert type(config.step_size) is int
+    assert config.step_size == exact
+    assert type(config.average_reward_step_size) is int
+    assert type(config.trace_decay) is int
+    assert float(jnp.asarray(config.step_size, dtype=jnp.float32)) == float(exact)
+    json.dumps(payload, allow_nan=False)
+
+
+def test_step5_builtin_signed_zero_storage_is_preserved() -> None:
+    config = Step5AverageRewardTDConfig(
+        step_size=-0.0,
+        average_reward_step_size=-0.0,
+        trace_decay=-0.0,
+    )
+    payload = config.to_dict()
+
+    for field in ("step_size", "average_reward_step_size", "trace_decay"):
+        assert math.copysign(1.0, cast(float, getattr(config, field))) == -1.0
+        assert math.copysign(1.0, cast(float, payload[field])) == -1.0
+
+
 def test_numpy_integral_midpoint_uses_exact_integer_ratio() -> None:
     lower = 2**62
     tie = np.int64(lower + 2**38)

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -17,8 +17,8 @@ from alberta_framework.steps.step3 import Step3HordeConfig
 from alberta_framework.steps.step4 import Step4SARSAConfig
 from alberta_framework.steps.step5 import Step5AverageRewardTDConfig
 from alberta_framework.steps.step7 import Step7DynaConfig
-from alberta_framework.steps.step8 import Step8WorldModelConfig
-from alberta_framework.steps.step9 import Step9DreamingConfig
+from alberta_framework.steps.step8 import Step8WorldModelConfig, make_step8_world_model
+from alberta_framework.steps.step9 import Step9DreamingConfig, make_step9_components
 from alberta_framework.steps.step10 import Step10STOMPConfig
 
 _FacadeValues = Callable[[object], tuple[float, ...]]
@@ -257,6 +257,43 @@ def test_nonnegative_field_rejects_negative_value_that_underflows() -> None:
 def test_unit_interval_rejects_exact_value_above_endpoint() -> None:
     with pytest.raises(ValueError, match=r"gamma must be in \[0, 1\]"):
         Step4SARSAConfig(gamma=Fraction(1, 1) + Fraction(1, 2**200))
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        pytest.param(Step8WorldModelConfig, "utility_decay", id="step8"),
+        pytest.param(Step9DreamingConfig, "model_error_decay", id="step9"),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(Fraction(1, 1) - Fraction(1, 2**25), id="exact-tie"),
+        pytest.param(Fraction(1, 1) - Fraction(1, 2**200), id="exact-rational"),
+        pytest.param(math.nextafter(1.0, 0.0), id="builtin-float"),
+    ],
+)
+def test_half_open_interval_rejects_value_that_rounds_to_one(
+    config_type: type[Step8WorldModelConfig] | type[Step9DreamingConfig],
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=rf"{field} must be in \[0, 1\)"):
+        config_type(**{field: cast(Any, value)})
+
+
+def test_half_open_interval_accepts_value_that_rounds_below_one() -> None:
+    value = Fraction(1, 1) - Fraction(1, 2**25) - Fraction(1, 2**200)
+    expected = float(np.nextafter(np.float32(1.0), np.float32(0.0)))
+
+    step8 = Step8WorldModelConfig(utility_decay=value)
+    step9 = Step9DreamingConfig(model_error_decay=value)
+
+    assert step8.utility_decay == expected
+    assert step9.model_error_decay == expected
+    make_step8_world_model(step8)
+    make_step9_components(step9)
 
 
 def test_finite_overflow_boundary_accepts_below_and_rejects_tie() -> None:

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -13,8 +13,8 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.options import SubtaskSpec
-from alberta_framework.steps.step3 import Step3HordeConfig
-from alberta_framework.steps.step4 import Step4SARSAConfig
+from alberta_framework.steps.step3 import Step3HordeConfig, make_step3_horde_spec
+from alberta_framework.steps.step4 import Step4SARSAConfig, make_step4_sarsa_agent
 from alberta_framework.steps.step5 import Step5AverageRewardTDConfig
 from alberta_framework.steps.step7 import Step7DynaConfig
 from alberta_framework.steps.step8 import Step8WorldModelConfig, make_step8_world_model
@@ -260,6 +260,71 @@ def test_unit_interval_rejects_exact_value_above_endpoint() -> None:
 
 
 @pytest.mark.parametrize(
+    "value",
+    [Fraction(1, 2**150), Fraction(1, 2**149)],
+    ids=("underflows-to-zero", "minimum-subnormal"),
+)
+def test_gvf_probabilities_reject_nonzero_subnormal_inputs(value: Fraction) -> None:
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        Step3HordeConfig(gammas=(value,), lamdas=(0.0,))
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        Step4SARSAConfig(gamma=value)
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        Step4SARSAConfig(lamda=value)
+
+
+def test_gvf_probabilities_accept_minimum_normal_and_reach_core() -> None:
+    minimum_normal = Fraction(1, 2**126)
+    expected = float.fromhex("0x1.0p-126")
+    step3 = Step3HordeConfig(gammas=(minimum_normal,), lamdas=(minimum_normal,))
+    step4 = Step4SARSAConfig(gamma=minimum_normal, lamda=minimum_normal)
+
+    assert step3.gammas == (expected,)
+    assert step3.lamdas == (expected,)
+    assert step4.gamma == expected
+    assert step4.lamda == expected
+    make_step3_horde_spec(step3)
+    make_step4_sarsa_agent(step4)
+
+
+def test_zero_host_with_subnormal_ratio_is_rejected_before_core() -> None:
+    class SubnormalRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2**149)
+
+    value = SubnormalRatioFloat(0.0)
+
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        Step3HordeConfig(gammas=(value,), lamdas=(0.0,))
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        Step4SARSAConfig(gamma=value)
+
+
+def test_host_comparisons_cannot_hide_invalid_narrowed_domains() -> None:
+    class NegativeRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 1)
+
+    class AboveUnitRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (2, 1)
+
+    negative = NegativeRatioFloat(0.5)
+    above_unit = AboveUnitRatioFloat(0.5)
+
+    with pytest.raises(ValueError, match="step_size must be non-negative"):
+        Step4SARSAConfig(step_size=negative)
+    with pytest.raises(ValueError, match="step_size must be non-negative"):
+        Step5AverageRewardTDConfig(step_size=negative)
+    with pytest.raises(ValueError, match="option_importance_clip must be positive"):
+        Step10STOMPConfig(option_importance_clip=negative)
+    with pytest.raises(ValueError, match=r"gammas must be in \[0, 1\]"):
+        Step3HordeConfig(gammas=(above_unit,), lamdas=(0.0,))
+    with pytest.raises(ValueError, match=r"trace_decay must be in \[0, 1\]"):
+        Step5AverageRewardTDConfig(trace_decay=above_unit)
+
+
+@pytest.mark.parametrize(
     ("config_type", "field"),
     [
         pytest.param(Step8WorldModelConfig, "utility_decay", id="step8"),
@@ -286,9 +351,40 @@ def test_half_open_interval_rejects_value_that_rounds_to_one(
 def test_half_open_interval_accepts_value_that_rounds_below_one() -> None:
     value = Fraction(1, 1) - Fraction(1, 2**25) - Fraction(1, 2**200)
     expected = float(np.nextafter(np.float32(1.0), np.float32(0.0)))
+    step8 = Step8WorldModelConfig(utility_decay=value)
+    step9 = Step9DreamingConfig(model_error_decay=value)
+
+    assert step8.utility_decay == expected
+    assert step9.model_error_decay == expected
+    make_step8_world_model(step8)
+    make_step9_components(step9)
+
+
+@pytest.mark.parametrize(
+    ("offset", "accepted"),
+    [
+        (-Fraction(1, 2**80), True),
+        (Fraction(0, 1), False),
+        (Fraction(1, 2**80), False),
+    ],
+    ids=("below", "tie", "above"),
+)
+def test_half_open_decay_rejects_values_that_round_to_one(
+    offset: Fraction,
+    accepted: bool,
+) -> None:
+    value = Fraction(1, 1) - Fraction(1, 2**25) + offset
+
+    if not accepted:
+        with pytest.raises(ValueError, match=r"must be in \[0, 1\)"):
+            Step8WorldModelConfig(utility_decay=value)
+        with pytest.raises(ValueError, match=r"must be in \[0, 1\)"):
+            Step9DreamingConfig(model_error_decay=value)
+        return
 
     step8 = Step8WorldModelConfig(utility_decay=value)
     step9 = Step9DreamingConfig(model_error_decay=value)
+    expected = float(np.nextafter(np.float32(1.0), np.float32(0.0)))
 
     assert step8.utility_decay == expected
     assert step9.model_error_decay == expected
@@ -351,6 +447,43 @@ def test_numpy_float64_midpoint_neighborhood_rounds_once() -> None:
     assert above_config.step_size == expected_upper
 
 
+def test_float_subclass_cannot_disagree_with_its_exact_ratio() -> None:
+    class RatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (3, 4)
+
+    value = RatioFloat(0.5)
+
+    assert Step3HordeConfig(step_size=value).step_size == 0.75
+    assert Step8WorldModelConfig(step_size=value).step_size == 0.75
+
+
+def test_float_subclass_cannot_spoof_builtin_identity() -> None:
+    class RatioFloat(float):
+        def __getattribute__(self, name: str) -> object:
+            if name == "__class__":
+                return float
+            return super().__getattribute__(name)
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (3, 4)
+
+    value = RatioFloat(0.5)
+
+    assert Step3HordeConfig(step_size=value).step_size == 0.75
+
+
+def test_nonfinite_float_subclass_cannot_bypass_exact_ratio_storage() -> None:
+    class RatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 1)
+
+    config = Step9DreamingConfig(dream_surprise_weight=RatioFloat(float("nan")))
+
+    assert config.dream_surprise_weight == 1.0
+    json.dumps(config.to_dict(), allow_nan=False)
+
+
 @pytest.mark.parametrize(
     "value",
     [np.float16(0.1), np.float32(0.1), np.float64(0.1), np.int32(1), np.int64(1)],
@@ -369,13 +502,14 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
 
 
 @pytest.mark.parametrize(
-    "config_and_payload",
+    ("config_and_payload", "field"),
     [
         pytest.param(
             lambda: (
                 Step3HordeConfig(step_size=0.1),
                 Step3HordeConfig(step_size=0.1).to_dict(),
             ),
+            "step_size",
             id="step3",
         ),
         pytest.param(
@@ -383,6 +517,7 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step4SARSAConfig(step_size=0.1),
                 Step4SARSAConfig(step_size=0.1).to_dict(),
             ),
+            "step_size",
             id="step4",
         ),
         pytest.param(
@@ -390,6 +525,7 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step5AverageRewardTDConfig(step_size=0.1),
                 Step5AverageRewardTDConfig(step_size=0.1).to_dict(),
             ),
+            "step_size",
             id="step5",
         ),
         pytest.param(
@@ -397,6 +533,7 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step7DynaConfig(planning_priority_propagation=0.1),
                 Step7DynaConfig(planning_priority_propagation=0.1).to_dict(),
             ),
+            "planning_priority_propagation",
             id="step7",
         ),
         pytest.param(
@@ -404,6 +541,7 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step8WorldModelConfig(step_size=0.1),
                 Step8WorldModelConfig(step_size=0.1).to_dict(),
             ),
+            "step_size",
             id="step8",
         ),
         pytest.param(
@@ -411,6 +549,7 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step9DreamingConfig(model_step_size=0.1),
                 Step9DreamingConfig(model_step_size=0.1).to_dict(),
             ),
+            "model_step_size",
             id="step9",
         ),
         pytest.param(
@@ -418,16 +557,19 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
                 Step10STOMPConfig(base_step_size=0.1),
                 Step10STOMPConfig(base_step_size=0.1).to_config(),
             ),
+            "base_step_size",
             id="step10",
         ),
     ],
 )
 def test_builtin_float_serialization_value_is_preserved(
     config_and_payload: Callable[[], tuple[object, dict[str, Any]]],
+    field: str,
 ) -> None:
     _, payload = config_and_payload()
 
-    selected = next(value for value in payload.values() if value == 0.1)
+    selected = payload[field]
+    assert type(selected) is float
     assert selected == 0.1
     json.dumps(payload, allow_nan=False)
 

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -287,6 +287,37 @@ def test_gvf_probabilities_accept_minimum_normal_and_reach_core() -> None:
     make_step4_sarsa_agent(step4)
 
 
+@pytest.mark.parametrize(
+    "build_config",
+    [
+        pytest.param(
+            lambda value: Step3HordeConfig(gammas=(value,), lamdas=(0.0,)),
+            id="step3-gamma",
+        ),
+        pytest.param(
+            lambda value: Step3HordeConfig(gammas=(0.0,), lamdas=(value,)),
+            id="step3-lamda",
+        ),
+        pytest.param(
+            lambda value: Step4SARSAConfig(gamma=value),
+            id="step4-gamma",
+        ),
+        pytest.param(
+            lambda value: Step4SARSAConfig(lamda=value),
+            id="step4-lamda",
+        ),
+    ],
+)
+def test_gvf_probabilities_reject_exact_subnormal_that_rounds_to_normal(
+    build_config: Callable[[Any], object],
+) -> None:
+    value = Fraction(1, 2**126) - Fraction(1, 2**200)
+    assert float(np.float32(value)) == float.fromhex("0x1.0p-126")
+
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        build_config(value)
+
+
 def test_zero_host_with_subnormal_ratio_is_rejected_before_core() -> None:
     class SubnormalRatioFloat(float):
         def as_integer_ratio(self) -> tuple[int, int]:

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -1,0 +1,403 @@
+"""Exact binary32 canonicalization shared by the merged Step facades."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable
+from fractions import Fraction
+from typing import Any, cast
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.options import SubtaskSpec
+from alberta_framework.steps.step3 import Step3HordeConfig
+from alberta_framework.steps.step4 import Step4SARSAConfig
+from alberta_framework.steps.step5 import Step5AverageRewardTDConfig
+from alberta_framework.steps.step7 import Step7DynaConfig
+from alberta_framework.steps.step8 import Step8WorldModelConfig
+from alberta_framework.steps.step9 import Step9DreamingConfig
+from alberta_framework.steps.step10 import Step10STOMPConfig
+
+_FacadeValues = Callable[[object], tuple[float, ...]]
+
+
+def _step3_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step3HordeConfig(
+        gammas=(scalar,),
+        lamdas=(scalar,),
+        step_size=scalar,
+        obgd_kappa=scalar,
+        sparsity=scalar,
+    )
+    return (
+        config.gammas[0],
+        config.lamdas[0],
+        config.step_size,
+        config.obgd_kappa,
+        config.sparsity,
+    )
+
+
+def _step4_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step4SARSAConfig(
+        gamma=scalar,
+        epsilon_start=scalar,
+        epsilon_end=scalar,
+        lamda=scalar,
+        step_size=scalar,
+        meta_step_size=scalar,
+        bounder_kappa=scalar,
+        sparsity=scalar,
+    )
+    return (
+        config.gamma,
+        config.epsilon_start,
+        config.epsilon_end,
+        config.lamda,
+        config.step_size,
+        config.meta_step_size,
+        config.bounder_kappa,
+        config.sparsity,
+    )
+
+
+def _step5_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step5AverageRewardTDConfig(
+        step_size=scalar,
+        average_reward_step_size=scalar,
+        trace_decay=scalar,
+    )
+    return (
+        config.step_size,
+        config.average_reward_step_size,
+        config.trace_decay,
+    )
+
+
+def _step7_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step7DynaConfig(
+        planning_importance_ratio_clip=scalar,
+        planning_priority_propagation=scalar,
+        planning_utility_step_size=scalar,
+    )
+    return (
+        config.planning_importance_ratio_clip,
+        config.planning_priority_propagation,
+        config.planning_utility_step_size,
+    )
+
+
+def _step8_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step8WorldModelConfig(
+        step_size=scalar,
+        sparsity=scalar,
+        leaky_relu_slope=scalar,
+        utility_decay=scalar,
+    )
+    return (
+        config.step_size,
+        config.sparsity,
+        config.leaky_relu_slope,
+        config.utility_decay,
+    )
+
+
+def _step9_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step9DreamingConfig(
+        model_step_size=scalar,
+        model_sparsity=scalar,
+        model_gamma=scalar,
+        dreaming_max_model_error=scalar,
+        model_error_decay=scalar,
+        behavior_model_step_size=scalar,
+        dream_surprise_weight=scalar,
+        dream_utility_weight=scalar,
+    )
+    return (
+        config.model_step_size,
+        config.model_sparsity,
+        config.model_gamma,
+        config.dreaming_max_model_error,
+        config.model_error_decay,
+        config.behavior_model_step_size,
+        config.dream_surprise_weight,
+        config.dream_utility_weight,
+    )
+
+
+def _step10_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step10STOMPConfig(
+        subtask_specs=(
+            SubtaskSpec(
+                feature_index=0,
+                threshold=scalar,
+                pseudo_reward_scale=scalar,
+            ),
+        ),
+        base_step_size=scalar,
+        base_avg_reward_step_size=scalar,
+        base_trace_decay=scalar,
+        option_step_size=scalar,
+        option_avg_reward_step_size=scalar,
+        option_trace_decay=scalar,
+        option_gamma=scalar,
+        option_model_decay=scalar,
+        option_model_step_size=scalar,
+        epsilon_base=scalar,
+        epsilon_option=scalar,
+        option_target_epsilon=scalar,
+        option_importance_clip=scalar,
+    )
+    spec = config.subtask_specs[0]
+    return (
+        spec.threshold,
+        spec.pseudo_reward_scale,
+        config.base_step_size,
+        config.base_avg_reward_step_size,
+        config.base_trace_decay,
+        config.option_step_size,
+        config.option_avg_reward_step_size,
+        config.option_trace_decay,
+        config.option_gamma,
+        config.option_model_decay,
+        config.option_model_step_size,
+        config.epsilon_base,
+        config.epsilon_option,
+        cast(float, config.option_target_epsilon),
+        config.option_importance_clip,
+    )
+
+
+@pytest.mark.parametrize(
+    "facade_values",
+    [
+        pytest.param(_step3_values, id="step3"),
+        pytest.param(_step4_values, id="step4"),
+        pytest.param(_step5_values, id="step5"),
+        pytest.param(_step7_values, id="step7"),
+        pytest.param(_step8_values, id="step8"),
+        pytest.param(_step9_values, id="step9"),
+        pytest.param(_step10_values, id="step10"),
+    ],
+)
+def test_all_float32_bound_fields_round_exact_fraction_once(
+    facade_values: _FacadeValues,
+) -> None:
+    above_half_midpoint = (
+        Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
+    )
+    expected = float(np.nextafter(np.float32(0.5), np.float32(1.0)))
+
+    values = facade_values(above_half_midpoint)
+
+    assert values
+    assert all(value == expected for value in values)
+    json.dumps(values, allow_nan=False)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) - Fraction(1, 2**60),
+            1.0,
+        ),
+        (Fraction(1, 1) + Fraction(1, 2**24), 1.0),
+        (
+            Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60),
+            float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+        ),
+    ],
+    ids=("below", "tie-even", "above"),
+)
+def test_fraction_midpoint_neighborhood_rounds_once(
+    value: Fraction,
+    expected: float,
+) -> None:
+    assert Step5AverageRewardTDConfig(step_size=value).step_size == expected
+
+
+def test_fraction_odd_lower_significand_tie_rounds_up() -> None:
+    odd_lower_tie = Fraction(1, 1) + Fraction(3, 2**24)
+    expected = float(np.nextafter(np.float32(1.0), np.float32(2.0), dtype=np.float32))
+    expected = float(np.nextafter(np.float32(expected), np.float32(2.0)))
+
+    assert Step8WorldModelConfig(step_size=odd_lower_tie).step_size == expected
+
+
+def test_subnormal_tie_and_above_round_with_even_zero() -> None:
+    half_min_subnormal = Fraction(1, 2**150)
+    just_above = half_min_subnormal + Fraction(1, 2**200)
+    min_subnormal = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+
+    assert Step8WorldModelConfig(step_size=half_min_subnormal).step_size == 0.0
+    assert Step8WorldModelConfig(step_size=just_above).step_size == min_subnormal
+
+
+def test_positive_field_rejects_value_that_rounds_to_zero() -> None:
+    with pytest.raises(ValueError, match="option_importance_clip must be positive"):
+        Step10STOMPConfig(option_importance_clip=Fraction(1, 2**150))
+
+
+def test_nonnegative_field_rejects_negative_value_that_underflows() -> None:
+    with pytest.raises(ValueError, match="model_step_size must be non-negative"):
+        Step9DreamingConfig(model_step_size=Fraction(-1, 2**1200))
+
+
+def test_unit_interval_rejects_exact_value_above_endpoint() -> None:
+    with pytest.raises(ValueError, match=r"gamma must be in \[0, 1\]"):
+        Step4SARSAConfig(gamma=Fraction(1, 1) + Fraction(1, 2**200))
+
+
+def test_finite_overflow_boundary_accepts_below_and_rejects_tie() -> None:
+    overflow_midpoint = (2**25 - 1) * 2**103
+    maximum = float(np.finfo(np.float32).max)
+
+    config = Step7DynaConfig(
+        planning_importance_ratio_clip=overflow_midpoint - 1,
+    )
+    assert config.planning_importance_ratio_clip == maximum
+    with pytest.raises(ValueError, match="must be finite"):
+        Step7DynaConfig(planning_importance_ratio_clip=overflow_midpoint)
+
+
+def test_large_integral_midpoint_uses_binary32_ties_to_even() -> None:
+    lower = 2**64
+    tie = lower + 2**40
+    above = tie + 1
+    expected_upper = float(np.nextafter(np.float32(lower), np.float32(np.inf)))
+
+    assert Step9DreamingConfig(dreaming_max_model_error=tie).dreaming_max_model_error == float(
+        lower
+    )
+    assert (
+        Step9DreamingConfig(dreaming_max_model_error=above).dreaming_max_model_error
+        == expected_upper
+    )
+
+
+def test_numpy_integral_midpoint_uses_exact_integer_ratio() -> None:
+    lower = 2**62
+    tie = np.int64(lower + 2**38)
+    above = np.int64(int(tie) + 1)
+    expected_upper = float(np.nextafter(np.float32(lower), np.float32(np.inf)))
+
+    assert Step9DreamingConfig(dreaming_max_model_error=tie).dreaming_max_model_error == float(
+        lower
+    )
+    assert (
+        Step9DreamingConfig(dreaming_max_model_error=above).dreaming_max_model_error
+        == expected_upper
+    )
+
+
+def test_numpy_float64_midpoint_neighborhood_rounds_once() -> None:
+    tie = np.float64(float.fromhex("0x1.000001p0"))
+    above = np.nextafter(tie, np.float64(np.inf))
+    expected_upper = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+
+    tie_config = Step8WorldModelConfig(step_size=tie)
+    above_config = Step8WorldModelConfig(step_size=above)
+
+    assert type(tie_config.step_size) is float
+    assert tie_config.step_size == 1.0
+    assert above_config.step_size == expected_upper
+
+
+@pytest.mark.parametrize(
+    "value",
+    [np.float16(0.1), np.float32(0.1), np.float64(0.1), np.int32(1), np.int64(1)],
+)
+def test_numpy_real_and_integral_scalars_canonicalize_for_json(value: object) -> None:
+    config = Step3HordeConfig(step_size=cast(Any, value))
+
+    assert type(config.step_size) is float
+    json.dumps(config.to_dict(), allow_nan=False)
+
+
+@pytest.mark.parametrize("value", [jnp.float32(0.5), jnp.int32(1)])
+def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None:
+    with pytest.raises(ValueError, match="step_size must be a real number"):
+        Step3HordeConfig(step_size=cast(Any, value))
+
+
+@pytest.mark.parametrize(
+    "config_and_payload",
+    [
+        pytest.param(
+            lambda: (
+                Step3HordeConfig(step_size=0.1),
+                Step3HordeConfig(step_size=0.1).to_dict(),
+            ),
+            id="step3",
+        ),
+        pytest.param(
+            lambda: (
+                Step4SARSAConfig(step_size=0.1),
+                Step4SARSAConfig(step_size=0.1).to_dict(),
+            ),
+            id="step4",
+        ),
+        pytest.param(
+            lambda: (
+                Step5AverageRewardTDConfig(step_size=0.1),
+                Step5AverageRewardTDConfig(step_size=0.1).to_dict(),
+            ),
+            id="step5",
+        ),
+        pytest.param(
+            lambda: (
+                Step7DynaConfig(planning_priority_propagation=0.1),
+                Step7DynaConfig(planning_priority_propagation=0.1).to_dict(),
+            ),
+            id="step7",
+        ),
+        pytest.param(
+            lambda: (
+                Step8WorldModelConfig(step_size=0.1),
+                Step8WorldModelConfig(step_size=0.1).to_dict(),
+            ),
+            id="step8",
+        ),
+        pytest.param(
+            lambda: (
+                Step9DreamingConfig(model_step_size=0.1),
+                Step9DreamingConfig(model_step_size=0.1).to_dict(),
+            ),
+            id="step9",
+        ),
+        pytest.param(
+            lambda: (
+                Step10STOMPConfig(base_step_size=0.1),
+                Step10STOMPConfig(base_step_size=0.1).to_config(),
+            ),
+            id="step10",
+        ),
+    ],
+)
+def test_builtin_float_serialization_value_is_preserved(
+    config_and_payload: Callable[[], tuple[object, dict[str, Any]]],
+) -> None:
+    _, payload = config_and_payload()
+
+    selected = next(value for value in payload.values() if value == 0.1)
+    assert selected == 0.1
+    json.dumps(payload, allow_nan=False)
+
+
+def test_signed_zero_survives_validation_and_serialization() -> None:
+    config = Step3HordeConfig(gammas=(-0.0,), lamdas=(0.0,))
+    payload = config.to_dict()
+
+    assert math.copysign(1.0, config.gammas[0]) == -1.0
+    assert math.copysign(1.0, cast(list[float], payload["gammas"])[0]) == -1.0


### PR DESCRIPTION
## Outcome

Closes #295.

The Step 3/4/5/7/8/9/10 facades now validate exact host-domain values and
their actual IEEE-754 binary32 sinks before construction. They use the shared
exact-ratio converter once, preserve valid built-in JSON float payloads, and
canonicalize non-built-in `Real` values to the value JAX executes.

The final repair also fails closed on:

- float subclasses whose comparison value, exact ratio, or advertised
  `__class__` disagree;
- half-open decays that are below 1 in the host domain but round to float32
  1.0;
- narrowed negative or above-one values hidden by custom host comparisons;
- Step 5 narrowed values outside their declared domains; and
- nonzero subnormal/underflowing Step 3/4 GVF probabilities that the core
  rejects.

## Failing-test-first and review evidence

The original boundary panel produced 15 failures and 17 passes before the
source repair. Independent adversarial review then reproduced the subclass,
half-open, dual-domain, Step 5, and facade-to-core GVF gaps before each was
patched.

Exact head `9c28a34a75ae8b92863aae26cc74a8a6ac8d396f` on main
`23088407926290ba3d974f7ac3edf6454e863754` passes:

- final union boundary panel: 52 passed;
- source-stable production/RNG/pipeline affected panel: 783 passed;
- repository Ruff: clean;
- strict mypy: 165 source files clean;
- `git diff --check`: clean; and
- independent adversarial review: no remaining definite blocker.

The earlier exact-head CI failure was the pre-existing
`birth_timestamp` wall-clock equality flake in
`test_prototype_dream_isolation.py`, not a changed Step path. This repaired
head has a fresh CI run and must not merge until that run is green.

This PR changes seven Step facade modules, one Step-internal validation helper,
and one test module. It consumes the merged shared `_float32.py`; no duplicate
converter or output artifact is added. None of these paths is registered by
the five frozen evidence claims, whose pre-existing invalid status is not
silenced or revalidated.

