### PR TITLE
fix(upgd): reject exhausted utility clocks atomically

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -96,6 +96,7 @@ _RAW_GLOBAL_PROFILES = frozenset(
         "official_experiment_global",
     }
 )
+_INT32_MAX = 2_147_483_647
 
 
 def _static_zero_scale(scale: float, value: Array) -> Array:
@@ -103,6 +104,14 @@ def _static_zero_scale(scale: float, value: Array) -> Array:
     if scale == 0.0:
         return jnp.zeros_like(value)
     return scale * value
+
+
+def _saturating_increment(value: Array, increment: Array | int = 1) -> Array:
+    """Increment a non-negative int32 counter without lifetime wraparound."""
+
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    increment_array = jnp.asarray(increment, dtype=jnp.int32)
+    return value + jnp.minimum(increment_array, maximum - value)
 
 
 @dataclass(frozen=True)
@@ -399,7 +408,7 @@ class CanonicalUPGD:
         next_key = split_keys[0]
         noise_keys = split_keys[1:]
         beta = self._config.utility_decay
-        next_step = state.step + jnp.array(1, dtype=jnp.int32)
+        next_step = _saturating_increment(state.step)
 
         corrected_leaves: list[Array] = []
         new_utility_leaves: list[Array] = []
@@ -440,7 +449,7 @@ class CanonicalUPGD:
                 next_age = jnp.full_like(age, next_step)
                 correction_clock = next_step.astype(param.dtype)
             else:
