### PR TITLE
fix(optimizers): clip AGC per output unit, not per input feature

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -151,13 +151,14 @@ class ObGDBounding(Bounder):
 def _unitwise_norm(x: Array) -> Array:
     """Compute unit-wise L2 norm.
 
-    For 2D+ arrays (e.g. weight matrices ``(fan_in, fan_out)``):
-    L2 norm over all axes except the last, with keepdims for broadcasting.
+    For 2D+ arrays (weight matrices laid out ``(fan_out, fan_in)`` throughout
+    this framework, so each row is one output unit's incoming weights): L2
+    norm over all axes except the first, with keepdims for broadcasting.
     For 1D arrays (biases): absolute value per element.
     For scalars: absolute value.
     """
     if x.ndim >= 2:
-        return jnp.sqrt(jnp.sum(x**2, axis=tuple(range(x.ndim - 1)), keepdims=True))
+        return jnp.sqrt(jnp.sum(x**2, axis=tuple(range(1, x.ndim)), keepdims=True))
     return jnp.abs(x)
 
 

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -1,5 +1,6 @@
 """Tests for the MLPLearner and run_mlp_learning_loop."""
 
+import math
 import time
 
 import chex
@@ -714,9 +715,30 @@ class TestAGCBounding:
         bounder = AGCBounding(clip_factor=0.01, eps=1e-3)
         _, frac = bounder.bound(steps, error, params)
 
-        # 2D has 3 output units (all clipped), 1D has 3 elements (none clipped)
-        # Total units = 6, clipped = 3 -> frac = 0.5
-        assert float(frac) == pytest.approx(0.5, abs=0.01)
+        # 2D (fan_out=2, fan_in=3) has 2 output units (all clipped), 1D has 3
+        # elements (none clipped). Total units = 5, clipped = 2 -> frac = 0.4
+        assert float(frac) == pytest.approx(0.4, abs=0.01)
+
+    def test_clipping_is_per_output_unit_not_per_input_column(self):
+        """Rows of (fan_out, fan_in) are the units; a loud row must not shield a quiet one."""
+        bounder = AGCBounding(clip_factor=0.01, eps=1e-3)
+        error = jnp.array(1.0)
+        # Case 1: identical unit weights, unit 0 takes a huge step, unit 1 a tiny one.
+        params = (jnp.ones((2, 2)),)
+        steps = (jnp.array([[1e3, 0.0], [1e-3, 0.0]], dtype=jnp.float32),)
+        (clipped,), frac = bounder.bound(steps, error, params)
+        # unit 1's own budget is clip_factor * ||w_1|| = 0.01 * sqrt(2) > 1e-3: untouched
+        assert float(clipped[1, 0]) == pytest.approx(1e-3, rel=1e-5)
+        # unit 0 is clipped to its own budget
+        assert float(jnp.linalg.norm(clipped[0])) == pytest.approx(0.01 * math.sqrt(2.0), rel=1e-4)
+        assert float(frac) == pytest.approx(0.5)
+        # Case 2: unit 0 has huge weights, unit 1 tiny weights; only unit 1 moves.
+        params = (jnp.array([[1e3, 1e3], [1e-3, 1e-3]], dtype=jnp.float32),)
+        steps = (jnp.array([[0.0, 0.0], [0.5, 0.5]], dtype=jnp.float32),)
+        (clipped,), frac = bounder.bound(steps, error, params)
+        # unit 1's budget is 0.01 * ||[1e-3, 1e-3]|| = 1.41e-5; its step must be clipped there
+        assert float(jnp.linalg.norm(clipped[1])) == pytest.approx(0.01 * math.sqrt(2e-6), rel=1e-4)
+        assert float(frac) == pytest.approx(0.5)
 
     def test_mlp_with_agc_runs(self):
         """MLPLearner with AGCBounding should run without error in a scan loop."""


### PR DESCRIPTION
Closes #439.

## Issue

`_unitwise_norm` reduced over every axis except the last, but every weight matrix in this framework is `(fan_out, fan_in)`, so `AGCBounding` measured and clipped per input column: a quiet output unit sharing a column with a loud one was scaled by ~1e-5, a unit 5e4× over its own budget passed untouched, and `frac_clipped` counted input features.

## New state

`_unitwise_norm` reduces over all axes except the first (rows = output units) with `keepdims`, and its docstring states the `(fan_out, fan_in)` layout; biases and scalars are unchanged. Uniform inputs (the existing tests) produce the same clipped values as before; only the per-unit attribution and `frac_clipped`'s denominator change.

Failing-test-first: `TestAGCBounding::test_clipping_is_per_output_unit_not_per_input_column` (both cases above: quiet unit untouched / over-budget unit clipped to its own budget, `frac_clipped == 0.5`) fails on `main` and passes here. `test_metric_fraction_clipped`'s pinned fraction moves from `0.5` (3 "units" read off the wrong axis of a `(2, 3)` matrix + 3 biases) to `0.4` (2 output units + 3 biases); its comment is corrected.

## Evidence

Falsifier from #439 at this head:

```text
CASE 1: unit1 step: got 0.001        want 0.001        (ratio 1x)
CASE 2: unit1 |step|: got 1.41421e-05 want 1.41421e-05  frac_clipped = 0.5
```

Verification at `8d91aaf99070c5e87c16c15301bbc0c770dfad2a`:

```text
.venv/bin/python -m pytest tests/test_mlp_learner.py tests/test_multi_head_learner.py tests/test_config_serialization.py tests/test_optimizers*.py tests/test_upgd.py -q -o addopts=""   -> 297 passed
.venv/bin/python -m ruff check .                                                                                                                       -> All checks passed!
.venv/bin/python -m mypy                                                                                                                               -> Success: no issues found in 164 source files
```

`core/optimizers.py` is imported by the robot track and stays importable (public API unchanged); it is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:8d91aaf99070c5e87c16c15301bbc0c770dfad2a -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
