### PR TITLE
fix(experiments): validate extracted parameter coordinates

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -14,8 +14,10 @@ Two conventions matter for downstream analysis:
   :func:`aggregate_metrics`.
 """
 
-from collections.abc import Callable, Sequence
-from typing import Any, NamedTuple, cast
+import math
+from collections.abc import Callable, Iterable, Sequence
+from numbers import Complex, Number
+from typing import Any, NamedTuple, NoReturn, cast
 
 import jax.random as jr
 import numpy as np
@@ -421,9 +423,10 @@ def extract_hyperparameter_results(
         Dictionary mapping param value to (mean, std) tuple
 
     Raises:
-        ValueError: If ``param_extractor`` maps more than one configuration to
-            the same value; a sensitivity curve built from a silently
-            truncated, insertion-order-dependent subset is not a measurement.
+        ValueError: If ``param_extractor`` returns a noncanonical dictionary
+            coordinate or maps more than one configuration to the same value;
+            a sensitivity curve built from a silently truncated,
+            insertion-order-dependent subset is not a measurement.
     """
     performance = get_final_performance(results, metric)
 
@@ -432,7 +435,8 @@ def extract_hyperparameter_results(
 
     names_by_value: dict[Any, list[str]] = {}
     for name in performance:
-        names_by_value.setdefault(param_extractor(name), []).append(name)
+        coordinate = _require_hyperparameter_coordinate(param_extractor(name), name=name)
+        names_by_value.setdefault(coordinate, []).append(name)
     collisions = {value: names for value, names in names_by_value.items() if len(names) > 1}
     if collisions:
         described = "; ".join(f"{value!r} <- {names}" for value, names in collisions.items())
@@ -440,3 +444,48 @@ def extract_hyperparameter_results(
             f"param_extractor maps several configurations to one value: {described}"
         )
     return {value: performance[names[0]] for value, names in names_by_value.items()}
+
+
+def _require_hyperparameter_coordinate(value: object, *, name: str) -> Any:
+    """Require one stable dictionary coordinate without narrowing valid key types."""
+
+    def reject() -> NoReturn:
+        raise ValueError(
+            "param_extractor returned a noncanonical coordinate for "
+            f"configuration {name!r}; coordinates must be hashable, reflexive, "
+            "and finite when numeric"
+        )
+
+    value_type = type(value)
+    if issubclass(value_type, (tuple, frozenset)):
+        try:
+            for component in cast(Iterable[object], value):
+                _require_hyperparameter_coordinate(component, name=name)
+        except Exception:
+            reject()
+
+    if issubclass(value_type, Complex):
+        try:
+            number = complex(cast(Complex, value))
+        except Exception:
+            reject()
+        if not math.isfinite(number.real) or not math.isfinite(number.imag):
+            reject()
+    elif issubclass(value_type, Number):
+        try:
+            number_real = float(cast(Any, value))
+        except Exception:
+            reject()
+        if not math.isfinite(number_real):
+            reject()
+
+    try:
+        first_hash = hash(value)
+        if hash(value) != first_hash:
+            reject()
+        reflexive = value == value
+        if type(reflexive) not in (bool, np.bool_) or not bool(reflexive):
+            reject()
+    except Exception:
+        reject()
+    return value

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -15,8 +15,9 @@ Two conventions matter for downstream analysis:
 """
 
 import math
-from collections.abc import Callable, Iterable, Sequence
-from numbers import Complex, Number
+from collections.abc import Callable, Sequence
+from decimal import Decimal
+from fractions import Fraction
 from typing import Any, NamedTuple, NoReturn, cast
 
 import jax.random as jr
@@ -31,6 +32,32 @@ from alberta_framework.core.learners import (
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
 from alberta_framework.utils.statistics import common_final_window
+
+_NUMPY_COORDINATE_TYPES = frozenset(
+    np.dtype(dtype_code).type
+    for dtype_code in (
+        "?",
+        "b",
+        "B",
+        "h",
+        "H",
+        "i",
+        "I",
+        "l",
+        "L",
+        "q",
+        "Q",
+        "e",
+        "f",
+        "d",
+        "g",
+        "F",
+        "D",
+        "G",
+        "S",
+        "U",
+    )
+)
 
 
 class ExperimentConfig(NamedTuple):
@@ -417,15 +444,19 @@ def extract_hyperparameter_results(
     Args:
         results: Dictionary of aggregated results
         metric: Metric to evaluate
-        param_extractor: Function to extract param value from config name
+        param_extractor: Function to extract a canonical immutable coordinate
+            from a config name. Accepted scalar coordinates are exact ``None``,
+            ``bool``, ``int``, finite ``float`` or ``complex``, finite ``Decimal``,
+            ``Fraction``, ``str``, ``bytes``, and the corresponding supported exact
+            NumPy scalar types. Exact tuples and frozensets may compose them.
 
     Returns:
         Dictionary mapping param value to (mean, std) tuple
 
     Raises:
-        ValueError: If ``param_extractor`` returns a noncanonical dictionary
-            coordinate or maps more than one configuration to the same value;
-            a sensitivity curve built from a silently truncated,
+        ValueError: If ``param_extractor`` returns a coordinate outside the
+            canonical immutable-key contract or maps more than one configuration
+            to the same value; a sensitivity curve built from a silently truncated,
             insertion-order-dependent subset is not a measurement.
     """
     performance = get_final_performance(results, metric)
@@ -447,45 +478,53 @@ def extract_hyperparameter_results(
 
 
 def _require_hyperparameter_coordinate(value: object, *, name: str) -> Any:
-    """Require one stable dictionary coordinate without narrowing valid key types."""
+    """Require one coordinate whose finiteness and hash semantics are intrinsic.
+
+    Accepted coordinates are exact immutable Python scalar types, ``Decimal``,
+    ``Fraction``, supported exact NumPy scalar types, and exact ``tuple`` or
+    ``frozenset`` compositions of those types. User-defined subclasses and keys
+    are deliberately excluded because calling their conversion, equality, or hash
+    methods cannot establish a durable dictionary-key contract.
+    """
 
     def reject() -> NoReturn:
         raise ValueError(
             "param_extractor returned a noncanonical coordinate for "
-            f"configuration {name!r}; coordinates must be hashable, reflexive, "
-            "and finite when numeric"
+            f"configuration {name!r}; coordinates must use canonical immutable "
+            "scalar types or exact tuple/frozenset compositions, and floating "
+            "or complex coordinates must be finite"
         )
 
     value_type = type(value)
-    if issubclass(value_type, (tuple, frozenset)):
-        try:
-            for component in cast(Iterable[object], value):
-                _require_hyperparameter_coordinate(component, name=name)
-        except Exception:
-            reject()
+    if value_type in (tuple, frozenset):
+        for component in cast(tuple[object, ...] | frozenset[object], value):
+            _require_hyperparameter_coordinate(component, name=name)
+        return value
 
-    if issubclass(value_type, Complex):
-        try:
-            number = complex(cast(Complex, value))
-        except Exception:
+    if value is None or value_type in (bool, int, str, bytes, Fraction):
+        return value
+
+    if value_type is float:
+        if not math.isfinite(cast(float, value)):
             reject()
+        return value
+
+    if value_type is complex:
+        number = cast(complex, value)
         if not math.isfinite(number.real) or not math.isfinite(number.imag):
             reject()
-    elif issubclass(value_type, Number):
-        try:
-            number_real = float(cast(Any, value))
-        except Exception:
-            reject()
-        if not math.isfinite(number_real):
-            reject()
+        return value
 
-    try:
-        first_hash = hash(value)
-        if hash(value) != first_hash:
+    if value_type is Decimal:
+        if not cast(Decimal, value).is_finite():
             reject()
-        reflexive = value == value
-        if type(reflexive) not in (bool, np.bool_) or not bool(reflexive):
+        return value
+
+    if value_type in _NUMPY_COORDINATE_TYPES:
+        if np.dtype(value_type).kind in ("f", "c") and not bool(
+            np.isfinite(cast(Any, value))
+        ):
             reject()
-    except Exception:
-        reject()
-    return value
+        return value
+
+    reject()

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -389,6 +389,55 @@ def test_extract_hyperparameter_results_keeps_injective_extractors() -> None:
     assert extracted == {0.01: (1.0, 0.0), 0.1: (3.0, 0.0)}
 
 
+@pytest.mark.parametrize(
+    "coordinate",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        complex(float("nan"), 0.0),
+        ("nested", float("nan")),
+    ],
+)
+def test_extract_hyperparameter_results_rejects_nonfinite_coordinates(
+    coordinate: object,
+) -> None:
+    results = {"lr_0.01": _flat_trace("lr_0.01", 1.0)}
+    with pytest.raises(
+        ValueError,
+        match=r"^param_extractor returned a noncanonical coordinate for "
+        r"configuration 'lr_0\.01'",
+    ):
+        extract_hyperparameter_results(results, param_extractor=lambda _: coordinate)
+
+
+@pytest.mark.parametrize("coordinate", [[], {}, np.asarray([0.01])])
+def test_extract_hyperparameter_results_rejects_unhashable_coordinates(
+    coordinate: object,
+) -> None:
+    results = {"lr_0.01": _flat_trace("lr_0.01", 1.0)}
+    with pytest.raises(
+        ValueError,
+        match=r"^param_extractor returned a noncanonical coordinate for "
+        r"configuration 'lr_0\.01'",
+    ):
+        extract_hyperparameter_results(results, param_extractor=lambda _: coordinate)
+
+
+def test_extract_hyperparameter_results_keeps_canonical_categorical_coordinates() -> None:
+    results = {
+        "sgd": _flat_trace("sgd", 1.0),
+        "adam": _flat_trace("adam", 3.0),
+    }
+    extracted = extract_hyperparameter_results(
+        results, param_extractor=lambda name: ("optimizer", name)
+    )
+    assert extracted == {
+        ("optimizer", "sgd"): (1.0, 0.0),
+        ("optimizer", "adam"): (3.0, 0.0),
+    }
+
+
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:
     poisoned = _two_seed_trace()
     poisoned.metric_arrays["squared_error"][0, 1] = np.inf

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from decimal import Decimal
+from fractions import Fraction
 from typing import Any, Never
 
 import numpy as np
@@ -396,7 +398,11 @@ def test_extract_hyperparameter_results_keeps_injective_extractors() -> None:
         float("inf"),
         float("-inf"),
         complex(float("nan"), 0.0),
+        Decimal("NaN"),
+        Decimal("Infinity"),
+        np.longdouble("nan"),
         ("nested", float("nan")),
+        frozenset(("nested", float("inf"))),
     ],
 )
 def test_extract_hyperparameter_results_rejects_nonfinite_coordinates(
@@ -436,6 +442,104 @@ def test_extract_hyperparameter_results_keeps_canonical_categorical_coordinates(
         ("optimizer", "sgd"): (1.0, 0.0),
         ("optimizer", "adam"): (3.0, 0.0),
     }
+
+
+@pytest.mark.parametrize(
+    "coordinate",
+    [
+        None,
+        True,
+        -7,
+        0.125,
+        1.0 + 2.0j,
+        "adam",
+        b"adam",
+        Decimal("0.125"),
+        Fraction(1, 8),
+        np.bool_(True),
+        np.int64(7),
+        np.float32(0.125),
+        np.complex64(1.0 + 2.0j),
+        np.str_("adam"),
+        np.bytes_("adam"),
+        ("optimizer", np.float32(0.125)),
+        frozenset(("optimizer", np.int16(7))),
+    ],
+)
+def test_extract_hyperparameter_results_keeps_canonical_coordinate_families(
+    coordinate: object,
+) -> None:
+    extracted = extract_hyperparameter_results(
+        {"candidate": _flat_trace("candidate", 1.0)},
+        param_extractor=lambda _: coordinate,
+    )
+
+    assert len(extracted) == 1
+    assert next(iter(extracted)) is coordinate
+
+
+class _NonfiniteFloatThatConvertsFinite(float):
+    def __new__(cls) -> _NonfiniteFloatThatConvertsFinite:
+        return super().__new__(cls, float("inf"))
+
+    def __complex__(self) -> complex:
+        return 0j
+
+
+def test_extract_hyperparameter_results_rejects_spoofed_numeric_subclasses() -> None:
+    coordinate = _NonfiniteFloatThatConvertsFinite()
+    assert coordinate == float("inf")
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: coordinate,
+        )
+
+
+@pytest.mark.parametrize(
+    "coordinate",
+    [
+        10**1000,
+        Fraction(10**1000, 3),
+        Decimal("1e4000"),
+        np.longdouble("1e4000"),
+    ],
+)
+def test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates(
+    coordinate: object,
+) -> None:
+    extracted = extract_hyperparameter_results(
+        {"candidate": _flat_trace("candidate", 1.0)},
+        param_extractor=lambda _: coordinate,
+    )
+
+    assert len(extracted) == 1
+    assert next(iter(extracted)) is coordinate
+
+
+class _DelayedHashDrift:
+    def __init__(self) -> None:
+        self.hash_calls = 0
+
+    def __hash__(self) -> int:
+        self.hash_calls += 1
+        return 7 if self.hash_calls <= 2 else self.hash_calls
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+
+def test_extract_hyperparameter_results_rejects_user_defined_coordinate_keys() -> None:
+    coordinate = _DelayedHashDrift()
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: coordinate,
+        )
+
+    assert coordinate.hash_calls == 0
 
 
 def test_get_metric_timeseries_rejects_nonfinite_samples() -> None:


### PR DESCRIPTION
Follow-up hardening for #358.

A non-injective extractor is now rejected, but NaN coordinates remain non-reflexive dictionary keys (so repeated NaNs evade collision detection), non-finite numeric coordinates can enter a sensitivity result, and unhashable coordinates leak raw TypeError. This change preserves arbitrary well-behaved categorical keys while requiring each coordinate, including tuple/frozenset components, to be hashable, hash-stable, reflexive, and finite when numeric.

Failing-first: 8 adversarial coordinate cases failed against the #358 implementation; the three canonical/collision paths passed.

Verification at 4331e22c6d610421bcf6e0c0a8accfbd6f060b74:

- 49 affected experiment/utils tests passed.
- Ruff passed on the changed source and tests.
- Strict mypy passed on experiments.py.
- outputs/ is untouched.

This is validation hardening only; it does not run a benchmark or create/promote scientific evidence.

<!-- evidence-head:4331e22c6d610421bcf6e0c0a8accfbd6f060b74 -->
<!-- evidence-row:logs -->
- [x] logs: failing-first and verification results inline above