### PR TITLE
fix(step11): reject illegal OaK facade config

### DIFF
--- a/alberta_framework/steps/_float32_validation.py
+++ b/alberta_framework/steps/_float32_validation.py
@@ -17,7 +17,7 @@ def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, f
     real = cast(Real, value)
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
+    except Exception:
         raise ValueError(f"{name} must be finite, got {value!r}") from None
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must be finite, got {value!r}")

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -34,6 +34,7 @@ from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.oak import (
@@ -166,6 +167,9 @@ class Step11OaKConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_NUMPY_INTEGER_TYPES = frozenset(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+)
 
 
 def _require_real(name: str, value: object) -> float:
@@ -176,9 +180,7 @@ def _require_real(name: str, value: object) -> float:
 def _require_unit_interval(name: str, value: object) -> float:
     real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
-        real < 0.0
-        or not real <= 1.0
-        or numerator < 0
+        numerator < 0
         or numerator > denominator
         or narrowed < 0.0
         or not narrowed <= 1.0
@@ -189,14 +191,14 @@ def _require_unit_interval(name: str, value: object) -> float:
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+    if numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+    if numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
     return canonical_float32_storage(real, narrowed)
 
@@ -209,9 +211,12 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+    if actual_type is int:
+        number = cast(int, value)
+    elif actual_type in _NUMPY_INTEGER_TYPES:
+        number = int(cast(Integral, value))
+    else:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
@@ -240,7 +245,7 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
         "option_planning_backups_per_step",
         config.option_planning_backups_per_step,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_INT32_MAX - 1,
     )
     if type(config.subtask_specs) is not tuple:
         raise ValueError(
@@ -248,7 +253,7 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
         )
     canonical_specs: list[SubtaskSpec] = []
     for spec in config.subtask_specs:
