### PR TITLE
fix(forager): reject numeric aliases in scorer layout

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -3504,10 +3504,25 @@ def _parse_scorer_output(
         {"schema_version", "horizon", "seeds", "result_root", "records"},
         "qualified scorer output",
     )
+    output_horizon = _integer(
+        payload["horizon"],
+        "qualified scorer horizon",
+        minimum=1,
+        maximum=2**31 - 1,
+    )
+    output_seeds = _array(payload["seeds"], "qualified scorer seeds")
+    if len(output_seeds) != 1:
+        raise ForagerMatchedExecutorError("qualified scorer must emit exactly one seed")
+    output_seed = _integer(
+        output_seeds[0],
+        "qualified scorer seed",
+        minimum=0,
+        maximum=2**31 - 1,
+    )
     if (
         payload["schema_version"] != SCORER_OUTPUT_SCHEMA
-        or payload["horizon"] != plan.protocol.horizon
-        or payload["seeds"] != [seed]
+        or output_horizon != plan.protocol.horizon
+        or output_seed != seed
         or payload["result_root"] != candidate.result_root
     ):
         raise ForagerMatchedExecutorError("qualified scorer output contract drift")
@@ -3539,13 +3554,46 @@ def _parse_scorer_output(
     ).as_posix()
     sample_count = (plan.protocol.horizon + 99) // 100
     tail_start = int(0.9 * sample_count)
+    record_seed = _integer(
+        record["seed"],
+        "qualified scorer record seed",
+        minimum=0,
+        maximum=2**31 - 1,
+    )
+    reward_shape = _array(record["reward_shape"], "qualified scorer reward shape")
+    if len(reward_shape) != 1:
+        raise ForagerMatchedExecutorError("qualified scorer reward shape must have one dimension")
+    reward_length = _integer(
+        reward_shape[0],
+        "qualified scorer reward length",
+        minimum=1,
+        maximum=2**31 - 1,
+    )
+    ema_sample_count = _integer(
+        record["ema_sample_count"],
+        "qualified scorer EMA sample count",
+        minimum=1,
+        maximum=2**31 - 1,
+    )
+    ema_tail_start_index = _integer(
+        record["ema_tail_start_index"],
+        "qualified scorer EMA tail start index",
+        minimum=0,
+        maximum=2**31 - 1,
+    )
+    ema_tail_sample_count = _integer(
+        record["ema_tail_sample_count"],
+        "qualified scorer EMA tail sample count",
+        minimum=1,
+        maximum=2**31 - 1,
+    )
     if (
-        record["seed"] != seed
+        record_seed != seed
         or record["archive_path"] != expected_archive
-        or record["reward_shape"] != [plan.protocol.horizon]
-        or record["ema_sample_count"] != sample_count
-        or record["ema_tail_start_index"] != tail_start
-        or record["ema_tail_sample_count"] != sample_count - tail_start
+        or reward_length != plan.protocol.horizon
+        or ema_sample_count != sample_count
+        or ema_tail_start_index != tail_start
+        or ema_tail_sample_count != sample_count - tail_start
     ):
         raise ForagerMatchedExecutorError("qualified scorer seed/horizon/trace layout drift")
     _sha256(record["npz_sha256"], "qualified scorer NPZ digest")

--- a/tests/test_forager_matched_executor.py
+++ b/tests/test_forager_matched_executor.py
@@ -2078,6 +2078,41 @@ def test_scorer_output_rejects_extra_reward_values_and_noncanonical_bytes(
         )
 
 
+@pytest.mark.parametrize(
+    ("path", "replacement"),
+    [
+        (("horizon",), 499_712.0),
+        (("seeds", 0), float(2_300_001)),
+        (("records", 0, "seed"), float(2_300_001)),
+        (("records", 0, "reward_shape", 0), 499_712.0),
+        (("records", 0, "ema_sample_count"), 4_998.0),
+        (("records", 0, "ema_tail_start_index"), 4_498.0),
+        (("records", 0, "ema_tail_sample_count"), 500.0),
+        (("records", 0, "ema_tail_sample_count"), True),
+    ],
+)
+def test_scorer_output_rejects_numeric_aliases_for_integer_fields(
+    tmp_path: Path,
+    path: tuple[str | int, ...],
+    replacement: float | bool,
+) -> None:
+    plan = _plan(tmp_path)
+    seed = plan.protocol.active_seeds[0]
+    payload = executor.decode_strict_json(_scoring_output(plan, seed))
+    target: Any = payload
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = replacement
+
+    with pytest.raises(executor.ForagerMatchedExecutorError, match="must be an integer"):
+        executor._parse_scorer_output(
+            executor.canonical_json_bytes(payload),
+            plan=plan,
+            candidate=plan.candidates[0],
+            seed=seed,
+        )
+
+
 def test_execute_seed_rejects_raw_archive_mutation_during_scoring(tmp_path: Path) -> None:
     plan = _plan(tmp_path)
     live = _runtime(tmp_path, plan)


### PR DESCRIPTION
Closes #450.

## What changed

`_parse_scorer_output` validated integer-valued scorer layout fields (horizon, seeds, record seed, reward length, EMA sample count, EMA tail start index, EMA tail sample count) using bare equality (`!=`) instead of an exact-type integer check. Python/JSON numeric aliases such as `4998.0 == 4998` (or `True == 1`) let malformed qualified-scorer output cross the validation boundary undetected — the accepted float value was then retained in the parsed record, so downstream hash-only evidence could be built from an artifact that actually violates its documented integer schema.

confirmed directly before touching the source: a real plan fixture with `ema_sample_count` set to `float(...)` (numerically equal to, but not type-equal to, the expected integer) was accepted by `_parse_scorer_output` instead of being rejected.

fix: route every integer-valued layout field through the executor's existing exact `_integer` validator (already used by sibling parsers, requiring `type(value) is int`) before comparing against the frozen protocol-derived value, and validate the seed list and reward shape each contain exactly one element.

## Reachability

Real, installed CLI path — confirmed directly: `pyproject.toml`'s `alberta-forager-matched-campaign = alberta_framework.benchmarks.forager_matched_campaign:main` → campaign execution/recovery → `executor.execute_seed`/`executor.score_seed_archive` → `_parse_scorer_output`. This parser consumes canonical bytes emitted by the qualified in-image scorer subprocess — not hardcoded-safe values — and must independently validate them before evidence artifacts are constructed. Not re-exported from either `__init__.py`; reachability is through the installed console script.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_executor.py -q -o addopts=""
93 passed in 4.50s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_executor.py tests/test_forager_matched_executor.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_scorer_output_rejects_numeric_aliases_for_integer_fields`, parametrized over 8 float/bool aliases across every affected field (horizon, seed, record seed, reward-shape length, EMA sample count, EMA tail start index, EMA tail sample count), asserting `ForagerMatchedExecutorError` matching `"must be an integer"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_executor.py`, kept the test), reran — 8/8 failed. 7 of the 8 float aliases were silently accepted (`DID NOT RAISE`), directly reproducing the bug. The 8th (a boolean alias on `ema_tail_sample_count`) still raised an error under the old code, but the *wrong* one (`"layout drift"` instead of `"must be an integer"`) — because for this specific fixture, `True`'s value (`1`) doesn't happen to coincide with the field's expected numeric value, so the old bare-equality check catches it for an unrelated reason (wrong number, not wrong type). This doesn't weaken the finding: the other 7 cases conclusively demonstrate the type-confusion bug where the numeric value *does* coincide, which is the realistic failure mode for a scorer emitting `4998.0` instead of `4998`. restored the fix, 93/93 green again.

## Evidence

<!-- evidence-head -->
c993d3861ae5abf2b1cc42c991b512e6efe29832

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_forager_matched_executor.py -q -o addopts="" -k test_scorer_output_rejects_numeric_aliases_for_integer_fields
FAILED [path0-499712.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path1-2300001.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path2-2300001.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path3-499712.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path4-4998.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path5-4498.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path6-500.0] - DID NOT RAISE ForagerMatchedExecutorError
FAILED [path7-True] - AssertionError: Regex pattern did not match. Actual message: 'qualified scorer seed/horizon/trace layout drift'
8 failed, 85 deselected in 1.53s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_forager_matched_executor.py -q -o addopts=""
93 passed in 3.86s
```

<!-- evidence-row:domain-artifact -->
```text
float 4998.0
accepted malformed float-valued integer field
```
independently reran the full touched test file (93 tests), ruff, and mypy myself; independently confirmed the installed console-script → campaign → executor → parser call chain in source before writing the reachability claim; did my own revert-and-confirm-red mutation check and independently verified the path7 nuance is honestly disclosed, not a masked failure.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the reachability chain, did my own revert-and-confirm-red mutation check including verifying the path7 nuance, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
