### PR TITLE
fix(experiments): require one configuration and unique seeds in aggregate_metrics

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -150,13 +150,22 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
         AggregatedResults with aggregated metrics
 
     Raises:
-        ValueError: If ``results`` is empty, or any metric sample is non-finite.
+        ValueError: If ``results`` is empty, mixes configuration names or seed
+            identities, drifts in metric keys, or any metric sample is
+            non-finite.
     """
     if not results:
         raise ValueError("Cannot aggregate empty results list")
 
-    config_name = results[0].config_name
+    config_names = sorted({r.config_name for r in results})
+    if len(config_names) != 1:
+        raise ValueError(
+            f"aggregate_metrics requires runs from one configuration; got {config_names}"
+        )
+    config_name = config_names[0]
     seeds = [r.seed for r in results]
+    if len(set(seeds)) != len(seeds):
+        raise ValueError(f"aggregate_metrics requires unique seed identities; got {seeds}")
 
     # Get all metric keys from first result
     if any(

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -330,6 +330,27 @@ def test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed() -> None:
         )
 
 
+def test_aggregate_metrics_rejects_runs_from_different_configs() -> None:
+    """Two arms must not be averaged into one AggregatedResults under the first arm's name."""
+    treatment = _single_run(0, [9.0, 9.0])._replace(config_name="treatment")
+    with pytest.raises(
+        ValueError,
+        match=r"^aggregate_metrics requires runs from one configuration; "
+        r"got \['candidate', 'treatment'\]$",
+    ):
+        aggregate_metrics([_single_run(0, [1.0, 1.0]), treatment])
+
+
+def test_aggregate_metrics_rejects_duplicate_seed_identities() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^aggregate_metrics requires unique seed identities; got \[0, 1, 0\]$",
+    ):
+        aggregate_metrics(
+            [_single_run(0, [1.0, 1.0]), _single_run(1, [2.0, 2.0]), _single_run(0, [3.0, 3.0])]
+        )
+
+
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:
     poisoned = _two_seed_trace()
     poisoned.metric_arrays["squared_error"][0, 1] = np.inf


### PR DESCRIPTION
Closes #345.

## Issue

`aggregate_metrics` took the first run's `config_name` and the raw seed list, so runs from two arms (or the same seed twice) were averaged into one `AggregatedResults` labelled with the first arm and `n_seeds` counting the duplicates: `baseline [0, 1, 2, 0, 1, 2] n_seeds=6 mean=5.0` for a 1.0 baseline and a 9.0 treatment.

## New state

`aggregate_metrics` refuses mixed configuration names (`aggregate_metrics requires runs from one configuration; got ['candidate', 'treatment']`) and repeated seed identities (`… requires unique seed identities; got [0, 1, 0]`) before building the artifact — the same invariants `run_multi_seed_experiment` already enforces one layer up (#25/#27). Well-formed inputs are unchanged.

Failing-test-first: `test_aggregate_metrics_rejects_runs_from_different_configs` and `test_aggregate_metrics_rejects_duplicate_seed_identities` fail on `main` and pass here.

## Evidence

Falsifier from #345 at this head:

```text
ValueError: aggregate_metrics requires runs from one configuration; got ['baseline', 'treatment']
```

Verification at `324798112f725763434ae521b2d30314d5cd5e57`:

```text
.venv/bin/python -m pytest tests/test_experiments_validation.py tests/test_statistics_validation.py tests/test_utils_smoke.py -q -o addopts=""   -> 152 passed
.venv/bin/python -m ruff check .                                                                                            -> All checks passed!
.venv/bin/python -m mypy                                                                                                    -> Success: no issues found in 164 source files
```

`utils/experiments.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:324798112f725763434ae521b2d30314d5cd5e57 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
