### PR TITLE
fix(actor-critic): reject inverted or non-finite continuous action bounds

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -816,8 +816,9 @@ class ContinuousActorCriticAgent:
                 raise ValueError(f"{name} must be finite when set") from exc
             if not math.isfinite(narrowed):
                 raise ValueError(f"{name} must remain finite once narrowed to float32")
-            preserve_builtin = type(bound) is int or type(bound) is float
-            canonical_bounds[name] = float(bound) if preserve_builtin else narrowed
+            # Only an actual built-in float is already the binary64 payload JAX will
+            # narrow exactly; ints and other reals store the validated binary32 value.
+            canonical_bounds[name] = bound if type(bound) is float else narrowed
         low = canonical_bounds["action_low"]
         high = canonical_bounds["action_high"]
         if low is not None and high is not None and low > high:

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -799,11 +799,14 @@ class ContinuousActorCriticAgent:
             raise ValueError("action_dim must be positive")
         if config.log_sigma_min > config.log_sigma_max:
             raise ValueError("log_sigma_min must be <= log_sigma_max")
+        canonical_bounds: dict[str, float | None] = {}
         for name in ("action_low", "action_high"):
             bound = getattr(config, name)
             if bound is None:
+                canonical_bounds[name] = None
                 continue
-            if isinstance(bound, bool) or not isinstance(bound, Real):
+            actual_type = type(bound)
+            if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
                 raise ValueError(f"{name} must be a finite real number when set")
             if not math.isfinite(bound):
                 raise ValueError(f"{name} must be finite when set")
@@ -813,12 +816,18 @@ class ContinuousActorCriticAgent:
                 raise ValueError(f"{name} must be finite when set") from exc
             if not math.isfinite(narrowed):
                 raise ValueError(f"{name} must remain finite once narrowed to float32")
-        if (
-            config.action_low is not None
-            and config.action_high is not None
-            and config.action_low > config.action_high
-        ):
+            preserve_builtin = actual_type is int or actual_type is float
+            canonical_bounds[name] = float(bound) if preserve_builtin else narrowed
+        low = canonical_bounds["action_low"]
+        high = canonical_bounds["action_high"]
+        if low is not None and high is not None and low > high:
             raise ValueError("action_low must be <= action_high")
+        if (low, high) != (config.action_low, config.action_high) or any(
+            type(value) is not float
+            for value in (config.action_low, config.action_high)
+            if value is not None
+        ):
+            config = dataclasses.replace(config, action_low=low, action_high=high)
         self._config = config
         self._bounder = bounder
 

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Any
 
 import chex
@@ -796,6 +797,16 @@ class ContinuousActorCriticAgent:
             raise ValueError("action_dim must be positive")
         if config.log_sigma_min > config.log_sigma_max:
             raise ValueError("log_sigma_min must be <= log_sigma_max")
+        for name in ("action_low", "action_high"):
+            bound = getattr(config, name)
+            if bound is not None and not math.isfinite(bound):
+                raise ValueError(f"{name} must be finite when set")
+        if (
+            config.action_low is not None
+            and config.action_high is not None
+            and config.action_low > config.action_high
+        ):
+            raise ValueError("action_low must be <= action_high")
         self._config = config
         self._bounder = bounder
 

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -816,7 +816,7 @@ class ContinuousActorCriticAgent:
                 raise ValueError(f"{name} must be finite when set") from exc
             if not math.isfinite(narrowed):
                 raise ValueError(f"{name} must remain finite once narrowed to float32")
-            preserve_builtin = actual_type is int or actual_type is float
+            preserve_builtin = type(bound) is int or type(bound) is float
             canonical_bounds[name] = float(bound) if preserve_builtin else narrowed
         low = canonical_bounds["action_low"]
         high = canonical_bounds["action_high"]

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -808,11 +808,9 @@ class ContinuousActorCriticAgent:
             actual_type = type(bound)
             if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
                 raise ValueError(f"{name} must be a finite real number when set")
-            if not math.isfinite(bound):
-                raise ValueError(f"{name} must be finite when set")
             try:
                 narrowed = round_real_to_float32(bound)
-            except (TypeError, ValueError, OverflowError) as exc:
+            except Exception as exc:
                 raise ValueError(f"{name} must be finite when set") from exc
             if not math.isfinite(narrowed):
                 raise ValueError(f"{name} must remain finite once narrowed to float32")

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+from numbers import Real
 from typing import Any
 
 import chex
@@ -30,6 +31,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
@@ -799,8 +801,18 @@ class ContinuousActorCriticAgent:
             raise ValueError("log_sigma_min must be <= log_sigma_max")
         for name in ("action_low", "action_high"):
             bound = getattr(config, name)
-            if bound is not None and not math.isfinite(bound):
+            if bound is None:
+                continue
+            if isinstance(bound, bool) or not isinstance(bound, Real):
+                raise ValueError(f"{name} must be a finite real number when set")
+            if not math.isfinite(bound):
                 raise ValueError(f"{name} must be finite when set")
+            try:
+                narrowed = round_real_to_float32(bound)
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError(f"{name} must be finite when set") from exc
+            if not math.isfinite(narrowed):
+                raise ValueError(f"{name} must remain finite once narrowed to float32")
         if (
             config.action_low is not None
             and config.action_high is not None

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -6,6 +6,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework import ContinuousActorCriticAgent as TopLevelContinuousActorCriticAgent
 from alberta_framework.core import (
@@ -200,6 +201,27 @@ def test_continuous_actor_critic_log_sigma_clipping() -> None:
     )
     assert float(result.state.log_sigma[0]) <= 1.0
     assert float(result.state.log_sigma[0]) >= -2.0
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "message"),
+    [
+        (1.0, -1.0, "action_low must be <= action_high"),
+        (float("nan"), 1.0, "action_low must be finite"),
+        (-1.0, float("inf"), "action_high must be finite"),
+        (0.5, 0.5, None),
+    ],
+)
+def test_continuous_actor_critic_rejects_inverted_or_nonfinite_action_bounds(
+    low: float, high: float, message: str | None
+) -> None:
+    """low > high makes jnp.clip return high for every input: a constant-action policy."""
+    config = ContinuousActorCriticConfig(action_dim=2, action_low=low, action_high=high)
+    if message is None:
+        ContinuousActorCriticAgent(config)
+        return
+    with pytest.raises(ValueError, match=message):
+        ContinuousActorCriticAgent(config)
 
 
 def test_continuous_actor_critic_action_clipping() -> None:

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import ContinuousActorCriticAgent as TopLevelContinuousActorCriticAgent
@@ -209,19 +212,28 @@ def test_continuous_actor_critic_log_sigma_clipping() -> None:
         (1.0, -1.0, "action_low must be <= action_high"),
         (float("nan"), 1.0, "action_low must be finite"),
         (-1.0, float("inf"), "action_high must be finite"),
+        (1e100, None, "action_low must remain finite once narrowed to float32"),
+        (None, -1e100, "action_high must remain finite once narrowed to float32"),
+        (-3.5e38, 3.5e38, "action_low must remain finite once narrowed to float32"),
         (0.5, 0.5, None),
+        (-float(np.finfo(np.float32).max), float(np.finfo(np.float32).max), None),
     ],
 )
 def test_continuous_actor_critic_rejects_inverted_or_nonfinite_action_bounds(
-    low: float, high: float, message: str | None
+    low: float | None, high: float | None, message: str | None
 ) -> None:
     """low > high makes jnp.clip return high for every input: a constant-action policy."""
     config = ContinuousActorCriticConfig(action_dim=2, action_low=low, action_high=high)
     if message is None:
-        ContinuousActorCriticAgent(config)
+        agent = ContinuousActorCriticAgent(config)
+        state = agent.init(feature_dim=1, key=jr.key(2))
+        _state, action, _mean, _sigma = agent.start(state, jnp.array([1.0], dtype=jnp.float32))
+        assert bool(jnp.all(jnp.isfinite(action)))
         return
-    with pytest.raises(ValueError, match=message):
-        ContinuousActorCriticAgent(config)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match=message):
+            ContinuousActorCriticAgent(config)
 
 
 def test_continuous_actor_critic_action_clipping() -> None:

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -312,6 +312,23 @@ def test_continuous_actor_critic_canonicalizes_real_bounds_to_float() -> None:
     assert float(action[0]) <= 0.25 and float(action[0]) >= -0.25
 
 
+def test_continuous_actor_critic_normalizes_conversion_hook_failures() -> None:
+    from fractions import Fraction
+
+    class BrokenFraction(Fraction):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("conversion hook failed")
+
+    with pytest.raises(ValueError, match="action_low must be finite"):
+        ContinuousActorCriticAgent(
+            ContinuousActorCriticConfig(
+                action_dim=1,
+                action_low=BrokenFraction(-1, 1),
+                action_high=1.0,
+            )
+        )
+
+
 def test_continuous_actor_critic_action_clipping() -> None:
     """Sampled actions respect the configured action bounds."""
     config = ContinuousActorCriticConfig(

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -269,6 +269,34 @@ def test_continuous_actor_critic_rejects_bounds_that_only_spoof_float(field: str
         ContinuousActorCriticAgent(config)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("action_low", (2**25 - 1) * 2**103 - 1),
+        ("action_high", -((2**25 - 1) * 2**103 - 1)),
+        ("action_low", 2**64 + 2**40 + 1),
+    ],
+)
+def test_continuous_actor_critic_stores_exact_float32_for_integer_bounds(
+    field: str, value: int
+) -> None:
+    """A built-in int must not be stored as float(value): that payload double-rounds in JAX."""
+    from alberta_framework._float32 import round_real_to_float32
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        agent = ContinuousActorCriticAgent(
+            ContinuousActorCriticConfig(action_dim=1, **{field: value})  # type: ignore[arg-type]
+        )
+        stored = getattr(agent.config, field)
+        assert type(stored) is float
+        assert stored == round_real_to_float32(value)
+        assert float(np.float32(stored)) == stored
+        state = agent.init(feature_dim=1, key=jr.key(3))
+        _state, action, _mean, _sigma = agent.start(state, jnp.array([1.0], dtype=jnp.float32))
+        assert bool(jnp.all(jnp.isfinite(action)))
+
+
 def test_continuous_actor_critic_canonicalizes_real_bounds_to_float() -> None:
     from fractions import Fraction
 

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -236,6 +236,54 @@ def test_continuous_actor_critic_rejects_inverted_or_nonfinite_action_bounds(
             ContinuousActorCriticAgent(config)
 
 
+class _FloatSpoof:
+    """Not a Real: reports float through __class__ and never compares as out of range."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (0, 1)
+
+    def __float__(self) -> float:
+        return 0.0
+
+    def __lt__(self, other: object) -> bool:
+        return False
+
+    def __le__(self, other: object) -> bool:
+        return False
+
+    def __gt__(self, other: object) -> bool:
+        return False
+
+    def __ge__(self, other: object) -> bool:
+        return False
+
+
+@pytest.mark.parametrize("field", ["action_low", "action_high"])
+def test_continuous_actor_critic_rejects_bounds_that_only_spoof_float(field: str) -> None:
+    config = ContinuousActorCriticConfig(action_dim=1, **{field: _FloatSpoof()})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=f"{field} must be a finite real number"):
+        ContinuousActorCriticAgent(config)
+
+
+def test_continuous_actor_critic_canonicalizes_real_bounds_to_float() -> None:
+    from fractions import Fraction
+
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=1, action_low=Fraction(-1, 4), action_high=np.float64(0.25)
+        )
+    )
+    assert type(agent.config.action_low) is float and agent.config.action_low == -0.25
+    assert type(agent.config.action_high) is float and agent.config.action_high == 0.25
+    state = agent.init(feature_dim=1, key=jr.key(1))
+    _state, action, _mean, _sigma = agent.start(state, jnp.array([1.0], dtype=jnp.float32))
+    assert float(action[0]) <= 0.25 and float(action[0]) >= -0.25
+
+
 def test_continuous_actor_critic_action_clipping() -> None:
     """Sampled actions respect the configured action bounds."""
     config = ContinuousActorCriticConfig(


### PR DESCRIPTION
Hardens ContinuousActorCritic action bounds before any JAX clipping or policy execution.

Changes:
- require actual non-bool Real values or None
- round accepted values directly into the float32 execution domain and reject non-finite narrowing
- canonicalize non-builtin reals and exact integers to JSON-safe sink values
- reject inverted low/high bounds after canonicalization
- normalize all ordinary conversion-hook failures to ValueError

Validation at exact head 1ae04f5:
- continuous actor-critic suite: 28 passed under RuntimeWarning-as-error
- Ruff: clean
- strict mypy for actor_critic.py: clean
- git diff --check: clean

No benchmark campaign was run and no outputs or evidence artifacts were modified.