### PR TITLE
fix(ci): bind prereg amendment and JAX config

### DIFF
--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -21,6 +21,7 @@ DRIVER_PATH: Final = ".github/scripts/ipmnist_prereg.py"
 AUTHORIZED_LOGIN: Final = "lalalune"
 AUTHORIZED_USER_ID: Final = 18_633_264
 AUTHORIZED_ASSOCIATION: Final = "MEMBER"
+RUNNER_IDENTITY: Final = "github-hosted-macos-14-arm64-apple-m1"
 EXPECTED_CONFIG: Final = {
     "n_tasks": 60,
     "task_length": 5000,
@@ -33,6 +34,16 @@ EXPECTED_POLICY: Final = {
     "evidence_class": "development_screening_diagnostic",
     "development_only": True,
     "scientific_promotion_allowed": False,
+}
+EXPECTED_JAX_CONFIG: Final = {
+    "jax_enable_x64": False,
+    "jax_default_matmul_precision": None,
+    "jax_disable_jit": False,
+    "jax_numpy_dtype_promotion": "standard",
+    "jax_numpy_rank_promotion": "allow",
+    "jax_random_seed_offset": 0,
+    "jax_threefry_partitionable": True,
+    "jax_default_prng_impl": "threefry2x32",
 }
 
 
@@ -79,7 +90,7 @@ def _lower_hex(value: str, length: int, *, name: str) -> str:
     return value
 
 
-def authorization_line(
+def _launch_binding(
     protocol: Protocol,
     *,
     source: str,
@@ -98,14 +109,61 @@ def authorization_line(
         raise ValueError("ref_name must be a non-empty tag name without whitespace")
     seeds = ",".join(str(seed) for seed in protocol.seeds)
     return (
-        f"ASI_PREREG_LAUNCH_V1 issue={protocol.issue} protocol={protocol.key} "
+        f"issue={protocol.issue} protocol={protocol.key} "
         f"source={source} tree={tree} uv_lock_sha256={uv_lock_sha256} "
         f"workflow_blob_sha1={workflow_blob_sha1} driver_blob_sha1={driver_blob_sha1} "
-        f"ref={ref_name} runner=macos-14-arm64 seeds={seeds} "
-        "registration_amendment=source-and-runner-as-bound "
+        f"ref={ref_name} runner={RUNNER_IDENTITY} seeds={seeds} n={len(protocol.seeds)}"
+    )
+
+
+def authorization_line(
+    protocol: Protocol,
+    *,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
+    workflow_blob_sha1: str,
+    driver_blob_sha1: str,
+    ref_name: str,
+) -> str:
+    binding = _launch_binding(
+        protocol,
+        source=source,
+        tree=tree,
+        uv_lock_sha256=uv_lock_sha256,
+        workflow_blob_sha1=workflow_blob_sha1,
+        driver_blob_sha1=driver_blob_sha1,
+        ref_name=ref_name,
+    )
+    return (
+        f"ASI_PREREG_LAUNCH_V1 {binding} "
         "protocol_approval=approved seed_budget=approved "
         "compute=authorized-uncompensated"
     )
+
+
+def registration_amendment_line(
+    protocol: Protocol,
+    *,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
+    workflow_blob_sha1: str,
+    driver_blob_sha1: str,
+    ref_name: str,
+) -> str:
+    if protocol.key != "issue188":
+        raise ValueError("a separate registration amendment is required only for issue188")
+    binding = _launch_binding(
+        protocol,
+        source=source,
+        tree=tree,
+        uv_lock_sha256=uv_lock_sha256,
+        workflow_blob_sha1=workflow_blob_sha1,
+        driver_blob_sha1=driver_blob_sha1,
+        ref_name=ref_name,
+    )
+    return f"ASI_PREREG_AMENDMENT_V1 {binding} compute=uncompensated"
 
 
 def classify_outcome(
@@ -139,6 +197,35 @@ def _parse_utc(value: str) -> dt.datetime:
     if parsed.tzinfo is None or parsed.utcoffset() != dt.timedelta(0):
         raise RuntimeError("authorization timestamp must identify UTC")
     return parsed
+
+
+def _matching_owner_comments(
+    comments: list[Any], *, expected_body: str
+) -> list[dict[str, Any]]:
+    return [
+        cast(dict[str, Any], comment)
+        for comment in comments
+        if isinstance(comment, dict)
+        and comment.get("body") == expected_body
+        and isinstance(comment.get("user"), dict)
+        and comment["user"].get("login") == AUTHORIZED_LOGIN
+        and comment["user"].get("id") == AUTHORIZED_USER_ID
+        and comment.get("author_association") == AUTHORIZED_ASSOCIATION
+    ]
+
+
+def _unchanged_comment_timestamp(
+    comment: dict[str, Any], *, label: str
+) -> tuple[str, dt.datetime]:
+    created_at = comment.get("created_at")
+    updated_at = comment.get("updated_at")
+    if not isinstance(created_at, str) or not created_at:
+        raise RuntimeError(f"{label} timestamps are missing or invalid")
+    if not isinstance(updated_at, str) or not updated_at:
+        raise RuntimeError(f"{label} timestamps are missing or invalid")
+    if updated_at != created_at:
+        raise RuntimeError(f"{label} comment must be exact and never edited")
+    return created_at, _parse_utc(updated_at)
 
 
 def _github_json(path: str, *, token: str) -> Any:
@@ -250,6 +337,19 @@ def verify_launch_authorization(
         driver_blob_sha1=driver_blob_sha1,
         ref_name=ref_name,
     )
+    expected_amendment = (
+        registration_amendment_line(
+            protocol,
+            source=source,
+            tree=tree,
+            uv_lock_sha256=uv_lock_sha256,
+            workflow_blob_sha1=workflow_blob_sha1,
+            driver_blob_sha1=driver_blob_sha1,
+            ref_name=ref_name,
+        )
+        if protocol.key == "issue188"
+        else None
+    )
     if run_attempt != 1:
         raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
 
@@ -288,16 +388,7 @@ def verify_launch_authorization(
         )
 
     comments = _github_pages(f"/repos/{repository}/issues/{protocol.issue}/comments", token=token)
-    matches = [
-        cast(dict[str, Any], comment)
-        for comment in comments
-        if isinstance(comment, dict)
-        and comment.get("body") == expected_line
-        and isinstance(comment.get("user"), dict)
-        and comment["user"].get("login") == AUTHORIZED_LOGIN
-        and comment["user"].get("id") == AUTHORIZED_USER_ID
-        and comment.get("author_association") == AUTHORIZED_ASSOCIATION
-    ]
+    matches = _matching_owner_comments(comments, expected_body=expected_line)
     if len(matches) != 1:
         raise RuntimeError(
             "expected exactly one standalone project-owner authorization comment; "
@@ -305,20 +396,34 @@ def verify_launch_authorization(
         )
     comment = matches[0]
     run_created_at = current.get("created_at")
-    comment_created_at = comment.get("created_at")
-    comment_updated_at = comment.get("updated_at")
     if not isinstance(run_created_at, str) or not run_created_at:
         raise RuntimeError("authorization timestamps are missing or invalid")
-    if not isinstance(comment_created_at, str) or not comment_created_at:
-        raise RuntimeError("authorization timestamps are missing or invalid")
-    if not isinstance(comment_updated_at, str) or not comment_updated_at:
-        raise RuntimeError("authorization timestamps are missing or invalid")
-    if comment_updated_at != comment_created_at:
-        raise RuntimeError("authorization comment must be exact and never edited")
-    if _parse_utc(comment_updated_at) >= _parse_utc(run_created_at):
+    authorization_created_at, authorization_time = _unchanged_comment_timestamp(
+        comment, label="authorization"
+    )
+    if authorization_time >= _parse_utc(run_created_at):
         raise RuntimeError("project-owner authorization must be durable before workflow dispatch")
+    amendment: dict[str, Any] | None = None
+    amendment_created_at: str | None = None
+    if expected_amendment is not None:
+        amendment_matches = _matching_owner_comments(
+            comments, expected_body=expected_amendment
+        )
+        if len(amendment_matches) != 1:
+            raise RuntimeError(
+                "expected exactly one standalone issue188 registration amendment comment; "
+                f"found {len(amendment_matches)}"
+            )
+        amendment = amendment_matches[0]
+        amendment_created_at, amendment_time = _unchanged_comment_timestamp(
+            amendment, label="registration amendment"
+        )
+        if amendment_time >= authorization_time:
+            raise RuntimeError(
+                "issue188 registration amendment must be durable before final authorization"
+            )
     return {
-        "schema": "asi.ipmnist_prereg.launch_preflight.v1",
+        "schema": "asi.ipmnist_prereg.launch_preflight.v2",
         "protocol": asdict(protocol),
         "source": source,
         "tree": tree,
@@ -326,16 +431,30 @@ def verify_launch_authorization(
         "workflow_blob_sha1": workflow_blob_sha1,
         "driver_blob_sha1": driver_blob_sha1,
         "ref_name": ref_name,
-        "runner": "macos-14-arm64",
+        "runner": RUNNER_IDENTITY,
         "run_id": run_id,
         "run_attempt": run_attempt,
         "run_url": current.get("html_url"),
         "authorization_comment_id": comment.get("id"),
         "authorization_comment_url": comment.get("html_url"),
-        "authorization_created_at": comment.get("created_at"),
-        "authorization_updated_at": comment.get("updated_at"),
+        "authorization_created_at": authorization_created_at,
+        "authorization_updated_at": authorization_created_at,
         "authorization_line": expected_line,
         "authorization_sha256": hashlib.sha256(expected_line.encode()).hexdigest(),
+        "registration_amendment_comment_id": (
+            amendment.get("id") if amendment is not None else None
+        ),
+        "registration_amendment_comment_url": (
+            amendment.get("html_url") if amendment is not None else None
+        ),
+        "registration_amendment_created_at": amendment_created_at,
+        "registration_amendment_updated_at": amendment_created_at,
+        "registration_amendment_line": expected_amendment,
+        "registration_amendment_sha256": (
+            hashlib.sha256(expected_amendment.encode()).hexdigest()
+            if expected_amendment is not None
+            else None
+        ),
     }
 
 
@@ -438,6 +557,8 @@ def _validate_runtime(environment: dict[str, Any]) -> None:
     }
     if any(packages.get(name) != version for name, version in expected_packages.items()):
         raise ValueError(f"unexpected locked package receipt: {packages}")
+    if jax.get("config") != EXPECTED_JAX_CONFIG:
+        raise ValueError(f"unexpected JAX config receipt: {jax.get('config')}")
     devices = jax.get("devices")
     if jax.get("backend") != "cpu" or not isinstance(devices, list) or len(devices) != 1:
         raise ValueError(f"expected exactly one JAX CPU device, got {jax}")
@@ -472,12 +593,13 @@ def _validate_runner_receipt(
             "packages",
             "jax_backend",
             "jax_devices",
+            "jax_config",
         },
         context="runner receipt",
     )
     cpu_brand = payload["cpu_brand"]
     if (
-        payload["schema"] != "asi.ipmnist_prereg.runner.v1"
+        payload["schema"] != "asi.ipmnist_prereg.runner.v2"
         or payload["runner_label"] != "macos-14"
         or not isinstance(cpu_brand, str)
         or "Apple M1" not in cpu_brand
@@ -497,6 +619,10 @@ def _validate_runner_receipt(
     jax_binding = cast(dict[str, Any], environment["jax"])
     if payload["jax_devices"] != jax_binding["devices"]:
         raise ValueError("runner receipt JAX devices differ from shard provenance")
+    if payload["jax_config"] != EXPECTED_JAX_CONFIG:
+        raise ValueError("runner receipt JAX config differs from the frozen launch contract")
+    if payload["jax_config"] != jax_binding["config"]:
+        raise ValueError("runner receipt JAX config differs from shard provenance")
 
 
 def validate_result_bundle(

--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -18,6 +18,7 @@ from typing import Any, Final, cast
 
 WORKFLOW_PATH: Final = ".github/workflows/ipmnist-prereg.yml"
 DRIVER_PATH: Final = ".github/scripts/ipmnist_prereg.py"
+AUTHORIZED_REPOSITORY: Final = "elizaOS/asi"
 AUTHORIZED_LOGIN: Final = "lalalune"
 AUTHORIZED_USER_ID: Final = 18_633_264
 AUTHORIZED_ASSOCIATION: Final = "MEMBER"
@@ -34,6 +35,13 @@ EXPECTED_POLICY: Final = {
     "evidence_class": "development_screening_diagnostic",
     "development_only": True,
     "scientific_promotion_allowed": False,
+}
+EXPECTED_PACKAGES: Final = {
+    "chex": "0.1.92",
+    "jax": "0.11.0",
+    "jaxlib": "0.11.0",
+    "numpy": "2.5.1",
+    "scikit-learn": "1.9.0",
 }
 EXPECTED_JAX_CONFIG: Final = {
     "jax_enable_x64": False,
@@ -85,7 +93,9 @@ def protocol_for(key: str) -> Protocol:
 
 
 def _lower_hex(value: str, length: int, *, name: str) -> str:
-    if len(value) != length or any(char not in "0123456789abcdef" for char in value):
+    if not isinstance(value, str) or len(value) != length or any(
+        char not in "0123456789abcdef" for char in value
+    ):
         raise ValueError(f"{name} must be exactly {length} lowercase hexadecimal characters")
     return value
 
@@ -105,7 +115,9 @@ def _launch_binding(
     uv_lock_sha256 = _lower_hex(uv_lock_sha256, 64, name="uv_lock_sha256")
     workflow_blob_sha1 = _lower_hex(workflow_blob_sha1, 40, name="workflow_blob_sha1")
     driver_blob_sha1 = _lower_hex(driver_blob_sha1, 40, name="driver_blob_sha1")
-    if not ref_name or any(char.isspace() for char in ref_name):
+    if not isinstance(ref_name, str) or not ref_name or any(
+        char.isspace() for char in ref_name
+    ):
         raise ValueError("ref_name must be a non-empty tag name without whitespace")
     seeds = ",".join(str(seed) for seed in protocol.seeds)
     return (
@@ -209,6 +221,7 @@ def _matching_owner_comments(
         and comment.get("body") == expected_body
         and isinstance(comment.get("user"), dict)
         and comment["user"].get("login") == AUTHORIZED_LOGIN
+        and type(comment["user"].get("id")) is int
         and comment["user"].get("id") == AUTHORIZED_USER_ID
         and comment.get("author_association") == AUTHORIZED_ASSOCIATION
     ]
@@ -226,6 +239,19 @@ def _unchanged_comment_timestamp(
     if updated_at != created_at:
         raise RuntimeError(f"{label} comment must be exact and never edited")
     return created_at, _parse_utc(updated_at)
+
+
+def _canonical_comment_record(
+    comment: dict[str, Any], *, repository: str, issue: int, label: str
+) -> tuple[int, str]:
+    comment_id = comment.get("id")
+    if type(comment_id) is not int or comment_id <= 0:
+        raise RuntimeError(f"{label} comment ID must be a positive built-in integer")
+    expected_url = f"https://github.com/{repository}/issues/{issue}#issuecomment-{comment_id}"
+    comment_url = comment.get("html_url")
+    if comment_url != expected_url:
+        raise RuntimeError(f"{label} comment URL is not the canonical GitHub issue record")
+    return comment_id, expected_url
 
 
 def _github_json(path: str, *, token: str) -> Any:
@@ -327,6 +353,12 @@ def verify_launch_authorization(
     run_attempt: int,
     token: str,
 ) -> dict[str, Any]:
+    if repository != AUTHORIZED_REPOSITORY:
+        raise RuntimeError(f"repository must be exactly {AUTHORIZED_REPOSITORY}")
+    if type(run_id) is not int or run_id <= 0:
+        raise RuntimeError("run_id must be a positive built-in integer")
+    if type(run_attempt) is not int or run_attempt != 1:
+        raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
     protocol = protocol_for(protocol_key)
     expected_line = authorization_line(
         protocol,
@@ -350,12 +382,11 @@ def verify_launch_authorization(
         if protocol.key == "issue188"
         else None
     )
-    if run_attempt != 1:
-        raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
-
     current = _github_json(f"/repos/{repository}/actions/runs/{run_id}", token=token)
     if not isinstance(current, dict):
         raise RuntimeError("current workflow run metadata is unavailable")
+    if type(current.get("id")) is not int or type(current.get("run_attempt")) is not int:
+        raise RuntimeError("current workflow run ID and attempt must be built-in integers")
     expected_title = f"ipmnist-{protocol.key}-{source}"
     required_current = {
         "id": run_id,
@@ -372,6 +403,9 @@ def verify_launch_authorization(
     }
     if mismatched:
         raise RuntimeError(f"current workflow run binding mismatch: {mismatched}")
+    expected_run_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    if current.get("html_url") != expected_run_url:
+        raise RuntimeError("current workflow run URL is not the canonical GitHub Actions record")
 
     matching_runs = [
         run
@@ -380,7 +414,7 @@ def verify_launch_authorization(
         and run.get("head_sha") == source
         and run.get("display_title") == expected_title
     ]
-    matching_ids = sorted(int(run["id"]) for run in matching_runs)
+    matching_ids = sorted(run["id"] for run in matching_runs)
     if matching_ids != [run_id]:
         raise RuntimeError(
             "this protocol/source must have exactly one dispatch; "
@@ -395,6 +429,12 @@ def verify_launch_authorization(
             f"found {len(matches)}"
         )
     comment = matches[0]
+    authorization_comment_id, authorization_comment_url = _canonical_comment_record(
+        comment,
+        repository=repository,
+        issue=protocol.issue,
+        label="authorization",
+    )
     run_created_at = current.get("created_at")
     if not isinstance(run_created_at, str) or not run_created_at:
         raise RuntimeError("authorization timestamps are missing or invalid")
@@ -404,6 +444,8 @@ def verify_launch_authorization(
     if authorization_time >= _parse_utc(run_created_at):
         raise RuntimeError("project-owner authorization must be durable before workflow dispatch")
     amendment: dict[str, Any] | None = None
+    amendment_comment_id: int | None = None
+    amendment_comment_url: str | None = None
     amendment_created_at: str | None = None
     if expected_amendment is not None:
         amendment_matches = _matching_owner_comments(
@@ -415,6 +457,16 @@ def verify_launch_authorization(
                 f"found {len(amendment_matches)}"
             )
         amendment = amendment_matches[0]
+        amendment_comment_id, amendment_comment_url = _canonical_comment_record(
+            amendment,
+            repository=repository,
+            issue=protocol.issue,
+            label="registration amendment",
+        )
+        if amendment_comment_id == authorization_comment_id:
+            raise RuntimeError(
+                "issue188 registration amendment and final authorization must be distinct records"
+            )
         amendment_created_at, amendment_time = _unchanged_comment_timestamp(
             amendment, label="registration amendment"
         )
@@ -434,19 +486,15 @@ def verify_launch_authorization(
         "runner": RUNNER_IDENTITY,
         "run_id": run_id,
         "run_attempt": run_attempt,
-        "run_url": current.get("html_url"),
-        "authorization_comment_id": comment.get("id"),
-        "authorization_comment_url": comment.get("html_url"),
+        "run_url": expected_run_url,
+        "authorization_comment_id": authorization_comment_id,
+        "authorization_comment_url": authorization_comment_url,
         "authorization_created_at": authorization_created_at,
         "authorization_updated_at": authorization_created_at,
         "authorization_line": expected_line,
         "authorization_sha256": hashlib.sha256(expected_line.encode()).hexdigest(),
-        "registration_amendment_comment_id": (
-            amendment.get("id") if amendment is not None else None
-        ),
-        "registration_amendment_comment_url": (
-            amendment.get("html_url") if amendment is not None else None
-        ),
+        "registration_amendment_comment_id": amendment_comment_id,
+        "registration_amendment_comment_url": amendment_comment_url,
         "registration_amendment_created_at": amendment_created_at,
         "registration_amendment_updated_at": amendment_created_at,
         "registration_amendment_line": expected_amendment,
@@ -547,17 +595,17 @@ def _validate_runtime(environment: dict[str, Any]) -> None:
     process = cast(dict[str, Any], environment["process_environment"])
     if python != {"implementation": "CPython", "version": "3.12.12"}:
         raise ValueError(f"unexpected Python receipt: {python}")
-    if host.get("system") != "Darwin" or host.get("machine") != "arm64":
-        raise ValueError(f"runner must be Darwin arm64, got {host}")
-    expected_packages = {
-        "jax": "0.11.0",
-        "jaxlib": "0.11.0",
-        "numpy": "2.5.1",
-        "scikit-learn": "1.9.0",
-    }
-    if any(packages.get(name) != version for name, version in expected_packages.items()):
+    release = host.get("release")
+    if (
+        host.get("system") != "Darwin"
+        or host.get("machine") != "arm64"
+        or not isinstance(release, str)
+        or release.split(".", maxsplit=1)[0] != "23"
+    ):
+        raise ValueError(f"runner must be macOS 14 (Darwin 23) arm64, got {host}")
+    if packages != EXPECTED_PACKAGES:
         raise ValueError(f"unexpected locked package receipt: {packages}")
-    if jax.get("config") != EXPECTED_JAX_CONFIG:
+    if _canonical_json(jax.get("config")) != _canonical_json(EXPECTED_JAX_CONFIG):
         raise ValueError(f"unexpected JAX config receipt: {jax.get('config')}")
     devices = jax.get("devices")
     if jax.get("backend") != "cpu" or not isinstance(devices, list) or len(devices) != 1:
@@ -586,10 +634,16 @@ def _validate_runner_receipt(
         {
             "schema",
             "runner_label",
+            "runner_environment",
+            "runner_os",
+            "runner_arch",
             "cpu_brand",
             "platform",
+            "macos_version",
             "machine",
             "python",
+            "python_optimization_level",
+            "python_optimize_environment",
             "packages",
             "jax_backend",
             "jax_devices",
@@ -598,30 +652,45 @@ def _validate_runner_receipt(
         context="runner receipt",
     )
     cpu_brand = payload["cpu_brand"]
+    runner_platform = payload["platform"]
+    optimization_level = payload["python_optimization_level"]
+    if not isinstance(runner_platform, dict):
+        raise ValueError("runner platform receipt must be a structured object")
+    _require_exact_keys(
+        runner_platform,
+        {"system", "release", "machine"},
+        context="runner platform receipt",
+    )
     if (
         payload["schema"] != "asi.ipmnist_prereg.runner.v2"
         or payload["runner_label"] != "macos-14"
+        or payload["runner_environment"] != "github-hosted"
+        or payload["runner_os"] != "macOS"
+        or payload["runner_arch"] != "ARM64"
         or not isinstance(cpu_brand, str)
         or "Apple M1" not in cpu_brand
-        or not isinstance(payload["platform"], str)
-        or not payload["platform"]
+        or not isinstance(payload["macos_version"], str)
+        or not payload["macos_version"].startswith("14.")
         or payload["machine"] != "arm64"
         or payload["python"] != "3.12.12"
+        or type(optimization_level) is not int
+        or optimization_level != 0
+        or payload["python_optimize_environment"] != "0"
         or payload["jax_backend"] != "cpu"
     ):
         raise ValueError(f"unexpected macos-14 arm64 runner receipt: {payload}")
+    host_binding = cast(dict[str, Any], environment["platform"])
+    if _canonical_json(runner_platform) != _canonical_json(host_binding):
+        raise ValueError("runner platform receipt differs from shard provenance")
     packages = cast(dict[str, Any], environment["packages"])
-    expected_packages = {
-        name: packages[name] for name in ("jax", "jaxlib", "numpy", "scikit-learn")
-    }
-    if payload["packages"] != expected_packages:
+    if _canonical_json(payload["packages"]) != _canonical_json(packages):
         raise ValueError("runner receipt package versions differ from shard provenance")
     jax_binding = cast(dict[str, Any], environment["jax"])
-    if payload["jax_devices"] != jax_binding["devices"]:
+    if _canonical_json(payload["jax_devices"]) != _canonical_json(jax_binding["devices"]):
         raise ValueError("runner receipt JAX devices differ from shard provenance")
-    if payload["jax_config"] != EXPECTED_JAX_CONFIG:
+    if _canonical_json(payload["jax_config"]) != _canonical_json(EXPECTED_JAX_CONFIG):
         raise ValueError("runner receipt JAX config differs from the frozen launch contract")
-    if payload["jax_config"] != jax_binding["config"]:
+    if _canonical_json(payload["jax_config"]) != _canonical_json(jax_binding["config"]):
         raise ValueError("runner receipt JAX config differs from shard provenance")
 
 
@@ -641,12 +710,30 @@ def validate_result_bundle(
         merge_shards,
     )
 
+    if root.is_symlink():
+        raise ValueError("repository root must not be a symlink")
+    try:
+        root = root.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError("repository root is unavailable") from exc
+    if runner_receipt.is_symlink() or not runner_receipt.is_file():
+        raise ValueError("runner receipt must be one regular non-symlink file")
     protocol = protocol_for(protocol_key)
     source = _lower_hex(source, 40, name="source")
     tree = _lower_hex(tree, 40, name="tree")
     uv_lock_sha256 = _lower_hex(uv_lock_sha256, 64, name="uv_lock_sha256")
     namespace = root / "outputs" / "ipmnist_screening" / protocol.namespace
     shards_dir = namespace / "shards"
+    for label, directory in (
+        ("outputs root", root / "outputs"),
+        ("screening root", root / "outputs" / "ipmnist_screening"),
+        ("protocol namespace", namespace),
+        ("shards directory", shards_dir),
+    ):
+        if directory.is_symlink():
+            raise ValueError(f"{label} must not be a symlink")
+        if not directory.is_dir():
+            raise ValueError(f"{label} must be one existing directory")
     expected_pairs = {
         (arm, seed) for arm in (protocol.control, protocol.candidate) for seed in protocol.seeds
     }
@@ -658,6 +745,11 @@ def validate_result_bundle(
             f"missing={sorted(str(path) for path in expected_paths - observed_paths)}, "
             f"unexpected={sorted(str(path) for path in observed_paths - expected_paths)}"
         )
+    symlinked_shards = sorted(str(path) for path in expected_paths if path.is_symlink())
+    if symlinked_shards:
+        raise ValueError(f"shard inputs must not be symlinks: {symlinked_shards}")
+    if any(not path.is_file() for path in expected_paths):
+        raise ValueError("every shard input must be one regular file")
     sorted_paths = sorted(expected_paths)
     shards = [load_shard(path) for path in sorted_paths]
     for path, shard in zip(sorted_paths, shards, strict=True):
@@ -700,6 +792,8 @@ def validate_result_bundle(
     summary_path = namespace / (
         "summary.json" if protocol.key == "issue51" else "summary_resid_gate_ablation_r3.json"
     )
+    if summary_path.is_symlink() or not summary_path.is_file():
+        raise ValueError("summary must be one regular non-symlink file")
     summary, summary_raw = _strict_json_bytes(summary_path)
     expected_summary_keys = {
         "schema",
@@ -737,6 +831,12 @@ def validate_result_bundle(
         except (OSError, ValueError) as exc:
             raise ValueError("fresh strict-v2 merge input escaped the repository root") from exc
         expected_manifest.append(entry)
+    expected_manifest_paths = {
+        path.relative_to(root).as_posix() for path in expected_paths
+    }
+    observed_manifest_paths = {entry.get("path") for entry in expected_manifest}
+    if observed_manifest_paths != expected_manifest_paths:
+        raise ValueError("fresh strict-v2 manifest paths do not match the exact shard namespace")
     _validate_summary_reconstruction(
         summary=summary,
         recomputed=recomputed,
@@ -843,8 +943,8 @@ def _preflight_command(args: argparse.Namespace) -> int:
 def _validate_command(args: argparse.Namespace) -> int:
     payload = validate_result_bundle(
         protocol_key=args.protocol,
-        root=args.root.resolve(strict=True),
-        runner_receipt=args.runner_receipt.resolve(strict=True),
+        root=args.root,
+        runner_receipt=args.runner_receipt,
         source=args.source,
         tree=args.tree,
         uv_lock_sha256=args.uv_lock_sha256,

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -35,6 +35,7 @@ env:
   JAX_PLATFORMS: cpu
   OMP_NUM_THREADS: "1"
   PYTHONHASHSEED: "0"
+  PYTHONOPTIMIZE: "0"
   XLA_FLAGS: --xla_force_host_platform_device_count=1
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 
@@ -44,6 +45,17 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 360
     steps:
+      - name: Require the exact GitHub-hosted runner context
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_ENVIRONMENT" != "github-hosted" \
+             || "$RUNNER_OS" != "macOS" \
+             || "$RUNNER_ARCH" != "ARM64" ]]; then
+            echo "runner context is not GitHub-hosted macOS ARM64" >&2
+            exit 1
+          fi
+
       - name: Check out the exact launch object
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
@@ -113,6 +125,12 @@ jobs:
             *) echo "unsupported protocol" >&2; exit 1 ;;
           esac
           target="outputs/ipmnist_screening/$namespace"
+          for parent in outputs outputs/ipmnist_screening; do
+            if [[ -L "$parent" ]]; then
+              echo "output parent must not be a symlink: $parent" >&2
+              exit 1
+            fi
+          done
           if [[ -e "$target" || -L "$target" ]]; then
             echo "append-only namespace is already occupied: $target" >&2
             exit 1
@@ -127,12 +145,20 @@ jobs:
             echo "setup-uv did not install exact uv 0.9.24" >&2
             exit 1
           fi
+          if [[ "$PYTHONOPTIMIZE" != "0" ]]; then
+            echo "PYTHONOPTIMIZE must be exactly zero" >&2
+            exit 1
+          fi
           uv python install --managed-python 3.12.12
           python_path="$(uv python find --managed-python --no-project 3.12.12)"
           identity="$("$python_path" -c \
             'import platform; print(platform.python_implementation(), platform.python_version(), platform.machine())')"
           if [[ "$identity" != "CPython 3.12.12 arm64" ]]; then
             echo "uv-managed Python identity mismatch: $identity" >&2
+            exit 1
+          fi
+          if [[ "$("$python_path" -c 'import sys; print(sys.flags.optimize)')" != "0" ]]; then
+            echo "uv-managed Python unexpectedly enabled optimized mode" >&2
             exit 1
           fi
           echo "path=$python_path" >> "$GITHUB_OUTPUT"
@@ -182,13 +208,19 @@ jobs:
           uv run --no-sync python - "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
           import importlib.metadata
           import json
+          import os
           import platform
           import sys
           from pathlib import Path
 
           import jax
 
+          def require(condition, message):
+              if not condition:
+                  raise RuntimeError(message)
+
           expected = {
+              "chex": "0.1.92",
               "jax": "0.11.0",
               "jaxlib": "0.11.0",
               "numpy": "2.5.1",
@@ -204,15 +236,29 @@ jobs:
               "jax_threefry_partitionable": True,
               "jax_default_prng_impl": "threefry2x32",
           }
-          assert platform.python_implementation() == "CPython"
-          assert platform.python_version() == "3.12.12"
-          assert platform.system() == "Darwin"
-          assert platform.machine() == "arm64"
-          assert {name: importlib.metadata.version(name) for name in expected} == expected
+          runner_environment = os.environ.get("RUNNER_ENVIRONMENT")
+          runner_os = os.environ.get("RUNNER_OS")
+          runner_arch = os.environ.get("RUNNER_ARCH")
+          macos_version = platform.mac_ver()[0]
+          require(sys.flags.optimize == 0, "Python optimized mode is forbidden")
+          require(os.environ.get("PYTHONOPTIMIZE") == "0", "PYTHONOPTIMIZE must be zero")
+          require(runner_environment == "github-hosted", "runner must be GitHub-hosted")
+          require(runner_os == "macOS", "runner OS must be macOS")
+          require(runner_arch == "ARM64", "runner architecture must be ARM64")
+          require(platform.python_implementation() == "CPython", "CPython is required")
+          require(platform.python_version() == "3.12.12", "Python 3.12.12 is required")
+          require(platform.system() == "Darwin", "Darwin is required")
+          require(platform.machine() == "arm64", "arm64 is required")
+          require(platform.release().split(".", maxsplit=1)[0] == "23", "Darwin 23 is required")
+          require(macos_version.startswith("14."), "macOS 14 is required")
+          package_versions = {
+              name: importlib.metadata.version(name) for name in expected
+          }
+          require(package_versions == expected, "locked package versions differ")
           devices = jax.devices()
-          assert jax.default_backend() == "cpu"
-          assert len(devices) == 1
-          assert devices[0].platform == "cpu"
+          require(jax.default_backend() == "cpu", "JAX backend must be CPU")
+          require(len(devices) == 1, "exactly one JAX device is required")
+          require(devices[0].platform == "cpu", "JAX device must be CPU")
           jax_config = {
               "jax_enable_x64": bool(jax.config.jax_enable_x64),
               "jax_default_matmul_precision": (
@@ -229,7 +275,7 @@ jobs:
               ),
               "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
           }
-          assert jax_config == expected_jax_config
+          require(jax_config == expected_jax_config, "JAX semantic config differs")
           destination = Path(sys.argv[2])
           destination.parent.mkdir(parents=True, exist_ok=True)
           encoded = (
@@ -237,10 +283,20 @@ jobs:
                   {
                       "schema": "asi.ipmnist_prereg.runner.v2",
                       "runner_label": "macos-14",
+                      "runner_environment": runner_environment,
+                      "runner_os": runner_os,
+                      "runner_arch": runner_arch,
                       "cpu_brand": sys.argv[1],
-                      "platform": platform.platform(),
+                      "platform": {
+                          "system": platform.system(),
+                          "release": platform.release(),
+                          "machine": platform.machine(),
+                      },
+                      "macos_version": macos_version,
                       "machine": platform.machine(),
                       "python": platform.python_version(),
+                      "python_optimization_level": sys.flags.optimize,
+                      "python_optimize_environment": os.environ.get("PYTHONOPTIMIZE"),
                       "packages": expected,
                       "jax_backend": jax.default_backend(),
                       "jax_config": jax_config,
@@ -284,6 +340,7 @@ jobs:
           data_home="$RUNNER_TEMP/openml-cache"
           uv run --no-sync python - "$data_home" <<'PY'
           import hashlib
+          import os
           import sys
           from pathlib import Path
 
@@ -295,12 +352,16 @@ jobs:
 
           data_home = Path(sys.argv[1])
           x, y = load_mnist_train(data_home)
-          assert x.shape == (60_000, 784)
-          assert y.shape == (60_000,)
+          if sys.flags.optimize != 0 or os.environ.get("PYTHONOPTIMIZE") != "0":
+              raise RuntimeError("Python optimized mode is forbidden for dataset validation")
+          if x.shape != (60_000, 784) or y.shape != (60_000,):
+              raise RuntimeError(f"unexpected canonical MNIST shapes: {x.shape}, {y.shape}")
           cache = data_home / MNIST_CACHE_RELATIVE_PATH
           raw = cache.read_bytes()
-          assert len(raw) == 15_469_256
-          assert hashlib.sha256(raw).hexdigest() == MNIST_CACHE_SHA256
+          if len(raw) != 15_469_256:
+              raise RuntimeError(f"unexpected canonical MNIST cache size: {len(raw)}")
+          if hashlib.sha256(raw).hexdigest() != MNIST_CACHE_SHA256:
+              raise RuntimeError("canonical MNIST cache digest mismatch")
           PY
 
       - name: Run the frozen arms sequentially and merge once

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -113,7 +113,7 @@ jobs:
             *) echo "unsupported protocol" >&2; exit 1 ;;
           esac
           target="outputs/ipmnist_screening/$namespace"
-          if [[ -e "$target" ]]; then
+          if [[ -e "$target" || -L "$target" ]]; then
             echo "append-only namespace is already occupied: $target" >&2
             exit 1
           fi
@@ -194,6 +194,16 @@ jobs:
               "numpy": "2.5.1",
               "scikit-learn": "1.9.0",
           }
+          expected_jax_config = {
+              "jax_enable_x64": False,
+              "jax_default_matmul_precision": None,
+              "jax_disable_jit": False,
+              "jax_numpy_dtype_promotion": "standard",
+              "jax_numpy_rank_promotion": "allow",
+              "jax_random_seed_offset": 0,
+              "jax_threefry_partitionable": True,
+              "jax_default_prng_impl": "threefry2x32",
+          }
           assert platform.python_implementation() == "CPython"
           assert platform.python_version() == "3.12.12"
           assert platform.system() == "Darwin"
@@ -203,12 +213,29 @@ jobs:
           assert jax.default_backend() == "cpu"
           assert len(devices) == 1
           assert devices[0].platform == "cpu"
+          jax_config = {
+              "jax_enable_x64": bool(jax.config.jax_enable_x64),
+              "jax_default_matmul_precision": (
+                  None
+                  if jax.config.jax_default_matmul_precision is None
+                  else str(jax.config.jax_default_matmul_precision)
+              ),
+              "jax_disable_jit": bool(jax.config.jax_disable_jit),
+              "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion),
+              "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+              "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+              "jax_threefry_partitionable": bool(
+                  jax.config.jax_threefry_partitionable
+              ),
+              "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+          }
+          assert jax_config == expected_jax_config
           destination = Path(sys.argv[2])
           destination.parent.mkdir(parents=True, exist_ok=True)
           encoded = (
               json.dumps(
                   {
-                      "schema": "asi.ipmnist_prereg.runner.v1",
+                      "schema": "asi.ipmnist_prereg.runner.v2",
                       "runner_label": "macos-14",
                       "cpu_brand": sys.argv[1],
                       "platform": platform.platform(),
@@ -216,6 +243,7 @@ jobs:
                       "python": platform.python_version(),
                       "packages": expected,
                       "jax_backend": jax.default_backend(),
+                      "jax_config": jax_config,
                       "jax_devices": [
                           {
                               "id": int(device.id),

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -15,6 +15,7 @@ _authorization_line = cast(Any, _DRIVER["authorization_line"])
 _registration_amendment_line = cast(Any, _DRIVER["registration_amendment_line"])
 _classify_outcome = cast(Any, _DRIVER["classify_outcome"])
 _strict_json = cast(Any, _DRIVER["_strict_json"])
+_validate_runner_receipt = cast(Any, _DRIVER["_validate_runner_receipt"])
 _validate_runtime = cast(Any, _DRIVER["_validate_runtime"])
 _validate_summary_reconstruction = cast(Any, _DRIVER["_validate_summary_reconstruction"])
 _validate_result_bundle = cast(Any, _DRIVER["validate_result_bundle"])
@@ -59,6 +60,29 @@ def test_authorization_line_binds_every_launch_identity() -> None:
         "runner=github-hosted-macos-14-arm64-apple-m1 seeds=0,1,2 n=3 "
         "protocol_approval=approved seed_budget=approved compute=authorized-uncompensated"
     )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"source": cast(Any, 1)},
+        {"ref_name": cast(Any, 1)},
+    ],
+)
+def test_authorization_line_rejects_nonstring_source_or_ref(
+    overrides: dict[str, Any],
+) -> None:
+    arguments: dict[str, Any] = {
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "workflow_blob_sha1": "4" * 40,
+        "driver_blob_sha1": "5" * 40,
+        "ref_name": "ipmnist-prereg-example",
+    }
+    arguments.update(overrides)
+    with pytest.raises(ValueError):
+        _authorization_line(_PROTOCOLS["issue51"], **arguments)
 
 
 def test_issue188_amendment_line_binds_the_complete_registered_change() -> None:
@@ -139,33 +163,40 @@ def _launch_api_payloads(comment: dict[str, Any]) -> tuple[dict[str, Any], list[
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-16T10:00:00Z",
-        "html_url": "https://example.invalid/run/123",
+        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
     }
     return current, [comment]
 
 
 def _verify_with_comment(
-    monkeypatch: pytest.MonkeyPatch, comment: dict[str, Any]
+    monkeypatch: pytest.MonkeyPatch,
+    comment: dict[str, Any],
+    *,
+    current_overrides: dict[str, Any] | None = None,
+    invocation_overrides: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     current, comments = _launch_api_payloads(comment)
+    current.update(current_overrides or {})
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
     monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_pages", lambda *_args, **_kwargs: comments)
+    arguments: dict[str, Any] = {
+        "protocol_key": "issue51",
+        "repository": "elizaOS/asi",
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "workflow_blob_sha1": "4" * 40,
+        "driver_blob_sha1": "5" * 40,
+        "ref_name": "ipmnist-prereg-example",
+        "run_id": 123,
+        "run_attempt": 1,
+        "token": "token",
+    }
+    arguments.update(invocation_overrides or {})
     return cast(
         dict[str, Any],
-        _verify_launch_authorization(
-            protocol_key="issue51",
-            repository="elizaOS/asi",
-            source="1" * 40,
-            tree="2" * 40,
-            uv_lock_sha256="3" * 64,
-            workflow_blob_sha1="4" * 40,
-            driver_blob_sha1="5" * 40,
-            ref_name="ipmnist-prereg-example",
-            run_id=123,
-            run_attempt=1,
-            token="token",
-        ),
+        _verify_launch_authorization(**arguments),
     )
 
 
@@ -186,7 +217,7 @@ def _authorization_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:00:00Z",
         "updated_at": "2026-08-16T09:00:00Z",
-        "html_url": "https://example.invalid/comment/456",
+        "html_url": "https://github.com/elizaOS/asi/issues/51#issuecomment-456",
     }
     comment.update(overrides)
     return comment
@@ -206,6 +237,7 @@ def test_launch_authorization_accepts_exact_unedited_project_owner_comment(
     [
         {"author_association": "OWNER"},
         {"user": {"id": 1, "login": "lalalune"}},
+        {"user": {"id": 18_633_264.0, "login": "lalalune"}},
         {"updated_at": "2026-08-16T09:30:00Z"},
     ],
 )
@@ -226,6 +258,50 @@ def test_launch_authorization_requires_strictly_pre_dispatch_timestamp(
                 created_at="2026-08-16T10:00:00Z",
                 updated_at="2026-08-16T10:00:00Z",
             ),
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"id": None},
+        {"id": -1},
+        {"id": 456.0},
+        {"html_url": None},
+        {"html_url": "https://github.com/elizaOS/asi/issues/51#issuecomment-999"},
+        {"html_url": "https://attacker.invalid/issues/51#issuecomment-456"},
+    ],
+)
+def test_launch_authorization_rejects_noncanonical_comment_record(
+    monkeypatch: pytest.MonkeyPatch, overrides: dict[str, Any]
+) -> None:
+    with pytest.raises(RuntimeError, match="authorization comment"):
+        _verify_with_comment(monkeypatch, _authorization_comment(**overrides))
+
+
+@pytest.mark.parametrize(
+    ("current_overrides", "invocation_overrides"),
+    [
+        ({"id": 123.0}, {}),
+        ({"run_attempt": 1.0}, {}),
+        ({"html_url": None}, {}),
+        ({"html_url": "https://attacker.invalid/actions/runs/123"}, {}),
+        ({}, {"run_id": 123.0}),
+        ({}, {"run_attempt": True}),
+        ({}, {"repository": "attacker/asi"}),
+    ],
+)
+def test_launch_authorization_rejects_noncanonical_run_record_or_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+    current_overrides: dict[str, Any],
+    invocation_overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(RuntimeError, match="repository|run"):
+        _verify_with_comment(
+            monkeypatch,
+            _authorization_comment(),
+            current_overrides=current_overrides,
+            invocation_overrides=invocation_overrides,
         )
 
 
@@ -261,7 +337,7 @@ def _issue188_authorization_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:30:00Z",
         "updated_at": "2026-08-16T09:30:00Z",
-        "html_url": "https://example.invalid/comment/456",
+        "html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-456",
     }
     comment.update(overrides)
     return comment
@@ -284,7 +360,7 @@ def _issue188_amendment_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:00:00Z",
         "updated_at": "2026-08-16T09:00:00Z",
-        "html_url": "https://example.invalid/comment/455",
+        "html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-455",
     }
     comment.update(overrides)
     return comment
@@ -302,7 +378,7 @@ def _verify_issue188(
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-16T10:00:00Z",
-        "html_url": "https://example.invalid/run/123",
+        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
     }
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
     monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
@@ -336,6 +412,51 @@ def test_issue188_requires_one_exact_amendment_before_final_authorization(
 
     with pytest.raises(RuntimeError, match="amendment"):
         _verify_issue188(monkeypatch, [authorization])
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"id": None},
+        {"id": -1},
+        {"id": 455.0},
+        {"html_url": None},
+        {"html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-999"},
+        {"html_url": "https://attacker.invalid/issues/188#issuecomment-455"},
+    ],
+)
+def test_issue188_rejects_noncanonical_amendment_record(
+    monkeypatch: pytest.MonkeyPatch, overrides: dict[str, Any]
+) -> None:
+    with pytest.raises(RuntimeError, match="amendment comment"):
+        _verify_issue188(
+            monkeypatch,
+            [_issue188_amendment_comment(**overrides), _issue188_authorization_comment()],
+        )
+
+
+def test_issue188_requires_distinct_amendment_and_authorization_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorization = _issue188_authorization_comment()
+    amendment = _issue188_amendment_comment(
+        id=authorization["id"],
+        html_url=authorization["html_url"],
+    )
+    with pytest.raises(RuntimeError, match="distinct"):
+        _verify_issue188(monkeypatch, [amendment, authorization])
+
+
+@pytest.mark.parametrize("duplicate", ["amendment", "authorization"])
+def test_issue188_rejects_duplicate_exact_owner_records(
+    monkeypatch: pytest.MonkeyPatch, duplicate: str
+) -> None:
+    amendment = _issue188_amendment_comment()
+    authorization = _issue188_authorization_comment()
+    comments = [amendment, authorization]
+    comments.append(dict(amendment if duplicate == "amendment" else authorization))
+    with pytest.raises(RuntimeError, match="exactly one"):
+        _verify_issue188(monkeypatch, comments)
 
 
 @pytest.mark.parametrize(
@@ -502,6 +623,12 @@ def test_workflow_installs_exact_uv_managed_python() -> None:
     assert '"jax_disable_jit": False' in workflow
     assert '"jax_random_seed_offset": 0' in workflow
     assert '"jax_default_prng_impl": "threefry2x32"' in workflow
+    assert '"chex": "0.1.92"' in workflow
+    assert 'PYTHONOPTIMIZE: "0"' in workflow
+    assert 'RUNNER_ENVIRONMENT' in workflow
+    assert 'sys.flags.optimize == 0' in workflow
+    assert 'macos_version.startswith("14.")' in workflow
+    assert 'for parent in outputs outputs/ipmnist_screening' in workflow
     assert '[[ -e "$target" || -L "$target" ]]' in workflow
 
 
@@ -598,9 +725,9 @@ def _runtime_environment() -> dict[str, object]:
     return {
         "schema": "alberta.ipmnist_screening.runtime.v1",
         "python": {"implementation": "CPython", "version": "3.12.12"},
-        "platform": {"system": "Darwin", "release": "24.0", "machine": "arm64"},
+        "platform": {"system": "Darwin", "release": "23.6.0", "machine": "arm64"},
         "packages": {
-            "chex": "0.1.91",
+            "chex": "0.1.92",
             "jax": "0.11.0",
             "jaxlib": "0.11.0",
             "numpy": "2.5.1",
@@ -648,6 +775,43 @@ def _runtime_environment() -> dict[str, object]:
     ],
 )
 def test_runtime_rejects_any_jax_semantic_config_drift(field: str, value: object) -> None:
+    environment = _runtime_environment()
+    jax_binding = cast(dict[str, Any], environment["jax"])
+    config = cast(dict[str, Any], jax_binding["config"])
+    config[field] = value
+    with pytest.raises(ValueError, match="JAX config"):
+        _validate_runtime(environment)
+
+
+def test_runtime_rejects_chex_version_drift() -> None:
+    environment = _runtime_environment()
+    packages = cast(dict[str, Any], environment["packages"])
+    packages["chex"] = "9.9.9"
+    with pytest.raises(ValueError, match="locked package"):
+        _validate_runtime(environment)
+
+
+@pytest.mark.parametrize("release", ["24.0.0", "22.6.0", "not-a-release", None])
+def test_runtime_rejects_non_macos14_release(release: object) -> None:
+    environment = _runtime_environment()
+    platform_binding = cast(dict[str, Any], environment["platform"])
+    platform_binding["release"] = release
+    with pytest.raises(ValueError, match="macOS 14"):
+        _validate_runtime(environment)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("jax_enable_x64", 0),
+        ("jax_disable_jit", 0.0),
+        ("jax_random_seed_offset", False),
+        ("jax_threefry_partitionable", 1),
+    ],
+)
+def test_runtime_rejects_equal_but_wrong_type_jax_config(
+    field: str, value: object
+) -> None:
     environment = _runtime_environment()
     jax_binding = cast(dict[str, Any], environment["jax"])
     config = cast(dict[str, Any], jax_binding["config"])
@@ -725,13 +889,19 @@ def _write_runner_receipt(root: Path) -> Path:
     receipt = {
         "schema": "asi.ipmnist_prereg.runner.v2",
         "runner_label": "macos-14",
+        "runner_environment": "github-hosted",
+        "runner_os": "macOS",
+        "runner_arch": "ARM64",
         "cpu_brand": "Apple M1 (Virtual)",
-        "platform": "macOS-14-arm64",
+        "platform": environment["platform"],
+        "macos_version": "14.7.6",
         "machine": "arm64",
         "python": "3.12.12",
+        "python_optimization_level": 0,
+        "python_optimize_environment": "0",
         "packages": {
             name: cast(dict[str, Any], environment["packages"])[name]
-            for name in ("jax", "jaxlib", "numpy", "scikit-learn")
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
         },
         "jax_backend": "cpu",
         "jax_devices": jax_binding["devices"],
@@ -740,6 +910,45 @@ def _write_runner_receipt(root: Path) -> Path:
     path = root / "runner.json"
     path.write_text(json.dumps(receipt, allow_nan=False), encoding="utf-8")
     return path
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("runner_environment", "self-hosted"),
+        ("runner_os", "Linux"),
+        ("runner_arch", "X64"),
+        ("macos_version", "15.0"),
+        ("python_optimization_level", 1),
+        ("python_optimization_level", False),
+        ("python_optimize_environment", "1"),
+    ],
+)
+def test_runner_receipt_rejects_host_or_optimized_runtime_forgery(
+    field: str, value: object
+) -> None:
+    environment = _runtime_environment()
+    receipt_path_payload = {
+        "schema": "asi.ipmnist_prereg.runner.v2",
+        "runner_label": "macos-14",
+        "runner_environment": "github-hosted",
+        "runner_os": "macOS",
+        "runner_arch": "ARM64",
+        "cpu_brand": "Apple M1 (Virtual)",
+        "platform": environment["platform"],
+        "macos_version": "14.7.6",
+        "machine": "arm64",
+        "python": "3.12.12",
+        "python_optimization_level": 0,
+        "python_optimize_environment": "0",
+        "packages": environment["packages"],
+        "jax_backend": "cpu",
+        "jax_devices": cast(dict[str, Any], environment["jax"])["devices"],
+        "jax_config": cast(dict[str, Any], environment["jax"])["config"],
+    }
+    receipt_path_payload[field] = value
+    with pytest.raises(ValueError, match="runner receipt"):
+        _validate_runner_receipt(receipt_path_payload, environment=environment)
 
 
 def test_result_bundle_recomputes_summary_from_exact_shards(
@@ -801,6 +1010,78 @@ def test_result_bundle_rejects_runner_jax_config_drift(
     runner_receipt.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
 
     with pytest.raises(ValueError, match="JAX config"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("jax_enable_x64", 0),
+        ("jax_disable_jit", 0.0),
+        ("jax_random_seed_offset", False),
+        ("jax_threefry_partitionable", 1),
+    ],
+)
+def test_result_bundle_rejects_equal_but_wrong_type_runner_jax_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+) -> None:
+    _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    payload = json.loads(runner_receipt.read_text(encoding="utf-8"))
+    payload["jax_config"][field] = value
+    runner_receipt.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JAX config"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_equal_but_wrong_type_runner_device_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    payload = json.loads(runner_receipt.read_text(encoding="utf-8"))
+    payload["jax_devices"][0]["id"] = False
+    runner_receipt.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JAX devices"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_runner_platform_not_bound_to_shards(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    payload = json.loads(runner_receipt.read_text(encoding="utf-8"))
+    payload["platform"]["release"] = "forged"
+    runner_receipt.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="platform"):
         _validate_result_bundle(
             protocol_key="issue51",
             root=tmp_path,
@@ -890,6 +1171,59 @@ def test_result_bundle_rejects_shard_filename_payload_swap(
     )
 
     with pytest.raises(ValueError, match="filename/payload"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_symlinked_shard_even_if_summary_is_resigned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from alberta_framework.benchmarks.ipmnist_screening import merge_shards
+
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    shards_dir = summary_path.parent / "shards"
+    victim = shards_dir / "sigma0_shiftnorm_d099_seed0.json"
+    escaped = tmp_path / "escaped-but-inside-root.json"
+    escaped.write_bytes(victim.read_bytes())
+    victim.unlink()
+    victim.symlink_to(escaped)
+
+    paths = sorted(path.relative_to(tmp_path) for path in shards_dir.glob("*.json"))
+    summary = merge_shards(paths, control_name="sigma0_shiftnorm_d099", slope_window=15)
+    for entry in summary["shard_manifest"]:
+        raw_path = Path(entry["path"])
+        entry["path"] = raw_path.resolve(strict=True).relative_to(tmp_path).as_posix()
+    summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="symlink"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_symlinked_protocol_namespace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    namespace = summary_path.parent
+    moved = tmp_path / "moved-namespace"
+    namespace.rename(moved)
+    namespace.symlink_to(moved, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="namespace.*symlink"):
         _validate_result_bundle(
             protocol_key="issue51",
             root=tmp_path,

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -12,8 +12,10 @@ _ROOT = Path(__file__).resolve().parents[1]
 _DRIVER = runpy.run_path(_ROOT / ".github" / "scripts" / "ipmnist_prereg.py")
 _PROTOCOLS = cast(dict[str, Any], _DRIVER["PROTOCOLS"])
 _authorization_line = cast(Any, _DRIVER["authorization_line"])
+_registration_amendment_line = cast(Any, _DRIVER["registration_amendment_line"])
 _classify_outcome = cast(Any, _DRIVER["classify_outcome"])
 _strict_json = cast(Any, _DRIVER["_strict_json"])
+_validate_runtime = cast(Any, _DRIVER["_validate_runtime"])
 _validate_summary_reconstruction = cast(Any, _DRIVER["_validate_summary_reconstruction"])
 _validate_result_bundle = cast(Any, _DRIVER["validate_result_bundle"])
 _verify_launch_authorization = cast(Any, _DRIVER["verify_launch_authorization"])
@@ -53,9 +55,29 @@ def test_authorization_line_binds_every_launch_identity() -> None:
         "ASI_PREREG_LAUNCH_V1 issue=51 protocol=issue51 "
         f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
         f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
-        "ref=ipmnist-prereg-example runner=macos-14-arm64 seeds=0,1,2 "
-        "registration_amendment=source-and-runner-as-bound "
+        "ref=ipmnist-prereg-example "
+        "runner=github-hosted-macos-14-arm64-apple-m1 seeds=0,1,2 n=3 "
         "protocol_approval=approved seed_budget=approved compute=authorized-uncompensated"
+    )
+
+
+def test_issue188_amendment_line_binds_the_complete_registered_change() -> None:
+    line = _registration_amendment_line(
+        _PROTOCOLS["issue188"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    assert line == (
+        "ASI_PREREG_AMENDMENT_V1 issue=188 protocol=issue188 "
+        f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
+        f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
+        "ref=ipmnist-prereg-example "
+        "runner=github-hosted-macos-14-arm64-apple-m1 seeds=3,4,5,6,7,8,9,10,11,12 "
+        "n=10 compute=uncompensated"
     )
 
 
@@ -222,6 +244,144 @@ def test_launch_authorization_requires_valid_utc_timestamps(
         )
 
 
+def _issue188_authorization_comment(**overrides: Any) -> dict[str, Any]:
+    body = _authorization_line(
+        _PROTOCOLS["issue188"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    comment: dict[str, Any] = {
+        "id": 456,
+        "body": body,
+        "user": {"id": 18_633_264, "login": "lalalune"},
+        "author_association": "MEMBER",
+        "created_at": "2026-08-16T09:30:00Z",
+        "updated_at": "2026-08-16T09:30:00Z",
+        "html_url": "https://example.invalid/comment/456",
+    }
+    comment.update(overrides)
+    return comment
+
+
+def _issue188_amendment_comment(**overrides: Any) -> dict[str, Any]:
+    body = _registration_amendment_line(
+        _PROTOCOLS["issue188"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    comment: dict[str, Any] = {
+        "id": 455,
+        "body": body,
+        "user": {"id": 18_633_264, "login": "lalalune"},
+        "author_association": "MEMBER",
+        "created_at": "2026-08-16T09:00:00Z",
+        "updated_at": "2026-08-16T09:00:00Z",
+        "html_url": "https://example.invalid/comment/455",
+    }
+    comment.update(overrides)
+    return comment
+
+
+def _verify_issue188(
+    monkeypatch: pytest.MonkeyPatch,
+    comments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    current = {
+        "id": 123,
+        "event": "workflow_dispatch",
+        "head_sha": "1" * 40,
+        "display_title": f"ipmnist-issue188-{'1' * 40}",
+        "run_attempt": 1,
+        "path": ".github/workflows/ipmnist-prereg.yml",
+        "created_at": "2026-08-16T10:00:00Z",
+        "html_url": "https://example.invalid/run/123",
+    }
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_pages", lambda *_args, **_kwargs: comments)
+    return cast(
+        dict[str, Any],
+        _verify_launch_authorization(
+            protocol_key="issue188",
+            repository="elizaOS/asi",
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="3" * 64,
+            workflow_blob_sha1="4" * 40,
+            driver_blob_sha1="5" * 40,
+            ref_name="ipmnist-prereg-example",
+            run_id=123,
+            run_attempt=1,
+            token="token",
+        ),
+    )
+
+
+def test_issue188_requires_one_exact_amendment_before_final_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    amendment = _issue188_amendment_comment()
+    authorization = _issue188_authorization_comment()
+    payload = _verify_issue188(monkeypatch, [amendment, authorization])
+    assert payload["registration_amendment_comment_id"] == 455
+    assert payload["registration_amendment_created_at"] == "2026-08-16T09:00:00Z"
+
+    with pytest.raises(RuntimeError, match="amendment"):
+        _verify_issue188(monkeypatch, [authorization])
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"body": "ASI_PREREG_AMENDMENT_V1 source=wrong"},
+        {"author_association": "OWNER"},
+        {"user": {"id": 1, "login": "lalalune"}},
+        {"updated_at": "2026-08-16T09:15:00Z"},
+    ],
+)
+def test_issue188_rejects_inexact_edited_or_wrong_author_amendment(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(RuntimeError, match="amendment"):
+        _verify_issue188(
+            monkeypatch,
+            [_issue188_amendment_comment(**overrides), _issue188_authorization_comment()],
+        )
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-timestamp",
+        "2026-08-16T09:00:00",
+        "2026-08-16T10:00:00+01:00",
+        "2026-08-16T09:30:00Z",
+        "2026-08-16T09:45:00Z",
+    ],
+)
+def test_issue188_amendment_must_be_valid_utc_and_precede_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+    timestamp: str,
+) -> None:
+    with pytest.raises(RuntimeError, match="amendment|timestamp"):
+        _verify_issue188(
+            monkeypatch,
+            [
+                _issue188_amendment_comment(created_at=timestamp, updated_at=timestamp),
+                _issue188_authorization_comment(),
+            ],
+        )
+
+
 def _searched_workflow_run(run_id: int) -> dict[str, Any]:
     return {
         "id": run_id,
@@ -339,6 +499,10 @@ def test_workflow_installs_exact_uv_managed_python() -> None:
     assert 'uv python find --managed-python --no-project 3.12.12' in workflow
     assert "CPython 3.12.12 arm64" in workflow
     assert '--python "$PYTHON_PATH"' in workflow
+    assert '"jax_disable_jit": False' in workflow
+    assert '"jax_random_seed_offset": 0' in workflow
+    assert '"jax_default_prng_impl": "threefry2x32"' in workflow
+    assert '[[ -e "$target" || -L "$target" ]]' in workflow
 
 
 def test_summary_reconstruction_rejects_resigned_derived_metrics_and_manifest() -> None:
@@ -470,6 +634,28 @@ def _runtime_environment() -> dict[str, object]:
     }
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("jax_enable_x64", True),
+        ("jax_default_matmul_precision", "highest"),
+        ("jax_disable_jit", True),
+        ("jax_numpy_dtype_promotion", "strict"),
+        ("jax_numpy_rank_promotion", "raise"),
+        ("jax_random_seed_offset", 1),
+        ("jax_threefry_partitionable", False),
+        ("jax_default_prng_impl", "rbg"),
+    ],
+)
+def test_runtime_rejects_any_jax_semantic_config_drift(field: str, value: object) -> None:
+    environment = _runtime_environment()
+    jax_binding = cast(dict[str, Any], environment["jax"])
+    config = cast(dict[str, Any], jax_binding["config"])
+    config[field] = value
+    with pytest.raises(ValueError, match="JAX config"):
+        _validate_runtime(environment)
+
+
 def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from alberta_framework.benchmarks.ipmnist_screening import (
         ScreeningRunResult,
@@ -537,7 +723,7 @@ def _write_runner_receipt(root: Path) -> Path:
     environment = _runtime_environment()
     jax_binding = cast(dict[str, Any], environment["jax"])
     receipt = {
-        "schema": "asi.ipmnist_prereg.runner.v1",
+        "schema": "asi.ipmnist_prereg.runner.v2",
         "runner_label": "macos-14",
         "cpu_brand": "Apple M1 (Virtual)",
         "platform": "macOS-14-arm64",
@@ -549,6 +735,7 @@ def _write_runner_receipt(root: Path) -> Path:
         },
         "jax_backend": "cpu",
         "jax_devices": jax_binding["devices"],
+        "jax_config": jax_binding["config"],
     }
     path = root / "runner.json"
     path.write_text(json.dumps(receipt, allow_nan=False), encoding="utf-8")
@@ -570,6 +757,58 @@ def test_result_bundle_recomputes_summary_from_exact_shards(
     )
     assert result["outcome"] == "replicated"
     assert result["mean_diff"] == pytest.approx(0.005)
+
+
+def test_result_bundle_rejects_consistently_resigned_jax_config_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from alberta_framework.benchmarks.ipmnist_screening import merge_shards
+
+    summary_path = _write_issue51_bundle(tmp_path, monkeypatch)
+    shards_dir = summary_path.parent / "shards"
+    for path in shards_dir.glob("*.json"):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["environment"]["jax"]["config"]["jax_disable_jit"] = True
+        path.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
+    paths = sorted(path.relative_to(tmp_path) for path in shards_dir.glob("*.json"))
+    summary_path.write_text(
+        json.dumps(
+            merge_shards(paths, control_name="sigma0_shiftnorm_d099", slope_window=15),
+            allow_nan=False,
+        ),
+        encoding="utf-8",
+    )
+    runner_receipt = _write_runner_receipt(tmp_path)
+
+    with pytest.raises(ValueError, match="JAX config"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
+
+
+def test_result_bundle_rejects_runner_jax_config_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_issue51_bundle(tmp_path, monkeypatch)
+    runner_receipt = _write_runner_receipt(tmp_path)
+    payload = json.loads(runner_receipt.read_text(encoding="utf-8"))
+    payload["jax_config"]["jax_random_seed_offset"] = 1
+    runner_receipt.write_text(json.dumps(payload, allow_nan=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JAX config"):
+        _validate_result_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            runner_receipt=runner_receipt,
+            source="1" * 40,
+            tree="2" * 40,
+            uv_lock_sha256="4" * 64,
+        )
 
 
 def test_result_bundle_rejects_resigned_summary_metric(


### PR DESCRIPTION
## Outcome

Closes #307.

This code-only follow-up makes the IPMNIST launch path fail closed before data:

- freezes, explicitly checks, records, and independently validates eight intended JAX 0.11 semantic config values;
- requires one exact standalone unedited owner `ASI_PREREG_AMENDMENT_V1` record for #188, binding source/tree/lock/workflow+driver blobs/immutable ref/GitHub-hosted macOS-14 arm64 M1/seeds/n/compute mode;
- enforces strict valid-UTC amendment < launch authorization < dispatch ordering;
- requires positive immutable issue-comment IDs and their exact GitHub `html_url` identities for both amendment and authorization receipts;
- rejects self-hosted, wrong-OS/architecture, non-macOS-14, non-M1, and optimized-Python runner receipts;
- checks GitHub's non-overridable `RUNNER_ENVIRONMENT`, `RUNNER_OS`, and `RUNNER_ARCH` values before checkout, then records and revalidates them;
- replaces every workflow runtime/dataset `assert` with explicit fail-closed exceptions, pins `PYTHONOPTIMIZE=0`, and checks `sys.flags.optimize == 0` before data;
- rejects dangling-symlink output namespaces and retains the preregistered `macos-14` runner label.

The first review reproduced three fail-open classes: consistently re-signed JAX drift, #188 launch authorization without a prior durable amendment, and runner/comment receipts that claimed identities they did not validate. It also found that Python optimized mode could erase the pre-data `assert` gates. The repaired head has adversarial coverage for all four classes.

## Exact-head validation

Rebased base: `e222be985be0205ca10c841b2b65dcae0e74d2c5`

Head: `aa23f0787a39cd9f5ca3ac8d4ea292a6382e72a2`

- workflow-driver suite: **74 passed**
- exact workflow/screening selection: **188 passed, 192 deselected**
- repository Ruff: clean
- default mypy: **164 source files**, clean
- direct strict mypy for `.github/scripts/ipmnist_prereg.py`: clean
- actionlint 1.7.10: clean
- every workflow Bash `run` block parses with `bash -n`
- `git diff --check`: clean

At the guarded push there were zero workflow-dispatch runs and zero exact `ASI_PREREG_LAUNCH_V1` / `ASI_PREREG_AMENDMENT_V1` comments on #51 and #188. No authorization, dataset, seed, output namespace, or preregistration artifact was consumed. Only the workflow driver, workflow, and unit tests change; no registered evidence source or artifact is modified.

## Scientific boundary

Both protocols remain `development_screening_diagnostic`, explicitly development-only, and permanently nonpromoting. The workflow produces only a 90-day result/recovery bundle; it does not populate `reference-dev`, authenticate execution, or create scientific evidence. A launch remains blocked until this PR merges and the applicable exact amendment/authorization records are durably posted in the required order.
