### PR TITLE
fix(experiential-memory): bound max_age to the int32 age domain

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -272,6 +272,10 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         raise ValueError("max_age must be an integer")
     if config.max_age < 0:
         raise ValueError("max_age must be non-negative")
+    if config.max_age > _INT32_MAX:
+        raise ValueError(
+            "max_age must be <= int32 max; ages saturate there, so larger values cannot be met"
+        )
 
     for name in (
         "distance_scale",

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -180,6 +180,8 @@ def test_single_tiny_positive_neighbor_score_still_has_unit_weight() -> None:
         ("max_uncertainty", -0.1),
         ("max_safety_cost", float("nan")),
         ("max_age", -1),
+        ("max_age", 2**31),
+        ("max_age", 10**10),
         ("max_age", 1.5),
         ("staleness_scale", float("inf")),
         ("utility_decay", 1.1),


### PR DESCRIPTION
Closes #429.

## Issue

`_validate_config` accepted any non-negative int for `max_age`, but ages are `int32` and saturate at `INT32_MAX`; a larger value constructed and wrote fine, then failed at the first `query`/`step` with a raw JAX `OverflowError` naming a jit argument.

## New state

`max_age > INT32_MAX` is rejected at construction (`max_age must be <= int32 max; ages saturate there, so larger values cannot be met`). `INT32_MAX` itself and every smaller value are unchanged.

Failing-test-first: two new rows (`2**31`, `10**10`) in `test_config_rejects_invalid_or_nonfinite_values` fail on `main` and pass here.

## Evidence

Verification at `306c37767fac05041dbb3acd7f2e9a00ce5e713e`:

```text
.venv/bin/python -m pytest tests/test_experiential_memory.py tests/test_experiential_memory_policy.py -q -o addopts=""   -> 78 passed
.venv/bin/python -m ruff check .                                                                                       -> All checks passed!
.venv/bin/python -m mypy                                                                                               -> Success: no issues found in 164 source files
```

`core/experiential_memory.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:306c37767fac05041dbb3acd7f2e9a00ce5e713e -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
