### PR TITLE
fix(screening): fail closed on sentinel probes for hidden-RMS discovered rules

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -5120,6 +5120,21 @@ def _hidden_rms_frozen_probe_input(
     )
 
 
+def _discovered_rule_frozen_probe_input(
+    hyperparameters: Mapping[str, float],
+) -> FrozenProbeInputFn:
+    """Select the sentinel probe for a discovered-rule arm from its flags.
+
+    ``flag_hidden_rms`` switches the discovered-rule forward pass to the same
+    hidden-layer RMS normalization as ``sigma0_hidden_norm``, so those arms
+    must fail closed exactly like it; the remaining discovered rules deploy
+    the plain MLP behind an EMA input normalizer.
+    """
+    if float(hyperparameters.get("flag_hidden_rms", 0.0)) != 0.0:
+        return _hidden_rms_frozen_probe_input
+    return _ema_frozen_probe_input
+
+
 def _rff_frozen_probe_input(
     state: Any, observation: Array, hyperparameters: Mapping[str, float]
 ) -> Array:
@@ -5896,7 +5911,7 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                 mechanism="discovered_rule",
                 hyperparameters=_discovered_rule_hp(**disc_hp),
                 factory=_make_discovered_rule_learner,
-                frozen_probe_input=_ema_frozen_probe_input,
+                frozen_probe_input=_discovered_rule_frozen_probe_input(disc_hp),
                 description=disc_description,
             )
         )
@@ -5925,7 +5940,9 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                     surprise_slow=0.9996305719081341,
                 ),
                 factory=_make_discovered_rule_learner,
-                frozen_probe_input=_ema_frozen_probe_input,
+                frozen_probe_input=_discovered_rule_frozen_probe_input(
+                    {"flag_hidden_rms": diag_rms}
+                ),
                 description=(
                     "disc_r1 structure at champion-scale constants "
                     f"({diag_axis}): shift-adaptive norm + surprise-gated "

--- a/tests/test_ipmnist_recurring_adapter.py
+++ b/tests/test_ipmnist_recurring_adapter.py
@@ -6,18 +6,21 @@ import dataclasses
 from collections.abc import Mapping
 from typing import Any
 
+import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 from jax import Array
 
 from alberta_framework.benchmarks.ipmnist_screening import (
+    SCREENING_REGISTRY,
     build_recurring_ipmnist_online_indices,
     ipmnist_permutation_sha256,
     ipmnist_sentinel_set_sha256,
     run_recurring_ipmnist_retention_development,
     screening_spec,
 )
-from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig, init_mlp_params
 
 pytestmark = pytest.mark.unit
 
@@ -214,3 +217,34 @@ def test_adapter_rejects_ambiguous_or_unbound_recurrence_inputs(
             sentinel_indices=sentinels,
             relearning_window=1,
         )
+
+
+def _hidden_rms_active(spec: Any) -> bool:
+    return any(
+        float(spec.hyperparameters.get(key, 0.0)) != 0.0
+        for key in ("hidden_rms", "flag_hidden_rms")
+    )
+
+
+def test_hidden_rms_active_arms_refuse_plain_mlp_sentinel_probes() -> None:
+    """Arms whose forward pass RMS-normalizes hidden layers cannot be probed with mlp_logits."""
+    active = sorted(name for name, spec in SCREENING_REGISTRY.items() if _hidden_rms_active(spec))
+    assert {"sigma0_hidden_norm", "disc_r1", "disc_r2", "disc_r3", "disc_r1_pscale"} <= set(active)
+    sentinel_inputs = jnp.zeros((2, CONFIG.input_dim), dtype=jnp.float32)
+    for name in active:
+        spec = SCREENING_REGISTRY[name]
+        init_fn, _step_fn = spec.factory(spec.hyperparameters)
+        state = init_fn(init_mlp_params(jr.key(0), CONFIG))
+        with pytest.raises(NotImplementedError, match="hidden-RMS"):
+            spec.frozen_probe_input(state, sentinel_inputs, spec.hyperparameters)
+
+
+def test_hidden_rms_inactive_sibling_keeps_its_input_side_probe() -> None:
+    spec = screening_spec("disc_r1_pscale_norms")
+    assert not _hidden_rms_active(spec)
+    init_fn, _step_fn = spec.factory(spec.hyperparameters)
+    state = init_fn(init_mlp_params(jr.key(0), CONFIG))
+    sentinel_inputs = jnp.ones((2, CONFIG.input_dim), dtype=jnp.float32)
+    probed = spec.frozen_probe_input(state, sentinel_inputs, spec.hyperparameters)
+    assert probed.shape == sentinel_inputs.shape
+

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -4581,13 +4581,19 @@ class TestDiscoveredRuleFactory:
     def test_discovered_arms_registered(self, name, flags, lr):
         from alberta_framework.benchmarks.ipmnist_screening import (
             _ema_frozen_probe_input,
+            _hidden_rms_frozen_probe_input,
             _make_discovered_rule_learner,
         )
 
         spec = screening_spec(name)
         assert spec.mechanism == "discovered_rule"
         assert spec.factory is _make_discovered_rule_learner
-        assert spec.frozen_probe_input is _ema_frozen_probe_input
+        expected_probe = (
+            _hidden_rms_frozen_probe_input
+            if flags["flag_hidden_rms"] != 0.0
+            else _ema_frozen_probe_input
+        )
+        assert spec.frozen_probe_input is expected_probe
         assert spec.hyperparameters["step_size"] == pytest.approx(lr, rel=1e-12)
         for key, value in flags.items():
             assert spec.hyperparameters[key] == value


### PR DESCRIPTION
Closes #319.

## Issue

`disc_r1`, `disc_r2`, `disc_r3`, and `disc_r1_pscale` set `flag_hidden_rms=1.0`, which RMS-normalizes both hidden layers inside their deployed forward pass, but were registered with the input-side `_ema_frozen_probe_input`. The recurring-retention harness therefore scored `mlp_logits` on a model those arms never run: on the #319 synthetic stream `disc_r1_pscale` reported `forgetting=0.50 / recovery=0.50` while the deployed forward gives `0.42 / 0.46`, and its `flag_hidden_rms=0.0` sibling shows zero discrepancy.

## New state

`_discovered_rule_frozen_probe_input(hp)` selects the probe from `flag_hidden_rms`: hidden-RMS discovered rules get the existing fail-closed `_hidden_rms_frozen_probe_input` (exactly like `sigma0_hidden_norm`); the rest keep the EMA input probe. No arm whose forward pass diverges from `mlp_logits` can be sentinel-probed with it. Arm hyperparameters, factories, and every online-trace path are untouched, so no shard or summary changes.

Failing-test-first: `test_hidden_rms_active_arms_refuse_plain_mlp_sentinel_probes` (registry-wide invariant over both `hidden_rms` and `flag_hidden_rms`) fails on `main` (`DID NOT RAISE NotImplementedError`) and passes here; `test_hidden_rms_inactive_sibling_keeps_its_input_side_probe` pins the control. The existing `test_discovered_arms_registered` pinned the defective probe and now derives the expected probe from the flag.

Composable with #190: once a per-arm `frozen_probe_logits` harness lands, these four arms can be routed to a hidden-RMS logits probe (using the discovered rule's `hidden_rms_epsilon`) instead of failing closed; until then failing closed is the honest state.

## Evidence

At this head the #319 falsifier now stops at the probe:

```text
NotImplementedError: sentinel probes are unsupported for hidden-RMS-normalized arms: the deployed forward pass is not the plain protocol MLP
```

Verification at `0ab16256f3dc4df9f93d6f76aac428ec0dd4a022`:

```text
.venv/bin/python -m pytest tests/test_ipmnist_recurring_adapter.py -q -o addopts=""   -> 9 passed
.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""           -> 306 passed
.venv/bin/python -m ruff check .                                                       -> All checks passed!
.venv/bin/python -m mypy                                                               -> Success: no issues found in 164 source files
```

`benchmarks/ipmnist_screening.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:0ab16256f3dc4df9f93d6f76aac428ec0dd4a022 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
