### PR TITLE
fix(experiments): reject metric schema drift across seeds

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -158,6 +158,12 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
     seeds = [r.seed for r in results]
 
     # Get all metric keys from first result
+    if any(
+        not r.metrics_history
+        or any(set(metrics) != set(results[0].metrics_history[0]) for metrics in r.metrics_history)
+        for r in results
+    ):
+        raise ValueError("all runs must contain the same metric keys at every step")
     metric_keys = list(results[0].metrics_history[0].keys())
 
     # Build metric arrays: (n_seeds, n_steps)

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -269,6 +269,25 @@ def test_aggregate_metrics_rejects_nonfinite_samples() -> None:
         )
 
 
+def test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed() -> None:
+    """A metric appearing in only one seed must not be silently discarded."""
+    with pytest.raises(ValueError, match="same metric keys"):
+        aggregate_metrics(
+            [
+                _single_run(0, [1.0, 2.0]),
+                SingleRunResult(
+                    config_name="candidate",
+                    seed=1,
+                    metrics_history=[
+                        {"squared_error": 3.0, "accuracy": 0.4},
+                        {"squared_error": 4.0, "accuracy": 0.8},
+                    ],
+                    final_state=LinearLearner().init(2),
+                ),
+            ]
+        )
+
+
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:
     poisoned = _two_seed_trace()
     poisoned.metric_arrays["squared_error"][0, 1] = np.inf


### PR DESCRIPTION
Closes #308.

## What changed

`aggregate_metrics` derived its metric-key schema only from `results[0].metrics_history[0]`, then built `metric_arrays`/`summary` from that fixed key set. If a later seed (or a later step within any seed) emitted a metric-key set that differed from that first snapshot, the extra/missing metric was silently absent from the aggregate instead of raising — a multi-seed experiment report can quietly drop part of the recorded data with no error.

confirmed directly before touching the source:

```text
input seed-1 metric keys: ['accuracy', 'squared_error']
aggregated metric keys: ['squared_error']
accuracy silently lost: True
```

fix: before deriving the schema, `aggregate_metrics` now checks every run has a non-empty history and every step across every run shares the same metric-key set as the reference (first) step, raising `ValueError` on drift instead of silently truncating.

## Reachability

`run_multi_seed_experiment` calls `aggregate_metrics(group_results)` at `alberta_framework/utils/experiments.py:302` on every ordinary multi-seed run with real learner-produced metric dictionaries. Both `aggregate_metrics` and `run_multi_seed_experiment` are listed in `alberta_framework.utils.__all__` — confirmed directly in `alberta_framework/utils/__init__.py` — so this is reachable from a publicly-exported entry point (`alberta_framework.utils.aggregate_metrics`), not just an internal helper. Not currently re-exported from the package-root `alberta_framework/__init__.py`.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_experiments_validation.py -q -o addopts=""
19 passed in 1.44s

$ .venv/bin/ruff check alberta_framework/utils/experiments.py tests/test_experiments_validation.py
All checks passed!

$ .venv/bin/mypy
Success: no issues found in 164 source files
```

New test: `test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed`, matching the file's existing convention of building a second `SingleRunResult` with a diverging metrics-history schema and asserting `pytest.raises(ValueError, match=...)`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/utils/experiments.py`, kept the test), reran — failed with `Failed: DID NOT RAISE ValueError`. Restored the fix, 19/19 green again.

## Evidence

<!-- evidence-head -->
526c64c46213f1839ac95bd87e60489d57434c98

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_experiments_validation.py -q -o addopts="" -k test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed
FAILED tests/test_experiments_validation.py::test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed - Failed: DID NOT RAISE ValueError
1 failed, 18 deselected in 0.41s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_experiments_validation.py -q -o addopts=""
19 passed in 1.06s
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
from alberta_framework.utils.experiments import aggregate_metrics, SingleRunResult
from alberta_framework.core.learners import LinearLearner
seed0 = SingleRunResult(config_name='candidate', seed=0,
    metrics_history=[{'squared_error': 1.0}, {'squared_error': 2.0}],
    final_state=LinearLearner().init(2))
seed1 = SingleRunResult(config_name='candidate', seed=1,
    metrics_history=[{'squared_error': 3.0, 'accuracy': 0.4}, {'squared_error': 4.0, 'accuracy': 0.8}],
    final_state=LinearLearner().init(2))
try:
    result = aggregate_metrics([seed0, seed1])
    print('aggregated metric keys:', list(result.metric_arrays.keys()))
except ValueError as e:
    print('rejected ->', e)
"
rejected -> all runs must contain the same metric keys at every step
```
independently reran the focused suite, ruff, and mypy myself; independently confirmed the `alberta_framework.utils.__all__` export and the real call site at `experiments.py:302` before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently reproduced the schema-drift rejection while confirming ordinary matching-schema data still aggregates, verified the export chain directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported

