### PR TITLE
fix(prototype-agent): reject configs whose transitions can never commit

### DIFF
--- a/alberta_framework/core/_float32_scalars.py
+++ b/alberta_framework/core/_float32_scalars.py
@@ -1,0 +1,82 @@
+"""Shared validation for configuration scalars that are consumed as float32.
+
+A configuration scalar is checked in both domains that matter: the exact host
+value (so a lying ``as_integer_ratio`` or a value that only *rounds* into
+range cannot pass) and its binary32 rounding (so a host-finite value that
+narrows to infinity, zero, or the excluded end of a half-open interval is
+refused before it can freeze an EMA or divide by zero at the sink).  Only an
+actual built-in ``float`` is stored as-is — JAX narrows it once, exactly as
+validated here — while ints and other reals are stored as the validated
+binary32 value.
+"""
+
+from __future__ import annotations
+
+import math
+from numbers import Real
+from typing import Any, cast
+
+from alberta_framework._float32 import round_real_to_float32
+
+
+def validated_float32_scalar(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> float:
+    """Return the canonical stored value of one float32-consumed scalar or fail closed.
+
+    Raises:
+        ValueError: If ``value`` is not an actual non-bool real, does not narrow
+            to a finite binary32, or leaves the declared domain either as the
+            exact host value or once narrowed to binary32.
+    """
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    real = cast(Any, value)
+    try:
+        narrowed = round_real_to_float32(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a finite real number") from error
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must remain finite once narrowed to float32")
+
+    def in_domain(candidate: Any) -> bool:
+        if positive and not candidate > 0:
+            return False
+        if lower is not None and not candidate >= lower:
+            return False
+        if upper is not None:
+            if upper_inclusive:
+                return bool(candidate <= upper)
+            return bool(candidate < upper)
+        return True
+
+    domain = _describe_domain(positive, lower, upper, upper_inclusive)
+    if not in_domain(real):
+        raise ValueError(f"{name} must be {domain}")
+    if not in_domain(narrowed):
+        raise ValueError(f"{name} must remain {domain} once narrowed to float32")
+    return real if type(real) is float else narrowed
+
+
+def _describe_domain(
+    positive: bool, lower: float | None, upper: float | None, upper_inclusive: bool
+) -> str:
+    if upper is not None:
+        floor = lower if lower is not None else "-inf"
+        bracket = "]" if upper_inclusive else ")"
+        return f"in [{floor}, {upper}{bracket}"
+    if positive:
+        return "positive"
+    if lower is not None:
+        return f">= {lower}"
+    return "finite"
+
+
+__all__ = ["validated_float32_scalar"]

--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -48,6 +48,8 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
+from numbers import Real
 from typing import Any, cast
 
 import chex
@@ -249,6 +251,35 @@ def _rollback_multi_head_result(
             update_applied=result.update_applied & outer_update_applied,
         ),
     )
+
+
+def _require_finite_scalar(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> None:
+    """Fail closed on non-real, non-finite, or out-of-range configuration scalars.
+
+    Bare ``<`` / ``<=`` comparisons let NaN through; a NaN scale or bound then
+    rejects every transition while the loop publishes zero errors.
+    """
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    if positive and number <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    if lower is not None and number < lower:
+        raise ValueError(f"{name} must be >= {lower}")
+    if upper is not None and (number > upper or (not upper_inclusive and number == upper)):
+        bracket = "]" if upper_inclusive else ")"
+        floor = lower if lower is not None else "-inf"
+        raise ValueError(f"{name} must be in [{floor}, {upper}{bracket}")
 
 
 class LatentWorldModel:
@@ -637,6 +668,8 @@ class LatentWorldModel:
             & action_valid
             & jnp.all(jnp.isfinite(reward_arr))
             & jnp.all(jnp.isfinite(discount_arr))
+            & jnp.all(discount_arr >= 0.0)
+            & jnp.all(discount_arr <= 1.0)
             & jnp.all(jnp.isfinite(next_observation_arr))
         )
         safe_observation = jnp.where(
@@ -806,37 +839,31 @@ class LatentWorldModel:
             raise ValueError("n_actions must be positive")
         if config.latent_dim <= 0:
             raise ValueError("latent_dim must be positive")
-        if not 0.0 <= config.gamma <= 1.0:
-            raise ValueError("gamma must be in [0, 1]")
+        _require_finite_scalar("gamma", config.gamma, lower=0.0, upper=1.0)
         if config.observation_scale is not None:
             if len(config.observation_scale) != config.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
-            if any(scale <= 0.0 for scale in config.observation_scale):
-                raise ValueError("observation_scale values must be positive")
-        if config.reward_scale <= 0.0:
-            raise ValueError("reward_scale must be positive")
-        if config.encoder_scale <= 0.0:
-            raise ValueError("encoder_scale must be positive")
-        if config.encoder_bias_scale < 0.0:
-            raise ValueError("encoder_bias_scale must be non-negative")
+            for scale in config.observation_scale:
+                _require_finite_scalar("observation_scale values", scale, positive=True)
+        _require_finite_scalar("reward_scale", config.reward_scale, positive=True)
+        _require_finite_scalar("encoder_scale", config.encoder_scale, positive=True)
+        _require_finite_scalar("encoder_bias_scale", config.encoder_bias_scale, lower=0.0)
         if any(size <= 0 for size in config.hidden_sizes):
             raise ValueError("hidden_sizes must contain only positive widths")
-        if not 0.0 <= config.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= config.surprise_decay < 1.0:
-            raise ValueError("surprise_decay must be in [0, 1)")
-        if not 0.0 <= config.collapse_decay < 1.0:
-            raise ValueError("collapse_decay must be in [0, 1)")
-        if config.min_latent_std < 0.0:
-            raise ValueError("min_latent_std must be non-negative")
-        if config.max_latent_delta <= 0.0:
-            raise ValueError("max_latent_delta must be positive")
-        if config.encoder_step_size <= 0.0:
-            raise ValueError("encoder_step_size must be positive")
-        if config.max_encoder_update <= 0.0:
-            raise ValueError("max_encoder_update must be positive")
-        if not 0.0 <= config.encoder_collapse_gate_threshold <= 1.0:
-            raise ValueError("encoder_collapse_gate_threshold must be in [0, 1]")
+        for name in ("utility_decay", "surprise_decay", "collapse_decay"):
+            _require_finite_scalar(
+                name, getattr(config, name), lower=0.0, upper=1.0, upper_inclusive=False
+            )
+        _require_finite_scalar("min_latent_std", config.min_latent_std, lower=0.0)
+        _require_finite_scalar("max_latent_delta", config.max_latent_delta, positive=True)
+        _require_finite_scalar("encoder_step_size", config.encoder_step_size, positive=True)
+        _require_finite_scalar("max_encoder_update", config.max_encoder_update, positive=True)
+        _require_finite_scalar(
+            "encoder_collapse_gate_threshold",
+            config.encoder_collapse_gate_threshold,
+            lower=0.0,
+            upper=1.0,
+        )
 
 
 def run_latent_world_model_learning_loop(

--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -48,8 +48,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from numbers import Real
 from typing import Any, cast
 
 import chex
@@ -59,6 +57,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.multi_head_learner import (
     AnyOptimizer,
     MultiHeadMLPLearner,
@@ -253,35 +252,6 @@ def _rollback_multi_head_result(
     )
 
 
-def _require_finite_scalar(
-    name: str,
-    value: object,
-    *,
-    positive: bool = False,
-    lower: float | None = None,
-    upper: float | None = None,
-    upper_inclusive: bool = True,
-) -> None:
-    """Fail closed on non-real, non-finite, or out-of-range configuration scalars.
-
-    Bare ``<`` / ``<=`` comparisons let NaN through; a NaN scale or bound then
-    rejects every transition while the loop publishes zero errors.
-    """
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a finite real number")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real number")
-    if positive and number <= 0.0:
-        raise ValueError(f"{name} must be positive")
-    if lower is not None and number < lower:
-        raise ValueError(f"{name} must be >= {lower}")
-    if upper is not None and (number > upper or (not upper_inclusive and number == upper)):
-        bracket = "]" if upper_inclusive else ")"
-        floor = lower if lower is not None else "-inf"
-        raise ValueError(f"{name} must be in [{floor}, {upper}{bracket}")
-
-
 class LatentWorldModel:
     """Latent model for ``(z_t, a_t) -> (z_{t+1}, r, gamma)``.
 
@@ -298,7 +268,7 @@ class LatentWorldModel:
         head_optimizer: AnyOptimizer | None = None,
     ):
         """Initialize the latent world model."""
-        self._validate_config(config)
+        config = self._validate_config(config)
         self._config = config
         self._observation_scale = (
             tuple(1.0 for _ in range(config.observation_dim))
@@ -832,37 +802,64 @@ class LatentWorldModel:
             update_applied=update_applied,
         )
 
-    def _validate_config(self, config: LatentWorldModelConfig) -> None:
+    def _validate_config(self, config: LatentWorldModelConfig) -> LatentWorldModelConfig:
+        """Fail closed on malformed configuration and return its canonical float32 form."""
         if config.observation_dim <= 0:
             raise ValueError("observation_dim must be positive")
         if config.n_actions <= 0:
             raise ValueError("n_actions must be positive")
         if config.latent_dim <= 0:
             raise ValueError("latent_dim must be positive")
-        _require_finite_scalar("gamma", config.gamma, lower=0.0, upper=1.0)
-        if config.observation_scale is not None:
-            if len(config.observation_scale) != config.observation_dim:
-                raise ValueError("observation_scale length must equal observation_dim")
-            for scale in config.observation_scale:
-                _require_finite_scalar("observation_scale values", scale, positive=True)
-        _require_finite_scalar("reward_scale", config.reward_scale, positive=True)
-        _require_finite_scalar("encoder_scale", config.encoder_scale, positive=True)
-        _require_finite_scalar("encoder_bias_scale", config.encoder_bias_scale, lower=0.0)
         if any(size <= 0 for size in config.hidden_sizes):
             raise ValueError("hidden_sizes must contain only positive widths")
-        for name in ("utility_decay", "surprise_decay", "collapse_decay"):
-            _require_finite_scalar(
-                name, getattr(config, name), lower=0.0, upper=1.0, upper_inclusive=False
+        observation_scale = config.observation_scale
+        if observation_scale is not None:
+            if len(observation_scale) != config.observation_dim:
+                raise ValueError("observation_scale length must equal observation_dim")
+            observation_scale = tuple(
+                validated_float32_scalar("observation_scale values", scale, positive=True)
+                for scale in observation_scale
             )
-        _require_finite_scalar("min_latent_std", config.min_latent_std, lower=0.0)
-        _require_finite_scalar("max_latent_delta", config.max_latent_delta, positive=True)
-        _require_finite_scalar("encoder_step_size", config.encoder_step_size, positive=True)
-        _require_finite_scalar("max_encoder_update", config.max_encoder_update, positive=True)
-        _require_finite_scalar(
-            "encoder_collapse_gate_threshold",
-            config.encoder_collapse_gate_threshold,
-            lower=0.0,
-            upper=1.0,
+        return dataclasses.replace(
+            config,
+            gamma=validated_float32_scalar("gamma", config.gamma, lower=0.0, upper=1.0),
+            observation_scale=observation_scale,
+            reward_scale=validated_float32_scalar(
+                "reward_scale", config.reward_scale, positive=True
+            ),
+            encoder_scale=validated_float32_scalar(
+                "encoder_scale", config.encoder_scale, positive=True
+            ),
+            encoder_bias_scale=validated_float32_scalar(
+                "encoder_bias_scale", config.encoder_bias_scale, lower=0.0
+            ),
+            min_latent_std=validated_float32_scalar(
+                "min_latent_std", config.min_latent_std, lower=0.0
+            ),
+            max_latent_delta=validated_float32_scalar(
+                "max_latent_delta", config.max_latent_delta, positive=True
+            ),
+            encoder_step_size=validated_float32_scalar(
+                "encoder_step_size", config.encoder_step_size, positive=True
+            ),
+            max_encoder_update=validated_float32_scalar(
+                "max_encoder_update", config.max_encoder_update, positive=True
+            ),
+            encoder_collapse_gate_threshold=validated_float32_scalar(
+                "encoder_collapse_gate_threshold",
+                config.encoder_collapse_gate_threshold,
+                lower=0.0,
+                upper=1.0,
+            ),
+            utility_decay=validated_float32_scalar(
+                "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+            surprise_decay=validated_float32_scalar(
+                "surprise_decay", config.surprise_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+            collapse_decay=validated_float32_scalar(
+                "collapse_decay", config.collapse_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
         )
 
 

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -46,6 +46,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -563,10 +564,11 @@ class PrototypeAgentConfig:
                 "dream_next_observation_mode must be "
                 "'model_prediction' or 'sample_one_hot'"
             )
-        if not math.isfinite(self.horde_step_size):
-            raise ValueError("horde_step_size must be finite")
-        if self.horde_step_size <= 0.0:
-            raise ValueError("horde_step_size must be positive")
+        object.__setattr__(
+            self,
+            "horde_step_size",
+            validated_float32_scalar("horde_step_size", self.horde_step_size, positive=True),
+        )
         if self.auto_curate_every < 0:
             raise ValueError("auto_curate_every must be non-negative")
         if not isinstance(self.learn_state_builder_from_world_model, bool):

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -563,6 +563,8 @@ class PrototypeAgentConfig:
                 "dream_next_observation_mode must be "
                 "'model_prediction' or 'sample_one_hot'"
             )
+        if not math.isfinite(self.horde_step_size):
+            raise ValueError("horde_step_size must be finite")
         if self.horde_step_size <= 0.0:
             raise ValueError("horde_step_size must be positive")
         if self.auto_curate_every < 0:
@@ -608,6 +610,12 @@ class PrototypeAgentConfig:
                     "world_model.n_actions must match oak.n_primitive_actions, "
                     f"got {self.world_model.n_actions} and "
                     f"{self.oak.n_primitive_actions}"
+                )
+            if self.world_model.gamma <= 0.0:
+                raise ValueError(
+                    "world_model.gamma must be positive: the legacy update synthesizes "
+                    "transitions with discount=gamma and terminated=False, which the "
+                    "boundary contract rejects when gamma is zero"
                 )
         if self.world_model_ensemble is not None:
             ensemble_model = self.world_model_ensemble.model

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
+from numbers import Real
 from typing import Any, cast
 
 import chex
@@ -242,6 +244,35 @@ def _action_world_model_state_is_valid(
         & (state.step_count >= 0)
         & (finite_bounds | empty_bounds)
     )
+
+
+def _require_finite_scalar(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> None:
+    """Fail closed on non-real, non-finite, or out-of-range configuration scalars.
+
+    Bare ``<`` / ``<=`` comparisons let NaN through; a NaN scale or bound then
+    rejects every transition while the loop publishes zero errors.
+    """
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    if positive and number <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    if lower is not None and number < lower:
+        raise ValueError(f"{name} must be >= {lower}")
+    if upper is not None and (number > upper or (not upper_inclusive and number == upper)):
+        bracket = "]" if upper_inclusive else ")"
+        floor = lower if lower is not None else "-inf"
+        raise ValueError(f"{name} must be in [{floor}, {upper}{bracket}")
 
 
 class ActionConditionedWorldModel:
@@ -557,6 +588,8 @@ class ActionConditionedWorldModel:
             & action_valid
             & jnp.all(jnp.isfinite(reward_arr))
             & jnp.all(jnp.isfinite(discount_arr))
+            & jnp.all(discount_arr >= 0.0)
+            & jnp.all(discount_arr <= 1.0)
             & jnp.all(jnp.isfinite(next_obs))
         )
         safe_obs = jnp.where(inputs_valid, obs, jnp.zeros_like(obs))
@@ -658,25 +691,25 @@ class ActionConditionedWorldModel:
             raise ValueError("observation_dim must be positive")
         if config.n_actions <= 0:
             raise ValueError("n_actions must be positive")
-        if not 0.0 <= config.gamma <= 1.0:
-            raise ValueError("gamma must be in [0, 1]")
+        _require_finite_scalar("gamma", config.gamma, lower=0.0, upper=1.0)
         if config.observation_scale is not None:
             if len(config.observation_scale) != config.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
-            if any(scale <= 0.0 for scale in config.observation_scale):
-                raise ValueError("observation_scale values must be positive")
-        if config.reward_scale <= 0.0:
-            raise ValueError("reward_scale must be positive")
+            for scale in config.observation_scale:
+                _require_finite_scalar("observation_scale values", scale, positive=True)
+        _require_finite_scalar("reward_scale", config.reward_scale, positive=True)
         if any(size <= 0 for size in config.hidden_sizes):
             raise ValueError("hidden_sizes must contain only positive widths")
-        if not 0.0 <= config.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= config.error_decay < 1.0:
-            raise ValueError("error_decay must be in [0, 1)")
-        if config.observation_clip_margin < 0.0:
-            raise ValueError("observation_clip_margin must be non-negative")
-        if config.max_delta_scale <= 0.0:
-            raise ValueError("max_delta_scale must be positive")
+        _require_finite_scalar(
+            "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        _require_finite_scalar(
+            "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        _require_finite_scalar(
+            "observation_clip_margin", config.observation_clip_margin, lower=0.0
+        )
+        _require_finite_scalar("max_delta_scale", config.max_delta_scale, positive=True)
 
 
 def run_action_conditioned_world_model_learning_loop(

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from numbers import Real
 from typing import Any, cast
 
 import chex
@@ -26,6 +24,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.multi_head_learner import (
     AnyOptimizer,
     MultiHeadMLPLearner,
@@ -246,35 +245,6 @@ def _action_world_model_state_is_valid(
     )
 
 
-def _require_finite_scalar(
-    name: str,
-    value: object,
-    *,
-    positive: bool = False,
-    lower: float | None = None,
-    upper: float | None = None,
-    upper_inclusive: bool = True,
-) -> None:
-    """Fail closed on non-real, non-finite, or out-of-range configuration scalars.
-
-    Bare ``<`` / ``<=`` comparisons let NaN through; a NaN scale or bound then
-    rejects every transition while the loop publishes zero errors.
-    """
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a finite real number")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real number")
-    if positive and number <= 0.0:
-        raise ValueError(f"{name} must be positive")
-    if lower is not None and number < lower:
-        raise ValueError(f"{name} must be >= {lower}")
-    if upper is not None and (number > upper or (not upper_inclusive and number == upper)):
-        bracket = "]" if upper_inclusive else ")"
-        floor = lower if lower is not None else "-inf"
-        raise ValueError(f"{name} must be in [{floor}, {upper}{bracket}")
-
-
 class ActionConditionedWorldModel:
     """One-step model for ``(observation, action) -> (next_obs, reward, discount)``.
 
@@ -294,7 +264,7 @@ class ActionConditionedWorldModel:
         head_optimizer: AnyOptimizer | None = None,
     ):
         """Initialize the world model."""
-        self._validate_config(config)
+        config = self._validate_config(config)
         self._config = config
         self._observation_scale = (
             tuple(1.0 for _ in range(config.observation_dim))
@@ -686,30 +656,44 @@ class ActionConditionedWorldModel:
             update_applied=update_applied,
         )
 
-    def _validate_config(self, config: ActionConditionedWorldModelConfig) -> None:
+    def _validate_config(
+        self, config: ActionConditionedWorldModelConfig
+    ) -> ActionConditionedWorldModelConfig:
+        """Fail closed on malformed configuration and return its canonical float32 form."""
         if config.observation_dim <= 0:
             raise ValueError("observation_dim must be positive")
         if config.n_actions <= 0:
             raise ValueError("n_actions must be positive")
-        _require_finite_scalar("gamma", config.gamma, lower=0.0, upper=1.0)
-        if config.observation_scale is not None:
-            if len(config.observation_scale) != config.observation_dim:
-                raise ValueError("observation_scale length must equal observation_dim")
-            for scale in config.observation_scale:
-                _require_finite_scalar("observation_scale values", scale, positive=True)
-        _require_finite_scalar("reward_scale", config.reward_scale, positive=True)
         if any(size <= 0 for size in config.hidden_sizes):
             raise ValueError("hidden_sizes must contain only positive widths")
-        _require_finite_scalar(
-            "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        observation_scale = config.observation_scale
+        if observation_scale is not None:
+            if len(observation_scale) != config.observation_dim:
+                raise ValueError("observation_scale length must equal observation_dim")
+            observation_scale = tuple(
+                validated_float32_scalar("observation_scale values", scale, positive=True)
+                for scale in observation_scale
+            )
+        return dataclasses.replace(
+            config,
+            gamma=validated_float32_scalar("gamma", config.gamma, lower=0.0, upper=1.0),
+            observation_scale=observation_scale,
+            reward_scale=validated_float32_scalar(
+                "reward_scale", config.reward_scale, positive=True
+            ),
+            utility_decay=validated_float32_scalar(
+                "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+            error_decay=validated_float32_scalar(
+                "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+            observation_clip_margin=validated_float32_scalar(
+                "observation_clip_margin", config.observation_clip_margin, lower=0.0
+            ),
+            max_delta_scale=validated_float32_scalar(
+                "max_delta_scale", config.max_delta_scale, positive=True
+            ),
         )
-        _require_finite_scalar(
-            "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
-        )
-        _require_finite_scalar(
-            "observation_clip_margin", config.observation_clip_margin, lower=0.0
-        )
-        _require_finite_scalar("max_delta_scale", config.max_delta_scale, positive=True)
 
 
 def run_action_conditioned_world_model_learning_loop(

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import warnings
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.dreaming import (
@@ -277,6 +281,82 @@ def test_config_rejects_non_finite_scalars(overrides: dict[str, object]) -> None
     )
     with pytest.raises(ValueError, match="finite"):
         ActionConditionedWorldModel(config)
+
+
+class _FloatSpoof:
+    """Not a Real: reports float through __class__ and never compares as out of range."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (1, 2)
+
+    def __float__(self) -> float:
+        return 0.5
+
+    def __le__(self, other: object) -> bool:
+        return True
+
+    def __lt__(self, other: object) -> bool:
+        return True
+
+    def __ge__(self, other: object) -> bool:
+        return True
+
+    def __gt__(self, other: object) -> bool:
+        return True
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"reward_scale": _FloatSpoof()}, "reward_scale must be a finite real number"),
+        ({"observation_clip_margin": _FloatSpoof()}, "must be a finite real number"),
+        ({"reward_scale": 1e100}, "reward_scale must remain finite once narrowed"),
+        ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
+        ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
+        ({"max_delta_scale": 1e-100}, "max_delta_scale must remain positive once narrowed"),
+        ({"observation_scale": (1e-100, 1.0)}, "must remain positive once narrowed"),
+        (
+            {"utility_decay": 1.0 - 1e-10},
+            r"utility_decay must remain in \[0.0, 1.0\) once narrowed",
+        ),
+        ({"error_decay": 1.0 - 1e-10}, r"error_decay must remain in \[0.0, 1.0\) once narrowed"),
+        ({"gamma": Fraction(1, 1) + Fraction(1, 2**60)}, r"gamma must be in \[0.0, 1.0\]"),
+    ],
+)
+def test_config_rejects_scalars_that_leave_the_float32_domain(
+    overrides: dict[str, object], message: str
+) -> None:
+    """Host-finite values must also stay finite and in range once narrowed to float32."""
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=(), **overrides  # type: ignore[arg-type]
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match=message):
+            ActionConditionedWorldModel(config)
+
+
+def test_config_canonicalizes_real_scalars_and_preserves_builtin_floats() -> None:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            reward_scale=Fraction(1, 4),
+            observation_scale=(np.float64(2.0), 1),
+            utility_decay=0.99,
+        )
+    )
+    assert type(model.config.reward_scale) is float and model.config.reward_scale == 0.25
+    assert model.config.observation_scale == (2.0, 1.0)
+    assert all(type(value) is float for value in model.config.observation_scale)
+    assert model.config.utility_decay == 0.99
+    restored = ActionConditionedWorldModel.from_config(model.to_config())
+    assert restored.config == model.config
 
 
 @pytest.mark.parametrize("discount", [1.5, -0.5, 5.0])

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -6,6 +6,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.dreaming import (
     ActionConditionedDreamWorld,
@@ -255,6 +256,45 @@ def test_default_discounts_do_not_inherit_the_reward_dtype() -> None:
             defaulted.discount_predictions, explicit.discount_predictions
         )
         assert bool(jnp.all(defaulted.updates_applied))
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"observation_clip_margin": float("nan")},
+        {"max_delta_scale": float("nan")},
+        {"max_delta_scale": float("inf")},
+        {"reward_scale": float("nan")},
+        {"reward_scale": float("inf")},
+        {"observation_scale": (float("nan"), 1.0)},
+        {"utility_decay": float("nan")},
+        {"error_decay": float("nan")},
+        {"gamma": float("nan")},
+    ],
+)
+def test_config_rejects_non_finite_scalars(overrides: dict[str, object]) -> None:
+    """A NaN scalar passes a bare `< 0` check and yields an all-rejected run scoring 0.0."""
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=(), **overrides  # type: ignore[arg-type]
+    )
+    with pytest.raises(ValueError, match="finite"):
+        ActionConditionedWorldModel(config)
+
+
+@pytest.mark.parametrize("discount", [1.5, -0.5, 5.0])
+def test_update_rejects_out_of_range_discounts(discount: float) -> None:
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=(), step_size=0.05, sparsity=0.0
+    )
+    model = ActionConditionedWorldModel(config)
+    state = model.init(jr.key(8))
+    obs = jnp.array([0.1, -0.2], dtype=jnp.float32)
+    result = model.update(state, obs, jnp.int32(1), 0.5, discount, jnp.array([0.2, 0.1]))
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == int(state.step_count)
+    chex.assert_trees_all_equal(
+        result.state.learner_state.trunk_params, state.learner_state.trunk_params
+    )
+    accepted = model.update(state, obs, jnp.int32(1), 0.5, 0.9, jnp.array([0.2, 0.1]))
+    assert bool(accepted.update_applied)
 
 
 def test_guarded_dreamer_rejects_warmup_and_accepts_after_real_updates() -> None:

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import math
+import warnings
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 from jax import Array
 
@@ -123,6 +125,80 @@ def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:
     )
     chex.assert_trees_all_close(defaulted.discount_errors, explicit.discount_errors)
     chex.assert_trees_all_close(defaulted.discount_predictions, explicit.discount_predictions)
+class _FloatSpoof:
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (1, 2)
+
+    def __float__(self) -> float:
+        return 0.5
+
+    def __le__(self, other: object) -> bool:
+        return True
+
+    def __lt__(self, other: object) -> bool:
+        return True
+
+    def __ge__(self, other: object) -> bool:
+        return True
+
+    def __gt__(self, other: object) -> bool:
+        return True
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"encoder_scale": _FloatSpoof()}, "encoder_scale must be a finite real number"),
+        ({"reward_scale": 1e100}, "reward_scale must remain finite once narrowed"),
+        ({"encoder_scale": 1e-100}, "encoder_scale must remain positive once narrowed"),
+        ({"max_latent_delta": 1e-100}, "max_latent_delta must remain positive once narrowed"),
+        (
+            {"surprise_decay": 1.0 - 1e-10},
+            r"surprise_decay must remain in \[0.0, 1.0\) once narrowed",
+        ),
+        (
+            {"collapse_decay": 1.0 - 1e-10},
+            r"collapse_decay must remain in \[0.0, 1.0\) once narrowed",
+        ),
+        ({"encoder_step_size": 1e100}, "encoder_step_size must remain finite once narrowed"),
+    ],
+)
+def test_latent_config_rejects_scalars_that_leave_the_float32_domain(
+    overrides: dict[str, object], message: str
+) -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2, n_actions=2, latent_dim=4, hidden_sizes=(8,), **overrides  # type: ignore[arg-type]
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match=message):
+            LatentWorldModel(config)
+
+
+def test_latent_config_canonicalizes_real_scalars() -> None:
+    from fractions import Fraction
+
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            latent_dim=4,
+            hidden_sizes=(8,),
+            encoder_scale=Fraction(1, 2),
+            min_latent_std=np.float64(0.05),
+        )
+    )
+    assert type(model.config.encoder_scale) is float and model.config.encoder_scale == 0.5
+    assert type(model.config.min_latent_std) is float
+    assert model.config.min_latent_std == float(np.float32(0.05))
+    restored = LatentWorldModel.from_config(model.to_config())
+    assert restored.config == model.config
+
+
 @pytest.mark.parametrize("discount", [1.5, -0.5])
 def test_latent_update_rejects_out_of_range_discounts(discount: float) -> None:
     config = LatentWorldModelConfig(observation_dim=2, n_actions=2, latent_dim=4, hidden_sizes=(8,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -123,6 +123,18 @@ def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:
     )
     chex.assert_trees_all_close(defaulted.discount_errors, explicit.discount_errors)
     chex.assert_trees_all_close(defaulted.discount_predictions, explicit.discount_predictions)
+@pytest.mark.parametrize("discount", [1.5, -0.5])
+def test_latent_update_rejects_out_of_range_discounts(discount: float) -> None:
+    config = LatentWorldModelConfig(observation_dim=2, n_actions=2, latent_dim=4, hidden_sizes=(8,))
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(3))
+    obs = jnp.array([0.1, -0.2], dtype=jnp.float32)
+    result = model.update(state, obs, jnp.int32(1), 0.5, discount, jnp.array([0.2, 0.1]))
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == int(state.step_count)
+    chex.assert_trees_all_equal(
+        result.state.learner_state.trunk_params, state.learner_state.trunk_params
+    )
 
 
 def test_latent_world_model_scan_loop_and_config_roundtrip() -> None:
@@ -445,6 +457,15 @@ def test_trainable_encoder_serialization_roundtrip() -> None:
         {"max_encoder_update": -1.0},
         {"encoder_collapse_gate_threshold": -0.1},
         {"encoder_collapse_gate_threshold": 1.5},
+        {"encoder_step_size": float("nan")},
+        {"max_encoder_update": float("nan")},
+        {"min_latent_std": float("nan")},
+        {"min_latent_std": float("inf")},
+        {"max_latent_delta": float("nan")},
+        {"encoder_scale": float("nan")},
+        {"encoder_bias_scale": float("nan")},
+        {"reward_scale": float("inf")},
+        {"observation_scale": (float("nan"), 1.0)},
     ],
 )
 def test_trainable_encoder_config_validation_fails_closed(

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -6,6 +6,9 @@ do not establish an integrated Alberta Plan completion result.
 
 from __future__ import annotations
 
+import warnings
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -223,11 +226,34 @@ class TestPrototypeAgentConfigValidation:
         with pytest.raises(ValueError, match="horde_step_size"):
             PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=0.0)
 
-    @pytest.mark.parametrize("value", [float("nan"), float("inf")])
-    def test_horde_step_size_finite(self, value: float) -> None:
-        """A NaN/inf step size passed the `<= 0` check and died later blaming the agent state."""
-        with pytest.raises(ValueError, match="horde_step_size must be finite"):
-            PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=value)
+    @pytest.mark.parametrize(
+        ("value", "message"),
+        [
+            (float("nan"), "horde_step_size must be a finite real number"),
+            (float("inf"), "horde_step_size must be a finite real number"),
+            (1e100, "horde_step_size must remain finite once narrowed to float32"),
+            (5e-324, "horde_step_size must remain positive once narrowed to float32"),
+            (1e-50, "horde_step_size must remain positive once narrowed to float32"),
+            (Fraction(1, 10**400), "horde_step_size must remain positive once narrowed"),
+        ],
+    )
+    def test_horde_step_size_must_be_positive_in_float32(self, value: object, message: str) -> None:
+        """The Horde consumes float32: host-finite values narrowing to inf or 0 are refused."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match=message):
+                PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=value)  # type: ignore[arg-type]
+
+    def test_horde_step_size_canonicalizes_reals_and_round_trips(self) -> None:
+        config = PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=Fraction(1, 8))
+        assert type(config.horde_step_size) is float and config.horde_step_size == 0.125
+        big = PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=(2**25 - 1) * 2**103 - 1)
+        assert big.horde_step_size == float(np.finfo(np.float32).max)
+        restored = PrototypeAgentConfig.from_config(big.to_config())
+        assert restored.horde_step_size == big.horde_step_size
+        agent = PrototypeAgent(_minimal_config())
+        state = agent.start(agent.init(jr.key(0)), jnp.zeros(OBS_DIM))
+        assert int(agent.update(state, 0.1, jnp.ones(OBS_DIM)).state.step_count) == 1
 
     def test_legacy_world_model_gamma_zero_is_rejected(self) -> None:
         """gamma == 0 makes the legacy update synthesize discount=0, terminated=False forever."""

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -85,10 +85,12 @@ def _oak_cfg(
 def _wm_cfg(
     obs_dim: int = OBS_DIM,
     n_actions: int = N_PRIM,
+    gamma: float = 0.99,
 ) -> ActionConditionedWorldModelConfig:
     return ActionConditionedWorldModelConfig(
         observation_dim=obs_dim,
         n_actions=n_actions,
+        gamma=gamma,
         hidden_sizes=(),  # linear for speed
         step_size=0.1,
         error_decay=0.99,
@@ -220,6 +222,17 @@ class TestPrototypeAgentConfigValidation:
     def test_horde_step_size_positive(self) -> None:
         with pytest.raises(ValueError, match="horde_step_size"):
             PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=0.0)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf")])
+    def test_horde_step_size_finite(self, value: float) -> None:
+        """A NaN/inf step size passed the `<= 0` check and died later blaming the agent state."""
+        with pytest.raises(ValueError, match="horde_step_size must be finite"):
+            PrototypeAgentConfig(oak=_oak_cfg(), horde_step_size=value)
+
+    def test_legacy_world_model_gamma_zero_is_rejected(self) -> None:
+        """gamma == 0 makes the legacy update synthesize discount=0, terminated=False forever."""
+        with pytest.raises(ValueError, match="world_model.gamma must be positive"):
+            PrototypeAgentConfig(oak=_oak_cfg(), world_model=_wm_cfg(gamma=0.0))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #427. Stacked on #420 (`fix/world-model-fail-closed-config-and-discount`) to reuse its shared `core/_float32_scalars.py::validated_float32_scalar` rather than adding another local converter; only the top commits are new. Rebases to a small diff once #420 lands.

## Issue

`PrototypeAgentConfig` accepted `world_model.gamma == 0.0`, but the legacy `update`/`scan` wrapper synthesizes every transition with `discount=gamma` and `terminated=False`, which the boundary contract rejects: 100% of transitions were rejected and the run reported exact `0.0` TD errors and `step_count 0` with no error. It also accepted a NaN/inf `horde_step_size` that failed later in `start()` blaming the agent state.

## New state

`__post_init__` rejects `world_model.gamma <= 0.0` when a legacy world model is configured (`world_model.gamma must be positive: the legacy update synthesizes transitions with discount=gamma and terminated=False, which the boundary contract rejects when gamma is zero`), and validates `horde_step_size` in its float32 sink through the shared `validated_float32_scalar` helper: actual-class gate, exact binary32 narrowing, positive on both the host value and the narrowed value (`1e100` → `must remain finite once narrowed to float32`; `5e-324` / `1e-50` / `Fraction(1, 10**400)` → `must remain positive once narrowed to float32`), canonical float storage (built-in floats preserved; ints and other reals stored as the validated binary32 value, so `(2**25-1)*2**103-1` stores the float32 max and round-trips through `to_config`/`from_config`). Every previously valid config is unchanged.

Failing-test-first: `test_legacy_world_model_gamma_zero_is_rejected`, `test_horde_step_size_must_be_positive_in_float32[nan|inf|1e100|5e-324|1e-50|Fraction]` (under `-W error`), and `test_horde_step_size_canonicalizes_reals_and_round_trips` fail on `main` and pass here.

## Evidence

Falsifier from #427 at this head:

```text
ValueError: world_model.gamma must be positive: the legacy update synthesizes transitions with discount=gamma and terminated=False, which the boundary contract rejects when gamma is zero
```

Verification at `c97ef4815093f8c423b3e717c27e6b469896b748`:

```text
.venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts=""   -> 91 passed
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

Composes cleanly with #399 (`git merge-tree` clean). `core/prototype_agent.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:c97ef4815093f8c423b3e717c27e6b469896b748 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
