### PR TITLE
fix(upgd): refuse a configured bounder that adaptive kappa would discard

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -327,7 +327,10 @@ class UPGDLearner:
             when no gradient-alignment meta-rule is active. Disable for lean
             non-meta UPGD benchmarks to reduce carry traffic.
         adaptive_kappa_mode: Optional online control law for ObGD ``kappa``.
-            ``"none"`` uses the configured bounder unchanged. ``"loss_ratio"``
+            ``"none"`` uses the configured bounder unchanged; every other mode
+            bounds with plain ObGD at ``adaptive_kappa_base`` (scaled by the
+            law), so a configured ``bounder`` must be ``None`` or an
+            :class:`ObGDBounding` with that same kappa. ``"loss_ratio"``
             computes an effective kappa from the learner's fast/slow loss EMAs,
             lowering kappa when fast loss exceeds slow loss and raising it when
             the stream appears stable. ``"gradient_alignment"`` learns a
@@ -755,6 +758,24 @@ class UPGDLearner:
         if adaptive_kappa_base <= 0.0:
             msg = f"adaptive_kappa_base must be positive, got {adaptive_kappa_base}"
             raise ValueError(msg)
+        if adaptive_kappa_mode != "none" and bounder is not None:
+            configured = bounder.to_config()
+            if type(bounder) is not ObGDBounding:
+                msg = (
+                    "adaptive_kappa_mode bounds every update with plain ObGD at "
+                    "adaptive_kappa_base and would silently discard the configured "
+                    f"{configured.get('type', type(bounder).__name__)} bounder; pass "
+                    "bounder=None or an ObGDBounding whose kappa equals adaptive_kappa_base"
+                )
+                raise ValueError(msg)
+            if float(configured["kappa"]) != float(adaptive_kappa_base):
+                msg = (
+                    "adaptive_kappa_mode bounds every update at adaptive_kappa_base="
+                    f"{adaptive_kappa_base}, which disagrees with the configured "
+                    f"ObGDBounding kappa={configured['kappa']}; make them equal or use "
+                    "adaptive_kappa_mode='none'"
+                )
+                raise ValueError(msg)
         if adaptive_kappa_min <= 0.0:
             msg = f"adaptive_kappa_min must be positive, got {adaptive_kappa_min}"
             raise ValueError(msg)

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -327,9 +327,10 @@ class UPGDLearner:
             when no gradient-alignment meta-rule is active. Disable for lean
             non-meta UPGD benchmarks to reduce carry traffic.
         adaptive_kappa_mode: Optional online control law for ObGD ``kappa``.
-            ``"none"`` uses the configured bounder unchanged; every other mode
-            bounds with plain ObGD at ``adaptive_kappa_base`` (scaled by the
-            law), so a configured ``bounder`` must be ``None`` or an
+            ``"none"`` uses the configured bounder unchanged, and
+            ``bounder=None`` disables bounding in every mode. When a bounder is
+            configured, every other mode uses plain ObGD at
+            ``adaptive_kappa_base`` (scaled by the law), so it must be an
             :class:`ObGDBounding` with that same kappa. ``"loss_ratio"``
             computes an effective kappa from the learner's fast/slow loss EMAs,
             lowering kappa when fast loss exceeds slow loss and raising it when

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -23,8 +23,9 @@ so noise effects are unmistakable) and ``sparsity=0.5`` round-trips.
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
-from alberta_framework.core.optimizers import ObGDBounding
+from alberta_framework.core.optimizers import AdaptiveObGDBounding, ObGDBounding
 from alberta_framework.core.upgd import (
     UPGDLearner,
     UPGDLearningResult,
@@ -1098,6 +1099,36 @@ class TestUpdateMetrics:
         )
 
         assert float(adaptive_delta) > float(static_delta)
+
+    @pytest.mark.parametrize(
+        ("bounder", "reason"),
+        [
+            (ObGDBounding(kappa=2.0), "kappa 2.0 disagrees with adaptive_kappa_base=0.5"),
+            (AdaptiveObGDBounding(kappa=0.5), "the RMS stage would be silently dropped"),
+        ],
+    )
+    def test_adaptive_kappa_refuses_a_bounder_it_would_silently_discard(self, bounder, reason):
+        del reason
+        with pytest.raises(ValueError, match="adaptive_kappa_mode"):
+            UPGDLearner(
+                n_heads=1,
+                hidden_sizes=(4,),
+                bounder=bounder,
+                adaptive_kappa_mode="loss_ratio",
+                adaptive_kappa_base=0.5,
+            )
+
+    def test_adaptive_kappa_accepts_a_matching_obgd_bounder_or_none(self):
+        UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(4,),
+            bounder=ObGDBounding(kappa=0.5),
+            adaptive_kappa_mode="loss_ratio",
+            adaptive_kappa_base=0.5,
+        )
+        UPGDLearner(
+            n_heads=1, hidden_sizes=(4,), adaptive_kappa_mode="loss_ratio", adaptive_kappa_base=0.5
+        )
 
     def test_gradient_alignment_can_learn_kappa_multiplier(self):
         learner = UPGDLearner(


### PR DESCRIPTION
Closes #392.

## Issue

Every `adaptive_kappa_mode` other than `"none"` bounds with plain ObGD at `adaptive_kappa_base` and never consulted `self._bounder`, so a configured `ObGDBounding` with a different kappa (4× step change) or an `AdaptiveObGDBounding` (RMS stage dropped, 268×) was silently replaced — even during warm-up — confounding any adaptive-kappa ablation with a bounder swap.

## New state

`UPGDLearner.__init__` refuses, when `adaptive_kappa_mode != "none"`, a configured bounder that the adaptive branch would discard: any bounder that is not exactly `ObGDBounding`, or an `ObGDBounding` whose kappa differs from `adaptive_kappa_base`. `bounder=None` continues to disable bounding in every mode; a matching `ObGDBounding` (the shipped `step2_strict_digit_readout_default` pairing) is unchanged. The `adaptive_kappa_mode` docstring states both cases. No update arithmetic changes.

Failing-test-first: `test_adaptive_kappa_refuses_a_bounder_it_would_silently_discard[ObGDBounding(2.0)|AdaptiveObGDBounding]` fail on `main` and pass here; `test_adaptive_kappa_accepts_a_matching_obgd_bounder_or_none` pins the accepted pairings.

## Evidence

Falsifier from #392 at this head:

```text
ValueError: adaptive_kappa_mode bounds every update with plain ObGD at adaptive_kappa_base and would silently discard the configured AdaptiveObGDBounding bounder; pass bounder=None or an ObGDBounding whose kappa equals adaptive_kappa_base
```

Functional verification at `86a9474a2de994da4684ad3dff0ecb9d279caf1c`:

```text
.venv/bin/python -m pytest tests/test_upgd.py tests/test_step2*.py -q -o addopts=""   -> 84 passed
.venv/bin/python -m ruff check .                                                     -> All checks passed!
.venv/bin/python -m mypy                                                             -> Success: no issues found in 164 source files
```

Contract-only tip verification at `453f290134b787371835f49e21310de8d36a7443`:

```text
.venv/bin/python -m pytest tests/test_upgd.py -k adaptive_kappa -q -o addopts=""   -> 4 passed
.venv/bin/python -m ruff check alberta_framework/core/upgd.py tests/test_upgd.py   -> All checks passed!
.venv/bin/python -m mypy alberta_framework/core/upgd.py                            -> Success: no issues found
```

Composes cleanly with #375; the combined core audit passed 377 affected tests, full Ruff, and strict mypy across 165 source files. `core/upgd.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:453f290134b787371835f49e21310de8d36a7443 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, and falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
Maintainer contract audit/repair: OpenAI / Codex.
