### PR TITLE
fix(actor-critic): emit the policy that produced each recorded action

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -139,9 +139,12 @@ class ActorCriticArrayResult:
     Attributes:
         state: Final agent state.
         actions: Per-step actions, shape ``(num_steps,)``.
-        policies: Per-step policy probabilities at ``observations[t]`` — the
-            distribution that produced ``actions[t]`` — shape
-            ``(num_steps, n_actions)``.
+        policies: Per-step pre-update agent policy probabilities at
+            ``observations[t]``, shape ``(num_steps, n_actions)``. When actions
+            are sampled by this runner, this is the distribution that produced
+            ``actions[t]``. When fixed actions are supplied, this is the current
+            agent policy evaluated at that state, not provenance for the
+            external behavior policy.
         values: Per-step previous-state value estimates, shape ``(num_steps,)``.
         td_errors: Per-step TD errors, shape ``(num_steps,)``.
     """
@@ -533,7 +536,9 @@ def run_actor_critic_from_arrays(
         terminated: Terminal flags, shape ``(num_steps,)``. Required unless
             ``discounts`` is provided.
         next_observations: Next observations, shape ``(num_steps, feature_dim)``.
-        actions: Optional fixed current actions, shape ``(num_steps,)``.
+        actions: Optional fixed current actions, shape ``(num_steps,)``. Their
+            behavior-policy probabilities are not known; returned ``policies``
+            are the current agent policy evaluated before each update.
         discounts: Optional transition discounts, shape ``(num_steps,)``.
 
     Returns:

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -139,7 +139,9 @@ class ActorCriticArrayResult:
     Attributes:
         state: Final agent state.
         actions: Per-step actions, shape ``(num_steps,)``.
-        policies: Per-step policy probabilities, shape ``(num_steps, n_actions)``.
+        policies: Per-step policy probabilities at ``observations[t]`` — the
+            distribution that produced ``actions[t]`` — shape
+            ``(num_steps, n_actions)``.
         values: Per-step previous-state value estimates, shape ``(num_steps,)``.
         td_errors: Per-step TD errors, shape ``(num_steps,)``.
     """
@@ -560,8 +562,9 @@ def run_actor_critic_from_arrays(
                 last_action=fixed_action.astype(jnp.int32),
             )
             current_action = fixed_action.astype(jnp.int32)
+            current_policy = agent.policy(started_state, obs)
         else:
-            started_state, current_action, _policy = agent.start(carry, obs)
+            started_state, current_action, current_policy = agent.start(carry, obs)
         result = agent.update(
             started_state,
             reward,
@@ -579,7 +582,7 @@ def run_actor_critic_from_arrays(
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            result.policy,
+            jnp.where(result.update_applied, current_policy, jnp.zeros_like(current_policy)),
             result.value,
             result.td_error,
             result.update_applied,

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -258,6 +258,35 @@ def test_run_actor_critic_from_arrays_scan() -> None:
     chex.assert_tree_all_finite((result.policies, result.values, result.td_errors))
 
 
+def test_run_actor_critic_from_arrays_policies_align_with_actions() -> None:
+    """policies[t] must be the distribution that produced actions[t], at observations[t]."""
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=3, actor_step_size=0.5, gamma=0.9))
+    state = agent.init(feature_dim=2, key=jr.key(5))
+    state = state.replace(  # type: ignore[attr-defined]
+        actor_weights=jnp.array([[3.0, 0.0], [0.0, 3.0], [0.0, 0.0]], dtype=jnp.float32)
+    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+    rewards = jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32)
+    terminated = jnp.array([False, False, False])
+
+    result = run_actor_critic_from_arrays(
+        agent, state, observations, rewards, terminated, next_observations
+    )
+
+    loop_state = state
+    for step in range(3):
+        expected_policy = agent.policy(loop_state, observations[step])
+        chex.assert_trees_all_close(result.policies[step], expected_policy)
+        started, _action, _probs = agent.start(loop_state, observations[step])
+        started = started.replace(last_action=result.actions[step])  # type: ignore[attr-defined]
+        loop_state = agent.update(
+            started, rewards[step], next_observations[step], discount=0.9
+        ).state
+    for step in range(3):
+        assert float(result.policies[step][result.actions[step]]) > 0.5
+
+
 def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
     agent = ActorCriticAgent(
         ActorCriticConfig(

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -258,8 +258,8 @@ def test_run_actor_critic_from_arrays_scan() -> None:
     chex.assert_tree_all_finite((result.policies, result.values, result.td_errors))
 
 
-def test_run_actor_critic_from_arrays_policies_align_with_actions() -> None:
-    """policies[t] must be the distribution that produced actions[t], at observations[t]."""
+def test_run_actor_critic_from_arrays_sampled_policies_align_with_actions() -> None:
+    """On-policy rows report the distribution that sampled each action."""
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=3, actor_step_size=0.5, gamma=0.9))
     state = agent.init(feature_dim=2, key=jr.key(5))
     state = state.replace(  # type: ignore[attr-defined]
@@ -299,6 +299,9 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
         )
     )
     state = agent.init(feature_dim=2, key=jr.key(13))
