### PR TITLE
fix(world-model-ensemble): stop max_raw_gradient_norm deadlocking legal training

### DIFF
--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -226,15 +226,27 @@ class RecurrentLatentWorldModelEnsembleConfig:
     """Fixed architecture, optimizer, warmup, and numeric bounds.
 
     The ``max_*`` fields are fail-closed validity gates, not tuned
-    hyperparameters: an observation, reward, parameter, prediction, loss, or
-    raw gradient whose magnitude exceeds its bound causes the whole event to
-    be rejected with persistent state untouched.  Their internal consistency
-    is validated at construction: ``variance_floor < max_variance``,
-    ``gradient_clip_norm <= max_raw_gradient_norm``, and
-    ``learning_rate * gradient_clip_norm <= max_parameter_magnitude`` (so a
-    single clipped step cannot itself breach the parameter bound).  The
-    default magnitudes are coarse sanity ceilings far above any healthy
-    operating range, not derived quantities.
+    hyperparameters: an observation, reward, parameter, prediction, or loss
+    whose magnitude exceeds its bound causes the whole event to be rejected
+    with persistent state untouched.  Their internal consistency is validated
+    at construction: ``variance_floor < max_variance``, ``gradient_clip_norm
+    <= max_raw_gradient_norm``, and ``learning_rate * gradient_clip_norm <=
+    max_parameter_magnitude`` (so a single clipped step cannot itself breach
+    the parameter bound).  The default magnitudes are coarse sanity ceilings
+    far above any healthy operating range, not derived quantities.
+
+    Per-member raw NLL gradients are validated for finiteness only, not
+    against ``max_raw_gradient_norm``: the reachable raw gradient scales as
+    ``residual / variance``, so a well-trained low-noise member can legally
+    exceed any fixed ceiling on an ordinary in-bounds transition, and because
+    a rejection leaves state unchanged, a norm ceiling here creates a
+    deadlock rather than a safety gate.  ``gradient_clip_norm`` already
+    bounds the committed step magnitude, and ``candidate_parameters_valid`` /
+    ``candidate_state_valid`` independently confirm the post-clip candidate is
+    finite and in-bounds before it is committed.  ``max_raw_gradient_norm``
+    still bounds the representation gradient (a returned diagnostic signal,
+    never itself clipped) and constrains ``gradient_clip_norm`` at
+    construction.
     """
 
     observation_dim: int
@@ -1054,7 +1066,40 @@ class RecurrentLatentWorldModelEnsemble:
         self,
         state: RecurrentLatentWorldModelEnsembleState,
         diagnostics: RecurrentLatentWorldModelDiagnostics,
+        next_decision_observation: Array | None = None,
     ) -> RecurrentLatentWorldModelUpdateResult:
+        # A rejection never mutates `state`, but the *cache* previously
+        # defaulted to the invalid zero cache unconditionally.  Since `decide`
+        # and `update` both require a valid, owned start cache, that made
+        # every rejection -- regardless of cause -- a permanent deadlock: no
+        # later event, however legal, could ever be accepted again.
+        #
+        # When the incoming state and decision cache were themselves sound
+        # (`state_valid & cache_valid`), we know `state` is a legitimate
+        # anchor and `next_decision_observation` was at least well-typed (the
+        # shape/dtype contract in `update` runs unconditionally before any
+        # validity gate). Re-owning `state` with that observation makes the
+        # rejection retryable: the very next `decide`/`update` call
+        # independently re-validates the observation and every other input,
+        # so nothing unsound is smuggled through -- it only stops a single
+        # bad or over-strict event from freezing every event after it.
+        if next_decision_observation is None:
+            recoverable_cache = self._zero_start_cache()
+        else:
+            recoverable = diagnostics.state_valid & diagnostics.cache_valid
+            recoverable_cache = cast(
+                RecurrentLatentStartCache,
+                jax.lax.cond(
+                    recoverable,
+                    lambda: RecurrentLatentStartCache(
+                        owner_event_count=state.event_count,
+                        owner_hidden_states=state.member_hidden_states,
+                        observation=next_decision_observation,
+                        valid=jnp.asarray(True, dtype=jnp.bool_),
+                    ),
+                    self._zero_start_cache,
+                ),
+            )
         return RecurrentLatentWorldModelUpdateResult(
             state=state,
             prediction=self._zero_prediction(),
@@ -1072,7 +1117,7 @@ class RecurrentLatentWorldModelEnsemble:
             member_updates_applied=jnp.zeros(
                 (self._config.ensemble_size,), dtype=jnp.bool_
             ),
-            next_start_cache=self._zero_start_cache(),
+            next_start_cache=recoverable_cache,
             diagnostics=diagnostics,
         )
 
@@ -1217,10 +1262,14 @@ class RecurrentLatentWorldModelEnsemble:
                 member_losses.append(loss)
                 member_gradients.append(gradient)
                 gradient_norms.append(gradient_norm)
+                # Finiteness only -- see the class docstring.  The raw norm is
+                # not compared against max_raw_gradient_norm: a well-trained
+                # low-noise member legally produces residual / variance
+                # gradients that dwarf any fixed ceiling on an ordinary
+                # in-bounds transition, and gradient_clip_norm (applied below)
+                # already bounds the committed step regardless of raw scale.
                 member_gradients_valid.append(
-                    _tree_all_finite(gradient)
-                    & jnp.isfinite(gradient_norm)
-                    & (gradient_norm <= cfg.max_raw_gradient_norm)
+                    _tree_all_finite(gradient) & jnp.isfinite(gradient_norm)
                 )
             losses = jnp.stack(member_losses)
             gradient_norm_array = jnp.stack(gradient_norms)
@@ -1369,7 +1418,9 @@ class RecurrentLatentWorldModelEnsemble:
                 jax.lax.cond(
                     applied,
                     lambda: result,
-                    lambda: self._rejected_result(state, diagnostics),
+                    lambda: self._rejected_result(
+                        state, diagnostics, next_decision_observation
+                    ),
                 ),
             )
 
@@ -1378,7 +1429,9 @@ class RecurrentLatentWorldModelEnsemble:
             jax.lax.cond(
                 can_attempt,
                 accepted_branch,
-                lambda _: self._rejected_result(state, rejected_diagnostics),
+                lambda _: self._rejected_result(
+                    state, rejected_diagnostics, next_decision_observation
+                ),
                 operand=None,
             ),
         )

--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -1067,6 +1067,7 @@ class RecurrentLatentWorldModelEnsemble:
         state: RecurrentLatentWorldModelEnsembleState,
         diagnostics: RecurrentLatentWorldModelDiagnostics,
         next_decision_observation: Array | None = None,
+        transition_boundary: Array | None = None,
     ) -> RecurrentLatentWorldModelUpdateResult:
         # A rejection never mutates `state`, but the *cache* previously
         # defaulted to the invalid zero cache unconditionally.  Since `decide`
@@ -1074,19 +1075,30 @@ class RecurrentLatentWorldModelEnsemble:
         # every rejection -- regardless of cause -- a permanent deadlock: no
         # later event, however legal, could ever be accepted again.
         #
-        # When the incoming state and decision cache were themselves sound
-        # (`state_valid & cache_valid`), we know `state` is a legitimate
-        # anchor and `next_decision_observation` was at least well-typed (the
-        # shape/dtype contract in `update` runs unconditionally before any
-        # validity gate). Re-owning `state` with that observation makes the
-        # rejection retryable: the very next `decide`/`update` call
-        # independently re-validates the observation and every other input,
-        # so nothing unsound is smuggled through -- it only stops a single
-        # bad or over-strict event from freezing every event after it.
-        if next_decision_observation is None:
+        # Re-owning the unchanged state is safe only after an authoritative,
+        # in-domain, off-boundary transition reached a *late* numerical or
+        # candidate-state rejection.  In particular, `cache_valid` says only
+        # that the caller supplied a cache whose own flags are true; ownership
+        # and exact cached-prediction checks are what bind it to this state,
+        # observation, and action.  Minting a valid cache before those checks
+        # would launder an arbitrary `next_decision_observation` through a
+        # stale or tampered decision.  A rejected boundary also cannot recover
+        # this way because the unchanged state has not committed the required
+        # recurrent reset.
+        if next_decision_observation is None or transition_boundary is None:
             recoverable_cache = self._zero_start_cache()
         else:
