### PR TITLE
fix(step1): reject illegal linear TD facade config

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -77,16 +77,11 @@ def _float32_from_ratio(
     return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
 
 
-def round_real_to_float32(value: Real) -> float:
-    """Round a standard exact-ratio real directly to IEEE binary32.
-
-    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
-    round-to-nearest, ties-to-even semantics without an intermediate binary64
-    conversion. Real implementations that cannot expose an exact ratio are
-    rejected instead of being silently double-rounded.
-    """
-    if isinstance(value, bool):
-        raise TypeError("real value must not be a bool")
+def _real_ratio(value: Real) -> tuple[int, int, bool]:
+    """Return one normalized exact ratio and its zero-sign metadata."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise TypeError("value must be an actual non-bool real")
     if isinstance(value, Integral):
         ratio: object = (int(value), 1)
     else:
@@ -106,14 +101,35 @@ def round_real_to_float32(value: Real) -> float:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)
     denominator = int(denominator_raw)
-    negative_zero = (
-        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
-    )
-    return _float32_from_ratio(
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+    negative_zero = numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    return numerator, denominator, negative_zero
+
+
+def round_real_to_float32_with_ratio(value: Real) -> tuple[int, int, float]:
+    """Read one exact ratio and return it with its binary32 rounding."""
+    numerator, denominator, negative_zero = _real_ratio(value)
+    narrowed = _float32_from_ratio(
         numerator,
         denominator,
         negative_zero=negative_zero,
     )
+    return numerator, denominator, narrowed
 
 
-__all__ = ["round_real_to_float32"]
+def round_real_to_float32(value: Real) -> float:
+    """Round a standard exact-ratio real directly to IEEE binary32.
+
+    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
+    round-to-nearest, ties-to-even semantics without an intermediate binary64
+    conversion. Real implementations that cannot expose an exact ratio are
+    rejected instead of being silently double-rounded.
+    """
+    return round_real_to_float32_with_ratio(value)[2]
+
+
+__all__ = ["round_real_to_float32", "round_real_to_float32_with_ratio"]

--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import struct
 from numbers import Integral, Real
+from typing import cast
 
 
 def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
@@ -82,21 +83,23 @@ def _real_ratio(value: Real) -> tuple[int, int, bool]:
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise TypeError("value must be an actual non-bool real")
-    if isinstance(value, Integral):
-        ratio: object = (int(value), 1)
+    if issubclass(actual_type, Integral):
+        ratio: object = (int(cast(Integral, value)), 1)
     else:
-        ratio_method = getattr(value, "as_integer_ratio", None)
+        ratio_method = getattr(actual_type, "as_integer_ratio", None)
         if not callable(ratio_method):
             raise TypeError("real value must expose as_integer_ratio")
-        ratio = ratio_method()
-    if not isinstance(ratio, tuple) or len(ratio) != 2:
+        ratio = ratio_method(value)
+    if type(ratio) is not tuple or len(ratio) != 2:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator_raw, denominator_raw = ratio
+    num_type = type(numerator_raw)
+    den_type = type(denominator_raw)
     if (
-        isinstance(numerator_raw, bool)
-        or not isinstance(numerator_raw, Integral)
-        or isinstance(denominator_raw, bool)
-        or not isinstance(denominator_raw, Integral)
+        issubclass(num_type, bool)
+        or not issubclass(num_type, Integral)
+        or issubclass(den_type, bool)
+        or not issubclass(den_type, Integral)
     ):
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)

--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -24,7 +24,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, RMSprop
 from alberta_framework.core.learners import LinearLearner, run_learning_loop
 from alberta_framework.core.normalizers import (
@@ -62,65 +62,72 @@ _VALID_OPTIMIZERS: frozenset[str] = frozenset(
 )
 _VALID_NORMALIZERS: frozenset[str] = frozenset({"none", "ema", "welford", "streaming_batch"})
 _VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
+_INT32_MAX: int = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> tuple[float, float]:
-    """Return a JSON scalar and the value consumed by float32 JAX sinks."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
     try:
-        narrowed = round_real_to_float32(value)
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
     if not isinstance(value, (int, float, np.floating)):
-        return narrowed, narrowed
+        return narrowed
     try:
         number = float(value)
     except (OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must be a finite real number, got {value!r}") from None
+        return narrowed
     if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite, got {value!r}")
-
-    # Preserve ordinary built-in/NumPy-float serialization when it narrows to
-    # exactly the checked sink value.  Extended-precision inputs at a rounding
-    # boundary must instead retain the direct float32 value: routing them
-    # through binary64 can double-round a finite float32 to infinity.
+        raise ValueError("scalar must be finite")
     with np.errstate(invalid="ignore", over="ignore", under="ignore"):
         renarrowed = np.asarray(number, dtype=np.float32)
     if not bool(np.array_equal(narrowed, renarrowed)):
         number = float(narrowed)
-    return number, float(narrowed)
+    return number
+
+
+def _require_real(name: str, value: object) -> tuple[float, float]:
+    """Return a JSON scalar and the value consumed by float32 JAX sinks."""
+    real, _, _, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed), narrowed
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    if value < 0.0 or not value <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    number, _ = _require_real(name, value)
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    if value < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    number, _ = _require_real(name, value)
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    if value <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
-    number, narrowed = _require_real(name, value)
-    if narrowed <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(f"{name} must remain positive in float32, got {value!r}")
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(
@@ -128,25 +135,26 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
-    exclusive_maximum: int | None = None,
+    maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
 
 
 def _validate_step1_config(config: Step1KernelConfig) -> None:
-    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1)
-    num_relevant = _require_int("num_relevant", config.num_relevant, minimum=1)
+    feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX)
+    num_relevant = _require_int("num_relevant", config.num_relevant, minimum=1, maximum=_INT32_MAX)
     if num_relevant > feature_dim:
         raise ValueError(
             f"num_relevant ({num_relevant}) must be <= feature_dim ({feature_dim})"
@@ -354,12 +362,9 @@ def run_step1_smoke(
     the production kernel can initialize, compile, update online, and return
     finite metrics.
     """
-    if steps < 1:
-        raise ValueError(f"steps must be positive, got {steps}")
-    if final_window < 1 or final_window > steps:
-        raise ValueError(
-            f"final_window must be in [1, steps], got {final_window}"
-        )
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    final_window = _require_int("final_window", final_window, minimum=1, maximum=steps)
     cfg = config or Step1KernelConfig()
     learner = make_step1_learner(cfg)
     stream = make_step1_stream(cfg)

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -489,6 +489,37 @@ def test_step1_rejects_class_property_spoofing_float() -> None:
         Step1KernelConfig(step_size=value)  # type: ignore[arg-type]
 
 
+def test_step1_rejects_spoofed_int_class_with_negative_ratio() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="step_size must be non-negative"):
+        Step1KernelConfig(step_size=SpoofedIntFloat(0.5))
+
+
+def test_step1_rejects_spoofed_ratio_components() -> None:
+    class SpoofedComponent:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __int__(self) -> int:
+            return 1
+
+    class BadRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[Any, Any]:
+            return (SpoofedComponent(), 2)
+
+    with pytest.raises(ValueError, match="must narrow to a finite float32"):
+        Step1KernelConfig(step_size=BadRatioFloat(0.5))
+
+
+
 
 def test_step2_kernel_factory_and_smoke_are_finite() -> None:
     config = Step2KernelConfig(feature_dim=4, n_heads=2, hidden_sizes=(8,))

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -122,6 +122,7 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("feature_dim", float("nan")),
     ("feature_dim", float("inf")),
     ("feature_dim", None),
+    ("feature_dim", 2**31),
     ("num_relevant", 0),
     ("num_relevant", -1),
     ("num_relevant", True),
@@ -131,6 +132,7 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("num_relevant", float("nan")),
     ("num_relevant", float("inf")),
     ("num_relevant", None),
+    ("num_relevant", 2**31),
     ("optimizer", "unknown_opt"),
     ("optimizer", 123),
     ("optimizer", None),
@@ -148,26 +150,31 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("step_size", -1.0),
     ("step_size", "0.01"),
     ("step_size", None),
+    ("step_size", 1e100),
     ("meta_step_size", float("nan")),
     ("meta_step_size", float("inf")),
     ("meta_step_size", True),
     ("meta_step_size", False),
     ("meta_step_size", -0.01),
+    ("meta_step_size", 1e100),
     ("drift_rate_w", float("nan")),
     ("drift_rate_w", float("inf")),
     ("drift_rate_w", True),
     ("drift_rate_w", False),
     ("drift_rate_w", -0.001),
+    ("drift_rate_w", 1e100),
     ("drift_rate_b", float("nan")),
     ("drift_rate_b", float("inf")),
     ("drift_rate_b", True),
     ("drift_rate_b", False),
     ("drift_rate_b", -0.001),
+    ("drift_rate_b", 1e100),
     ("noise_std", float("nan")),
     ("noise_std", float("inf")),
     ("noise_std", True),
     ("noise_std", False),
     ("noise_std", -1.0),
+    ("noise_std", 1e100),
     ("feature_std", float("nan")),
     ("feature_std", float("inf")),
     ("feature_std", True),
@@ -176,6 +183,7 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("feature_std", -1.0),
     ("feature_std", "1.0"),
     ("feature_std", None),
+    ("feature_std", 1e100),
     ("ema_decay", float("nan")),
     ("ema_decay", float("inf")),
     ("ema_decay", True),
@@ -183,6 +191,7 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("ema_decay", -0.1),
     ("ema_decay", 1.1),
     ("ema_decay", "0.99"),
+    ("ema_decay", 1e100),
     ("streaming_batch_momentum", float("nan")),
     ("streaming_batch_momentum", float("inf")),
     ("streaming_batch_momentum", True),
@@ -190,6 +199,7 @@ _INVALID_STEP1_FIELDS: tuple[tuple[str, Any], ...] = (
     ("streaming_batch_momentum", -0.1),
     ("streaming_batch_momentum", 1.1),
     ("streaming_batch_momentum", "0.99"),
+    ("streaming_batch_momentum", 1e100),
 )
 
 
@@ -373,6 +383,111 @@ def test_step1_fraction_float32_overflow_midpoint_is_exact() -> None:
     assert just_below.step_size == float(np.finfo(np.float32).max)
     with pytest.raises(ValueError, match="step_size"):
         Step1KernelConfig(optimizer="lms", step_size=overflow_midpoint)
+
+
+def test_step1_config_preserves_float32_boundaries() -> None:
+    f32_max = float(np.finfo(np.float32).max)
+    config = Step1KernelConfig(
+        feature_dim=2**31 - 1,
+        num_relevant=2**31 - 1,
+        optimizer="lms",
+        normalizer="ema",
+        stream="alberta",
+        step_size=f32_max,
+        meta_step_size=f32_max,
+        drift_rate_w=f32_max,
+        drift_rate_b=f32_max,
+        noise_std=f32_max,
+        feature_std=f32_max,
+        ema_decay=1.0,
+        streaming_batch_momentum=1.0,
+    )
+    assert config.feature_dim == 2**31 - 1
+    assert config.num_relevant == 2**31 - 1
+    assert config.step_size == f32_max
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "64"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+        ({"final_window": 0}, "final_window"),
+        ({"final_window": -1}, "final_window"),
+        ({"final_window": 300}, "final_window"),
+        ({"final_window": True}, "final_window"),
+    ],
+)
+def test_step1_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step1_smoke(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "ema_decay",
+        "streaming_batch_momentum",
+    ],
+)
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_step1_unit_interval_rejects_adversarial_ratio_floats(
+    field: str, ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=rf"{field} must be in \[0, 1\]"):
+        Step1KernelConfig(**{field: HiddenBoundaryFloat(0.5)})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "step_size",
+        "meta_step_size",
+        "drift_rate_w",
+        "drift_rate_b",
+        "noise_std",
+    ],
+)
+def test_step1_nonnegative_rejects_adversarial_negative_ratio(field: str) -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 1)
+
+    with pytest.raises(ValueError, match=rf"{field} must be non-negative"):
+        Step1KernelConfig(**{field: HiddenNegativeFloat(0.5)})
+
+
+def test_step1_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        Step1KernelConfig(step_size=value)  # type: ignore[arg-type]
+
 
 
 def test_step2_kernel_factory_and_smoke_are_finite() -> None:


### PR DESCRIPTION
Closes #425.

## What changed

`Step1KernelConfig` and `run_step1_smoke` now strictly validate scalar hyperparameters, float32 execution sink bounds, and exact integer ratios before constructing Step 1 components. Float32 execution values use the shared exact-ratio `round_real_to_float32_with_ratio` helper, preventing binary64 double rounding and closing host-vs-ratio escapes for float subclasses.

Exact float32 overflow is rejected across `step_size`, `meta_step_size`, `drift_rate_w`, `drift_rate_b`, `noise_std`, `feature_std`, `ema_decay`, and `streaming_batch_momentum`; legal zero/one endpoints remain valid. Integer feature dimensions, relevant counts, and smoke parameters (`steps`, `seed`, `final_window`) are bounded to standard signed int32 bounds (`2**31 - 1`).

## Scope

• `alberta_framework/_float32.py`
• `alberta_framework/steps/step1.py`
• `tests/test_production_steps.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 1 focused test suite: 154 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported