### PR TITLE
fix(step5): reject illegal differential TD facade config

### DIFF
--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -24,13 +24,14 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from numbers import Real
+from numbers import Integral, Real
 from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.average_reward import (
     DifferentialTDArrayResult,
     DifferentialTDConfig,
@@ -45,20 +46,43 @@ _STEP5_CONFIG_KEYS_ERROR = (
     "Step5AverageRewardTDConfig payload keys must be exactly "
     "['average_reward_step_size', 'step_size', 'trace_decay']"
 )
+_INT32_MAX = 2**31 - 1
 
 
-def _finite_float32_scalar(name: str, value: object) -> float:
+def _narrow_float32(name: str, value: Any) -> float:
     """Validate a real scalar before the core narrows it to float32."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real scalar")
     try:
-        with np.errstate(invalid="ignore", over="ignore"):
-            narrowed = np.asarray(value, dtype=np.float32)
+        narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32") from None
-    if narrowed.shape != () or not bool(np.isfinite(narrowed)):
+    if not bool(np.isfinite(narrowed)):
         raise ValueError(f"{name} must narrow to a finite float32")
+    if isinstance(value, (int, float)) and (bool(narrowed != 0.0) or value == 0):
+        return float(value)
     return float(narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(value)
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max")
+    return number
 
 
 @dataclass(frozen=True)
@@ -71,11 +95,11 @@ class Step5AverageRewardTDConfig:
 
     def __post_init__(self) -> None:
         """Reject malformed scientific scalars before JAX execution."""
-        step_size = _finite_float32_scalar("step_size", self.step_size)
-        average_reward_step_size = _finite_float32_scalar(
+        step_size = _narrow_float32("step_size", self.step_size)
+        average_reward_step_size = _narrow_float32(
             "average_reward_step_size", self.average_reward_step_size
         )
-        trace_decay = _finite_float32_scalar("trace_decay", self.trace_decay)
+        trace_decay = _narrow_float32("trace_decay", self.trace_decay)
         if self.step_size < 0.0:
             raise ValueError("step_size must be non-negative")
         if self.average_reward_step_size < 0.0:
@@ -99,7 +123,11 @@ class Step5AverageRewardTDConfig:
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
-        return asdict(self)
+        return {
+            "step_size": float(self.step_size),
+            "average_reward_step_size": float(self.average_reward_step_size),
+            "trace_decay": float(self.trace_decay),
+        }
 
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step5AverageRewardTDConfig:
@@ -173,10 +201,9 @@ def run_step5_smoke(
     seed: int = 0,
 ) -> Step5SmokeResult:
     """Run a tiny deterministic Step 5 integration probe."""
-    if steps < 1:
-        raise ValueError("steps must be positive")
-    if feature_dim < 1:
-        raise ValueError("feature_dim must be positive")
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    feature_dim = _require_int("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config or Step5AverageRewardTDConfig()
     learner = make_step5_td_learner(cfg)

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -227,6 +227,39 @@ def test_step5_smoke_health_gate_reports_any_refused_update(
     assert not result.finite
 
 
+def test_step5_exact_fraction_rounding() -> None:
+    midpoint = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    config = Step5AverageRewardTDConfig(
+        step_size=midpoint,
+        average_reward_step_size=Fraction(1, 100),
+        trace_decay=Fraction(0, 1),
+    )
+    expected_f32 = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert config.step_size == expected_f32
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "32"}, "steps"),
+        ({"feature_dim": 0}, "feature_dim"),
+        ({"feature_dim": -1}, "feature_dim"),
+        ({"feature_dim": 2**31}, "feature_dim"),
+        ({"feature_dim": False}, "feature_dim"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_step5_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step5_smoke(**kwargs)
+
+
 def test_step6_facade_config_roundtrip_one_step_and_smoke() -> None:
     config = Step6DifferentialSARSAConfig(
         n_actions=2,


### PR DESCRIPTION
Closes #372.

## What changed

`Step5AverageRewardTDConfig` now validates scalar hyper-parameters with `round_real_to_float32` from `alberta_framework/_float32.py`, preventing binary64 double rounding for `Fraction` and extended-precision inputs before float32 execution sinks.

In addition, `run_step5_smoke` now strictly bounds `steps`, `feature_dim`, and `seed` to signed int32 max (`2**31 - 1`).

## Scope

• `alberta_framework/steps/step5.py`
• `tests/test_step5_step6_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 5 & 6 production suite: 154 passed;
• affected average reward suite: 22 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported