### PR TITLE
fix(upgd): accrue unit-recycling budget against mature units and cap the carry

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -292,8 +292,9 @@ class UPGDLearner:
         head_repetition_warmup_steps: Number of initial steps before the
             repeated-target boost can turn on.
         unit_replacement_rate: Optional hidden-unit recycling rate per step,
-            expressed as a fraction of units per layer. ``0`` disables
-            recycling while still tracking per-unit utility.
+            expressed as a fraction of the layer's mature units; at most one
+            unit per layer is recycled per step. ``0`` disables recycling
+            while still tracking per-unit utility.
         unit_maturity_threshold: Minimum age before a hidden unit can be
             recycled.
         unit_utility_decay: Optional EMA decay for hidden-unit utilities. When
@@ -2917,9 +2918,6 @@ class UPGDLearner:
             new_accumulators = []
             new_replacement_counts = []
             for i in range(n_trunk):
-                layer_size = new_unit_utilities[i].shape[0]
-                layer_size_f = jnp.array(layer_size, dtype=jnp.float32)
-
                 mature = new_unit_ages[i] >= maturity
                 if self._unit_replacement_criterion == "stale_gradient_ratio":
                     util_norm = new_unit_long_utilities[i] / (
@@ -2978,9 +2976,13 @@ class UPGDLearner:
                     )
                 else:
                     rate_scale = jnp.array(1.0, dtype=jnp.float32)
+                # Budget accrues against the units that are eligible (mature)
+                # right now, as in the reference GnT scheduler; immature units
+                # earn no budget, so warm-up cannot bank a replacement burst.
+                n_mature = jnp.sum(mature).astype(jnp.float32)
                 accum = (
                     state.unit_replacement_accumulators[i]
-                    + rate * layer_size_f * rate_scale
+                    + rate * n_mature * rate_scale
                 )
                 do_replace = accum >= 1.0
                 gated = jnp.logical_and(
@@ -3080,7 +3082,10 @@ class UPGDLearner:
                 new_unit_ages[i] = unit_age.at[unit_idx].set(
                     jnp.where(gated, jnp.int32(0), unit_age[unit_idx])
                 )
-                new_accumulators.append(jnp.where(gated, accum - 1.0, accum))
+                # Never carry more than the one replacement a step can deliver.
+                new_accumulators.append(
+                    jnp.minimum(jnp.where(gated, accum - 1.0, accum), 1.0)
+                )
                 new_replacement_counts.append(
                     unit_replacement_counts[i] + gated.astype(jnp.float32)
                 )

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -1544,6 +1544,46 @@ class TestUtilityTracking:
         assert float(result_always.state.unit_replacement_accumulators[0]) > 0.0
         assert float(result_gated.state.unit_replacement_accumulators[0]) == 0.0
 
+    def test_recycling_budget_does_not_accrue_while_every_unit_is_immature(self):
+        """Warm-up debt must not be discharged as a replacement burst at maturity."""
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(32,),
+            sparsity=0.0,
+            step_size=0.0,
+            perturbation_sigma=0.0,
+            unit_replacement_rate=0.02,
+            unit_maturity_threshold=50,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(31))
+        for _ in range(49):
+            state = learner.update(state, jnp.zeros(3), jnp.zeros(1)).state
+        assert int(jnp.max(state.unit_ages[0])) == 49
+        assert float(state.unit_replacement_accumulators[0]) == 0.0
+        assert float(state.unit_replacement_counts[0]) == 0.0
+        for _ in range(11):
+            state = learner.update(state, jnp.zeros(3), jnp.zeros(1)).state
+        # rate * 32 mature units = 0.64 per step -> at most one replacement per step,
+        # and no more than ceil(7.04) in eleven steps; the old debt would fire every step.
+        assert float(state.unit_replacement_counts[0]) <= 8.0
+        assert float(state.unit_replacement_accumulators[0]) <= 1.0
+
+    def test_recycling_budget_never_carries_more_than_one_pending_unit(self):
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.0,
+            perturbation_sigma=0.0,
+            unit_replacement_rate=0.5,
+            unit_maturity_threshold=0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(32))
+        for _ in range(20):
+            state = learner.update(state, jnp.zeros(3), jnp.zeros(1)).state
+        assert float(state.unit_replacement_counts[0]) == 20.0
+        assert float(state.unit_replacement_accumulators[0]) <= 1.0
+
     def test_loss_pressure_recycling_budget_scales_with_loss_spike(self):
         learner = UPGDLearner(
             n_heads=1,


### PR DESCRIPTION
Closes #406.

## Issue

The unit-recycling accumulator added `unit_replacement_rate * layer_size` every step (scaled by the budget mode) but could pay one unit per step, so the default mode banked a warm-up debt that fired as a burst once units matured, and rates above `1/layer_size` accrued unbounded debt while producing bit-identical arms.

## New state

Budget accrues against the mature count (`rate * n_mature * rate_scale`) and the carried accumulator is capped at one pending replacement, matching the CBP fix in #371 and the reference scheduler. Selection, gates, budget modes, and `unit_replacement_counts` (which already reports the gated decision) are unchanged; the `unit_replacement_rate` docstring states the semantics.

Failing-test-first: `test_recycling_budget_does_not_accrue_while_every_unit_is_immature` and `test_recycling_budget_never_carries_more_than_one_pending_unit` fail on `main` and pass here; the existing gated / loss-pressure budget tests are unchanged.

## Evidence

Falsifier from #406 at this head:

```text
    rate   rate*H   expected total  actual total  leftover accum
   0.125      1.0            40.0          40.0             0.0
    0.25      2.0            80.0          40.0             1.0
     0.5      4.0           160.0          40.0             1.0
     1.0      8.0           320.0          40.0             1.0
```

Verification at `5cb972f67c402bafd5cd61bb566ddb935def86cb`:

```text
.venv/bin/python -m pytest tests/test_upgd.py tests/test_step2*.py -q -o addopts=""   -> 83 passed
.venv/bin/python -m ruff check .                                                     -> All checks passed!
.venv/bin/python -m mypy                                                             -> Success: no issues found in 164 source files
```

Composes cleanly with #375, #393, #402 (`git merge-tree` clean). `core/upgd.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:5cb972f67c402bafd5cd61bb566ddb935def86cb -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
