### PR TITLE
fix(micro-continual): record the spec that actually ran in each shard

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -74,7 +74,7 @@ from functools import lru_cache
 from numbers import Real
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, cast
 
 import jax
 import jax.numpy as jnp
@@ -148,12 +148,39 @@ _BAYES_DOMAIN = 404
 
 def _require_finite_real(value: object, name: str) -> float:
     """Return one canonical float after rejecting non-real and non-finite values."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if type(value) is bool or not issubclass(type(value), Real):
         raise ValueError(f"{name} must be a finite real number, got {value!r}")
-    number = float(value)
+    try:
+        number = float(cast(Any, value))
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real number, got {value!r}") from exc
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number, got {value!r}")
     return number
+
+
+def _freeze_micro_hyperparameters(value: object, *, context: str) -> Mapping[str, float]:
+    """Copy one primitive-only hyperparameter mapping behind an immutable view."""
+    if not issubclass(type(value), Mapping):
+        raise ValueError(f"{context} must be an object with non-empty string keys")
+    try:
+        items = list(cast(Mapping[object, object], value).items())
+    except Exception as exc:
+        raise ValueError(
+            f"{context} must be an object with non-empty string keys"
+        ) from exc
+    frozen: dict[str, float] = {}
+    for key, raw_value in items:
+        if type(key) is not str or not key:
+            raise ValueError(f"{context} keys must be non-empty strings")
+        frozen[key] = _require_finite_real(raw_value, f"{context}[{key!r}]")
+    return MappingProxyType(frozen)
+
+
+def _require_nonempty_string(value: object, *, context: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{context} must be a non-empty string")
+    return value
 
 
 # =============================================================================
@@ -642,7 +669,15 @@ class MicroArmSpec:
     description: str
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "hyperparameters", MappingProxyType(dict(self.hyperparameters)))
+        _require_nonempty_string(self.name, context="MicroArmSpec.name")
+        _require_nonempty_string(self.mechanism, context="MicroArmSpec.mechanism")
+        object.__setattr__(
+            self,
+            "hyperparameters",
+            _freeze_micro_hyperparameters(
+                self.hyperparameters, context="MicroArmSpec.hyperparameters"
+            ),
+        )
 
 
 def _make_sgd_raw_learner(
@@ -789,6 +824,17 @@ class MicroRunResult:
     overall_accuracy: float
     wall_clock_seconds: float
 
+    def __post_init__(self) -> None:
+        _require_nonempty_string(self.arm_name, context="MicroRunResult.arm_name")
+        _require_nonempty_string(self.mechanism, context="MicroRunResult.mechanism")
+        object.__setattr__(
+            self,
+            "hyperparameters",
+            _freeze_micro_hyperparameters(
+                self.hyperparameters, context="MicroRunResult.hyperparameters"
+            ),
+        )
+
 
 def run_micro_arm(
     config: MicroStreamConfig,
@@ -881,6 +927,11 @@ def micro_shard_path(out_dir: Path | str, family: str, arm_name: str, seed: int)
 
 def micro_shard_payload(result: MicroRunResult) -> dict[str, Any]:
     """Serialize one run to a mergeable shard, recording the spec that actually ran."""
+    if result.arm_name not in MICRO_ARM_REGISTRY:
+        raise ValueError(
+            f"arm_name {result.arm_name!r} is not a registered micro arm; "
+            "unregistered results cannot be serialized into the registered-arm shard schema"
+        )
     return {
         "schema": MICRO_SHARD_SCHEMA,
         "suite_version": MICRO_GAUSS_SUITE_VERSION,
@@ -961,6 +1012,11 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         raise ValueError(f"{path}: mechanism must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):
         raise ValueError(f"{path}: hyperparameters must be an object")
+    payload["hyperparameters"] = dict(
+        _freeze_micro_hyperparameters(
+            payload["hyperparameters"], context=f"{path}: hyperparameters"
+        )
+    )
     environment = payload.get("environment")
     required_environment_fields = ("jax", "numpy", "python", "platform")
     if not isinstance(environment, dict) or any(

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -637,9 +637,12 @@ class MicroArmSpec:
 
     name: str
     mechanism: str
-    hyperparameters: dict[str, float]
+    hyperparameters: Mapping[str, float]
     factory: MicroArmFactory
     description: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "hyperparameters", MappingProxyType(dict(self.hyperparameters)))
 
 
 def _make_sgd_raw_learner(
@@ -774,6 +777,8 @@ class MicroRunResult:
 
     family: str
     arm_name: str
+    mechanism: str
+    hyperparameters: Mapping[str, float]
     seed: int
     hidden1: int
     hidden2: int
@@ -850,6 +855,8 @@ def run_micro_arm(
     return MicroRunResult(
         family=config.family,
         arm_name=spec.name,
+        mechanism=spec.mechanism,
+        hyperparameters=MappingProxyType(dict(spec.hyperparameters)),
         seed=int(seed),
         hidden1=hidden1,
         hidden2=hidden2,
@@ -873,16 +880,15 @@ def micro_shard_path(out_dir: Path | str, family: str, arm_name: str, seed: int)
 
 
 def micro_shard_payload(result: MicroRunResult) -> dict[str, Any]:
-    """Serialize one run to a mergeable shard."""
-    spec = micro_arm_spec(result.arm_name)
+    """Serialize one run to a mergeable shard, recording the spec that actually ran."""
     return {
         "schema": MICRO_SHARD_SCHEMA,
         "suite_version": MICRO_GAUSS_SUITE_VERSION,
         "evidence_policy": dict(NONPROMOTING_POLICY),
         "family": result.family,
         "arm_name": result.arm_name,
-        "mechanism": spec.mechanism,
-        "hyperparameters": dict(spec.hyperparameters),
+        "mechanism": result.mechanism,
+        "hyperparameters": dict(result.hyperparameters),
         "seed": result.seed,
         "hidden1": result.hidden1,
         "hidden2": result.hidden2,

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -78,6 +78,16 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
 
 pytestmark = pytest.mark.unit
 
+
+class _FloatClassSpoof:
+    @property
+    def __class__(self) -> type[float]:
+        return float
+
+    def __float__(self) -> float:
+        return 0.1
+
+
 TINY = MicroStreamConfig(
     family="input_permutation",
     n_regimes=4,
@@ -819,6 +829,60 @@ class TestShards:
         with pytest.raises(TypeError):
             spec.hyperparameters["step_size"] = 123.0  # type: ignore[index]
         assert micro_arm_spec("sgd_raw").hyperparameters["step_size"] != 123.0
+
+    def test_direct_run_result_construction_copies_and_freezes_hyperparameters(self):
+        external = {"step_size": 0.5, "weight_decay": 0.3}
+        result = dataclasses.replace(self._result(), hyperparameters=external)
+        external["step_size"] = 0.9
+
+        assert result.hyperparameters == {"step_size": 0.5, "weight_decay": 0.3}
+        with pytest.raises(TypeError):
+            result.hyperparameters["step_size"] = 0.7  # type: ignore[index]
+
+    @pytest.mark.parametrize(
+        "hyperparameters",
+        [
+            {1: 0.1},
+            {"": 0.1},
+            {"step_size": float("nan")},
+            {"step_size": float("inf")},
+            {"step_size": True},
+            {"step_size": [0.1]},
+            {"step_size": _FloatClassSpoof()},
+        ],
+    )
+    def test_arm_specs_reject_noncanonical_hyperparameters(
+        self, hyperparameters: object
+    ) -> None:
+        with pytest.raises(ValueError, match="hyperparameters"):
+            dataclasses.replace(
+                micro_arm_spec("sgd_raw"),
+                hyperparameters=hyperparameters,  # type: ignore[arg-type]
+            )
+
+    def test_payload_rejects_an_unregistered_result_name(self):
+        result = dataclasses.replace(self._result(), arm_name="unregistered_candidate")
+        with pytest.raises(ValueError, match="unregistered_candidate.*registered"):
+            micro_shard_payload(result)
+
+    @pytest.mark.parametrize(
+        "hyperparameters",
+        [
+            {"step_size": "0.01"},
+            {"step_size": True},
+            {"step_size": None},
+            {"step_size": [0.01]},
+            {"": 0.01},
+        ],
+    )
+    def test_load_rejects_noncanonical_hyperparameters(
+        self, tmp_path: Path, hyperparameters: object
+    ) -> None:
+        payload = micro_shard_payload(self._result())
+        payload["hyperparameters"] = hyperparameters
+        path = self._write_payload(tmp_path, payload)
+        with pytest.raises(ValueError, match="hyperparameters"):
+            load_micro_shard(path)
 
     def test_payload_roundtrip(self, tmp_path: Path):
         result = self._result()

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -786,6 +786,40 @@ class TestShards:
     def _result(self, seed=0, arm="sgd_raw"):
         return run_micro_arm(TINY, arm, seed=seed, hidden1=8, hidden2=6)
 
+    def test_payload_records_the_spec_that_actually_ran(self, tmp_path: Path):
+        """A custom spec sharing a registry name must not be serialized as the registry arm."""
+        registry = micro_arm_spec("sgd_raw")
+        custom = dataclasses.replace(
+            registry, hyperparameters={"step_size": 0.5, "weight_decay": 0.3}
+        )
+        registry_run = run_micro_arm(TINY, "sgd_raw", seed=0, hidden1=8, hidden2=6)
+        custom_run = run_micro_arm(TINY, custom, seed=0, hidden1=8, hidden2=6)
+        assert custom_run.overall_accuracy != registry_run.overall_accuracy
+        assert custom_run.mechanism == registry.mechanism
+        assert custom_run.hyperparameters == {"step_size": 0.5, "weight_decay": 0.3}
+        assert registry_run.hyperparameters == registry.hyperparameters
+
+        payload = micro_shard_payload(custom_run)
+        assert payload["hyperparameters"] == {"step_size": 0.5, "weight_decay": 0.3}
+        assert payload["mechanism"] == registry.mechanism
+        assert payload["hyperparameters"] is not custom_run.hyperparameters
+
+        path_a = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 0)
+        write_micro_shard(path_a, payload)
+        path_b = micro_shard_path(tmp_path, TINY.family, "sgd_raw", 1)
+        write_micro_shard(
+            path_b,
+            micro_shard_payload(run_micro_arm(TINY, "sgd_raw", seed=1, hidden1=8, hidden2=6)),
+        )
+        with pytest.raises(ValueError, match="hyperparameters"):
+            merge_micro_shards([path_a, path_b], bayes_samples=1_000)
+
+    def test_registry_specs_cannot_be_mutated_through_lookup(self):
+        spec = micro_arm_spec("sgd_raw")
+        with pytest.raises(TypeError):
+            spec.hyperparameters["step_size"] = 123.0  # type: ignore[index]
+        assert micro_arm_spec("sgd_raw").hyperparameters["step_size"] != 123.0
+
     def test_payload_roundtrip(self, tmp_path: Path):
         result = self._result()
         payload = micro_shard_payload(result)


### PR DESCRIPTION
Closes #361.

micro_shard_payload previously re-looked up the registry by arm name, so a custom MicroArmSpec run was serialized with metadata that never ran and the cross-seed drift guard was vacuous. The run result now carries the actual mechanism and hyperparameters, and registry specs copy/freeze their mappings.

Release hardening on the rebased head also makes direct MicroRunResult construction copy and freeze a primitive-only mapping, validates exact non-empty string keys and finite real values on both construction and load, rejects __class__ type spoofing, and makes the supported-name boundary symmetric: the registered-arm loader allowlist is retained and the serializer refuses unregistered result names before writing an unreadable shard. Custom specs remain supported when they intentionally share a registered arm name; their actual recorded contract is what cross-seed merge validation compares.

Failing-first: 13 adversarial direct-construction, invalid-hyperparameter, unknown-name, and loader cases failed on the original #362 implementation before the hardening guard.

Verification at a3a56e89960bed6d6e72cf027dc58c90288621cc:

- 237 micro-continual and rule-discovery tests passed (2 pre-existing sklearn deprecation warnings).
- Ruff passed on changed source/tests.
- Strict mypy passed on micro_continual.py.
- Rebased after merged #341 curve-domain validation.
- outputs/ is untouched; no benchmark or seed lane was executed.

This remains permanently nonpromoting development infrastructure.

<!-- evidence-head:a3a56e89960bed6d6e72cf027dc58c90288621cc -->
<!-- evidence-row:logs -->
- [x] logs: failing-first and verification results inline above