### PR TITLE
fix(memory-policy): normalize finite action mass without overflow

### DIFF
--- a/alberta_framework/core/experiential_memory_policy.py
+++ b/alberta_framework/core/experiential_memory_policy.py
@@ -37,6 +37,7 @@ EXPERIENTIAL_MEMORY_POLICY_SCHEMA = "alberta.experiential-memory-policy.v1"
 _POLICY_TYPE = "ExperientialMemoryPolicy"
 _ACTION_SEMANTICS = "categorical-score-mass-not-action-identifiers"
 _SELECTION_SEMANTICS = "lowest-index-argmax-over-safe-positive-mass"
+_FLOAT32_MAX = 3.4028234663852886e38
 
 
 def _require_array(
@@ -240,17 +241,32 @@ class ExperientialMemoryPolicy:
         finite = jnp.all(jnp.isfinite(action_mass))
         nonnegative = jnp.all(action_mass >= 0.0)
         safe_finite_mass = jnp.where(jnp.isfinite(action_mass), action_mass, 0.0)
-        total_action_mass = jnp.sum(safe_finite_mass)
+        mass_scale = jnp.max(safe_finite_mass)
+        scale_mantissa, scale_exponent = jnp.frexp(mass_scale)
+        safe_mantissa = jnp.where(mass_scale > 0.0, scale_mantissa, 1.0)
+        scaled_mass = jnp.ldexp(safe_finite_mass, -scale_exponent) / safe_mantissa
+        scaled_total = jnp.sum(scaled_mass)
         action_mass_valid = (
             finite
             & nonnegative
-            & jnp.isfinite(total_action_mass)
-            & (total_action_mass > 0.0)
+            & jnp.isfinite(scaled_total)
+            & (scaled_total > 0.0)
         )
-        denominator = jnp.where(action_mass_valid, total_action_mass, 1.0)
+        safe_scaled_total = jnp.where(action_mass_valid, scaled_total, 1.0)
+        total_overflows = mass_scale > _FLOAT32_MAX / safe_scaled_total
+        safe_scale_for_total = jnp.where(
+            total_overflows,
+            _FLOAT32_MAX / safe_scaled_total,
+            mass_scale,
+        )
+        total_action_mass = jnp.where(
+            action_mass_valid,
+            safe_scale_for_total * safe_scaled_total,
+            jnp.sum(safe_finite_mass),
+        )
         normalized = jnp.where(
             action_mass_valid,
-            safe_finite_mass / denominator,
+            scaled_mass / safe_scaled_total,
             jnp.zeros_like(action_mass),
         )
         eligible = hard_safety_mask & (safe_finite_mass > 0.0)

--- a/alberta_framework/core/experiential_memory_policy.py
+++ b/alberta_framework/core/experiential_memory_policy.py
@@ -253,16 +253,24 @@ class ExperientialMemoryPolicy:
             & (scaled_total > 0.0)
         )
         safe_scaled_total = jnp.where(action_mass_valid, scaled_total, 1.0)
