### PR TITLE
fix(micro-continual): bind the idempotent shard skip to the network size

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1445,7 +1445,11 @@ def _run_or_skip_shard(
     hidden1: int,
     hidden2: int,
 ) -> Path:
-    """Idempotent shard execution: existing shards are validated and kept."""
+    """Idempotent shard execution: existing shards are validated and kept.
+
+    A shard is only reused when it was produced by the same stream config
+    and the same network size; anything else must go to a fresh directory.
+    """
     path = micro_shard_path(out_dir, config.family, arm_name, seed)
     if path.exists():
         payload = load_micro_shard(path)
@@ -1453,6 +1457,13 @@ def _run_or_skip_shard(
             raise ValueError(
                 f"{path}: existing shard was produced by a different stream "
                 "config; use a fresh --out directory"
+            )
+        if (payload["hidden1"], payload["hidden2"]) != (hidden1, hidden2):
+            raise ValueError(
+                f"{path}: existing shard was produced by a different network size "
+                f"(hidden1={payload['hidden1']}, hidden2={payload['hidden2']}); "
+                f"requested hidden1={hidden1}, hidden2={hidden2}; "
+                "use a fresh --out directory"
             )
         logger.info("shard exists, skipping: %s", path)
         return path

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1272,6 +1272,24 @@ class TestCLI:
         assert main(argv) == 0  # idempotent skip, not an overwrite
         assert path.read_bytes() == first
 
+    def test_run_refuses_to_skip_a_shard_from_a_different_network_size(self, tmp_path: Path):
+        """The idempotent skip must bind hidden1/hidden2, not only the stream config."""
+        base = [
+            "run", "--family", "input_permutation", "--arm", "sgd_raw",
+            "--seed", "0", "--out", str(tmp_path), *self.ARGS[:-4],
+        ]
+        assert main([*base, "--hidden1", "8", "--hidden2", "6"]) == 0
+        path = micro_shard_path(tmp_path, "input_permutation", "sgd_raw", 0)
+        first = path.read_bytes()
+        with pytest.raises(
+            ValueError,
+            match=r"existing shard was produced by a different network size "
+            r"\(hidden1=8, hidden2=6\); requested hidden1=16, hidden2=6; "
+            r"use a fresh --out directory",
+        ):
+            main([*base, "--hidden1", "16", "--hidden2", "6"])
+        assert path.read_bytes() == first
+
     def test_ladder_partial_arms_writes_summary_only(self, tmp_path: Path):
         argv = [
             "ladder", "--family", "input_permutation", "--seeds", "0",


### PR DESCRIPTION
Closes #323.

## Issue

`_run_or_skip_shard` reused an existing shard whenever its `stream_config` matched, ignoring `hidden1`/`hidden2`. `run --hidden1 64 --hidden2 32` into a directory holding the `8/6` shard for the same `(family, arm, seed)` exited 0 without measuring anything, and a mixed directory only failed later at merge after the whole wave had been computed.

## New state

The skip also binds the persisted network size and refuses with `existing shard was produced by a different network size (hidden1=…, hidden2=…); requested hidden1=…, hidden2=…; use a fresh --out directory` — the same contract the stream-config check already uses. Matching reruns still skip byte-for-byte; nothing about the run, shard, or merge arithmetic changes.

Failing-test-first: `TestCLI::test_run_refuses_to_skip_a_shard_from_a_different_network_size` fails on `main` (exit 0, `shard exists, skipping`) and passes here.

## Evidence

Falsifier from #323 at this head:

```text
0
ValueError: …/input_permutation_sgd_raw_seed0.json: existing shard was produced by a different network size (hidden1=8, hidden2=6); requested hidden1=64, hidden2=32; use a fresh --out directory
```

Verification at `94381d6ca4df4c7dd7ba3e8bd5bcd7d26a760ea0`:

```text
.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""   -> 161 passed
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

Composes cleanly with #322 (`git merge-tree` clean; different function). `benchmarks/micro_continual.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:94381d6ca4df4c7dd7ba3e8bd5bcd7d26a760ea0 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
