### PR TITLE
fix(multi-head-learner): reject targets that are not one per head

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -774,6 +774,13 @@ class MultiHeadMLPLearner:
             MultiHeadMLPUpdateResult with updated state, predictions,
             errors, and per-head metrics
 
+        Raises:
+            ValueError: If ``targets`` is not one value per head. A
+                broadcastable scalar or length-1 target would silently reuse
+                its single value for every head via JAX's clamped static
+                indexing, training and reporting a finite (non-NaN) error for
+                heads that were meant to be inactive.
+
         The learner and configured normalizer form one clock transaction. A
         validity, alignment, estimator-horizon, or uint64-capacity failure
         prevents the nested update call and preserves every persistent JAX
@@ -781,6 +788,11 @@ class MultiHeadMLPLearner:
         are outside that bit-exact contract.
         """
         n_heads = self._n_heads
+        targets = jnp.asarray(targets, dtype=jnp.float32)
+        if targets.shape != (n_heads,):
+            raise ValueError(
+                f"targets must have shape ({n_heads},), got {targets.shape}"
+            )
         counter_status = self._counter_status(state)
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
             jnp.isfinite(targets) | jnp.isnan(targets)

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -277,6 +277,50 @@ class TestMultiHeadUpdateAllActive:
 
 
 # =============================================================================
+# Update tests — validation
+# =============================================================================
+
+
+class TestMultiHeadUpdateValidation:
+    """``update`` must reject targets that are not one value per head.
+
+    JAX clamps static out-of-bounds indices instead of raising, so a
+    shorter-than-``n_heads`` targets array (a scalar or length-1 array is the
+    most common accident) silently reused its single value for every head:
+    every head reported a finite squared error and trained, instead of the
+    NaN/inactive behavior the caller intended for the heads it never supplied.
+    """
+
+    @pytest.mark.parametrize("shape", [(1,), (), (4, 1), (5,)])
+    def test_update_rejects_targets_that_are_not_one_per_head(self, shape):
+        learner = MultiHeadMLPLearner(
+            n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        obs = jnp.array([1.0, -0.5, 0.25])
+        with pytest.raises(ValueError, match=r"targets must have shape \(4,\)"):
+            learner.update(state, obs, jnp.full(shape, 2.0, dtype=jnp.float32))
+
+    def test_length_one_targets_previously_silently_trained_every_head(self):
+        """Regression guard: shape (1,) must not longer look like all-active.
+
+        Before the shape check, a length-1 ``targets`` array silently
+        clamped-indexed the same value onto every head, producing a finite
+        (non-NaN) error for every head instead of raising. This test would
+        have failed to reject the mismatch on the pre-fix implementation
+        (the ``update`` call would have returned a result with no NaNs
+        instead of raising).
+        """
+        learner = MultiHeadMLPLearner(
+            n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        obs = jnp.array([1.0, -0.5, 0.25])
+        with pytest.raises(ValueError, match=r"targets must have shape \(4,\)"):
+            learner.update(state, obs, jnp.array([2.0], dtype=jnp.float32))
+
+
+# =============================================================================
 # Update tests — partial active
 # =============================================================================
 


### PR DESCRIPTION
Closes #452.

## Issue

`MultiHeadMLPLearner.update` documented `targets: (n_heads,)` but never checked it. Because the per-head loop indexes with a static Python int (`safe_targets[i]` for `i in range(n_heads)`), a shorter `targets` array — a scalar or length-1 array is the natural accident — hit JAX's clamped static indexing instead of raising: every head silently read the same clamped value, trained, and reported a finite `squared_error`/`error` as if it had been intentionally active. This corrupts the per-head metric for every learner built on top of this class: `HordeLearner`, `SARSAAgent`, and `CBPMultiHeadMLPLearner`.

This is the identical defect class fixed for `UPGDLearner.update` by #402, left open one layer down in the shared-trunk base class.

## New state

`update` coerces `targets` to float32 and raises `targets must have shape (n_heads,), got …` before any masking or arithmetic, mirroring #402's fix exactly. The shape check is static (resolved at trace time), so `jit` cost is nil; well-formed calls are unchanged.

Failing-test-first: `TestMultiHeadUpdateValidation` (5 cases: `(1,)`, `()`, `(4, 1)`, `(5,)`, and an explicit length-1 regression guard) fails on `main` and passes here — see verification below.

## Evidence

Falsifier at this head, reproducing the pre-fix corruption directly against `MultiHeadMLPLearner`:

```python
learner = MultiHeadMLPLearner(n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01)
state = learner.init(feature_dim=3, key=jr.key(0))
obs = jnp.array([1.0, -0.5, 0.25])
result = learner.update(state, obs, jnp.array([2.0]))   # length-1, should be (4,)
```

On `main` (`c38398f`) this returns silently:
```
errors:            [2.7823083 1.3104744 1.8547904 1.3284886]   # all 4 "active"
per_head_metrics[:,0]: [7.7412395 1.7173431 3.4402475 1.764882]  # 3 phantom squared errors
```
instead of raising, or matching the documented NaN-for-inactive contract. At this PR's head it raises `ValueError: targets must have shape (4,), got (1,)`.

Verification at `f3ee044d1cb0aaffda2d353a224d0739e3da94d8`:

```text
.venv/bin/python -m pytest tests/test_multi_head_learner.py -q -o addopts=""
  -> 66 passed

.venv/bin/python -m pytest tests/test_horde.py tests/test_continual_backprop.py tests/test_sarsa.py \
  tests/test_actor_critic.py tests/test_pipeline.py tests/test_mixed_horde.py tests/test_off_policy_horde.py \
  tests/test_stacked_horde.py tests/test_independent_demon_horde.py tests/test_horde_actor_critic.py -q -o addopts=""
  -> 228 passed in 248.35s

.venv/bin/python -m pytest tests/test_options.py tests/test_ftl_world_model.py tests/test_average_reward.py \
  tests/test_checkpoints.py tests/test_action_conditioned_world_model.py \
  tests/test_recurrent_latent_world_model_ensemble.py tests/test_world_model.py tests/test_world_model_ensemble.py \
  tests/test_prototype_world_model_ensemble.py tests/test_latent_world_model.py -q -o addopts=""
  -> 202 passed in 323.88s

.venv/bin/python -m ruff check .   -> All checks passed!
.venv/bin/python -m mypy           -> Success: no issues found in 165 source files
git diff --check                   -> clean
```

Confirmed on unpatched `main` (stash-based A/B at the same commit) that all 5 `TestMultiHeadUpdateValidation` cases fail: four with the wrong exception type/message (opaque `IndexError`/`TypeError`/`ValueError` from deeper JAX broadcasting), and the length-1 regression case with "DID NOT RAISE ValueError" — i.e. the silent-corruption path.

`core/multi_head_learner.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:f3ee044d1cb0aaffda2d353a224d0739e3da94d8 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest across the direct module and every downstream caller, ruff, mypy, falsifier output at the evidence head)

## Scope note

`HordeLearner.update`/`update_with_discounts` also lack a `cumulants`/`discounts` shape check, but every invalid shape I tried there (`(1,)`, scalar, `(4, 1)`) already crashes with a confusing but real exception rather than silently corrupting — the arithmetic (`cumulants + bootstrap`) or `_report_head_values`'s reshape fails before a result is returned. That's a rough-edges/opaque-error issue, not the silent-corruption class this PR fixes, so I left it out to keep this one variable. Happy to file a follow-up issue if a maintainer wants clean validation there too.

Provider/model/client: anthropic / claude-sonnet-5 / Claude Code 2.1.233 (contribute-to-asi skill, lane rama0x1-asi-claude-worker).

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05WQFFAG90RT8QNRYR6WGVD","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T18:18:16.938Z","completed_at":"2026-08-16T18:18:41.327Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"78165307f11d359ce71735801a17fa0da090abf2f37c9da84af04055762f1bfe","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"25afe002-f6c1-49cc-b059-17dfb0b9673b","object_id":"sha256:78165307f11d359ce71735801a17fa0da090abf2f37c9da84af04055762f1bfe","sha256":"78165307f11d359ce71735801a17fa0da090abf2f37c9da84af04055762f1bfe"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"Z8QNbRcNg8uHQ2aQKVK9_mqivPAhdFCwFRxV3PtaQYVtC0-5T6sn7Y9WkT_2X3qAIENq8GESvZkKAfC9Hk2yCA"}} -->
