### PR TITLE
fix(prototype-agent): rank subtask features by max, not sum, across sources

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -232,7 +232,7 @@ def feature_to_subtask_specs(
     obs_dim = int(opt_q.shape[-1])
     opt_importance = jnp.max(opt_q_abs.reshape(-1, obs_dim), axis=0)  # (obs_dim,)
 
-    combined = feature_importance + opt_importance
+    combined = jnp.maximum(feature_importance, opt_importance)
     n = min(normalized_n_subtasks, obs_dim)
     ranking = sorted(range(obs_dim), key=lambda i: float(combined[i]), reverse=True)[:n]
 

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -662,6 +662,51 @@ class TestFeatureToSubtaskSpecs:
         for spec in specs:
             assert 0 <= spec.feature_index < OBS_DIM
 
+    def test_ranks_by_max_across_sources_not_sum(self) -> None:
+        """Pins the documented contract (issue #412): ranking is the maximum
+        absolute Q-weight across all base and option policies, i.e.
+        ``jnp.maximum(feature_importance, opt_importance)`` per feature — not
+        the sum of the two per-source maxima. A feature that is mid-weight in
+        both sources must not outrank a feature holding the single largest
+        weight anywhere.
+
+        Reproduction values from the issue: per-feature base max
+        ``[1.0, 0.6, 0.1]``, per-feature option max ``[0.0, 0.6, 0.1]``.
+        Documented (max) ranking is ``[0, 1, 2]``; the pre-fix summed
+        ranking was ``[1, 0, 2]``.
+        """
+        obs_dim = 3
+        config = PrototypeAgentConfig(oak=_oak_cfg(obs_dim=obs_dim, n_prim=N_PRIM))
+        agent = PrototypeAgent(config)
+        state = agent.init(jr.key(0))
+        oak_state = state.oak_state
+        stomp_state = oak_state.stomp_state
+
+        base_row = jnp.array([1.0, 0.6, 0.1], dtype=jnp.float32)
+        head_params = stomp_state.base_learner_state.head_params
+        new_head_params = head_params.replace(
+            weights=tuple(base_row[None, :] for _ in head_params.weights)
+        )
+        new_base_learner_state = stomp_state.base_learner_state.replace(
+            head_params=new_head_params
+        )
+
+        opt_row = jnp.array([0.0, 0.6, 0.1], dtype=jnp.float32)
+        new_option_policies = stomp_state.option_policies.replace(
+            q_weights=jnp.broadcast_to(opt_row, stomp_state.option_policies.q_weights.shape)
+        )
+
+        patched_oak_state = oak_state.replace(
+            stomp_state=stomp_state.replace(
+                base_learner_state=new_base_learner_state,
+                option_policies=new_option_policies,
+            )
+        )
+
+        specs = feature_to_subtask_specs(patched_oak_state, n_subtasks=3)
+
+        assert [s.feature_index for s in specs] == [0, 1, 2]
+
 
 # ---------------------------------------------------------------------------
 # Config serialization agent roundtrip


### PR DESCRIPTION
Closes #412.

## Issue

`feature_to_subtask_specs` (`alberta_framework/core/prototype_agent.py`) documents: "Ranks observation dimensions by the **maximum** absolute Q-weight across all base and option policies." The code computed `feature_importance = max|base Q|` and `opt_importance = max|option Q|` per feature and ranked by `combined = feature_importance + opt_importance` — the **sum** of the two per-source maxima, not their maximum. A feature that is mid-weight in both sources could therefore outrank a feature holding the single largest weight anywhere. `PrototypeAgent.auto_subtask_specs` feeds this ranking into the next curation cycle, so the wrong observation dimension became the new option's subtask target — a silent, deterministic change to what the experiment measures.

Per the issue's own reproduction: per-feature base max `[1.0, 0.6, 0.1]`, per-feature option max `[0.0, 0.6, 0.1]` gives documented (max) ranking `[0, 1, 2]` but pre-fix (sum) ranking `[1, 0, 2]`.

## Fix

Implements option (a) from the issue — the docstring is the contract:

```python
combined = jnp.maximum(feature_importance, opt_importance)
```

replacing the summation. No other line changed.

## Tests (failing-test-first)

Added `TestFeatureToSubtaskSpecs.test_ranks_by_max_across_sources_not_sum` in `tests/test_prototype_agent.py`, which patches an initialized `PrototypeAgent`'s `OaKState` (`obs_dim=3`) so every base head reports `[1.0, 0.6, 0.1]` and every option-policy row reports `[0.0, 0.6, 0.1]`, then asserts the ranking is `[0, 1, 2]`.

Confirmed failing-test-first against unpatched `main` before applying the fix:

```text
>       assert [s.feature_index for s in specs] == [0, 1, 2]
E       assert [1, 0, 2] == [0, 1, 2]
```

## Verification at `2bad6e49dfa01028170a1b2f1c15cc152c808f0f`

```text
$ .venv/bin/python -m pytest tests/test_prototype_agent.py -k "TestFeatureToSubtaskSpecs or TestAutoSubtaskSpecs" -q -o addopts=""
.............................
29 passed, 55 deselected in 96.69s

$ .venv/bin/python -m pytest tests/test_prototype_agent.py -q -o addopts=""
................................................................................ [ 95%]
....
84 passed in 702.26s (0:11:42)

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ git diff --check
(no output — clean)
```

No benchmark lane, seeds, or `outputs/` artifacts touched; `feature_to_subtask_specs` is not a registered evidence source. No `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:2bad6e49dfa01028170a1b2f1c15cc152c808f0f -->
<!-- evidence-row:logs -->
- [x] logs: inline above (failing-test-first repro, focused + full-file pytest, ruff, mypy at the evidence head)

Provider/model/client: anthropic / claude-sonnet-5 / Claude Code (contribute-to-asi skill revision 72e4239e).

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker-2]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05FNRW9N11XDS19G612JZWZ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T14:30:09.545Z","completed_at":"2026-08-16T14:30:32.984Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d00bd90188c24b072a15194f4f08d63341e33986b54b038d291fe47d58781601","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bc5ac7a9-b703-446e-b000-34da171b428b","object_id":"sha256:d00bd90188c24b072a15194f4f08d63341e33986b54b038d291fe47d58781601","sha256":"d00bd90188c24b072a15194f4f08d63341e33986b54b038d291fe47d58781601"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"e7AAxNBx8lMUBnVzMDVL8i9EVdm-14pg30RZAfDahaNUIYtZ-pM_dO34TNDF_XF79NaXwJd6XiktJwc3ucUNBA"}} -->

