### PR TITLE
feat(screening): register gated L2-init mechanism-dissection arm

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -5067,6 +5067,137 @@ def _make_l2init_ema_norm_learner(
     return init_fn, full_step
 
 
+@chex.dataclass(frozen=True)
+class UPGDGatedL2InitNormState:
+    """Lean-UPGD utility EMA/clock, a frozen copy of the initial parameters,
+    and the EMA input-normalizer state (see
+    :func:`_make_sigma0_gated_l2init_learner`)."""
+
+    utility: dict[str, Array]
+    step: Array
+    init_params: dict[str, Array]
+    norm: EMANormState
+
+
+def _make_sigma0_gated_l2init_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    """``sigma0_ndecay099`` champion plus an additive, utility-GATED pull
+    toward the initial weights.
+
+    Ported idea: continuous utility-scaled soft resets (CCBP,
+    OpenReview:UJqXhFFzKu; Calibrated Partial Resets, arXiv:2607.24996)
+    report that a *continuous*, per-unit-utility-scaled partial pull of
+    every hidden parameter toward its initial value dominates both
+    decay-based (L2/Shrink-and-Perturb) and hard-reset (CBP/ReDO) methods at
+    long horizons. This arm tests that mechanism's isolated marginal
+    contribution on top of the campaign champion, reusing the champion's own
+    UPGD utility gate as the per-unit "graded reset" weight: ``1 - gate`` is
+    large for low-utility (unprotected) units and near zero for high-utility
+    (protected) ones, so the pull toward init is concentrated exactly where
+    the source papers' utility-scaled reset is meant to act. ``sigma0_ndecay099``
+    exposes no separate hidden-unit-firing utility signal of its own (unlike
+    CBP-family arms), so the UPGD gate is the closest available substitute
+    -- a documented deviation from the source papers' own utility statistic.
+
+    Deviation from the source papers: they replace their baseline's
+    decay/reset term outright; here the pull is an ADDITIVE new term next to
+    the champion's existing uniform decoupled weight decay (rather than a
+    replacement), so this measures the isolated contribution of graded,
+    utility-gated pull-toward-init rather than a full swap of the
+    regularizer family.
+
+    ``l2init_pull_scale = 0`` (the default) is inert: the new term is
+    multiplied by exactly zero and the step routes through the identical
+    ``lean_upgd_w_update`` call the champion factory's own inert path uses,
+    so the trajectory is bit-exact against ``sigma0_ndecay099`` (pinned by a
+    unit test) rather than relying on floating-point cancellation of a zero
+    term.
+    """
+    noise_std = hp["noise_std"]
+    norm_decay = hp["norm_decay"]
+    norm_epsilon = hp["norm_epsilon"]
+    pull_scale = hp.get("l2init_pull_scale", 0.0)
+    lean_hp = {
+        name: hp[name] for name in ("step_size", "utility_decay", "noise_std", "weight_decay")
+    }
+
+    def init_fn(params: dict[str, Array]) -> UPGDGatedL2InitNormState:
+        return UPGDGatedL2InitNormState(  # type: ignore[call-arg]
+            utility={name: jnp.zeros_like(value) for name, value in params.items()},
+            step=jnp.array(0, dtype=jnp.int32),
+            init_params={name: value for name, value in params.items()},
+            norm=_init_input_norm_state(params),
+        )
+
+    def full_step(
+        params: dict[str, Array],
+        state: UPGDGatedL2InitNormState,
+        x: Array,
+        y: Array,
+        key: Array,
+    ) -> tuple[dict[str, Array], UPGDGatedL2InitNormState, StepMetrics]:
+        x_norm, new_norm = ema_normalize(state.norm, x, norm_decay, norm_epsilon)
+        (loss, logits), grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(
+            params, x_norm, y
+        )
+        noise = _sorted_flat_noise(key, params, noise_std)
+        if pull_scale == 0.0:
+            # Exact champion path: call the identical function the champion
+            # factory's own inert path calls, rather than relying on
+            # floating-point cancellation of a zero-scaled extra term.
+            lean_state = LeanUPGDState(  # type: ignore[call-arg]
+                utility=state.utility, step=state.step
+            )
+            inert_new_params, new_lean = lean_upgd_w_update(
+                params, lean_state, grads, noise, lean_hp
+            )
+            metrics = _step_metrics(inert_new_params, x_norm, y, loss, logits)
+            return (
+                inert_new_params,
+                UPGDGatedL2InitNormState(  # type: ignore[call-arg]
+                    utility=new_lean.utility,
+                    step=new_lean.step,
+                    init_params=state.init_params,
+                    norm=new_norm,
+                ),
+                metrics,
+            )
+        beta = hp["utility_decay"]
+        step_size = hp["step_size"]
+        decay_factor = 1.0 - step_size * hp["weight_decay"]
+        count = state.step + jnp.array(1, dtype=jnp.int32)
+        utility = {
+            name: beta * state.utility[name] + (1.0 - beta) * (-grads[name] * params[name])
+            for name in params
+        }
+        global_max = jnp.max(
+            jnp.stack([jnp.max(utility[name]) for name in sorted(params)])
+        )
+        bias_correction = 1.0 - jnp.power(
+            jnp.asarray(beta, dtype=jnp.float32), count.astype(jnp.float32)
+        )
+        new_params: dict[str, Array] = {}
+        for name in params:
+            gate = jax.nn.sigmoid((utility[name] / bias_correction) / global_max)
+            pull = pull_scale * (1.0 - gate) * (params[name] - state.init_params[name])
+            new_params[name] = (
+                params[name] * decay_factor
+                - step_size * pull
+                - step_size * ((grads[name] + noise[name]) * (1.0 - gate))
+            )
+        metrics = _step_metrics(new_params, x_norm, y, loss, logits)
+        return (
+            new_params,
+            UPGDGatedL2InitNormState(  # type: ignore[call-arg]
+                utility=utility, step=count, init_params=state.init_params, norm=new_norm
+            ),
+            metrics,
+        )
+
+    return init_fn, full_step
+
+
 # =============================================================================
 # Config registry
 # =============================================================================
@@ -5674,6 +5805,22 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                 ),
             )
         )
+    specs.append(
+        ScreeningSpec(
+            name="sigma0_ndecay099_gated_l2init",
+            base_learner="upgd_w",
+            mechanism="gated_l2_init",
+            hyperparameters=_sigma0_ext_hp(norm_decay=0.99, l2init_pull_scale=0.01),
+            factory=_make_sigma0_gated_l2init_learner,
+            description=(
+                "sigma0_ndecay099 champion plus an additive utility-gated pull "
+                "toward init (CCBP/Calibrated-Partial-Resets-style graded reset; "
+                "l2init_pull_scale=0.01, matching the repo's established L2-Init "
+                "regularization strength); l2init_pull_scale=0 reduces bit-exactly "
+                "to the champion."
+            ),
+        )
+    )
     # --- Wave 8: update-rule family swaps under the sigma0_ndecay099 champion's
     # conditioning (EMA input normalizer decay 0.99 + the exact UPGD utility
     # gate, no perturbation).  Only the descent direction changes per arm.

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -5082,7 +5082,7 @@ class UPGDGatedL2InitNormState:
 def _make_sigma0_gated_l2init_learner(
     hp: Mapping[str, float],
 ) -> tuple[LearnerInitFn, ScreeningStepFn]:
-    """``sigma0_ndecay099`` champion plus an additive, utility-GATED pull
+    """``sigma0_ndecay099`` baseline plus an additive, utility-gated pull
     toward the initial weights.
 
     Ported idea: continuous utility-scaled soft resets (CCBP,
@@ -5091,7 +5091,7 @@ def _make_sigma0_gated_l2init_learner(
     every hidden parameter toward its initial value dominates both
     decay-based (L2/Shrink-and-Perturb) and hard-reset (CBP/ReDO) methods at
     long horizons. This arm tests that mechanism's isolated marginal
-    contribution on top of the campaign champion, reusing the champion's own
+    contribution on top of that historical baseline, reusing the baseline's own
     UPGD utility gate as the per-unit "graded reset" weight: ``1 - gate`` is
     large for low-utility (unprotected) units and near zero for high-utility
     (protected) ones, so the pull toward init is concentrated exactly where
@@ -5102,14 +5102,14 @@ def _make_sigma0_gated_l2init_learner(
 
     Deviation from the source papers: they replace their baseline's
     decay/reset term outright; here the pull is an ADDITIVE new term next to
-    the champion's existing uniform decoupled weight decay (rather than a
+    the baseline's existing uniform decoupled weight decay (rather than a
     replacement), so this measures the isolated contribution of graded,
     utility-gated pull-toward-init rather than a full swap of the
     regularizer family.
 
     ``l2init_pull_scale = 0`` (the default) is inert: the new term is
     multiplied by exactly zero and the step routes through the identical
-    ``lean_upgd_w_update`` call the champion factory's own inert path uses,
+    ``lean_upgd_w_update`` call the baseline factory's own inert path uses,
     so the trajectory is bit-exact against ``sigma0_ndecay099`` (pinned by a
     unit test) rather than relying on floating-point cancellation of a zero
     term.
@@ -5812,12 +5812,13 @@ def _build_registry() -> dict[str, ScreeningSpec]:
             mechanism="gated_l2_init",
             hyperparameters=_sigma0_ext_hp(norm_decay=0.99, l2init_pull_scale=0.01),
             factory=_make_sigma0_gated_l2init_learner,
+            frozen_probe_input=_ema_frozen_probe_input,
             description=(
-                "sigma0_ndecay099 champion plus an additive utility-gated pull "
+                "sigma0_ndecay099 historical baseline plus an additive utility-gated pull "
                 "toward init (CCBP/Calibrated-Partial-Resets-style graded reset; "
                 "l2init_pull_scale=0.01, matching the repo's established L2-Init "
                 "regularization strength); l2init_pull_scale=0 reduces bit-exactly "
-                "to the champion."
+                "to the baseline."
             ),
         )
     )

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -52,6 +52,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     _make_rff_rls_learner,
     _make_sgd_ema_norm_learner,
     _make_sgd_momentum_gate_learner,
