### PR TITLE
fix(cbp): validate every hidden width in init_cbp_state

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -175,7 +175,7 @@ def init_cbp_state(
         mlp_state: An initialized :class:`MultiHeadMLPState`. Used only
             to validate that ``hidden_sizes`` matches the trunk shape.
         hidden_sizes: Hidden layer sizes from the learner constructor.
-            Must match ``len(mlp_state.trunk_params.weights)``.
+            Must match the trunk layer count and every layer's width.
         key: JAX random key for replacement weight sampling.
 
     Returns:
@@ -189,6 +189,14 @@ def init_cbp_state(
             f"count ({len(mlp_state.trunk_params.weights)})."
         )
         raise ValueError(msg)
+    for layer_idx, (width, weight) in enumerate(
+        zip(hidden_sizes, mlp_state.trunk_params.weights, strict=True)
+    ):
+        if int(weight.shape[0]) != int(width):
+            raise ValueError(
+                f"hidden_sizes[{layer_idx}]={width} does not match trunk layer "
+                f"{layer_idx} width ({weight.shape[0]})"
+            )
 
     utilities = tuple(
         jnp.zeros(h, dtype=jnp.float32) for h in hidden_sizes

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -7,6 +7,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.continual_backprop import (
     CBPLearningResult,
@@ -72,6 +73,18 @@ class TestInitCbpStateShapes:
         except ValueError:
             return
         raise AssertionError("expected ValueError on mismatched hidden_sizes")
+
+    def test_init_cbp_state_width_mismatch_raises(self):
+        """The count can match while a width does not; that must not silently reshape."""
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(8, 4), sparsity=0.0)
+        mlp_state = learner.init(feature_dim=4, key=jr.key(0))
+        with pytest.raises(
+            ValueError,
+            match=r"^hidden_sizes\[1\]=1 does not match trunk layer 1 width \(4\)$",
+        ):
+            init_cbp_state(mlp_state, (8, 1), key=jr.key(1))
+        with pytest.raises(ValueError, match=r"^hidden_sizes\[0\]=1 does not match"):
+            init_cbp_state(mlp_state, (1, 4), key=jr.key(1))
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #403.

## Issue

`init_cbp_state` compared only the number of hidden layers, so a width mismatch was accepted and the tracker's `utilities` silently reshaped on the first update while `ages` stayed one entry wide — defeating the maturity gate and losing the age reset of replaced units.

## New state

`init_cbp_state` checks each layer's width against the trunk (`hidden_sizes[1]=1 does not match trunk layer 1 width (4)`) after the existing count check; the docstring states the full contract. Matching shapes are unchanged.

Failing-test-first: `test_init_cbp_state_width_mismatch_raises` fails on `main` and passes here.

## Evidence

Falsifier from #403 at this head:

```text
ValueError: hidden_sizes[0]=1 does not match trunk layer 0 width (8)
```

Verification at `b03c1b3c4a9cfa3f202bf6531a4d7d54f61cd1e7`:

```text
.venv/bin/python -m pytest tests/test_continual_backprop.py tests/test_plasticity_gate.py -q -o addopts=""   -> 26 passed
.venv/bin/python -m ruff check .                                                                        -> All checks passed!
.venv/bin/python -m mypy                                                                                -> Success: no issues found in 164 source files
```

Composes cleanly with #371 (`git merge-tree` clean). `core/continual_backprop.py` is imported by the robot track and stays importable; it is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:b03c1b3c4a9cfa3f202bf6531a4d7d54f61cd1e7 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
