### PR TITLE
fix(statistics): require one common final window across compared methods

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -28,6 +28,7 @@ from alberta_framework.core.learners import (
 )
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
+from alberta_framework.utils.statistics import common_final_window
 
 
 class ExperimentConfig(NamedTuple):
@@ -354,14 +355,16 @@ def get_final_performance(
 
         Raises:
         ValueError: If ``window`` is not positive, a metric array has no
-            time steps, or any metric sample is non-finite. ``window=0`` is
-            not "the last step": ``arr[:, -0:]`` is the full trace, so the
-            helper refuses rather than silently reporting a full-horizon mean.
+            time steps, any metric sample is non-finite, or ``window`` exceeds
+            the shortest trace while trace lengths differ between methods.
+            ``window=0`` is not "the last step": ``arr[:, -0:]`` is the full
+            trace, so the helper refuses rather than silently reporting a
+            full-horizon mean.
     """
     if window <= 0:
         raise ValueError(f"window must be positive (got {window})")
 
-    performance: dict[str, tuple[float, float]] = {}
+    metric_arrays: dict[str, NDArray[np.float64]] = {}
     for name, agg in results.items():
         arr = agg.metric_arrays[metric]
         if arr.shape[1] == 0:
@@ -370,7 +373,15 @@ def get_final_performance(
                 f"for {metric!r}"
             )
         _require_finite_metric_array(arr, metric)
-        final_window = min(window, arr.shape[1])
+        metric_arrays[name] = arr
+    if not metric_arrays:
+        return {}
+    final_window = common_final_window(
+        {name: arr.shape[1] for name, arr in metric_arrays.items()}, window, metric
+    )
+
+    performance: dict[str, tuple[float, float]] = {}
+    for name, arr in metric_arrays.items():
         final_means = np.mean(arr[:, -final_window:], axis=1)
         std = float(np.std(final_means, ddof=1)) if len(final_means) > 1 else 0.0
         performance[name] = (float(np.mean(final_means)), std)

--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -4,6 +4,7 @@ Provides functions for computing confidence intervals, significance tests,
 effect sizes, and multiple comparison corrections.
 """
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
@@ -516,6 +517,33 @@ def holm_correction(
     return significant
 
 
+def common_final_window(step_counts: Mapping[str, int], window: int, metric: str) -> int:
+    """Return the number of final steps every method averages, or fail closed.
+
+    The documented ``min(window, n_steps)`` convention only holds when it
+    yields the same window for every method. When ``window`` exceeds the
+    shortest trace and the traces differ in length, a per-method minimum
+    would silently compare methods over different horizons.
+
+    Raises:
+        ValueError: If ``step_counts`` is empty or the per-method
+            ``min(window, n_steps)`` values disagree.
+    """
+    if not step_counts:
+        raise ValueError("at least one method is required to derive a final window")
+    final_windows = {min(window, n_steps) for n_steps in step_counts.values()}
+    if len(final_windows) != 1:
+        described = ", ".join(
+            f"{name}: {n_steps} steps" for name, n_steps in sorted(step_counts.items())
+        )
+        raise ValueError(
+            f"window={window} exceeds the shortest {metric!r} trace and the traces differ "
+            f"in length ({described}); every method must average the same number of "
+            "final steps"
+        )
+    return final_windows.pop()
+
+
 def pairwise_comparisons(
     results: "dict[str, AggregatedResults]",  # noqa: F821
     metric: str = "squared_error",
@@ -539,9 +567,10 @@ def pairwise_comparisons(
 
     Raises:
         ValueError: If ``window`` is not positive, a metric has no steps, seed identities are
-            duplicated, seeds do not match metric rows, or seeds differ between methods used
-            by a paired test. Paired rows are aligned by seed identity; Mann-Whitney samples
-            remain unpaired.
+            duplicated, seeds do not match metric rows, seeds differ between methods used
+            by a paired test, or ``window`` exceeds the shortest trace while trace lengths
+            differ between methods. Paired rows are aligned by seed identity; Mann-Whitney
+            samples remain unpaired.
     """
     from alberta_framework.utils.experiments import AggregatedResults
 
@@ -552,7 +581,7 @@ def pairwise_comparisons(
     n = len(names)
 
     # Extract final values for each method
-    final_values: dict[str, NDArray[np.float64]] = {}
+    metric_arrays: dict[str, NDArray[np.float64]] = {}
     seeds_by_name: dict[str, list[int]] = {}
     for name, agg in results.items():
         if not isinstance(agg, AggregatedResults):
@@ -570,12 +599,18 @@ def pairwise_comparisons(
                 f"AggregatedResults {name!r} must contain at least one metric step "
                 f"for {metric!r}"
             )
-        final_window = min(window, arr.shape[1])
-        final_values[name] = np.mean(arr[:, -final_window:], axis=1)
+        metric_arrays[name] = arr
         seeds_by_name[name] = agg.seeds
 
     if n < 2:
         return {}
+
+    final_window = common_final_window(
+        {name: arr.shape[1] for name, arr in metric_arrays.items()}, window, metric
+    )
+    final_values: dict[str, NDArray[np.float64]] = {
+        name: np.mean(arr[:, -final_window:], axis=1) for name, arr in metric_arrays.items()
+    }
 
     if test not in ("ttest", "mann_whitney", "wilcoxon"):
         raise ValueError(f"Unknown test: {test}")

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -233,6 +233,48 @@ def test_get_final_performance_rejects_empty_time_axis() -> None:
         get_final_performance({"empty": empty}, window=1)
 
 
+def test_get_final_performance_rejects_unequal_final_windows() -> None:
+    """Two methods must not be averaged over different numbers of final steps."""
+    short = AggregatedResults(
+        config_name="short",
+        seeds=[0, 1],
+        metric_arrays={"squared_error": np.full((2, 3), 2.0, dtype=np.float64)},
+        summary={},
+    )
+    long = AggregatedResults(
+        config_name="long",
+        seeds=[0, 1],
+        metric_arrays={"squared_error": np.full((2, 8), 2.0, dtype=np.float64)},
+        summary={},
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"^window=5 exceeds the shortest 'squared_error' trace and the traces differ "
+        r"in length \(long: 8 steps, short: 3 steps\); every method must average the same "
+        r"number of final steps$",
+    ):
+        get_final_performance({"short": short, "long": long}, window=5)
+
+
+def test_get_final_performance_accepts_unequal_trace_lengths_when_window_fits() -> None:
+    short = AggregatedResults(
+        config_name="short",
+        seeds=[0, 1],
+        metric_arrays={"squared_error": np.asarray([[9.0, 1.0, 1.0], [9.0, 3.0, 3.0]])},
+        summary={},
+    )
+    long = AggregatedResults(
+        config_name="long",
+        seeds=[0, 1],
+        metric_arrays={
+            "squared_error": np.asarray([[9.0] * 6 + [1.0, 1.0], [9.0] * 6 + [3.0, 3.0]])
+        },
+        summary={},
+    )
+    performance = get_final_performance({"short": short, "long": long}, window=2)
+    assert performance["short"] == performance["long"] == (2.0, pytest.approx(np.sqrt(2.0)))
+
+
 def test_get_final_performance_window_longer_than_trace_uses_full_trace() -> None:
     """The documented min(window, n_steps) convention is unchanged for window > 0."""
     result = get_final_performance({"candidate": _two_seed_trace()}, window=100)

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -852,3 +852,40 @@ class TestPairwiseComparisons:
         result = pairwise_comparisons({"a": a, "b": b}, test="mann_whitney", window=1)
 
         assert result[("a", "b")].statistic == pytest.approx(0.0)
+
+    @staticmethod
+    def _settled_trace(name: str, n_steps: int, transient: float) -> AggregatedResults:
+        """Three seeds that start at ``transient`` and settle at exactly 1.0 after step 9."""
+        arr = np.ones((3, n_steps), dtype=np.float64)
+        arr[:, : min(10, n_steps)] = transient
+        return AggregatedResults(
+            config_name=name,
+            seeds=[0, 1, 2],
+            metric_arrays={"squared_error": arr},
+            summary={},
+        )
+
+    @pytest.mark.parametrize("test", ["ttest", "wilcoxon", "mann_whitney"])
+    def test_unequal_final_windows_rejected(self, test: str) -> None:
+        """A window longer than the shortest trace must not silently shrink per method."""
+        short = self._settled_trace("short", n_steps=20, transient=5.0)
+        long = self._settled_trace("long", n_steps=400, transient=5.0)
+
+        with pytest.raises(
+            ValueError,
+            match=r"^window=100 exceeds the shortest 'squared_error' trace and the traces "
+            r"differ in length \(long: 400 steps, short: 20 steps\); every method must "
+            r"average the same number of final steps$",
+        ):
+            pairwise_comparisons({"short": short, "long": long}, test=test, window=100)
+
+    def test_unequal_trace_lengths_accepted_when_window_fits_every_trace(self) -> None:
+        short = self._settled_trace("short", n_steps=20, transient=5.0)
+        long = self._settled_trace("long", n_steps=400, transient=7.0)
+
+        result = pairwise_comparisons(
+            {"short": short, "long": long}, test="mann_whitney", window=10
+        )
+
+        assert result[("short", "long")].effect_size == pytest.approx(0.0)
+        assert not result[("short", "long")].significant


### PR DESCRIPTION
Closes #311.

## Issue

`pairwise_comparisons` and `get_final_performance` recomputed `final_window = min(window, n_steps)` per method, so methods with different trace lengths were averaged over different horizons whenever `window` exceeded the shortest trace. Two methods with identical settled loss (`1.0`) but different budgets (20 vs 400 steps) came back as `{'short': 3.0, 'long': 1.0}` and a paired t-test with `p=0.0, significant=True`.

## New state

`common_final_window` (statistics.py) derives the one window every method averages and raises when the per-method `min(window, n_steps)` values disagree; both public helpers use it. Equal-length traces keep the documented convention (`test_get_final_performance_window_longer_than_trace_uses_full_trace` unchanged); unequal-length traces with `window` ≤ every trace still average exactly `window` steps each (pinned by two new acceptance tests).

Failing-test-first: `test_unequal_final_windows_rejected[ttest|wilcoxon|mann_whitney]` and `test_get_final_performance_rejects_unequal_final_windows` fail on `main` (`DID NOT RAISE ValueError`) and pass here.

## Evidence

Falsifier from #311 at this head:

```text
ValueError: window=100 exceeds the shortest 'squared_error' trace and the traces differ in length (long: 400 steps, short: 20 steps); every method must average the same number of final steps
window=10 -> {'short': (1.0, 0.0), 'long': (1.0, 0.0)}
```

Verification at `a60da5b6ebc219771a2e40ea970f6c13017538c6`:

```text
.venv/bin/python -m pytest tests/test_statistics_validation.py tests/test_experiments_validation.py tests/test_utils_smoke.py -q -o addopts=""
149 passed
.venv/bin/python -m ruff check .      -> All checks passed!
.venv/bin/python -m mypy              -> Success: no issues found in 164 source files
```

Composes cleanly with open #309 (`git merge-tree` clean; different function in `experiments.py`). No benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:a60da5b6ebc219771a2e40ea970f6c13017538c6 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
