### PR TITLE
fix(ia): reject nonfinite cerebellum step sizes

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -37,6 +37,7 @@ References:
 from __future__ import annotations
 
 import dataclasses
+import math
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -111,7 +112,7 @@ class ExoCerebellumConfig:
             raise ValueError("n_demons must be positive")
         if self.obs_dim <= 0:
             raise ValueError("obs_dim must be positive")
-        if self.step_size <= 0.0:
+        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
             raise ValueError("step_size must be positive")
 
     def to_config(self) -> dict[str, Any]:

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import dataclasses
 import math
 from collections.abc import Mapping
+from numbers import Real
 from typing import Any, cast
 
 import chex
@@ -47,6 +48,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.normalizers import (
     _checked_lifetime_words_increment,
     _lifetime_counter_valid,
@@ -85,6 +87,33 @@ RECOMMENDATION_PROTOCOL_LIFETIME_COUNTER_DELTA_NBYTES = 24
 
 _INT32_MAX = 2**31 - 1
 
+
+def _positive_float32_scalar(name: str, value: object) -> float:
+    """Validate and canonicalize a positive scalar in its execution dtype."""
+    message = f"{name} must be a finite positive float32 scalar"
+    preserve_builtin_float = type(value) is float
+    preserve_builtin_int = type(value) is int
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        if value <= 0:
+            raise ValueError
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(message) from error
+    if not math.isfinite(narrowed) or narrowed <= 0.0:
+        raise ValueError(message)
+
+    # A valid built-in float already has an exact binary64 payload, so keeping
+    # it preserves existing serialized configs without changing its float32
+    # sink. Other Real implementations are stored as that exact sink. A small
+    # built-in integer is likewise safe only when it is exactly representable.
+    if preserve_builtin_float:
+        return cast(float, value)
+    if preserve_builtin_int and value == narrowed:
+        return float(value)
+    return narrowed
+
 # ---------------------------------------------------------------------------
 # Exo-cerebellum
 # ---------------------------------------------------------------------------
@@ -112,8 +141,8 @@ class ExoCerebellumConfig:
             raise ValueError("n_demons must be positive")
         if self.obs_dim <= 0:
             raise ValueError("obs_dim must be positive")
-        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
+        step_size = _positive_float32_scalar("step_size", self.step_size)
+        object.__setattr__(self, "step_size", step_size)
 
     def to_config(self) -> dict[str, Any]:
         return {"type": "ExoCerebellumConfig", **dataclasses.asdict(self)}

--- a/tests/test_intelligence_amplification_horizon.py
+++ b/tests/test_intelligence_amplification_horizon.py
@@ -527,3 +527,9 @@ def test_malformed_shapes_and_dtypes_fail_before_mutation() -> None:
         np.asarray(source.step_words),
         np.zeros((2,), dtype=np.uint32),
     )
+
+
+@pytest.mark.parametrize("step_size", [float("nan"), float("inf"), float("-inf")])
+def test_cerebellum_config_rejects_nonfinite_step_size(step_size: float) -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=step_size)

--- a/tests/test_intelligence_amplification_horizon.py
+++ b/tests/test_intelligence_amplification_horizon.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Any, cast
 
 import chex
@@ -529,7 +530,47 @@ def test_malformed_shapes_and_dtypes_fail_before_mutation() -> None:
     )
 
 
-@pytest.mark.parametrize("step_size", [float("nan"), float("inf"), float("-inf")])
-def test_cerebellum_config_rejects_nonfinite_step_size(step_size: float) -> None:
+@pytest.mark.parametrize(
+    "step_size",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        1.0e100,
+        1.0e-100,
+        True,
+        np.bool_(True),
+        np.asarray(0.05),
+    ],
+)
+def test_cerebellum_config_rejects_values_outside_its_float32_sink(
+    step_size: object,
+) -> None:
     with pytest.raises(ValueError, match="step_size"):
         ExoCerebellumConfig(step_size=step_size)
