### PR TITLE
fix(dual-replay): keep calibrated priorities inside the documented unit range

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -38,6 +38,7 @@ import json
 import math
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from numbers import Real
 from typing import Any, Literal, cast
 
 import chex
@@ -47,6 +48,8 @@ import jax.random as jr
 import numpy as np
 import numpy.typing as npt
 from jax import Array
+
+from alberta_framework._float32 import round_real_to_float32
 
 DUAL_REPLAY_CONFIG_SCHEMA = "alberta.dual-replay.config.v1"
 DUAL_REPLAY_CHECKPOINT_SCHEMA = "alberta.dual-replay.checkpoint.v1"
@@ -103,6 +106,31 @@ class DualReplayConfig:
     max_aleatoric_uncertainty: float = 1.0
     aleatoric_downweight_scale: float = 1.0
     max_persistent_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate float32-consumed scalars in their sink domain and canonicalize them."""
+        for name in _POSITIVE_FLOAT32_FIELDS:
+            object.__setattr__(
+                self,
+                name,
+                _require_float32_real(name, getattr(self, name), strictly_positive=True),
+            )
+        object.__setattr__(
+            self,
+            "calibrated_priority_threshold",
+            _require_float32_real(
+                "calibrated_priority_threshold",
+                self.calibrated_priority_threshold,
+                strictly_positive=False,
+                maximum=1,
+            ),
+        )
+        for name in ("calibrated_replacement_margin", "max_aleatoric_uncertainty"):
+            object.__setattr__(
+                self,
+                name,
+                _require_float32_real(name, getattr(self, name), strictly_positive=False),
+            )
 
     @property
     def long_term_capacity(self) -> int:
@@ -385,13 +413,59 @@ class DualReplayResourceAccounting:
     samples: Array
 
 
-def _validate_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise ValueError(f"{name} must be a real number")
-    result = float(value)
-    if not math.isfinite(result):
-        raise ValueError(f"{name} must be finite")
-    return result
+_POSITIVE_FLOAT32_FIELDS = (
+    "surprise_scale",
+    "coverage_scale",
+    "progress_scale",
+    "surprise_weight",
+    "coverage_weight",
+    "progress_weight",
+    "aleatoric_downweight_scale",
+)
+
+
+def _require_float32_real(
+    name: str,
+    value: object,
+    *,
+    strictly_positive: bool,
+    maximum: int | None = None,
+) -> float:
+    """Validate one host scalar in its exact domain and its float32 sink.
+
+    Zero is only admitted where the exact domain allows it; a nonzero value
+    that narrows to zero, or a finite value that narrows to infinity, is
+    rejected because the compiled sink would silently run a different rule.
+    Built-in payloads that already narrow exactly are preserved for
+    serialization; other reals are canonicalized to the exact sink value.
+    """
+    domain = "positive" if strictly_positive else "non-negative"
+    if maximum is not None:
+        domain = f"{domain} and at most {maximum}"
+    preserve_builtin_payload = type(value) is int or type(value) is float
+    if isinstance(value, bool | np.bool_) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be finite and {domain}")
+    try:
+        if strictly_positive:
+            if value <= 0:
+                raise ValueError
+        elif value < 0:
+            raise ValueError
+        if maximum is not None and value > cast(Real, maximum):
+            raise ValueError
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite and {domain}") from error
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32")
+    if value != 0 and narrowed == 0.0:
+        raise ValueError(f"{name} must not underflow to zero in float32")
+    if not preserve_builtin_payload:
+        return narrowed
+    number = float(value)
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = float(np.float32(number))
+    return number if narrowed == renarrowed else narrowed
 
 
 def _validate_positive_int(name: str, value: object) -> int:
@@ -431,47 +505,17 @@ def _validate_config(config: DualReplayConfig) -> None:
     if config.max_representation_lag < 0:
         raise ValueError("max_representation_lag must be non-negative")
 
-    positive = (
-        "surprise_scale",
-        "coverage_scale",
-        "progress_scale",
-        "surprise_weight",
-        "coverage_weight",
-        "progress_weight",
-        "aleatoric_downweight_scale",
-    )
-    narrowed: dict[str, float] = {}
-    for name in positive:
-        if _validate_real(name, getattr(config, name)) <= 0.0:
-            raise ValueError(f"{name} must be positive")
-        narrowed[name] = float(np.float32(getattr(config, name)))
-        if not math.isfinite(narrowed[name]) or narrowed[name] <= 0.0:
-            raise ValueError(f"{name} must remain positive and finite in float32 arithmetic")
-    weight_sum = float(
-        np.float32(narrowed["surprise_weight"])
-        + np.float32(narrowed["coverage_weight"])
-        + np.float32(narrowed["progress_weight"])
-    )
+    with np.errstate(over="ignore"):
+        weight_sum = float(
+            np.float32(config.surprise_weight)
+            + np.float32(config.coverage_weight)
+            + np.float32(config.progress_weight)
+        )
     if not math.isfinite(weight_sum):
         raise ValueError(
             "surprise_weight, coverage_weight, and progress_weight must have a "
             "finite float32 sum"
         )
-    threshold = _validate_real(
-        "calibrated_priority_threshold", config.calibrated_priority_threshold
-    )
-    if not 0.0 <= threshold <= 1.0:
-        raise ValueError("calibrated_priority_threshold must be in [0, 1]")
-    margin = _validate_real(
-        "calibrated_replacement_margin", config.calibrated_replacement_margin
-    )
-    if margin < 0.0:
-        raise ValueError("calibrated_replacement_margin must be non-negative")
-    maximum = _validate_real(
-        "max_aleatoric_uncertainty", config.max_aleatoric_uncertainty
-    )
-    if maximum < 0.0:
-        raise ValueError("max_aleatoric_uncertainty must be non-negative")
     if config.max_persistent_bytes is not None:
         _validate_positive_int("max_persistent_bytes", config.max_persistent_bytes)
         if config.max_persistent_bytes > _UINT32_MAX:

--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -440,9 +440,23 @@ def _validate_config(config: DualReplayConfig) -> None:
         "progress_weight",
         "aleatoric_downweight_scale",
     )
+    narrowed: dict[str, float] = {}
     for name in positive:
         if _validate_real(name, getattr(config, name)) <= 0.0:
             raise ValueError(f"{name} must be positive")
+        narrowed[name] = float(np.float32(getattr(config, name)))
+        if not math.isfinite(narrowed[name]) or narrowed[name] <= 0.0:
+            raise ValueError(f"{name} must remain positive and finite in float32 arithmetic")
+    weight_sum = float(
+        np.float32(narrowed["surprise_weight"])
+        + np.float32(narrowed["coverage_weight"])
+        + np.float32(narrowed["progress_weight"])
+    )
+    if not math.isfinite(weight_sum):
+        raise ValueError(
+            "surprise_weight, coverage_weight, and progress_weight must have a "
+            "finite float32 sum"
+        )
     threshold = _validate_real(
         "calibrated_priority_threshold", config.calibrated_priority_threshold
     )
@@ -1354,15 +1368,16 @@ class DualReplayMemory:
             jnp.clip(nearest / jnp.asarray(cfg.coverage_scale, dtype=jnp.float32), 0.0, 1.0),
             jnp.asarray(1.0, dtype=jnp.float32),
         )
-        weight_sum = jnp.asarray(
-            cfg.surprise_weight + cfg.coverage_weight + cfg.progress_weight,
-            dtype=jnp.float32,
+        surprise_weight = jnp.asarray(cfg.surprise_weight, dtype=jnp.float32)
+        coverage_weight = jnp.asarray(cfg.coverage_weight, dtype=jnp.float32)
+        progress_weight = jnp.asarray(cfg.progress_weight, dtype=jnp.float32)
+        weight_sum = surprise_weight + coverage_weight + progress_weight
+        raw_priority = jnp.clip(
+            (surprise_weight * surprise + coverage_weight * coverage + progress_weight * progress)
+            / weight_sum,
+            0.0,
+            1.0,
         )
-        raw_priority = (
-            jnp.asarray(cfg.surprise_weight, dtype=jnp.float32) * surprise
-            + jnp.asarray(cfg.coverage_weight, dtype=jnp.float32) * coverage
-            + jnp.asarray(cfg.progress_weight, dtype=jnp.float32) * progress
-        ) / weight_sum
         components_available = (
             transition.epistemic_surprise_available
             & transition.learning_progress_available

--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -465,7 +465,7 @@ def _require_float32_real(
     number = float(value)
     with np.errstate(invalid="ignore", over="ignore", under="ignore"):
         renarrowed = float(np.float32(number))
-    return number if narrowed == renarrowed else narrowed
+    return cast(float, value) if narrowed == renarrowed else narrowed
 
 
 def _validate_positive_int(name: str, value: object) -> int:

--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -443,26 +443,34 @@ def _require_float32_real(
     if maximum is not None:
         domain = f"{domain} and at most {maximum}"
     preserve_builtin_payload = type(value) is int or type(value) is float
-    if isinstance(value, bool | np.bool_) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be finite and {domain}")
-    try:
+    real_value = cast(Any, value)
+
+    def in_domain(candidate: Any) -> bool:
         if strictly_positive:
-            if value <= 0:
-                raise ValueError
-        elif value < 0:
+            if not candidate > 0:
+                return False
+        elif not candidate >= 0:
+            return False
+        return maximum is None or bool(candidate <= maximum)
+
+    try:
+        if not in_domain(real_value):
             raise ValueError
-        if maximum is not None and value > cast(Real, maximum):
-            raise ValueError
-        narrowed = round_real_to_float32(value)
+        narrowed = round_real_to_float32(real_value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(f"{name} must be finite and {domain}") from error
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must narrow to a finite float32")
-    if value != 0 and narrowed == 0.0:
+    if real_value != 0 and narrowed == 0.0:
         raise ValueError(f"{name} must not underflow to zero in float32")
+    if not in_domain(narrowed):
+        raise ValueError(f"{name} must remain {domain} once narrowed to float32")
     if not preserve_builtin_payload:
         return narrowed
-    number = float(value)
+    number = float(real_value)
     with np.errstate(invalid="ignore", over="ignore", under="ignore"):
         renarrowed = float(np.float32(number))
     return cast(float, value) if narrowed == renarrowed else narrowed

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -597,6 +597,16 @@ def test_config_canonicalizes_real_scalars_and_preserves_builtin_payload() -> No
     assert builtin.config.surprise_weight == 0.1
     assert builtin.config.coverage_weight == 0.2
     assert builtin.config.progress_weight == 0.4
+    integer = _strict_memory(
+        surprise_weight=2**54 + 1,
+        calibrated_priority_threshold=0,
+    )
+    assert type(integer.config.surprise_weight) is int
+    assert integer.config.surprise_weight == 2**54 + 1
+    assert type(integer.config.calibrated_priority_threshold) is int
+    assert integer.config.calibrated_priority_threshold == 0
+    assert integer.to_config()["config"]["surprise_weight"] == 2**54 + 1
+    assert integer.to_config()["config"]["calibrated_priority_threshold"] == 0
     canonical = _strict_memory(
         surprise_weight=np.float64(0.25),
         coverage_weight=np.int64(1),

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -623,6 +623,87 @@ def test_config_canonicalizes_real_scalars_and_preserves_builtin_payload() -> No
     assert DualReplayMemory.from_config(payload).config == canonical.config
 
 
+class _LyingFloat(float):
+    """A real float subclass whose exact ratio disagrees with its host value."""
+
+    def __new__(cls, value: float, ratio: tuple[int, int]) -> _LyingFloat:
+        instance = super().__new__(cls, value)
+        instance._ratio = ratio  # type: ignore[attr-defined]
+        return instance
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return self._ratio  # type: ignore[attr-defined,no-any-return]
+
+
+class _FloatSpoof:
+    """Not a Real at all, but reports ``float`` through ``__class__``."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (1, 2)
+
+    def __float__(self) -> float:
+        return 0.5
+
+    def __le__(self, other: Any) -> bool:
+        return bool(0.5 <= other)
+
+    def __lt__(self, other: Any) -> bool:
+        return bool(0.5 < other)
+
+    def __gt__(self, other: Any) -> bool:
+        return bool(0.5 > other)
+
+    def __ge__(self, other: Any) -> bool:
+        return bool(0.5 >= other)
+
+    def __ne__(self, other: object) -> bool:
+        return other != 0.5
+
+    def __eq__(self, other: object) -> bool:
+        return other == 0.5
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@pytest.mark.parametrize(
+    ("field", "ratio"),
+    [
+        ("surprise_scale", (-1, 1)),
+        ("surprise_weight", (-1, 1)),
+        ("aleatoric_downweight_scale", (0, 1)),
+        ("calibrated_priority_threshold", (-1, 1)),
+        ("calibrated_priority_threshold", (2, 1)),
+        ("calibrated_replacement_margin", (-1, 1)),
+        ("max_aleatoric_uncertainty", (-1, 1)),
+    ],
+)
+def test_config_rejects_reals_whose_exact_ratio_leaves_the_domain(
+    field: str, ratio: tuple[int, int]
+) -> None:
+    """Host value 0.5 is in every domain; the narrowed sink value must be too."""
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: _LyingFloat(0.5, ratio)})
+
+
+@pytest.mark.parametrize("field", _FLOAT32_SCALARS)
+def test_config_rejects_objects_that_only_spoof_float_through_class(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: _FloatSpoof()})
+
+
+def test_config_accepts_honest_float_subclasses_as_canonical_floats() -> None:
+    memory = _strict_memory(surprise_weight=_LyingFloat(0.5, (1, 2)))
+    assert type(memory.config.surprise_weight) is float
+    assert memory.config.surprise_weight == 0.5
+    payload = memory.to_config()
+    json.dumps(payload, allow_nan=False)
+    assert DualReplayMemory.from_config(payload).config == memory.config
+
+
 def test_config_rejects_calibration_weights_whose_float32_sum_overflows_without_warnings() -> None:
     with pytest.raises(ValueError, match="finite float32 sum"):
         _strict_memory(surprise_weight=2e38, coverage_weight=2e38, progress_weight=2e38)

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -461,6 +461,72 @@ def test_calibrated_priority_uses_surprise_coverage_and_progress_exactly() -> No
     assert bool(result.wrote_long_term)
 
 
+def test_calibrated_priority_stays_within_unit_range_for_unequal_weights() -> None:
+    memory = DualReplayMemory(
+        _config(
+            long_term_policy="calibrated",
+            surprise_scale=1.0,
+            coverage_scale=1.0,
+            progress_scale=1.0,
+            surprise_weight=0.1,
+            coverage_weight=0.2,
+            progress_weight=0.4,
+        )
+    )
+    first = memory.record(
+        memory.init(jr.key(3)),
+        _prediction(1, epistemic=1.0, aleatoric=0.1),
+        _outcome(1, progress=1.0),
+    )
+
+    assert float(first.surprise_component) == 1.0
+    assert float(first.coverage_component) == 1.0
+    assert float(first.progress_component) == 1.0
+    assert bool(first.wrote_long_term)
+    assert float(first.long_term_priority) == 1.0
+    assert bool(memory.state_valid(first.state))
+    memory.validate_state(first.state)
+
+    second = memory.record(
+        first.state,
+        _prediction(2, epistemic=0.1, aleatoric=0.1),
+        _outcome(2, progress=0.1),
+    )
+    assert bool(second.state_valid)
+    assert bool(second.wrote_short_term)
+    assert int(second.state.accepted_transition_count) == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("surprise_scale", 1e-46),
+        ("coverage_scale", 1e-46),
+        ("progress_scale", 1e-46),
+        ("aleatoric_downweight_scale", 1e-46),
+        ("surprise_weight", 1e-46),
+        ("coverage_weight", 6e38),
+    ],
+)
+def test_config_rejects_calibration_scalars_that_degenerate_in_float32(
+    field: str, value: float
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        DualReplayMemory(replace(_config(long_term_policy="calibrated"), **{field: value}))
+
+
+def test_config_rejects_calibration_weights_whose_float32_sum_overflows() -> None:
+    with pytest.raises(ValueError, match="finite float32 sum"):
+        DualReplayMemory(
+            _config(
+                long_term_policy="calibrated",
+                surprise_weight=2e38,
+                coverage_weight=2e38,
+                progress_weight=2e38,
+            )
+        )
+
+
 def test_calibrated_coverage_and_long_term_eviction_provenance_are_explicit() -> None:
     memory = DualReplayMemory(
         _config(

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import warnings
 from dataclasses import fields, replace
+from fractions import Fraction
 from typing import Any
 
 import jax
@@ -497,34 +499,123 @@ def test_calibrated_priority_stays_within_unit_range_for_unequal_weights() -> No
     assert int(second.state.accepted_transition_count) == 2
 
 
+_FLOAT32_SCALARS = (
+    "surprise_scale",
+    "coverage_scale",
+    "progress_scale",
+    "surprise_weight",
+    "coverage_weight",
+    "progress_weight",
+    "aleatoric_downweight_scale",
+    "calibrated_priority_threshold",
+    "calibrated_replacement_margin",
+    "max_aleatoric_uncertainty",
+)
+_ZERO_ALLOWED = (
+    "calibrated_priority_threshold",
+    "calibrated_replacement_margin",
+    "max_aleatoric_uncertainty",
+)
+
+
+def _strict_memory(**overrides: Any) -> DualReplayMemory:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        return DualReplayMemory(_config(long_term_policy="calibrated", **overrides))
+
+
+@pytest.mark.parametrize("field", _FLOAT32_SCALARS)
 @pytest.mark.parametrize(
-    ("field", "value"),
+    "value",
     [
-        ("surprise_scale", 1e-46),
-        ("coverage_scale", 1e-46),
-        ("progress_scale", 1e-46),
-        ("aleatoric_downweight_scale", 1e-46),
-        ("surprise_weight", 1e-46),
-        ("coverage_weight", 6e38),
+        1e-46,
+        6e38,
+        Fraction(1, 10**400),
+        Fraction(1, 2**150),
+        2**128,
+        float("inf"),
+        np.float64("nan"),
     ],
 )
-def test_config_rejects_calibration_scalars_that_degenerate_in_float32(
-    field: str, value: float
+def test_config_rejects_scalars_that_underflow_or_overflow_float32_without_warnings(
+    field: str, value: object
 ) -> None:
     with pytest.raises(ValueError, match=field):
-        DualReplayMemory(replace(_config(long_term_policy="calibrated"), **{field: value}))
+        _strict_memory(**{field: value})
 
 
-def test_config_rejects_calibration_weights_whose_float32_sum_overflows() -> None:
+@pytest.mark.parametrize("field", _FLOAT32_SCALARS)
+def test_config_enforces_exact_float32_underflow_and_overflow_midpoints(field: str) -> None:
+    minimum_subnormal = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+    underflow_midpoint = Fraction(1, 2**150)
+    overflow_midpoint = Fraction(((2**24 - 1) * 2**104) + 2**103)
+    upper_bounded = field == "calibrated_priority_threshold"
+
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: underflow_midpoint})
+    above = _strict_memory(**{field: underflow_midpoint + Fraction(1, 2**200)})
+    assert getattr(above.config, field) == minimum_subnormal
+    if upper_bounded:
+        with pytest.raises(ValueError, match=field):
+            _strict_memory(**{field: Fraction(1, 1) + Fraction(1, 2**60)})
+        return
+    below_overflow = _strict_memory(**{field: overflow_midpoint - 1})
+    assert getattr(below_overflow.config, field) == float(np.finfo(np.float32).max)
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: overflow_midpoint})
+
+
+@pytest.mark.parametrize("field", _ZERO_ALLOWED)
+def test_config_keeps_explicit_zero_where_the_domain_allows_it(field: str) -> None:
+    memory = _strict_memory(**{field: 0.0})
+    assert getattr(memory.config, field) == 0.0
+    memory = _strict_memory(**{field: 0})
+    assert getattr(memory.config, field) == 0
+
+
+@pytest.mark.parametrize("field", _FLOAT32_SCALARS)
+def test_config_rounds_exact_rationals_and_large_integers_directly_to_float32(
+    field: str,
+) -> None:
+    upper_bounded = field == "calibrated_priority_threshold"
+    scale = Fraction(1, 2**4) if upper_bounded else Fraction(1, 1)
+    midpoint = (Fraction(1, 1) + Fraction(1, 2**24)) * scale
+    offset = Fraction(1, 2**60) * scale
+    next_float32 = float(np.nextafter(np.float32(scale), np.float32(2.0 * float(scale))))
+    assert getattr(_strict_memory(**{field: midpoint - offset}).config, field) == float(scale)
+    assert getattr(_strict_memory(**{field: midpoint}).config, field) == float(scale)
+    assert getattr(_strict_memory(**{field: midpoint + offset}).config, field) == next_float32
+    if not upper_bounded:
+        # Above the float32 tie at 2**54 + 2**30, but float64 first rounds it onto the tie
+        # and ties-to-even would then land on 2**54: the exact ratio must round up.
+        big = 2**54 + 2**30 + 1
+        assert getattr(_strict_memory(**{field: big}).config, field) == float(2**54 + 2**31)
+
+
+def test_config_canonicalizes_real_scalars_and_preserves_builtin_payload() -> None:
+    builtin = _strict_memory(surprise_weight=0.1, coverage_weight=0.2, progress_weight=0.4)
+    assert builtin.config.surprise_weight == 0.1
+    assert builtin.config.coverage_weight == 0.2
+    assert builtin.config.progress_weight == 0.4
+    canonical = _strict_memory(
+        surprise_weight=np.float64(0.25),
+        coverage_weight=np.int64(1),
+        progress_weight=Fraction(1, 4),
+    )
+    for value in (
+        canonical.config.surprise_weight,
+        canonical.config.coverage_weight,
+        canonical.config.progress_weight,
+    ):
+        assert type(value) is float
+    payload = canonical.to_config()
+    json.dumps(payload, allow_nan=False)
+    assert DualReplayMemory.from_config(payload).config == canonical.config
+
+
+def test_config_rejects_calibration_weights_whose_float32_sum_overflows_without_warnings() -> None:
     with pytest.raises(ValueError, match="finite float32 sum"):