-        if not isinstance(spec, SubtaskSpec):
+        if type(spec) is not SubtaskSpec:
             raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
         feature_index = _require_int(
             "feature_index",

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -29,15 +29,13 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
-from typing import Any
+from numbers import Integral
+from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.oak import (
     KeyboardChordLearnerConfig,
     KeyboardChordLearnerState,
@@ -53,6 +51,10 @@ from alberta_framework.core.oak import (
     update_keyboard_chord_learner,
 )
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.steps._float32_validation import (
+    canonical_float32_storage,
+    finite_real_and_float32,
+)
 
 
 @dataclass(frozen=True)
@@ -167,49 +169,36 @@ _INT32_MAX = 2**31 - 1
 
 
 def _require_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    try:
-        execution_value = round_real_to_float32(value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
-        raise ValueError(f"{name} must be finite in float32, got {value!r}") from error
-    if not bool(np.isfinite(execution_value)):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-    return execution_value
+    real, _, _, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    original_value: Any = value
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
-        not isinstance(value, bool)
-        and isinstance(value, Real)
-        and (original_value < 0 or original_value > 1)
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
     ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    number = _require_real(name, value)
-    if not 0.0 <= number <= 1.0:
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    if not isinstance(value, bool) and isinstance(value, Real) and value < 0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    number = _require_real(name, value)
-    if number < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    if not isinstance(value, bool) and isinstance(value, Real) and value <= 0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
-    number = _require_real(name, value)
-    if number <= 0.0:
-        raise ValueError(
-            f"{name} must be positive in float32 execution sink, got {value!r}"
-        )
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(
@@ -217,36 +206,43 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
-    exclusive_maximum: int | None = None,
+    maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    observation_dim = _require_int(
+        "observation_dim",
+        config.observation_dim,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     n_primitive_actions = _require_int(
         "n_primitive_actions",
         config.n_primitive_actions,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     option_planning_backups_per_step = _require_int(
         "option_planning_backups_per_step",
         config.option_planning_backups_per_step,
         minimum=0,
-        exclusive_maximum=_INT32_MAX,
+        maximum=_INT32_MAX,
     )
-    if not isinstance(config.subtask_specs, tuple):
+    if type(config.subtask_specs) is not tuple:
         raise ValueError(
             f"subtask_specs must be a tuple of SubtaskSpec, got {config.subtask_specs!r}"
         )
@@ -254,7 +250,12 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
     for spec in config.subtask_specs:
         if not isinstance(spec, SubtaskSpec):
             raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
-        feature_index = _require_int("feature_index", spec.feature_index, minimum=0)
+        feature_index = _require_int(
+            "feature_index",
+            spec.feature_index,
+            minimum=0,
+            maximum=_INT32_MAX,
+        )
         if feature_index >= observation_dim:
             raise ValueError(
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
@@ -268,9 +269,8 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
             "max_option_steps",
             spec.max_option_steps,
             minimum=1,
+            maximum=_INT32_MAX,
         )
-        if max_option_steps > _INT32_MAX:
-            raise ValueError("max_option_steps must fit int32 telemetry")
         canonical_specs.append(
             SubtaskSpec(
                 feature_index=feature_index,
@@ -463,7 +463,8 @@ def run_step11_smoke(
     Returns:
         :class:`Step11SmokeResult` with shape/fineness summary.
     """
-    steps = _require_int("steps", steps, minimum=1)
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config
     if cfg is None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -152,6 +152,7 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("observation_dim", float("nan")),
     ("observation_dim", float("inf")),
     ("observation_dim", None),
+    ("observation_dim", 2**31),
     ("n_primitive_actions", 0),
     ("n_primitive_actions", -1),
     ("n_primitive_actions", True),
@@ -161,8 +162,8 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_primitive_actions", float("nan")),
     ("n_primitive_actions", float("inf")),
     ("n_primitive_actions", None),
+    ("n_primitive_actions", 2**31),
     ("option_planning_backups_per_step", -1),
-    ("option_planning_backups_per_step", 2**31 - 1),
     ("option_planning_backups_per_step", 2**31),
     ("option_planning_backups_per_step", True),
     ("option_planning_backups_per_step", False),
@@ -179,12 +180,14 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("base_step_size", -1.0),
     ("base_step_size", "0.05"),
     ("base_step_size", None),
+    ("base_step_size", 1e100),
     ("base_avg_reward_step_size", float("nan")),
     ("base_avg_reward_step_size", float("inf")),
     ("base_avg_reward_step_size", True),
     ("base_avg_reward_step_size", False),
     ("base_avg_reward_step_size", -0.01),
     ("base_avg_reward_step_size", "0.01"),
+    ("base_avg_reward_step_size", 1e100),
     ("base_trace_decay", float("nan")),
     ("base_trace_decay", float("inf")),
     ("base_trace_decay", True),
@@ -192,23 +195,27 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("base_trace_decay", -0.1),
     ("base_trace_decay", 1.1),
     ("base_trace_decay", "0.0"),
+    ("base_trace_decay", 1e100),
     ("option_step_size", float("nan")),
     ("option_step_size", float("inf")),
     ("option_step_size", True),
     ("option_step_size", False),
     ("option_step_size", -1.0),
     ("option_step_size", "0.05"),
+    ("option_step_size", 1e100),
     ("option_avg_reward_step_size", float("nan")),
     ("option_avg_reward_step_size", float("inf")),
     ("option_avg_reward_step_size", True),
     ("option_avg_reward_step_size", False),
     ("option_avg_reward_step_size", -0.01),
+    ("option_avg_reward_step_size", 1e100),
     ("option_trace_decay", float("nan")),
     ("option_trace_decay", float("inf")),
     ("option_trace_decay", True),
     ("option_trace_decay", False),
     ("option_trace_decay", -0.1),
     ("option_trace_decay", 1.1),
+    ("option_trace_decay", 1e100),
     ("option_gamma", float("nan")),
     ("option_gamma", float("inf")),
     ("option_gamma", float("-inf")),
@@ -217,6 +224,7 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("option_gamma", -0.1),
     ("option_gamma", 1.1),
     ("option_gamma", "0.99"),
+    ("option_gamma", 1e100),
     ("option_model_decay", float("nan")),
     ("option_model_decay", float("inf")),
     ("option_model_decay", True),
@@ -224,12 +232,14 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("option_model_decay", -0.1),
     ("option_model_decay", 1.1),
     ("option_model_decay", "0.95"),
+    ("option_model_decay", 1e100),
     ("option_model_step_size", float("nan")),
     ("option_model_step_size", float("inf")),
     ("option_model_step_size", True),
     ("option_model_step_size", False),
     ("option_model_step_size", -0.1),
     ("option_model_step_size", "0.1"),
+    ("option_model_step_size", 1e100),
     ("epsilon_base", float("nan")),
     ("epsilon_base", float("inf")),
     ("epsilon_base", True),
@@ -237,12 +247,14 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("epsilon_base", -0.1),
     ("epsilon_base", 1.1),
     ("epsilon_base", "0.1"),
+    ("epsilon_base", 1e100),
     ("epsilon_option", float("nan")),
     ("epsilon_option", float("inf")),
     ("epsilon_option", True),
     ("epsilon_option", False),
     ("epsilon_option", -0.1),
     ("epsilon_option", 1.1),
+    ("epsilon_option", 1e100),
     ("utility_ema_decay", float("nan")),
     ("utility_ema_decay", float("inf")),
     ("utility_ema_decay", float("-inf")),
@@ -251,6 +263,7 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("utility_ema_decay", -0.1),
     ("utility_ema_decay", 1.1),
     ("utility_ema_decay", "0.99"),
+    ("utility_ema_decay", 1e100),
     ("curation_threshold", float("nan")),
     ("curation_threshold", float("inf")),
     ("curation_threshold", float("-inf")),
@@ -259,6 +272,7 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("curation_threshold", -0.1),
     ("curation_threshold", "0.0"),
     ("curation_threshold", None),
+    ("curation_threshold", 1e100),
 )
 
 
@@ -377,7 +391,7 @@ def test_step11_oak_fields_preserve_legal_endpoints() -> None:
     assert restored.utility_ema_decay == 0.0
     assert restored.curation_threshold == 0.0
     assert restored.subtask_specs[0].feature_index == 0
-    assert restored.subtask_specs[0].threshold == float(np.float32(1e-12))
+    assert restored.subtask_specs[0].threshold == 1e-12
     assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
     assert restored.subtask_specs[0].max_option_steps == 1
     assert agent.config.stomp.option_gamma == 0.0
@@ -1058,3 +1072,86 @@ def test_step11_state_stays_finite_200_steps() -> None:
     chex.assert_tree_all_finite(result.state.stomp_state.base_learner_state)
     chex.assert_tree_all_finite(result.state.utility_ema)
     chex.assert_tree_all_finite(result.td_errors)
+
+
+def test_step11_config_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    spec = SubtaskSpec(
+        feature_index=2**31 - 2,
+        threshold=f32_max,
+        pseudo_reward_scale=f32_max,
+        max_option_steps=2**31 - 1,
+    )
+    config = Step11OaKConfig(
+        subtask_specs=(spec,),
+        observation_dim=2**31 - 1,
+        n_primitive_actions=2**31 - 1,
+        base_step_size=f32_max,
+        base_avg_reward_step_size=f32_max,
+        base_trace_decay=1.0,
+        option_step_size=f32_max,
+        option_avg_reward_step_size=f32_max,
+        option_trace_decay=1.0,
+        option_gamma=1.0,
+        option_model_decay=1.0,
+        option_model_step_size=f32_max,
+        option_planning_backups_per_step=2**31 - 1,
+        epsilon_base=1.0,
+        epsilon_option=1.0,
+        utility_ema_decay=1.0,
+        curation_threshold=f32_max,
+    )
+    assert config.observation_dim == 2**31 - 1
+    assert config.option_planning_backups_per_step == 2**31 - 1
+    assert config.base_step_size == f32_max
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "64"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_step11_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step11_smoke(**kwargs)
+
+
+def test_step11_oak_rejects_spoofed_subtask_specs_container() -> None:
+    class SpoofedTuple(list):
+        @property
+        def __class__(self) -> type[tuple]:
+            return tuple
+
+    with pytest.raises(ValueError, match="subtask_specs"):
+        Step11OaKConfig(
+            subtask_specs=SpoofedTuple([SubtaskSpec(feature_index=0)]),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_step11_oak_rejects_adversarial_ratio_floats(ratio: tuple[int, int]) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match="option_gamma"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0),),
+            option_gamma=HiddenBoundaryFloat(0.5),
+        )

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -164,7 +164,8 @@ _INVALID_STEP11_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_primitive_actions", None),
     ("n_primitive_actions", 2**31),
     ("option_planning_backups_per_step", -1),
-    ("option_planning_backups_per_step", 2**31),
+        ("option_planning_backups_per_step", 2**31),
+        ("option_planning_backups_per_step", 2**31 - 1),
     ("option_planning_backups_per_step", True),
     ("option_planning_backups_per_step", False),
     ("option_planning_backups_per_step", "0"),
@@ -1095,15 +1096,33 @@ def test_step11_config_preserves_float32_boundaries() -> None:
         option_gamma=1.0,
         option_model_decay=1.0,
         option_model_step_size=f32_max,
-        option_planning_backups_per_step=2**31 - 1,
+        option_planning_backups_per_step=2**31 - 2,
         epsilon_base=1.0,
         epsilon_option=1.0,
         utility_ema_decay=1.0,
         curation_threshold=f32_max,
     )
     assert config.observation_dim == 2**31 - 1
-    assert config.option_planning_backups_per_step == 2**31 - 1
+    assert config.option_planning_backups_per_step == 2**31 - 2
     assert config.base_step_size == f32_max
+
+
+def test_step11_oak_normalizes_conversion_hook_failures() -> None:
+    class BrokenFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("conversion hook failed")
+
+    with pytest.raises(ValueError, match="option_gamma must be finite"):
+        Step11OaKConfig(option_gamma=BrokenFloat(0.5))
+
+
+def test_step11_oak_rejects_integer_subclass_conversion_hooks() -> None:
+    class LyingInt(int):
+        def __int__(self) -> int:
+            return 1
+
+    with pytest.raises(ValueError, match="observation_dim"):
+        Step11OaKConfig(observation_dim=LyingInt(-1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reconciles the broad Step 11 OaK facade contract with current shared validators and core STOMP limits.

Changes:
- validate/canonicalize all float32-consumed scientific scalars through the shared exact-ratio policy
- normalize ordinary conversion-hook failures to ValueError
- accept only trusted builtin/NumPy integer families and enforce signed-int32 dimensions/counters
- keep option_planning_backups_per_step strictly below INT32_MAX, matching STOMPConfig
- require exact tuple and SubtaskSpec records
- validate smoke steps/seed and retain all-update health checks

Validation at exact head 1f0cfdc:
- Step 11 suite: 204 tests passed before one test-only misplaced assertion; corrected boundary panel: 14 passed
- options + STOMP planning consumers: 33 passed
- Ruff: clean
- strict mypy for both changed source files: clean
- git diff --check: clean

No benchmark campaign was run and no outputs or evidence artifacts were modified.