### PR TITLE
fix(cbp): accrue replacement budget against mature units and cap the carry

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -144,9 +144,11 @@ class ContinualBackpropState:
             ``utilities``.
         replacement_accumulators: One scalar per hidden layer that
             accumulates the (fractional) number of replacements
-            scheduled by ``replacement_rate * num_units`` each step.
-            Whenever an accumulator exceeds 1.0 a single unit in that
-            layer is replaced and the accumulator is decremented by 1.
+            scheduled by ``replacement_rate * num_mature_units`` each
+            step. Whenever an accumulator reaches 1.0 and a mature unit
+            exists, a single unit in that layer is replaced and the
+            accumulator is decremented by 1; it never carries more than
+            one pending replacement.
             This makes ``replacement_rate << 1`` behave as expected in
             the JIT-compiled scan loop without integer arithmetic.
         rng_key: PRNG key used to draw fresh weights for replaced
@@ -465,16 +467,34 @@ def maybe_replace_units(
     Returns:
         Updated ``(mlp_state, cbp_state)``.
     """
-    if not config.enabled:
-        return mlp_state, cbp_state
+    new_mlp_state, new_cbp_state, _replaced = replace_units_with_flags(
+        mlp_state, cbp_state, config, sparsity
+    )
+    return new_mlp_state, new_cbp_state
 
+
+def replace_units_with_flags(
+    mlp_state: MultiHeadMLPState,
+    cbp_state: ContinualBackpropState,
+    config: ContinualBackpropConfig,
+    sparsity: float,
+) -> tuple[MultiHeadMLPState, ContinualBackpropState, Array]:
+    """Run :func:`maybe_replace_units` and also return the per-layer replacement flags.
+
+    Returns:
+        ``(mlp_state, cbp_state, replaced)`` where ``replaced`` is a boolean
+        array with one entry per hidden layer that is ``True`` exactly when
+        that layer's gated replacement fired this step.
+    """
     n_layers = len(cbp_state.utilities)
-    if n_layers == 0:
-        return mlp_state, cbp_state
+    no_replacements = jnp.zeros((n_layers,), dtype=jnp.bool_)
+    if not config.enabled or n_layers == 0:
+        return mlp_state, cbp_state, no_replacements
 
     rate = jnp.asarray(config.replacement_rate, dtype=jnp.float32)
     accum_arr = cbp_state.replacement_accumulators
     new_accum_list: list[Array] = []
+    replaced_flags: list[Array] = []
 
     new_mlp_state = mlp_state
     new_cbp_state = cbp_state
@@ -510,12 +530,13 @@ def maybe_replace_units(
         # more than the one replacement a step can deliver.
         accum_after = jnp.minimum(jnp.where(gated, accum - 1.0, accum), 1.0)
         new_accum_list.append(accum_after)
+        replaced_flags.append(gated)
 
     new_cbp_state = new_cbp_state.replace(  # type: ignore[attr-defined]
         replacement_accumulators=jnp.stack(new_accum_list),
         rng_key=rng_key,
     )
-    return new_mlp_state, new_cbp_state
+    return new_mlp_state, new_cbp_state, jnp.stack(replaced_flags)
 
 
 # =============================================================================
@@ -922,22 +943,14 @@ class CBPMultiHeadMLPLearner:
             self._cbp_config.decay_rate,
         )
 
-        # 4. Possibly replace low-utility mature units.
-        # Track which layers actually replaced for diagnostics. We
-        # detect by checking whether the accumulator decremented.
-        old_accum = new_cbp_state.replacement_accumulators
-        new_post_state, new_cbp_state = maybe_replace_units(
+        # 4. Possibly replace low-utility mature units, reporting the exact
+        #    gated decision per layer as the diagnostic.
+        new_post_state, new_cbp_state, replacements_made = replace_units_with_flags(
             post_state,
             new_cbp_state,
             self._cbp_config,
             self._sparsity,
         )
-        new_accum = new_cbp_state.replacement_accumulators
-        replacements_made = (old_accum + jnp.float32(
-            self._cbp_config.replacement_rate
-        ) * jnp.array(
-            [s for s in self._hidden_sizes], dtype=jnp.float32
-        )) - new_accum >= 0.5
 
         new_state = CBPMultiHeadMLPState(  # type: ignore[call-arg]
             mlp_state=new_post_state,

--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -46,10 +46,10 @@ original Dohare implementation uses in practice.
 
 Replacement
 -----------
-On every step, ``replacement_rate * num_hidden_units`` units (rounded
-up) per layer are *eligible* for replacement. Of those, only units that
-are at least ``maturity_threshold`` updates old AND have the lowest
-utility in the layer are actually replaced. Replaced units have their
+On every step, ``replacement_rate * num_mature_units`` fractional
+replacements accrue per layer (units younger than ``maturity_threshold``
+earn no budget), and at most one accumulated replacement is delivered per
+step: the mature unit with the lowest utility in the layer is replaced. Replaced units have their
 incoming weights re-drawn via :func:`sparse_init` and their outgoing
 weights zeroed (so a freshly initialized unit does not destabilize the
 prediction immediately). The unit's age and utility are reset to 0.
@@ -480,10 +480,12 @@ def maybe_replace_units(
     new_cbp_state = cbp_state
     rng_key = cbp_state.rng_key
     for layer_idx in range(n_layers):
-        layer_size = cbp_state.utilities[layer_idx].shape[0]
-        layer_size_f = jnp.asarray(layer_size, dtype=jnp.float32)
-        # Add this step's fractional replacements to the accumulator.
-        accum = accum_arr[layer_idx] + rate * layer_size_f
+        # Add this step's fractional replacements to the accumulator, accrued
+        # against the units that are actually eligible (mature) right now, as in
+        # the reference GnT implementation; immature units earn no budget.
+        eligible = new_cbp_state.ages[layer_idx] >= config.maturity_threshold
+        n_eligible = jnp.sum(eligible).astype(jnp.float32)
+        accum = accum_arr[layer_idx] + rate * n_eligible
         # Will we replace one unit this step?
         do_replace = accum >= 1.0
         # Pick lowest-utility mature unit from the *current* CBP state.
@@ -504,8 +506,9 @@ def maybe_replace_units(
             new_cbp_state,
             subkey,
         )
-        # Decrement accumulator only if we actually replaced.
-        accum_after = jnp.where(gated, accum - 1.0, accum)
+        # Decrement accumulator only if we actually replaced, and never carry
+        # more than the one replacement a step can deliver.
+        accum_after = jnp.minimum(jnp.where(gated, accum - 1.0, accum), 1.0)
         new_accum_list.append(accum_after)
 
     new_cbp_state = new_cbp_state.replace(  # type: ignore[attr-defined]

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -331,6 +331,45 @@ class TestReplacement:
         )
 
 
+    def _replacement_trace(
+        self, *, n_units: int, rate: float, maturity: int, steps: int
+    ) -> tuple[list[int], float]:
+        """Drive maybe_replace_units with ages advancing one per step; count replacements."""
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(n_units,), sparsity=0.0)
+        mlp_state = learner.init(feature_dim=3, key=jr.key(1))
+        cbp_state = init_cbp_state(mlp_state, (n_units,), key=jr.key(2))
+        config = ContinualBackpropConfig(
+            decay_rate=0.99, replacement_rate=rate, maturity_threshold=maturity, enabled=True
+        )
+        replaced_per_step: list[int] = []
+        for step in range(steps):
+            cbp_state = cbp_state.replace(  # type: ignore[attr-defined]
+                ages=(jnp.full((n_units,), step, dtype=jnp.int32),),
+                utilities=(jnp.linspace(0.001, 1.0, n_units, dtype=jnp.float32),),
+            )
+            before = float(cbp_state.replacement_accumulators[0])
+            mlp_state, cbp_state = maybe_replace_units(mlp_state, cbp_state, config, sparsity=0.0)
+            after = float(cbp_state.replacement_accumulators[0])
+            replaced_per_step.append(int(before + rate * n_units + 0.5 - after >= 1.0))
+        return replaced_per_step, float(cbp_state.replacement_accumulators[0])
+
+    def test_replacement_budget_does_not_accrue_while_every_unit_is_immature(self):
+        """No warm-up debt: rate 1e-3 on 32 units is ~1 per 31 steps, not 32 in a row."""
+        replaced, _ = self._replacement_trace(n_units=32, rate=1e-3, maturity=1000, steps=1100)
+        assert sum(replaced[:1000]) == 0
+        burst = sum(replaced[1000:1040])
+        assert burst <= 2, f"warm-up debt discharged as a burst of {burst} replacements"
+        assert 1 <= sum(replaced) <= 4
+
+    def test_replacement_budget_never_carries_more_than_one_pending_unit(self):
+        """rate * n_units > 1 saturates at one replacement per step without unbounded debt."""
+        replaced, final_accumulator = self._replacement_trace(
+            n_units=8, rate=0.5, maturity=0, steps=20
+        )
+        assert sum(replaced) == 20
+        assert final_accumulator <= 1.0
+
+
 # =============================================================================
 # enabled=False returns unchanged state
 # =============================================================================

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -20,6 +20,7 @@ from alberta_framework.core.continual_backprop import (
     _select_replacement_index,
     init_cbp_state,
     maybe_replace_units,
+    replace_units_with_flags,
     run_cbp_learning_loop,
     update_utility,
 )
@@ -347,10 +348,10 @@ class TestReplacement:
                 ages=(jnp.full((n_units,), step, dtype=jnp.int32),),
                 utilities=(jnp.linspace(0.001, 1.0, n_units, dtype=jnp.float32),),
             )
-            before = float(cbp_state.replacement_accumulators[0])
-            mlp_state, cbp_state = maybe_replace_units(mlp_state, cbp_state, config, sparsity=0.0)
-            after = float(cbp_state.replacement_accumulators[0])
-            replaced_per_step.append(int(before + rate * n_units + 0.5 - after >= 1.0))
+            mlp_state, cbp_state, replaced = replace_units_with_flags(
+                mlp_state, cbp_state, config, sparsity=0.0
+            )
+            replaced_per_step.append(int(bool(replaced[0])))
         return replaced_per_step, float(cbp_state.replacement_accumulators[0])
 
     def test_replacement_budget_does_not_accrue_while_every_unit_is_immature(self):
@@ -368,6 +369,41 @@ class TestReplacement:
         )
         assert sum(replaced) == 20
         assert final_accumulator <= 1.0
+
+
+    def test_wrapper_replacements_made_is_the_gated_decision(self):
+        """replacements_made must not be re-inferred from the old rate * hidden_size formula."""
+        learner = CBPMultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(32,),
+            cbp_config=ContinualBackpropConfig(
+                decay_rate=0.99, replacement_rate=0.02, maturity_threshold=1000, enabled=True
+            ),
+            step_size=0.01,
+            sparsity=0.0,
+            use_layer_norm=False,
+        )
+        state = learner.init(feature_dim=4, key=jr.key(9))
+        obs = jnp.array([0.4, -0.2, 0.7, 1.0], dtype=jnp.float32)
+        result = learner.update(state, obs, jnp.array([1.5], dtype=jnp.float32))
+        assert int(jnp.max(result.state.cbp_state.ages[0])) == 1
+        assert float(result.state.cbp_state.replacement_accumulators[0]) == 0.0
+        assert not bool(result.replacements_made[0])
+
+        matured = result.state.replace(  # type: ignore[attr-defined]
+            cbp_state=result.state.cbp_state.replace(  # type: ignore[attr-defined]
+                ages=(jnp.full((32,), 5000, dtype=jnp.int32),),
+                replacement_accumulators=jnp.array([0.9], dtype=jnp.float32),
+            )
+        )
+        weights_before = matured.mlp_state.trunk_params.weights[0]
+        fired = learner.update(matured, obs, jnp.array([1.5], dtype=jnp.float32))
+        assert bool(fired.replacements_made[0])
+        changed_rows = jnp.any(
+            fired.state.mlp_state.trunk_params.weights[0] != weights_before, axis=1
+        )
+        assert int(jnp.sum(fired.state.cbp_state.ages[0] == 0)) == 1
+        assert int(jnp.sum(changed_rows)) >= 1
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #370.

## Issue

`maybe_replace_units` accrued `replacement_rate * layer_size` every step but could pay at most one unit per step, so budget accrued against zero eligible units during the maturity warm-up and was discharged as a burst that re-initialized whole layers at `t = maturity_threshold` (32/32 units in 32 consecutive steps at `rate=1e-3, maturity=1000`), and rates above `1/layer_size` accrued unbounded debt while producing bit-identical arms.

## New state

The accumulator accrues `replacement_rate * n_mature_units` (units younger than `maturity_threshold` earn no budget), matching the reference GnT implementation, and never carries more than one pending replacement. Selection (lowest-utility mature unit), the one-per-step delivery, and the replacement itself are unchanged. The module docstring's Replacement paragraph now states the actual semantics.

`replace_units_with_flags` returns the exact gated per-layer decision alongside the states (`maybe_replace_units` keeps its two-tuple signature by wrapping it), and `CBPMultiHeadMLPLearner.update` reports that decision as `replacements_made` instead of re-inferring it from the old accrual formula. `ContinualBackpropState.replacement_accumulators` docstring states the actual semantics.

Failing-test-first: `test_replacement_budget_does_not_accrue_while_every_unit_is_immature`, `test_replacement_budget_never_carries_more_than_one_pending_unit`, and the wrapper-level `test_wrapper_replacements_made_is_the_gated_decision` (immature 32-unit layer at rate 0.02 → `replacements_made=[False]`, accumulator 0.0; matured layer with 0.9 pending → `[True]` and exactly one row re-initialised) fail on `main` / the previous head and pass here; the existing forced-replacement / maturity-protection tests are unchanged.

## Evidence

Falsifier from #370 at this head:

```text
rate=0.001 n_units=32 maturity=1000 steps=1100
actually replaced = 3   max per step = 1   final accumulator = 0.1
first replacement at step 1030; replacements in steps 1030..1070: 2 of 32 units
```

Verification at `49804652d264f5eb484dc0e5e9f05ca48c5e00d1`:

```text
.venv/bin/python -m pytest tests/test_continual_backprop.py tests/test_plasticity_gate.py tests/test_multi_head_learner.py -q -o addopts=""   -> 89 passed
.venv/bin/python -m ruff check .                                                                                            -> All checks passed!
.venv/bin/python -m mypy                                                                                                    -> Success: no issues found in 164 source files
```

`core/continual_backprop.py` is imported by the robot track and stays importable (public API unchanged); it is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:49804652d264f5eb484dc0e5e9f05ca48c5e00d1 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