-        DualReplayMemory(
-            _config(
-                long_term_policy="calibrated",
-                surprise_weight=2e38,
-                coverage_weight=2e38,
-                progress_weight=2e38,
-            )
-        )
+        _strict_memory(surprise_weight=2e38, coverage_weight=2e38, progress_weight=2e38)
 
 
 def test_calibrated_coverage_and_long_term_eviction_provenance_are_explicit() -> None:


### PR DESCRIPTION
Closes #313.

## Issue

`_calibrated_priority` divided a float32-accumulated numerator by a weight sum rounded once from float64. With weights such as `(0.1, 0.2, 0.4)` and saturated components the priority came out `1.0000001192092896`; it was stored as an insertion priority, `DualReplayState` failed its own `<= 1.0` invariant, and every later `record`/`sample` silently returned `state_valid=False` while `checkpoint_payload` raised. Calibration scalars were validated in float64 but consumed after a float32 cast, so `float32(1e-46) == 0.0` produced `0/0 = NaN` priorities and three `2e38` weights an `inf` weight sum.

## New state

The three weights are narrowed to float32 once, the weight sum is accumulated from those same values, and the combination is clipped to the documented `[0, 1]`.

Every float32-consumed config scalar (`surprise/coverage/progress_scale`, `surprise/coverage/progress_weight`, `aleatoric_downweight_scale`, `calibrated_priority_threshold`, `calibrated_replacement_margin`, `max_aleatoric_uncertainty`) now goes through the shared exact converter (`alberta_framework._float32.round_real_to_float32`) in `DualReplayConfig.__post_init__`: exact-domain check first (positive / non-negative / `[0, 1]`), then reject nonzero→zero underflow and finite→infinity overflow, keep explicit zero only for the threshold, margin, and aleatoric cap, preserve built-in payloads that narrow identically, and canonicalize other reals (`Fraction`, `np.float64`, `np.int64`, large ints that would double-round through float64) to the exact sink value. The float32 weight-sum probe runs inside an `np.errstate` boundary; the whole rejection path is warning-free under `-W error`. Default `(1.0, 1.0, 1.0)` weights are exact in float32, so every existing pinned value — including the eager/jit/scan bitwise-equality and checkpoint digest tests — is unchanged.

