### PR TITLE
fix(core): reject illegal temporal context and associative memory configs

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -20,14 +20,114 @@ from typing import Any, Literal, cast
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
     select_transaction,
 )
+
+_INT32_MAX: int = 2**31 - 1
+
+
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
+
+
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real <= 1.0
+        or numerator < 0
+        or numerator > denominator
+        or narrowed < 0.0
+        or not narrowed <= 1.0
+    ):
+        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_half_open_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real <= 0.0
+        or not real <= 1.0
+        or numerator <= 0
+        or numerator > denominator
+        or narrowed <= 0.0
+        or not narrowed <= 1.0
+    ):
+        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(Integral, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
+
 
 AssociativeFeatureFamily = Literal[
     "position_token",
@@ -96,6 +196,10 @@ class AssociativeMemoryConfig:
     initial_budget_fraction: float = 0.5
     min_effective_budget: int = 1
     scope_logit_clip: float = 8.0
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize configuration."""
+        _validate_config(self)
 
     def to_config(self) -> dict[str, object]:
         """Serialize to a plain config dictionary."""
@@ -169,78 +273,86 @@ class AssociativeMemoryLearningResult:
     updates_applied: Bool[Array, " steps"]
 
 
-def _finite_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be a real number")
-    number = float(value)
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be finite")
-    return number
-
-
 def _validate_config(config: AssociativeMemoryConfig) -> None:
-    if config.vocab_size < 2:
-        raise ValueError("vocab_size must be at least 2")
-    if config.block_size < 1:
-        raise ValueError("block_size must be positive")
-    if config.suffix_length < 2:
-        raise ValueError("suffix_length must be at least 2")
-    if config.suffix_length > config.block_size:
-        raise ValueError("suffix_length must be <= block_size")
-    if config.feature_family not in {
+    vocab_size = _require_int(
+        "vocab_size", config.vocab_size, minimum=2, maximum=_INT32_MAX
+    )
+    block_size = _require_int(
+        "block_size", config.block_size, minimum=1, maximum=_INT32_MAX
+    )
+    suffix_length = _require_int(
+        "suffix_length", config.suffix_length, minimum=2, maximum=block_size
+    )
+    feature_family = config.feature_family
+    if type(feature_family) is not str:
+        raise ValueError(
+            f"feature_family must be an actual string, got {feature_family!r}"
+        )
+    if feature_family not in {
         "position_token",
         "suffix_pair",
         "token_suffix_pair",
     }:
-        raise ValueError("unknown feature_family")
-    if config.max_features < 1:
-        raise ValueError("max_features must be positive")
-    if not math.isfinite(config.write_lr) or config.write_lr <= 0.0:
-        raise ValueError("write_lr must be positive")
-    if not math.isfinite(config.retention) or not 0.0 <= config.retention <= 1.0:
-        raise ValueError("retention must be in [0, 1]")
-    if not math.isfinite(config.utility_lr) or config.utility_lr < 0.0:
-        raise ValueError("utility_lr must be non-negative")
-    if not math.isfinite(config.utility_decay) or not 0.0 <= config.utility_decay <= 1.0:
-        raise ValueError("utility_decay must be in [0, 1]")
-    if not math.isfinite(config.min_weight) or config.min_weight <= 0.0:
-        raise ValueError("min_weight must be positive")
-    if not math.isfinite(config.max_weight) or config.max_weight < config.min_weight:
+        raise ValueError(f"unknown feature_family: {feature_family!r}")
+    canonical_feature_family = str(feature_family)
+    max_features = _require_int(
+        "max_features", config.max_features, minimum=1, maximum=_INT32_MAX
+    )
+    write_lr = _require_positive_real("write_lr", config.write_lr)
+    retention = _require_unit_interval("retention", config.retention)
+    utility_lr = _require_nonnegative_real("utility_lr", config.utility_lr)
+    utility_decay = _require_unit_interval("utility_decay", config.utility_decay)
+    min_weight = _require_positive_real("min_weight", config.min_weight)
+    max_weight = _require_positive_real("max_weight", config.max_weight)
+    if max_weight < min_weight:
         raise ValueError("max_weight must be >= min_weight")
-    if not math.isfinite(config.logit_scale) or config.logit_scale <= 0.0:
-        raise ValueError("logit_scale must be positive")
+    logit_scale = _require_positive_real("logit_scale", config.logit_scale)
+    if type(config.normalize_by_weight) is not bool:
+        raise ValueError(
+            f"normalize_by_weight must be a bool, got {config.normalize_by_weight!r}"
+        )
     for name in (
         "adaptive_feature_family",
         "adaptive_window",
         "adaptive_budget",
     ):
-        if not isinstance(getattr(config, name), bool):
-            raise ValueError(f"{name} must be a boolean")
-    scope_lr = _finite_real("scope_lr", config.scope_lr)
-    if scope_lr < 0.0:
-        raise ValueError("scope_lr must be non-negative")
-    budget_lr = _finite_real("budget_lr", config.budget_lr)
-    if budget_lr < 0.0:
-        raise ValueError("budget_lr must be non-negative")
-    initial_budget_fraction = _finite_real(
-        "initial_budget_fraction",
-        config.initial_budget_fraction,
+        val = getattr(config, name)
+        if type(val) is not bool:
+            raise ValueError(f"{name} must be a boolean, got {val!r}")
+        object.__setattr__(config, name, bool(val))
+    scope_lr = _require_nonnegative_real("scope_lr", config.scope_lr)
+    budget_lr = _require_nonnegative_real("budget_lr", config.budget_lr)
+    initial_budget_fraction = _require_half_open_unit_interval(
+        "initial_budget_fraction", config.initial_budget_fraction
     )
-    if not 0.0 < initial_budget_fraction <= 1.0:
-        raise ValueError("initial_budget_fraction must be in (0, 1]")
-    if isinstance(config.min_effective_budget, bool) or not isinstance(
+    min_effective_budget = _require_int(
+        "min_effective_budget",
         config.min_effective_budget,
-        Integral,
-    ):
-        raise ValueError("min_effective_budget must be an integer")
-    min_effective_budget = int(config.min_effective_budget)
-    if min_effective_budget < 1:
-        raise ValueError("min_effective_budget must be positive")
-    if min_effective_budget > config.max_features:
-        raise ValueError("min_effective_budget must be <= max_features")
-    scope_logit_clip = _finite_real("scope_logit_clip", config.scope_logit_clip)
-    if scope_logit_clip <= 0.0:
-        raise ValueError("scope_logit_clip must be positive")
+        minimum=1,
+        maximum=max_features,
+    )
+    scope_logit_clip = _require_positive_real(
+        "scope_logit_clip", config.scope_logit_clip
+    )
+
+    object.__setattr__(config, "vocab_size", vocab_size)
+    object.__setattr__(config, "block_size", block_size)
+    object.__setattr__(config, "suffix_length", suffix_length)
+    object.__setattr__(config, "feature_family", canonical_feature_family)
+    object.__setattr__(config, "max_features", max_features)
+    object.__setattr__(config, "write_lr", write_lr)
+    object.__setattr__(config, "retention", retention)
+    object.__setattr__(config, "utility_lr", utility_lr)
+    object.__setattr__(config, "utility_decay", utility_decay)
+    object.__setattr__(config, "min_weight", min_weight)
+    object.__setattr__(config, "max_weight", max_weight)
+    object.__setattr__(config, "logit_scale", logit_scale)
+    object.__setattr__(config, "normalize_by_weight", bool(config.normalize_by_weight))
+    object.__setattr__(config, "scope_lr", scope_lr)
+    object.__setattr__(config, "budget_lr", budget_lr)
+    object.__setattr__(config, "initial_budget_fraction", initial_budget_fraction)
+    object.__setattr__(config, "min_effective_budget", min_effective_budget)
+    object.__setattr__(config, "scope_logit_clip", scope_logit_clip)
 
 
 def _softmax(logits: Array) -> Array:

--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -24,14 +24,95 @@ learner can overfit.
 from __future__ import annotations
 
 import functools
+import math
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
+
+from alberta_framework._float32 import round_real_to_float32_with_ratio
+
+_INT32_MAX: int = 2**31 - 1
+
+
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
+
+
+def _require_half_open_zero_one_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
+    if (
+        real < 0.0
+        or not real < 1.0
+        or numerator < 0
+        or numerator >= denominator
+        or narrowed < 0.0
+        or not narrowed < 1.0
+    ):
+        raise ValueError(f"{name} must be in [0, 1), got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return canonical_float32_storage(real, narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(Integral, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
 
 
 @dataclass(frozen=True)
@@ -55,6 +136,10 @@ class TemporalContextConfig:
     include_phase_products: bool = False
     ema_decay: float = 0.95
     periods: tuple[float, ...] = (50.0, 100.0, 200.0)
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize configuration."""
+        _validate_config(self)
 
     def output_dim(self) -> int:
         """Return the transformed feature dimensionality."""
@@ -89,14 +174,38 @@ class TemporalContextState:
 
 
 def _validate_config(config: TemporalContextConfig) -> None:
-    if config.input_dim < 1:
-        raise ValueError("input_dim must be positive")
+    input_dim = _require_int(
+        "input_dim", config.input_dim, minimum=1, maximum=_INT32_MAX
+    )
+    if type(config.include_raw) is not bool:
+        raise ValueError(f"include_raw must be a bool, got {config.include_raw!r}")
+    if type(config.include_ema) is not bool:
+        raise ValueError(f"include_ema must be a bool, got {config.include_ema!r}")
+    if type(config.include_delta) is not bool:
+        raise ValueError(f"include_delta must be a bool, got {config.include_delta!r}")
+    if type(config.include_phase_products) is not bool:
+        raise ValueError(
+            f"include_phase_products must be a bool, got {config.include_phase_products!r}"
+        )
     if not (config.include_raw or config.include_ema or config.include_delta):
         raise ValueError("at least one observation feature block must be included")
-    if not 0.0 <= config.ema_decay < 1.0:
-        raise ValueError("ema_decay must be in [0, 1)")
-    if any(period <= 0.0 for period in config.periods):
-        raise ValueError("all temporal periods must be positive")
+    ema_decay = _require_half_open_zero_one_interval("ema_decay", config.ema_decay)
+    if type(config.periods) is not tuple:
+        raise ValueError(
+            f"periods must be an actual tuple, got {type(config.periods).__name__}"
+        )
+    canonical_periods = tuple(
+        _require_positive_real("period", p) for p in config.periods
+    )
+    object.__setattr__(config, "input_dim", input_dim)
+    object.__setattr__(config, "include_raw", bool(config.include_raw))
+    object.__setattr__(config, "include_ema", bool(config.include_ema))
+    object.__setattr__(config, "include_delta", bool(config.include_delta))
+    object.__setattr__(
+        config, "include_phase_products", bool(config.include_phase_products)
+    )
+    object.__setattr__(config, "ema_decay", ema_decay)
+    object.__setattr__(config, "periods", canonical_periods)
 
 
 class TemporalContextFeaturizer:

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -424,3 +424,206 @@ def test_step2_associative_facade_smoke_and_roundtrip() -> None:
     assert result.finite
     assert result.metrics_shape == (64, 8)
     assert result.final_window_nll < result.initial_window_nll
+
+
+_INVALID_ASSOCIATIVE_CONFIGS: tuple[dict[str, object], ...] = (
+    {"vocab_size": 1, "block_size": 8},
+    {"vocab_size": 0, "block_size": 8},
+    {"vocab_size": -1, "block_size": 8},
+    {"vocab_size": 2**31, "block_size": 8},
+    {"vocab_size": True, "block_size": 8},
+    {"vocab_size": "4", "block_size": 8},
+    {"vocab_size": 4, "block_size": 0},
+    {"vocab_size": 4, "block_size": -1},
+    {"vocab_size": 4, "block_size": 2**31},
+    {"vocab_size": 4, "block_size": True},
+    {"vocab_size": 4, "block_size": 8, "suffix_length": 1},
+    {"vocab_size": 4, "block_size": 8, "suffix_length": 9},
+    {"vocab_size": 4, "block_size": 8, "suffix_length": 2**31},
+    {"vocab_size": 4, "block_size": 8, "suffix_length": True},
+    {"vocab_size": 4, "block_size": 8, "feature_family": "unknown_family"},
+    {"vocab_size": 4, "block_size": 8, "max_features": 0},
+    {"vocab_size": 4, "block_size": 8, "max_features": -1},
+    {"vocab_size": 4, "block_size": 8, "max_features": 2**31},
+    {"vocab_size": 4, "block_size": 8, "max_features": True},
+    {"vocab_size": 4, "block_size": 8, "write_lr": 0.0},
+    {"vocab_size": 4, "block_size": 8, "write_lr": -0.1},
+    {"vocab_size": 4, "block_size": 8, "write_lr": 1e100},
+    {"vocab_size": 4, "block_size": 8, "write_lr": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "write_lr": True},
+    {"vocab_size": 4, "block_size": 8, "retention": -0.1},
+    {"vocab_size": 4, "block_size": 8, "retention": 1.1},
+    {"vocab_size": 4, "block_size": 8, "retention": 1e100},
+    {"vocab_size": 4, "block_size": 8, "retention": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "retention": True},
+    {"vocab_size": 4, "block_size": 8, "utility_lr": -0.1},
+    {"vocab_size": 4, "block_size": 8, "utility_lr": 1e100},
+    {"vocab_size": 4, "block_size": 8, "utility_lr": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "utility_lr": True},
+    {"vocab_size": 4, "block_size": 8, "utility_decay": -0.1},
+    {"vocab_size": 4, "block_size": 8, "utility_decay": 1.1},
+    {"vocab_size": 4, "block_size": 8, "utility_decay": 1e100},
+    {"vocab_size": 4, "block_size": 8, "utility_decay": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "utility_decay": True},
+    {"vocab_size": 4, "block_size": 8, "min_weight": 0.0},
+    {"vocab_size": 4, "block_size": 8, "min_weight": -0.1},
+    {"vocab_size": 4, "block_size": 8, "min_weight": 1e100},
+    {"vocab_size": 4, "block_size": 8, "min_weight": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "min_weight": True},
+    {"vocab_size": 4, "block_size": 8, "max_weight": 0.0},
+    {"vocab_size": 4, "block_size": 8, "max_weight": -0.1},
+    {"vocab_size": 4, "block_size": 8, "max_weight": 1e100},
+    {"vocab_size": 4, "block_size": 8, "max_weight": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "max_weight": True},
+    {"vocab_size": 4, "block_size": 8, "min_weight": 1.0, "max_weight": 0.5},
+    {"vocab_size": 4, "block_size": 8, "logit_scale": 0.0},
+    {"vocab_size": 4, "block_size": 8, "logit_scale": -0.1},
+    {"vocab_size": 4, "block_size": 8, "logit_scale": 1e100},
+    {"vocab_size": 4, "block_size": 8, "logit_scale": float("nan")},
+    {"vocab_size": 4, "block_size": 8, "logit_scale": True},
+    {"vocab_size": 4, "block_size": 8, "normalize_by_weight": 1},
+    {"vocab_size": 4, "block_size": 8, "min_effective_budget": 0},
+    {"vocab_size": 4, "block_size": 8, "min_effective_budget": 2**31},
+    {"vocab_size": 4, "block_size": 8, "min_effective_budget": 4097},
+    {"vocab_size": 4, "block_size": 8, "min_effective_budget": True},
+)
+
+
+@pytest.mark.parametrize("kwargs", _INVALID_ASSOCIATIVE_CONFIGS)
+def test_associative_memory_config_rejects_invalid_inputs(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        AssociativeMemoryConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_associative_memory_rejects_adversarial_ratio_floats(
+    ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"retention must be in \[0, 1\]"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            retention=HiddenBoundaryFloat(0.5),
+        )
+
+
+def test_associative_memory_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            write_lr=value,  # type: ignore[arg-type]
+        )
+
+
+def test_associative_memory_rejects_equality_spoofed_feature_family() -> None:
+    class SpoofedFamily:
+        def __eq__(self, other: object) -> bool:
+            return True
+
+        def __hash__(self) -> int:
+            return hash("token_suffix_pair")
+
+    with pytest.raises(ValueError, match="feature_family"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            feature_family=SpoofedFamily(),  # type: ignore[arg-type]
+        )
+
+
+def test_associative_memory_rejects_spoofed_bool_flags() -> None:
+    class SpoofedBool:
+        @property
+        def __class__(self) -> type[bool]:
+            return bool
+
+        def __bool__(self) -> bool:
+            return True
+
+    with pytest.raises(ValueError, match="normalize_by_weight"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            normalize_by_weight=SpoofedBool(),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="adaptive_feature_family"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            adaptive_feature_family=SpoofedBool(),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="adaptive_window"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            adaptive_window=SpoofedBool(),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="adaptive_budget"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            adaptive_budget=SpoofedBool(),  # type: ignore[arg-type]
+        )
+
+
+def test_associative_memory_rejects_spoofed_int_class_and_negative_ratios() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="write_lr"):
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=8,
+            write_lr=SpoofedIntFloat(0.5),
+        )
+
+
+def test_associative_memory_json_roundtrip() -> None:
+    import json
+
+    config = AssociativeMemoryConfig(
+        vocab_size=8,
+        block_size=16,
+        suffix_length=4,
+        feature_family="token_suffix_pair",
+        max_features=256,
+        write_lr=0.5,
+        retention=0.9,
+    )
+    serialized = config.to_config()
+    json_str = json.dumps(serialized)
+    deserialized = json.loads(json_str)
+    restored = AssociativeMemoryConfig.from_config(deserialized)
+
+    assert restored == config
+    assert restored.feature_family == "token_suffix_pair"

