### PR TITLE
fix(retention): require distinct frozen states across sentinel checkpoints

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -637,6 +637,15 @@ def _validate_sentinel_snapshots(
         )
         if prior_state != snapshot.learner_state_sha256_before:
             raise ValueError("all sentinel probes at one checkpoint must use one frozen state")
+    states_by_digest: dict[str, list[int]] = {}
+    for checkpoint_step, digest in checkpoint_states.items():
+        states_by_digest.setdefault(digest, []).append(checkpoint_step)
+    for shared_steps in states_by_digest.values():
+        if len(shared_steps) > 1:
+            raise ValueError(
+                "sentinel probes at different checkpoints must use distinct frozen states; "
+                f"checkpoint steps {sorted(shared_steps)} all declare one learner state"
+            )
     return resolved
 
 

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -243,6 +243,44 @@ def test_missing_reordered_or_malformed_sentinel_snapshots_fail_closed() -> None
         dataclasses.replace(snapshots[0], learner_state_sha256_after=_sha("f"))
 
 
+def test_sentinel_probes_at_one_checkpoint_must_share_one_frozen_state() -> None:
+    protocol = _protocol()
+    snapshots = _snapshots(protocol, retaining=True)
+    drifted = dataclasses.replace(
+        snapshots[2], learner_state_sha256_before=_sha("9"), learner_state_sha256_after=_sha("9")
+    )
+    with pytest.raises(ValueError, match="one frozen state"):
+        build_recurring_ipmnist_retention_report(
+            protocol=protocol,
+            trace=_trace(retaining=True),
+            sentinel_snapshots=(*snapshots[:2], drifted, *snapshots[3:]),
+        )
+
+
+def test_sentinel_probes_at_different_checkpoints_must_use_distinct_frozen_states() -> None:
+    """Re-scoring one learner state at every boundary would report zero forgetting."""
+    protocol = _protocol()
+    one_state = _sha("7")
+    snapshots = tuple(
+        dataclasses.replace(
+            snapshot,
+            learner_state_sha256_before=one_state,
+            learner_state_sha256_after=one_state,
+        )
+        for snapshot in _snapshots(protocol, retaining=True)
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"^sentinel probes at different checkpoints must use distinct frozen states; "
+        r"checkpoint steps \[4, 8, 12\] all declare one learner state$",
+    ):
+        build_recurring_ipmnist_retention_report(
+            protocol=protocol,
+            trace=_trace(retaining=True),
+            sentinel_snapshots=snapshots,
+        )
+
+
 def test_report_is_explicitly_threshold_free_development_only_and_nonpromoting() -> None:
     protocol = _protocol()
     report = build_recurring_ipmnist_retention_report(


### PR DESCRIPTION
Closes #329.

## Issue

`_validate_sentinel_snapshots` enforced one learner state per checkpoint but accepted the same state at every phase boundary. Re-scoring one frozen learner at A0, B0, and A1 produced a fully validated report with `peak_to_revisit_forgetting = 0.0` and `revisit_recovery = 0.0` — the masking the A/B/A schedule exists to prevent.

## New state

After the per-checkpoint check, the validator groups checkpoints by declared learner-state digest and refuses when more than one checkpoint step shares one: `sentinel probes at different checkpoints must use distinct frozen states; checkpoint steps [4, 8, 12] all declare one learner state`. Every genuine run advances the learner across a phase between checkpoints, so accepted reports are unchanged.

Failing-test-first: `test_sentinel_probes_at_different_checkpoints_must_use_distinct_frozen_states` fails on `main` (report accepted) and passes here; `test_sentinel_probes_at_one_checkpoint_must_share_one_frozen_state` pins the pre-existing per-checkpoint rule alongside it.

## Evidence

Falsifier from #329 at this head:

```text
ValueError: sentinel probes at different checkpoints must use distinct frozen states; checkpoint steps [4, 8, 12] all declare one learner state
```

Verification at `8520c1f71e0187141afabedadd7bdcf1a75d3ef6`:

```text
.venv/bin/python -m pytest tests/test_recurring_ipmnist_retention.py tests/test_ipmnist_recurring_adapter.py -q -o addopts=""   -> 17 passed
.venv/bin/python -m ruff check .                                                                                             -> All checks passed!
.venv/bin/python -m mypy                                                                                                     -> Success: no issues found in 164 source files
```

`evaluation/recurring_ipmnist_retention.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:8520c1f71e0187141afabedadd7bdcf1a75d3ef6 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