-            recoverable = diagnostics.state_valid & diagnostics.cache_valid
+            recoverable = (
+                diagnostics.state_valid
+                & diagnostics.cache_valid
+                & diagnostics.input_valid
+                & diagnostics.ownership_valid
+                & diagnostics.boundary_semantics_valid
+                & diagnostics.capacity_available
+                & diagnostics.cached_prediction_exact
+                & diagnostics.predictions_valid
+                & ~transition_boundary
+            )
             recoverable_cache = cast(
                 RecurrentLatentStartCache,
                 jax.lax.cond(
@@ -1419,7 +1431,10 @@ class RecurrentLatentWorldModelEnsemble:
                     applied,
                     lambda: result,
                     lambda: self._rejected_result(
-                        state, diagnostics, next_decision_observation
+                        state,
+                        diagnostics,
+                        next_decision_observation,
+                        boundary,
                     ),
                 ),
             )
@@ -1430,7 +1445,10 @@ class RecurrentLatentWorldModelEnsemble:
                 can_attempt,
                 accepted_branch,
                 lambda _: self._rejected_result(
-                    state, rejected_diagnostics, next_decision_observation
+                    state,
+                    rejected_diagnostics,
+                    next_decision_observation,
+                    boundary,
                 ),
                 operand=None,
             ),

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -343,29 +343,41 @@ def test_member_gradient_validity_is_finiteness_only_not_a_raw_norm_ceiling() ->
     assert bool(result.diagnostics.candidate_state_valid)
 
 
-def test_rejection_returns_a_retryable_cache_not_a_permanent_deadlock() -> None:
-    """Regression for issue #366.
-
-    A rejection must not poison every later event.  When the incoming state
-    and decision cache were themselves sound, the returned ``next_start_cache``
-    must re-own the unchanged state so the next legal event is judged on its
-    own merits instead of being auto-rejected by a permanently invalid cache.
-    """
-    model = RecurrentLatentWorldModelEnsemble(_config())
+def test_late_numeric_rejection_returns_a_retryable_authoritative_cache() -> None:
+    """A trusted off-boundary event may recover after a late numerical veto."""
+    model = RecurrentLatentWorldModelEnsemble(
+        _config(
+            gradient_clip_norm=1.0,
+            max_raw_gradient_norm=1.0,
+            max_loss_magnitude=1.0e8,
+        )
+    )
     state = model.init(jr.key(21))
     decision = _decision(model, state)
-    wrong_reset = jnp.asarray((-9.0, -9.0), dtype=jnp.float32)
+    far_bootstrap = jnp.asarray((50.0, -50.0), dtype=jnp.float32)
 
-    rejected = model.update(state, decision, _transition(next_decision_observation=wrong_reset))
+    rejected = model.update(
+        state,
+        decision,
+        _transition(
+            bootstrap_observation=far_bootstrap,
+            next_decision_observation=far_bootstrap,
+        ),
+    )
     assert bool(rejected.diagnostics.rejected)
-    assert not bool(rejected.diagnostics.boundary_semantics_valid)
-    # Sanity: this rejection's own recoverability precondition holds.
     assert bool(rejected.diagnostics.state_valid)
     assert bool(rejected.diagnostics.cache_valid)
+    assert bool(rejected.diagnostics.input_valid)
+    assert bool(rejected.diagnostics.ownership_valid)
+    assert bool(rejected.diagnostics.boundary_semantics_valid)
+    assert bool(rejected.diagnostics.capacity_available)
+    assert bool(rejected.diagnostics.cached_prediction_exact)
+    assert bool(rejected.diagnostics.predictions_valid)
+    assert not bool(rejected.diagnostics.representation_gradient_valid)
     _assert_tree_equal(rejected.state, state)
 
     assert bool(rejected.next_start_cache.valid)
-    np.testing.assert_array_equal(rejected.next_start_cache.observation, wrong_reset)
+    np.testing.assert_array_equal(rejected.next_start_cache.observation, far_bootstrap)
     np.testing.assert_array_equal(
         rejected.next_start_cache.owner_hidden_states, state.member_hidden_states
     )
@@ -378,15 +390,116 @@ def test_rejection_returns_a_retryable_cache_not_a_permanent_deadlock() -> None:
     recovered = model.update(
         state,
         next_decision,
-        _transition(observation=wrong_reset, next_decision_observation=BOOTSTRAP),
+        _transition(
+            observation=far_bootstrap,
+            bootstrap_observation=far_bootstrap,
+            next_decision_observation=far_bootstrap,
+        ),
     )
     assert bool(recovered.diagnostics.applied)
+
+
+def test_stale_decision_cannot_launder_a_new_observation_into_an_owned_cache() -> None:
+    """A locally valid cache flag is not authority to mint the next owner."""
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    state = model.init(jr.key(22))
+    decision = _decision(model, state)
+    stale_decision = cast(Any, decision).replace(
+        owner_event_count=decision.owner_event_count + jnp.int32(1)
+    )
+    untrusted_next = jnp.asarray((7.0, -8.0), dtype=jnp.float32)
+
+    rejected = model.update(
+        state,
+        stale_decision,
+        _transition(
+            bootstrap_observation=untrusted_next,
+            next_decision_observation=untrusted_next,
+        ),
+    )
+    assert bool(rejected.diagnostics.state_valid)
+    assert bool(rejected.diagnostics.cache_valid)
+    assert bool(rejected.diagnostics.input_valid)
+    assert not bool(rejected.diagnostics.ownership_valid)
+    assert not bool(rejected.next_start_cache.valid)
+    assert not bool(model.decide(state, rejected.next_start_cache, ACTION).valid)
+
+
+def test_invalid_transition_or_boundary_cannot_mint_a_recovery_cache() -> None:
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    state = model.init(jr.key(23))
+    decision = _decision(model, state)
+    nonfinite_next = jnp.asarray((jnp.inf, 0.0), dtype=jnp.float32)
+    wrong_reset = jnp.asarray((-9.0, -9.0), dtype=jnp.float32)
+
+    invalid_input = model.update(
+        state,
+        decision,
+        _transition(
+            bootstrap_observation=nonfinite_next,
+            next_decision_observation=nonfinite_next,
+        ),
+    )
+    assert not bool(invalid_input.diagnostics.input_valid)
+    assert not bool(invalid_input.next_start_cache.valid)
+
+    invalid_boundary = model.update(
+        state,
+        decision,
+        _transition(next_decision_observation=wrong_reset),
+    )
+    assert not bool(invalid_boundary.diagnostics.boundary_semantics_valid)
+    assert not bool(invalid_boundary.next_start_cache.valid)
+
+
+def test_tampered_cached_prediction_cannot_mint_a_recovery_cache() -> None:
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    state = model.init(jr.key(24))
+    decision = _decision(model, state)
+    tampered_prediction = cast(Any, decision.prediction).replace(
+        mean_reward=decision.prediction.mean_reward + jnp.float32(1.0)
+    )
+    tampered_decision = cast(Any, decision).replace(prediction=tampered_prediction)
+
+    rejected = model.update(state, tampered_decision, _transition())
+    assert bool(rejected.diagnostics.ownership_valid)
+    assert not bool(rejected.diagnostics.cached_prediction_exact)
+    assert not bool(rejected.next_start_cache.valid)
+
+
+def test_late_boundary_rejection_cannot_skip_the_required_recurrent_reset() -> None:
+    model = RecurrentLatentWorldModelEnsemble(
+        _config(
+            gradient_clip_norm=1.0,
+            max_raw_gradient_norm=1.0,
+            max_loss_magnitude=1.0e8,
+        )
+    )
+    state = model.init(jr.key(25))
+    decision = _decision(model, state)
+    far_bootstrap = jnp.asarray((50.0, -50.0), dtype=jnp.float32)
+    reset_observation = jnp.asarray((-2.0, 3.0), dtype=jnp.float32)
+
+    rejected = model.update(
+        state,
+        decision,
+        _transition(
+            discount=0.0,
+            terminated=True,
+            bootstrap_observation=far_bootstrap,
+            next_decision_observation=reset_observation,
+        ),
+    )
+    assert bool(rejected.diagnostics.boundary_semantics_valid)
+    assert bool(rejected.diagnostics.cached_prediction_exact)
+    assert not bool(rejected.diagnostics.representation_gradient_valid)
+    assert not bool(rejected.next_start_cache.valid)
 
 
 def test_state_invalid_rejection_still_returns_a_non_recoverable_cache() -> None:
     """A corrupt/invalid *state* must not be re-owned as if it were legal."""
     model = RecurrentLatentWorldModelEnsemble(_config())
-    valid_state = model.init(jr.key(22))
+    valid_state = model.init(jr.key(26))
     valid_decision = _decision(model, valid_state)
     corrupt_state = cast(Any, valid_state).replace(
         event_count=jnp.asarray(1, dtype=jnp.int32)

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -25,6 +25,7 @@ from alberta_framework.core.recurrent_latent_world_model_ensemble import (
     RecurrentLatentWorldModelEnsemble,
     RecurrentLatentWorldModelEnsembleConfig,
     RecurrentLatentWorldModelEnsembleState,
+    _tree_l2_norm,
     load_recurrent_latent_world_model_ensemble_checkpoint,
     save_recurrent_latent_world_model_ensemble_checkpoint,
 )
@@ -294,6 +295,108 @@ def test_off_boundary_reset_substitution_and_boundary_discount_errors_reject_ato
         _assert_tree_equal(rejected.state, state)
         assert not bool(rejected.prediction.availability.prediction)
         assert not bool(rejected.representation_gradient_available)
+
+
+def test_member_gradient_validity_is_finiteness_only_not_a_raw_norm_ceiling() -> None:
+    """Regression for issue #366.
+
+    ``residual / variance`` scaling means a well-trained low-noise member can
+    legally produce a per-member raw NLL gradient far above any fixed
+    ``max_raw_gradient_norm`` ceiling on an ordinary in-bounds transition.
+    ``gradient_clip_norm`` already bounds the committed step regardless of
+    raw scale, so the finite-but-huge case must still apply, not reject.
+    """
+    model = RecurrentLatentWorldModelEnsemble(
+        _config(gradient_clip_norm=1.0, max_raw_gradient_norm=5_000.0)
+    )
+    state = model.init(jr.key(20))
+    decision = _decision(model, state)
+    far_bootstrap = jnp.asarray((900.0, -900.0), dtype=jnp.float32)
+    stopped_targets = jnp.concatenate(
+        (far_bootstrap, jnp.asarray((0.5, 0.9), dtype=jnp.float32))
+    )
+    member_norms = []
+    for index in range(model.config.ensemble_size):
+        _, gradient = jax.value_and_grad(model._member_nll)(  # noqa: SLF001
+            state.member_parameters[index],
+            state.member_hidden_states[index],
+            OBSERVATION,
+            ACTION,
+            stopped_targets,
+        )
+        member_norms.append(float(_tree_l2_norm(gradient)))
+
+    # The whole point of the regression: the raw gradient genuinely, legally
+    # exceeds the configured ceiling before this fix would have rejected it.
+    assert all(norm > model.config.max_raw_gradient_norm for norm in member_norms)
+
+    result = model.update(
+        state,
+        decision,
+        _transition(
+            bootstrap_observation=far_bootstrap,
+            next_decision_observation=far_bootstrap,
+        ),
+    )
+    assert bool(result.diagnostics.applied)
+    assert bool(jnp.all(result.diagnostics.member_gradients_valid))
+    assert bool(result.diagnostics.candidate_state_valid)
+
+
+def test_rejection_returns_a_retryable_cache_not_a_permanent_deadlock() -> None:
+    """Regression for issue #366.
+
+    A rejection must not poison every later event.  When the incoming state
+    and decision cache were themselves sound, the returned ``next_start_cache``
+    must re-own the unchanged state so the next legal event is judged on its
+    own merits instead of being auto-rejected by a permanently invalid cache.
+    """
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    state = model.init(jr.key(21))
+    decision = _decision(model, state)
+    wrong_reset = jnp.asarray((-9.0, -9.0), dtype=jnp.float32)
+
+    rejected = model.update(state, decision, _transition(next_decision_observation=wrong_reset))
+    assert bool(rejected.diagnostics.rejected)
+    assert not bool(rejected.diagnostics.boundary_semantics_valid)
+    # Sanity: this rejection's own recoverability precondition holds.
+    assert bool(rejected.diagnostics.state_valid)
+    assert bool(rejected.diagnostics.cache_valid)
+    _assert_tree_equal(rejected.state, state)
+
+    assert bool(rejected.next_start_cache.valid)
+    np.testing.assert_array_equal(rejected.next_start_cache.observation, wrong_reset)
+    np.testing.assert_array_equal(
+        rejected.next_start_cache.owner_hidden_states, state.member_hidden_states
+    )
+    assert int(rejected.next_start_cache.owner_event_count) == int(state.event_count)
+
+    # Prove the chain is genuinely un-poisoned: decide/update from the
+    # recovered cache work normally, evaluated on their own merits.
+    next_decision = model.decide(state, rejected.next_start_cache, ACTION)
+    assert bool(next_decision.valid)
+    recovered = model.update(
+        state,
+        next_decision,
+        _transition(observation=wrong_reset, next_decision_observation=BOOTSTRAP),
+    )
+    assert bool(recovered.diagnostics.applied)
+
+
+def test_state_invalid_rejection_still_returns_a_non_recoverable_cache() -> None:
+    """A corrupt/invalid *state* must not be re-owned as if it were legal."""
+    model = RecurrentLatentWorldModelEnsemble(_config())
+    valid_state = model.init(jr.key(22))
+    valid_decision = _decision(model, valid_state)
+    corrupt_state = cast(Any, valid_state).replace(
+        event_count=jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert not bool(model.state_valid(corrupt_state))
+
+    result = model.update(corrupt_state, valid_decision, _transition())
+    assert not bool(result.diagnostics.state_valid)
+    assert bool(result.diagnostics.rejected)
+    assert not bool(result.next_start_cache.valid)
 
 
 def test_exact_observation_action_and_cache_ownership_reject_stale_or_tampered_inputs() -> None:


### PR DESCRIPTION
Closes #366.

Agent disclosure: client `claude-code`, provider `anthropic`, model
`claude-sonnet-5`.

## Bug

`RecurrentLatentWorldModelEnsemble.update()` rejected the whole event
(state unchanged) whenever any member's raw NLL gradient norm exceeded
`max_raw_gradient_norm`. The raw gradient scales as `residual / variance`,
so a well-trained low-noise member legally produces a raw gradient far
above any fixed ceiling on an ordinary in-bounds transition —
`gradient_clip_norm` already bounds the *committed* step regardless of raw
scale, so the ceiling rejected exactly the case the clipper exists for.

Worse, a rejection returned the zero/invalid `next_start_cache`
unconditionally. Since `decide()`/`update()` both require a valid, owned
start cache, the very first false rejection made every later
`decide`/`update` call fail ownership forever — a **permanent** deadlock,
not a transient reject, exactly as described in the issue.

## Fix

Two changes, one bug:

1. `member_gradients_valid` is now finiteness-only (dropped the
   `gradient_norm <= max_raw_gradient_norm` comparison).
   `gradient_clip_norm` (already applied to every committed step) plus the
   existing `candidate_parameters_valid` / `candidate_state_valid` gates
   still bound what gets committed. `max_raw_gradient_norm` is unchanged
   for the representation gradient (a returned diagnostic, never itself
   clipped) and still constrains `gradient_clip_norm` at construction —
   this is option (a) from the issue.
2. `_rejected_result()` now re-owns the unchanged `state` in
   `next_start_cache` (observation = `next_decision_observation`) whenever
   the incoming state and decision cache were themselves sound
   (`state_valid & cache_valid`). The next `decide`/`update` call
   independently re-validates the observation and every other input, so
   nothing unsound is smuggled through — this only removes the
   *permanence* of a lockup, whatever its cause. This is option (c) from
   the issue, applied regardless of which of (a)/(b) was chosen. A state
   that is itself invalid (e.g. tampered/corrupt) still gets the
   non-recoverable zero cache, unchanged from before.

`max_raw_gradient_norm` is otherwise untouched: the representation
gradient can still legitimately reject at an extreme enough shift (see the
±200 case in verification below) — the fix guarantees that rejection is no
longer permanent, not that every rejection is eliminated.

## Verification

Head: `ae408df40bfe59e95561f158eb6627e8be330672`

Environment: CPU only (`JAX_PLATFORMS=cpu`; this container has no GPU and
`jax_plugins.xla_cuda12` fails to init otherwise — harmless, JAX falls back
to CPU).

Exact reproduction of the issue's own repro (`observation_dim=2,
n_actions=2, latent_dim=8, ensemble_size=3, uncertainty_warmup_steps=0,
max_updates=100000`, all other fields default), 30,000 steps on the fixed
`obs=(0.25,-0.5) -> bootstrap=(0.75,0.125)` transition, then legal shifted
bootstraps:

```text
learned member_aleatoric_variances (post-training): ~0.0011-0.0012 per head/member
                                    before fix   |   after fix
shift +-10   (ceiling 1e5)  applied=True         |  applied=True   (unchanged - was already accepted)
shift +-50   (ceiling 1e5)  applied=False        |  applied=True   member_gradients_valid=[T,T,T]
shift +-100  (ceiling 1e5)  applied=False        |  applied=True   member_gradients_valid=[T,T,T]
shift +-200  (ceiling 1e5)  applied=False        |  applied=False  (representation_gradient_valid
                                                                     still trips here - unaddressed,
                                                                     out of scope, see below)
repeated +-50 shift, 50x    0/50 applied         |  1/50 applied, cache stays valid=True throughout
one rejection at +-50, then carrying
next_start_cache through 29 ordinary
in-bounds transitions exactly like the
issue's scan-loop scenario             0/29 applied  |  n/a (± 50 no longer rejects post-fix at all)
```

Because the ±50/±100 false positive is gone post-fix, I additionally
verified the *permanence* mechanism directly using the still-genuinely-
rejecting ±200 case (representation-gradient ceiling, untouched by this
fix):

```text
extreme +-200 shift: applied=False, representation_gradient_valid=False (expected, unaddressed)
result.next_start_cache.valid: True   (was False before this fix)
result.next_start_cache.{owner_event_count,owner_hidden_states}: unchanged from input state
result.state: bit-identical to input state (rejection is still a strict no-op)
decide(state, result.next_start_cache, action).valid: True
a subsequent ORDINARY in-bounds transition from that recovered cache: applied=True
```

i.e. the ±200 shift still correctly rejects (a real, separate gate this PR
does not touch), but it no longer poisons the run: the next legal event is
judged on its own merits instead of being auto-rejected by a permanently
invalid cache.

Failing-test-first: both new regression tests were run against the
pre-fix source and fail there (`assert bool(result.diagnostics.applied)`
and `assert bool(rejected.next_start_cache.valid)` respectively), then
pass against this PR's diff.

```text
$ JAX_PLATFORMS=cpu .venv/bin/python -m pytest tests/test_recurrent_latent_world_model_ensemble.py -q -o addopts=""
22 passed in 58.62s

$ .venv/bin/python -m ruff check alberta_framework/core/recurrent_latent_world_model_ensemble.py tests/test_recurrent_latent_world_model_ensemble.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ .venv/bin/python -m pytest --collect-only -q
7332 tests collected in 6.40s   (no collection-time breakage repo-wide)

$ git diff --check
(clean)
```

I was not able to complete a full run of `tests/test_prototype_agent.py`
(the module's real integration consumer) within this session — the
container is CPU-only and shared with other concurrent agents, and that
suite is slow under JAX/CPU contention. It does not currently exercise
this ensemble's `update()` path at all (`grep -rl
"RecurrentLatentWorldModelEnsemble" tests/` matches only the module's own
dedicated test file), so I do not believe it would have caught this
regardless; noting the gap rather than skipping it silently. `import
alberta_framework.core.prototype_agent` succeeds cleanly with this diff.

## Scope

`RecurrentLatentWorldModelEnsemble` is `EVIDENCE_LEVEL = "L0"`,
`SCIENTIFIC_PROMOTION_ALLOWED = False`, and is not a registered evidence
source (not referenced in `docs/status.md`,
`docs/evidence/negative-results.md`, or `evaluation/evidence_manifest.py`).
No benchmark lane, seed schedule, or `outputs/` artifact is touched by
this change.

<!-- evidence-head:ae408df40bfe59e95561f158eb6627e8be330672 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (full commands + real output; no attachment host available in this environment)

## Maintainer ownership repair

At `ae408df40bfe59e95561f158eb6627e8be330672`, retry-cache recovery is restricted to authoritative, in-domain, off-boundary transitions that passed exact cached-prediction validation and reached only a late numerical/candidate rejection. Stale owners, mismatched inputs/actions, invalid next observations, boundary-semantic failures, tampered cached predictions, and rejected boundary resets all return an invalid cache. The expanded focused suite passes 26 tests; repository-wide Ruff and strict mypy pass. No outputs were touched.


---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05FBAWV9R3BSKTM99AK44NY","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T14:24:27.547Z","completed_at":"2026-08-16T14:25:15.354Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"bc107a6d93144c6d64a35bc67408e4e977bf63e4d668532c5f384773d481d1d1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b4f51c2a-b3d1-4ee6-a94c-005e3adaf74c","object_id":"sha256:bc107a6d93144c6d64a35bc67408e4e977bf63e4d668532c5f384773d481d1d1","sha256":"bc107a6d93144c6d64a35bc67408e4e977bf63e4d668532c5f384773d481d1d1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"sHo6CM5a_Q9lDKrEL03erTPY9SAZ1WXBsUIu_oYE29LrAdDXFSmY5ry1-EXlglr3XFV3GY_O4Z7ZRcrfqL98BQ"}} -->
