### PR TITLE
fix(feature-discovery): exclude inactive tasks from top-k utility

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -601,12 +601,24 @@ class FixedBudgetFeatureLearner:
         if self._utility_aggregation == "max":
             return jnp.max(weighted_activity, axis=0)
         if self._utility_aggregation == "topk":
-            k = min(self._utility_top_k, self._n_tasks)
-            return jnp.mean(jnp.sort(weighted_activity, axis=0)[-k:, :], axis=0)
+            return self._active_topk_mean(weighted_activity, active_mask)
         if self._utility_task_balancing in {"active", "active_inverse_frequency"}:
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
             return jnp.sum(weighted_activity, axis=0) / active_count
         return jnp.mean(weighted_activity, axis=0)
+
+    def _active_topk_mean(self, weighted: Array, active_mask: Array) -> Array:
+        """Mean of the top-k per-task rows; under task balancing only active rows compete."""
+        k = min(self._utility_top_k, self._n_tasks)
+        if self._utility_task_balancing == "none":
+            return jnp.mean(jnp.sort(weighted, axis=0)[-k:, :], axis=0)
+        scores = jnp.where(active_mask[:, None], weighted, -jnp.inf)
+        selected, _ = jax.lax.top_k(jnp.swapaxes(scores, 0, 1), k)
+        selected_count = jnp.minimum(jnp.sum(active_mask.astype(jnp.int32)), k)
+        selected_mask = jnp.arange(k) < selected_count
+        selected_sum = jnp.sum(jnp.where(selected_mask[None, :], selected, 0.0), axis=1)
+        safe_count = jnp.maximum(selected_count, 1)
+        return jnp.where(selected_count > 0, selected_sum / safe_count, 0.0)
 
     def _aggregate_task_feature_signal(
         self,
@@ -630,8 +642,7 @@ class FixedBudgetFeatureLearner:
         if self._utility_aggregation == "max":
             return jnp.max(weighted_signal, axis=0)
         if self._utility_aggregation == "topk":
-            k = min(self._utility_top_k, self._n_tasks)
-            return jnp.mean(jnp.sort(weighted_signal, axis=0)[-k:, :], axis=0)
+            return self._active_topk_mean(weighted_signal, active_mask)
         if self._utility_task_balancing in {"active", "active_inverse_frequency"}:
             active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
             return jnp.sum(weighted_signal, axis=0) / active_count

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import pytest
+from jax.experimental import checkify
 
 from alberta_framework import (
     FixedBudgetFeatureLearner,
@@ -300,6 +301,83 @@ class TestInteractionFeatureDiscoveryStream:
 
 class TestFixedBudgetFeatureLearner:
     """Tests for explicit feature construction, utility, and replacement."""
+
+    def test_active_topk_excludes_inactive_zero_placeholders(self) -> None:
+        """Mirror of the #275 fix for the interaction learner: inactive heads are not zeros."""
+        learner = FixedBudgetFeatureLearner(
+            n_features=1,
+            n_tasks=4,
+            candidate_count=0,
+            utility_aggregation="topk",
+            utility_top_k=2,
+            utility_task_balancing="active",
+        )
+        active_mask = jnp.asarray((True, False, False, False), dtype=jnp.bool_)
+        activity = jnp.ones((4,), dtype=jnp.float32)
+        signed_signal = jnp.asarray(((-4.0,), (99.0,), (99.0,), (99.0,)), dtype=jnp.float32)
+        utility = learner._aggregate_task_feature_signal(signed_signal, active_mask, activity)
+        np.testing.assert_array_equal(utility, np.asarray((-4.0,), dtype=np.float32))
+
+        output_weights = jnp.asarray(((6.0,), (5.0,), (5.0,), (5.0,)), dtype=jnp.float32)
+        features = jnp.ones((1,), dtype=jnp.float32)
+        for top_k in (1, 2, 4):
+            probe = FixedBudgetFeatureLearner(
+                n_features=1,
+                n_tasks=4,
+                candidate_count=0,
+                utility_aggregation="topk",
+                utility_top_k=top_k,
+                utility_task_balancing="active",
+            )
+            utility = probe._output_utility_signal(output_weights, features, active_mask, activity)
+            np.testing.assert_array_equal(utility, np.asarray((6.0,), dtype=np.float32))
+
+    @pytest.mark.parametrize(
+        "reducer_name", ["_aggregate_task_feature_signal", "_output_utility_signal"]
+    )
+    def test_active_topk_all_inactive_avoids_zero_division(self, reducer_name: str) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=1,
+            n_tasks=4,
+            candidate_count=0,
+            utility_aggregation="topk",
+            utility_top_k=2,
+            utility_task_balancing="active",
+        )
+        active_mask = jnp.zeros((4,), dtype=jnp.bool_)
+        activity = jnp.ones((4,), dtype=jnp.float32)
+        if reducer_name == "_aggregate_task_feature_signal":
+            args: tuple[Any, ...] = (
+                jnp.asarray(((1.0,), (2.0,), (3.0,), (4.0,)), dtype=jnp.float32),
+                active_mask,
+                activity,
+            )
+        else:
+            args = (
+                jnp.ones((4, 1), dtype=jnp.float32),
+                jnp.ones((1,), dtype=jnp.float32),
+                active_mask,
+                activity,
+            )
+        checked = checkify.checkify(getattr(learner, reducer_name), errors=checkify.float_checks)
+        error, utility = checked(*args)
+        error.throw()
+        np.testing.assert_array_equal(utility, np.zeros((1,), dtype=np.float32))
+
+    def test_unbalanced_topk_still_averages_largest_heads(self) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=1,
+            n_tasks=4,
+            candidate_count=0,
+            utility_aggregation="topk",
+            utility_top_k=2,
+            utility_task_balancing="none",
+        )
+        signal = jnp.asarray(((4.0,), (2.0,), (0.5,), (0.0,)), dtype=jnp.float32)
+        utility = learner._aggregate_task_feature_signal(
+            signal, jnp.ones((4,), dtype=jnp.bool_), jnp.ones((4,), dtype=jnp.float32)
+        )
+        np.testing.assert_array_equal(utility, np.asarray((3.0,), dtype=np.float32))
 
     def test_init_shapes(self) -> None:
         learner = FixedBudgetFeatureLearner(


### PR DESCRIPTION
Closes #379.

## Issue

`FixedBudgetFeatureLearner`'s top-k utility (`_output_utility_signal`, `_aggregate_task_feature_signal`) averaged the zero placeholders of inactive tasks under active task balancing (`top_k=2` on a single active head with signal 6.0 reported `3.0`; `top_k=4` reported `1.5`), diluting sparse-label steps against dense ones and flipping which slot `worst_active` discards. #275/#276 fixed the identical code in the interaction learner only.

## New state

A shared `_active_topk_mean` implements the #276 semantics for both reducers: under task balancing, inactive rows are masked to `-inf`, `jax.lax.top_k` selects among active rows, and the mean divides by `min(#active, k)` with a guarded all-inactive branch; the `"none"` balancing branch stays byte-identical (`jnp.sort(...)[-k:]` mean).

Failing-test-first: `test_active_topk_excludes_inactive_zero_placeholders` fails on `main` and passes here; `test_active_topk_all_inactive_avoids_zero_division` (checkify float checks on both reducers) and `test_unbalanced_topk_still_averages_largest_heads` pin the guarded and unchanged branches.

## Evidence

Falsifier from #379 at this head: `top_k 1/2/4 -> [6.] [6.] [6.]`; ranking probe now `A -> 5.0, B -> 3.0` (matches the fixed interaction learner).

Verification at `d7bcea6979f00ff7308b41041d39201ce83fc7e8`:

```text
.venv/bin/python -m pytest tests/test_feature_discovery.py tests/test_interaction_task_utility_weights.py -q -o addopts=""   -> 110 passed
.venv/bin/python -m ruff check .                                                                                            -> All checks passed!
.venv/bin/python -m mypy                                                                                                    -> Success: no issues found in 164 source files
```

`core/feature_discovery.py` is not a registered evidence source (`core/interaction_features.py` is, and is untouched); no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:d7bcea6979f00ff7308b41041d39201ce83fc7e8 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
