### PR TITLE
fix(rule-discovery): validate genome shape and batch size before evaluation

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -778,9 +778,20 @@ def evaluate_population(
 
     Paired evaluation: every genome sees the identical stream and identical
     network init per seed (the screening convention).
+
+    Raises:
+        ValueError: If ``seeds`` are not unique valid seeds, ``genomes`` is not
+            a ``(n_genomes, GENOME_SIZE)`` matrix, or ``batch_size`` is not a
+            positive built-in ``int``.
     """
     seeds = require_unique_jax_seeds(seeds, name="seeds")
+    if type(batch_size) is not int or batch_size < 1:
+        raise ValueError(f"batch_size must be a positive built-in int, got {batch_size!r}")
     genomes = jnp.asarray(genomes, dtype=jnp.float32)
+    if genomes.ndim != 2 or genomes.shape[1] != GENOME_SIZE:
+        raise ValueError(
+            f"genomes must have shape (n_genomes, {GENOME_SIZE}), got {tuple(genomes.shape)}"
+        )
     n_genomes = int(genomes.shape[0])
     total = np.zeros((n_genomes,), dtype=np.float64)
     for seed in seeds:

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -18,6 +18,7 @@ Search executions happen through the CLI, never inside pytest.
 """
 
 import dataclasses
+import re
 
 import jax.numpy as jnp
 import jax.random as jr
@@ -374,6 +375,41 @@ def test_evaluate_population_rejects_noncanonical_seed_schedules_before_material
             jnp.zeros((1, GENOME_SIZE), dtype=jnp.float32),
             MICRO_SUITE["M1"],
             seeds=seeds,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(2, 16), (2, GENOME_SIZE + 1), (GENOME_SIZE,), (1, 2, GENOME_SIZE)],
+)
+def test_evaluate_population_rejects_malformed_genome_shapes_before_materialization(
+    monkeypatch: pytest.MonkeyPatch, shape: tuple[int, ...]
+) -> None:
+    def unexpected_materialization(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("malformed genomes reached stream materialization")
+
+    monkeypatch.setattr(rule_discovery, "_materialize_eval", unexpected_materialization)
+    expected = f"genomes must have shape (n_genomes, {GENOME_SIZE}), got {shape}"
+    with pytest.raises(ValueError, match=rf"^{re.escape(expected)}$"):
+        evaluate_population(jnp.zeros(shape, dtype=jnp.float32), MICRO_SUITE["M1"], seeds=(0,))
+
+
+@pytest.mark.parametrize("batch_size", [0, -4, True])
+def test_evaluate_population_rejects_non_positive_batch_size_before_materialization(
+    monkeypatch: pytest.MonkeyPatch, batch_size: object
+) -> None:
+    def unexpected_materialization(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("invalid batch_size reached stream materialization")
+
+    monkeypatch.setattr(rule_discovery, "_materialize_eval", unexpected_materialization)
+    with pytest.raises(ValueError, match="batch_size must be a positive built-in int"):
+        evaluate_population(
+            jnp.zeros((2, GENOME_SIZE), dtype=jnp.float32),
+            MICRO_SUITE["M1"],
+            seeds=(0,),
+            batch_size=batch_size,  # type: ignore[arg-type]
         )
 
 


### PR DESCRIPTION
Closes #331.

## Issue

`evaluate_population` accepted any genome width — a 16-wide matrix broadcast its single continuous gene onto all 18 constants and returned a plausible in-range accuracy (`[0.25 0.25]`) for input `decode_genome` refuses — and looped forever on `batch_size <= 0` (CLI-reachable through `--batch-size`).

## New state

Before any stream is materialized, `evaluate_population` requires `genomes` to be a `(n_genomes, GENOME_SIZE)` matrix (`genomes must have shape (n_genomes, 33), got (2, 16)`) and `batch_size` to be a positive built-in `int`. Placement and message shape follow the existing seed guard; valid inputs are unchanged.

Failing-test-first: `test_evaluate_population_rejects_malformed_genome_shapes_before_materialization[…]` (4 shapes: 16-wide, 34-wide, 1-D, 3-D) and `test_evaluate_population_rejects_non_positive_batch_size_before_materialization[0|-4|True]` fail on `main` and pass here (the `batch_size` cases previously hung; the width cases either returned numbers or raised from inside the traced step).

## Evidence

Falsifiers from #331 at this head:

```text
ValueError: genomes must have shape (n_genomes, 33), got (2, 16)
ValueError: batch_size must be a positive built-in int, got 0
```

Verification at `7fde9d634f5c62d263859ed6c38212c9a3adbb3f`:

```text
.venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts=""   -> 44 passed
.venv/bin/python -m ruff check .                                            -> All checks passed!
.venv/bin/python -m mypy                                                    -> Success: no issues found in 164 source files
```

Composes cleanly with #326 (`git merge-tree` clean; different functions). `benchmarks/rule_discovery.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:7fde9d634f5c62d263859ed6c38212c9a3adbb3f -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
