### PR TITLE
fix(upgd): continue converged saturated clocks

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -111,7 +111,11 @@ def _saturating_increment(value: Array, increment: Array | int = 1) -> Array:
 
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     increment_array = jnp.asarray(increment, dtype=jnp.int32)
-    return value + jnp.minimum(increment_array, maximum - value)
+    return jnp.where(
+        value <= maximum - increment_array,
+        value + increment_array,
+        maximum,
+    )
 
 
 @dataclass(frozen=True)
@@ -377,12 +381,12 @@ class CanonicalUPGD:
         equation-level parity tests.  Normal operation omits it and samples
         ``N(0, noise_std**2)`` from ``key``.
 
-        The final representable int32 clock event is applied.  Once the clock
-        reaches ``INT32_MAX``, later calls reject atomically: parameters,
+        The final representable int32 clock event is applied.  A saturated
+        clock may continue only after its active leaf-dtype bias-correction
+        denominator is exactly one.  If an active saturated clock still needs
+        to advance that denominator, the update rejects atomically: parameters,
         optimizer state, and the key remain exact; computed payloads are
-        neutral; and ``metrics["update_applied"]`` is false.  This avoids both
-        counter wraparound and silently continuing an EMA with a frozen bias-
-        correction clock.
+        neutral; and ``metrics["update_applied"]`` is false.
         """
 
         param_leaves, structure = _flatten_with_none(params)
@@ -415,8 +419,7 @@ class CanonicalUPGD:
         next_key = split_keys[0]
         noise_keys = split_keys[1:]
         beta = self._config.utility_decay
-        maximum_step = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
-        capacity_available = state.step < maximum_step
+        maximum_counter = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
         next_step = _saturating_increment(state.step)
 
         corrected_leaves: list[Array] = []
@@ -426,6 +429,7 @@ class CanonicalUPGD:
         eligible_masks: list[Array] = []
         active_masks: list[Array] = []
         clean_gradients: list[Array] = []
+        capacity_available = jnp.asarray(True, dtype=jnp.bool_)
 
         for param, gradient, utility, age, mask_leaf in zip(
             param_leaves,
@@ -461,14 +465,29 @@ class CanonicalUPGD:
                 next_age = _saturating_increment(age, active.astype(jnp.int32))
                 correction_clock = next_age.astype(param.dtype)
             bias_correction = 1.0 - jnp.power(beta, correction_clock)
+            correction_denominator = (
+                jnp.maximum(bias_correction, self._config.epsilon)
+                if self._config.profile == "safe_extended"
+                else bias_correction
+            )
+            denominator_converged = correction_denominator == jnp.asarray(
+                1.0, dtype=bias_correction.dtype
+            )
+            if self._config.uses_global_clock:
+                saturated_active = (state.step >= maximum_counter) & jnp.any(active)
+                leaf_capacity_available = (~saturated_active) | jnp.all(
+                    denominator_converged
+                )
+            else:
+                leaf_capacity_available = ~jnp.any(
+                    active
+                    & (age >= maximum_counter)
+                    & ~denominator_converged
+                )
+            capacity_available = capacity_available & leaf_capacity_available
             corrected = jnp.where(
                 next_age > 0,
-                next_utility
-                / (
-                    jnp.maximum(bias_correction, self._config.epsilon)
-                    if self._config.profile == "safe_extended"
-                    else bias_correction
-                ),
+                next_utility / correction_denominator,
                 0.0,
             )
 

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -386,7 +386,9 @@ class CanonicalUPGD:
         denominator is exactly one.  If an active saturated clock still needs
         to advance that denominator, the update rejects atomically: parameters,
         optimizer state, and the key remain exact; computed payloads are
-        neutral; and ``metrics["update_applied"]`` is false.
+        neutral; and ``metrics["update_applied"]`` is false.  The refusal
+        branch excludes the numerical proposal from reverse-mode
+        differentiation, preserving the same identity boundary there.
         """
 
         param_leaves, structure = _flatten_with_none(params)
@@ -415,26 +417,22 @@ class CanonicalUPGD:
             if noise_structure != structure:
                 raise ValueError("noise must share the parameter PyTree structure")
 
-        split_keys = jr.split(key, len(param_leaves) + 1)
-        next_key = split_keys[0]
-        noise_keys = split_keys[1:]
         beta = self._config.utility_decay
         maximum_counter = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
         next_step = _saturating_increment(state.step)
 
-        corrected_leaves: list[Array] = []
-        new_utility_leaves: list[Array] = []
-        new_age_leaves: list[Array] = []
         finite_masks: list[Array] = []
-        eligible_masks: list[Array] = []
         active_masks: list[Array] = []
         clean_gradients: list[Array] = []
+        new_age_leaves: list[Array] = []
+        correction_denominators: list[Array] = []
         capacity_available = jnp.asarray(True, dtype=jnp.bool_)
+        eligible_count = jnp.array(0.0, dtype=jnp.float32)
+        nonfinite_count = jnp.array(0.0, dtype=jnp.float32)
 
