### PR TITLE
fix(micro-continual): refuse to rank arms measured on different seed sets

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1026,7 +1026,16 @@ def merge_micro_shards(
     paths: Sequence[Path | str], bayes_samples: int = 200_000
 ) -> dict[str, Any]:
     """Merge shards of one (family, config) into a ranked summary with the
-    analytic Bayes reference attached."""
+    analytic Bayes reference attached.
+
+    Every arm must carry the same seed set: the ranking and the Bayes
+    reference are only meaningful as paired comparisons on shared streams.
+
+    Raises:
+        ValueError: If shards duplicate an ``(arm, seed)`` pair, span more
+            than one stream config or environment, drift within an arm, or
+            cover different seed sets across arms.
+    """
     shards = [load_micro_shard(path) for path in paths]
     config, reference_environment = _micro_shard_batch_contract(shards)
     quarter = max(1, config.n_regimes // 4)
@@ -1039,6 +1048,12 @@ def merge_micro_shards(
                 f"duplicate shard for arm={shard['arm_name']} seed={shard['seed']}"
             )
         per_seed[shard["seed"]] = shard
+    seed_sets = {arm: tuple(sorted(per_seed)) for arm, per_seed in sorted(by_arm.items())}
+    if len(set(seed_sets.values())) != 1:
+        raise ValueError(
+            f"seed sets differ across arms: {seed_sets}; "
+            "merge_micro_shards ranks arms on paired seeds only"
+        )
 
     entries: list[dict[str, Any]] = []
     all_seeds: set[int] = set()

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1028,6 +1028,34 @@ class TestShards:
         assert 0.0 < summary["bayes_reference"]["bayes_accuracy_mean"] <= 1.0
         assert summary["bayes_reference"]["chance"] == pytest.approx(1.0 / 3.0)
 
+    def test_merge_rejects_arms_with_different_seed_sets(self, tmp_path: Path):
+        """A ranked summary must compare arms on the same paired seeds."""
+        paths = []
+        for arm, seeds in (("sgd_raw", (0, 1, 2)), ("naive_bayes", (1, 2, 3))):
+            for seed in seeds:
+                result = run_micro_arm(TINY, arm, seed=seed, hidden1=8, hidden2=6)
+                path = micro_shard_path(tmp_path, TINY.family, arm, seed)
+                write_micro_shard(path, micro_shard_payload(result))
+                paths.append(path)
+        with pytest.raises(
+            ValueError,
+            match=r"^seed sets differ across arms: "
+            r"\{'naive_bayes': \(1, 2, 3\), 'sgd_raw': \(0, 1, 2\)\}; "
+            r"merge_micro_shards ranks arms on paired seeds only$",
+        ):
+            merge_micro_shards(paths, bayes_samples=1_000)
+
+    def test_merge_rejects_arm_missing_one_seed(self, tmp_path: Path):
+        paths = []
+        for arm, seeds in (("sgd_raw", (0, 1)), ("naive_bayes", (0,))):
+            for seed in seeds:
+                result = run_micro_arm(TINY, arm, seed=seed, hidden1=8, hidden2=6)
+                path = micro_shard_path(tmp_path, TINY.family, arm, seed)
+                write_micro_shard(path, micro_shard_payload(result))
+                paths.append(path)
+        with pytest.raises(ValueError, match="seed sets differ across arms"):
+            merge_micro_shards(paths, bayes_samples=1_000)
+
     def test_merge_rejects_mixed_configs(self, tmp_path: Path):
         result_a = run_micro_arm(TINY, "sgd_raw", seed=0, hidden1=8, hidden2=6)
         other = tiny("input_permutation", n_regimes=3)


### PR DESCRIPTION
Closes #321.

## Issue

`merge_micro_shards` averaged each arm over whatever seeds it happened to have, ranked those means, and attached a Bayes reference over the seed union. A partial or failed ladder silently published a ranking that compared arms across different stream geometries (`naive_bayes [7] 0.400` ranked above `sgd_raw [0,1,2,3] 0.355`; `bayes_reference.seeds = [0,1,2,3,7]`).

## New state

`merge_micro_shards` requires one shared seed set across arms and raises `seed sets differ across arms: {…}; merge_micro_shards ranks arms on paired seeds only` otherwise — the same predicate `transfer_validation` already applies. Ranking, spread, slope, and Bayes-reference arithmetic are unchanged for paired inputs, so every existing summary produced from a complete ladder is reproduced byte-for-byte apart from `created_unix`.

Failing-test-first: `test_merge_rejects_arms_with_different_seed_sets` and `test_merge_rejects_arm_missing_one_seed` fail on `main` and pass here.

## Evidence

Falsifier from #321 at this head:

```text
ValueError: seed sets differ across arms: {'naive_bayes': (7,), 'sgd_raw': (0, 1, 2, 3)}; merge_micro_shards ranks arms on paired seeds only
```

Verification at `b651f552797625915f37c351df7e36bd9a5f3d98`:

```text
.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""   -> 162 passed
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

`benchmarks/micro_continual.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:b651f552797625915f37c351df7e36bd9a5f3d98 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
