### PR TITLE
fix(world-model): build default discounts in float32 regardless of reward dtype

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -850,9 +850,10 @@ def run_latent_world_model_learning_loop(
 ) -> LatentWorldModelLearningResult:
     """Run online latent world-model learning over transition arrays."""
     if discounts is None:
-        discounts = jnp.full_like(
-            rewards,
+        discounts = jnp.full(
+            jnp.shape(rewards),
             jnp.asarray(model.config.gamma, dtype=jnp.float32),
+            dtype=jnp.float32,
         )
 
     def _scan_fn(

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -690,9 +690,10 @@ def run_action_conditioned_world_model_learning_loop(
 ) -> ActionConditionedWorldModelLearningResult:
     """Run online one-step model learning over transition arrays."""
     if discounts is None:
-        discounts = jnp.full_like(
-            rewards,
+        discounts = jnp.full(
+            jnp.shape(rewards),
             jnp.asarray(model.config.gamma, dtype=jnp.float32),
+            dtype=jnp.float32,
         )
 
     def _scan_fn(

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -221,6 +221,42 @@ def test_action_conditioned_world_model_scan_loop_shapes() -> None:
     chex.assert_tree_all_finite(result.prediction_errors)
 
 
+def test_default_discounts_do_not_inherit_the_reward_dtype() -> None:
+    """An integer or bool reward array must not truncate gamma into the default discounts."""
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        hidden_sizes=(),
+        step_size=0.05,
+        sparsity=0.0,
+    )
+    model = ActionConditionedWorldModel(config)
+    state = model.init(jr.key(8))
+    observations = jnp.array([[0.0, 0.0], [0.1, 0.0], [0.1, 0.2]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.1, 0.0], [0.1, 0.2], [0.2, 0.2]], dtype=jnp.float32)
+    actions = jnp.array([0, 1, 0], dtype=jnp.int32)
+    integer_rewards = jnp.array([1, 0, 1], dtype=jnp.int32)
+    float_rewards = integer_rewards.astype(jnp.float32)
+    explicit = run_action_conditioned_world_model_learning_loop(
+        model,
+        state,
+        observations,
+        actions,
+        float_rewards,
+        next_observations,
+        jnp.full((3,), config.gamma, dtype=jnp.float32),
+    )
+    for rewards in (float_rewards, integer_rewards, integer_rewards.astype(jnp.bool_)):
+        defaulted = run_action_conditioned_world_model_learning_loop(
+            model, state, observations, actions, rewards, next_observations
+        )
+        chex.assert_trees_all_close(defaulted.discount_errors, explicit.discount_errors)
+        chex.assert_trees_all_close(
+            defaulted.discount_predictions, explicit.discount_predictions
+        )
+        assert bool(jnp.all(defaulted.updates_applied))
+
+
 def test_guarded_dreamer_rejects_warmup_and_accepts_after_real_updates() -> None:
     config = ActionConditionedWorldModelConfig(
         observation_dim=2,

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -96,6 +96,35 @@ def test_latent_world_model_update_and_prediction_shapes() -> None:
     chex.assert_tree_all_finite(result.latent_std_mean)
 
 
+def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(8,),
+    )
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(3))
+    observations = jnp.array([[0.0, 0.0], [0.1, 0.0], [0.1, 0.2]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.1, 0.0], [0.1, 0.2], [0.2, 0.2]], dtype=jnp.float32)
+    actions = jnp.array([0, 1, 0], dtype=jnp.int32)
+    integer_rewards = jnp.array([1, 0, 1], dtype=jnp.int32)
+    explicit = run_latent_world_model_learning_loop(
+        model,
+        state,
+        observations,
+        actions,
+        integer_rewards.astype(jnp.float32),
+        next_observations,
+        jnp.full((3,), config.gamma, dtype=jnp.float32),
+    )
+    defaulted = run_latent_world_model_learning_loop(
+        model, state, observations, actions, integer_rewards, next_observations
+    )
+    chex.assert_trees_all_close(defaulted.discount_errors, explicit.discount_errors)
+    chex.assert_trees_all_close(defaulted.discount_predictions, explicit.discount_predictions)
+
+
 def test_latent_world_model_scan_loop_and_config_roundtrip() -> None:
     config = LatentWorldModelConfig(
         observation_dim=2,


### PR DESCRIPTION
Closes #386.

## Issue

Both world-model learning loops derived the default discount vector with `jnp.full_like(rewards, gamma)`, which inherits the reward dtype: `int32` rewards truncated `gamma` to `0` and `bool` rewards to `True`, training the discount head on the wrong constant while every update was accepted (`discount_errors ≈ 0` instead of `≈ 0.99`).

## New state

The default is built with `jnp.full(jnp.shape(rewards), gamma, dtype=jnp.float32)` in both loops; integer, bool, and float reward arrays now produce identical discount targets, predictions, and errors. Explicitly passed `discounts` are unchanged.

Failing-test-first: `test_default_discounts_do_not_inherit_the_reward_dtype` (action-conditioned; float/int32/bool vs an explicit `full(gamma)` run) and `test_latent_default_discounts_do_not_inherit_the_reward_dtype` fail on `main` and pass here.

## Evidence

Falsifier from #386 at this head:

```text
ACWM int32 rewards: discount targets = [0.99 0.99 0.99 0.99] | updates_applied all = True
LWM  int32 rewards: discount predictions = [0.7348 0.6286 0.7645] (== float32 run)
```

Verification at `486a46c0c8cfbd60c828965ac316639f689add4a`:

```text
.venv/bin/python -m pytest tests/test_action_conditioned_world_model.py tests/test_latent_world_model.py tests/test_world_model*.py -q -o addopts=""   -> 66 passed
.venv/bin/python -m ruff check .                                                                                                    -> All checks passed!
.venv/bin/python -m mypy                                                                                                            -> Success: no issues found in 164 source files
```

Neither module is a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:486a46c0c8cfbd60c828965ac316639f689add4a -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
