### PR TITLE
fix(step8): reject illegal world model facade config

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -70,7 +70,15 @@ class Step8WorldModelConfig:
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
-        payload["hidden_sizes"] = list(self.hidden_sizes)
+        payload["hidden_sizes"] = [int(h) for h in self.hidden_sizes]
+        payload["observation_dim"] = int(self.observation_dim)
+        if self.n_actions is not None:
+            payload["n_actions"] = int(self.n_actions)
+        payload["action_dim"] = int(self.action_dim)
+        payload["step_size"] = float(self.step_size)
+        payload["sparsity"] = float(self.sparsity)
+        payload["leaky_relu_slope"] = float(self.leaky_relu_slope)
+        payload["utility_decay"] = float(self.utility_decay)
         return payload
 
     @classmethod
@@ -96,6 +104,16 @@ class Step8WorldModelConfig:
             predict_delta=self.predict_delta,
             utility_decay=self.utility_decay,
         )
+
+
+_INT32_MAX = 2**31 - 1
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
@@ -126,34 +144,48 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_nonnegative_real(name: str, value: object) -> float:
-    real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return canonical_float32_storage(real, narrowed)
-
-
-def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
-    n_actions = (
-        None if config.n_actions is None else _require_int("n_actions", config.n_actions, minimum=1)
+    observation_dim = _require_int(
+        "observation_dim",
+        config.observation_dim,
+        minimum=1,
+        maximum=_INT32_MAX,
     )
-    action_dim = _require_int("action_dim", config.action_dim, minimum=1)
-    if not isinstance(config.hidden_sizes, tuple):
-        raise ValueError(f"hidden_sizes must be a tuple of integers, got {config.hidden_sizes!r}")
+    n_actions = (
+        None
+        if config.n_actions is None
+        else _require_int("n_actions", config.n_actions, minimum=1, maximum=_INT32_MAX)
+    )
+    action_dim = _require_int("action_dim", config.action_dim, minimum=1, maximum=_INT32_MAX)
+    if type(config.hidden_sizes) is not tuple:
+        raise TypeError(
+            f"hidden_sizes must be an actual tuple, got {type(config.hidden_sizes).__name__}"
+        )
     hidden_sizes = tuple(
-        _require_int("hidden_sizes", size, minimum=1) for size in config.hidden_sizes
+        _require_int("hidden_sizes", size, minimum=1, maximum=_INT32_MAX)
+        for size in config.hidden_sizes
     )
     step_size = _require_nonnegative_real("step_size", config.step_size)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
@@ -162,6 +194,10 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
         config.leaky_relu_slope,
     )
     utility_decay = _require_half_open_unit_interval("utility_decay", config.utility_decay)
+    if type(config.use_layer_norm) is not bool:
+        raise TypeError(f"use_layer_norm must be a bool, got {config.use_layer_norm!r}")
+    if type(config.predict_delta) is not bool:
+        raise TypeError(f"predict_delta must be a bool, got {config.predict_delta!r}")
     object.__setattr__(config, "observation_dim", observation_dim)
     object.__setattr__(config, "n_actions", n_actions)
     object.__setattr__(config, "action_dim", action_dim)
@@ -170,6 +206,8 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     object.__setattr__(config, "sparsity", sparsity)
     object.__setattr__(config, "leaky_relu_slope", leaky_relu_slope)
     object.__setattr__(config, "utility_decay", utility_decay)
+    object.__setattr__(config, "use_layer_norm", bool(config.use_layer_norm))
+    object.__setattr__(config, "predict_delta", bool(config.predict_delta))
 
 
 @dataclass(frozen=True)

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -9,6 +9,7 @@ after the facade rejects them. Legal endpoints stay constructible.
 from __future__ import annotations
 
 import json
+from fractions import Fraction
 from typing import Any
 
 import chex
@@ -34,39 +35,46 @@ _INVALID_WORLD_MODEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("observation_dim", -1),
     ("observation_dim", 1.5),
     ("observation_dim", "4"),
+    ("observation_dim", 2**31),
     ("n_actions", True),
     ("n_actions", False),
     ("n_actions", 0),
     ("n_actions", -1),
     ("n_actions", 1.5),
     ("n_actions", "2"),
+    ("n_actions", 2**31),
     ("action_dim", True),
     ("action_dim", False),
     ("action_dim", 0),
     ("action_dim", -1),
     ("action_dim", 1.5),
     ("action_dim", "1"),
+    ("action_dim", 2**31),
     ("hidden_sizes", (True,)),
     ("hidden_sizes", (False,)),
     ("hidden_sizes", (0,)),
     ("hidden_sizes", (-1,)),
     ("hidden_sizes", (1.5,)),
     ("hidden_sizes", ("64",)),
+    ("hidden_sizes", (2**31,)),
     ("step_size", float("nan")),
     ("step_size", float("inf")),
     ("step_size", True),
     ("step_size", False),
     ("step_size", -1.0),
+    ("step_size", 1e100),
     ("sparsity", float("nan")),
     ("sparsity", True),
     ("sparsity", -0.1),
     ("sparsity", 1.1),
+    ("sparsity", 1e100),
     ("utility_decay", float("nan")),
     ("utility_decay", float("inf")),
     ("utility_decay", True),
     ("utility_decay", False),
     ("utility_decay", -0.1),
     ("utility_decay", 1.0),
+    ("utility_decay", 1e100),
     ("leaky_relu_slope", float("nan")),
     ("leaky_relu_slope", float("inf")),
     ("leaky_relu_slope", float("-inf")),
@@ -74,6 +82,7 @@ _INVALID_WORLD_MODEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("leaky_relu_slope", False),
     ("leaky_relu_slope", "0.01"),
     ("leaky_relu_slope", -0.01),
+    ("leaky_relu_slope", 1e100),
 )
 
 
@@ -262,3 +271,101 @@ def test_step8_world_model_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert type(payload["utility_decay"]) is float
     assert model.to_config()["config"]["utility_decay"] == 0.5
     assert model.to_config()["config"]["leaky_relu_slope"] == 0.5
+
+
+def test_step8_world_model_rejects_float32_overflow() -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        Step8WorldModelConfig(step_size=1e100)
+    with pytest.raises(ValueError, match="sparsity"):
+        Step8WorldModelConfig(sparsity=1e100)
+    with pytest.raises(ValueError, match="leaky_relu_slope"):
+        Step8WorldModelConfig(leaky_relu_slope=1e100)
+    with pytest.raises(ValueError, match="utility_decay"):
+        Step8WorldModelConfig(utility_decay=1e100)
+
+
+def test_step8_world_model_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    config = Step8WorldModelConfig(
+        observation_dim=2**31 - 1,
+        n_actions=2**31 - 1,
+        action_dim=2**31 - 1,
+        hidden_sizes=(2**31 - 1,),
+        step_size=f32_max,
+        sparsity=1.0,
+        leaky_relu_slope=f32_max,
+        utility_decay=0.99,
+    )
+    assert config.observation_dim == 2**31 - 1
+    assert config.n_actions == 2**31 - 1
+    assert config.action_dim == 2**31 - 1
+    assert config.hidden_sizes == (2**31 - 1,)
+    assert config.step_size == f32_max
+    assert config.sparsity == 1.0
+    assert config.leaky_relu_slope == f32_max
+
+
+def test_step8_world_model_exact_fraction_rounding() -> None:
+    midpoint = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    config = Step8WorldModelConfig(
+        step_size=midpoint,
+        sparsity=Fraction(1, 4),
+        leaky_relu_slope=midpoint,
+        utility_decay=Fraction(1, 2),
+    )
+    expected_f32 = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert config.step_size == expected_f32
+    assert config.leaky_relu_slope == expected_f32
+    assert config.sparsity == 0.25
+    assert config.utility_decay == 0.5
+
+
+def test_step8_world_model_rejects_spoofed_tuple_container() -> None:
+    class SpoofedTuple(list):
+        @property
+        def __class__(self) -> type[tuple]:
+            return tuple
+
+    with pytest.raises(TypeError, match="hidden_sizes"):
+        Step8WorldModelConfig(hidden_sizes=SpoofedTuple([64]))  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="hidden_sizes"):
+        Step8WorldModelConfig(hidden_sizes=[64])  # type: ignore[arg-type]
+
+
+def test_step8_world_model_rejects_non_bool_flags() -> None:
+    class SpoofedBool:
+        @property
+        def __class__(self) -> type[bool]:
+            return bool
+
+        def __bool__(self) -> bool:
+            return True
+
+    with pytest.raises(TypeError, match="use_layer_norm"):
+        Step8WorldModelConfig(use_layer_norm=SpoofedBool())  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="predict_delta"):
+        Step8WorldModelConfig(predict_delta=SpoofedBool())  # type: ignore[arg-type]
+
+
+def test_step8_world_model_rejects_spoofed_int_class_and_adversarial_ratios() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="step_size"):
+        Step8WorldModelConfig(step_size=SpoofedIntFloat(0.5))
+
+    with pytest.raises(ValueError, match="sparsity"):
+        Step8WorldModelConfig(sparsity=SpoofedIntFloat(0.5))
+
+    with pytest.raises(ValueError, match="leaky_relu_slope"):
+        Step8WorldModelConfig(leaky_relu_slope=SpoofedIntFloat(0.5))
+
+    with pytest.raises(ValueError, match="utility_decay"):
+        Step8WorldModelConfig(utility_decay=SpoofedIntFloat(0.5))


### PR DESCRIPTION
Closes #359.

## What changed

`Step8WorldModelConfig` now validates every scientific scalar and dimension before constructing one-step world models. Float32 execution values use the shared exact-ratio `round_real_to_float32` helper, preventing binary64 double rounding for `Fraction` and extended-precision inputs.

Exact float32 overflow is rejected across `step_size`, `sparsity`, `leaky_relu_slope`, `utility_decay`; legal zero/one endpoints remain valid. Observation dimension, discrete action count, action dimension, and hidden layer dimensions are bounded to signed int32 max (`2**31 - 1`).

## Scope

• `alberta_framework/steps/step8.py`
• `tests/test_step8_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 8 production suite: 64 passed;
• affected world model suite: 5 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported