### PR TITLE
fix(dual-replay): report no aleatoric control under the reservoir policy

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -1565,7 +1565,7 @@ class DualReplayMemory:
             coverage_component = jnp.asarray(0.0, dtype=jnp.float32)
             progress_component = jnp.asarray(0.0, dtype=jnp.float32)
             aleatoric_passed = jnp.asarray(False)
-            aleatoric_available = transition.aleatoric_uncertainty_available
+            aleatoric_available = jnp.asarray(False)
             next_key, draw_key = jr.split(_key_from_data(state.rng_key_data))
             selection = reservoir_selection(draw_key, candidate_number, cfg.long_term_capacity)
             wrote_long = selection.selected

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -436,6 +436,30 @@ def test_reservoir_selection_contract_and_lifetime_calculations_are_exact() -> N
     assert int(state.long_term_write_count + state.long_term_rejection_count) == 11
 
 
+def test_reservoir_policy_reports_no_aleatoric_control_rather_than_a_veto() -> None:
+    """Reservoir applies no aleatoric control, so ``available`` must be False, not a fake veto."""
+    memory = DualReplayMemory(_config(long_term_policy="reservoir", max_aleatoric_uncertainty=1.0))
+    state = memory.init(jr.key(11))
+    signals = [(0.0, True), (2.0, True), (0.0, False), (2.0, False)]
+    for provenance, (aleatoric, available) in enumerate(signals, start=1):
+        result = memory.record(
+            state,
+            _prediction(
+                provenance,
+                aleatoric=aleatoric,
+                aleatoric_available=available,
+            ),
+            _outcome(provenance),
+        )
+        assert bool(result.input_valid)
+        assert not bool(result.aleatoric_control_available)
+        assert not bool(result.aleatoric_control_passed)
+        assert not bool(result.long_term_priority_available)
+        state = result.state
+    assert int(state.accepted_transition_count) == 4
+    assert int(jnp.sum(state.long_term.valid)) > 0
+
+
 def test_calibrated_priority_uses_surprise_coverage_and_progress_exactly() -> None:
     memory = DualReplayMemory(
         _config(


### PR DESCRIPTION
Closes #363.

Under long_term_policy="reservoir" no aleatoric control is applied, but the write receipt copied the signal-availability bit while hard-coding passed=False. That fabricated an aleatoric veto on every row with an available signal, including retained candidates.

The reservoir branch now reports both aleatoric_control_available=False and aleatoric_control_passed=False, matching its already-neutral priority diagnostics. Selection, RNG, state updates, and the calibrated branch are unchanged. The regression exercises low/high aleatoric values with both available and unavailable signal metadata.

Verification at 363ef20ed5df2be459e3ee3db17baccc825695fd:

- Rebased cleanly after merged #315 float32 priority/config hardening.
- 156 dual-replay tests passed under -W error.
- Ruff passed on changed source/tests.
- Strict mypy passed on dual_replay.py.
- outputs/ is untouched; no benchmark or seed lane was executed.

This is receipt/reporting correctness only and creates no scientific evidence.

<!-- evidence-head:363ef20ed5df2be459e3ee3db17baccc825695fd -->
<!-- evidence-row:logs -->
- [x] logs: verification results inline above