+    state = state.replace(  # type: ignore[attr-defined]
+        actor_weights=jnp.array([[0.0, 3.0], [3.0, 0.0]], dtype=jnp.float32)
+    )
     observations = jnp.array(
         [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
     )
@@ -322,9 +325,11 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
 
     loop_state = state
     loop_td_errors = []
+    loop_policies = []
     for obs, reward, action, discount, next_obs in zip(
         observations, rewards, actions, discounts, next_observations, strict=True
     ):
+        loop_policies.append(agent.policy(loop_state, obs))
         loop_state = loop_state.replace(  # type: ignore[attr-defined]
             last_observation=obs,
             last_action=action,
@@ -339,6 +344,10 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
         loop_td_errors.append(loop_result.td_error)
 
     chex.assert_trees_all_close(scan_result.actions, actions)
+    chex.assert_trees_all_close(scan_result.policies, jnp.stack(loop_policies))
+    # The first supplied action is deliberately unlikely under the agent. The
+    # returned row is a target-policy evaluation, not claimed behavior provenance.
+    assert float(scan_result.policies[0, scan_result.actions[0]]) < 0.1
     chex.assert_trees_all_close(scan_result.td_errors, jnp.stack(loop_td_errors))
     chex.assert_trees_all_close(scan_result.state.actor_weights, loop_state.actor_weights)
     chex.assert_trees_all_close(


### PR DESCRIPTION
Closes #382.

## Issue

`run_actor_critic_from_arrays` emitted `result.policy` — the post-update softmax at `next_observations[t]` — as `policies[t]`, so the policy row was off by one state and one update relative to `actions[t]` and `values[t]` (`policies[0] = [0.045, 0.909, 0.045]` for an action taken with probability 0.909; `log π(a_t|s_t)` wrong by 3 nats).

## New state

The scan captures the pre-update agent policy at `observations[t]` — from `agent.start` when sampling, from `agent.policy(started_state, obs)` on the fixed-actions branch — and emits it as `policies[t]`, mirroring the continuous runner's `current_mean/current_sigma`. On a rejected update the row is neutralized to zeros, exactly as `actions[t]` is neutralized to `0`. The docstrings (`b23b417`, maintainer) state that `policies[t]` is the sampling distribution only when this runner samples the actions; with fixed behavior actions it is the agent's own policy at that state, not provenance for the external behavior policy. `values`, `td_errors`, `actions`, and the carried state are unchanged.

Failing-test-first: `test_run_actor_critic_from_arrays_sampled_policies_align_with_actions` (replays the scan step-by-step and asserts `policies[t] == agent.policy(state_t, observations[t])`) fails on `main` and passes here; `test_run_actor_critic_from_arrays_fixed_actions_matches_loop` now also pins the fixed-actions rows to the pre-update agent policy.

## Evidence

Falsifier from #382 at this head:

```text
reported == at observations[t] ? True   reported == at next_obs[t] ? False
log pi(a_t|s_t) from returned arrays: [-0.0949 -0.0949 -0.7177]
log pi(a_t|s_t) ground truth        : [-0.0949 -0.0949 -0.7177]
```

Verification at `b23b4178ea5b9661a930df96ffebd002b5a3f111`:

```text
.venv/bin/python -m pytest tests/test_actor_critic.py tests/test_continuous_actor_critic.py -q -o addopts=""   -> 28 passed
.venv/bin/python -m ruff check .                                                                            -> All checks passed!
.venv/bin/python -m mypy                                                                                    -> Success: no issues found in 164 source files
```

`core/actor_critic.py` is imported by the robot track and stays importable (signature unchanged); it is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:b23b4178ea5b9661a930df96ffebd002b5a3f111 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
