### PR TITLE
fix(micro-continual): validate per-regime curves as exact reals in their metric domain

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -910,6 +910,34 @@ def write_micro_shard(path: Path | str, payload: dict[str, Any]) -> None:
     atomic_write_new(Path(path), encoded)
 
 
+_MICRO_CURVE_DOMAINS: dict[str, tuple[float, float | None]] = {
+    "per_regime_accuracy": (0.0, 1.0),
+    "per_regime_loss": (0.0, None),
+    "per_regime_plasticity": (0.0, 1.0),
+}
+
+
+def _validated_curve(
+    value: object,
+    *,
+    n_regimes: int,
+    lower: float,
+    upper: float | None,
+    context: str,
+) -> list[float]:
+    """Return one per-regime curve as exact finite floats inside its metric domain."""
+    if not isinstance(value, list) or len(value) != n_regimes:
+        raise ValueError(f"{context} must be a list of {n_regimes} finite real numbers")
+    curve: list[float] = []
+    for index, entry in enumerate(value):
+        number = _require_finite_real(entry, f"{context}[{index}]")
+        if number < lower or (upper is not None and number > upper):
+            domain = f"[{lower}, {upper}]" if upper is not None else f">= {lower}"
+            raise ValueError(f"{context}[{index}] must lie in {domain}, got {number!r}")
+        curve.append(number)
+    return curve
+
+
 def load_micro_shard(path: Path | str) -> dict[str, Any]:
     """Load and structurally validate one micro shard."""
     path = Path(path)
@@ -944,12 +972,14 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
             f"{path}: family {payload.get('family')!r} does not match "
             f"stream_config family {config.family!r}"
         )
-    for fieldname in ("per_regime_accuracy", "per_regime_loss", "per_regime_plasticity"):
-        values = np.asarray(payload.get(fieldname, []), dtype=np.float64)
-        if values.shape != (config.n_regimes,) or not np.all(np.isfinite(values)):
-            raise ValueError(
-                f"{path}: {fieldname} must be finite with shape ({config.n_regimes},)"
-            )
+    for fieldname, (lower, upper) in _MICRO_CURVE_DOMAINS.items():
+        payload[fieldname] = _validated_curve(
+            payload.get(fieldname),
+            n_regimes=config.n_regimes,
+            lower=lower,
+            upper=upper,
+            context=f"{path}: {fieldname}",
+        )
     payload["wall_clock_seconds"] = _validated_wall_clock_seconds(
         payload.get("wall_clock_seconds"), path
     )

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -18,6 +18,7 @@ import dataclasses
 import json
 import math
 from pathlib import Path
+from typing import Any
 
 import chex
 import jax
@@ -966,6 +967,41 @@ class TestShards:
         path.write_text(json.dumps(payload), encoding="utf-8")
         with pytest.raises(ValueError, match="per_regime_accuracy"):
             load_micro_shard(path)
+
+    @pytest.mark.parametrize(
+        ("fieldname", "mutate", "reason"),
+        [
+            ("per_regime_accuracy", lambda curve: [str(v) for v in curve], "numeric strings"),
+            ("per_regime_accuracy", lambda curve: [True] + curve[1:], "booleans"),
+            ("per_regime_accuracy", lambda curve: [5.0] + curve[1:], "accuracy above 1"),
+            ("per_regime_accuracy", lambda curve: [-0.5] + curve[1:], "negative accuracy"),
+            ("per_regime_loss", lambda curve: [-1.0] + curve[1:], "negative loss"),
+            ("per_regime_loss", lambda curve: [str(v) for v in curve], "numeric strings"),
+            ("per_regime_plasticity", lambda curve: [1.5] + curve[1:], "plasticity above 1"),
+            ("per_regime_plasticity", lambda curve: [False] + curve[1:], "booleans"),
+        ],
+    )
+    def test_load_rejects_curves_outside_their_measured_domain(
+        self, tmp_path: Path, fieldname: str, mutate: Any, reason: str
+    ):
+        """Every per-regime curve is a list of exact reals inside its metric's domain."""
+        payload = micro_shard_payload(self._result())
+        payload[fieldname] = mutate(list(payload[fieldname]))
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError, match=fieldname):
+            load_micro_shard(path)
+
+    def test_load_canonicalizes_integer_curve_entries_to_floats(self, tmp_path: Path):
+        payload = micro_shard_payload(self._result())
+        payload["per_regime_accuracy"] = [0] + list(payload["per_regime_accuracy"][1:])
+        payload["per_regime_plasticity"] = [1] + list(payload["per_regime_plasticity"][1:])
+        path = tmp_path / "ok.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        loaded = load_micro_shard(path)
+        assert loaded["per_regime_accuracy"][0] == 0.0
+        assert type(loaded["per_regime_accuracy"][0]) is float
+        assert loaded["per_regime_plasticity"][0] == 1.0
 
     @pytest.mark.parametrize(
         ("fieldname", "bad_value"),


### PR DESCRIPTION
Closes #340.

## Issue

`load_micro_shard` coerced `per_regime_accuracy` / `per_regime_loss` / `per_regime_plasticity` through `np.asarray(dtype=float64)` and checked only shape and finiteness, so numeric strings, booleans, and out-of-domain values reached the ranked summary; a shard at `5.0` accuracy topped a merge whose analytic Bayes ceiling was `0.80`.

## New state

`_validated_curve` requires each curve to be a list of exactly `n_regimes` exact finite reals (bool/str rejected via the existing `_require_finite_real`) inside its metric's domain — accuracy and plasticity in `[0, 1]`, loss `>= 0` — and canonicalizes entries to `float`. Valid shards written by `micro_shard_payload` are unchanged (their entries are already floats in range), so merges and transfer validation reproduce byte-for-byte apart from `created_unix`.

Failing-test-first: `test_load_rejects_curves_outside_their_measured_domain` (8 cases) fails on `main` and passes here; `test_load_canonicalizes_integer_curve_entries_to_floats` pins the accepted path.

## Evidence

Falsifier from #340 at this head:

```text
ValueError: …/numeric_strings.json: per_regime_accuracy[0] must be a finite real number, got '0.9'
```

Verification at `8d190cbbf5d52f10ec9cee1747ab0ada9e852c56`:

```text
.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""   -> 169 passed
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

Composes cleanly with #322 (`git merge-tree` clean). `benchmarks/micro_continual.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:8d190cbbf5d52f10ec9cee1747ab0ada9e852c56 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
