### PR TITLE
fix(world-model-ensemble): refuse initial states the module would reject

### DIFF
--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -1552,18 +1552,20 @@ def load_recurrent_latent_world_model_ensemble_checkpoint(
     if metadata.get("scientific_promotion_allowed") is not False:
         raise ValueError("checkpoint cannot claim scientific promotion")
     key = jr.key(0) if template_key is None else template_key
-    template = model.init(key)
-    expected_budget = model.resource_budget(template).to_config()
-    if metadata.get("resource_budget") != expected_budget:
-        raise ValueError("checkpoint resource budget does not match config")
+    # The template supplies only the checkpoint's static PyTree contract.  It
+    # must not make restoration depend on whether this unrelated random draw
+    # happens to fit the configured parameter bound; the persisted state is
+    # validated immediately after it is reconstructed.
+    template = model._initial_state(key)
     restored, second_metadata = load_checkpoint(template, path)
     if second_metadata != metadata:
         raise ValueError("checkpoint metadata changed between reads")
     state = cast(RecurrentLatentWorldModelEnsembleState, restored)
     if not bool(jax.device_get(model.state_valid(state))):
         raise ValueError("restored recurrent latent ensemble state is invalid")
-    if model.resource_budget(state).to_config() != expected_budget:
-        raise ValueError("restored recurrent latent ensemble resource budget is invalid")
+    expected_budget = model.resource_budget(state).to_config()
+    if metadata.get("resource_budget") != expected_budget:
+        raise ValueError("checkpoint resource budget does not match config and state")
     return model, state
 
 

--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -304,6 +304,12 @@ class RecurrentLatentWorldModelEnsembleConfig:
             raise ValueError("gradient_clip_norm cannot exceed max_raw_gradient_norm")
         if self.learning_rate * self.gradient_clip_norm > self.max_parameter_magnitude:
             raise ValueError("one clipped update exceeds max_parameter_magnitude")
+        initial_variance_bias = abs(self.initial_variance_logit)
+        if initial_variance_bias > self.max_parameter_magnitude:
+            raise ValueError(
+                f"initial variance bias magnitude {initial_variance_bias} exceeds "
+                f"max_parameter_magnitude={self.max_parameter_magnitude}"
+            )
         if self.state_nbytes > _MAX_STATE_NBYTES:
             raise ValueError(
                 f"configured persistent state needs {self.state_nbytes} bytes; "
@@ -333,6 +339,15 @@ class RecurrentLatentWorldModelEnsembleConfig:
         recurrent += self.latent_dim * joined + self.latent_dim
         heads = 2 * (self.target_dim * self.latent_dim + self.target_dim)
         return recurrent + heads
+
+    @property
+    def initial_variance_logit(self) -> float:
+        """Variance-head bias that starts every member at sqrt(floor * max) variance."""
+        desired_variance = math.sqrt(self.variance_floor * self.max_variance)
+        variance_ratio = (desired_variance - self.variance_floor) / (
+            self.max_variance - self.variance_floor
+        )
+        return math.log(variance_ratio / (1.0 - variance_ratio))
 
     @property
     def state_nbytes(self) -> int:
@@ -605,7 +620,7 @@ class RecurrentLatentWorldModelEnsemble:
 
     def __init__(self, config: RecurrentLatentWorldModelEnsembleConfig):
         self._config = config
-        template = self.init(jr.key(0))
+        template = self._initial_state(jr.key(0))
         self._member_signature = _static_signature(template.member_parameters[0])
         self._state_signature = _static_signature(template)
         self._start_signature = _static_signature(self._zero_start_cache())
@@ -648,11 +663,7 @@ class RecurrentLatentWorldModelEnsemble:
             fan_in = jnp.asarray(shape[1], dtype=jnp.float32)
             return jr.normal(current_key, shape, dtype=jnp.float32) * scale / jnp.sqrt(fan_in)
 
-        desired_variance = math.sqrt(cfg.variance_floor * cfg.max_variance)
-        variance_ratio = (desired_variance - cfg.variance_floor) / (
-            cfg.max_variance - cfg.variance_floor
-        )
-        variance_logit = math.log(variance_ratio / (1.0 - variance_ratio))
+        variance_logit = cfg.initial_variance_logit
         return RecurrentLatentMemberParameters(
             gate_kernel=kernel(keys[0], (2 * cfg.latent_dim, joined)),
             gate_bias=jnp.zeros((2 * cfg.latent_dim,), dtype=jnp.float32),
@@ -669,7 +680,25 @@ class RecurrentLatentWorldModelEnsemble:
         )
 
     def init(self, key: Array) -> RecurrentLatentWorldModelEnsembleState:
-        """Initialize distinct member parameters and an isolated bootstrap key."""
+        """Initialize distinct member parameters and an isolated bootstrap key.
+
+        Raises:
+            ValueError: If ``key`` is not one JAX PRNG key, or the drawn
+                initial parameters would already fail the configured
+                ``max_parameter_magnitude`` bound (an initialized state that
+                the module itself rejects would make every later event a
+                silent no-op).
+        """
+        state = self._initial_state(key)
+        if not bool(self._state_valid(state)):
+            raise ValueError(
+                "initialized parameters exceed max_parameter_magnitude="
+                f"{self._config.max_parameter_magnitude}; lower initialization_scale "
+                "or raise the bound"
+            )
+        return state
+
+    def _initial_state(self, key: Array) -> RecurrentLatentWorldModelEnsembleState:
         key_data = jr.key_data(key)
         if key_data.shape != (2,) or key_data.dtype != jnp.uint32:
             raise ValueError("key must be one JAX PRNG key")

--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -304,7 +304,7 @@ class RecurrentLatentWorldModelEnsembleConfig:
             raise ValueError("gradient_clip_norm cannot exceed max_raw_gradient_norm")
         if self.learning_rate * self.gradient_clip_norm > self.max_parameter_magnitude:
             raise ValueError("one clipped update exceeds max_parameter_magnitude")
-        initial_variance_bias = abs(self.initial_variance_logit)
+        initial_variance_bias = self.initial_variance_bias_magnitude
         if initial_variance_bias > self.max_parameter_magnitude:
             raise ValueError(
                 f"initial variance bias magnitude {initial_variance_bias} exceeds "
@@ -348,6 +348,11 @@ class RecurrentLatentWorldModelEnsembleConfig:
             self.max_variance - self.variance_floor
         )
         return math.log(variance_ratio / (1.0 - variance_ratio))
+
+    @property
+    def initial_variance_bias_magnitude(self) -> float:
+        """Magnitude of the stored float32 variance bias, as ``_parameters_valid`` sees it."""
+        return float(np.float32(abs(self.initial_variance_logit)))
 
     @property
     def state_nbytes(self) -> int:
@@ -681,6 +686,11 @@ class RecurrentLatentWorldModelEnsemble:
 
     def init(self, key: Array) -> RecurrentLatentWorldModelEnsembleState:
         """Initialize distinct member parameters and an isolated bootstrap key.
+
+        This is a deliberately host-side entry point: it evaluates the drawn
+        parameters against ``max_parameter_magnitude`` eagerly and raises, so
+        it must not be wrapped in ``jax.jit``; compile the ``start`` /
+        ``decide`` / ``update`` transitions instead.
 
         Raises:
             ValueError: If ``key`` is not one JAX PRNG key, or the drawn

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -158,6 +158,34 @@ def test_initialization_is_distinct_fixed_width_and_exactly_accounted() -> None:
     assert budget.replay_capacity == 0
 
 
+def test_config_rejects_an_initial_variance_bias_outside_the_parameter_bound() -> None:
+    """The deterministic variance-head initializer must fit inside max_parameter_magnitude."""
+    expected = (
+        r"^initial variance bias magnitude 5\.75646[0-9]* exceeds max_parameter_magnitude=1\.0$"
+    )
+    with pytest.raises(ValueError, match=expected):
+        _config(max_parameter_magnitude=1.0)
+
+
+def test_init_refuses_to_return_a_state_it_would_reject() -> None:
+    """A bound that admits the deterministic bias can still be breached by drawn kernels."""
+    model = RecurrentLatentWorldModelEnsemble(
+        _config(initialization_scale=50.0, max_parameter_magnitude=6.0)
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"^initialized parameters exceed max_parameter_magnitude=6\.0; "
+        r"lower initialization_scale or raise the bound$",
+    ):
+        model.init(jr.key(0))
+
+
+def test_init_state_is_valid_for_every_accepted_default_scale() -> None:
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    for seed in range(4):
+        assert bool(model.state_valid(model.init(jr.key(seed))))
+
+
 def test_start_and_decide_are_read_only_predict_before_update_caches() -> None:
     model = RecurrentLatentWorldModelEnsemble(_config())
     state = model.init(jr.key(0))

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -575,6 +575,28 @@ def test_digest_bound_checkpoint_roundtrip_preserves_exact_future_stream(tmp_pat
     _assert_tree_equal(original_next, restored_next)
 
 
+def test_checkpoint_restore_does_not_depend_on_an_unrelated_template_draw(
+    tmp_path: Path,
+) -> None:
+    """A valid persisted draw must restore even when the default template draw is invalid."""
+    model = RecurrentLatentWorldModelEnsemble(
+        _config(initialization_scale=5.0, max_parameter_magnitude=8.0)
+    )
+    state = model.init(jr.key(3))
+    assert bool(model.state_valid(state))
+    with pytest.raises(ValueError, match="initialized parameters exceed"):
+        model.init(jr.key(0))
+
+    checkpoint = tmp_path / "seed-dependent-init.ckpt"
+    save_recurrent_latent_world_model_ensemble_checkpoint(model, state, checkpoint)
+
+    restored_model, restored_state = load_recurrent_latent_world_model_ensemble_checkpoint(
+        checkpoint
+    )
+    assert restored_model.to_config() == model.to_config()
+    _assert_tree_equal(restored_state, state)
+
+
 def test_checkpoint_rejects_metadata_config_and_resource_tampering(tmp_path: Path) -> None:
     model = RecurrentLatentWorldModelEnsemble(_config())
     state = model.init(jr.key(91))

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -186,6 +186,30 @@ def test_init_state_is_valid_for_every_accepted_default_scale() -> None:
         assert bool(model.state_valid(model.init(jr.key(seed))))
 
 
+def test_initial_variance_bias_bound_is_exact_at_its_float32_endpoint() -> None:
+    """The bound is compared against the stored float32 bias, not its binary64 origin."""
+    default = _config()
+    sink = float(np.float32(abs(default.initial_variance_logit)))
+    assert default.initial_variance_bias_magnitude == sink
+    assert sink != abs(default.initial_variance_logit)
+
+    endpoint = RecurrentLatentWorldModelEnsemble(_config(max_parameter_magnitude=sink))
+    state = endpoint.init(jr.key(0))
+    assert bool(endpoint.state_valid(state))
+    stored = float(jnp.max(jnp.abs(state.member_parameters[0].variance_bias)))
+    assert stored == sink
+
+    below = float(np.nextafter(np.float32(sink), np.float32(0.0)))
+    with pytest.raises(ValueError, match="initial variance bias magnitude"):
+        _config(max_parameter_magnitude=below)
+
+
+def test_init_is_a_host_side_entry_point() -> None:
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    with pytest.raises(jax.errors.TracerBoolConversionError):
+        jax.jit(model.init)(jr.key(0))
+
+
 def test_start_and_decide_are_read_only_predict_before_update_caches() -> None:
     model = RecurrentLatentWorldModelEnsemble(_config())
     state = model.init(jr.key(0))


### PR DESCRIPTION
Closes #333.

## Issue

An accepted `RecurrentLatentWorldModelEnsembleConfig` could return an initial state that its own `state_valid()` rejects, silently pinning later transactions at event zero. A second audit found that a valid state drawn with one key could be saved but not restored when the unrelated default checkpoint-template draw exceeded the bound.

## New state

- Construction rejects a parameter bound below the actual stored float32 variance-head bias, including exact endpoint and next-neighbour behavior.
- `init()` is an explicit host-side entry point and raises instead of returning a rejected state.
- Checkpoint restore uses its local random draw only for the static PyTree contract, then validates the reconstructed persisted state and its resource budget. Valid restore no longer depends on unrelated template values; metadata/resource tampering still fails closed.
- No schema, accepted transition arithmetic, evidence artifact, or benchmark output changed.

## Verification

At repaired head `c194168fb1834aaa66ec8c99c659c2eb50322a25`:

```text
5 adversarial init/float32/checkpoint/tamper tests under RuntimeWarning-as-error -> passed
Ruff (changed source + test)                                                    -> passed
strict mypy (changed source)                                                    -> passed
```

The complete affected module suite passed 25/25 on the immediately prior repair tree; the final rebase added only a disjoint mainline micro-curve merge. Fresh CI is authoritative for this exact head. An enlarged adjacent batch reached an unrelated PrototypeAgent compilation lane without a failure before it was intentionally bounded; it is not reported as a completed gate.

`core/recurrent_latent_world_model_ensemble.py` is not a registered evidence source. No benchmark lane, seed schedule, or `outputs/` artifact was touched.

<!-- evidence-head:c194168fb1834aaa66ec8c99c659c2eb50322a25 -->
<!-- evidence-row:logs -->
- [x] logs: inline above