### PR TITLE
fix(upgd): require one target per head in update

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1900,7 +1900,18 @@ class UPGDLearner:
         Returns:
             :class:`UPGDUpdateResult` with the updated state, predictions,
             errors, and 1D metrics array.
+
+        Raises:
+            ValueError: If ``targets`` is not one value per head; a
+                broadcastable scalar or length-1 target would train every head
+                while the active-head count normalizing the loss and step
+                sizes counted one.
         """
+        targets = jnp.asarray(targets, dtype=jnp.float32)
+        if targets.shape != (self._n_heads,):
+            raise ValueError(
+                f"targets must have shape ({self._n_heads},), got {targets.shape}"
+            )
         slope = self._leaky_relu_slope
         ln = self._use_layer_norm
         sigma = jnp.array(self._perturbation_sigma, dtype=jnp.float32)

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -23,6 +23,7 @@ so noise effects are unmistakable) and ``sparsity=0.5`` round-trips.
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.optimizers import ObGDBounding
 from alberta_framework.core.upgd import (
@@ -329,6 +330,17 @@ class TestInitShapes:
 
 class TestValidation:
     """Invalid deployment configurations should fail before JIT compilation."""
+
+    @pytest.mark.parametrize("shape", [(1,), (), (4, 1), (5,)])
+    def test_update_rejects_targets_that_are_not_one_per_head(self, shape):
+        """A broadcastable target must not train every head while n_active counts 1."""
+        learner = UPGDLearner(
+            n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01, perturbation_sigma=0.0
+        )
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        obs = jnp.array([1.0, -0.5, 0.25])
+        with pytest.raises(ValueError, match=r"targets must have shape \(4,\)"):
+            learner.update(state, obs, jnp.full(shape, 2.0, dtype=jnp.float32))
 
     def test_rejects_invalid_core_dimensions(self):
         invalid_kwargs = [


### PR DESCRIPTION
Closes #401.

## Issue

`UPGDLearner.update` documented `targets: (n_heads,)` but never checked it; a scalar or length-1 target broadcast to every head while `n_active` counted 1, so the reported loss was `n_heads`× inflated and head/trunk steps `n_heads`× too large under mean normalization, with a healthy-looking run.

## New state

`update` coerces `targets` to float32 and raises `targets must have shape (n_heads,), got …` when it is not exactly one value per head, before any masking or arithmetic. Well-formed calls are unchanged (the shape check is static, so `jit` cost is nil); every caller — including `pipeline.py`'s array path — inherits the contract.

Failing-test-first: `TestValidation::test_update_rejects_targets_that_are_not_one_per_head[(1,)|()|(4,1)|(5,)]` fails on `main` and passes here.

## Evidence

Falsifier from #401 at this head:

```text
ValueError: targets must have shape (4,), got (1,)
```

Verification at `308e54fda99d1070012eca5b8697781152e5d9fa`:

```text
.venv/bin/python -m pytest tests/test_upgd.py tests/test_step2*.py tests/test_pipeline*.py -q -o addopts=""   -> 101 passed
.venv/bin/python -m ruff check .                                                                             -> All checks passed!
.venv/bin/python -m mypy                                                                                     -> Success: no issues found in 164 source files
```

Composes cleanly with #375 and #393 (`git merge-tree` clean). `core/upgd.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:308e54fda99d1070012eca5b8697781152e5d9fa -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
