### PR TITLE
fix(pipeline): reject illegal pipeline facade config

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -77,16 +77,11 @@ def _float32_from_ratio(
     return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
 
 
-def round_real_to_float32(value: Real) -> float:
-    """Round a standard exact-ratio real directly to IEEE binary32.
-
-    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
-    round-to-nearest, ties-to-even semantics without an intermediate binary64
-    conversion. Real implementations that cannot expose an exact ratio are
-    rejected instead of being silently double-rounded.
-    """
-    if isinstance(value, bool):
-        raise TypeError("real value must not be a bool")
+def _real_ratio(value: Real) -> tuple[int, int, bool]:
+    """Return one normalized exact ratio and its zero-sign metadata."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise TypeError("value must be an actual non-bool real")
     if isinstance(value, Integral):
         ratio: object = (int(value), 1)
     else:
@@ -106,14 +101,35 @@ def round_real_to_float32(value: Real) -> float:
         raise TypeError("as_integer_ratio must return an integer pair")
     numerator = int(numerator_raw)
     denominator = int(denominator_raw)
-    negative_zero = (
-        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
-    )
-    return _float32_from_ratio(
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+    negative_zero = numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    return numerator, denominator, negative_zero
+
+
+def round_real_to_float32_with_ratio(value: Real) -> tuple[int, int, float]:
+    """Read one exact ratio and return it with its binary32 rounding."""
+    numerator, denominator, negative_zero = _real_ratio(value)
+    narrowed = _float32_from_ratio(
         numerator,
         denominator,
         negative_zero=negative_zero,
     )
+    return numerator, denominator, narrowed
 
 
-__all__ = ["round_real_to_float32"]
+def round_real_to_float32(value: Real) -> float:
+    """Round a standard exact-ratio real directly to IEEE binary32.
+
+    Integer and ``as_integer_ratio`` inputs are rounded with IEEE
+    round-to-nearest, ties-to-even semantics without an intermediate binary64
+    conversion. Real implementations that cannot expose an exact ratio are
+    rejected instead of being silently double-rounded.
+    """
+    return round_real_to_float32_with_ratio(value)[2]
+
+
+__all__ = ["round_real_to_float32", "round_real_to_float32_with_ratio"]

--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -24,16 +24,20 @@ runners.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
+from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.associative_memory import (
     AssociativeFeatureFamily,
     AssociativeMemoryConfig,
@@ -87,6 +91,122 @@ CumulantFn = Callable[[Array, Array, Array], Array]
 Signature: ``(observation, reward, terminated) -> Array(n_demons,)``.
 """
 
+_INT32_MAX: int = 2**31 - 1
+
+
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
+
+
+def _require_real(name: str, value: object) -> float:
+    real, _, _, narrowed = finite_real_and_float32(name, value)
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real <= 0.0
+        or not real <= 1.0
+        or numerator <= 0
+        or numerator > denominator
+        or narrowed <= 0.0
+        or not narrowed <= 1.0
+    ):
+        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_half_open_zero_one_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real < 1.0
+        or numerator < 0
+        or numerator >= denominator
+        or narrowed < 0.0
+        or not narrowed < 1.0
+    ):
+        raise ValueError(f"{name} must be in [0, 1), got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(Integral, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
+
 
 @dataclass(frozen=True)
 class Step2FeatureConfig:
@@ -107,18 +227,19 @@ class Step2FeatureConfig:
 
     def __post_init__(self) -> None:
         """Validate observation and feature settings."""
-        if self.observation_dim < 1:
-            msg = f"observation_dim must be positive, got {self.observation_dim}"
-            raise ValueError(msg)
+        observation_dim = _require_int(
+            "observation_dim", self.observation_dim, minimum=1, maximum=_INT32_MAX
+        )
         if not (self.include_raw or self.include_ema or self.include_delta):
             msg = "at least one of include_raw/include_ema/include_delta is required"
             raise ValueError(msg)
-        if not 0.0 <= self.ema_decay < 1.0:
-            msg = f"ema_decay must be in [0, 1), got {self.ema_decay}"
-            raise ValueError(msg)
-        if any(period <= 0.0 for period in self.periods):
-            msg = "all periods must be positive"
-            raise ValueError(msg)
+        ema_decay = _require_half_open_zero_one_interval("ema_decay", self.ema_decay)
+        canonical_periods = tuple(
+            _require_positive_real("period", p) for p in self.periods
+        )
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "ema_decay", ema_decay)
+        object.__setattr__(self, "periods", canonical_periods)
 
     @classmethod
     def identity(cls, observation_dim: int) -> Step2FeatureConfig:
