### PR TITLE
fix(rule-discovery): reject duplicate search and holdout task names

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -846,6 +846,15 @@ def crossover(key: Array, first: Array, second: Array) -> Array:
     return jnp.where(mask, first, second)
 
 
+def _require_unique_task_names(task_names: Sequence[str], *, name: str) -> tuple[str, ...]:
+    names = tuple(task_names)
+    if not names:
+        raise ValueError(f"{name} must be non-empty")
+    if len(set(names)) != len(names):
+        raise ValueError(f"{name} must contain unique task names; got {list(names)}")
+    return names
+
+
 def evaluate_suite(
     genomes: Array,
     task_names: Sequence[str],
@@ -854,7 +863,13 @@ def evaluate_suite(
     batch_size: int = 256,
     suite: Mapping[str, EvalConfig] | None = None,
 ) -> tuple[np.ndarray, dict[str, np.ndarray]]:
-    """Mean accuracy across the named micro tasks; also per-task vectors."""
+    """Mean accuracy across the named micro tasks; also per-task vectors.
+
+    Raises:
+        ValueError: If ``task_names`` is empty or repeats a task, which would
+            silently turn the equal-weight task mean into a weighted one.
+    """
+    task_names = _require_unique_task_names(task_names, name="task_names")
     registry = MICRO_SUITE if suite is None else suite
     per_task: dict[str, np.ndarray] = {}
     for name in task_names:
@@ -1041,6 +1056,8 @@ def run_search(
     eval_seeds = require_unique_jax_seeds(eval_seeds, name="eval_seeds")
     holdout_seeds = require_unique_jax_seeds(holdout_seeds, name="holdout_seeds")
     search_seed = require_jax_seed(search_seed, name="search_seed")
+    task_names = _require_unique_task_names(task_names, name="task_names")
+    holdout_names = _require_unique_task_names(holdout_names, name="holdout_names")
     if set(task_names) & set(holdout_names):
         raise ValueError("search tasks and holdout tasks must be disjoint")
     if set(eval_seeds) & set(holdout_seeds):

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -41,6 +41,7 @@ from alberta_framework.benchmarks.rule_discovery import (
     decode_genome,
     describe_genome,
     evaluate_population,
+    evaluate_suite,
     genome_from_config,
     init_rule_state,
     mutate,
@@ -417,6 +418,67 @@ def test_evaluate_population_preserves_distinct_seed_order_and_mean(
 
     assert observed == [7, 3]
     np.testing.assert_array_equal(result, np.asarray([5.0, 5.0]))
+
+
+@pytest.mark.parametrize("task_names", [("M1", "M1", "M2"), ("M2", "M2")])
+def test_evaluate_suite_rejects_duplicate_task_names_before_evaluation(
+    monkeypatch: pytest.MonkeyPatch, task_names: tuple[str, ...]
+) -> None:
+    def unexpected_evaluation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("duplicate task names reached population evaluation")
+
+    monkeypatch.setattr(rule_discovery, "evaluate_population", unexpected_evaluation)
+    with pytest.raises(ValueError, match="task_names must contain unique task names"):
+        evaluate_suite(
+            jnp.zeros((1, GENOME_SIZE), dtype=jnp.float32),
+            task_names,
+            seeds=(0,),
+        )
+
+
+def test_evaluate_suite_is_an_equal_weight_task_mean(monkeypatch: pytest.MonkeyPatch) -> None:
+    per_task_value = {"M1": 0.05, "M2": 0.175}
+
+    def evaluation(genomes: jnp.ndarray, config: object, **kwargs: object) -> np.ndarray:
+        del kwargs
+        name = next(key for key, value in MICRO_SUITE.items() if value is config)
+        return np.full((genomes.shape[0],), per_task_value[name])
+
+    monkeypatch.setattr(rule_discovery, "evaluate_population", evaluation)
+    mean, per_task = evaluate_suite(
+        jnp.zeros((2, GENOME_SIZE), dtype=jnp.float32), ("M1", "M2"), seeds=(0,)
+    )
+    np.testing.assert_allclose(mean, np.asarray([0.1125, 0.1125]))
+    assert set(per_task) == {"M1", "M2"}
+
+
+@pytest.mark.parametrize(
+    ("flag", "values", "name"),
+    [
+        ("--tasks", ("M1", "M1"), "task_names"),
+        ("--holdout-tasks", ("M1p", "M1p"), "holdout_names"),
+    ],
+)
+def test_cli_rejects_duplicate_task_names_before_search(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, flag: str, values: tuple[str, ...], name: str
+) -> None:
+    def unexpected_search(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("duplicate task names reached genome generation")
+
+    monkeypatch.setattr(rule_discovery, "random_genomes", unexpected_search)
+    output = tmp_path / "must-not-exist.json"
+    argv = [
+        "search", "--out", str(output), "--n-random", "2", "--population", "2",
+        "--generations", "0", "--elite", "1", "--eval-seeds", "0", "--holdout-seeds", "101",
+        "--tasks", "M1", "--holdout-tasks", "M1p",
+    ]
+    index = argv.index(flag)
+    argv[index + 1 : index + 2] = list(values)
+    with pytest.raises(ValueError, match=f"{name} must contain unique task names"):
+        rule_discovery.main(argv)
+    assert not output.exists()
 
 
 def test_cli_rejects_duplicate_evaluation_seeds_before_search(


### PR DESCRIPTION
Closes #325.

## Issue

`evaluate_suite` evaluated a repeated task name twice, stored it once in `per_task`, and counted it twice in the task mean, so `('M1', 'M1', 'M2')` returned `2/3·M1 + 1/3·M2 = 0.0917` where the documented equal-weight mean is `0.1125`. `run_search` guards duplicate seeds (#127/#136) but accepted duplicate `task_names`/`holdout_names`, and the CLI wrote the duplicate into `settings.task_names`.

## New state

`_require_unique_task_names` refuses empty or repeated task lists (`task_names must contain unique task names; got […]`), applied in `evaluate_suite` and in `run_search`'s pre-compute validation block for both `task_names` and `holdout_names` — the same shape and placement as the existing eval-seed guard. Unique inputs are unchanged; `settings` still serializes lists.

Failing-test-first: `test_evaluate_suite_rejects_duplicate_task_names_before_evaluation[…]` (2 cases) and `test_cli_rejects_duplicate_task_names_before_search[--tasks|--holdout-tasks]` fail on `main` and pass here; `test_evaluate_suite_is_an_equal_weight_task_mean` pins the documented mean.

## Evidence

Falsifier from #325 at this head:

```text
ValueError: task_names must contain unique task names; got ['M1', 'M1', 'M2']
```

Verification at `b39b159b784ff2c8d48f958ebcf35219837e7250`:

```text
.venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts=""   -> 42 passed
.venv/bin/python -m ruff check .                                            -> All checks passed!
.venv/bin/python -m mypy                                                    -> Success: no issues found in 164 source files
```

`benchmarks/rule_discovery.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:b39b159b784ff2c8d48f958ebcf35219837e7250 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