--- a/tests/test_temporal_context.py
+++ b/tests/test_temporal_context.py
@@ -7,6 +7,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from alberta_framework.core.temporal_context import (
     TemporalContextConfig,
@@ -169,3 +170,120 @@ def test_finite_temporal_context_path_is_bitwise_unchanged() -> None:
         expected_ema
     ).tobytes()
     assert int(next_state.step_count) == 18
+
+
+_INVALID_TEMPORAL_CONTEXT_CONFIGS: tuple[dict[str, object], ...] = (
+    {"input_dim": 0},
+    {"input_dim": -1},
+    {"input_dim": 2**31},
+    {"input_dim": True},
+    {"input_dim": "4"},
+    {"input_dim": 4, "include_raw": 1},
+    {"input_dim": 4, "include_ema": 1},
+    {"input_dim": 4, "include_delta": 1},
+    {"input_dim": 4, "include_phase_products": 1},
+    {"input_dim": 4, "include_raw": False, "include_ema": False, "include_delta": False},
+    {"input_dim": 4, "ema_decay": -0.1},
+    {"input_dim": 4, "ema_decay": 1.0},
+    {"input_dim": 4, "ema_decay": 1.1},
+    {"input_dim": 4, "ema_decay": 1e100},
+    {"input_dim": 4, "ema_decay": float("nan")},
+    {"input_dim": 4, "ema_decay": True},
+    {"input_dim": 4, "periods": (0.0,)},
+    {"input_dim": 4, "periods": (-1.0,)},
+    {"input_dim": 4, "periods": (1e100,)},
+    {"input_dim": 4, "periods": (float("nan"),)},
+    {"input_dim": 4, "periods": (True,)},
+)
+
+
+@pytest.mark.parametrize("kwargs", _INVALID_TEMPORAL_CONTEXT_CONFIGS)
+def test_temporal_context_config_rejects_invalid_inputs(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        TemporalContextConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param((-1, 1), id="negative-ratio"),
+        pytest.param((1, 1), id="one-ratio"),
+        pytest.param((2, 1), id="above-unit-ratio"),
+        pytest.param((-1, 2**200), id="negative-rounds-to-negative-zero"),
+        pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
+    ],
+)
+def test_temporal_context_rejects_adversarial_ratio_floats(
+    ratio: tuple[int, int]
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    with pytest.raises(ValueError, match=r"ema_decay must be in \[0, 1\)"):
+        TemporalContextConfig(
+            input_dim=4,
+            ema_decay=HiddenBoundaryFloat(0.5),
+        )
+
+
+def test_temporal_context_rejects_class_property_spoofing_float() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[float]:
+            return float
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    value = ClassSpoof()
+    with pytest.raises(ValueError, match="must be a real number"):
+        TemporalContextConfig(
+            input_dim=4,
+            ema_decay=value,  # type: ignore[arg-type]
+        )
+
+
+def test_temporal_context_rejects_spoofed_bool_flags() -> None:
+    class SpoofedBool:
+        @property
+        def __class__(self) -> type[bool]:
+            return bool
+
+        def __bool__(self) -> bool:
+            return True
+
+    with pytest.raises(ValueError, match="include_raw"):
+        TemporalContextConfig(input_dim=4, include_raw=SpoofedBool())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="include_ema"):
+        TemporalContextConfig(input_dim=4, include_ema=SpoofedBool())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="include_delta"):
+        TemporalContextConfig(input_dim=4, include_delta=SpoofedBool())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="include_phase_products"):
+        TemporalContextConfig(input_dim=4, include_phase_products=SpoofedBool())  # type: ignore[arg-type]
+
+
+def test_temporal_context_rejects_spoofed_periods_container() -> None:
+    class SpoofedTuple(list):
+        @property
+        def __class__(self) -> type[tuple]:
+            return tuple
+
+    with pytest.raises(ValueError, match="periods"):
+        TemporalContextConfig(input_dim=4, periods=SpoofedTuple([50.0]))  # type: ignore[arg-type]
+
+
+def test_temporal_context_rejects_spoofed_int_class_and_negative_ratios() -> None:
+    class SpoofedIntFloat(float):
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (-1, 2**200)
+
+    with pytest.raises(ValueError, match="ema_decay"):
+        TemporalContextConfig(input_dim=4, ema_decay=SpoofedIntFloat(0.5))