@@ -187,24 +308,24 @@ class Step2UPGDConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        if self.observation_dim < 1:
-            msg = f"observation_dim must be positive, got {self.observation_dim}"
-            raise ValueError(msg)
-        if self.n_heads < 1:
-            msg = f"n_heads must be positive, got {self.n_heads}"
-            raise ValueError(msg)
-        if not self.hidden_sizes or any(size < 1 for size in self.hidden_sizes):
+        observation_dim = _require_int(
+            "observation_dim", self.observation_dim, minimum=1, maximum=_INT32_MAX
+        )
+        n_heads = _require_int("n_heads", self.n_heads, minimum=1, maximum=_INT32_MAX)
+        if not isinstance(self.hidden_sizes, tuple) or not self.hidden_sizes:
             msg = (
                 "hidden_sizes must contain at least one positive size, "
                 f"got {self.hidden_sizes!r}"
             )
             raise ValueError(msg)
-        if self.step_size < 0.0:
-            msg = f"step_size must be non-negative, got {self.step_size}"
-            raise ValueError(msg)
-        if not 0.0 <= self.sparsity <= 1.0:
-            msg = f"sparsity must be in [0, 1], got {self.sparsity}"
-            raise ValueError(msg)
+        canonical_hidden = tuple(
+            _require_int("hidden_sizes element", size, minimum=1, maximum=_INT32_MAX)
+            for size in self.hidden_sizes
+        )
+        step_size = _require_nonnegative_real("step_size", self.step_size)
+        sparsity = _require_unit_interval("sparsity", self.sparsity)
+        if not isinstance(self.use_layer_norm, bool):
+            raise ValueError(f"use_layer_norm must be a bool, got {self.use_layer_norm!r}")
         if self.learner_preset not in ("default", "strict_digit_readout"):
             msg = f"unknown learner_preset {self.learner_preset!r}"
             raise ValueError(msg)
@@ -240,6 +361,11 @@ class Step2UPGDConfig:
                 "use sparsity=0.5 and use_layer_norm=True"
             )
             raise ValueError(msg)
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_heads", n_heads)
+        object.__setattr__(self, "hidden_sizes", canonical_hidden)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "sparsity", sparsity)
 
     @classmethod
     def strict_digit_readout(
@@ -306,26 +432,58 @@ class Step2AssociativePipelineConfig:
 
     def __post_init__(self) -> None:
         """Validate integer context settings."""
-        if self.vocab_size < 2:
-            raise ValueError("vocab_size must be at least 2")
-        if self.block_size < 1:
-            raise ValueError("block_size must be positive")
-        if self.suffix_length < 2 or self.suffix_length > self.block_size:
-            raise ValueError("suffix_length must be in [2, block_size]")
-        if self.max_features < 1:
-            raise ValueError("max_features must be positive")
-        if self.scope_lr < 0.0:
-            raise ValueError("scope_lr must be non-negative")
-        if self.budget_lr < 0.0:
-            raise ValueError("budget_lr must be non-negative")
-        if not 0.0 < self.initial_budget_fraction <= 1.0:
-            raise ValueError("initial_budget_fraction must be in (0, 1]")
-        if self.min_effective_budget < 1:
-            raise ValueError("min_effective_budget must be positive")
-        if self.min_effective_budget > self.max_features:
-            raise ValueError("min_effective_budget must be <= max_features")
-        if self.scope_logit_clip <= 0.0:
-            raise ValueError("scope_logit_clip must be positive")
+        vocab_size = _require_int("vocab_size", self.vocab_size, minimum=2, maximum=_INT32_MAX)
+        block_size = _require_int("block_size", self.block_size, minimum=1, maximum=_INT32_MAX)
+        suffix_length = _require_int(
+            "suffix_length", self.suffix_length, minimum=2, maximum=block_size
+        )
+        max_features = _require_int(
+            "max_features", self.max_features, minimum=1, maximum=_INT32_MAX
+        )
+        write_lr = _require_nonnegative_real("write_lr", self.write_lr)
+        retention = _require_unit_interval("retention", self.retention)
+        utility_lr = _require_nonnegative_real("utility_lr", self.utility_lr)
+        utility_decay = _require_unit_interval("utility_decay", self.utility_decay)
+        min_weight = _require_nonnegative_real("min_weight", self.min_weight)
+        max_weight = _require_positive_real("max_weight", self.max_weight)
+        logit_scale = _require_positive_real("logit_scale", self.logit_scale)
+        if not isinstance(self.normalize_by_weight, bool):
+            raise ValueError(
+                f"normalize_by_weight must be a bool, got {self.normalize_by_weight!r}"
+            )
+        if not isinstance(self.adaptive_feature_family, bool):
+            raise ValueError(
+                f"adaptive_feature_family must be a bool, got {self.adaptive_feature_family!r}"
+            )
+        if not isinstance(self.adaptive_window, bool):
+            raise ValueError(f"adaptive_window must be a bool, got {self.adaptive_window!r}")
+        if not isinstance(self.adaptive_budget, bool):
+            raise ValueError(f"adaptive_budget must be a bool, got {self.adaptive_budget!r}")
+        scope_lr = _require_nonnegative_real("scope_lr", self.scope_lr)
+        budget_lr = _require_nonnegative_real("budget_lr", self.budget_lr)
+        initial_budget_fraction = _require_half_open_unit_interval(
+            "initial_budget_fraction", self.initial_budget_fraction
+        )
+        min_effective_budget = _require_int(
+            "min_effective_budget", self.min_effective_budget, minimum=1, maximum=max_features
+        )
+        scope_logit_clip = _require_positive_real("scope_logit_clip", self.scope_logit_clip)
+        object.__setattr__(self, "vocab_size", vocab_size)
+        object.__setattr__(self, "block_size", block_size)
+        object.__setattr__(self, "suffix_length", suffix_length)
+        object.__setattr__(self, "max_features", max_features)
+        object.__setattr__(self, "write_lr", write_lr)
+        object.__setattr__(self, "retention", retention)
+        object.__setattr__(self, "utility_lr", utility_lr)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "min_weight", min_weight)
+        object.__setattr__(self, "max_weight", max_weight)
+        object.__setattr__(self, "logit_scale", logit_scale)
+        object.__setattr__(self, "scope_lr", scope_lr)
+        object.__setattr__(self, "budget_lr", budget_lr)
+        object.__setattr__(self, "initial_budget_fraction", initial_budget_fraction)
+        object.__setattr__(self, "min_effective_budget", min_effective_budget)
+        object.__setattr__(self, "scope_logit_clip", scope_logit_clip)
 
     def output_dim(self) -> int:
         """Return the associative probability-vector dimensionality."""
@@ -383,24 +541,24 @@ class HordeActorCriticPipelineConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        if self.n_actions < 1:
-            msg = f"n_actions must be positive, got {self.n_actions}"
-            raise ValueError(msg)
-        if self.actor_step_size < 0.0:
-            msg = f"actor_step_size must be non-negative, got {self.actor_step_size}"
-            raise ValueError(msg)
-        if not 0.0 <= self.actor_lamda <= 1.0:
-            msg = f"actor_lamda must be in [0, 1], got {self.actor_lamda}"
-            raise ValueError(msg)
-        if self.temperature <= 0.0:
-            msg = f"temperature must be positive, got {self.temperature}"
-            raise ValueError(msg)
-        if self.value_head_index < 0:
-            msg = (
-                "value_head_index must be non-negative, "
-                f"got {self.value_head_index}"
-            )
-            raise ValueError(msg)
+        n_actions = _require_int("n_actions", self.n_actions, minimum=1, maximum=_INT32_MAX)
+        actor_step_size = _require_nonnegative_real("actor_step_size", self.actor_step_size)
+        actor_lamda = _require_unit_interval("actor_lamda", self.actor_lamda)
+        temperature = _require_positive_real("temperature", self.temperature)
+        value_head_index = _require_int(
+            "value_head_index", self.value_head_index, minimum=0, maximum=_INT32_MAX
+        )
+        actor_obgd_kappa = (
+            _require_positive_real("actor_obgd_kappa", self.actor_obgd_kappa)
+            if self.actor_obgd_kappa is not None
+            else None
+        )
+        object.__setattr__(self, "n_actions", n_actions)
+        object.__setattr__(self, "actor_step_size", actor_step_size)
+        object.__setattr__(self, "actor_lamda", actor_lamda)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "value_head_index", value_head_index)
+        object.__setattr__(self, "actor_obgd_kappa", actor_obgd_kappa)
 
     def to_horde_actor_critic_config(self) -> HordeActorCriticConfig:
         """Return the core actor-critic config."""
