### PR TITLE
fix(rule-discovery): reject non-finite genomes before evaluation

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -792,6 +792,8 @@ def evaluate_population(
         raise ValueError(
             f"genomes must have shape (n_genomes, {GENOME_SIZE}), got {tuple(genomes.shape)}"
         )
+    if not bool(jnp.all(jnp.isfinite(genomes))):
+        raise ValueError("genomes must contain only finite values")
     n_genomes = int(genomes.shape[0])
     total = np.zeros((n_genomes,), dtype=np.float64)
     for seed in seeds:

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -396,6 +396,20 @@ def test_evaluate_population_rejects_malformed_genome_shapes_before_materializat
         evaluate_population(jnp.zeros(shape, dtype=jnp.float32), MICRO_SUITE["M1"], seeds=(0,))
 
 
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_evaluate_population_rejects_nonfinite_genomes_before_materialization(
+    monkeypatch: pytest.MonkeyPatch, invalid: float
+) -> None:
+    def unexpected_materialization(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("non-finite genomes reached stream materialization")
+
+    monkeypatch.setattr(rule_discovery, "_materialize_eval", unexpected_materialization)
+    genomes = jnp.zeros((2, GENOME_SIZE), dtype=jnp.float32).at[1, 0].set(invalid)
+    with pytest.raises(ValueError, match="genomes must contain only finite values"):
+        evaluate_population(genomes, MICRO_SUITE["M1"], seeds=(0,))
+
+
 @pytest.mark.parametrize("batch_size", [0, -4, True])
 def test_evaluate_population_rejects_non_positive_batch_size_before_materialization(
     monkeypatch: pytest.MonkeyPatch, batch_size: object


### PR DESCRIPTION
Closes #413.

## What changed

`evaluate_population` validated the genome matrix's shape but never its values. A `NaN` (or `inf`/`-inf`) gene — e.g. an invalid learning-rate gene — entered the JAX screening loop and returned a plausible-looking finite accuracy score instead of being rejected, silently allowing an invalid candidate to be ranked alongside genuine ones.

confirmed directly before touching the source:

```text
before
result: array([0.09775001])
is_finite: [ True]
```
(a `(1, GENOME_SIZE)` float32 matrix with the `lr` gene set to `NaN`, evaluated on `MICRO_SUITE["M1"]`, seed 0, batch size 1 — returned a finite score instead of raising.)

fix: after dtype conversion and shape validation, reject any non-finite genome value before materializing an evaluation stream, matching the existing preflight-validation style already used for shape and batch-size checks in this same function.

## Reachability

`evaluate_population` is called by `evaluate_suite`, which is called throughout `run_search`; `main()` exposes `run_search` via `python -m alberta_framework.benchmarks.rule_discovery search ...` — confirmed directly. Not re-exported from either `alberta_framework/__init__.py` or `alberta_framework/benchmarks/__init__.py`, but directly importable with a module CLI entry point — real candidate matrices flow through this path and are not hardcoded-safe at the `evaluate_population` API boundary.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts=""
52 passed, 2 warnings in 85.59s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/rule_discovery.py tests/test_rule_discovery.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_evaluate_population_rejects_nonfinite_genomes_before_materialization`, parametrized over `nan`, `inf`, `-inf`, using `monkeypatch` to replace `_materialize_eval` with a function that raises `AssertionError` if reached — confirming the guard fires *before* materialization, not just that the call eventually errors somehow.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/rule_discovery.py`, kept the test), reran — all 3 cases failed with `AssertionError: non-finite genomes reached stream materialization`, proving the non-finite genome actually reached the guarded call. restored the fix, 3/3 green again.

## Evidence

<!-- evidence-head -->
a388af8ba99a194f2f099a61b36f8cb3a0e46062

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts="" -k test_evaluate_population_rejects_nonfinite_genomes_before_materialization
FAILED [nan] - AssertionError: non-finite genomes reached stream materialization
FAILED [inf] - AssertionError: non-finite genomes reached stream materialization
FAILED [-inf] - AssertionError: non-finite genomes reached stream materialization
3 failed, 49 deselected in 3.41s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_rule_discovery.py -q -o addopts="" -k test_evaluate_population_rejects_nonfinite_genomes_before_materialization
3 passed, 49 deselected in 3.01s
```

<!-- evidence-row:domain-artifact -->
```text
before
result: array([0.09775001])
is_finite: [ True]
```
independently reran the full touched test file (52 tests), ruff, and mypy myself; independently confirmed the guard's placement in source is before the `_materialize_eval` loop (not merely somewhere in the function); independently confirmed the call chain (`evaluate_suite` → `run_search` → `main()` CLI) before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the guard's placement and the reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