-        for param, gradient, utility, age, mask_leaf in zip(
+        for param, gradient, age, mask_leaf in zip(
             param_leaves,
             grad_leaves,
-            utility_leaves,
             age_leaves,
             mask_leaves,
             strict=True,
@@ -451,13 +449,6 @@ class CanonicalUPGD:
                 clean_gradient = jnp.where(finite, gradient_array, 0.0)
 
             active = eligible & finite
-            instantaneous = -clean_gradient * param
-            next_utility = jnp.where(
-                active,
-                _static_zero_scale(beta, utility)
-                + (1.0 - beta) * instantaneous,
-                utility,
-            )
             if self._config.uses_global_clock:
                 next_age = jnp.full_like(age, next_step)
                 correction_clock = next_step.astype(param.dtype)
@@ -485,219 +476,225 @@ class CanonicalUPGD:
                     & ~denominator_converged
                 )
             capacity_available = capacity_available & leaf_capacity_available
-            corrected = jnp.where(
-                next_age > 0,
-                next_utility / correction_denominator,
-                0.0,
-            )
 
             clean_gradients.append(clean_gradient)
             finite_masks.append(finite)
-            eligible_masks.append(eligible)
             active_masks.append(active)
-            new_utility_leaves.append(next_utility)
             new_age_leaves.append(next_age)
-            corrected_leaves.append(corrected)
-
-        if self._config.resolved_normalization == "global":
-            maximum = jnp.array(-jnp.inf, dtype=jnp.float32)
-            has_active = jnp.array(False)
-            reference_leaves = (
-                new_utility_leaves
-                if self._config.profile in _RAW_GLOBAL_PROFILES
-                else corrected_leaves
-            )
-            for reference, active in zip(
-                reference_leaves,
-                active_masks,
-                strict=True,
-            ):
-                leaf_maximum = jnp.max(
-                    jnp.where(active, reference, -jnp.inf),
-                    initial=-jnp.inf,
-                )
-                maximum = jnp.maximum(maximum, leaf_maximum.astype(jnp.float32))
-                has_active = has_active | jnp.any(active)
-            global_maximum = jnp.where(has_active, maximum, 0.0)
-            denominator = (
-                _safe_signed_denominator(
-                    global_maximum,
-                    self._config.epsilon,
-                )
-                if self._config.profile == "safe_extended"
-                else global_maximum
-            )
-            normalized_leaves = [
-                jnp.where(
-                    active,
-                    corrected / denominator.astype(corrected.dtype),
-                    0.0,
-                )
-                for corrected, active in zip(
-                    corrected_leaves,
-                    active_masks,
-                    strict=True,
-                )
-            ]
-        else:
-            global_maximum = jnp.array(jnp.nan, dtype=jnp.float32)
-            if self._config.profile == "paper_local_literal":
-                denominator_leaves = new_utility_leaves
-                local_epsilon: float | None = None
-            elif self._config.profile == "official_experiment_local":
-                denominator_leaves = corrected_leaves
-                local_epsilon = 1e-12
-            else:
-                denominator_leaves = corrected_leaves
-                local_epsilon = self._config.epsilon
-            normalized_leaves = [
-                _local_normalize(
-                    corrected,
-                    denominator_utility,
-                    active,
-                    local_epsilon,
-                )
-                for corrected, denominator_utility, active in zip(
-                    corrected_leaves,
-                    denominator_leaves,
-                    active_masks,
-                    strict=True,
-                )
-            ]
-
-        new_param_leaves: list[Array] = []
-        gate_leaves: list[Array] = []
-        perturbation_leaves: list[Array] = []
-        gate_sum = jnp.array(0.0, dtype=jnp.float32)
-        utility_sum = jnp.array(0.0, dtype=jnp.float32)
-        eligible_count = jnp.array(0.0, dtype=jnp.float32)
-        nonfinite_count = jnp.array(0.0, dtype=jnp.float32)
-
-        for (
-            param,
-            gradient,
-            normalized,
-            corrected,
-            finite,
-            eligible,
-            active,
-            noise_key,
-            supplied_noise,
-        ) in zip(
-            param_leaves,
-            clean_gradients,
-            normalized_leaves,
-            corrected_leaves,
-            finite_masks,
-            eligible_masks,
-            active_masks,
-            noise_keys,
-            supplied_noise_leaves,
-            strict=True,
-        ):
-            gate = jnp.where(active, jax.nn.sigmoid(normalized), 0.0)
-            if supplied_noise is None:
-                sampled_noise = (
-                    jr.normal(noise_key, param.shape, dtype=param.dtype) * self._config.noise_std
-                )
-            else:
-                sampled_noise = jnp.asarray(supplied_noise, dtype=param.dtype)
-                if sampled_noise.shape != param.shape:
-                    raise ValueError("every noise leaf must match its parameter shape")
-            finite_noise = jnp.where(jnp.isfinite(sampled_noise), sampled_noise, 0.0)
-            perturbation = jnp.where(active, finite_noise, 0.0)
-
-            if self._config.mode == "protecting":
-                direction = (gradient + perturbation) * (1.0 - gate)
-            else:
-                direction = gradient + perturbation * (1.0 - gate)
-
-            decayed = param * (1.0 - self._config.step_size * self._config.weight_decay)
-            direction_step = self._config.step_size * self._config.direction_multiplier
-            candidate = decayed - direction_step * direction
-            updated = jnp.where(finite, candidate, param)
-
             count = jnp.sum(active.astype(jnp.float32))
-            gate_sum = gate_sum + jnp.sum(gate.astype(jnp.float32))
-            utility_sum = utility_sum + jnp.sum(
-                jnp.where(active, jnp.abs(corrected), 0.0).astype(jnp.float32)
-            )
             eligible_count = eligible_count + count
             nonfinite_count = nonfinite_count + jnp.sum((~finite).astype(jnp.float32))
+            correction_denominators.append(correction_denominator)
 
-            new_param_leaves.append(updated)
-            gate_leaves.append(gate)
-            perturbation_leaves.append(perturbation)
+        def apply_update(_: None) -> CanonicalUPGDUpdate:
+            split_keys = jr.split(key, len(param_leaves) + 1)
+            next_key = split_keys[0]
+            noise_keys = split_keys[1:]
 
-        count_floor = jnp.maximum(eligible_count, 1.0)
-        proposed_params = jax.tree_util.tree_unflatten(structure, new_param_leaves)
-        proposed_state = CanonicalUPGDState(  # type: ignore[call-arg]
-            utility_ema=jax.tree_util.tree_unflatten(structure, new_utility_leaves),
-            utility_age=jax.tree_util.tree_unflatten(structure, new_age_leaves),
-            step=next_step,
-        )
-        committed_params = jax.tree.map(
-            lambda proposed, current: jnp.where(
-                capacity_available,
-                proposed,
-                current,
-            ),
-            proposed_params,
-            params,
-        )
-        committed_state = jax.tree.map(
-            lambda proposed, current: jnp.where(
-                capacity_available,
-                proposed,
-                current,
-            ),
-            proposed_state,
-            state,
-        )
-        committed_key = jax.lax.cond(
+            corrected_leaves: list[Array] = []
+            new_utility_leaves: list[Array] = []
+            for param, gradient, utility, next_age, active, correction_denominator in zip(
+                param_leaves,
+                clean_gradients,
+                utility_leaves,
+                new_age_leaves,
+                active_masks,
+                correction_denominators,
+                strict=True,
+            ):
+                instantaneous = -gradient * param
+                next_utility = jnp.where(
+                    active,
+                    _static_zero_scale(beta, utility)
+                    + (1.0 - beta) * instantaneous,
+                    utility,
+                )
+                corrected = jnp.where(
+                    next_age > 0,
+                    next_utility / correction_denominator,
+                    0.0,
+                )
+                new_utility_leaves.append(next_utility)
+                corrected_leaves.append(corrected)
+
+            if self._config.resolved_normalization == "global":
+                maximum = jnp.array(-jnp.inf, dtype=jnp.float32)
+                has_active = jnp.array(False)
+                reference_leaves = (
+                    new_utility_leaves
+                    if self._config.profile in _RAW_GLOBAL_PROFILES
+                    else corrected_leaves
+                )
+                for reference, active in zip(
+                    reference_leaves,
+                    active_masks,
+                    strict=True,
+                ):
+                    leaf_maximum = jnp.max(
+                        jnp.where(active, reference, -jnp.inf),
+                        initial=-jnp.inf,
+                    )
+                    maximum = jnp.maximum(maximum, leaf_maximum.astype(jnp.float32))
+                    has_active = has_active | jnp.any(active)
+                global_maximum = jnp.where(has_active, maximum, 0.0)
+                denominator = (
+                    _safe_signed_denominator(
+                        global_maximum,
+                        self._config.epsilon,
+                    )
+                    if self._config.profile == "safe_extended"
+                    else global_maximum
+                )
+                normalized_leaves = [
+                    jnp.where(
+                        active,
+                        corrected / denominator.astype(corrected.dtype),
+                        0.0,
+                    )
+                    for corrected, active in zip(
+                        corrected_leaves,
+                        active_masks,
+                        strict=True,
+                    )
+                ]
+            else:
+                global_maximum = jnp.array(jnp.nan, dtype=jnp.float32)
+                if self._config.profile == "paper_local_literal":
+                    denominator_leaves = new_utility_leaves
+                    local_epsilon: float | None = None
+                elif self._config.profile == "official_experiment_local":
+                    denominator_leaves = corrected_leaves
+                    local_epsilon = 1e-12
+                else:
+                    denominator_leaves = corrected_leaves
+                    local_epsilon = self._config.epsilon
+                normalized_leaves = [
+                    _local_normalize(
+                        corrected,
+                        denominator_utility,
+                        active,
+                        local_epsilon,
+                    )
+                    for corrected, denominator_utility, active in zip(
+                        corrected_leaves,
+                        denominator_leaves,
+                        active_masks,
+                        strict=True,
+                    )
+                ]
+
+            new_param_leaves: list[Array] = []
+            gate_leaves: list[Array] = []
+            perturbation_leaves: list[Array] = []
+            gate_sum = jnp.array(0.0, dtype=jnp.float32)
+            utility_sum = jnp.array(0.0, dtype=jnp.float32)
+
+            for (
+                param,
+                gradient,
+                normalized,
+                corrected,
+                finite,
+                active,
+                noise_key,
+                supplied_noise,
+            ) in zip(
+                param_leaves,
+                clean_gradients,
+                normalized_leaves,
+                corrected_leaves,
+                finite_masks,
+                active_masks,
+                noise_keys,
+                supplied_noise_leaves,
+                strict=True,
+            ):
+                gate = jnp.where(active, jax.nn.sigmoid(normalized), 0.0)
+                if supplied_noise is None:
+                    sampled_noise = (
+                        jr.normal(noise_key, param.shape, dtype=param.dtype)
+                        * self._config.noise_std
+                    )
+                else:
+                    sampled_noise = jnp.asarray(supplied_noise, dtype=param.dtype)
+                    if sampled_noise.shape != param.shape:
+                        raise ValueError("every noise leaf must match its parameter shape")
+                finite_noise = jnp.where(jnp.isfinite(sampled_noise), sampled_noise, 0.0)
+                perturbation = jnp.where(active, finite_noise, 0.0)
+
+                if self._config.mode == "protecting":
+                    direction = (gradient + perturbation) * (1.0 - gate)
+                else:
+                    direction = gradient + perturbation * (1.0 - gate)
+
+                decayed = param * (1.0 - self._config.step_size * self._config.weight_decay)
+                direction_step = self._config.step_size * self._config.direction_multiplier
+                candidate = decayed - direction_step * direction
+                updated = jnp.where(finite, candidate, param)
+
+                gate_sum = gate_sum + jnp.sum(gate.astype(jnp.float32))
+                utility_sum = utility_sum + jnp.sum(
+                    jnp.where(active, jnp.abs(corrected), 0.0).astype(jnp.float32)
+                )
+
+                new_param_leaves.append(updated)
+                gate_leaves.append(gate)
+                perturbation_leaves.append(perturbation)
+
+            count_floor = jnp.maximum(eligible_count, 1.0)
+            proposed_state = CanonicalUPGDState(  # type: ignore[call-arg]
+                utility_ema=jax.tree_util.tree_unflatten(structure, new_utility_leaves),
+                utility_age=jax.tree_util.tree_unflatten(structure, new_age_leaves),
+                step=next_step,
+            )
+            return CanonicalUPGDUpdate(  # type: ignore[call-arg]
+                params=jax.tree_util.tree_unflatten(structure, new_param_leaves),
+                state=proposed_state,
+                next_key=next_key,
+                scaled_utility=jax.tree_util.tree_unflatten(structure, gate_leaves),
+                corrected_utility=jax.tree_util.tree_unflatten(
+                    structure, corrected_leaves
+                ),
+                perturbation=jax.tree_util.tree_unflatten(
+                    structure, perturbation_leaves
+                ),
+                metrics={
+                    "update_applied": jnp.asarray(True, dtype=jnp.bool_),
+                    "mean_scaled_utility": gate_sum / count_floor,
+                    "mean_absolute_utility": utility_sum / count_floor,
+                    "global_maximum_utility": global_maximum,
+                    "eligible_parameter_count": eligible_count,
+                    "nonfinite_or_missing_count": nonfinite_count,
+                },
+            )
+
+        def reject_update(_: None) -> CanonicalUPGDUpdate:
+            zero_tree = jax.tree.map(jnp.zeros_like, params)
+            zero_metric = jnp.array(0.0, dtype=jnp.float32)
+            return CanonicalUPGDUpdate(  # type: ignore[call-arg]
+                params=params,
+                state=state,
+                next_key=key,
+                scaled_utility=zero_tree,
+                corrected_utility=zero_tree,
+                perturbation=zero_tree,
+                metrics={
+                    "update_applied": jnp.asarray(False, dtype=jnp.bool_),
+                    "mean_scaled_utility": zero_metric,
+                    "mean_absolute_utility": zero_metric,
+                    "global_maximum_utility": zero_metric,
+                    "eligible_parameter_count": eligible_count,
+                    "nonfinite_or_missing_count": nonfinite_count,
+                },
+            )
+
+        result: CanonicalUPGDUpdate = jax.lax.cond(
             capacity_available,
-            lambda _: next_key,
-            lambda _: key,
+            apply_update,
+            reject_update,
             operand=None,
         )
-        zero_tree = jax.tree.map(jnp.zeros_like, params)
-        scaled_utility = jax.tree.map(
-            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
-            jax.tree_util.tree_unflatten(structure, gate_leaves),
-            zero_tree,
-        )
-        corrected_utility = jax.tree.map(
-            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
-            jax.tree_util.tree_unflatten(structure, corrected_leaves),
-            zero_tree,
-        )
-        perturbation = jax.tree.map(
-            lambda proposed, zero: jnp.where(capacity_available, proposed, zero),
-            jax.tree_util.tree_unflatten(structure, perturbation_leaves),
-            zero_tree,
-        )
-        return CanonicalUPGDUpdate(  # type: ignore[call-arg]
-            params=committed_params,
-            state=committed_state,
-            next_key=committed_key,
-            scaled_utility=scaled_utility,
-            corrected_utility=corrected_utility,
-            perturbation=perturbation,
-            metrics={
-                "update_applied": capacity_available,
-                "mean_scaled_utility": jnp.where(
-                    capacity_available, gate_sum / count_floor, 0.0
-                ),
-                "mean_absolute_utility": jnp.where(
-                    capacity_available, utility_sum / count_floor, 0.0
-                ),
-                "global_maximum_utility": jnp.where(
-                    capacity_available, global_maximum, 0.0
-                ),
-                "eligible_parameter_count": eligible_count,
-                "nonfinite_or_missing_count": nonfinite_count,
-            },
-        )
+        return result
 
 
 # This Alberta-derived transform was introduced separately from the official RL

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -310,59 +310,58 @@ def test_lifetime_counter_capacity_rejects_the_complete_update(
     normalization: str,
     compiled: bool,
 ) -> None:
-    params = {"w": jnp.array([2.0], dtype=jnp.float32)}
-    gradients = {"w": jnp.array([-0.5], dtype=jnp.float32)}
-    optimizer = CanonicalUPGD(
-        CanonicalUPGDConfig(
-            step_size=0.1,
-            utility_decay=0.9,
-            noise_std=0.0,
-            profile=profile,  # type: ignore[arg-type]
-            normalization=normalization,  # type: ignore[arg-type]
+    with jax.enable_x64():
+        params = {"w": jnp.array([2.0], dtype=jnp.float64)}
+        gradients = {"w": jnp.array([-0.5], dtype=jnp.float64)}
+        optimizer = CanonicalUPGD(
+            CanonicalUPGDConfig(
+                step_size=0.1,
+                utility_decay=0.999999999,
+                noise_std=0.0,
+                profile=profile,  # type: ignore[arg-type]
+                normalization=normalization,  # type: ignore[arg-type]
+            )
         )
-    )
-    maximum = jnp.iinfo(jnp.int32).max
-    state = optimizer.init(params).replace(
-        utility_ema={"w": jnp.array([1.0], dtype=jnp.float32)},
-        utility_age={"w": jnp.array([maximum], dtype=jnp.int32)},
-        step=jnp.array(maximum, dtype=jnp.int32),
-    )
+        maximum = jnp.iinfo(jnp.int32).max
+        state = optimizer.init(params).replace(
+            utility_ema={"w": jnp.array([1.0], dtype=jnp.float64)},
+            utility_age={"w": jnp.array([maximum], dtype=jnp.int32)},
+            step=jnp.array(maximum, dtype=jnp.int32),
+        )
 
-    def apply_update(state, params, gradients, key, noise):
-        return optimizer.update(state, params, gradients, key, noise=noise)
+        def apply_update(state, params, gradients, key, noise):
+            return optimizer.update(state, params, gradients, key, noise=noise)
 
-    update = jax.jit(apply_update) if compiled else apply_update
-    result = update(
-        state,
-        params,
-        gradients,
-        jr.key(0),
-        {"w": jnp.zeros(1, dtype=jnp.float32)},
-    )
+        update = jax.jit(apply_update) if compiled else apply_update
+        result = update(
+            state,
+            params,
+            gradients,
+            jr.key(0),
+            {"w": jnp.zeros(1, dtype=jnp.float64)},
+        )
 
-    assert int(result.state.step) == maximum
-    assert int(result.state.utility_age["w"][0]) == maximum
-    chex.assert_trees_all_equal(result.params, params)
-    chex.assert_trees_all_equal(result.state, state)
-    chex.assert_trees_all_equal(result.next_key, jr.key(0))
-    chex.assert_trees_all_equal(
-        result.corrected_utility,
-        jax.tree.map(jnp.zeros_like, params),
-    )
-    chex.assert_trees_all_equal(
-        result.scaled_utility,
-        jax.tree.map(jnp.zeros_like, params),
-    )
-    assert not bool(result.metrics["update_applied"])
+        assert int(result.state.step) == maximum
+        assert int(result.state.utility_age["w"][0]) == maximum
+        chex.assert_trees_all_equal(result.params, params)
+        chex.assert_trees_all_equal(result.state, state)
+        chex.assert_trees_all_equal(result.next_key, jr.key(0))
+        chex.assert_trees_all_equal(
+            result.corrected_utility,
+            jax.tree.map(jnp.zeros_like, params),
+        )
+        chex.assert_trees_all_equal(
+            result.scaled_utility,
+            jax.tree.map(jnp.zeros_like, params),
+        )
+        assert not bool(result.metrics["update_applied"])
 
 
 @pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
 def test_final_representable_lifetime_update_is_consumed_before_capacity(
     profile: str,
 ) -> None:
-    previous_x64 = jax.config.x64_enabled
-    jax.config.update("jax_enable_x64", True)
-    try:
+    with jax.enable_x64():
         params = {"w": jnp.array([2.0], dtype=jnp.float64)}
         gradients = {"w": jnp.array([-0.5], dtype=jnp.float64)}
         decay = 0.999999999
@@ -396,8 +395,115 @@ def test_final_representable_lifetime_update_is_consumed_before_capacity(
         assert int(result.state.utility_age["w"][0]) == maximum
         assert float(result.corrected_utility["w"][0]) == pytest.approx(1.0)
         assert bool(result.metrics["update_applied"])
-    finally:
-        jax.config.update("jax_enable_x64", previous_x64)
+
+
+@pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_converged_float32_bias_clock_continues_after_counter_saturation(
+    profile: str,
+    compiled: bool,
+) -> None:
+    params = {"w": jnp.array([2.0], dtype=jnp.float32)}
+    gradients = {"w": jnp.array([-0.5], dtype=jnp.float32)}
+    optimizer = CanonicalUPGD(
+        CanonicalUPGDConfig(
+            step_size=0.1,
+            utility_decay=0.9,
+            noise_std=0.0,
+            profile=profile,  # type: ignore[arg-type]
+            normalization="global",
+        )
+    )
+    maximum = jnp.iinfo(jnp.int32).max
+    state = optimizer.init(params).replace(
+        utility_ema={"w": jnp.array([1.0], dtype=jnp.float32)},
+        utility_age={"w": jnp.array([maximum], dtype=jnp.int32)},
+        step=jnp.array(maximum, dtype=jnp.int32),
+    )
+    key = jr.key(5)
+    update = jax.jit(optimizer.update) if compiled else optimizer.update
+    result = update(
+        state,
+        params,
+        gradients,
+        key,
+        noise={"w": jnp.zeros(1, dtype=jnp.float32)},
+    )
+
+    assert bool(result.metrics["update_applied"])
+    assert int(result.state.step) == maximum
+    assert int(result.state.utility_age["w"][0]) == maximum
+    assert float(result.corrected_utility["w"][0]) == pytest.approx(1.0)
+    assert float(result.params["w"][0]) != float(params["w"][0])
+    assert not jnp.array_equal(jr.key_data(result.next_key), jr.key_data(key))
+
+
+def test_safe_profile_global_saturation_does_not_consume_inactive_clock() -> None:
+    with jax.enable_x64():
+        maximum = jnp.iinfo(jnp.int32).max
+        params = {"w": jnp.array([2.0, 3.0], dtype=jnp.float64)}
+        gradients = {"w": jnp.array([-0.25, -0.5], dtype=jnp.float64)}
+        optimizer = CanonicalUPGD(
+            CanonicalUPGDConfig(
+                step_size=0.1,
+                utility_decay=0.999999999,
+                noise_std=0.0,
+                profile="safe_extended",
+                normalization="global",
+            )
+        )
+        state = optimizer.init(params).replace(
+            utility_ema={"w": jnp.ones(2, dtype=jnp.float64)},
+            utility_age={"w": jnp.array([maximum, 0], dtype=jnp.int32)},
+            step=jnp.array(maximum, dtype=jnp.int32),
+        )
+        key = jr.key(23)
+        result = jax.jit(optimizer.update)(
+            state,
+            params,
+            gradients,
+            key,
+            mask={"w": jnp.array([False, True])},
+            noise={"w": jnp.zeros(2, dtype=jnp.float64)},
+        )
+
+        assert bool(result.metrics["update_applied"])
+        chex.assert_trees_all_equal(
+            result.state.utility_age["w"],
+            jnp.array([maximum, 1], dtype=jnp.int32),
+        )
+        assert float(result.params["w"][0]) != float(params["w"][0])
+        assert float(result.params["w"][1]) != float(params["w"][1])
+        assert not jnp.array_equal(jr.key_data(result.next_key), jr.key_data(key))
+
+
+@pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
+def test_corrupt_negative_counters_do_not_overflow_to_the_lifetime_limit(
+    profile: str,
+) -> None:
+    params = {"w": jnp.array([2.0], dtype=jnp.float32)}
+    optimizer = CanonicalUPGD(
+        CanonicalUPGDConfig(
+            utility_decay=0.9,
+            noise_std=0.0,
+            profile=profile,  # type: ignore[arg-type]
+            normalization="global",
+        )
+    )
+    state = optimizer.init(params).replace(
+        utility_age={"w": jnp.array([-1], dtype=jnp.int32)},
+        step=jnp.array(-1, dtype=jnp.int32),
+    )
+    result = jax.jit(optimizer.update)(
+        state,
+        params,
+        {"w": jnp.array([-0.5], dtype=jnp.float32)},
+        jr.key(0),
+        noise={"w": jnp.zeros(1, dtype=jnp.float32)},
+    )
+
+    assert int(result.state.step) == 0
+    assert int(result.state.utility_age["w"][0]) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -477,6 +477,60 @@ def test_safe_profile_global_saturation_does_not_consume_inactive_clock() -> Non
         assert not jnp.array_equal(jr.key_data(result.next_key), jr.key_data(key))
 
 
+@pytest.mark.parametrize("mode", ["protecting", "non_protecting"])
+def test_safe_profile_exhausted_active_clock_rejects_available_peer_atomically(
+    mode: str,
+) -> None:
+    with jax.enable_x64():
+        maximum = jnp.iinfo(jnp.int32).max
+        params = {
+            "available": jnp.array([2.0], dtype=jnp.float64),
+            "exhausted": jnp.array([3.0], dtype=jnp.float64),
+        }
+        gradients = {
+            "available": jnp.array([-0.25], dtype=jnp.float64),
+            "exhausted": jnp.array([-0.5], dtype=jnp.float64),
+        }
+        optimizer = CanonicalUPGD(
+            CanonicalUPGDConfig(
+                step_size=0.1,
+                utility_decay=0.999999999,
+                noise_std=0.0,
+                mode=mode,  # type: ignore[arg-type]
+                profile="safe_extended",
+                normalization="global",
+            )
+        )
+        state = optimizer.init(params).replace(
+            utility_ema=jax.tree.map(jnp.ones_like, params),
+            utility_age={
+                "available": jnp.array([maximum - 1], dtype=jnp.int32),
+                "exhausted": jnp.array([maximum], dtype=jnp.int32),
+            },
+            step=jnp.array(maximum, dtype=jnp.int32),
+        )
+        key = jr.key(29)
+        result = jax.jit(optimizer.update)(
+            state,
+            params,
+            gradients,
+            key,
+            noise=jax.tree.map(jnp.zeros_like, params),
+        )
+
+        assert not bool(result.metrics["update_applied"])
+        chex.assert_trees_all_equal(result.params, params)
+        chex.assert_trees_all_equal(result.state, state)
+        chex.assert_trees_all_equal(
+            jr.key_data(result.next_key),
+            jr.key_data(key),
+        )
+        zero_tree = jax.tree.map(jnp.zeros_like, params)
+        chex.assert_trees_all_equal(result.scaled_utility, zero_tree)
+        chex.assert_trees_all_equal(result.corrected_utility, zero_tree)
+        chex.assert_trees_all_equal(result.perturbation, zero_tree)
+
+
 @pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
 def test_corrupt_negative_counters_do_not_overflow_to_the_lifetime_limit(
     profile: str,

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -532,6 +532,78 @@ def test_safe_profile_exhausted_active_clock_rejects_available_peer_atomically(
 
 
 @pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
+@pytest.mark.parametrize("mode", ["protecting", "non_protecting"])
+@pytest.mark.parametrize("compiled", [False, True])
+def test_lifetime_refusal_is_reverse_mode_atomic_when_proposal_is_nonfinite(
+    profile: str,
+    mode: str,
+    compiled: bool,
+) -> None:
+    with jax.enable_x64():
+        maximum = jnp.iinfo(jnp.int32).max
+        if profile == "paper_global":
+            param = jnp.array([0.0], dtype=jnp.float64)
+            gradient = jnp.array([0.0], dtype=jnp.float64)
+            utility = jnp.array([0.0], dtype=jnp.float64)
+        else:
+            param = jnp.array([2.0], dtype=jnp.float64)
+            gradient = jnp.array([-0.5], dtype=jnp.float64)
+            utility = jnp.array([jnp.finfo(jnp.float64).max], dtype=jnp.float64)
+        params = {"w": param}
+        optimizer = CanonicalUPGD(
+            CanonicalUPGDConfig(
+                step_size=0.1,
+                utility_decay=0.999999999,
+                noise_std=0.0,
+                mode=mode,  # type: ignore[arg-type]
+                profile=profile,  # type: ignore[arg-type]
+                normalization="global",
+            )
+        )
+        state = optimizer.init(params).replace(
+            utility_ema={"w": utility},
+            utility_age={"w": jnp.array([maximum], dtype=jnp.int32)},
+            step=jnp.array(maximum, dtype=jnp.int32),
+        )
+        key = jr.key(31)
+        noise = {"w": jnp.zeros(1, dtype=jnp.float64)}
+        result = optimizer.update(
+            state,
+            params,
+            {"w": gradient},
+            key,
+            noise=noise,
+        )
+
+        assert not bool(result.metrics["update_applied"])
+        chex.assert_trees_all_equal(result.params, params)
+        chex.assert_trees_all_equal(result.state, state)
+        chex.assert_trees_all_equal(result.next_key, key)
+        zero_tree = jax.tree.map(jnp.zeros_like, params)
+        chex.assert_trees_all_equal(result.scaled_utility, zero_tree)
+        chex.assert_trees_all_equal(result.corrected_utility, zero_tree)
+        chex.assert_trees_all_equal(result.perturbation, zero_tree)
+
+        def rejected_identity_loss(param_leaf, utility_leaf):
+            local_state = state.replace(utility_ema={"w": utility_leaf})
+            update = optimizer.update(
+                local_state,
+                {"w": param_leaf},
+                {"w": gradient},
+                key,
+                noise=noise,
+            )
+            return jnp.sum(update.params["w"]) + jnp.sum(update.state.utility_ema["w"])
+
+        gradient_fn = jax.grad(rejected_identity_loss, argnums=(0, 1))
+        if compiled:
+            gradient_fn = jax.jit(gradient_fn)
+        param_gradient, utility_gradient = gradient_fn(param, utility)
+        chex.assert_trees_all_equal(param_gradient, jnp.ones_like(param))
+        chex.assert_trees_all_equal(utility_gradient, jnp.ones_like(utility))
+
+
+@pytest.mark.parametrize("profile", ["paper_global", "safe_extended"])
 def test_corrupt_negative_counters_do_not_overflow_to_the_lifetime_limit(
     profile: str,
 ) -> None:


### PR DESCRIPTION
Closes #334.

## Why this follow-up is needed

Merged #335 fixed the int32 counter wraparound, but its unconditional capacity check rejects every `CanonicalUPGD.update` once the global diagnostic step reaches `INT32_MAX`. That over-refuses valid operation in two reachable cases:

- the active correction denominator is already exactly `1` in the parameter leaf's execution dtype, such as ordinary float32 with `utility_decay=0.9`; and
- `safe_extended` has a saturated global diagnostic step or inactive saturated age while the active per-element correction clock still has capacity.

This is a post-merge correction to #335, retaining its useful counter saturation and atomic fail-close machinery.

## Contract

- Consume the final representable event (`INT32_MAX - 1 -> INT32_MAX`).
- Continue after saturation only when every active saturated clock's effective correction denominator is exactly `1` in that leaf's execution dtype.
- Refuse the complete update when any active saturated correction remains load-bearing.
- On refusal, preserve parameters, optimizer state, and PRNG key exactly; return neutral computed payloads and `metrics["update_applied"] == false`.
- Ignore inactive saturated `safe_extended` ages, allowing unsaturated active peers to advance.
- Preserve the public/config/checkpoint state schema and all existing exports.

The saturating helper is also written without the subtraction overflow that could map a corrupt/restored `-1` counter directly to `INT32_MAX`. Such negative states remain invalid input; this is defensive hardening, not a new supported-state contract.

## Failing-test-first evidence

On merged #335's unconditional implementation with the regression commit applied:

```text
7 failed, 14 passed, 38 deselected
```

The failures cover eager/JIT float32 continuation for `paper_global` and `safe_extended`, reachable masked `safe_extended` continuation, and negative-counter overflow hardening.

At exact head `835e5858d15dadaaf76fc3d53843be6f6f945d8e`:

```text
135 passed in 143.94s
ruff check: passed
strict mypy: Success: no issues found in 165 source files
git diff --check: passed
```

The 135-test warning-as-error panel is:

- `tests/test_canonical_upgd.py`
- `tests/test_canonical_adaupgd.py`
- `tests/test_upgd_ipmnist.py`

A separate JIT-gradient probe remained finite on the continuation path and exactly identity on atomic refusal. Both protecting and non-protecting modes are covered for rejection atomicity and RNG rollback.

No `outputs/` artifact changed. `canonical_upgd.py` and its tests are not in the current five-claim registered evidence-source inventory; this change makes no promotion claim.

## Independent reverse-mode atomicity repair

An independent exact-head review found that `835e5858d15dadaaf76fc3d53843be6f6f945d8e` preserved refusal values forward, but its post-hoc `jnp.where` commit allowed NaN/Inf arithmetic from the discarded proposal to poison reverse-mode gradients. The failure reproduced for `paper_global` and `safe_extended`, in protecting and non-protecting modes, under eager and JIT-compiled `jax.grad`.

With the retained regression applied to `835e5858d15dadaaf76fc3d53843be6f6f945d8e`:

```text
8 failed in 9.05s
```

At repaired head `e9b2482289a3419c33fbcdbc9808ba3abcf09244`:

```text
8 passed in 6.50s  # eager/JIT x both profiles x both modes
46 passed, 23 deselected in 20.34s  # saturated-clock + representative update panel
2 passed in 11.16s  # lean-IPMNIST parity + checkpoint roundtrip
ruff check (changed source/test): passed
strict mypy canonical_upgd.py: Success: no issues found
git diff --check: passed
```

Separate continuation probes at the repaired head kept eager and JIT reverse-mode gradients finite and exactly equal for both profiles and both modes. The repair performs clock/eligibility preflight first, executes the numerical proposal only inside the applied `jax.lax.cond` branch, and returns the original parameters, state, and key directly from the refusal branch. This preserves the existing forward contract while making the refusal boundary reverse-mode atomic.