The domain is enforced on both the host value and the exact narrowed sink (`narrowed > 0` / `>= 0` / `<= maximum`), the type gate uses the actual class (`issubclass(type(value), Real)` with bool exclusions) so a `__class__` spoof cannot pass, and honest float subclasses are canonicalized to primitive `float`. Built-in `int`/`float` payloads that narrow identically are preserved as-is (`c48fe63`, maintainer).

Failing-test-first: `test_calibrated_priority_stays_within_unit_range_for_unequal_weights` fails on `main` and passes here. Public-path regressions added: dishonest `float` subclass whose `as_integer_ratio()` leaves the domain for a positive field, each non-negative field, and both sides of the threshold interval (`test_config_rejects_reals_whose_exact_ratio_leaves_the_domain`, 7 cases), `__class__` spoof rejection on all ten scalars, honest-subclass canonicalization with a strict `json.dumps(allow_nan=False)` round trip; underflow/overflow/non-finite rejection for all ten scalars without warnings (`test_config_rejects_scalars_that_underflow_or_overflow_float32_without_warnings`, 70 cases), exact float32 underflow/overflow midpoints (`test_config_enforces_exact_float32_underflow_and_overflow_midpoints`), explicit-zero preservation where allowed, ties-to-even rational rounding plus the `2**54 + 2**30 + 1` double-rounding integer, payload preservation/canonicalization round trip, and the warning-free overflowing weight triple.

## Evidence

Falsifier from #313 at this head:

```text
1.0 True
True True 2
```

Review items at this head:

```text
calibrated_priority_threshold=1e-46 -> rejected: calibrated_priority_threshold must not underflow to zero in float32
max_aleatoric_uncertainty=6e38     -> rejected: max_aleatoric_uncertainty must narrow to a finite float32
calibrated_replacement_margin=6e38 -> rejected: calibrated_replacement_margin must narrow to a finite float32
weights 2e38 x3                    -> rejected: ... must have a finite float32 sum
calibrated_priority_threshold=0.0  -> accepted, stored 0.0
```

Verification at `cbf8f720ec0c43af6f7abc4d230e5bdd5228faf2`:

```text
.venv/bin/python -m pytest tests/test_dual_replay.py tests/test_experiential_memory.py -q -o addopts="" -W error -> 202 passed (no warnings under strict policy)
.venv/bin/python -m ruff check .                                                  -> All checks passed!
.venv/bin/python -m mypy                                                          -> Success: no issues found in 165 source files
```

`core/dual_replay.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:cbf8f720ec0c43af6f7abc4d230e5bdd5228faf2 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest incl. `-W error`, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).