### PR TITLE
fix(experiments): refuse non-injective hyperparameter extractors

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -419,10 +419,24 @@ def extract_hyperparameter_results(
 
     Returns:
         Dictionary mapping param value to (mean, std) tuple
+
+    Raises:
+        ValueError: If ``param_extractor`` maps more than one configuration to
+            the same value; a sensitivity curve built from a silently
+            truncated, insertion-order-dependent subset is not a measurement.
     """
     performance = get_final_performance(results, metric)
 
     if param_extractor is None:
         return {k: v for k, v in performance.items()}
 
-    return {param_extractor(name): perf for name, perf in performance.items()}
+    names_by_value: dict[Any, list[str]] = {}
+    for name in performance:
+        names_by_value.setdefault(param_extractor(name), []).append(name)
+    collisions = {value: names for value, names in names_by_value.items() if len(names) > 1}
+    if collisions:
+        described = "; ".join(f"{value!r} <- {names}" for value, names in collisions.items())
+        raise ValueError(
+            f"param_extractor maps several configurations to one value: {described}"
+        )
+    return {value: performance[names[0]] for value, names in names_by_value.items()}

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -150,13 +150,22 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
         AggregatedResults with aggregated metrics
 
     Raises:
-        ValueError: If ``results`` is empty, or any metric sample is non-finite.
+        ValueError: If ``results`` is empty, mixes configuration names or seed
+            identities, drifts in metric keys, or any metric sample is
+            non-finite.
     """
     if not results:
         raise ValueError("Cannot aggregate empty results list")
 
-    config_name = results[0].config_name
+    config_names = sorted({r.config_name for r in results})
+    if len(config_names) != 1:
+        raise ValueError(
+            f"aggregate_metrics requires runs from one configuration; got {config_names}"
+        )
+    config_name = config_names[0]
     seeds = [r.seed for r in results]
+    if len(set(seeds)) != len(seeds):
+        raise ValueError(f"aggregate_metrics requires unique seed identities; got {seeds}")
 
     # Get all metric keys from first result
     if any(

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -330,6 +330,27 @@ def test_aggregate_metrics_rejects_metric_schema_drift_in_later_seed() -> None:
         )
 
 
+def test_aggregate_metrics_rejects_runs_from_different_configs() -> None:
+    """Two arms must not be averaged into one AggregatedResults under the first arm's name."""
+    treatment = _single_run(0, [9.0, 9.0])._replace(config_name="treatment")
+    with pytest.raises(
+        ValueError,
+        match=r"^aggregate_metrics requires runs from one configuration; "
+        r"got \['candidate', 'treatment'\]$",
+    ):
+        aggregate_metrics([_single_run(0, [1.0, 1.0]), treatment])
+
+
+def test_aggregate_metrics_rejects_duplicate_seed_identities() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^aggregate_metrics requires unique seed identities; got \[0, 1, 0\]$",
+    ):
+        aggregate_metrics(
+            [_single_run(0, [1.0, 1.0]), _single_run(1, [2.0, 2.0]), _single_run(0, [3.0, 3.0])]
+        )
+
+
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:
     poisoned = _two_seed_trace()
     poisoned.metric_arrays["squared_error"][0, 1] = np.inf

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -17,6 +17,7 @@ from alberta_framework.utils.experiments import (
     ExperimentConfig,
     SingleRunResult,
     aggregate_metrics,
+    extract_hyperparameter_results,
     get_final_performance,
     get_metric_timeseries,
     run_multi_seed_experiment,
@@ -349,6 +350,43 @@ def test_aggregate_metrics_rejects_duplicate_seed_identities() -> None:
         aggregate_metrics(
             [_single_run(0, [1.0, 1.0]), _single_run(1, [2.0, 2.0]), _single_run(0, [3.0, 3.0])]
         )
+
+
+def _flat_trace(name: str, value: float) -> AggregatedResults:
+    return AggregatedResults(
+        config_name=name,
+        seeds=[0, 1],
+        metric_arrays={"squared_error": np.full((2, 3), value, dtype=np.float64)},
+        summary={},
+    )
+
+
+def test_extract_hyperparameter_results_rejects_colliding_parameter_values() -> None:
+    """A non-injective extractor must not silently keep the dict-last configuration."""
+    results = {
+        "lr_0.01_decay_0.0": _flat_trace("lr_0.01_decay_0.0", 1.0),
+        "lr_0.01_decay_0.1": _flat_trace("lr_0.01_decay_0.1", 9.0),
+        "lr_0.10_decay_0.0": _flat_trace("lr_0.10_decay_0.0", 3.0),
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"^param_extractor maps several configurations to one value: "
+        r"0\.01 <- \['lr_0\.01_decay_0\.0', 'lr_0\.01_decay_0\.1'\]$",
+    ):
+        extract_hyperparameter_results(
+            results, param_extractor=lambda name: float(name.split("_")[1])
+        )
+
+
+def test_extract_hyperparameter_results_keeps_injective_extractors() -> None:
+    results = {
+        "lr_0.01": _flat_trace("lr_0.01", 1.0),
+        "lr_0.10": _flat_trace("lr_0.10", 3.0),
+    }
+    extracted = extract_hyperparameter_results(
+        results, param_extractor=lambda name: float(name.split("_")[1])
+    )
+    assert extracted == {0.01: (1.0, 0.0), 0.1: (3.0, 0.0)}
 
 
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:


### PR DESCRIPTION
Closes #357. Stacked on #346 (`fix/aggregate-metrics-identity`): the first commit here is #346's; only `083f70f` is new. Rebases to a one-commit diff once #346 lands.

## Issue

`extract_hyperparameter_results` built its result with a dict comprehension, so an extractor mapping several configurations to one value silently kept whichever was inserted last: three configurations in, two points out, the `lr=0.01` point being the `decay=0.1` run only by insertion order.

## New state

Configurations are grouped by extracted value first; any value with more than one configuration raises `param_extractor maps several configurations to one value: 0.01 <- ['lr_0.01_decay_0.0', 'lr_0.01_decay_0.1']`. Injective extractors and the `param_extractor=None` path are unchanged.

Failing-test-first: `test_extract_hyperparameter_results_rejects_colliding_parameter_values` fails on `main` (returns the truncated dict) and passes here; `test_extract_hyperparameter_results_keeps_injective_extractors` pins the accepted path.

## Evidence

Falsifier from #357 at this head:

```text
ValueError: param_extractor maps several configurations to one value: 0.01 <- ['lr_0.01_decay_0.0', 'lr_0.01_decay_0.1']
```

Verification at `083f70f2387e77c48c0785b26bfa48f42720284c`:

```text
.venv/bin/python -m pytest tests/test_experiments_validation.py tests/test_utils_smoke.py -q -o addopts=""   -> 40 passed
.venv/bin/python -m ruff check .                                                                       -> All checks passed!
.venv/bin/python -m mypy                                                                               -> Success: no issues found in 164 source files
```

`utils/experiments.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:083f70f2387e77c48c0785b26bfa48f42720284c -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
