### PR TITLE
fix(step4): bound SARSA dimensions to int32 sinks

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -53,6 +53,7 @@ from alberta_framework.steps._float32_validation import (
 
 Step4OptimizerName = Literal["lms", "idbd", "autostep"]
 Step4BounderName = Literal["none", "obgd"]
+_INT32_MAX = 2**31 - 1
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 
 
@@ -176,6 +177,8 @@ def _require_positive_int(name: str, value: object) -> int:
     number = int(value)
     if number < 1:
         raise ValueError(f"{name} must be positive, got {value!r}")
+    if number > _INT32_MAX:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
@@ -185,6 +188,8 @@ def _require_nonneg_int(name: str, value: object) -> int:
     number = int(value)
     if number < 0:
         raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    if number > _INT32_MAX:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -69,9 +69,12 @@ _INVALID_STEP4_SCALARS: tuple[tuple[str, Any], ...] = (
     ("epsilon_decay_steps", False),
     ("epsilon_decay_steps", -1),
     ("epsilon_decay_steps", 1.5),
+    ("epsilon_decay_steps", 2**31),
     ("n_actions", True),
+    ("n_actions", 2**31),
     ("hidden_sizes", (0,)),
     ("hidden_sizes", (True,)),
+    ("hidden_sizes", (2**31,)),
 )
 
 
@@ -284,3 +287,18 @@ def test_step4_sarsa_scalars_canonicalize_nonbuiltin_reals() -> None:
     assert type(payload["epsilon_decay_steps"]) is int
     assert type(payload["hidden_sizes"][0]) is int
     assert agent.to_config()["type"] == "SARSAAgent"
+
+
+def test_step4_sarsa_dimensions_preserve_int32_maximum() -> None:
+    config = Step4SARSAConfig(
+        n_actions=np.int64(2**31 - 1),
+        epsilon_decay_steps=np.int64(2**31 - 1),
+        hidden_sizes=(np.int64(2**31 - 1),),
+    )
+
+    assert config.n_actions == 2**31 - 1
+    assert config.epsilon_decay_steps == 2**31 - 1
+    assert config.hidden_sizes == (2**31 - 1,)
+    assert type(config.n_actions) is int
+    assert type(config.epsilon_decay_steps) is int
+    assert type(config.hidden_sizes[0]) is int


### PR DESCRIPTION
Closes #349.

## Reconciled scope

PR #306 has already landed the shared exact float32 conversion and domain contracts on `main`. This branch was rebased onto that merge and now retains only the still-missing Step 4 hardening:

- reject `n_actions`, `epsilon_decay_steps`, and `hidden_sizes` above signed-int32 maximum before they reach JAX action, counter, and shape sinks;
- preserve and canonicalize the legal signed-int32 maximum for built-in and NumPy integral inputs.

The obsolete duplicate float32 converter, serialization rewrites, tuple restrictions, and unrelated enum/bool validation were removed.

## Scope

- `alberta_framework/steps/step4.py`
- `tests/test_step4_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

- Step 4 production + shared float32 contract: 119 passed;
- focused Ruff: passed;
- strict mypy for Step 4: passed;
- `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

- Initial contribution: AI-assisted, google / gemini-3.7-flash, Antigravity CLI (self-reported)
- Maintainer reconciliation: AI-assisted, OpenAI Codex