### PR TITLE
fix(step7): reject illegal Dyna facade config

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -121,6 +121,13 @@ class Step7DynaConfig:
         payload = asdict(self)
         payload["control"] = self.control.to_dict()
         payload["world_model"] = self.world_model.to_dict()
+        payload["planning_steps"] = int(self.planning_steps)
+        payload["planning_rollout_depth"] = int(self.planning_rollout_depth)
+        payload["planning_warmup_steps"] = int(self.planning_warmup_steps)
+        payload["planning_memory_size"] = int(self.planning_memory_size)
+        payload["planning_importance_ratio_clip"] = float(self.planning_importance_ratio_clip)
+        payload["planning_priority_propagation"] = float(self.planning_priority_propagation)
+        payload["planning_utility_step_size"] = float(self.planning_utility_step_size)
         return payload
 
     @classmethod
@@ -134,6 +141,9 @@ class Step7DynaConfig:
             cast(dict[str, object], data["world_model"])
         )
         return cls(**cast(Any, data))
+
+
+_INT32_MAX = 2**31 - 1
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
@@ -164,35 +174,52 @@ def _require_unit_interval(name: str, value: object) -> float:
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_planning_config(config: Step7DynaConfig) -> None:
-    planning_steps = _require_int("planning_steps", config.planning_steps, minimum=0)
+    planning_steps = _require_int(
+        "planning_steps",
+        config.planning_steps,
+        minimum=0,
+        maximum=_INT32_MAX,
+    )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",
         config.planning_warmup_steps,
         minimum=0,
+        maximum=_INT32_MAX,
     )
     planning_memory_size = _require_int(
         "planning_memory_size",
         config.planning_memory_size,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     importance_clip = _require_positive_real(
         "planning_importance_ratio_clip",
@@ -206,7 +233,17 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_utility_step_size",
         config.planning_utility_step_size,
     )
-    if config.planning_strategy not in (
+    if type(config.planning_apply_importance_correction) is not bool:
+        raise TypeError(
+            f"planning_apply_importance_correction must be a bool, got "
+            f"{config.planning_apply_importance_correction!r}"
+        )
+    strategy = config.planning_strategy
+    if type(strategy) is not str:
+        raise TypeError(
+            f"planning_strategy must be an actual string, got {strategy!r}"
+        )
+    if strategy not in (
         "random",
         "reward",
         "surprise",
@@ -218,6 +255,7 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
             "planning_strategy must be random, reward, surprise, predecessor, "
             "prioritized, or learned"
         )
+    canonical_strategy = str(strategy)
     if config.world_model.n_actions != config.control.n_actions:
         raise ValueError("world_model.n_actions must equal control.n_actions")
     object.__setattr__(config, "planning_steps", planning_steps)
@@ -227,6 +265,12 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     object.__setattr__(config, "planning_importance_ratio_clip", importance_clip)
     object.__setattr__(config, "planning_priority_propagation", propagation)
     object.__setattr__(config, "planning_utility_step_size", utility_step)
+    object.__setattr__(
+        config,
+        "planning_apply_importance_correction",
+        bool(config.planning_apply_importance_correction),
+    )
+    object.__setattr__(config, "planning_strategy", canonical_strategy)
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -9,6 +9,7 @@ pass after the facade rejects them. Legal endpoints stay constructible.
 from __future__ import annotations
 
 import json
+from fractions import Fraction
 from typing import Any
 
 import chex
@@ -47,6 +48,7 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_steps", 1.5),
     ("planning_steps", "1"),
     ("planning_steps", None),
+    ("planning_steps", 2**31),
     ("planning_rollout_depth", True),
     ("planning_rollout_depth", False),
     ("planning_rollout_depth", 0),
@@ -54,12 +56,14 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_rollout_depth", 1.5),
     ("planning_rollout_depth", "1"),
     ("planning_rollout_depth", None),
+    ("planning_rollout_depth", 2**31),
     ("planning_warmup_steps", True),
     ("planning_warmup_steps", False),
     ("planning_warmup_steps", -1),
     ("planning_warmup_steps", 1.5),
     ("planning_warmup_steps", "1"),
     ("planning_warmup_steps", None),
+    ("planning_warmup_steps", 2**31),
     ("planning_memory_size", True),
     ("planning_memory_size", False),
     ("planning_memory_size", 0),
@@ -67,6 +71,7 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_memory_size", 1.5),
     ("planning_memory_size", "1"),
     ("planning_memory_size", None),
+    ("planning_memory_size", 2**31),
     ("planning_importance_ratio_clip", float("nan")),
     ("planning_importance_ratio_clip", float("inf")),
     ("planning_importance_ratio_clip", float("-inf")),
@@ -76,6 +81,8 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_importance_ratio_clip", -1.0),
     ("planning_importance_ratio_clip", "10"),
     ("planning_importance_ratio_clip", None),
+    ("planning_importance_ratio_clip", 1e100),
+    ("planning_importance_ratio_clip", 1e-50),
     ("planning_priority_propagation", float("nan")),
     ("planning_priority_propagation", float("inf")),
     ("planning_priority_propagation", float("-inf")),
@@ -84,6 +91,7 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_priority_propagation", -0.1),
     ("planning_priority_propagation", "1"),
     ("planning_priority_propagation", None),
+    ("planning_priority_propagation", 1e100),
     ("planning_utility_step_size", float("nan")),
     ("planning_utility_step_size", float("inf")),
     ("planning_utility_step_size", float("-inf")),
@@ -93,6 +101,7 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_utility_step_size", 1.1),
     ("planning_utility_step_size", "0.2"),
     ("planning_utility_step_size", None),
+    ("planning_utility_step_size", 1e100),
 )
 
 
@@ -577,3 +586,129 @@ class TestScorePlanningActions:
             jnp.mean((prediction.next_observation - anchor) ** 2)
         )
         assert float(score) == pytest.approx(float(expected), rel=1e-6)
+
+
+def test_step7_dyna_rejects_float32_underflow_for_positive_fields() -> None:
+    with pytest.raises(ValueError, match="planning_importance_ratio_clip"):
+        Step7DynaConfig(planning_importance_ratio_clip=1e-50)
+    with pytest.raises(ValueError, match="planning_importance_ratio_clip"):
+        Step7DynaConfig(planning_importance_ratio_clip=1e-46)
+
+
+def test_step7_dyna_rejects_float32_overflow() -> None:
+    with pytest.raises(ValueError, match="planning_importance_ratio_clip"):
+        Step7DynaConfig(planning_importance_ratio_clip=1e100)
+    with pytest.raises(ValueError, match="planning_priority_propagation"):
+        Step7DynaConfig(planning_priority_propagation=1e100)
+    with pytest.raises(ValueError, match="planning_utility_step_size"):
+        Step7DynaConfig(planning_utility_step_size=1e100)
+
+
+def test_step7_dyna_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    config = Step7DynaConfig(
+        planning_steps=2**31 - 1,
+        planning_rollout_depth=2**31 - 1,
+        planning_warmup_steps=2**31 - 1,
+        planning_memory_size=2**31 - 1,
+        planning_importance_ratio_clip=f32_max,
+        planning_priority_propagation=f32_max,
+        planning_utility_step_size=1.0,
+    )
+    assert config.planning_steps == 2**31 - 1
+    assert config.planning_rollout_depth == 2**31 - 1
+    assert config.planning_warmup_steps == 2**31 - 1
+    assert config.planning_memory_size == 2**31 - 1
+    assert config.planning_importance_ratio_clip == f32_max
+    assert config.planning_priority_propagation == f32_max
+    assert config.planning_utility_step_size == 1.0
+
+
+def test_step7_dyna_exact_fraction_rounding() -> None:
+    midpoint = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    config = Step7DynaConfig(
+        planning_importance_ratio_clip=midpoint,
+        planning_priority_propagation=midpoint,
+        planning_utility_step_size=Fraction(1, 4),
+    )
+    expected_f32 = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert config.planning_importance_ratio_clip == expected_f32
+    assert config.planning_priority_propagation == expected_f32
+    assert config.planning_utility_step_size == 0.25
+
+
+def test_step7_dyna_rejects_equality_spoofed_strategy() -> None:
+    class SpoofedStrategy:
+        def __eq__(self, other: object) -> bool:
+            return True
+
+        def __hash__(self) -> int:
+            return hash("random")
+
+    with pytest.raises(TypeError, match="planning_strategy"):
+        Step7DynaConfig(planning_strategy=SpoofedStrategy())  # type: ignore[arg-type]
+
+
+def test_step7_dyna_rejects_non_bool_importance_correction() -> None:
+    class SpoofedBool:
+        @property
+        def __class__(self) -> type[bool]:
+            return bool
+
+        def __bool__(self) -> bool:
+            return True
+
+    with pytest.raises(TypeError, match="planning_apply_importance_correction"):
+        Step7DynaConfig(planning_apply_importance_correction=SpoofedBool())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="planning_apply_importance_correction"):
+        Step7DynaConfig(planning_apply_importance_correction=1)  # type: ignore[arg-type]
+
+
+def test_step7_dyna_rejects_spoofed_int_class_and_adversarial_ratios() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="planning_importance_ratio_clip"):
+        Step7DynaConfig(planning_importance_ratio_clip=SpoofedIntFloat(0.5))
+
+    with pytest.raises(ValueError, match="planning_priority_propagation"):
+        Step7DynaConfig(planning_priority_propagation=SpoofedIntFloat(0.5))
+
+    with pytest.raises(ValueError, match="planning_utility_step_size"):
+        Step7DynaConfig(planning_utility_step_size=SpoofedIntFloat(0.5))
+
+
+def test_step7_dyna_json_roundtrip() -> None:
+    config = Step7DynaConfig(
+        planning_steps=5,
+        planning_rollout_depth=2,
+        planning_warmup_steps=10,
+        planning_memory_size=128,
+        planning_strategy="prioritized",
+        planning_importance_ratio_clip=5.0,
+        planning_apply_importance_correction=False,
+        planning_priority_propagation=0.8,
+        planning_utility_step_size=0.1,
+    )
+    serialized = config.to_dict()
+    json_str = json.dumps(serialized)
+    deserialized = json.loads(json_str)
+    restored = Step7DynaConfig.from_dict(deserialized)
+
+    assert restored.planning_steps == config.planning_steps
+    assert restored.planning_rollout_depth == config.planning_rollout_depth
+    assert restored.planning_warmup_steps == config.planning_warmup_steps
+    assert restored.planning_memory_size == config.planning_memory_size
+    assert restored.planning_strategy == config.planning_strategy
+    assert restored.planning_importance_ratio_clip == config.planning_importance_ratio_clip
+    assert (
+        restored.planning_apply_importance_correction
+        == config.planning_apply_importance_correction
+    )
+    assert restored.planning_priority_propagation == config.planning_priority_propagation
+    assert restored.planning_utility_step_size == config.planning_utility_step_size


### PR DESCRIPTION
Closes #351.

## What changed

`Step7DynaConfig` now validates every scientific scalar and dimension before constructing Dyna planning components. Float32 execution values use the shared exact-ratio `round_real_to_float32` helper, preventing binary64 double rounding for `Fraction` and extended-precision inputs.

Exact float32 overflow is rejected across `planning_importance_ratio_clip`, `planning_priority_propagation`, `planning_utility_step_size`; legal zero/one endpoints remain valid; and strictly positive `planning_importance_ratio_clip` that collapses to zero is rejected. Planning step counts, rollout depth, warmup steps, and replay memory size are bounded to signed int32 max (`2**31 - 1`).

## Scope

• `alberta_framework/steps/step7.py`
• `tests/test_step7_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 7 production suite: 103 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported