### PR TITLE
fix(upgd): report the unscaled prediction loss in metrics

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -2076,7 +2076,12 @@ class UPGDLearner:
                         adaptive_simplex_gate * ce_loss
                         + (1.0 - adaptive_simplex_gate) * mse_loss
                     )
-                return loss, (logits_for_loss, hidden_for_loss)
+                # The gradient-budget scale shapes the differentiated objective only;
+                # the reported loss stays the unscaled prediction loss.
+                reported_loss = (
+                    mse_loss if self._readout_loss_mode == "two_timescale_simplex" else loss
+                )
+                return loss, (logits_for_loss, hidden_for_loss, reported_loss)
             preds = logits_for_loss
             sq = (preds - safe_targets) ** 2
             target_loss_weights = jnp.where(
@@ -2099,10 +2104,10 @@ class UPGDLearner:
                 ),
             )
             loss = 0.5 * jnp.sum(sq_masked) / denom
-            return loss, (logits_for_loss, hidden_for_loss)
+            return loss, (logits_for_loss, hidden_for_loss, loss)
 
         if not use_direct_mse_loss:
-            (loss_value, (logits, hidden_for_readout)), grads = jax.value_and_grad(
+            (_, (logits, hidden_for_readout, loss_value)), grads = jax.value_and_grad(
                 loss_and_aux_fn,
                 argnums=(0, 1, 2, 3),
                 has_aux=True,
@@ -2151,7 +2156,7 @@ class UPGDLearner:
                     ),
                 ),
             )
-            loss_value = slow_simplex_gradient_scale * 0.5 * jnp.sum(sq_masked) / denom
+            loss_value = 0.5 * jnp.sum(sq_masked) / denom
             logit_grads = jnp.where(
                 active_mask,
                 slow_simplex_gradient_scale

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1969,7 +1969,7 @@ class UPGDLearner:
             trunk_biases: tuple[Array, ...],
             head_weights: tuple[Array, ...],
             head_biases: tuple[Array, ...],
-        ) -> tuple[Array, tuple[Array, Array]]:
+        ) -> tuple[Array, tuple[Array, Array, Array]]:
             logits_for_loss, hidden_for_loss = self._forward_with_readout_input(
                 trunk_weights,
                 trunk_biases,

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -675,6 +675,28 @@ class TestUpdateMetrics:
             chex.assert_tree_all_finite(result.predictions)
             state = result.state
 
+    def test_reported_loss_is_not_scaled_by_the_slow_simplex_gradient_multiplier(self):
+        """metrics[0] must show the task-switch error even when the slow branch has zero budget."""
+        learner = UPGDLearner.step2_strict_digit_readout_default(n_heads=3, hidden_sizes=(8,))
+        state = learner.init(4, jr.key(0))
+        obs = jnp.ones(4)
+        target_a = jnp.array([1.0, 0.0, 0.0])
+        target_b = jnp.array([0.0, 0.0, 1.0])
+        reported: list[float] = []
+        true_half_se: list[float] = []
+        for step in range(230):
+            target = target_a if step < 200 else target_b
+            result = learner.update(state, obs, target)
+            state = result.state
+            reported.append(float(result.metrics[0]))
+            true_half_se.append(float(0.5 * jnp.sum((result.predictions - target) ** 2)))
+        assert max(true_half_se[200:210]) > 0.5
+        # The switch spike must be visible in the reported loss (it was identically 0.0).
+        assert reported[200] > 0.25
+        assert max(reported[200:210]) > 0.25
+        assert all(value >= 0.0 for value in reported)
+        assert reported[199] < reported[200]
+
     def test_sum_loss_normalization_scales_multihead_gradient(self):
         """Sum loss should avoid diluting gradients by active head count."""
         base_kwargs = dict(


### PR DESCRIPTION
Closes #374.

## Issue

The two-timescale simplex readout folded `slow_simplex_gradient_scale` (the slow-branch *gradient budget*, `0.0` in the shipped `step2_strict_digit_readout_default` factory) into the returned `loss_value`, so `metrics[0]` — documented as `mean_loss` — read identically `0.0` across a task switch whose true `0.5·SE` peaked at `0.99`.

## New state

`loss_and_aux_fn` still differentiates the scaled objective but returns the unscaled prediction loss in its auxiliary tuple, and the direct-MSE branch keeps the scale on the hand-computed gradients only; `metrics[0]` reports the unscaled loss (with the configured target weights and normalization). Gradients, updates, gates, and every other metric are bit-identical to before — only the reported number changes, and only in `two_timescale_simplex` mode.

Failing-test-first: `TestUpdateMetrics::test_reported_loss_is_not_scaled_by_the_slow_simplex_gradient_multiplier` fails on `main` (reported loss `0.0` at the switch) and passes here.

## Evidence

Falsifier from #374 at this head:

```text
 step   phase   metrics[0] reported   true 0.5*SE
  200       B            0.68458790      0.989012
  205       B            0.66639626      0.580911
  220       B            0.09658543      0.006874
```

(the reported value carries the factory's positive/negative target weights and normalization, so it is not numerically `0.5·SE`, but the switch spike is now visible instead of a flat zero)

Verification at `f3176ccd7b846233fc3df031066dd47f358329ae`:

```text
.venv/bin/python -m pytest tests/test_upgd.py tests/test_step2*.py -q -o addopts=""   -> 82 passed
.venv/bin/python -m ruff check .                                                     -> All checks passed!
.venv/bin/python -m mypy                                                             -> Success: no issues found in 164 source files
```

`core/upgd.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:f3176ccd7b846233fc3df031066dd47f358329ae -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