-        total_overflows = mass_scale > _FLOAT32_MAX / safe_scaled_total
-        safe_scale_for_total = jnp.where(
-            total_overflows,
-            _FLOAT32_MAX / safe_scaled_total,
-            mass_scale,
+        # Preserve the legacy direct sum bit-for-bit whenever it is already
+        # finite; only fall back to the scale-reconstructed total when the
+        # direct sum overflows. `jnp.minimum(..., _FLOAT32_MAX)` is a hard
+        # post-hoc clamp: `mass_scale * safe_scaled_total` may itself
+        # overflow to `inf` in float32 (e.g. exactly at the reported bug),
+        # but `minimum` against a finite bound is provably finite regardless
+        # of how the multiplication rounds, unlike reconstructing via
+        # division (`_FLOAT32_MAX / safe_scaled_total`) which can itself
+        # round upward and overflow back past `_FLOAT32_MAX` on
+        # multiplication.
+        direct_total = jnp.sum(safe_finite_mass)
+        saturated_total = jnp.minimum(
+            mass_scale * safe_scaled_total, _FLOAT32_MAX
         )
         total_action_mass = jnp.where(
             action_mass_valid,
-            safe_scale_for_total * safe_scaled_total,
-            jnp.sum(safe_finite_mass),
+            jnp.where(jnp.isfinite(direct_total), direct_total, saturated_total),
+            direct_total,
         )
         normalized = jnp.where(
             action_mass_valid,

--- a/tests/test_experiential_memory_policy.py
+++ b/tests/test_experiential_memory_policy.py
@@ -265,6 +265,35 @@ def test_finite_action_mass_sum_cannot_overflow_into_false_abstention() -> None:
     )
 
 
+def test_large_finite_action_mass_total_never_overflows_on_rounding() -> None:
+    """Regression for a reviewer-found rounding edge: reconstructing the
+    saturated total via `_FLOAT32_MAX / scaled_total * scaled_total` can
+    itself round upward past `_FLOAT32_MAX` on the multiply, so the fix must
+    be provably finite (a hard `jnp.minimum` clamp) rather than relying on
+    the division alone."""
+    memory = ExperientialMemory(_memory_config())
+    policy = ExperientialMemoryPolicy(memory)
+    rng = np.random.default_rng(1234)
+    float32_max = np.finfo(np.float32).max
+
+    for _ in range(200):
+        action_mass = tuple(
+            float(v)
+            for v in (rng.uniform(0.0, 1.0, size=3).astype(np.float32) * float32_max)
+        )
+        state = _write(
+            memory,
+            memory.init(),
+            _entry(11, action_mass=action_mass),
+        )
+        proposal = _propose(policy, state)
+
+        assert bool(jnp.isfinite(proposal.total_action_mass)), action_mass
+        direct_sum = float(np.sum(np.asarray(action_mass, dtype=np.float32)))
+        if np.isfinite(direct_sum):
+            assert float(proposal.total_action_mass) == direct_sum, action_mass
+
+
 def test_hard_safety_mask_and_lowest_index_tie_break_are_exact() -> None:
     memory = ExperientialMemory(_memory_config())
     policy = ExperientialMemoryPolicy(memory)

--- a/tests/test_experiential_memory_policy.py
+++ b/tests/test_experiential_memory_policy.py
@@ -241,6 +241,30 @@ def test_valid_retrieval_is_categorical_mass_with_separate_diagnostics() -> None
     _assert_trees_equal(state, before)
 
 
+def test_finite_action_mass_sum_cannot_overflow_into_false_abstention() -> None:
+    memory = ExperientialMemory(_memory_config())
+    policy = ExperientialMemoryPolicy(memory)
+    maximum = np.finfo(np.float32).max
+    state = _write(
+        memory,
+        memory.init(),
+        _entry(11, action_mass=(maximum, maximum, maximum)),
+    )
+
+    proposal = _propose(policy, state)
+
+    assert bool(proposal.retrieval.accepted)
+    assert bool(proposal.action_mass_valid)
+    assert bool(proposal.available)
+    assert int(proposal.action) == 0
+    assert float(proposal.total_action_mass) == maximum
+    np.testing.assert_allclose(
+        proposal.normalized_action_mass,
+        jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32),
+        rtol=1e-6,
+    )
+
+
 def test_hard_safety_mask_and_lowest_index_tie_break_are_exact() -> None:
     memory = ExperientialMemory(_memory_config())
     policy = ExperientialMemoryPolicy(memory)
@@ -330,7 +354,7 @@ def test_memory_version_staleness_uncertainty_and_safety_gates_are_inherited(
 
 @pytest.mark.parametrize(
     "action_mass",
-    [(-1.0, 2.0, 1.0), (0.0, 0.0, 0.0), (3.0e38, 3.0e38, 3.0e38)],
+    [(-1.0, 2.0, 1.0), (0.0, 0.0, 0.0)],
 )
 def test_invalid_or_zero_retrieved_action_mass_fails_closed(
     action_mass: tuple[float, float, float],

--- a/tests/test_experiential_memory_policy.py
+++ b/tests/test_experiential_memory_policy.py
@@ -289,7 +289,8 @@ def test_large_finite_action_mass_total_never_overflows_on_rounding() -> None:
         proposal = _propose(policy, state)
 
         assert bool(jnp.isfinite(proposal.total_action_mass)), action_mass
-        direct_sum = float(np.sum(np.asarray(action_mass, dtype=np.float32)))
+        with np.errstate(over="ignore"):
+            direct_sum = float(np.sum(np.asarray(action_mass, dtype=np.float32)))
         if np.isfinite(direct_sum):
             assert float(proposal.total_action_mass) == direct_sum, action_mass
 


### PR DESCRIPTION
Closes #314.

## What changed

`ExperientialMemoryPolicy._interpret_jit` directly summed the retrieved float32 categorical action masses via `jnp.sum(safe_finite_mass)`. A valid, finite, nonnegative mass vector such as `[float32_max, float32_max, float32_max]` overflows that sum to `inf`, so the policy set `action_mass_valid=False` and abstained with action `-1` even though the retrieval was accepted and the documented categorical distribution is exactly `[1/3, 1/3, 1/3]` with lowest-index action `0`.

confirmed directly through the real public path (`ExperientialMemory.write` → `.query` → `ExperientialMemoryPolicy.propose`) before touching the source:

```text
wrote True
retrieval.accepted True
retrieval.action [3.4028235e+38 3.4028235e+38 3.4028235e+38]
total_action_mass inf
action_mass_valid False
available False
action -1
normalized [0. 0. 0.]
```

fix: the policy now scales mass by its own max via `frexp`/`ldexp` before summing/normalizing — this is mathematically scale-invariant (`normalized = mass / sum(mass)` regardless of magnitude) and never overflows the intermediate sum, since every scaled term is bounded in `[0, 1]`. The reported diagnostic `total_action_mass` is finite-saturated at float32 max instead of `inf` when the true sum exceeds the representable range, rather than propagating a `nan`/`inf` sentinel to callers.

verified independently, beyond the report's own test, that the scale-invariant normalization is correct across the full magnitude range (asymmetric normal-scale mass, uniform mass, and an extreme-skew case), not just the uniform-float32_max case the regression test covers:

```text
[2. 1. 1.] -> [0.5  0.25 0.25] sum= 1.0 valid= True
[1. 1. 1.] -> [0.33333334 0.33333334 0.33333334] sum= 1.0 valid= True
[3.4e+38 1.0e+00 1.0e+00] -> [1. 0. 0.] sum= 1.0 valid= True
```
(the last case's `[1, 0, 0]` is float32's own inherent precision loss at a ~1e38 dynamic-range ratio, not a defect introduced by the scaling method — any float32 computation of that ratio underflows the smaller terms to 0.)

No paper formula is involved; the independent reference is first-principles categorical normalization (equal positive masses at any common finite scale have equal probability).

## Reachability

`ExperientialMemoryPolicy` is exported from both `alberta_framework.core` and the root `alberta_framework` package. `PrototypeAgent` constructs one when experiential memory is enabled (`alberta_framework/core/prototype_agent.py:2321`); its public `scan_transitions` path reaches `policy.propose(...)` with caller-supplied finite float32 action-mass vectors that are not hardcoded to a safe magnitude — confirmed directly by grepping the real (non-test) call site before writing this claim.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_experiential_memory_policy.py -q -o addopts=""
29 passed in 90.49s (strict RuntimeWarning mode)

$ .venv/bin/python -m ruff check alberta_framework/core/experiential_memory_policy.py tests/test_experiential_memory_policy.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 164 source files
```

New test: `test_finite_action_mass_sum_cannot_overflow_into_false_abstention`, using the real public write/query/propose path with three `float32_max` action masses, asserting the retrieval is accepted, mass is valid, action resolves to lowest-index `0`, `normalized_action_mass` is `[1/3, 1/3, 1/3]`, and `total_action_mass` reports the finite-saturated float32 max instead of `inf`. The pre-existing `test_invalid_or_zero_retrieved_action_mass_fails_closed` parametrization drops the `(3.0e38, 3.0e38, 3.0e38)` case — that mass is no longer invalid, since it was the bug, not a genuinely-invalid input; the negative and all-zero cases correctly remain in the "fails closed" table.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/core/experiential_memory_policy.py`, kept the test), reran — failed with `assert False` on `action_mass_valid`, reproducing the exact false-abstention behavior described above. Restored the fix, 29/29 green again.

Reviewer follow-up at the final head preserves the legacy direct sum bit-for-bit whenever it is finite, uses a hard finite clamp only after overflow, and retains a seeded 200-vector public-path boundary that failed the prior division-based reconstruction 19 times. The intentional NumPy reference overflow is scoped under `np.errstate`; the full focused file passes with `RuntimeWarning` promoted to an error.

## Evidence

<!-- evidence-head -->
3d216ef14d96350623316f35a317b04167616c39

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_experiential_memory_policy.py -q -o addopts="" -k test_finite_action_mass_sum_cannot_overflow_into_false_abstention
FAILED tests/test_experiential_memory_policy.py::test_finite_action_mass_sum_cannot_overflow_into_false_abstention - assert False
1 failed, 27 deselected in 1.10s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_experiential_memory_policy.py -q -o addopts=""
29 passed in 90.49s (strict RuntimeWarning mode)
```

<!-- evidence-row:domain-artifact -->
```text
$ .venv/bin/python -c "
import jax.numpy as jnp
_FLOAT32_MAX = 3.4028234663852886e38
def normalize(safe_finite_mass):
    mass_scale = jnp.max(safe_finite_mass)
    scale_mantissa, scale_exponent = jnp.frexp(mass_scale)
    safe_mantissa = jnp.where(mass_scale > 0.0, scale_mantissa, 1.0)
    scaled_mass = jnp.ldexp(safe_finite_mass, -scale_exponent) / safe_mantissa
    scaled_total = jnp.sum(scaled_mass)
    valid = scaled_total > 0.0
    safe_scaled_total = jnp.where(valid, scaled_total, 1.0)
    normalized = jnp.where(valid, scaled_mass / safe_scaled_total, jnp.zeros_like(safe_finite_mass))
    return normalized, scaled_total, valid
for case in [jnp.array([2.0, 1.0, 1.0], dtype=jnp.float32), jnp.array([1.0,1.0,1.0], dtype=jnp.float32), jnp.array([3.4e38, 1.0, 1.0], dtype=jnp.float32)]:
    norm, total, valid = normalize(case)
    print(case, '->', norm, 'sum=', float(jnp.sum(norm)), 'valid=', bool(valid))
"
[2. 1. 1.] -> [0.5  0.25 0.25] sum= 1.0 valid= True
[1. 1. 1.] -> [0.33333334 0.33333334 0.33333334] sum= 1.0 valid= True
[3.4e+38 1.0e+00 1.0e+00] -> [1. 0. 0.] sum= 1.0 valid= True
```
independently reran the focused suite, ruff, and mypy myself; independently verified the normalization stays correctly scale-invariant (sums to 1) across normal, uniform, and extreme-skew magnitudes, not just the uniform-max case in the regression test; independently confirmed the export chain and real call site before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently probed the scale-invariant normalization math across additional magnitude cases beyond the report's own test, verified the export chain and real call site directly, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported

