### PR TITLE
fix(steps): validate exact ratios against facade domains

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import math
 import struct
 from numbers import Integral, Real
+from typing import cast
+
+
+def _is_actual_integral(value: object) -> bool:
+    """Return whether the runtime type is a non-bool Integral subtype."""
+    actual_type = type(value)
+    return not issubclass(actual_type, bool) and issubclass(actual_type, Integral)
 
 
 def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
@@ -82,25 +89,25 @@ def _real_ratio(value: Real) -> tuple[int, int, bool]:
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise TypeError("value must be an actual non-bool real")
-    if isinstance(value, Integral):
-        ratio: object = (int(value), 1)
+    if _is_actual_integral(value):
+        ratio: object = (int(cast(Integral, value)), 1)
     else:
         ratio_method = getattr(value, "as_integer_ratio", None)
         if not callable(ratio_method):
             raise TypeError("real value must expose as_integer_ratio")
         ratio = ratio_method()
-    if not isinstance(ratio, tuple) or len(ratio) != 2:
+    if not issubclass(type(ratio), tuple):
         raise TypeError("as_integer_ratio must return an integer pair")
-    numerator_raw, denominator_raw = ratio
-    if (
-        isinstance(numerator_raw, bool)
-        or not isinstance(numerator_raw, Integral)
-        or isinstance(denominator_raw, bool)
-        or not isinstance(denominator_raw, Integral)
+    ratio_tuple = cast(tuple[object, ...], ratio)
+    if len(ratio_tuple) != 2:
+        raise TypeError("as_integer_ratio must return an integer pair")
+    numerator_raw, denominator_raw = ratio_tuple
+    if not _is_actual_integral(numerator_raw) or not _is_actual_integral(
+        denominator_raw
     ):
         raise TypeError("as_integer_ratio must return an integer pair")
-    numerator = int(numerator_raw)
-    denominator = int(denominator_raw)
+    numerator = int(cast(Integral, numerator_raw))
+    denominator = int(cast(Integral, denominator_raw))
     if denominator < 0:
         numerator = -numerator
         denominator = -denominator

--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -79,8 +79,9 @@ def _float32_from_ratio(
 
 def _real_ratio(value: Real) -> tuple[int, int, bool]:
     """Return one normalized exact ratio and its zero-sign metadata."""
-    if isinstance(value, bool):
-        raise TypeError("real value must not be a bool")
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise TypeError("value must be an actual non-bool real")
     if isinstance(value, Integral):
         ratio: object = (int(value), 1)
     else:

--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -77,14 +77,8 @@ def _float32_from_ratio(
     return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
 
 
-def round_real_to_float32(value: Real) -> float:
-    """Round a standard exact-ratio real directly to IEEE binary32.
-
-    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
-    round-to-nearest, ties-to-even semantics without an intermediate binary64
-    conversion. Real implementations that cannot expose an exact ratio are
-    rejected instead of being silently double-rounded.
-    """
+def _real_ratio(value: Real) -> tuple[int, int, bool]:
+    """Return one normalized exact ratio and its zero-sign metadata."""
     if isinstance(value, bool):
         raise TypeError("real value must not be a bool")
     if isinstance(value, Integral):
@@ -106,14 +100,41 @@ def round_real_to_float32(value: Real) -> float:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)
     denominator = int(denominator_raw)
-    negative_zero = (
-        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
-    )
-    return _float32_from_ratio(
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+    negative_zero = numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    return numerator, denominator, negative_zero
+
+
+def round_real_to_float32_with_ratio(value: Real) -> tuple[int, int, float]:
+    """Read one exact ratio and return it with its binary32 rounding.
+
+    Returning the same ratio used for rounding lets domain validators retain
+    facts that disappear at binary32 endpoints, such as a negative value that
+    rounds to ``-0.0`` or a value above one that rounds to ``1.0``.
+    """
+    numerator, denominator, negative_zero = _real_ratio(value)
+    rounded = _float32_from_ratio(
         numerator,
         denominator,
         negative_zero=negative_zero,
     )
+    return numerator, denominator, rounded
 
 
-__all__ = ["round_real_to_float32"]
+def round_real_to_float32(value: Real) -> float:
+    """Round a standard exact-ratio real directly to IEEE binary32.
+
+    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
+    round-to-nearest, ties-to-even semantics without an intermediate binary64
+    conversion. Real implementations that cannot expose an exact ratio are
+    rejected instead of being silently double-rounded.
+    """
+    _, _, rounded = round_real_to_float32_with_ratio(value)
+    return rounded
+
+
+__all__ = ["round_real_to_float32", "round_real_to_float32_with_ratio"]

--- a/alberta_framework/steps/_float32_validation.py
+++ b/alberta_framework/steps/_float32_validation.py
@@ -6,20 +6,20 @@ import math
 from numbers import Real
 from typing import cast
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 
-def finite_real_and_float32(name: str, value: object) -> tuple[Real, float]:
-    """Return the original real and its exact finite binary32 rounding."""
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
     try:
-        narrowed = round_real_to_float32(value)
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must be finite, got {value!r}") from None
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    return value, narrowed
+    return value, numerator, denominator, narrowed
 
 
 def canonical_float32_storage(value: Real, narrowed: float) -> float:

--- a/alberta_framework/steps/_float32_validation.py
+++ b/alberta_framework/steps/_float32_validation.py
@@ -11,15 +11,17 @@ from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
     """Return the original real, exact ratio, and finite binary32 rounding."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
     try:
-        numerator, denominator, narrowed = round_real_to_float32_with_ratio(value)
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must be finite, got {value!r}") from None
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must be finite, got {value!r}")
-    return value, numerator, denominator, narrowed
+    return real, numerator, denominator, narrowed
 
 
 def canonical_float32_storage(value: Real, narrowed: float) -> float:

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -173,27 +173,34 @@ _INT32_MAX = 2**31 - 1
 
 
 def _require_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
+    real, _, _, narrowed = finite_real_and_float32(name, value)
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -176,33 +176,49 @@ class Step3OneStepResult:
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_gvf_probability(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    if (real != 0.0 and real < _FLOAT32_MIN_NORMAL) or (
-        narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL
+    if (
+        (numerator != 0 and numerator << 126 < denominator)
+        or (real != 0.0 and real < _FLOAT32_MIN_NORMAL)
+        or (narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL)
     ):
         raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -140,33 +140,49 @@ class Step4OneStepResult:
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_gvf_probability(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    if (real != 0.0 and real < _FLOAT32_MIN_NORMAL) or (
-        narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL
+    if (
+        (numerator != 0 and numerator << 126 < denominator)
+        or (real != 0.0 and real < _FLOAT32_MIN_NORMAL)
+        or (narrowed != 0.0 and narrowed < _FLOAT32_MIN_NORMAL)
     ):
         raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -46,10 +46,10 @@ _STEP5_CONFIG_KEYS_ERROR = (
 )
 
 
-def _finite_float32_scalar(name: str, value: object) -> float:
-    """Validate a real scalar before the core narrows it to float32."""
-    _, narrowed = finite_real_and_float32(name, value)
-    return narrowed
+def _finite_float32_scalar(name: str, value: object) -> tuple[int, int, float]:
+    """Validate a real scalar and retain the exact ratio used for rounding."""
+    _, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    return numerator, denominator, narrowed
 
 
 def _compatible_float32_storage(value: object, narrowed: float) -> float:
@@ -71,16 +71,31 @@ class Step5AverageRewardTDConfig:
 
     def __post_init__(self) -> None:
         """Reject malformed scientific scalars before JAX execution."""
-        step_size = _finite_float32_scalar("step_size", self.step_size)
-        average_reward_step_size = _finite_float32_scalar(
+        step_numerator, _, step_size = _finite_float32_scalar(
+            "step_size",
+            self.step_size,
+        )
+        average_numerator, _, average_reward_step_size = _finite_float32_scalar(
             "average_reward_step_size", self.average_reward_step_size
         )
-        trace_decay = _finite_float32_scalar("trace_decay", self.trace_decay)
-        if self.step_size < 0.0 or step_size < 0.0:
+        trace_numerator, trace_denominator, trace_decay = _finite_float32_scalar(
+            "trace_decay",
+            self.trace_decay,
+        )
+        if self.step_size < 0.0 or step_numerator < 0 or step_size < 0.0:
             raise ValueError("step_size must be non-negative")
-        if self.average_reward_step_size < 0.0 or average_reward_step_size < 0.0:
+        if (
+            self.average_reward_step_size < 0.0
+            or average_numerator < 0
+            or average_reward_step_size < 0.0
+        ):
             raise ValueError("average_reward_step_size must be non-negative")
-        if not 0.0 <= self.trace_decay <= 1.0 or not 0.0 <= trace_decay <= 1.0:
+        if (
+            not 0.0 <= self.trace_decay <= 1.0
+            or trace_numerator < 0
+            or trace_numerator > trace_denominator
+            or not 0.0 <= trace_decay <= 1.0
+        ):
             raise ValueError("trace_decay must be in [0, 1]")
         # Preserve builtin floats and sink-exact builtin integers. Other Reals
         # need the already-rounded value so the JAX sink cannot double-round.

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -19,7 +19,7 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -27,7 +27,6 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAArrayResult,
@@ -36,41 +35,39 @@ from alberta_framework.core.average_reward import (
     DifferentialSARSAUpdateResult,
     run_differential_sarsa_from_arrays,
 )
+from alberta_framework.steps._float32_validation import finite_real_and_float32
 
 _INT32_MAX = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> Any:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    return value
-
-
-def _narrow_float32(name: str, value: Any) -> float:
-    """Narrow exactly as the JAX core does, without an intermediate float64."""
-    try:
-        narrowed = round_real_to_float32(value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if not bool(np.isfinite(narrowed)):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
-    if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
+def _compatible_float32_storage(value: object, narrowed: float) -> float:
+    """Preserve compatible builtin payloads without changing the JAX sink."""
+    if type(value) is float and (narrowed != 0.0 or value == 0):
+        return value
+    if type(value) is int and value == narrowed:
         return float(value)
     return narrowed
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if not 0.0 <= original <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return _narrow_float32(name, original)
+    return _compatible_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return _narrow_float32(name, original)
+    return _compatible_float32_storage(real, narrowed)
 
 
 def _require_int(
@@ -80,7 +77,7 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
     number = int(value)
     if minimum is not None and number < minimum:
@@ -142,7 +139,15 @@ class Step6DifferentialSARSAConfig:
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
-        return asdict(self)
+        return {
+            "n_actions": int(self.n_actions),
+            "q_step_size": float(self.q_step_size),
+            "average_reward_step_size": float(self.average_reward_step_size),
+            "trace_decay": float(self.trace_decay),
+            "epsilon_start": float(self.epsilon_start),
+            "epsilon_end": float(self.epsilon_end),
+            "epsilon_decay_steps": int(self.epsilon_decay_steps),
+        }
 
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step6DifferentialSARSAConfig:
@@ -203,6 +208,9 @@ def init_step6_state(
     initial_features: Array,
 ) -> DifferentialSARSAState:
     """Initialize and prime a differential SARSA state."""
+    feature_dim = _require_int(
+        "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+    )
     state = agent.init(feature_dim, key)
     state, _action = agent.start(state, initial_features)
     return cast(DifferentialSARSAState, state)
@@ -236,8 +244,11 @@ def run_step6_smoke(
     seed: int = 0,
 ) -> Step6SmokeResult:
     """Run a tiny deterministic Step 6 integration probe."""
-    steps = _require_int("steps", steps, minimum=1)
-    feature_dim = _require_int("feature_dim", feature_dim, minimum=1)
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    feature_dim = _require_int(
+        "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+    )
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config or Step6DifferentialSARSAConfig()
     agent = make_step6_differential_sarsa_agent(cfg)

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -77,9 +77,10 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if actual_type in (bool, np.bool_) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -137,22 +137,29 @@ class Step7DynaConfig:
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or narrowed <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -99,22 +99,36 @@ class Step8WorldModelConfig:
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0 or narrowed < 0.0 or not narrowed < 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real < 1.0
+        or numerator < 0
+        or numerator >= denominator
+        or narrowed < 0.0
+        or not narrowed < 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -180,27 +180,41 @@ class Step9DreamingConfig:
 
 
 def _require_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
+    real, _, _, narrowed = finite_real_and_float32(name, value)
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonneg_real(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or narrowed < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real <= 1.0 or narrowed < 0.0 or not narrowed <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    real, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or not real < 1.0 or narrowed < 0.0 or not narrowed < 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real < 1.0
+        or numerator < 0
+        or numerator >= denominator
+        or narrowed < 0.0
+        or not narrowed < 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1), got {value!r}")
     return canonical_float32_storage(real, narrowed)
 

--- a/tests/test_float32.py
+++ b/tests/test_float32.py
@@ -1,6 +1,7 @@
 """Exact boundary tests for host-real to IEEE binary32 narrowing."""
 
 from fractions import Fraction
+from numbers import Real
 
 import numpy as np
 import pytest
@@ -59,4 +60,21 @@ def test_preserves_signed_zero(value: float) -> None:
 @pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
 def test_rejects_bool_aliases(value: object) -> None:
     with pytest.raises(TypeError):
+        round_real_to_float32(value)  # type: ignore[arg-type]
+
+
+def test_rejects_non_real_whose_class_property_spoofs_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    assert isinstance(value, Real)
+    assert not issubclass(type(value), Real)
+
+    with pytest.raises(TypeError, match="actual non-bool real"):
         round_real_to_float32(value)  # type: ignore[arg-type]

--- a/tests/test_float32.py
+++ b/tests/test_float32.py
@@ -78,3 +78,38 @@ def test_rejects_non_real_whose_class_property_spoofs_float() -> None:
 
     with pytest.raises(TypeError, match="actual non-bool real"):
         round_real_to_float32(value)  # type: ignore[arg-type]
+
+
+def test_float_subclass_cannot_spoof_integral_ratio_dispatch() -> None:
+    class IntegralSpoofFloat(float):
+        calls = 0
+
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).calls += 1
+            return (-1, 2**200)
+
+    value = IntegralSpoofFloat(0.5)
+
+    assert _raw_float32(round_real_to_float32(value)) == 0x80000000
+    assert IntegralSpoofFloat.calls == 1
+
+
+def test_rejects_ratio_component_whose_class_property_spoofs_int() -> None:
+    class IntegerSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __int__(self) -> int:
+            return 1
+
+    class MalformedRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[object, int]:
+            return (IntegerSpoof(), 2)
+
+    with pytest.raises(TypeError, match="integer pair"):
+        round_real_to_float32(MalformedRatioFloat(0.5))

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -501,6 +501,68 @@ def test_step6_exact_ratio_is_read_once() -> None:
     assert config.q_step_size == 0.5
 
 
+def test_step6_class_spoof_cannot_bypass_exact_ratio_dispatch() -> None:
+    class IntegralSpoofFloat(float):
+        calls = 0
+
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).calls += 1
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="q_step_size"):
+        Step6DifferentialSARSAConfig(q_step_size=IntegralSpoofFloat(0.5))
+    assert IntegralSpoofFloat.calls == 1
+
+
+@pytest.mark.parametrize("field", ["n_actions", "epsilon_decay_steps"])
+def test_step6_integer_fields_reject_class_spoof(field: str) -> None:
+    class IntegerSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __int__(self) -> int:
+            return 2
+
+    with pytest.raises(ValueError, match=field):
+        Step6DifferentialSARSAConfig(**{field: IntegerSpoof()})
+
+
+@pytest.mark.parametrize(
+    "config_type",
+    [
+        pytest.param(Step7DynaConfig, id="step7"),
+        pytest.param(Step9DreamingConfig, id="step9"),
+    ],
+)
+def test_nested_step6_payload_refuses_integral_class_spoof(
+    config_type: type[Step7DynaConfig] | type[Step9DreamingConfig],
+) -> None:
+    class IntegralSpoofFloat(float):
+        calls = 0
+
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).calls += 1
+            return (-1, 2**200)
+
+    payload = config_type().to_dict()
+    control = payload["control"]
+    assert isinstance(control, dict)
+    control["q_step_size"] = IntegralSpoofFloat(0.5)
+
+    with pytest.raises(ValueError, match="q_step_size"):
+        config_type.from_dict(payload)
+    assert IntegralSpoofFloat.calls == 1
+
+
 def test_step6_builtin_float_serialization_and_signed_zero_are_preserved() -> None:
     config = Step6DifferentialSARSAConfig(
         q_step_size=0.1,

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -18,6 +18,7 @@ from alberta_framework.steps import (
     Step6DifferentialSARSAConfig,
     Step7DynaConfig,
     Step8WorldModelConfig,
+    Step9DreamingConfig,
     init_step6_state,
     init_step7_state,
     make_step5_td_learner,
@@ -269,6 +270,39 @@ def test_step6_smoke_rejects_non_integral_dimensions(field: str, value: Any) -> 
         run_step6_smoke(**{field: value})
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("steps", 0),
+        ("steps", 2**31),
+        ("feature_dim", 0),
+        ("feature_dim", 2**31),
+        ("seed", -1),
+        ("seed", 2**31),
+        ("seed", True),
+    ],
+)
+def test_step6_smoke_rejects_out_of_range_dimensions_and_seed(
+    field: str,
+    value: Any,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        run_step6_smoke(**{field: value})
+
+
+@pytest.mark.parametrize("feature_dim", [0, 2**31, True])
+def test_init_step6_state_rejects_invalid_feature_dim(feature_dim: Any) -> None:
+    agent = make_step6_differential_sarsa_agent()
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        init_step6_state(
+            agent,
+            feature_dim=feature_dim,
+            key=jr.key(0),
+            initial_features=jnp.ones((1,), dtype=jnp.float32),
+        )
+
+
 _INVALID_STEP6_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_actions", 0),
     ("n_actions", -1),
@@ -424,6 +458,86 @@ def test_step6_fields_enforce_exact_scientific_domains(
 ) -> None:
     with pytest.raises(ValueError, match=field):
         Step6DifferentialSARSAConfig(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "ratio"),
+    [
+        ("q_step_size", (-1, 2**200)),
+        ("average_reward_step_size", (-1, 2**200)),
+        ("trace_decay", (-1, 2**200)),
+        ("trace_decay", (2**200 + 1, 2**200)),
+        ("epsilon_start", (-1, 2**200)),
+        ("epsilon_start", (2**200 + 1, 2**200)),
+        ("epsilon_end", (-1, 2**200)),
+        ("epsilon_end", (2**200 + 1, 2**200)),
+    ],
+)
+def test_step6_fields_reject_hostile_exact_ratio_domains(
+    field: str,
+    ratio: tuple[int, int],
+) -> None:
+    class HostileRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=field):
+        Step6DifferentialSARSAConfig(**{field: HostileRatioFloat(0.5)})
+
+
+def test_step6_exact_ratio_is_read_once() -> None:
+    class StatefulRatioFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).calls += 1
+            if type(self).calls == 1:
+                return (1, 2)
+            return (-1, 1)
+
+    config = Step6DifferentialSARSAConfig(q_step_size=StatefulRatioFloat(0.5))
+
+    assert StatefulRatioFloat.calls == 1
+    assert config.q_step_size == 0.5
+
+
+def test_step6_builtin_float_serialization_and_signed_zero_are_preserved() -> None:
+    config = Step6DifferentialSARSAConfig(
+        q_step_size=0.1,
+        average_reward_step_size=-0.0,
+        trace_decay=-0.0,
+        epsilon_start=-0.0,
+        epsilon_end=-0.0,
+    )
+    payload = config.to_dict()
+
+    assert type(payload["q_step_size"]) is float
+    assert payload["q_step_size"] == 0.1
+    for field in (
+        "average_reward_step_size",
+        "trace_decay",
+        "epsilon_start",
+        "epsilon_end",
+    ):
+        assert type(payload[field]) is float
+        assert np.signbit(payload[field])
+    assert Step6DifferentialSARSAConfig.from_dict(payload) == config
+
+
+@pytest.mark.parametrize(
+    "wrap",
+    [
+        pytest.param(lambda control: Step7DynaConfig(control=control), id="step7"),
+        pytest.param(lambda control: Step9DreamingConfig(control=control), id="step9"),
+    ],
+)
+def test_nested_step7_and_step9_refuse_hostile_step6_ratio(wrap: Any) -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="q_step_size"):
+        wrap(Step6DifferentialSARSAConfig(q_step_size=HiddenNegativeFloat(0.5)))
 
 
 def test_step6_float32_narrowing_avoids_longdouble_double_rounding() -> None:

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -356,6 +356,137 @@ def test_host_comparisons_cannot_hide_invalid_narrowed_domains() -> None:
 
 
 @pytest.mark.parametrize(
+    "build_config",
+    [
+        pytest.param(lambda value: Step3HordeConfig(sparsity=value), id="step3"),
+        pytest.param(lambda value: Step4SARSAConfig(epsilon_start=value), id="step4"),
+        pytest.param(
+            lambda value: Step5AverageRewardTDConfig(trace_decay=value),
+            id="step5",
+        ),
+        pytest.param(
+            lambda value: Step7DynaConfig(planning_utility_step_size=value),
+            id="step7",
+        ),
+        pytest.param(lambda value: Step8WorldModelConfig(sparsity=value), id="step8"),
+        pytest.param(lambda value: Step9DreamingConfig(model_gamma=value), id="step9"),
+        pytest.param(lambda value: Step10STOMPConfig(epsilon_base=value), id="step10"),
+    ],
+)
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_exact_ratio_cannot_hide_outside_closed_unit_domain(
+    build_config: Callable[[Any], object],
+    ratio: tuple[int, int],
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"must be in \[0, 1\]"):
+        build_config(HiddenBoundaryFloat(0.5))
+
+
+@pytest.mark.parametrize(
+    "build_config",
+    [
+        pytest.param(lambda value: Step3HordeConfig(step_size=value), id="step3"),
+        pytest.param(lambda value: Step4SARSAConfig(step_size=value), id="step4"),
+        pytest.param(
+            lambda value: Step5AverageRewardTDConfig(step_size=value),
+            id="step5",
+        ),
+        pytest.param(
+            lambda value: Step7DynaConfig(planning_priority_propagation=value),
+            id="step7",
+        ),
+        pytest.param(lambda value: Step8WorldModelConfig(step_size=value), id="step8"),
+        pytest.param(
+            lambda value: Step9DreamingConfig(dreaming_max_model_error=value),
+            id="step9",
+        ),
+        pytest.param(lambda value: Step10STOMPConfig(base_step_size=value), id="step10"),
+    ],
+)
+def test_exact_ratio_cannot_hide_negative_underflow_from_nonnegative_domain(
+    build_config: Callable[[Any], object],
+) -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        build_config(HiddenNegativeFloat(0.5))
+
+
+@pytest.mark.parametrize(
+    "build_config",
+    [
+        pytest.param(
+            lambda value: Step3HordeConfig(gammas=(value,), lamdas=(0.0,)),
+            id="step3-gamma",
+        ),
+        pytest.param(
+            lambda value: Step3HordeConfig(gammas=(0.0,), lamdas=(value,)),
+            id="step3-lamda",
+        ),
+        pytest.param(lambda value: Step4SARSAConfig(gamma=value), id="step4-gamma"),
+        pytest.param(lambda value: Step4SARSAConfig(lamda=value), id="step4-lamda"),
+    ],
+)
+def test_exact_ratio_cannot_hide_nonzero_gvf_underflow(
+    build_config: Callable[[Any], object],
+) -> None:
+    class HiddenTinyFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2**150)
+
+    with pytest.raises(ValueError, match="zero or a normal float32"):
+        build_config(HiddenTinyFloat(0.5))
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        pytest.param(Step8WorldModelConfig, "utility_decay", id="step8"),
+        pytest.param(Step9DreamingConfig, "model_error_decay", id="step9"),
+    ],
+)
+def test_exact_ratio_cannot_hide_negative_underflow_from_half_open_domain(
+    config_type: type[Step8WorldModelConfig] | type[Step9DreamingConfig],
+    field: str,
+) -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match=rf"{field} must be in \[0, 1\)"):
+        config_type(**{field: cast(Any, HiddenNegativeFloat(0.5))})
+
+
+def test_exact_ratio_is_read_once_during_validation() -> None:
+    class StatefulRatioFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).calls += 1
+            if type(self).calls == 1:
+                return (1, 2)
+            return (2, 1)
+
+    value = StatefulRatioFloat(0.5)
+    config = Step8WorldModelConfig(step_size=value)
+
+    assert StatefulRatioFloat.calls == 1
+    assert config.step_size == 0.5
+
+
+@pytest.mark.parametrize(
     ("config_type", "field"),
     [
         pytest.param(Step8WorldModelConfig, "utility_decay", id="step8"),

--- a/tests/test_step_float32_validation.py
+++ b/tests/test_step_float32_validation.py
@@ -6,6 +6,7 @@ import json
 import math
 from collections.abc import Callable
 from fractions import Fraction
+from numbers import Real
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -16,6 +17,7 @@ from alberta_framework.core.options import SubtaskSpec
 from alberta_framework.steps.step3 import Step3HordeConfig, make_step3_horde_spec
 from alberta_framework.steps.step4 import Step4SARSAConfig, make_step4_sarsa_agent
 from alberta_framework.steps.step5 import Step5AverageRewardTDConfig
+from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
 from alberta_framework.steps.step7 import Step7DynaConfig
 from alberta_framework.steps.step8 import Step8WorldModelConfig, make_step8_world_model
 from alberta_framework.steps.step9 import Step9DreamingConfig, make_step9_components
@@ -77,6 +79,24 @@ def _step5_values(value: object) -> tuple[float, ...]:
         config.step_size,
         config.average_reward_step_size,
         config.trace_decay,
+    )
+
+
+def _step6_values(value: object) -> tuple[float, ...]:
+    scalar = cast(Any, value)
+    config = Step6DifferentialSARSAConfig(
+        q_step_size=scalar,
+        average_reward_step_size=scalar,
+        trace_decay=scalar,
+        epsilon_start=scalar,
+        epsilon_end=scalar,
+    )
+    return (
+        config.q_step_size,
+        config.average_reward_step_size,
+        config.trace_decay,
+        config.epsilon_start,
+        config.epsilon_end,
     )
 
 
@@ -184,6 +204,7 @@ def _step10_values(value: object) -> tuple[float, ...]:
         pytest.param(_step3_values, id="step3"),
         pytest.param(_step4_values, id="step4"),
         pytest.param(_step5_values, id="step5"),
+        pytest.param(_step6_values, id="step6"),
         pytest.param(_step7_values, id="step7"),
         pytest.param(_step8_values, id="step8"),
         pytest.param(_step9_values, id="step9"),
@@ -365,6 +386,10 @@ def test_host_comparisons_cannot_hide_invalid_narrowed_domains() -> None:
             id="step5",
         ),
         pytest.param(
+            lambda value: Step6DifferentialSARSAConfig(epsilon_start=value),
+            id="step6",
+        ),
+        pytest.param(
             lambda value: Step7DynaConfig(planning_utility_step_size=value),
             id="step7",
         ),
@@ -400,6 +425,10 @@ def test_exact_ratio_cannot_hide_outside_closed_unit_domain(
         pytest.param(
             lambda value: Step5AverageRewardTDConfig(step_size=value),
             id="step5",
+        ),
+        pytest.param(
+            lambda value: Step6DifferentialSARSAConfig(q_step_size=value),
+            id="step6",
         ),
         pytest.param(
             lambda value: Step7DynaConfig(planning_priority_propagation=value),
@@ -484,6 +513,62 @@ def test_exact_ratio_is_read_once_during_validation() -> None:
 
     assert StatefulRatioFloat.calls == 1
     assert config.step_size == 0.5
+
+
+@pytest.mark.parametrize(
+    "build_config",
+    [
+        pytest.param(lambda value: Step3HordeConfig(step_size=value), id="step3"),
+        pytest.param(lambda value: Step4SARSAConfig(step_size=value), id="step4"),
+        pytest.param(
+            lambda value: Step5AverageRewardTDConfig(step_size=value),
+            id="step5",
+        ),
+        pytest.param(
+            lambda value: Step6DifferentialSARSAConfig(q_step_size=value),
+            id="step6",
+        ),
+        pytest.param(
+            lambda value: Step7DynaConfig(planning_priority_propagation=value),
+            id="step7",
+        ),
+        pytest.param(lambda value: Step8WorldModelConfig(step_size=value), id="step8"),
+        pytest.param(
+            lambda value: Step9DreamingConfig(dreaming_max_model_error=value),
+            id="step9",
+        ),
+        pytest.param(lambda value: Step10STOMPConfig(base_step_size=value), id="step10"),
+    ],
+)
+def test_class_property_cannot_spoof_actual_real_type(
+    build_config: Callable[[Any], object],
+) -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+        def __lt__(self, other: object) -> bool:
+            return 0.5 < cast(Any, other)
+
+        def __le__(self, other: object) -> bool:
+            return 0.5 <= cast(Any, other)
+
+        def __gt__(self, other: object) -> bool:
+            return 0.5 > cast(Any, other)
+
+        def __ge__(self, other: object) -> bool:
+            return 0.5 >= cast(Any, other)
+
+    value = ClassSpoof()
+    assert isinstance(value, Real)
+    assert not issubclass(type(value), Real)
+
+    with pytest.raises(ValueError, match="must be a real number"):
+        build_config(value)
 
 
 @pytest.mark.parametrize(
@@ -751,6 +836,14 @@ def test_jax_array_scalars_remain_outside_the_real_facade(value: object) -> None
             ),
             "step_size",
             id="step5",
+        ),
+        pytest.param(
+            lambda: (
+                Step6DifferentialSARSAConfig(q_step_size=0.1),
+                Step6DifferentialSARSAConfig(q_step_size=0.1).to_dict(),
+            ),
+            "q_step_size",
+            id="step6",
         ),
         pytest.param(
             lambda: (


### PR DESCRIPTION
Closes #387

## Summary

Carry the exact numerator/denominator returned by the shared scalar converter through Step 3–10 validation, rather than comparing only the original `Real` object after it has supplied that ratio.

This closes exact-domain escapes where a concrete `float` subclass compares as an ordinary in-range value but exposes an exact ratio that is negative, above one, or nonzero below the GVF normal floor. The repair preserves compatible built-in float payloads and signed-zero serialization while making exact sign/unit/GVF rules fail closed.

Every Step 6 scientific scalar now uses the same single-read exact-ratio metadata. `q_step_size` and `average_reward_step_size` enforce exact non-negativity; `trace_decay`, `epsilon_start`, and `epsilon_end` enforce the exact closed unit interval; nested Step 7/9 payload construction refuses hostile Step 6 controls. Step 6 dimensions and seeds retain int32/bool guards.

The final runtime-type repair prevents dynamic `__class__` spoofing from routing a concrete float through the Integral shortcut, rejects spoofed non-Integral ratio components, and hardens Step 6 integer fields with the same actual-type rule.

## Exact-head evidence

Exact head `233ecb1f2b94e01cd3644a92d526f695e69789b0` is based directly on `origin/main` `751e9ab80db16a625a953ac264e2490210ed4f44`.

- original Step 6 hostile-domain selector: 10 failed before the exact-domain repair
- final class-spoof selector: 5 failed on predecessor `a49414af11dfb0a59bd6081086a61715c433186d`
- exact-head affected panel (`test_float32`, Step 5/6 production, central Step 3–10 validation): 290 passed
- changed-file Ruff passed
- strict mypy passed across 165 source files
- `git diff --check` passed
- no `outputs/**` artifact changes
- evidence registry exit 2 is the pre-existing registered-source drift state; this PR makes no performance or scientific-evidence claim

Overlapping open facade PRs that also edit the shared float32 helper must rebase after this change.