### PR TITLE
fix(step3): bound dimensions and surface refused smoke updates

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -46,6 +46,7 @@ from alberta_framework.steps._float32_validation import (
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
+_INT32_MAX = 2**31 - 1
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 Step3RoutingName = Literal["shared", "independent", "mixed"]
 
@@ -212,6 +213,8 @@ def _require_positive_int(name: str, value: object) -> int:
     number = int(value)
     if number < 1:
         raise ValueError(f"{name} must be positive, got {value!r}")
+    if number > _INT32_MAX:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
@@ -531,6 +534,8 @@ def run_step3_smoke(
     finite = bool(
         jnp.all(jnp.isfinite(result.per_demon_metrics))
         & jnp.all(jnp.isfinite(result.td_errors))
+        & jnp.all(result.updates_applied)
+        & jnp.all(result.head_updates_applied)
     )
     return Step3SmokeResult(
         config=cfg,

--- a/tests/test_step3_production.py
+++ b/tests/test_step3_production.py
@@ -15,6 +15,7 @@ import jax.random as jr
 import numpy as np
 import pytest
 
+import alberta_framework.steps.step3 as step3_module
 from alberta_framework.core.horde import run_horde_learning_loop
 from alberta_framework.steps import (
     Step3HordeConfig,
@@ -238,3 +239,37 @@ def test_step3_horde_scalars_canonicalize_nonbuiltin_reals() -> None:
     assert type(payload["sparsity"]) is float
     assert type(payload["obgd_kappa"]) is float
     assert horde.horde_spec.demons[0].gamma == 0.5
+
+
+def test_step3_horde_hidden_sizes_stay_in_int32_domain() -> None:
+    config = Step3HordeConfig(hidden_sizes=(np.int64(2**31 - 1),))
+
+    assert config.hidden_sizes == (2**31 - 1,)
+    assert type(config.hidden_sizes[0]) is int
+    with pytest.raises(ValueError, match="hidden_sizes.*int32 max"):
+        Step3HordeConfig(hidden_sizes=(2**31,))
+
+
+@pytest.mark.parametrize(
+    "rejected_field",
+    ["updates_applied", "head_updates_applied"],
+)
+def test_step3_smoke_health_gate_reports_refused_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    rejected_field: str,
+) -> None:
+    original_run = step3_module.run_horde_learning_loop
+
+    def _refuse_update(*args: Any, **kwargs: Any) -> Any:
+        result = original_run(*args, **kwargs)
+        if rejected_field == "updates_applied":
+            return result.replace(updates_applied=result.updates_applied.at[0].set(False))
+        return result.replace(
+            head_updates_applied=result.head_updates_applied.at[0, 0].set(False)
+        )
+
+    monkeypatch.setattr(step3_module, "run_horde_learning_loop", _refuse_update)
+
+    result = run_step3_smoke(steps=8, final_window=4)
+
+    assert not result.finite


### PR DESCRIPTION
Closes #339.

## Reconciled scope

PR #306 has already landed the shared exact float32 conversion and domain contracts on `main`. This branch was rebased onto that merge and now retains only the still-missing Step 3 hardening:

- reject `hidden_sizes` above signed-int32 maximum before they reach JAX shape sinks;
- require every smoke step and every requested demon update to have applied before `Step3SmokeResult.finite` can be true.

The per-demon health check is stricter than the original branch, which checked only the aggregate per-step flag and could miss a partial independent-Horde refusal. The obsolete duplicate float32 converter, serialization rewrites, tuple restrictions, and unrelated enum/bool validation were removed.

## Scope

- `alberta_framework/steps/step3.py`
- `tests/test_step3_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

- Step 3 production + shared float32 contract: 102 passed;
- focused Ruff: passed;
- strict mypy for Step 3: passed;
- `git diff --check`: clean.

## Scientific integrity

This is facade and development-smoke validation, not scientific evidence or a performance claim.

## Contribution provenance

- Initial contribution: AI-assisted, google / gemini-3.7-flash, Antigravity CLI (self-reported)
- Maintainer reconciliation: AI-assisted, OpenAI Codex