### PR TITLE
fix(prototype-agent): reject wrong-shaped scan arrays instead of reshaping them

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -2021,6 +2021,14 @@ def _unavailable_state_builder_learning_diagnostics() -> StateBuilderLearningDia
     )
 
 
+def _shaped_float_array(value: Any, shape: tuple[int, ...], *, name: str) -> Array:
+    """Coerce to float32 without ever reshaping: static shape drift is a caller error."""
+    array = jnp.asarray(value, dtype=jnp.float32)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    return array
+
+
 def _checked_finite_array(
     value: Any,
     shape: tuple[int, ...],
@@ -2029,7 +2037,7 @@ def _checked_finite_array(
     allow_nan: bool = False,
 ) -> Array:
     """Validate shape/finiteness eagerly and poison invalid traced values."""
-    array = jnp.asarray(value, dtype=jnp.float32).reshape(shape)
+    array = _shaped_float_array(value, shape, name=name)
     element_valid = ~jnp.isinf(array) if allow_nan else jnp.isfinite(array)
     valid = jnp.all(element_valid)
     if not _contains_tracer(array) and not bool(valid):
@@ -2040,7 +2048,7 @@ def _checked_finite_array(
 
 def _checked_unit_discount(value: Any, shape: tuple[int, ...], *, name: str) -> Array:
     """Validate finite ``[0, 1]`` discounts at eager and traced boundaries."""
-    array = jnp.asarray(value, dtype=jnp.float32).reshape(shape)
+    array = _shaped_float_array(value, shape, name=name)
     valid = jnp.all(
         jnp.isfinite(array) & (array >= 0.0) & (array <= 1.0)
     )

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -418,6 +418,37 @@ class TestPrototypeAgentScan:
         assert int(result.state.step_count) == n_steps
         chex.assert_tree_all_finite(result.oak_td_errors)
 
+    @pytest.mark.parametrize(
+        ("field", "shape"),
+        [
+            ("rewards", (8, 1)),
+            ("rewards", (2, 4)),
+            ("next_observations", (OBS_DIM, 8)),
+            ("next_observations", (2, 4 * OBS_DIM)),
+            ("discounts", (2, 4)),
+        ],
+    )
+    def test_scan_rejects_wrong_shaped_arrays_instead_of_reshaping(
+        self, field: str, shape: tuple[int, ...]
+    ) -> None:
+        """A transposed or wrongly stacked buffer must not be silently reinterpreted row-major."""
+        agent = PrototypeAgent(_minimal_config())
+        state = agent.start(agent.init(jr.key(0)), jnp.zeros(OBS_DIM))
+        n_steps = 8
+        arrays: dict[str, object] = {
+            "rewards": jr.normal(jr.key(42), (n_steps,)),
+            "next_observations": jr.normal(jr.key(43), (n_steps, OBS_DIM)),
+            "discounts": jnp.full((n_steps,), 0.9, dtype=jnp.float32),
+        }
+        arrays[field] = jnp.reshape(arrays[field], shape)
+        with pytest.raises(ValueError, match=f"{field} must have shape"):
+            agent.scan(
+                state,
+                arrays["rewards"],
+                arrays["next_observations"],
+                discounts=arrays["discounts"],
+            )
+
     def test_scan_matches_sequential(self) -> None:
         agent = PrototypeAgent(_minimal_config())
         init_state = agent.start(agent.init(jr.key(0)), jnp.zeros(OBS_DIM))


### PR DESCRIPTION
Closes #398.

## Issue

`PrototypeAgent.scan`'s validators coerced arrays with `jnp.asarray(...).reshape(shape)`, so a transposed observation matrix, a chunked block, or a `(2, 4)` discount matrix was silently reinterpreted row-major and every step reported `transition_valid=True`.

## New state

`_shaped_float_array` coerces to float32 and refuses static shape drift (`next_observations must have shape (8, 4), got (4, 8)`); `_checked_finite_array` and `_checked_unit_discount` use it, so `rewards`, `next_observations`, `discounts`, `horde_cumulants`, and `horde_discounts` now get the same contract the `update_transition` path already enforces via `_strict_float_array`. Correctly shaped inputs are unchanged.

Failing-test-first: `test_scan_rejects_wrong_shaped_arrays_instead_of_reshaping[…]` (5 shapes across rewards / next_observations / discounts) fails on `main` and passes here.

## Evidence

Falsifier from #398 at this head:

```text
ValueError: next_observations must have shape (8, 4), got (4, 8)
```

Verification at `0f208ffb7e8e431c908c73e0f61b57d0131ad85e`:

```text
.venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts=""   -> 88 passed
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

`core/prototype_agent.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:0f208ffb7e8e431c908c73e0f61b57d0131ad85e -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
