### PR TITLE
fix(screening): apply curve typing and domain checks to legacy v1 shards

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -8168,22 +8168,24 @@ def load_shard(path: Path) -> dict[str, Any]:
             payload["dataset_provenance"], config, context=str(path)
         )
     for fieldname in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
-        if is_v2:
-            raw_values = payload[fieldname]
-            if (
-                not isinstance(raw_values, list)
-                or len(raw_values) != config.n_tasks
-                or any(not _is_finite_json_number(value) for value in raw_values)
-            ):
-                raise ValueError(
-                    f"{path}: {fieldname} must be a list of finite JSON numbers "
-                    f"with length {config.n_tasks}"
-                )
-        values = np.asarray(payload[fieldname], dtype=np.float64)
+        # Curve typing and metric-domain checks apply to every schema: the
+        # legacy v1 shards are the campaign's live format, and a numeric
+        # string, boolean, or out-of-domain value would otherwise rank.
+        raw_values = payload.get(fieldname)
+        if (
+            not isinstance(raw_values, list)
+            or len(raw_values) != config.n_tasks
+            or any(not _is_finite_json_number(value) for value in raw_values)
+        ):
+            raise ValueError(
+                f"{path}: {fieldname} must be a list of finite JSON numbers "
+                f"with length {config.n_tasks}"
+            )
+        values = np.asarray(raw_values, dtype=np.float64)
         if values.shape != (config.n_tasks,) or not np.all(np.isfinite(values)):
             raise ValueError(f"{path}: {fieldname} must be finite with shape ({config.n_tasks},)")
-        if is_v2:
-            _require_screening_curve_domain(values, fieldname, context=str(path))
+        _require_screening_curve_domain(values, fieldname, context=str(path))
+        payload[fieldname] = [float(value) for value in values]
     payload["wall_clock_seconds"] = _validated_wall_clock_seconds(
         payload.get("wall_clock_seconds"), path
     )

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -1134,6 +1134,59 @@ class TestShardsAndMerge:
         path.write_text(json.dumps(payload), encoding="utf-8")
         return path
 
+    @pytest.mark.parametrize(
+        ("fieldname", "mutate", "message"),
+        [
+            ("per_task_accuracy", lambda curve: [5.0] * len(curve), r"must be in \[0, 1\]"),
+            ("per_task_accuracy", lambda curve: [-0.5] * len(curve), r"must be in \[0, 1\]"),
+            ("per_task_plasticity", lambda curve: [1.5] * len(curve), r"must be in \[0, 1\]"),
+            ("per_task_loss", lambda curve: [-1.0] * len(curve), "must be non-negative"),
+            (
+                "per_task_accuracy",
+                lambda curve: [str(v) for v in curve],
+                "must be a list of finite JSON numbers",
+            ),
+            (
+                "per_task_accuracy",
+                lambda curve: [True] * len(curve),
+                "must be a list of finite JSON numbers",
+            ),
+            (
+                "per_task_loss",
+                lambda curve: [str(v) for v in curve],
+                "must be a list of finite JSON numbers",
+            ),
+        ],
+    )
+    def test_load_shard_applies_curve_typing_and_domain_to_legacy_v1(
+        self, tmp_path, fieldname, mutate, message
+    ):
+        """v1 is the campaign's live shard format; its curves get the same domain checks as v2."""
+        path = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload[fieldname] = mutate(list(payload[fieldname]))
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError, match=message):
+            load_shard(path)
+
+    def test_load_shard_canonicalizes_legacy_v1_integer_curve_entries(self, tmp_path):
+        path = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["per_task_accuracy"] = [1] + payload["per_task_accuracy"][1:]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        loaded = load_shard(path)
+        assert loaded["per_task_accuracy"][0] == 1.0
+        assert type(loaded["per_task_accuracy"][0]) is float
+
+    def test_out_of_domain_legacy_shard_cannot_top_a_merge(self, tmp_path):
+        control = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
+        winner = self._write_inband_shard(tmp_path, "upgd_l2init", 0, 0.6)
+        payload = json.loads(winner.read_text(encoding="utf-8"))
+        payload["per_task_accuracy"] = [5.0] * SMALL.n_tasks
+        winner.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError, match=r"must be in \[0, 1\]"):
+            merge_shards([control, winner], control_name="upgd_w_control", slope_window=2)
+
     def test_load_shard_rejects_invalid_wall_clock_types_and_values(self, tmp_path):
         path = self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.5)
         payload = json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes #442.

## Issue

`load_shard` gated the finite-JSON-number typing and the accuracy/plasticity `[0, 1]` / loss `>= 0` domain checks on the v2 schema, but every shard in the campaign is legacy v1: a v1 shard with numeric strings, booleans, or an accuracy of `5.0` loaded, topped `merge_shards`, and set `confirmation_candidate`.

## New state

The curve loop applies the same typing (`must be a list of finite JSON numbers with length n_tasks`) and `_require_screening_curve_domain` checks to every schema, and canonicalizes loaded curve entries to `float`; the provenance/registry checks stay v2-only. All 450 real v1 shards under `outputs/ipmnist_screening/` that load on `main` still load at this head (the 9 `rls_head_*` shards with JSON `NaN` are already rejected on `main`); no artifact was modified.

Failing-test-first: `test_load_shard_applies_curve_typing_and_domain_to_legacy_v1[…]` (7 cases: accuracy above 1 / below 0, plasticity above 1, negative loss, numeric strings ×2, booleans) and `test_out_of_domain_legacy_shard_cannot_top_a_merge` fail on `main` and pass here; `test_load_shard_canonicalizes_legacy_v1_integer_curve_entries` pins canonicalization.

## Evidence

Falsifier from #442 at this head:

```text
ValueError: .../upgd_l2init_seed0.json: per_task_accuracy values must be in [0, 1]
ValueError: .../upgd_w_control_seed0.json: per_task_accuracy must be a list of finite JSON numbers with length 3
```

Verification at `6298d1c8b297d244e6d18007735834aed1d0a7eb`:

```text
.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q -o addopts=""   -> 315 passed
real v1 shards under outputs/ipmnist_screening: 450 loaded, 9 rejected (identical to main)
.venv/bin/python -m ruff check .                                             -> All checks passed!
.venv/bin/python -m mypy                                                     -> Success: no issues found in 164 source files
```

`benchmarks/ipmnist_screening.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:6298d1c8b297d244e6d18007735834aed1d0a7eb -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, artifact load sweep, ruff, mypy at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
