### PR TITLE
fix(retention): require distinct sentinel sets for the A and B permutations

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -299,6 +299,12 @@ class RecurringIPMNISTProtocol:
         )
         if len(set(permutation_digests)) != len(permutation_digests):
             raise ValueError("A and B must bind distinct pixel permutation digests")
+        sentinel_digests = tuple(binding.sentinel_set_sha256 for binding in self.sentinel_bindings)
+        if len(set(sentinel_digests)) != len(sentinel_digests):
+            raise ValueError("A and B must bind distinct sentinel set digests")
+        sentinel_ids = tuple(binding.sentinel_set_id for binding in self.sentinel_bindings)
+        if len(set(sentinel_ids)) != len(sentinel_ids):
+            raise ValueError("A and B must bind distinct sentinel set identities")
 
         _positive_int(self.relearning_window, name="relearning_window")
         if self.relearning_window > self.phases[0].length:

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -281,6 +281,22 @@ def test_sentinel_probes_at_different_checkpoints_must_use_distinct_frozen_state
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("sentinel_set_sha256", "A and B must bind distinct sentinel set digests"),
+        ("sentinel_set_id", "A and B must bind distinct sentinel set identities"),
+    ],
+)
+def test_protocol_rejects_a_and_b_sharing_one_sentinel_set(field: str, message: str) -> None:
+    """Distinct permutations transform the sentinel inputs, so shared sets cannot be genuine."""
+    protocol = _protocol()
+    a_binding, b_binding = protocol.sentinel_bindings
+    shared = dataclasses.replace(b_binding, **{field: getattr(a_binding, field)})
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        dataclasses.replace(protocol, sentinel_bindings=(a_binding, shared))
+
+
 def test_report_is_explicitly_threshold_free_development_only_and_nonpromoting() -> None:
     protocol = _protocol()
     report = build_recurring_ipmnist_retention_report(


### PR DESCRIPTION
Closes #343.

## Issue

`RecurringIPMNISTProtocol` required distinct permutation digests for A and B but let both bindings share one `sentinel_set_id` / `sentinel_set_sha256`, so A's pre-revisit probe could be bound to B's evaluation set while every downstream binding check passed.

## New state

`__post_init__` refuses shared sentinel set digests (`A and B must bind distinct sentinel set digests`) and shared identities (`A and B must bind distinct sentinel set identities`), next to the existing permutation-digest rule. The adapter derives distinct ids from distinct digests, so genuine protocols are unaffected.

Failing-test-first: `test_protocol_rejects_a_and_b_sharing_one_sentinel_set[sentinel_set_sha256|sentinel_set_id]` fails on `main` and passes here.

## Evidence

Falsifier from #343 at this head:

```text
ValueError: A and B must bind distinct sentinel set digests
```

Verification at `62d4dedd79540146139a3d5ec96e9b34c6efe075`:

```text
.venv/bin/python -m pytest tests/test_recurring_ipmnist_retention.py tests/test_ipmnist_recurring_adapter.py -q -o addopts=""   -> 21 passed
.venv/bin/python -m ruff check .                                                                                             -> All checks passed!
.venv/bin/python -m mypy                                                                                                     -> Success: no issues found in 165 source files
```

Rebased onto current main `e388f859212fa545d5e85f34427ab2b4c8f0f22c`, after #330. The shared test insertion conflict was resolved additively: both #330 checkpoint-state guards and this PR’s distinct A/B sentinel-binding guards are retained and pass together. `evaluation/recurring_ipmnist_retention.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:62d4dedd79540146139a3d5ec96e9b34c6efe075 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).