-                next_age = age + active.astype(jnp.int32)
+                next_age = _saturating_increment(age, active.astype(jnp.int32))
                 correction_clock = next_age.astype(param.dtype)
             bias_correction = 1.0 - jnp.power(beta, correction_clock)
             corrected = jnp.where(

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -376,6 +376,13 @@ class CanonicalUPGD:
         ``noise`` may supply the already-scaled perturbation PyTree ``xi`` for
         equation-level parity tests.  Normal operation omits it and samples
         ``N(0, noise_std**2)`` from ``key``.
+
+        The final representable int32 clock event is applied.  Once the clock
+        reaches ``INT32_MAX``, later calls reject atomically: parameters,
+        optimizer state, and the key remain exact; computed payloads are
+        neutral; and ``metrics["update_applied"]`` is false.  This avoids both
+        counter wraparound and silently continuing an EMA with a frozen bias-
+        correction clock.
         """
 
         param_leaves, structure = _flatten_with_none(params)
@@ -408,6 +415,8 @@ class CanonicalUPGD:
         next_key = split_keys[0]
         noise_keys = split_keys[1:]
         beta = self._config.utility_decay
+        maximum_step = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+        capacity_available = state.step < maximum_step
         next_step = _saturating_increment(state.step)
 
         corrected_leaves: list[Array] = []
@@ -602,28 +611,70 @@ class CanonicalUPGD:
             perturbation_leaves.append(perturbation)
 
         count_floor = jnp.maximum(eligible_count, 1.0)
-        next_state = CanonicalUPGDState(  # type: ignore[call-arg]
+        proposed_params = jax.tree_util.tree_unflatten(structure, new_param_leaves)
+        proposed_state = CanonicalUPGDState(  # type: ignore[call-arg]
             utility_ema=jax.tree_util.tree_unflatten(structure, new_utility_leaves),
             utility_age=jax.tree_util.tree_unflatten(structure, new_age_leaves),
             step=next_step,
         )
+        committed_params = jax.tree.map(
+            lambda proposed, current: jnp.where(
+                capacity_available,
+                proposed,
+                current,
+            ),
+            proposed_params,
+            params,
+        )
+        committed_state = jax.tree.map(
+            lambda proposed, current: jnp.where(
+                capacity_available,
+                proposed,
+                current,
+            ),
+            proposed_state,
+            state,
+        )
+        committed_key = jax.lax.cond(
+            capacity_available,
+            lambda _: next_key,
+            lambda _: key,
+            operand=None,
+        )
+        zero_tree = jax.tree.map(jnp.zeros_like, params)
+        scaled_utility = jax.tree.map(
+            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
+            jax.tree_util.tree_unflatten(structure, gate_leaves),
+            zero_tree,
+        )
+        corrected_utility = jax.tree.map(
+            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
+            jax.tree_util.tree_unflatten(structure, corrected_leaves),
+            zero_tree,
+        )
+        perturbation = jax.tree.map(
+            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
+            jax.tree_util.tree_unflatten(structure, perturbation_leaves),
+            zero_tree,
+        )
         return CanonicalUPGDUpdate(  # type: ignore[call-arg]
-            params=jax.tree_util.tree_unflatten(structure, new_param_leaves),
-            state=next_state,
-            next_key=next_key,
-            scaled_utility=jax.tree_util.tree_unflatten(structure, gate_leaves),
-            corrected_utility=jax.tree_util.tree_unflatten(
-                structure,
-                corrected_leaves,
-            ),
-            perturbation=jax.tree_util.tree_unflatten(
-                structure,
-                perturbation_leaves,
-            ),
+            params=committed_params,
+            state=committed_state,
+            next_key=committed_key,
+            scaled_utility=scaled_utility,
+            corrected_utility=corrected_utility,
+            perturbation=perturbation,
             metrics={
-                "mean_scaled_utility": gate_sum / count_floor,
-                "mean_absolute_utility": utility_sum / count_floor,
-                "global_maximum_utility": global_maximum,
+                "update_applied": capacity_available,
+                "mean_scaled_utility": jnp.where(
+                    capacity_available, gate_sum / count_floor, 0.0
+                ),
+                "mean_absolute_utility": jnp.where(
+                    capacity_available, utility_sum / count_floor, 0.0
+                ),
+                "global_maximum_utility": jnp.where(
+                    capacity_available, global_maximum, 0.0
+                ),
                 "eligible_parameter_count": eligible_count,
                 "nonfinite_or_missing_count": nonfinite_count,
             },
@@ -642,9 +693,6 @@ AlbertaAdaUPGDProfile = Literal["alberta_derived_first_order_adaptive_v1"]
 ALBERTA_ADAUPGD_PROFILE: AlbertaAdaUPGDProfile = (
     "alberta_derived_first_order_adaptive_v1"
 )
-
-_INT32_MAX = 2**31 - 1
-
 
 @dataclass(frozen=True)
 class AlbertaAdaUPGDConfig:

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -294,6 +294,47 @@ def test_ema_bias_correction_recovers_constant_signed_utility() -> None:
 
 
 @pytest.mark.parametrize(
+    "profile",
+    ["paper_global", "safe_extended"],
+)
+def test_lifetime_counters_saturate_without_disabling_utility_correction(
+    profile: str,
+) -> None:
+    params = {"w": jnp.array([2.0], dtype=jnp.float32)}
+    gradients = {"w": jnp.array([-0.5], dtype=jnp.float32)}
+    optimizer = CanonicalUPGD(
+        CanonicalUPGDConfig(
+            step_size=0.1,
+            utility_decay=0.9,
+            noise_std=0.0,
+            profile=profile,  # type: ignore[arg-type]
+            normalization="global",
+        )
+    )
+    maximum = jnp.iinfo(jnp.int32).max
+    state = optimizer.init(params).replace(
+        utility_ema={"w": jnp.array([1.0], dtype=jnp.float32)},
+        utility_age={"w": jnp.array([maximum], dtype=jnp.int32)},
+        step=jnp.array(maximum, dtype=jnp.int32),
+    )
+
+    result = optimizer.update(
+        state,
+        params,
+        gradients,
+        jr.key(0),
+        noise={"w": jnp.zeros(1, dtype=jnp.float32)},
+    )
+
+    assert int(result.state.step) == maximum
+    assert int(result.state.utility_age["w"][0]) == maximum
+    assert float(result.corrected_utility["w"][0]) == pytest.approx(1.0)
+    assert float(result.scaled_utility["w"][0]) == pytest.approx(
+        float(jax.nn.sigmoid(jnp.float32(1.0)))
+    )
+
+
+@pytest.mark.parametrize(
     ("profile", "normalized"),
     [
         (

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -294,11 +294,21 @@ def test_ema_bias_correction_recovers_constant_signed_utility() -> None:
 
 
 @pytest.mark.parametrize(
-    "profile",
-    ["paper_global", "safe_extended"],
+    ("profile", "normalization"),
+    [
+        ("paper_global", "global"),
+        ("official_readme_global", "global"),
+        ("official_experiment_global", "global"),
+        ("official_experiment_local", "local"),
+        ("paper_local_literal", "local"),
+        ("safe_extended", "global"),
+    ],
 )
-def test_lifetime_counters_saturate_without_disabling_utility_correction(
+@pytest.mark.parametrize("compiled", [False, True])
+def test_lifetime_counter_capacity_rejects_the_complete_update(
     profile: str,
+    normalization: str,
+    compiled: bool,
 ) -> None:
     params = {"w": jnp.array([2.0], dtype=jnp.float32)}
     gradients = {"w": jnp.array([-0.5], dtype=jnp.float32)}
@@ -308,7 +318,7 @@ def test_lifetime_counters_saturate_without_disabling_utility_correction(
             utility_decay=0.9,
             noise_std=0.0,
             profile=profile,  # type: ignore[arg-type]
-            normalization="global",
+            normalization=normalization,  # type: ignore[arg-type]
         )
     )
     maximum = jnp.iinfo(jnp.int32).max
@@ -318,20 +328,76 @@ def test_lifetime_counters_saturate_without_disabling_utility_correction(
         step=jnp.array(maximum, dtype=jnp.int32),
     )
 
-    result = optimizer.update(
+    def apply_update(state, params, gradients, key, noise):
+        return optimizer.update(state, params, gradients, key, noise=noise)
+
+    update = jax.jit(apply_update) if compiled else apply_update
+    result = update(
         state,
         params,
         gradients,
         jr.key(0),
-        noise={"w": jnp.zeros(1, dtype=jnp.float32)},
+        {"w": jnp.zeros(1, dtype=jnp.float32)},
     )
 
     assert int(result.state.step) == maximum
     assert int(result.state.utility_age["w"][0]) == maximum
-    assert float(result.corrected_utility["w"][0]) == pytest.approx(1.0)
-    assert float(result.scaled_utility["w"][0]) == pytest.approx(
-        float(jax.nn.sigmoid(jnp.float32(1.0)))
+    chex.assert_trees_all_equal(result.params, params)
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(result.next_key, jr.key(0))
+    chex.assert_trees_all_equal(
+        result.corrected_utility,
+        jax.tree.map(jnp.zeros_like, params),
     )
+    chex.assert_trees_all_equal(
+        result.scaled_utility,
+        jax.tree.map(jnp.zeros_like, params),
+    )
+    assert not bool(result.metrics["update_applied"])
+
+
+@pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
+def test_final_representable_lifetime_update_is_consumed_before_capacity(
+    profile: str,
+) -> None:
+    previous_x64 = jax.config.x64_enabled
+    jax.config.update("jax_enable_x64", True)
+    try:
+        params = {"w": jnp.array([2.0], dtype=jnp.float64)}
+        gradients = {"w": jnp.array([-0.5], dtype=jnp.float64)}
+        decay = 0.999999999
+        optimizer = CanonicalUPGD(
+            CanonicalUPGDConfig(
+                step_size=0.1,
+                utility_decay=decay,
+                noise_std=0.0,
+                profile=profile,  # type: ignore[arg-type]
+                normalization="global",
+            )
+        )
+        maximum = jnp.iinfo(jnp.int32).max
+        prior_step = int(maximum) - 1
+        correction = 1.0 - decay**prior_step
+        state = optimizer.init(params).replace(
+            utility_ema={"w": jnp.array([correction], dtype=jnp.float64)},
+            utility_age={"w": jnp.array([prior_step], dtype=jnp.int32)},
+            step=jnp.array(prior_step, dtype=jnp.int32),
+        )
+
+        result = optimizer.update(
+            state,
+            params,
+            gradients,
+            jr.key(1),
+            noise={"w": jnp.zeros(1, dtype=jnp.float64)},
+        )
+
+        assert int(result.state.step) == maximum
+        assert int(result.state.utility_age["w"][0]) == maximum
+        assert float(result.corrected_utility["w"][0]) == pytest.approx(1.0)
+        assert bool(result.metrics["update_applied"])
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #334.

## What changed

`CanonicalUPGD.update` used ordinary signed-int32 increments for its global
clock and safe-profile utility ages. At `INT32_MAX`, the next call wrapped the
clock negative, disabled bias correction, and changed the protection gate.

The original proposal saturated the clock and continued updating the EMA. That
is not equation-preserving for every allowed decay: with float64 parameters and
`utility_decay=0.999999999`, a reachable post-cap state reports corrected
utility `1.1167776491161645` for a constant signal whose correct value is `1`.

This revision therefore uses a fail-closed lifetime contract:

- the final representable event (`INT32_MAX - 1 -> INT32_MAX`) is consumed;
- later calls are atomic no-ops: parameters, optimizer state, and PRNG key are
  bit-exact and computed payloads are neutral;
- `metrics["update_applied"]` reports the rejection explicitly; and
- both global and per-element counters use a JAX-compatible saturating
  increment, so no intermediate/output counter wraps.

The capacity behavior is covered eagerly and under `jax.jit` for all six
profiles. A float64 near-one-decay regression proves the final representable
event still applies the exact bias correction before capacity is reached.

## Red / green evidence

With the repaired tests applied to the prior saturating-but-continuing source:

```text
4 failed, 38 deselected

- both profiles changed parameters after capacity instead of rejecting;
- the result did not expose update_applied.
```

Final exact-head gates:

```text
126 passed  # canonical UPGD, adaptive UPGD, and IPMNIST UPGD integration
ruff check: passed
mypy alberta_framework/core/canonical_upgd.py: passed
git diff --check: passed
```

No `outputs/` artifact was changed. `canonical_upgd.py` is not in the current
five-claim registered source inventory; historical development provenance is
left untouched.

## Evidence head

`1d85f719eca385c99c4d4eb040ae666cfad98cfe`

