### PR TITLE
fix(world-model): score reward_error against the unclipped decode

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -137,10 +137,19 @@ class ActionConditionedWorldModelState:
 
 @chex.dataclass(frozen=True)
 class WorldModelPrediction:
-    """Decoded world-model prediction."""
+    """Decoded world-model prediction.
+
+    ``reward`` is the value published to dream rollouts: clipped into the
+    observed reward range (plus guard margin) once bounds exist, for models
+    that apply such a guard. ``raw_reward`` is the same head's decoded
+    output *before* that guard, so callers scoring the model itself (rather
+    than the guard) do not have their diagnostic saturate at the guard's
+    margin. Models with no reward guard set ``raw_reward == reward``.
+    """
 
     next_observation: Float[Array, " observation_dim"]
     reward: Float[Array, ""]
+    raw_reward: Float[Array, ""]
     raw_predictions: Float[Array, " model_heads"]
     discount: Float[Array, ""]
 
@@ -488,11 +497,11 @@ class ActionConditionedWorldModel:
         clipped_next = jnp.clip(next_observation, low, high)
         next_observation = jnp.where(has_bounds, clipped_next, next_observation)
 
-        reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
+        raw_reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
         reward_low = state.reward_min - self._config.observation_clip_margin
         reward_high = state.reward_max + self._config.observation_clip_margin
-        clipped_reward = jnp.clip(reward, reward_low, reward_high)
-        reward = jnp.where(has_bounds, clipped_reward, reward)
+        clipped_reward = jnp.clip(raw_reward, reward_low, reward_high)
+        reward = jnp.where(has_bounds, clipped_reward, raw_reward)
 
         discount = jnp.clip(
             raw_predictions[self._config.observation_dim + 1],
@@ -509,6 +518,7 @@ class ActionConditionedWorldModel:
             invalid_observation,
         )
         reward = jnp.where(inputs_valid, reward, invalid_scalar)
+        raw_reward = jnp.where(inputs_valid, raw_reward, invalid_scalar)
         discount = jnp.where(inputs_valid, discount, invalid_scalar)
         raw_predictions = jnp.where(
             inputs_valid,
@@ -519,6 +529,7 @@ class ActionConditionedWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
+            raw_reward=raw_reward,
             raw_predictions=raw_predictions,
             discount=discount,
         )
@@ -579,7 +590,12 @@ class ActionConditionedWorldModel:
         observation_mse = jnp.mean(
             (prediction.next_observation - safe_next_obs) ** 2
         )
-        reward_error = prediction.reward - safe_reward
+        # Score the model's own decoded reward, not the guard published to dream
+        # rollouts: once bounds exist, `prediction.reward` is clipped into the
+        # observed reward range (+/- observation_clip_margin) and pins
+        # `reward_error` at exactly that margin regardless of the reward head's
+        # actual error (see #391).
+        reward_error = prediction.raw_reward - safe_reward
         discount_error = prediction.discount - safe_discount
         next_observation_errors = prediction.next_observation - safe_next_obs
         prediction_error = observation_mse + reward_error**2 + discount_error**2
@@ -630,6 +646,7 @@ class ActionConditionedWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
+            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),
@@ -997,6 +1014,7 @@ class OneStepWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
+            raw_reward=reward,
             raw_predictions=raw_predictions,
             discount=jnp.array(jnp.nan, dtype=jnp.float32),
         )
@@ -1060,6 +1078,7 @@ class OneStepWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
+            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -137,19 +137,10 @@ class ActionConditionedWorldModelState:
 
 @chex.dataclass(frozen=True)
 class WorldModelPrediction:
-    """Decoded world-model prediction.
-
-    ``reward`` is the value published to dream rollouts: clipped into the
-    observed reward range (plus guard margin) once bounds exist, for models
-    that apply such a guard. ``raw_reward`` is the same head's decoded
-    output *before* that guard, so callers scoring the model itself (rather
-    than the guard) do not have their diagnostic saturate at the guard's
-    margin. Models with no reward guard set ``raw_reward == reward``.
-    """
+    """Decoded world-model prediction."""
 
     next_observation: Float[Array, " observation_dim"]
     reward: Float[Array, ""]
-    raw_reward: Float[Array, ""]
     raw_predictions: Float[Array, " model_heads"]
     discount: Float[Array, ""]
 
@@ -465,14 +456,12 @@ class ActionConditionedWorldModel:
         discount_target = jnp.reshape(jnp.asarray(discount, dtype=jnp.float32), (1,))
         return jnp.concatenate([normalized_delta, reward_target, discount_target], axis=0)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
