### PR TITLE
fix(step11): reject non-integer smoke steps

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -463,8 +463,7 @@ def run_step11_smoke(
     Returns:
         :class:`Step11SmokeResult` with shape/fineness summary.
     """
-    if steps < 1:
-        raise ValueError("steps must be positive")
+    steps = _require_int("steps", steps, minimum=1)
 
     cfg = config
     if cfg is None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1028,6 +1028,12 @@ def test_run_step11_smoke_zero_steps_raises() -> None:
         run_step11_smoke(steps=0)
 
 
+@pytest.mark.parametrize("steps", [True, 1.5])
+def test_run_step11_smoke_rejects_non_integer_steps(steps: object) -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step11_smoke(steps=steps)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # Long-horizon fineness
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #355.

## What changed

Same pattern as #347/#348: `run_step11_smoke` validated `steps` with a plain `steps < 1` comparison instead of the file's own strict `_require_int(..., minimum=1)` helper — already used extensively elsewhere in this module (`observation_dim`, `n_primitive_actions`, `option_planning_backups_per_step`, `feature_index`). `steps=True` (an `int` subclass, `== 1`) is silently accepted as one transition; `steps=1.5` passes the `< 1` check and reaches JAX shape construction, raising a raw `TypeError` instead of the facade's documented `ValueError`.

confirmed directly before touching the source:

```text
steps=True: ACCEPTED; result.steps=True; primitive_actions_shape=(1,)
steps=1.5: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (2.5, 4).
```

fix: route `steps` through the existing `_require_int("steps", steps, minimum=1)` helper, matching every other validated field in this module.

## Reachability

`run_step11_smoke` is in `step11.py`'s own `__all__`, imported and re-exported by `alberta_framework/steps/__init__.py`'s `__all__` — confirmed directly. Publicly reachable as `alberta_framework.steps.run_step11_smoke`, no hardcoded-safe wrapper between caller and validation. Not re-exported from the package root and has no console entry point.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_step11_production.py -q -o addopts="" -k test_run_step11_smoke
6 passed, 168 deselected in 6.14s

$ .venv/bin/python -m ruff check alberta_framework/steps/step11.py tests/test_step11_production.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 164 source files
```

New test: `test_run_step11_smoke_rejects_non_integer_steps`, parametrized over `True` and `1.5`, asserting `ValueError` matching `"steps must be an integer"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/steps/step11.py`, kept the test), reran — both cases failed (`True` silently accepted instead of raising; `1.5` leaked the raw JAX `TypeError`), reproducing the exact bug described above. restored the fix, green again.

**Note on pre-existing unrelated failures:** the touched test file's full suite has two pre-existing failures (`test_step11_oak_validates_original_real_domain_before_narrowing`, `test_step11_oak_narrows_the_original_real_once`) — both are platform-specific `np.longdouble`-precision assumptions unrelated to this change. Independently confirmed both fail identically on an unmodified `origin/main` checkout (via `git stash`, rerunning against the pre-existing source) before writing this PR, so they're pre-existing, not introduced by this fix.

## Evidence

<!-- evidence-head -->
0f6b631cf27f25712225a50cee45185265218fa6

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_step11_production.py -q -o addopts="" -k test_run_step11_smoke_rejects_non_integer_steps
FAILED [True] - Failed: DID NOT RAISE ValueError
FAILED [1.5] - TypeError: Shapes must be 1D sequences of concrete values of integer type...
2 failed, 172 deselected in 2.51s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_step11_production.py -q -o addopts="" -k test_run_step11_smoke
6 passed, 168 deselected in 5.83s
```

<!-- evidence-row:domain-artifact -->
```text
steps=True: ACCEPTED; result.steps=True; primitive_actions_shape=(1,)
steps=1.5: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (2.5, 4).
```
independently reran the focused suite, ruff, and mypy myself; independently confirmed the two pre-existing unrelated failures reproduce identically on an unmodified checkout before attributing them as pre-existing; independently confirmed the export chain before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, ruff, and mypy myself, independently confirmed the pre-existing failures are unrelated by reproducing them on an unmodified checkout, verified the export chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