+    _make_sigma0_gated_l2init_learner,
     _make_snr_ema_norm_learner,
     _make_upgd_alpha_utility_learner,
     _make_upgd_autostep_learner,
@@ -4029,6 +4030,130 @@ class TestOptimizerFloorHybrids:
             assert not np.array_equal(
                 result.per_task_loss, champion.per_task_loss
             ), name
+
+
+class TestGatedL2Init:
+    """``sigma0_ndecay099_gated_l2init``: an additive, utility-gated pull
+    toward the initial weights on top of the campaign champion (ported CCBP /
+    Calibrated-Partial-Resets-style graded reset; see
+    :func:`alberta_framework.benchmarks.ipmnist_screening._make_sigma0_gated_l2init_learner`)."""
+
+    def test_pull_scale_zero_reduces_to_sigma0_ndecay099_bitwise(self):
+        """``l2init_pull_scale=0`` collapses the additive pull term to
+        exactly zero, so the trajectory equals the ``sigma0_ndecay099``
+        champion bit-for-bit (same normalizer, same gate, same decay)."""
+        hp = dict(screening_spec("sigma0_ndecay099_gated_l2init").hyperparameters)
+        hp["l2init_pull_scale"] = 0.0
+        init_fn, step_fn = _make_sigma0_gated_l2init_learner(hp)
+        champion = screening_spec("sigma0_ndecay099")
+        init_ref, step_ref = champion.factory(champion.hyperparameters)
+        params = init_mlp_params(jr.key(29), SMALL)
+        s_ours = init_fn(params)
+        s_ref = init_ref(params)
+        p_ours = p_ref = params
+        key = jr.key(43)
+        for i in range(5):
+            x = jr.normal(jr.fold_in(key, i), (SMALL.input_dim,)) + 0.1
+            y = jnp.array(i % SMALL.n_classes, jnp.int32)
+            p_ours, s_ours, _ = step_fn(p_ours, s_ours, x, y, jr.key(600 + i))
+            p_ref, s_ref, _ = step_ref(p_ref, s_ref, x, y, jr.key(600 + i))
+            for n in p_ours:
+                np.testing.assert_array_equal(
+                    np.asarray(p_ours[n]), np.asarray(p_ref[n]), err_msg=n
+                )
+
+    def test_registered_pull_scale_hand_computed(self):
+        """The registered arm equals a hand-computed normalize -> grad ->
+        gate -> ``w*(1-lr*wd) - lr*pull_scale*(1-gate)*(w-w0) -
+        lr*(1-gate)*grad`` trajectory, bit for bit."""
+        hp = screening_spec("sigma0_ndecay099_gated_l2init").hyperparameters
+        assert hp["l2init_pull_scale"] == 0.01
+        init_fn, step_fn = _make_sigma0_gated_l2init_learner(hp)
+        params = init_mlp_params(jr.key(14), SMALL)
+        w0 = {n: v for n, v in params.items()}
+        state = init_fn(params)
+        ref_params = params
+        ref_utility = {n: jnp.zeros_like(v) for n, v in params.items()}
+        norm_state = EMANormState(
+            mean=jnp.zeros(SMALL.input_dim),
+            var=jnp.ones(SMALL.input_dim),
+            count=jnp.array(0.0),
+        )
+        key = jr.key(15)
+        for i in range(4):
+            x = jr.normal(jr.fold_in(key, i), (SMALL.input_dim,)) * 2.0 + 0.5
+            y = jnp.array(i % SMALL.n_classes, jnp.int32)
+            params, state, _ = step_fn(params, state, x, y, jr.key(500 + i))
+            x_norm, norm_state = ema_normalize(
+                norm_state, x, hp["norm_decay"], hp["norm_epsilon"]
+            )
+            _, grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(
+                ref_params, x_norm, y
+            )
+            beta = hp["utility_decay"]
+            ref_utility = {
+                n: beta * ref_utility[n] + (1.0 - beta) * (-grads[n] * ref_params[n])
+                for n in ref_params
+            }
+            count = i + 1
+            bias_correction = 1.0 - beta**count
+            global_max = jnp.max(
+                jnp.stack([jnp.max(ref_utility[n]) for n in sorted(ref_params)])
+            )
+            new_ref: dict[str, jnp.ndarray] = {}
+            for n in ref_params:
+                gate = jax.nn.sigmoid((ref_utility[n] / bias_correction) / global_max)
+                pull = hp["l2init_pull_scale"] * (1.0 - gate) * (ref_params[n] - w0[n])
+                new_ref[n] = (
+                    ref_params[n] * (1.0 - hp["step_size"] * hp["weight_decay"])
+                    - hp["step_size"] * pull
+                    - hp["step_size"] * (grads[n] * (1.0 - gate))
+                )
+            ref_params = new_ref
+            for n in ref_params:
+                # Independently reordered floating-point ops (this hand
+                # derivation vs. the factory's fused expression) can diverge
+                # by a few ULP even when both implement the identical
+                # equation; the bit-exact contract lives in
+                # test_pull_scale_zero_reduces_to_sigma0_ndecay099_bitwise,
+                # which calls the champion's own reduction path directly.
+                np.testing.assert_allclose(
+                    np.asarray(params[n]),
+                    np.asarray(ref_params[n]),
+                    atol=1e-6,
+                    rtol=1e-5,
+                    err_msg=n,
+                )
+
+    def test_nonzero_pull_diverges_from_champion_and_stays_finite(self, small_data):
+        """The registered arm's trajectory differs from the champion's and
+        remains finite over a tiny-protocol smoke run."""
+        x, y = small_data
+        champion = run_screening_config(
+            x, y, screening_spec("sigma0_ndecay099"), seed=19, config=SMALL
+        )
+        result = run_screening_config(
+            x, y, screening_spec("sigma0_ndecay099_gated_l2init"), seed=19, config=SMALL
+        )
+        assert np.all(np.isfinite(result.per_task_accuracy))
+        assert np.all(np.isfinite(result.per_task_loss))
+        assert not np.array_equal(result.per_task_loss, champion.per_task_loss)
+
+    def test_key_is_unused_for_no_extra_randomness(self):
+        """The arm draws no perturbation noise (noise_std=0 by inheritance
+        from ``_sigma0_ext_hp``): different RNG keys must still reach an
+        identical result via the shared per-step noise draw's sigma=0
+        short-circuit."""
+        params = init_mlp_params(jr.key(3), SMALL)
+        x = jr.normal(jr.key(90), (SMALL.input_dim,))
+        y = jnp.array(2, jnp.int32)
+        spec = screening_spec("sigma0_ndecay099_gated_l2init")
+        init_fn, step_fn = spec.factory(spec.hyperparameters)
+        state = init_fn(params)
+        p_a, _, _ = step_fn(params, state, x, y, jr.key(0))
+        p_b, _, _ = step_fn(params, state, x, y, jr.key(987654))
+        for n in params:
+            np.testing.assert_array_equal(np.asarray(p_a[n]), np.asarray(p_b[n]), err_msg=n)
 
 
 class TestComparisonArms:

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -4034,9 +4034,13 @@ class TestOptimizerFloorHybrids:
 
 class TestGatedL2Init:
     """``sigma0_ndecay099_gated_l2init``: an additive, utility-gated pull
-    toward the initial weights on top of the campaign champion (ported CCBP /
+    toward the initial weights on top of a historical comparison baseline (ported CCBP /
     Calibrated-Partial-Resets-style graded reset; see
     :func:`alberta_framework.benchmarks.ipmnist_screening._make_sigma0_gated_l2init_learner`)."""
+
+    def test_registry_binds_ema_frozen_probe_input(self):
+        spec = screening_spec("sigma0_ndecay099_gated_l2init")
+        assert spec.frozen_probe_input is _ema_frozen_probe_input
 
     def test_pull_scale_zero_reduces_to_sigma0_ndecay099_bitwise(self):
         """``l2init_pull_scale=0`` collapses the additive pull term to


### PR DESCRIPTION
<!-- evidence-head:f704b86da63eb29d68b3fe741659b44ce8029db6 -->

## What this is

**Port (registration stage only — no benchmark claim).** Adds a new IPMNIST
screening arm, `sigma0_ndecay099_gated_l2init`, that ports the continuous,
per-unit-utility-scaled soft-reset idea from CCBP (OpenReview:UJqXhFFzKu) and
Calibrated Partial Resets (arXiv:2607.24996) onto the `sigma0_ndecay099`
frontier-wave champion's existing step (EMA input normalize -> UPGD-gated SGD
-> decoupled weight decay).

Mechanism: an additive pull of every hidden parameter toward its value at
initialization, scaled by `l2init_pull_scale * (1 - gate)`, where `gate` is
the champion's own UPGD-utility sigmoid gate reused as the per-unit "graded
reset" weight (the source papers' own firing-rate/utility statistic has no
analogue exposed by this base arm — documented deviation, see the factory's
docstring). The pull is additive alongside the champion's existing uniform
decoupled decay, not a replacement of it, so this isolates the marginal
contribution of the graded reset term specifically.
`l2init_pull_scale=0.01` (the repo's established L2-Init strength elsewhere:
`upgd_l2init`, `l2init_ema_norm`).

`l2init_pull_scale=0` reduces bit-exactly to `sigma0_ndecay099` — pinned,
failing-test-first, by calling the champion factory's own inert-path function
(`lean_upgd_w_update`) rather than relying on floating-point cancellation of
a zero-scaled term.

**Important framing correction vs. the docstring's "champion" language:**
`sigma0_ndecay099` is *not* the current overall IPMNIST campaign champion —
it was superseded first by `sigma0_shiftnorm_d099` (0.86459) and then by the
streaming-RLS-readout family, currently `rls_head_resid_l1_preset005`
(0.87114 ± 0.00010, n=20; see `docs/research/ipmnist-theory.md` and
`summary_rls_head_confirm.json`). This arm's gradient-based per-weight pull
does not compose with the RLS readout's mechanism, so it cannot challenge the
real incumbent directly. It is a **mechanism-dissection port** in the same
category as the existing pinned rows in `summary_comparison_vs_champion.json`
(`l2init_ema_norm`, `wclip_ema_norm`, `fade_head_ema_norm`, `snr_ema_norm`),
which are likewise measured against `sigma0_ndecay099` for the same
architectural reason, not against the current campaign leader.

Pre-registered before measuring, per the skill's process:
https://github.com/elizaOS/asi/discussions/396

## What I could NOT do, and why (please read before reviewing)

I could not obtain the promised 60-task, seeds-0-2 screening numbers
(`merge --control-name sigma0_ndecay099`) in my execution environment.
`sklearn.datasets.fetch_openml("mnist_784", ...)`, which the screening `run`
CLI depends on, fails there with a persistent `HTTP Error 504: Gateway
Timeout` from openml.org's data-list API after its built-in retries are
exhausted. This reproduces directly with plain `curl` against both
`www.openml.org` and `api.openml.org` (redirect followed), ~15-16s to a 504
each time — an upstream data-source outage in my sandbox, not a local
network block (TLS/redirect succeed; the backend gateway itself times out).

**This PR therefore makes no accuracy claim of any kind** — no win, no tie,
no loss. It registers the arm and pins its bit-exact reduction to the named
base, per the "Register the arm" stage of the campaign's ladder
(`CLAUDE.md` / the contribute-to-asi skill), and leaves the actual paired
screen for whoever next has a working path to the canonical MNIST cache.
The exact commands to run it are posted in the discussion thread linked
above and reproduced there for anyone continuing this.

## What changed

- `alberta_framework/benchmarks/ipmnist_screening.py`: new
  `UPGDGatedL2InitNormState` chex dataclass, `_make_sigma0_gated_l2init_learner`
  factory, and the `sigma0_ndecay099_gated_l2init` registry entry.
- `tests/test_ipmnist_screening.py`: `TestGatedL2Init` — bit-exact reduction
  at `pull_scale=0` against the champion factory's own inert path,
  hand-computed-trajectory check at the registered `pull_scale=0.01`,
  a finite/non-degenerate smoke run over `SMALL` config, and a check that no
  extra RNG draw occurs (noise_std=0 by inheritance from `_sigma0_ext_hp`).
- While verifying, found and fixed a real `mypy --strict` failure in the new
  factory: two variables both named `new_params` in the same function scope
  (the inert early-return path and the general path), which mypy's `strict`
  mode flags as `no-redef` because of the second one's explicit annotation.
  Renamed the inert-path variable to `inert_new_params`; no behavior change
  (confirmed: the 4 new tests and the full 310-test file still pass
  identically before/after the rename).

## Verification (commit `f704b86da63eb29d68b3fe741659b44ce8029db6`)

```
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -k GatedL2Init -q -o addopts=""
....                                                                     [100%]
4 passed, 306 deselected in 18.59s

$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""
310 passed in 259.87s (0:04:19)

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy         # uses pyproject.toml's files=["alberta_framework"]
Success: no issues found in 165 source files

$ git diff --check
(clean)
```

Not run / environment-limited: the actual 60-task benchmark shards (blocked
by the openml.org 504s described above); CPU-only sandbox, so no GPU-path
verification was applicable here anyway (this arm is CPU-cost-class
identical to `sigma0_ndecay099`, no new dependency).

<!-- evidence-row:logs -->
- [x] logs: pytest/ruff/mypy output pasted above is the full, unedited
  command output — see the "Verification" section (no separate attachment;
  no `run` shard was produced to attach as a domain-artifact, per the
  disclosed blocker).

## Deviations from pre-registration

- Pre-registered plan: post before running the screen shards, then report
  `mean_diff` / `per_seed_diff` / `all_seeds_improve` here. Actual: the run
  step failed for an infrastructure reason before any shard was produced, so
  there is nothing to report except that failure — reported in the
  discussion and above, honestly, per the pre-registration's own "what I
  will report if it loses" commitment (extended to "if it cannot run at
  all").

## What remains open

- The actual paired 60-task screen vs `sigma0_ndecay099` (seeds 0-2), and,
  only if it clears the +0.002-all-seeds-positive bar used by the existing
  `summary_comparison_vs_champion.json` rows, a 200-task confirmation.
- Given the existing L2-Init-family rows already in that summary
  (`l2init_ema_norm` +0.0025, `upgd_l2init` well below the raw-input
  champion), a small or negative delta is the realistic prior — flagged here
  so a reviewer doesn't read this PR as an implicit SOTA claim.

Never self-approve/self-merge; leaving this to independent review.



---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker-2]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05AT630V05BRERYQ8514FHC","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T13:05:11.264Z","completed_at":"2026-08-16T13:05:52.398Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7681a4f5c855de7d58461b43a2e574fe6abbd7202d4cab9bd4f6812031cb67e4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"22b18a71-e1c7-4a1e-9d3b-4d9575ef6aca","object_id":"sha256:7681a4f5c855de7d58461b43a2e574fe6abbd7202d4cab9bd4f6812031cb67e4","sha256":"7681a4f5c855de7d58461b43a2e574fe6abbd7202d4cab9bd4f6812031cb67e4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"QPRoyrmWPcnAZ7JjiHyMxn_9vRUd7pQHyjw410l2J98VtgEi3p53wY9PT-DoVWNgyn1ANLIRC9qaR_wYCcfJCQ"}} -->
