### PR TITLE
fix(step9): reject illegal dreaming facade config

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -25,7 +25,6 @@ floats; legal endpoints stay valid.
 from __future__ import annotations
 
 import functools
-import math
 from dataclasses import asdict, dataclass, field
 from numbers import Integral, Real
 from typing import Any, cast
@@ -34,8 +33,10 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAState,
@@ -146,7 +147,25 @@ class Step9DreamingConfig:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
         payload["control"] = self.control.to_dict()
-        payload["model_hidden_sizes"] = list(self.model_hidden_sizes)
+        payload["observation_dim"] = int(self.observation_dim)
+        payload["n_actions"] = int(self.n_actions)
+        payload["model_hidden_sizes"] = [int(s) for s in self.model_hidden_sizes]
+        payload["model_step_size"] = float(self.model_step_size)
+        payload["model_sparsity"] = float(self.model_sparsity)
+        payload["model_include_action_interactions"] = bool(self.model_include_action_interactions)
+        payload["model_use_layer_norm"] = bool(self.model_use_layer_norm)
+        payload["model_gamma"] = float(self.model_gamma)
+        payload["dreaming_warmup_steps"] = int(self.dreaming_warmup_steps)
+        payload["dreaming_max_model_error"] = float(self.dreaming_max_model_error)
+        payload["model_error_decay"] = float(self.model_error_decay)
+        payload["behavior_model_step_size"] = float(self.behavior_model_step_size)
+        payload["planning_budget"] = int(self.planning_budget)
+        payload["dream_rollout_horizon"] = int(self.dream_rollout_horizon)
+        payload["dream_candidate_count"] = int(self.dream_candidate_count)
+        payload["dream_surprise_weight"] = float(self.dream_surprise_weight)
+        payload["dream_utility_weight"] = float(self.dream_utility_weight)
+        payload["buffer_capacity"] = int(self.buffer_capacity)
+        payload["dreams_update_average_reward"] = bool(self.dreams_update_average_reward)
         return payload
 
     @classmethod
@@ -176,34 +195,44 @@ class Step9DreamingConfig:
         )
 
 
-def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+def _require_real(name: str, value: object) -> Any:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return number
+    return value
+
+
+def _narrow_float32(name: str, value: Any) -> float:
+    """Narrow exactly as downstream JAX kernels do, without intermediate double-rounding."""
+    try:
+        narrowed = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not bool(np.isfinite(narrowed)):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    if (type(value) is int or type(value) is float) and (bool(narrowed != 0.0) or value == 0):
+        return float(value)
+    return float(narrowed)
 
 
 def _require_nonneg_real(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if number < 0.0:
+    original = _require_real(name, value)
+    if original < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
+    original = _require_real(name, value)
+    if original < 0.0 or original > 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    number = _require_real(name, value)
-    if not 0.0 <= number < 1.0:
+    original = _require_real(name, value)
+    if original < 0.0 or original >= 1.0:
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
-    return number
+    return _narrow_float32(name, original)
 
 
 def _require_int(
@@ -213,7 +242,7 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
     number = int(value)
     if minimum is not None and number < minimum:
@@ -223,19 +252,29 @@ def _require_int(
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _require_bool(name: str, value: object) -> bool:
-    if not isinstance(value, bool):
-        raise ValueError(f"{name} must be a bool, got {value!r}")
-    return value
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise ValueError(f"{name} must be a bool, got {value!r}")
 
 
 def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
-    n_actions = _require_int("n_actions", config.n_actions, minimum=1)
+    observation_dim = _require_int(
+        "observation_dim",
+        config.observation_dim,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
+    n_actions = _require_int(
+        "n_actions",
+        config.n_actions,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     if config.control.n_actions != n_actions:
         raise ValueError(
             f"control.n_actions ({config.control.n_actions}) must equal "
@@ -247,7 +286,12 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
             f"{config.model_hidden_sizes!r}"
         )
     model_hidden_sizes = tuple(
-        _require_int("model_hidden_sizes", size, minimum=1)
+        _require_int(
+            "model_hidden_sizes",
+            size,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
         for size in config.model_hidden_sizes
     )
     model_step_size = _require_nonneg_real("model_step_size", config.model_step_size)
@@ -280,11 +324,17 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         "behavior_model_step_size",
         config.behavior_model_step_size,
     )
-    planning_budget = _require_int("planning_budget", config.planning_budget, minimum=0)
+    planning_budget = _require_int(
+        "planning_budget",
+        config.planning_budget,
+        minimum=0,
+        maximum=_INT32_MAX,
+    )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
@@ -293,13 +343,13 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         minimum=1,
         maximum=_INT32_MAX,
     )
-    dream_surprise_weight = _require_real(
+    dream_surprise_weight = _narrow_float32(
         "dream_surprise_weight",
-        config.dream_surprise_weight,
+        _require_real("dream_surprise_weight", config.dream_surprise_weight),
     )
-    dream_utility_weight = _require_real(
+    dream_utility_weight = _narrow_float32(
         "dream_utility_weight",
-        config.dream_utility_weight,
+        _require_real("dream_utility_weight", config.dream_utility_weight),
     )
     # Buffer ``size`` and ``index`` are int32. Leaving one count below the
     # maximum keeps repeated full-buffer increments and modulo updates in range.
@@ -318,6 +368,28 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
     object.__setattr__(config, "model_hidden_sizes", model_hidden_sizes)
     object.__setattr__(config, "model_step_size", model_step_size)
     object.__setattr__(config, "model_sparsity", model_sparsity)
+    object.__setattr__(
+        config,
+        "model_include_action_interactions",
+        model_include_action_interactions,
+    )
+    object.__setattr__(config, "model_use_layer_norm", model_use_layer_norm)
+    object.__setattr__(config, "model_gamma", model_gamma)
+    object.__setattr__(config, "dreaming_warmup_steps", dreaming_warmup_steps)
+    object.__setattr__(config, "dreaming_max_model_error", dreaming_max_model_error)
+    object.__setattr__(config, "model_error_decay", model_error_decay)
+    object.__setattr__(config, "behavior_model_step_size", behavior_model_step_size)
+    object.__setattr__(config, "planning_budget", planning_budget)
+    object.__setattr__(config, "dream_rollout_horizon", dream_rollout_horizon)
+    object.__setattr__(config, "dream_candidate_count", dream_candidate_count)
+    object.__setattr__(config, "dream_surprise_weight", dream_surprise_weight)
+    object.__setattr__(config, "dream_utility_weight", dream_utility_weight)
+    object.__setattr__(config, "buffer_capacity", buffer_capacity)
+    object.__setattr__(
+        config,
+        "dreams_update_average_reward",
+        dreams_update_average_reward,
+    )
     object.__setattr__(
         config,
         "model_include_action_interactions",
@@ -796,8 +868,8 @@ def run_step9_smoke(
     seed: int = 0,
 ) -> Step9SmokeResult:
     """Run a tiny deterministic Step 9 dreaming integration probe."""
-    if steps < 1:
-        raise ValueError("steps must be positive")
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config or Step9DreamingConfig()
     agent, model, buffer = make_step9_components(cfg)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -9,6 +9,7 @@ constructible.
 from __future__ import annotations
 
 import json
+from fractions import Fraction
 from typing import Any
 
 import chex
@@ -36,6 +37,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("observation_dim", 1.5),
     ("observation_dim", "4"),
     ("observation_dim", None),
+    ("observation_dim", 2**31),
     ("n_actions", True),
     ("n_actions", False),
     ("n_actions", 0),
@@ -43,6 +45,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_actions", 1.5),
     ("n_actions", "2"),
     ("n_actions", None),
+    ("n_actions", 2**31),
     ("model_hidden_sizes", (True,)),
     ("model_hidden_sizes", (False,)),
     ("model_hidden_sizes", (0,)),
@@ -51,6 +54,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("model_hidden_sizes", ("64",)),
     ("model_hidden_sizes", [64]),
     ("model_hidden_sizes", 64),
+    ("model_hidden_sizes", (2**31,)),
     ("model_step_size", float("nan")),
     ("model_step_size", float("inf")),
     ("model_step_size", float("-inf")),
@@ -59,6 +63,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("model_step_size", -1.0),
     ("model_step_size", "0.03"),
     ("model_step_size", None),
+    ("model_step_size", 1e100),
     ("model_sparsity", float("nan")),
     ("model_sparsity", float("inf")),
     ("model_sparsity", float("-inf")),
@@ -68,6 +73,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("model_sparsity", 1.1),
     ("model_sparsity", "0.9"),
     ("model_sparsity", None),
+    ("model_sparsity", 1e100),
     ("model_gamma", float("nan")),
     ("model_gamma", float("inf")),
     ("model_gamma", float("-inf")),
@@ -77,6 +83,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("model_gamma", 1.1),
     ("model_gamma", "0.99"),
     ("model_gamma", None),
+    ("model_gamma", 1e100),
     ("model_error_decay", float("nan")),
     ("model_error_decay", float("inf")),
     ("model_error_decay", float("-inf")),
@@ -86,12 +93,14 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("model_error_decay", 1.0),
     ("model_error_decay", "0.99"),
     ("model_error_decay", None),
+    ("model_error_decay", 1e100),
     ("dreaming_warmup_steps", True),
     ("dreaming_warmup_steps", False),
     ("dreaming_warmup_steps", -1),
     ("dreaming_warmup_steps", 1.5),
     ("dreaming_warmup_steps", "100"),
     ("dreaming_warmup_steps", None),
+    ("dreaming_warmup_steps", 2**31),
     ("dreaming_max_model_error", float("nan")),
     ("dreaming_max_model_error", float("inf")),
     ("dreaming_max_model_error", float("-inf")),
@@ -100,6 +109,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("dreaming_max_model_error", -0.1),
     ("dreaming_max_model_error", "1.0"),
     ("dreaming_max_model_error", None),
+    ("dreaming_max_model_error", 1e100),
     ("behavior_model_step_size", float("nan")),
     ("behavior_model_step_size", float("inf")),
     ("behavior_model_step_size", float("-inf")),
@@ -108,12 +118,14 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("behavior_model_step_size", -0.1),
     ("behavior_model_step_size", "0.05"),
     ("behavior_model_step_size", None),
+    ("behavior_model_step_size", 1e100),
     ("planning_budget", True),
     ("planning_budget", False),
     ("planning_budget", -1),
     ("planning_budget", 1.5),
     ("planning_budget", "1"),
     ("planning_budget", None),
+    ("planning_budget", 2**31),
     ("buffer_capacity", True),
     ("buffer_capacity", False),
     ("buffer_capacity", 0),
@@ -121,6 +133,8 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("buffer_capacity", 1.5),
     ("buffer_capacity", "64"),
     ("buffer_capacity", None),
+    ("buffer_capacity", 2**31 - 1),
+    ("buffer_capacity", 2**31),
     ("dream_rollout_horizon", True),
     ("dream_rollout_horizon", False),
     ("dream_rollout_horizon", 0),
@@ -128,6 +142,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("dream_rollout_horizon", 1.5),
     ("dream_rollout_horizon", "1"),
     ("dream_rollout_horizon", None),
+    ("dream_rollout_horizon", 2**31),
     ("dream_candidate_count", True),
     ("dream_candidate_count", False),
     ("dream_candidate_count", 0),
@@ -135,6 +150,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("dream_candidate_count", 1.5),
     ("dream_candidate_count", "1"),
     ("dream_candidate_count", None),
+    ("dream_candidate_count", 2**31),
     ("dream_surprise_weight", float("nan")),
     ("dream_surprise_weight", float("inf")),
     ("dream_surprise_weight", float("-inf")),
@@ -142,6 +158,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("dream_surprise_weight", False),
     ("dream_surprise_weight", "1.0"),
     ("dream_surprise_weight", None),
+    ("dream_surprise_weight", 1e100),
     ("dream_utility_weight", float("nan")),
     ("dream_utility_weight", float("inf")),
     ("dream_utility_weight", float("-inf")),
@@ -149,6 +166,7 @@ _INVALID_STEP9_FIELDS: tuple[tuple[str, Any], ...] = (
     ("dream_utility_weight", False),
     ("dream_utility_weight", "1.0"),
     ("dream_utility_weight", None),
+    ("dream_utility_weight", 1e100),
     ("model_include_action_interactions", 0),
     ("model_include_action_interactions", 1),
     ("model_include_action_interactions", "true"),
@@ -892,3 +910,77 @@ def test_step9_state_stays_finite_over_many_steps() -> None:
     )
     result = run_step9_smoke(cfg, steps=128, seed=7)
     assert result.finite
+
+
+def test_step9_config_rejects_float32_overflow() -> None:
+    with pytest.raises(ValueError, match="model_step_size"):
+        Step9DreamingConfig(model_step_size=1e100)
+    with pytest.raises(ValueError, match="dreaming_max_model_error"):
+        Step9DreamingConfig(dreaming_max_model_error=1e100)
+    with pytest.raises(ValueError, match="dream_surprise_weight"):
+        Step9DreamingConfig(dream_surprise_weight=1e100)
+
+
+def test_step9_config_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    config = Step9DreamingConfig(
+        observation_dim=2**31 - 1,
+        n_actions=2,
+        control=Step6DifferentialSARSAConfig(n_actions=2),
+        model_hidden_sizes=(2**31 - 1,),
+        model_step_size=f32_max,
+        model_sparsity=1.0,
+        model_gamma=1.0,
+        dreaming_warmup_steps=2**31 - 1,
+        dreaming_max_model_error=f32_max,
+        model_error_decay=1.0 - 2**-24,
+        behavior_model_step_size=f32_max,
+        planning_budget=2**31 - 1,
+        dream_rollout_horizon=2**31 - 1,
+        dream_candidate_count=2**31 - 1,
+        dream_surprise_weight=f32_max,
+        dream_utility_weight=f32_max,
+        buffer_capacity=2**31 - 2,
+    )
+    assert config.observation_dim == 2**31 - 1
+    assert config.model_hidden_sizes == (2**31 - 1,)
+    assert config.model_step_size == f32_max
+    assert config.buffer_capacity == 2**31 - 2
+
+
+def test_step9_config_exact_fraction_rounding() -> None:
+    midpoint = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    config = Step9DreamingConfig(
+        model_step_size=midpoint,
+        model_sparsity=Fraction(9, 10),
+        model_gamma=Fraction(99, 100),
+        dreaming_max_model_error=midpoint,
+        model_error_decay=Fraction(99, 100),
+        behavior_model_step_size=midpoint,
+        dream_surprise_weight=midpoint,
+        dream_utility_weight=midpoint,
+    )
+    expected_f32 = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert config.model_step_size == expected_f32
+    assert config.dreaming_max_model_error == expected_f32
+    assert config.behavior_model_step_size == expected_f32
+    assert config.dream_surprise_weight == expected_f32
+    assert config.dream_utility_weight == expected_f32
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "32"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_step9_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step9_smoke(**kwargs)


### PR DESCRIPTION
Closes #385.

## What changed

`Step9DreamingConfig` and `run_step9_smoke` now strictly validate scalar hyper-parameters and integer bounds before constructing dreaming components. Float32 execution values use the shared exact-ratio `round_real_to_float32` helper, preventing binary64 double rounding for `Fraction` and extended-precision inputs.

Exact float32 overflow is rejected across `model_step_size`, `model_sparsity`, `model_gamma`, `model_error_decay`, `dreaming_max_model_error`, `behavior_model_step_size`, `dream_surprise_weight`, and `dream_utility_weight`; legal zero/one endpoints remain valid. Integer dimensions, budgets, horizons, counts, buffer capacities, and smoke parameters are bounded to signed int32 max (`2**31 - 1`).

## Scope

• `alberta_framework/steps/step9.py`
• `tests/test_step9_production.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 9 production suite: 194 passed;
• affected dreaming core suite: 5 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported