### PR TITLE
fix(step6): reject bool and non-integral smoke dimensions

### DIFF
--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -236,10 +236,8 @@ def run_step6_smoke(
     seed: int = 0,
 ) -> Step6SmokeResult:
     """Run a tiny deterministic Step 6 integration probe."""
-    if steps < 1:
-        raise ValueError("steps must be positive")
-    if feature_dim < 1:
-        raise ValueError("feature_dim must be positive")
+    steps = _require_int("steps", steps, minimum=1)
+    feature_dim = _require_int("feature_dim", feature_dim, minimum=1)
 
     cfg = config or Step6DifferentialSARSAConfig()
     agent = make_step6_differential_sarsa_agent(cfg)

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -260,6 +260,15 @@ def test_step6_facade_config_roundtrip_one_step_and_smoke() -> None:
     assert smoke.agent_config["type"] == "DifferentialSARSAAgent"
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("steps", True), ("steps", 1.5), ("feature_dim", False), ("feature_dim", 1.5)),
+)
+def test_step6_smoke_rejects_non_integral_dimensions(field: str, value: Any) -> None:
+    with pytest.raises(ValueError, match=field):
+        run_step6_smoke(**{field: value})
+
+
 _INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_actions", 0),
     ("n_actions", -1),


### PR DESCRIPTION
Closes #347.

## What changed

`run_step6_smoke` validated `steps` and `feature_dim` with plain `< 1` comparisons. Because Python's `bool` is an `int` subclass, `steps=True`/`feature_dim=True` (`== 1`) pass the check and are silently accepted as valid dimensions instead of being rejected as a type error. Non-integral values such as `1.5` also pass the `< 1` check and reach JAX shape construction, which raises a lower-level `TypeError` (`Shapes must be 1D sequences of concrete values of integer type...`) instead of the facade's documented `ValueError` contract — an invalid smoke probe could silently run one transition with `steps=True`, or fail nondeterministically at a lower layer with an unhelpful error for a non-integral input.

confirmed directly before touching the source:

```text
{'steps': True} ACCEPTED True (1, 2)
{'steps': 1.5} TypeError Shapes must be 1D sequences of concrete values of integer type, got (2.5, 6).
{'feature_dim': True} ACCEPTED 32 (32, 2)
{'feature_dim': 1.5} TypeError Shapes must be 1D sequences of concrete values of integer type, got (33, 1.5).
```

fix: canonicalize both arguments through the file's existing strict `_require_int(..., minimum=1)` helper — already used elsewhere in this same file for `n_actions`, `epsilon_decay_steps` — which correctly rejects `bool` (`isinstance(value, bool)` check first) and non-`Integral` values before they ever reach JAX, raising a proper `ValueError` naming the offending field.

## Reachability

`run_step6_smoke` is exported by `alberta_framework.steps.__init__` and re-exported by the package-root `alberta_framework.__init__` — confirmed both directly, a real public entry point, not an internal-only helper.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_step5_step6_production.py -q -o addopts=""
145 passed in 9.71s

$ .venv/bin/python -m ruff check alberta_framework/steps/step6.py tests/test_step5_step6_production.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 164 source files
```

New test: `test_step6_smoke_rejects_non_integral_dimensions`, parametrized over `(steps, True)`, `(steps, 1.5)`, `(feature_dim, False)`, `(feature_dim, 1.5)`, asserting each raises `ValueError` naming the offending field.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/steps/step6.py`, kept the test), reran — 3/4 parametrized cases failed (the `steps=True` case silently accepted instead of raising, and both `1.5` cases leaked the raw JAX `TypeError` instead of `ValueError`), reproducing the exact bug described above. restored the fix, 145/145 green again.

## Evidence

<!-- evidence-head -->
440f35c8ffd88a2d6c511e1acbe85236681349c7

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_step5_step6_production.py -q -o addopts="" -k test_step6_smoke_rejects_non_integral_dimensions
FAILED [steps-True] - Failed: DID NOT RAISE ValueError
FAILED [steps-1.5] - TypeError: Shapes must be 1D sequences of concrete values of integer type...
FAILED [feature_dim-1.5] - TypeError: Shapes must be 1D sequences of concrete values of integer type...
3 failed, 1 passed, 141 deselected in 1.17s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_step5_step6_production.py -q -o addopts=""
145 passed in 9.71s
```

<!-- evidence-row:domain-artifact -->
```text
{'steps': True} ACCEPTED True (1, 2)
{'steps': 1.5} TypeError Shapes must be 1D sequences of concrete values of integer type, got (2.5, 6).
{'feature_dim': True} ACCEPTED 32 (32, 2)
{'feature_dim': 1.5} TypeError Shapes must be 1D sequences of concrete values of integer type, got (33, 1.5).
```
independently reran the focused suite, ruff, and mypy myself; independently confirmed the export chain (`alberta_framework.steps.__init__` and package-root `alberta_framework.__init__`) before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full test file, ruff, and mypy myself, independently confirmed the export chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