+
+
+def test_cerebellum_config_rounds_exact_reals_once_and_updates_with_that_sink() -> None:
+    midpoint_above = Fraction(1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    expected = float(np.nextafter(np.float32(1.0), np.float32(np.inf)))
+
+    config = ExoCerebellumConfig(n_demons=1, obs_dim=1, step_size=midpoint_above)
+    assert type(config.step_size) is float
+    assert config.step_size == expected
+    assert config.to_config()["step_size"] == expected
+
+    agent = ExoCerebellumAgent(config)
+    result = agent.update_result(
+        agent.init(),
+        jnp.asarray([1.0], dtype=jnp.float32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert float(result.state.weights[0, 0]) == expected
+
+
+def test_cerebellum_config_preserves_valid_builtin_float_serialization() -> None:
+    config = ExoCerebellumConfig(step_size=0.05)
+    assert type(config.step_size) is float
+    assert config.step_size == 0.05
+    assert config.to_config()["step_size"] == 0.05


### PR DESCRIPTION
Closes #327.

## What changed

`ExoCerebellumConfig.__post_init__` previously checked only `step_size <= 0.0`. The original PR added a host-finiteness check, but finite binary64 values could still become unusable at the learner's float32 sink:

- `1e100` narrowed to `inf`, so a normal public update staged invalid weights and was refused.
- `1e-100` narrowed to `0.0`, so the public update reported success while the weight stayed zero.
- bools and array-like values also passed the nominal scalar field.

The repaired head validates the original value as a non-bool `numbers.Real`, rounds it directly to IEEE binary32 through the shared exact-ratio converter, and rejects non-finite or non-positive float32 sinks. Non-builtin `Real` values and numeric subclasses are reduced to a plain built-in `float`, so caller-defined behavior cannot survive in the frozen config or its JSON payload. Ordinary valid built-in floats retain their existing binary64/JSON payload when that payload has the same valid float32 execution sink; exactly representable built-in integers retain the same compatibility behavior.

## Reachability

`ExoCerebellumConfig` is exported from `alberta_framework.core`. Both the Step 12 public facade (`alberta_framework/steps/step12.py:140`) and the continual-IA evaluation harness (`alberta_framework/evaluation/continual_ia.py:362`) construct it directly.

The regression covers the public `ExoCerebellumAgent.update_result` path, direct exact-ratio rounding above a binary32 midpoint, strict JSON serialization, and preservation of the existing `0.05` built-in payload.

## Verification

Exact head `402e232568537c1624565f7f63a5dff2e2719224` was composed without conflict onto main `45279f31d0a9e234cd9664a0ba8688e3203f75c5`.

```text
$ .venv/bin/python -m pytest \
    tests/test_intelligence_amplification_horizon.py \
    tests/test_step12_production.py \
    tests/test_continual_ia_evidence.py \
    tests/test_evidence_manifest.py \
    -q -o addopts=""
217 passed in 371.95s

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 164 source files
```

Independent adversarial probes also covered `Fraction`, NumPy scalar types, huge integers, overflow/subnormal rounding boundaries, `IntEnum`, a virtual `Real`, and hostile `float` subclasses. Every accepted value stored and serialized as an exact built-in finite positive float; invalid sinks and bool/array impostors failed at construction.

## Registered-evidence impact

`alberta_framework/core/intelligence_amplification.py` is one of the eight registered source paths for the historical continual-IA claim. This correctness change does not modify or rewrite any pinned `outputs/` artifact and does not create, promote, or strengthen scientific evidence. The historical artifact remains evidence only for its pinned source bytes.

## Evidence

<!-- evidence-head -->
402e232568537c1624565f7f63a5dff2e2719224

<!-- evidence-row:logs -->
```text
red (parent 2236232, repaired cases absent):
step_size=1e+100
constructed=1e+100
candidate_state_valid=False
update_applied=False
weight=0.0
step_size=1e-100
constructed=1e-100
candidate_state_valid=True
update_applied=True
weight=0.0

green (402e232):
rejected=float:1e+100
rejected=float:1e-100
rejected=bool:True
rejected=bool:np.True_
rejected=ndarray:array(0.05)
canonical_type=float
canonical_step_size=1.0000001192092896
update_applied=True
weight=1.0000001192092896
```

<!-- evidence-row:domain-artifact -->
```text
strict_json={"type": "ExoCerebellumConfig", "n_demons": 1, "obs_dim": 1, "step_size": 1.0000001192092896}
```
The midpoint input is `1 + 2^-24 + 2^-60`; direct ties-to-even binary32 rounding yields the next float above `1.0`, and a unit-input/unit-target public update from zero moves the weight by exactly that canonical sink.

## Provenance

AI provider/model: openai / gpt-5.6-sol (original fix, float32-domain repair, tests, and exact-head audit); anthropic / claude-sonnet-5 (original independent verification and PR creation)
Client / agent tooling: Codex; Claude Code
Attribution status: self-reported
