### PR TITLE
fix(step2): reject illegal GVF and memory facade config

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -77,16 +77,11 @@ def _float32_from_ratio(
     return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
 
 
-def round_real_to_float32(value: Real) -> float:
-    """Round a standard exact-ratio real directly to IEEE binary32.
-
-    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
-    round-to-nearest, ties-to-even semantics without an intermediate binary64
-    conversion. Real implementations that cannot expose an exact ratio are
-    rejected instead of being silently double-rounded.
-    """
-    if isinstance(value, bool):
-        raise TypeError("real value must not be a bool")
+def _real_ratio(value: Real) -> tuple[int, int, bool]:
+    """Return one normalized exact ratio and its zero-sign metadata."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise TypeError("value must be an actual non-bool real")
     if isinstance(value, Integral):
         ratio: object = (int(value), 1)
     else:
@@ -106,14 +101,35 @@ def round_real_to_float32(value: Real) -> float:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)
     denominator = int(denominator_raw)
-    negative_zero = (
-        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
-    )
-    return _float32_from_ratio(
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+    negative_zero = numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    return numerator, denominator, negative_zero
+
+
+def round_real_to_float32_with_ratio(value: Real) -> tuple[int, int, float]:
+    """Read one exact ratio and return it with its binary32 rounding."""
+    numerator, denominator, negative_zero = _real_ratio(value)
+    narrowed = _float32_from_ratio(
         numerator,
         denominator,
         negative_zero=negative_zero,
     )
+    return numerator, denominator, narrowed
 
 
-__all__ = ["round_real_to_float32"]
+def round_real_to_float32(value: Real) -> float:
+    """Round a standard exact-ratio real directly to IEEE binary32.
+
+    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
+    round-to-nearest, ties-to-even semantics without an intermediate binary64
+    conversion. Real implementations that cannot expose an exact ratio are
+    rejected instead of being silently double-rounded.
+    """
+    return round_real_to_float32_with_ratio(value)[2]
+
+
+__all__ = ["round_real_to_float32", "round_real_to_float32_with_ratio"]

--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import struct
 from numbers import Integral, Real
+from typing import cast
 
 
 def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
@@ -82,21 +83,23 @@ def _real_ratio(value: Real) -> tuple[int, int, bool]:
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise TypeError("value must be an actual non-bool real")
-    if isinstance(value, Integral):
-        ratio: object = (int(value), 1)
+    if issubclass(actual_type, Integral):
+        ratio: object = (int(cast(Integral, value)), 1)
     else:
-        ratio_method = getattr(value, "as_integer_ratio", None)
+        ratio_method = getattr(actual_type, "as_integer_ratio", None)
         if not callable(ratio_method):
             raise TypeError("real value must expose as_integer_ratio")
-        ratio = ratio_method()
-    if not isinstance(ratio, tuple) or len(ratio) != 2:
+        ratio = ratio_method(value)
+    if type(ratio) is not tuple or len(ratio) != 2:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator_raw, denominator_raw = ratio
+    num_type = type(numerator_raw)
+    den_type = type(denominator_raw)
     if (
-        isinstance(numerator_raw, bool)
-        or not isinstance(numerator_raw, Integral)
-        or isinstance(denominator_raw, bool)
-        or not isinstance(denominator_raw, Integral)
+        issubclass(num_type, bool)
+        or not issubclass(num_type, Integral)
+        or issubclass(den_type, bool)
+        or not issubclass(den_type, Integral)
     ):
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)

--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -17,16 +17,16 @@ contracts are exercised in ``tests/test_prototype_memory.py`` and
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
 from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.associative_memory import (
     AssociativeFeatureFamily,
     AssociativeMemoryConfig,
@@ -102,7 +102,7 @@ _STEP2_MEMORY_CONFIG_KEYS = frozenset(
         "bandwidth",
     }
 )
-_INT32_MAX = int(np.iinfo(np.int32).max)
+_INT32_MAX = 2**31 - 1
 
 
 def _require_exact_keys(
@@ -116,49 +116,77 @@ def _require_exact_keys(
         )
 
 
-def _require_real(name: str, value: object) -> Any:
-    if isinstance(value, bool) or not isinstance(value, Real):
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number, got {value!r}")
-    return value
-
-
-def _narrow_float32(name: str, value: Any) -> float:
-    """Narrow exactly as the downstream JAX kernels do."""
+    real = cast(Real, value)
     try:
-        narrowed = round_real_to_float32(value)
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if not bool(np.isfinite(narrowed)):
+    if not math.isfinite(narrowed):
         raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
-    if type(value) in (int, float) and (bool(narrowed != 0.0) or value == 0):
-        return float(value)
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: object, narrowed: float) -> float:
+    actual_type = type(value)
+    if (actual_type is int or actual_type is float) and (
+        bool(narrowed != 0.0) or value == 0
+    ):
+        return float(cast(int | float, value))
     return float(narrowed)
 
 
+def _require_real(name: str, value: object) -> float:
+    real, _, _, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed)
+
+
 def _require_unit_interval(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if not 0.0 <= original <= 1.0:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return _narrow_float32(name, original)
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real <= 0.0
+        or not real <= 1.0
+        or numerator <= 0
+        or numerator > denominator
+        or narrowed <= 0.0
+        or not narrowed <= 1.0
+    ):
+        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original < 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
         raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return _narrow_float32(name, original)
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if original <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
-    number = _narrow_float32(name, original)
-    if number <= 0.0:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
         raise ValueError(
             f"{name} must be positive in float32 execution sink, got {value!r}"
         )
-    return number
+    return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(
@@ -168,12 +196,10 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    try:
-        number = int(value)
-    except (OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must be an integer, got {value!r}") from None
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
@@ -261,18 +287,6 @@ def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -
     object.__setattr__(config, "n_heads", n_heads)
     object.__setattr__(config, "hidden_sizes", tuple(canonical_hidden))
     object.__setattr__(config, "step_size", step_size)
-
-
-def _require_half_open_unit_interval(name: str, value: object) -> float:
-    original = _require_real(name, value)
-    if not 0.0 < original <= 1.0:
-        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
-    number = _narrow_float32(name, original)
-    if number <= 0.0:
-        raise ValueError(
-            f"{name} must remain positive in float32 execution sink, got {value!r}"
-        )
-    return number
 
 
 def _validate_step2_memory_config(config: Step2MemoryConfig) -> None:
@@ -802,8 +816,7 @@ def collect_step2_arrays(
     experiments use their dedicated runners so they can capture full metadata,
     baselines, and paired seed statistics.
     """
-    if steps < 1:
-        raise ValueError(f"steps must be positive, got {steps}")
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
     state = stream.init(key)
     observations = []
     targets = []
@@ -827,10 +840,9 @@ def run_step2_smoke(
     utility/perturbation metrics, and config serialization.  It is not a
     canonical MLP comparison.
     """
-    if final_window < 1 or final_window > steps:
-        raise ValueError(
-            f"final_window must be in [1, steps], got {final_window}"
-        )
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    final_window = _require_int("final_window", final_window, minimum=1, maximum=steps)
     cfg = config or Step2KernelConfig()
     learner = make_step2_learner(cfg)
     stream = make_step2_stream(cfg)
@@ -867,10 +879,9 @@ def run_step2_associative_smoke(
     associative table should lower NLL over time.
     """
     cfg = config or Step2AssociativeConfig()
-    if steps < 2:
-        raise ValueError(f"steps must be at least 2, got {steps}")
-    if window < 1 or window > steps // 2:
-        raise ValueError(f"window must be in [1, steps//2], got {window}")
+    steps = _require_int("steps", steps, minimum=2, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    window = _require_int("window", window, minimum=1, maximum=steps // 2)
     pattern_count = min(8, max(2, steps // 8))
     key = jr.key(seed)
     patterns = jr.randint(

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -469,6 +469,8 @@ _INVALID_STEP2_KERNEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("noise_std", True),
     ("noise_std", False),
     ("noise_std", -1.0),
+    ("noise_std", 1e100),
+    ("step_size", 1e100),
 )
 
 
@@ -508,11 +510,13 @@ _INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
     ("update_rate", 0.0),
     ("update_rate", -0.1),
     ("update_rate", 1.1),
+    ("update_rate", 1e100),
     ("novelty_threshold", float("nan")),
     ("novelty_threshold", float("inf")),
     ("novelty_threshold", True),
     ("novelty_threshold", False),
     ("novelty_threshold", -0.01),
+    ("novelty_threshold", 1e100),
     ("bandwidth", float("nan")),
     ("bandwidth", float("inf")),
     ("bandwidth", True),
@@ -520,6 +524,7 @@ _INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
     ("bandwidth", 0.0),
     ("bandwidth", -0.01),
     ("bandwidth", None),
+    ("bandwidth", 1e100),
 )
 
 
@@ -931,6 +936,83 @@ def test_step2_config_from_dict_requires_exact_keys(config: Any) -> None:
     for malformed in (missing, extra):
         with pytest.raises(ValueError, match=type(config).__name__):
             type(config).from_dict(malformed)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "64"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+        ({"final_window": 0}, "final_window"),
+        ({"final_window": -1}, "final_window"),
+        ({"final_window": 300}, "final_window"),
+        ({"final_window": True}, "final_window"),
+    ],
+)
+def test_step2_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step2_smoke(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_step2_unit_interval_rejects_adversarial_ratio_floats(
+    ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"update_rate must be in \(0, 1\]"):
+        Step2MemoryConfig(update_rate=HiddenBoundaryFloat(0.5))
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        (Step2KernelConfig, "step_size"),
+        (Step2KernelConfig, "noise_std"),
+        (Step2StrictDigitReadoutConfig, "step_size"),
+        (Step2MemoryConfig, "novelty_threshold"),
+    ],
+)
+def test_step2_nonnegative_rejects_adversarial_negative_ratio(
+    config_type: type[Any], field: str
+) -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 1)
+
+    with pytest.raises(ValueError, match=rf"{field} must be non-negative"):
+        config_type(**{field: HiddenNegativeFloat(0.5)})
+
+
+def test_step2_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        Step2KernelConfig(step_size=value)  # type: ignore[arg-type]
+
 
 
 def test_step2_hybrid_factory_updates_upgd_and_memory() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -629,6 +629,38 @@ def test_step2_configs_enforce_exact_scientific_domains(
         config_type(**{field: value})
 
 
+def test_step2_rejects_spoofed_int_class_with_negative_ratio() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="step_size must be non-negative"):
+        Step2KernelConfig(step_size=SpoofedIntFloat(0.5))
+
+
+def test_step2_rejects_spoofed_ratio_components() -> None:
+    class SpoofedComponent:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __int__(self) -> int:
+            return 1
+
+    class BadRatioFloat(float):
+        def as_integer_ratio(self) -> tuple[Any, Any]:
+            return (SpoofedComponent(), 2)
+
+    with pytest.raises(ValueError, match="must narrow to a finite float32"):
+        Step2KernelConfig(step_size=BadRatioFloat(0.5))
+
+
+
+
 def test_step2_configs_use_direct_float32_narrowing_without_double_rounding() -> None:
     overflow_midpoint = np.ldexp(
         np.longdouble(2) - np.ldexp(np.longdouble(1), -24),


### PR DESCRIPTION
Closes #433.

## What changed

`Step2KernelConfig`, `Step2StrictDigitReadoutConfig`, `Step2MemoryConfig`, and smoke probes (`run_step2_smoke`, `run_step2_associative_smoke`, `collect_step2_arrays`) now strictly validate scalar hyperparameters, float32 execution sink bounds, and exact integer ratios before constructing Step 2 components. Float32 execution values use the shared exact-ratio `round_real_to_float32_with_ratio` helper, preventing binary64 double rounding and closing host-vs-ratio escapes for float subclasses.

Exact float32 overflow is rejected across `step_size`, `noise_std`, `update_rate`, `novelty_threshold`, and `bandwidth`; legal zero/one endpoints and signed zeroes remain preserved. Integer feature dimensions, head counts, hidden layer sizes, class/slot counts, and smoke parameters (`steps`, `seed`, `final_window`, `window`) are bounded to standard signed int32 bounds (`2**31 - 1`).

## Scope

• `alberta_framework/_float32.py`
• `alberta_framework/steps/step2.py`
• `tests/test_production_steps.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Step 2 focused test suite: 206 passed;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported