### PR TITLE
fix(step9): reject bool and non-integral smoke steps

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -795,8 +795,7 @@ def run_step9_smoke(
     seed: int = 0,
 ) -> Step9SmokeResult:
     """Run a tiny deterministic Step 9 dreaming integration probe."""
-    if steps < 1:
-        raise ValueError("steps must be positive")
+    steps = _require_int("steps", steps, minimum=1)
 
     cfg = config or Step9DreamingConfig()
     agent, model, buffer = make_step9_components(cfg)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -808,6 +808,12 @@ def test_step9_smoke_zero_steps_raises() -> None:
         run_step9_smoke(steps=0)
 
 
+@pytest.mark.parametrize("steps", [True, 1.5])
+def test_step9_smoke_rejects_non_integer_steps(steps: object) -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step9_smoke(steps=steps)  # type: ignore[arg-type]
+
+
 def test_step9_smoke_linear_model() -> None:
     """Linear (hidden_sizes=()) world model should work identically."""
     cfg = Step9DreamingConfig(


### PR DESCRIPTION
Closes #376.

## What changed

Same pattern as #348/#356/#368: `run_step9_smoke` validated `steps` with a plain `steps < 1` comparison instead of this module's own strict `_require_int(..., minimum=1)` helper. `steps=True` (an `int` subclass) is silently accepted as a one-step result; `steps=1.5` passes the `< 1` check and reaches JAX shape construction, raising a raw `TypeError` instead of the facade's documented `ValueError`.

confirmed directly before touching the source:

```text
steps=True: accepted, result.steps=True, shape=(1,)
steps=1.5: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (2.5, 4).
```

fix: route `steps` through the existing `_require_int("steps", steps, minimum=1)` helper, matching every other validated field in this module.

## Reachability

`run_step9_smoke` is imported and listed in `alberta_framework.steps.__init__`'s `__all__` — confirmed directly, publicly reachable. Not re-exported from the package root (that facade intentionally doesn't re-export every step module).

## Verification

```text
$ .venv/bin/python -m pytest tests/test_step9_production.py -q -o addopts=""
168 passed in 23.23s

$ .venv/bin/python -m ruff check alberta_framework/steps/step9.py tests/test_step9_production.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_step9_smoke_rejects_non_integer_steps`, parametrized over `True` and `1.5`, asserting `ValueError` matching `"steps must be an integer"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/steps/step9.py`, kept the test), reran — both cases failed (`True` silently accepted instead of raising; `1.5` leaked the raw JAX `TypeError`), reproducing the exact bug described above. restored the fix, 168/168 green again.

## Evidence

<!-- evidence-head -->
2f4706790b430bf870f0aa4596705f14eabd236a

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_step9_production.py -q -o addopts="" -k test_step9_smoke_rejects_non_integer_steps
FAILED [True] - Failed: DID NOT RAISE ValueError
FAILED [1.5] - TypeError: Shapes must be 1D sequences of concrete values of integer type...
2 failed, 166 deselected in 2.98s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_step9_production.py -q -o addopts="" -k test_step9_smoke_rejects_non_integer_steps
2 passed, 166 deselected in 0.38s
```

<!-- evidence-row:domain-artifact -->
```text
steps=True: accepted, result.steps=True, shape=(1,)
steps=1.5: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (2.5, 4).
```
independently reran the full touched test file (168 tests), ruff, and mypy myself; independently confirmed the export chain before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the export chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