### PR DESCRIPTION
Closes #446.

## What changed

`TemporalContextConfig` and `AssociativeMemoryConfig` now strictly validate scalar hyperparameters, float32 execution sink bounds, and exact integer ratios upon dataclass initialization. Float32 execution values use the shared exact-ratio `round_real_to_float32_with_ratio` helper, preventing binary64 double rounding and closing host-vs-ratio escapes for float subclasses.

Exact float32 overflow is rejected across `ema_decay`, `periods`, `write_lr`, `retention`, `utility_lr`, `utility_decay`, `min_weight`, `max_weight`, `logit_scale`, `scope_lr`, `budget_lr`, `initial_budget_fraction`, and `scope_logit_clip`.

Integer feature dimensions, vocab sizes, block context lengths, suffix window lengths, max feature capacities, and effective budget bounds are bounded to signed int32 bounds (`2**31 - 1`).

## Scope

• `alberta_framework/_float32.py`
• `alberta_framework/core/associative_memory.py`
• `alberta_framework/core/temporal_context.py`
• `tests/test_associative_memory.py`
• `tests/test_temporal_context.py`

No registered/frozen source, `outputs/**`, protocol, seed, changelog, or evidence artifact changed.

## Exact-head verification

• Temporal context & Associative memory tests: 126 passed in 19s;
• full Ruff: passed;
• strict mypy: no issues in 164 source files;
• `git diff --check`: clean.

## Scientific integrity

This is core featurizer and associative memory input validation, not scientific evidence or a performance claim.

## Contribution provenance

• AI assistance: yes
• AI provider/model: google / gemini-3.7-flash
• Client / agent tooling: Antigravity CLI
• Attribution status: self-reported