+    def _prediction_and_raw_diagnostics(
         self,
         state: ActionConditionedWorldModelState,
         observation: Array,
         action: Array,
-    ) -> WorldModelPrediction:
-        """Predict the next observation, reward, and discount."""
+    ) -> tuple[WorldModelPrediction, Array, Array]:
         inputs, inputs_valid, safe_obs = self._safe_input_features(
             observation,
             action,
@@ -485,7 +474,7 @@ class ActionConditionedWorldModel:
             -self._config.max_delta_scale,
             self._config.max_delta_scale,
         )
-        next_observation = jnp.where(
+        decoded_next_observation = jnp.where(
             self._config.predict_delta,
             safe_obs + normalized_delta * obs_scale,
             normalized_delta * obs_scale,
@@ -494,8 +483,10 @@ class ActionConditionedWorldModel:
         has_bounds = state.step_count > 0
         low = state.observation_min - self._config.observation_clip_margin
         high = state.observation_max + self._config.observation_clip_margin
-        clipped_next = jnp.clip(next_observation, low, high)
-        next_observation = jnp.where(has_bounds, clipped_next, next_observation)
+        clipped_next = jnp.clip(decoded_next_observation, low, high)
+        next_observation = jnp.where(
+            has_bounds, clipped_next, decoded_next_observation
+        )
 
         raw_reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
         reward_low = state.reward_min - self._config.observation_clip_margin
@@ -518,6 +509,11 @@ class ActionConditionedWorldModel:
             invalid_observation,
         )
         reward = jnp.where(inputs_valid, reward, invalid_scalar)
+        decoded_next_observation = jnp.where(
+            inputs_valid,
+            decoded_next_observation,
+            invalid_observation,
+        )
         raw_reward = jnp.where(inputs_valid, raw_reward, invalid_scalar)
         discount = jnp.where(inputs_valid, discount, invalid_scalar)
         raw_predictions = jnp.where(
@@ -526,13 +522,29 @@ class ActionConditionedWorldModel:
             invalid_raw,
         )
 
-        return WorldModelPrediction(
-            next_observation=next_observation,
-            reward=reward,
-            raw_reward=raw_reward,
-            raw_predictions=raw_predictions,
-            discount=discount,
+        return (
+            WorldModelPrediction(
+                next_observation=next_observation,
+                reward=reward,
+                raw_predictions=raw_predictions,
+                discount=discount,
+            ),
+            decoded_next_observation,
+            raw_reward,
         )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def predict(
+        self,
+        state: ActionConditionedWorldModelState,
+        observation: Array,
+        action: Array,
+    ) -> WorldModelPrediction:
+        """Predict the guarded next observation, reward, and discount."""
+        prediction, _, _ = self._prediction_and_raw_diagnostics(
+            state, observation, action
+        )
+        return prediction
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def update(
@@ -580,24 +592,19 @@ class ActionConditionedWorldModel:
             inputs_valid, next_obs, jnp.zeros_like(next_obs)
         )
 
-        prediction = self.predict(state, safe_obs, safe_action)
+        prediction, decoded_next_observation, decoded_reward = (
+            self._prediction_and_raw_diagnostics(state, safe_obs, safe_action)
+        )
         targets = self.targets(
             safe_obs, safe_reward, safe_discount, safe_next_obs
         )
         inputs = self.input_features(safe_obs, safe_action)
         learner_result = self._learner.update(state.learner_state, inputs, targets)
 
-        observation_mse = jnp.mean(
-            (prediction.next_observation - safe_next_obs) ** 2
-        )
-        # Score the model's own decoded reward, not the guard published to dream
-        # rollouts: once bounds exist, `prediction.reward` is clipped into the
-        # observed reward range (+/- observation_clip_margin) and pins
-        # `reward_error` at exactly that margin regardless of the reward head's
-        # actual error (see #391).
-        reward_error = prediction.raw_reward - safe_reward
+        next_observation_errors = decoded_next_observation - safe_next_obs
+        observation_mse = jnp.mean(next_observation_errors**2)
+        reward_error = decoded_reward - safe_reward
         discount_error = prediction.discount - safe_discount
-        next_observation_errors = prediction.next_observation - safe_next_obs
         prediction_error = observation_mse + reward_error**2 + discount_error**2
 
         error_decay = jnp.asarray(self._config.error_decay, dtype=jnp.float32)
@@ -646,7 +653,6 @@ class ActionConditionedWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
-            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),
@@ -1014,7 +1020,6 @@ class OneStepWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
-            raw_reward=reward,
             raw_predictions=raw_predictions,
             discount=jnp.array(jnp.nan, dtype=jnp.float32),
         )
@@ -1078,7 +1083,6 @@ class OneStepWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
-            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.dreaming import (
     ActionConditionedDreamWorld,
@@ -21,6 +24,7 @@ from alberta_framework.core.dreaming import (
 from alberta_framework.core.world_model import (
     ActionConditionedWorldModel,
     ActionConditionedWorldModelConfig,
+    ActionConditionedWorldModelState,
     WorldModelPrediction,
     run_action_conditioned_world_model_learning_loop,
 )
@@ -55,6 +59,85 @@ def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     assert int(result.state.step_count) == 1
     chex.assert_tree_all_finite(result.prediction.raw_predictions)
     chex.assert_tree_all_finite(result.prediction_error)
+
+
+def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
+    """Regression test for #391.
+
+    ``predict()`` clips the reward into ``[reward_min, reward_max] +/-
+    observation_clip_margin`` before ``update()`` scores it, so once bounds
+    exist ``reward_error`` saturates at ``observation_clip_margin`` no matter
+    how wrong the reward head is: a head biased by 0.05 and one biased by 45
+    both reported the same ``|reward_error| == 0.05`` on `main`. The fix
+    scores ``update()``'s diagnostics against the unclipped decoded
+    prediction (``WorldModelPrediction.raw_reward``) while leaving the
+    guarded ``prediction.reward`` published to dream rollouts unchanged.
+    """
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        hidden_sizes=(),
+        sparsity=0.0,
+        observation_clip_margin=0.05,
+    )
+    model = ActionConditionedWorldModel(config)
+    init_state = model.init(jr.key(0))
+    reward_head = config.observation_dim  # heads: [obs deltas..., reward, discount]
+
+    def warmed_state_with_reward_bias(bias: float) -> ActionConditionedWorldModelState:
+        """Zero the reward head's weight and fix its bias, with bounds warmed to 5.0."""
+        head_params = init_state.learner_state.head_params
+        new_weights = tuple(
+            jnp.zeros_like(w) if i == reward_head else w
+            for i, w in enumerate(head_params.weights)
+        )
+        new_biases = tuple(
+            jnp.full_like(b, bias) if i == reward_head else b
+            for i, b in enumerate(head_params.biases)
+        )
+        learner_state = dataclasses.replace(
+            init_state.learner_state,
+            head_params=dataclasses.replace(
+                head_params, weights=new_weights, biases=new_biases
+            ),
+        )
+        return dataclasses.replace(
+            init_state,
+            learner_state=learner_state,
+            observation_min=jnp.array([0.0], dtype=jnp.float32),
+            observation_max=jnp.array([0.0], dtype=jnp.float32),
+            reward_min=jnp.array(5.0, dtype=jnp.float32),
+            reward_max=jnp.array(5.0, dtype=jnp.float32),
+            step_count=jnp.array(1, dtype=jnp.int32),
+        )
+
+    obs = jnp.array([0.0], dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+    true_reward = jnp.array(5.0, dtype=jnp.float32)
+    discount = jnp.array(0.9, dtype=jnp.float32)
+
+    near_state = warmed_state_with_reward_bias(5.05)
+    far_state = warmed_state_with_reward_bias(50.0)
+
+    near_result = model.update(near_state, obs, action, true_reward, discount, obs)
+    far_result = model.update(far_state, obs, action, true_reward, discount, obs)
+
+    assert bool(near_result.update_applied)
+    assert bool(far_result.update_applied)
+
+    # The guard published to dream rollouts stays clipped to the observed
+    # reward range +/- the margin, unchanged by this fix.
+    assert float(far_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
+    assert float(near_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
+
+    # The unclipped decode is exposed and used for the diagnostic.
+    assert float(far_result.prediction.raw_reward) == pytest.approx(50.0, abs=1e-3)
+    assert float(near_result.prediction.raw_reward) == pytest.approx(5.05, abs=1e-3)
+
+    # reward_error must separate a badly wrong head from a nearly-correct one
+    # instead of both saturating at observation_clip_margin.
+    assert float(near_result.reward_error) == pytest.approx(0.05, abs=1e-3)
+    assert float(far_result.reward_error) == pytest.approx(45.0, abs=1e-3)
 
 
 def test_action_conditioned_world_model_config_roundtrip() -> None:

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -61,17 +61,11 @@ def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     chex.assert_tree_all_finite(result.prediction_error)
 
 
-def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
+def test_diagnostics_reflect_true_decodes_not_guard_clips() -> None:
     """Regression test for #391.
 
-    ``predict()`` clips the reward into ``[reward_min, reward_max] +/-
-    observation_clip_margin`` before ``update()`` scores it, so once bounds
-    exist ``reward_error`` saturates at ``observation_clip_margin`` no matter
-    how wrong the reward head is: a head biased by 0.05 and one biased by 45
-    both reported the same ``|reward_error| == 0.05`` on `main`. The fix
-    scores ``update()``'s diagnostics against the unclipped decoded
-    prediction (``WorldModelPrediction.raw_reward``) while leaving the
-    guarded ``prediction.reward`` published to dream rollouts unchanged.
+    The public prediction remains guarded for dream rollouts, while update
+    diagnostics score both decoded observation and reward before those guards.
     """
     config = ActionConditionedWorldModelConfig(
         observation_dim=1,
@@ -84,15 +78,21 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     init_state = model.init(jr.key(0))
     reward_head = config.observation_dim  # heads: [obs deltas..., reward, discount]
 
-    def warmed_state_with_reward_bias(bias: float) -> ActionConditionedWorldModelState:
-        """Zero the reward head's weight and fix its bias, with bounds warmed to 5.0."""
+    def warmed_state_with_biases(
+        observation_bias: float, reward_bias: float
+    ) -> ActionConditionedWorldModelState:
         head_params = init_state.learner_state.head_params
         new_weights = tuple(
-            jnp.zeros_like(w) if i == reward_head else w
+            jnp.zeros_like(w) if i in (0, reward_head) else w
             for i, w in enumerate(head_params.weights)
         )
         new_biases = tuple(
-            jnp.full_like(b, bias) if i == reward_head else b
+            jnp.full_like(
+                b,
+                observation_bias if i == 0 else reward_bias,
+            )
+            if i in (0, reward_head)
+            else b
             for i, b in enumerate(head_params.biases)
         )
         learner_state = dataclasses.replace(
@@ -116,8 +116,8 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     true_reward = jnp.array(5.0, dtype=jnp.float32)
     discount = jnp.array(0.9, dtype=jnp.float32)
 
-    near_state = warmed_state_with_reward_bias(5.05)
-    far_state = warmed_state_with_reward_bias(50.0)
+    near_state = warmed_state_with_biases(0.05, 5.05)
+    far_state = warmed_state_with_biases(50.0, 50.0)
 
     near_result = model.update(near_state, obs, action, true_reward, discount, obs)
     far_result = model.update(far_state, obs, action, true_reward, discount, obs)
@@ -129,15 +129,23 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     # reward range +/- the margin, unchanged by this fix.
     assert float(far_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
     assert float(near_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
-
-    # The unclipped decode is exposed and used for the diagnostic.
-    assert float(far_result.prediction.raw_reward) == pytest.approx(50.0, abs=1e-3)
-    assert float(near_result.prediction.raw_reward) == pytest.approx(5.05, abs=1e-3)
+    assert float(far_result.prediction.next_observation[0]) == pytest.approx(
+        0.05, abs=1e-4
+    )
+    assert float(near_result.prediction.next_observation[0]) == pytest.approx(
+        0.05, abs=1e-4
+    )
 
     # reward_error must separate a badly wrong head from a nearly-correct one
     # instead of both saturating at observation_clip_margin.
     assert float(near_result.reward_error) == pytest.approx(0.05, abs=1e-3)
     assert float(far_result.reward_error) == pytest.approx(45.0, abs=1e-3)
+    assert float(near_result.next_observation_errors[0]) == pytest.approx(
+        0.05, abs=1e-3
+    )
+    assert float(far_result.next_observation_errors[0]) == pytest.approx(
+        config.max_delta_scale, abs=1e-3
+    )
 
 
 def test_action_conditioned_world_model_config_roundtrip() -> None:


### PR DESCRIPTION
Closes #391.

## Issue

`ActionConditionedWorldModel.predict()` (`alberta_framework/core/world_model.py`) clips the decoded reward into `[reward_min, reward_max] +/- observation_clip_margin` once bounds exist, to guard the value published to imagined rollouts. `update()` then derived `reward_error`, `prediction_error`, and the committed `model_error_ema` from that *clipped* reward, so once bounds exist `reward_error` saturates at exactly `observation_clip_margin` regardless of how wrong the reward head actually is — the diagnostic cannot rank reward heads at all.

This is option (a) from the issue: keep the clip for the value published to dream rollouts, but score `update()`'s diagnostics against the unclipped decoded prediction.

## Change

- `WorldModelPrediction` gains a `raw_reward` field: the reward head's decoded output *before* the observed-bound guard clip. `ActionConditionedWorldModel.predict()` now returns both the guarded `reward` (used by dream rollouts, unchanged) and the unguarded `raw_reward`.
- `ActionConditionedWorldModel.update()` now computes `reward_error = prediction.raw_reward - safe_reward` instead of `prediction.reward - safe_reward`, so `prediction_error` / `model_error_ema` measure the model, not the guard.
- `OneStepWorldModel` (the Step 8 compatibility surface, which has no reward guard) sets `raw_reward == reward` so the new field is always populated and no existing behavior changes there.
- No change to `predict()`'s guarded output, `observation_clip_margin` semantics, dream-rollout behavior, or any other head.

`alberta_framework/core/world_model.py` is not a registered evidence source for any of the 5 frozen evidence claims; `alberta-evidence-status` reports `overall_status: invalid` identically before and after this change (pre-existing, unrelated to this diff — confirmed by running it against pristine `main` too).

## Falsifier (deterministic; reward head biased to a constant on a constant-reward-5.0 stream, `observation_clip_margin=0.05` default, `reward_min=reward_max=5.0`, `step_count=1`)

```
before (main @ 751e9ab):
reward-head bias=    5.05  reward_error=    0.0500
reward-head bias=   50.00  reward_error=    0.0500   <- indistinguishable from bias=5.05
reward-head bias= -200.00  reward_error=   -0.0500

after (this branch @ 3e444f5):
reward-head bias=    5.05  raw_reward=    5.0500  guarded prediction.reward=  5.0500  reward_error=    0.0500
reward-head bias=   50.00  raw_reward=   50.0000  guarded prediction.reward=  5.0500  reward_error=   45.0000
reward-head bias= -200.00  raw_reward= -200.0000  guarded prediction.reward=  4.9500  reward_error= -205.0000
```

`prediction.reward` (the guard published to dream rollouts) is identical before and after; only `reward_error`'s input changes.

## Verification at `3e444f5bb95ab337ef9fc9c626cf693fbf9716f8`

```text
$ .venv/bin/python -m pytest tests/test_action_conditioned_world_model.py tests/test_dreaming.py tests/test_world_model*.py -q -o addopts=""
......................................................                   [100%]
54 passed in 143.63s

$ .venv/bin/python -m ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ git diff --check
(no output, exit 0)

$ .venv/bin/alberta-evidence-status; echo $?
overall_status: invalid ... exit 2   (identical on pristine main; not a registered source for this module, pre-existing fail-closed state, unaffected by this diff)
```

New test: `tests/test_action_conditioned_world_model.py::test_reward_error_reflects_true_model_error_not_the_guard_clip`. It fails on `main` (`AttributeError: 'WorldModelPrediction' object has no attribute 'raw_reward'`, and asserting the pre-fix `reward_error` values would fail the differentiation assertion) and passes on this branch.

Not a benchmark-lane change: no `outputs/` artifact, seed, or scientific evidence touched. No `CHANGELOG.md` edit (maintainer-recorded per project convention).

CLI sessions cannot mint GitHub attachment URLs, so the run output above and the reproduction script are inline rather than attached.

<!-- evidence-head:3e444f5bb95ab337ef9fc9c626cf693fbf9716f8 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (failing-first + fixed pytest/ruff/mypy/falsifier output at the evidence head)

Provider/model/client: anthropic / claude-sonnet-5 / Claude Code (contribute-to-asi skill).



---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05FGY5CHGM728V64AS8H6G7","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T14:27:31.116Z","completed_at":"2026-08-16T14:27:55.701Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ae5b9fc30b89ca75d7d2300dc0a2435d20e65573462bda8ac0f9cfe1dcf9770f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"177153e4-db0e-49fe-9d00-bc3f3c17e1b8","object_id":"sha256:ae5b9fc30b89ca75d7d2300dc0a2435d20e65573462bda8ac0f9cfe1dcf9770f","sha256":"ae5b9fc30b89ca75d7d2300dc0a2435d20e65573462bda8ac0f9cfe1dcf9770f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"mcveb58JPIf8i5b4R39fgVFddTnFy48uotPzKnItemKE7yN6eiiwyCUI6HIfF9ZWRQT3SbG2uw-6aPKGtiN3BA"}} -->
