### PR TITLE
fix(step12): harden Prototype facade validation

### DIFF
--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -29,9 +29,8 @@ References:
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -39,7 +38,6 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.intelligence_amplification import (
     ExoCerebellumConfig,
     IAAgent,
@@ -55,6 +53,9 @@ from alberta_framework.core.intelligence_amplification import (
 )
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.steps._float32_validation import (
+    finite_real_and_float32,
+)
 
 
 @dataclass(frozen=True)
@@ -155,37 +156,9 @@ class Step12IAConfig:
 
 
 _INT32_MAX = 2**31 - 1
-
-
-def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
-    """Return the original real, exact ratio, and finite binary32 rounding."""
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    real = cast(Real, value)
-    try:
-        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
-    return real, numerator, denominator, narrowed
-
-
-def canonical_float32_storage(value: Real, narrowed: float) -> float:
-    if not isinstance(value, (int, float, np.floating)):
-        return narrowed
-    try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return narrowed
-    if not math.isfinite(number):
-        raise ValueError("scalar must be finite")
-    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
-        renarrowed = np.asarray(number, dtype=np.float32)
-    if not bool(np.array_equal(narrowed, renarrowed)):
-        number = float(narrowed)
-    return number
+_NUMPY_INTEGER_TYPES = frozenset(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
@@ -229,9 +202,13 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+    number: int
+    if actual_type is int:
+        number = cast(int, value)
+    elif actual_type in _NUMPY_INTEGER_TYPES:
+        number = int(cast(Integral, value))
+    else:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
@@ -263,13 +240,13 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
         minimum=0,
         maximum=_INT32_MAX - 1,
     )
-    if not isinstance(config.subtask_specs, tuple):
+    if type(config.subtask_specs) is not tuple:
         raise ValueError(
             f"subtask_specs must be a tuple of SubtaskSpec, got {config.subtask_specs!r}"
         )
     canonical_specs: list[SubtaskSpec] = []
     for spec in config.subtask_specs:
-        if not isinstance(spec, SubtaskSpec):
+        if type(spec) is not SubtaskSpec:
             raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
         feature_index = _require_int(
             "feature_index",

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -29,16 +29,17 @@ References:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from numbers import Integral, Real
-from typing import Any
+from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.intelligence_amplification import (
     ExoCerebellumConfig,
     IAAgent,
@@ -156,46 +157,68 @@ class Step12IAConfig:
 _INT32_MAX = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> Any:
-    """Return a concrete real scalar after direct float32 sink validation."""
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    return value
-
-
-def _narrow_float32(name: str, value: Any) -> float:
-    """Narrow exactly as downstream JAX kernels do, without intermediate double-rounding."""
+    real = cast(Real, value)
     try:
-        narrowed = round_real_to_float32(value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be finite in float32, got {value!r}") from exc
-    if not bool(np.isfinite(narrowed)):
-        raise ValueError(f"{name} must be finite in float32, got {value!r}")
-    return float(narrowed)
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original < 0.0 or original > 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return _narrow_float32(name, original)
+    return float(narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return _narrow_float32(name, original)
+    return float(narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
-    number = _narrow_float32(name, original)
-    if number <= 0.0:
-        raise ValueError(f"{name} must remain positive in float32, got {value!r}")
-    return number
+    return float(narrowed)
+
+
+def _require_real_scalar(name: str, value: object) -> float:
+    _, _, _, narrowed = finite_real_and_float32(name, value)
+    return float(narrowed)
 
 
 def _require_int(
@@ -205,9 +228,10 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
@@ -215,7 +239,7 @@ def _require_int(
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     return number
 
 
@@ -258,11 +282,10 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
             )
         threshold = _require_positive_real("threshold", spec.threshold)
-        pseudo_reward_scale = _require_real(
+        pseudo_reward_scale = _require_real_scalar(
             "pseudo_reward_scale",
             spec.pseudo_reward_scale,
         )
-        pseudo_reward_scale = _narrow_float32("pseudo_reward_scale", pseudo_reward_scale)
         max_option_steps = _require_int(
             "max_option_steps",
             spec.max_option_steps,

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -29,7 +29,7 @@ References:
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from numbers import Integral, Real
 from typing import Any
 
@@ -97,18 +97,26 @@ class Step12IAConfig:
         """Return a JSON-serializable representation."""
         return {
             "type": "Step12IAConfig",
-            "n_demons": self.n_demons,
-            "cerebellum_step_size": self.cerebellum_step_size,
-            "subtask_specs": [asdict(s) for s in self.subtask_specs],
-            "observation_dim": self.observation_dim,
-            "n_primitive_actions": self.n_primitive_actions,
-            "base_step_size": self.base_step_size,
-            "base_avg_reward_step_size": self.base_avg_reward_step_size,
-            "option_step_size": self.option_step_size,
-            "option_gamma": self.option_gamma,
-            "option_planning_backups_per_step": self.option_planning_backups_per_step,
-            "epsilon_base": self.epsilon_base,
-            "utility_ema_decay": self.utility_ema_decay,
+            "n_demons": int(self.n_demons),
+            "cerebellum_step_size": float(self.cerebellum_step_size),
+            "subtask_specs": [
+                {
+                    "feature_index": int(s.feature_index),
+                    "threshold": float(s.threshold),
+                    "pseudo_reward_scale": float(s.pseudo_reward_scale),
+                    "max_option_steps": int(s.max_option_steps),
+                }
+                for s in self.subtask_specs
+            ],
+            "observation_dim": int(self.observation_dim),
+            "n_primitive_actions": int(self.n_primitive_actions),
+            "base_step_size": float(self.base_step_size),
+            "base_avg_reward_step_size": float(self.base_avg_reward_step_size),
+            "option_step_size": float(self.option_step_size),
+            "option_gamma": float(self.option_gamma),
+            "option_planning_backups_per_step": int(self.option_planning_backups_per_step),
+            "epsilon_base": float(self.epsilon_base),
+            "utility_ema_decay": float(self.utility_ema_decay),
         }
 
     @classmethod
@@ -148,47 +156,46 @@ class Step12IAConfig:
 _INT32_MAX = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> float:
+def _require_real(name: str, value: object) -> Any:
     """Return a concrete real scalar after direct float32 sink validation."""
     if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
+    return value
+
+
+def _narrow_float32(name: str, value: Any) -> float:
+    """Narrow exactly as downstream JAX kernels do, without intermediate double-rounding."""
     try:
         narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be finite in float32, got {value!r}") from exc
     if not bool(np.isfinite(narrowed)):
         raise ValueError(f"{name} must be finite in float32, got {value!r}")
-    return narrowed
+    return float(narrowed)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    original: Any = value
+    original = _require_real(name, value)
     if original < 0.0 or original > 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return _require_real(name, value)
+    return _narrow_float32(name, original)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    original: Any = value
+    original = _require_real(name, value)
     if original < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return _require_real(name, value)
+    return _narrow_float32(name, original)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    original: Any = value
+    original = _require_real(name, value)
     if original <= 0.0:
         raise ValueError(f"{name} must be positive, got {value!r}")
-    narrowed = _require_real(name, value)
-    if narrowed <= 0.0:
+    number = _narrow_float32(name, original)
+    if number <= 0.0:
         raise ValueError(f"{name} must remain positive in float32, got {value!r}")
-    return narrowed
+    return number
 
 
 def _require_int(
@@ -196,9 +203,9 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
-    exclusive_maximum: int | None = None,
+    maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
     number = int(value)
     if minimum is not None and number < minimum:
@@ -207,24 +214,30 @@ def _require_int(
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_ia_facade_config(config: Step12IAConfig) -> None:
-    n_demons = _require_int("n_demons", config.n_demons, minimum=1)
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    n_demons = _require_int("n_demons", config.n_demons, minimum=1, maximum=_INT32_MAX)
+    observation_dim = _require_int(
+        "observation_dim",
+        config.observation_dim,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     n_primitive_actions = _require_int(
         "n_primitive_actions",
         config.n_primitive_actions,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     option_planning_backups_per_step = _require_int(
         "option_planning_backups_per_step",
         config.option_planning_backups_per_step,
         minimum=0,
-        exclusive_maximum=_INT32_MAX,
+        maximum=_INT32_MAX - 1,
     )
     if not isinstance(config.subtask_specs, tuple):
         raise ValueError(
@@ -234,7 +247,12 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
     for spec in config.subtask_specs:
         if not isinstance(spec, SubtaskSpec):
             raise ValueError(f"subtask_specs must contain SubtaskSpec values, got {spec!r}")
-        feature_index = _require_int("feature_index", spec.feature_index, minimum=0)
+        feature_index = _require_int(
+            "feature_index",
+            spec.feature_index,
+            minimum=0,
+            maximum=_INT32_MAX,
+        )
         if feature_index >= observation_dim:
             raise ValueError(
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
@@ -244,13 +262,13 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
             "pseudo_reward_scale",
             spec.pseudo_reward_scale,
         )
+        pseudo_reward_scale = _narrow_float32("pseudo_reward_scale", pseudo_reward_scale)
         max_option_steps = _require_int(
             "max_option_steps",
             spec.max_option_steps,
             minimum=1,
+            maximum=_INT32_MAX,
         )
-        if max_option_steps > _INT32_MAX:
-            raise ValueError("max_option_steps must fit int32 telemetry")
         canonical_specs.append(
             SubtaskSpec(
                 feature_index=feature_index,
@@ -426,8 +444,8 @@ def run_step12_smoke(
     Returns:
         :class:`Step12SmokeResult` with shape/fineness summary.
     """
-    if steps < 1:
-        raise ValueError("steps must be positive")
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config or Step12IAConfig()
     agent = make_step12_ia_agent(cfg)

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -193,6 +193,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_demons", float("nan")),
     ("n_demons", float("inf")),
     ("n_demons", None),
+    ("n_demons", 2**31),
     ("observation_dim", 0),
     ("observation_dim", -1),
     ("observation_dim", True),
@@ -202,6 +203,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("observation_dim", float("nan")),
     ("observation_dim", float("inf")),
     ("observation_dim", None),
+    ("observation_dim", 2**31),
     ("n_primitive_actions", 0),
     ("n_primitive_actions", -1),
     ("n_primitive_actions", True),
@@ -211,6 +213,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_primitive_actions", float("nan")),
     ("n_primitive_actions", float("inf")),
     ("n_primitive_actions", None),
+    ("n_primitive_actions", 2**31),
     ("cerebellum_step_size", float("nan")),
     ("cerebellum_step_size", float("inf")),
     ("cerebellum_step_size", float("-inf")),
@@ -220,6 +223,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("cerebellum_step_size", -1.0),
     ("cerebellum_step_size", "0.05"),
     ("cerebellum_step_size", None),
+    ("cerebellum_step_size", 1e100),
     ("base_step_size", float("nan")),
     ("base_step_size", float("inf")),
     ("base_step_size", float("-inf")),
@@ -228,18 +232,21 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("base_step_size", -1.0),
     ("base_step_size", "0.05"),
     ("base_step_size", None),
+    ("base_step_size", 1e100),
     ("base_avg_reward_step_size", float("nan")),
     ("base_avg_reward_step_size", float("inf")),
     ("base_avg_reward_step_size", True),
     ("base_avg_reward_step_size", False),
     ("base_avg_reward_step_size", -0.01),
     ("base_avg_reward_step_size", "0.01"),
+    ("base_avg_reward_step_size", 1e100),
     ("option_step_size", float("nan")),
     ("option_step_size", float("inf")),
     ("option_step_size", True),
     ("option_step_size", False),
     ("option_step_size", -1.0),
     ("option_step_size", "0.05"),
+    ("option_step_size", 1e100),
     ("option_gamma", float("nan")),
     ("option_gamma", float("inf")),
     ("option_gamma", float("-inf")),
@@ -248,6 +255,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("option_gamma", -0.1),
     ("option_gamma", 1.1),
     ("option_gamma", "0.99"),
+    ("option_gamma", 1e100),
     ("option_planning_backups_per_step", -1),
     ("option_planning_backups_per_step", 2**31 - 1),
     ("option_planning_backups_per_step", 2**31),
@@ -265,6 +273,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("epsilon_base", -0.1),
     ("epsilon_base", 1.1),
     ("epsilon_base", "0.1"),
+    ("epsilon_base", 1e100),
     ("utility_ema_decay", float("nan")),
     ("utility_ema_decay", float("inf")),
     ("utility_ema_decay", float("-inf")),
@@ -273,6 +282,7 @@ _INVALID_STEP12_FIELDS: tuple[tuple[str, Any], ...] = (
     ("utility_ema_decay", -0.1),
     ("utility_ema_decay", 1.1),
     ("utility_ema_decay", "0.99"),
+    ("utility_ema_decay", 1e100),
 )
 
 
@@ -1073,3 +1083,49 @@ def test_step12_state_stays_finite_200_steps() -> None:
     chex.assert_tree_all_finite(result.state.cortex_state.stomp_state.base_learner_state)
     chex.assert_tree_all_finite(result.predictions)
     chex.assert_tree_all_finite(result.cortex_td_errors)
+
+
+def test_step12_config_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    spec = SubtaskSpec(
+        feature_index=2**31 - 2,
+        threshold=f32_max,
+        pseudo_reward_scale=f32_max,
+        max_option_steps=2**31 - 1,
+    )
+    config = Step12IAConfig(
+        n_demons=2**31 - 1,
+        cerebellum_step_size=f32_max,
+        subtask_specs=(spec,),
+        observation_dim=2**31 - 1,
+        n_primitive_actions=2**31 - 1,
+        base_step_size=f32_max,
+        base_avg_reward_step_size=f32_max,
+        option_step_size=f32_max,
+        option_gamma=1.0,
+        option_planning_backups_per_step=2**31 - 2,
+        epsilon_base=1.0,
+        utility_ema_decay=1.0,
+    )
+    assert config.n_demons == 2**31 - 1
+    assert config.observation_dim == 2**31 - 1
+    assert config.option_planning_backups_per_step == 2**31 - 2
+    assert config.cerebellum_step_size == f32_max
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "64"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_step12_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step12_smoke(**kwargs)

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -1178,6 +1178,15 @@ def test_step12_rejects_spoofed_int_class_with_negative_ratio() -> None:
         Step12IAConfig(base_step_size=SpoofedIntFloat(0.5))
 
 
+def test_step12_rejects_integer_subclass_conversion_hooks() -> None:
+    class LyingInt(int):
+        def __int__(self) -> int:
+            return 3
+
+    with pytest.raises(ValueError, match="n_demons"):
+        Step12IAConfig(n_demons=LyingInt(-1))
+
+
 def test_step12_rejects_spoofed_ratio_components() -> None:
     class SpoofedComponent:
         @property
@@ -1191,5 +1200,5 @@ def test_step12_rejects_spoofed_ratio_components() -> None:
         def as_integer_ratio(self) -> tuple[Any, Any]:
             return (SpoofedComponent(), 2)
 
-    with pytest.raises(ValueError, match="must narrow to a finite float32"):
+    with pytest.raises(ValueError, match="must be finite"):
         Step12IAConfig(option_gamma=BadRatioFloat(0.5))

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -1129,3 +1129,67 @@ def test_step12_config_preserves_float32_boundaries() -> None:
 def test_step12_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         run_step12_smoke(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_step12_rejects_adversarial_ratio_floats(
+    ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"option_gamma must be in \[0, 1\]"):
+        Step12IAConfig(option_gamma=HiddenBoundaryFloat(0.5))
+
+
+def test_step12_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        Step12IAConfig(option_gamma=value)  # type: ignore[arg-type]
+
+
+def test_step12_rejects_spoofed_int_class_with_negative_ratio() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="base_step_size must be non-negative"):
+        Step12IAConfig(base_step_size=SpoofedIntFloat(0.5))
+
+
+def test_step12_rejects_spoofed_ratio_components() -> None:
+    class SpoofedComponent:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __int__(self) -> int:
+            return 1
+
+    class BadRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[Any, Any]:
+            return (SpoofedComponent(), 2)
+
+    with pytest.raises(ValueError, match="must narrow to a finite float32"):
+        Step12IAConfig(option_gamma=BadRatioFloat(0.5))


### PR DESCRIPTION
Reconciles the Step 12 Prototype facade with the shared exact float32 validator and current core contracts.

Changes:
- reuse the shared finite-real/float32 validation policy instead of a duplicate converter
- enforce exact trusted integer families and int32 bounds before JAX shapes/counters
- keep option planning backups below INT32_MAX, matching STOMPConfig
- require exact tuple/SubtaskSpec structure and reject conversion-hook integer subclasses
- retain fail-closed smoke health checks

Validation at exact head 717d686d:
- tests/test_step12_production.py: 192 passed
- post-rebase adversarial/static panel: 32 passed, 160 deselected
- Ruff: clean
- strict mypy for step12.py: clean
- git diff --check: clean

This is library/contract hardening only. No benchmark campaign was run and no outputs or evidence artifacts were modified.