### PR TITLE
fix(statistics): reject non-finite samples in every comparison test

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -219,11 +219,14 @@ def cohens_d(
         variance have a signed-infinite standardized difference.
 
     Raises:
-        ValueError: If either group is empty or the pooled degrees of freedom
+        ValueError: If either group is not a finite one-dimensional sample
+            vector, is empty, or the pooled degrees of freedom
             ``n_a + n_b - 2`` are not positive.
     """
     a = _require_sample_vector(values_a, name="values_a")
     b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
 
     n_a = len(a)
     n_b = len(b)
@@ -287,6 +290,8 @@ def ttest_comparison(
     """
     a = _require_sample_vector(values_a, name="values_a")
     b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
 
     if paired:
         if len(a) != len(b):
@@ -363,6 +368,8 @@ def mann_whitney_comparison(
     """
     a = _require_sample_vector(values_a, name="values_a")
     b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
 
     if len(a) == 0 or len(b) == 0:
         raise ValueError(
@@ -431,6 +438,8 @@ def wilcoxon_comparison(
     """
     a = _require_sample_vector(values_a, name="values_a")
     b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
 
     if len(a) != len(b):
         raise ValueError(

--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -75,6 +75,22 @@ def _require_finite_values(values: NDArray[np.floating], *, name: str) -> None:
         raise ValueError(f"{name} must be finite")
 
 
+def _require_sample_vector(values: object, *, name: str) -> NDArray[np.float64]:
+    """Return ``values`` as a rank-1 array: exactly one sample per seed.
+
+    A ``(n_seeds, n_steps)`` matrix would otherwise be flattened by the
+    spread estimators while ``n_seeds`` still reported the row count.
+    """
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(
+            f"{name} must be a one-dimensional sample vector (one value per seed), "
+            f"got shape {arr.shape}; reduce per seed first or use "
+            "compute_timeseries_statistics"
+        )
+    return arr
+
+
 def compute_statistics(
     values: NDArray[np.float64] | list[float],
     confidence_level: float = 0.95,
@@ -92,7 +108,7 @@ def compute_statistics(
         ValueError: If values is empty, any sample is non-finite, or
             ``confidence_level`` is not strictly between 0 and 1.
     """
-    arr = np.asarray(values)
+    arr = _require_sample_vector(values, name="values")
     n = len(arr)
     if n == 0:
         raise ValueError("values must be non-empty")
@@ -206,8 +222,8 @@ def cohens_d(
         ValueError: If either group is empty or the pooled degrees of freedom
             ``n_a + n_b - 2`` are not positive.
     """
-    a = np.asarray(values_a)
-    b = np.asarray(values_b)
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
 
     n_a = len(a)
     n_b = len(b)
@@ -269,8 +285,8 @@ def ttest_comparison(
             empty or the two unpaired groups have no positive pooled degrees
             of freedom.
     """
-    a = np.asarray(values_a)
-    b = np.asarray(values_b)
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
 
     if paired:
         if len(a) != len(b):
@@ -345,8 +361,8 @@ def mann_whitney_comparison(
     Raises:
         ValueError: If either sample is empty.
     """
-    a = np.asarray(values_a)
-    b = np.asarray(values_b)
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
 
     if len(a) == 0 or len(b) == 0:
         raise ValueError(
@@ -413,8 +429,8 @@ def wilcoxon_comparison(
             pairs, or are identical, for which the Wilcoxon signed-rank
             statistic is undefined.
     """
-    a = np.asarray(values_a)
-    b = np.asarray(values_b)
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
 
     if len(a) != len(b):
         raise ValueError(
@@ -678,7 +694,7 @@ def bootstrap_ci(
             ``statistic`` is not ``"mean"`` or ``"median"``, ``confidence_level``
             is not strictly between 0 and 1, or ``n_bootstrap`` is not positive.
     """
-    arr = np.asarray(values)
+    arr = _require_sample_vector(values, name="values")
     if len(arr) == 0:
         raise ValueError(
             "bootstrap_ci requires at least one value; got an empty array "

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -190,6 +190,42 @@ class TestSampleVectorContract:
             bootstrap_ci(np.asarray(4.2), n_bootstrap=10)
 
 
+class TestComparisonsRejectNonFiniteSamples:
+    """A poisoned seed must raise, not become p=nan / significant=False."""
+
+    @pytest.mark.parametrize("poison", [float("nan"), float("inf"), float("-inf")])
+    @pytest.mark.parametrize(
+        "comparison",
+        [
+            lambda a, b: ttest_comparison(a, b, paired=False),
+            lambda a, b: ttest_comparison(a, b, paired=True),
+            mann_whitney_comparison,
+            wilcoxon_comparison,
+            cohens_d,
+        ],
+        ids=["ttest", "paired-ttest", "mann_whitney", "wilcoxon", "cohens_d"],
+    )
+    def test_nonfinite_sample_rejected_without_warnings(
+        self, comparison: Any, poison: float
+    ) -> None:
+        clean = np.asarray([1.0, 2.0, 3.0, 4.5])
+        poisoned = np.asarray([2.0, poison, 3.0, 5.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=r"^values_b must be finite$"):
+                comparison(clean, poisoned)
+            with pytest.raises(ValueError, match=r"^values_a must be finite$"):
+                comparison(poisoned, clean)
+
+    def test_pairwise_comparisons_rejects_a_poisoned_seed(self) -> None:
+        a = _make_seeded_aggregated("a", [0, 1, 2], [0.0, 1.0, 2.0])
+        b = _make_seeded_aggregated("b", [0, 1, 2], [1.0, float("nan"), 3.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="must be finite"):
+                pairwise_comparisons({"a": a, "b": b}, test="ttest", window=1)
+
+
 class TestTimeseriesStatistics:
     def test_matches_per_column_compute_statistics(self) -> None:
         """Vectorised timeseries CI agrees with per-step scalar CI."""

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -27,6 +27,7 @@ Calibration (measured on this machine, scripts in the session scratchpad):
 """
 
 import warnings
+from typing import Any
 
 import numpy as np
 import pytest
@@ -129,6 +130,64 @@ class TestComputeStatistics:
             warnings.simplefilter("error")
             with pytest.raises(ValueError, match="confidence_level.*strictly between 0 and 1"):
                 compute_statistics([4.2], confidence_level=confidence_level)
+
+
+class TestSampleVectorContract:
+    """Every per-seed sample surface takes exactly one value per seed."""
+
+    _MATRIX = np.tile(np.arange(1.0, 6.0), (3, 1))  # (n_seeds=3, n_steps=5), rows identical
+
+    def test_compute_statistics_rejects_a_seed_by_step_matrix(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError,
+                match=r"^values must be a one-dimensional sample vector \(one value per seed\), "
+                r"got shape \(3, 5\); reduce per seed first or use "
+                r"compute_timeseries_statistics$",
+            ):
+                compute_statistics(self._MATRIX)
+
+    def test_bootstrap_ci_rejects_a_seed_by_step_matrix(self) -> None:
+        with pytest.raises(ValueError, match="values must be a one-dimensional sample vector"):
+            bootstrap_ci(self._MATRIX, n_bootstrap=10)
+
+    def test_cohens_d_rejects_seed_by_step_matrices(self) -> None:
+        with pytest.raises(
+            ValueError, match="values_a must be a one-dimensional sample vector"
+        ):
+            cohens_d(self._MATRIX, np.arange(1.0, 6.0))
+        with pytest.raises(
+            ValueError, match="values_b must be a one-dimensional sample vector"
+        ):
+            cohens_d(np.arange(1.0, 6.0), self._MATRIX)
+
+    @pytest.mark.parametrize(
+        "comparison",
+        [
+            lambda a, b: ttest_comparison(a, b),
+            lambda a, b: ttest_comparison(a, b, paired=True),
+            mann_whitney_comparison,
+            wilcoxon_comparison,
+        ],
+        ids=["ttest", "paired-ttest", "mann_whitney", "wilcoxon"],
+    )
+    def test_comparisons_reject_seed_by_step_matrices(self, comparison: Any) -> None:
+        vector = np.arange(1.0, 6.0) + 0.5
+        with pytest.raises(
+            ValueError, match="values_a must be a one-dimensional sample vector"
+        ):
+            comparison(self._MATRIX, vector)
+        with pytest.raises(
+            ValueError, match="values_b must be a one-dimensional sample vector"
+        ):
+            comparison(vector, self._MATRIX)
+
+    def test_scalar_and_zero_dimensional_inputs_are_rejected(self) -> None:
+        with pytest.raises(ValueError, match="values must be a one-dimensional sample vector"):
+            compute_statistics(np.asarray(4.2))
+        with pytest.raises(ValueError, match="values must be a one-dimensional sample vector"):
+            bootstrap_ci(np.asarray(4.2), n_bootstrap=10)
 
 
 class TestTimeseriesStatistics:


### PR DESCRIPTION
Closes #353. Stacked on #338 (`fix/statistics-sample-vectors`): the first commit here is #338's; only `4a3d69b` is new. Rebases to a one-commit diff once #338 lands.

## Issue

`ttest_comparison`, `mann_whitney_comparison`, `wilcoxon_comparison`, and `cohens_d` forwarded NaN/inf samples to SciPy and published `statistic=nan, p_value=nan, significant=False`, so a poisoned seed read as an honest non-result on the surface that decides A/B verdicts, while every summary helper already raised.

## New state

Each of the four functions requires finite samples right after the sample-vector check (`values_a must be finite` / `values_b must be finite`), so `pairwise_comparisons` now raises on a poisoned seed instead of returning `p=nan`. Finite inputs are unchanged.

Failing-test-first: `TestComparisonsRejectNonFiniteSamples` (15 cases across the four functions × nan/±inf, under `-W error`) and `test_pairwise_comparisons_rejects_a_poisoned_seed` fail on `main` and pass here.

## Evidence

Falsifier from #353 at this head:

```text
ValueError: values_a must be finite
```

Verification at `4a3d69b6478ecbd7628d013cdb14a8990c5a3dda`:

```text
.venv/bin/python -m pytest tests/test_statistics_validation.py tests/test_experiments_validation.py tests/test_utils_smoke.py tests/test_forager_matched_statistics.py -q -o addopts=""   -> 219 passed
.venv/bin/python -m ruff check .                                                              -> All checks passed!
.venv/bin/python -m mypy                                                                      -> Success: no issues found in 164 source files
```

`utils/statistics.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:4a3d69b6478ecbd7628d013cdb14a8990c5a3dda -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