@@ -1175,9 +1333,8 @@ def run_pipeline_smoke(
     seed: int = 0,
 ) -> AlbertaPipelineSmokeResult:
     """Run a deterministic Step 1-4 pipeline smoke probe."""
-    if steps < 1:
-        msg = f"steps must be positive, got {steps}"
-        raise ValueError(msg)
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
     cfg = config or AlbertaPipelineConfig()
     pipeline = make_alberta_pipeline(cfg)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -567,5 +567,228 @@ def test_observation_channel_cumulant_fn_rejects_invalid_shapes() -> None:
         observation_channel_cumulant_fn(n_demons=1, observation_dim=0)
 
 
+_INVALID_PIPELINE_FEATURE_FIELDS: tuple[tuple[str, object], ...] = (
+    ("observation_dim", 0),
+    ("observation_dim", -1),
+    ("observation_dim", 2**31),
+    ("observation_dim", True),
+    ("observation_dim", "4"),
+    ("ema_decay", -0.1),
+    ("ema_decay", 1.0),
+    ("ema_decay", 1.1),
+    ("ema_decay", 1e100),
+    ("ema_decay", float("nan")),
+    ("ema_decay", True),
+    ("ema_decay", "0.95"),
+    ("periods", (0.0,)),
+    ("periods", (-1.0,)),
+    ("periods", (1e100,)),
+    ("periods", (float("nan"),)),
+    ("periods", (True,)),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_PIPELINE_FEATURE_FIELDS)
+def test_pipeline_feature_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        Step2FeatureConfig(**{field: value})
+
+
+_INVALID_PIPELINE_UPGD_FIELDS: tuple[tuple[str, object], ...] = (
+    ("observation_dim", 0),
+    ("observation_dim", 2**31),
+    ("observation_dim", True),
+    ("n_heads", 0),
+    ("n_heads", 2**31),
+    ("n_heads", True),
+    ("hidden_sizes", ()),
+    ("hidden_sizes", (0,)),
+    ("hidden_sizes", (2**31,)),
+    ("hidden_sizes", (True,)),
+    ("step_size", -0.01),
+    ("step_size", 1e100),
+    ("step_size", float("nan")),
+    ("step_size", True),
+    ("sparsity", -0.1),
+    ("sparsity", 1.1),
+    ("sparsity", 1e100),
+    ("sparsity", float("nan")),
+    ("sparsity", True),
+    ("use_layer_norm", 1),
+    ("learner_preset", "unknown_preset"),
+    ("loss_normalization", "unknown_norm"),
+    ("readout_mode", "unknown_mode"),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_PIPELINE_UPGD_FIELDS)
+def test_pipeline_upgd_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        Step2UPGDConfig(**{field: value})
+
+
+_INVALID_PIPELINE_ASSOCIATIVE_FIELDS: tuple[tuple[str, object], ...] = (
+    ("vocab_size", 1),
+    ("vocab_size", 2**31),
+    ("vocab_size", True),
+    ("block_size", 0),
+    ("block_size", 2**31),
+    ("block_size", True),
+    ("suffix_length", 1),
+    ("suffix_length", 9),
+    ("suffix_length", True),
+    ("max_features", 0),
+    ("max_features", 2**31),
+    ("max_features", True),
+    ("write_lr", -0.1),
+    ("write_lr", 1e100),
+    ("write_lr", True),
+    ("retention", -0.1),
+    ("retention", 1.1),
+    ("retention", 1e100),
+    ("retention", True),
+    ("utility_lr", -0.1),
+    ("utility_lr", 1e100),
+    ("utility_lr", True),
+    ("utility_decay", -0.1),
+    ("utility_decay", 1.1),
+    ("utility_decay", 1e100),
+    ("utility_decay", True),
+    ("min_weight", -0.01),
+    ("min_weight", 1e100),
+    ("min_weight", True),
+    ("max_weight", 0.0),
+    ("max_weight", -1.0),
+    ("max_weight", 1e100),
+    ("max_weight", True),
+    ("logit_scale", 0.0),
+    ("logit_scale", -1.0),
+    ("logit_scale", 1e100),
+    ("logit_scale", True),
+    ("normalize_by_weight", 1),
+    ("adaptive_feature_family", 1),
+    ("adaptive_window", 1),
+    ("adaptive_budget", 1),
+    ("scope_lr", -0.1),
+    ("scope_lr", 1e100),
+    ("scope_lr", True),
+    ("budget_lr", -0.1),
+    ("budget_lr", 1e100),
+    ("budget_lr", True),
+    ("initial_budget_fraction", 0.0),
+    ("initial_budget_fraction", -0.1),
+    ("initial_budget_fraction", 1.1),
+    ("initial_budget_fraction", 1e100),
+    ("initial_budget_fraction", True),
+    ("min_effective_budget", 0),
+    ("min_effective_budget", 513),
+    ("min_effective_budget", True),
+    ("scope_logit_clip", 0.0),
+    ("scope_logit_clip", -1.0),
+    ("scope_logit_clip", 1e100),
+    ("scope_logit_clip", True),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_PIPELINE_ASSOCIATIVE_FIELDS)
+def test_pipeline_associative_fields_reject_invalid_inputs(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError):
+        Step2AssociativePipelineConfig(**{field: value})
+
+
+_INVALID_PIPELINE_HORDE_AC_FIELDS: tuple[tuple[str, object], ...] = (
+    ("n_actions", 0),
+    ("n_actions", 2**31),
+    ("n_actions", True),
+    ("actor_step_size", -0.01),
+    ("actor_step_size", 1e100),
+    ("actor_step_size", True),
+    ("actor_lamda", -0.1),
+    ("actor_lamda", 1.1),
+    ("actor_lamda", 1e100),
+    ("actor_lamda", True),
+    ("temperature", 0.0),
+    ("temperature", -1.0),
+    ("temperature", 1e100),
+    ("temperature", True),
+    ("value_head_index", -1),
+    ("value_head_index", 2**31),
+    ("value_head_index", True),
+    ("actor_obgd_kappa", 0.0),
+    ("actor_obgd_kappa", -1.0),
+    ("actor_obgd_kappa", 1e100),
+    ("actor_obgd_kappa", True),
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INVALID_PIPELINE_HORDE_AC_FIELDS)
+def test_pipeline_horde_ac_fields_reject_invalid_inputs(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        HordeActorCriticPipelineConfig(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 0}, "steps"),
+        ({"steps": -1}, "steps"),
+        ({"steps": 2**31}, "steps"),
+        ({"steps": True}, "steps"),
+        ({"steps": "24"}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_pipeline_smoke_rejects_invalid_inputs(kwargs: dict[str, object], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_pipeline_smoke(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_pipeline_unit_interval_rejects_adversarial_ratio_floats(
+    ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"sparsity must be in \[0, 1\]"):
+        Step2UPGDConfig(sparsity=HiddenBoundaryFloat(0.5))
+
+
+def test_pipeline_nonnegative_rejects_adversarial_negative_ratio() -> None:
+    class HiddenNegativeFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 1)
+
+    with pytest.raises(ValueError, match=r"step_size must be non-negative"):
+        Step2UPGDConfig(step_size=HiddenNegativeFloat(0.5))
+
+
+def test_pipeline_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        Step2UPGDConfig(step_size=value)  # type: ignore[arg-type]
+
+
 # silence the import lint warnings used in the test runner
 _ = jax


### PR DESCRIPTION
Closes #437.

## What changed

`Step2FeatureConfig`, `Step2UPGDConfig`, `Step2AssociativePipelineConfig`, `HordeActorCriticPipelineConfig`, and `run_pipeline_smoke` now strictly validate scalar hyperparameters, float32 execution sink bounds, and exact integer ratios before constructing pipeline components. Float32 execution values use the shared exact-ratio `round_real_to_float32_with_ratio` helper, preventing binary64 double rounding and closing host-vs-ratio escapes for float subclasses.

Exact float32 overflow is rejected across `ema_decay`, `periods`, `step_size`, `sparsity`, `write_lr`, `retention`, `utility_lr`, `utility_decay`, `min_weight`, `max_weight`, `logit_scale`, `scope_lr`, `budget_lr`, `initial_budget_fraction`, `scope_logit_clip`, `actor_step_size`, `actor_lamda`, `temperature`, and `actor_obgd_kappa`. Integer dimensions, counts, sizes, and smoke arguments (`steps`, `seed`) are bounded to standard signed int32 bounds (`2**31 - 1`).

## Scope

• `alberta_framework/_float32.py`
• `alberta_framework/pipeline.py`
• `tests/test_pipeline.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Pipeline test suite: 150 passed in 23s;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is facade input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported