### PR TITLE
fix(dreaming): mark non-finite world-model predictions as invalid dream steps

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -814,6 +814,15 @@ def action_features(action: Array, n_actions: int | None = None) -> Array:
     return jax.nn.one_hot(action_index, n_actions, dtype=jnp.float32)
 
 
+def _neutralize_invalid(value: Array, valid: Array) -> Array:
+    """Return zeros for rejected dream rows before weighted arithmetic."""
+    array = jnp.asarray(value)
+    mask = jnp.asarray(valid, dtype=jnp.bool_)
+    while mask.ndim < array.ndim:
+        mask = mask[..., None]
+    return jnp.where(mask, array, jnp.zeros_like(array))
+
+
 def imagined_transition_to_supervised_item(
     transition: ImaginedTransition,
     *,
@@ -843,8 +852,8 @@ def imagined_transition_to_supervised_item(
     else:
         raise ValueError(f"unknown supervised target {target!r}")
     return DreamSupervisedTrainingItem(
-        inputs=inputs,
-        targets=targets,
+        inputs=_neutralize_invalid(inputs, transition.valid),
+        targets=_neutralize_invalid(targets, transition.valid),
         weights=jnp.asarray(transition.valid, dtype=jnp.float32),
     )
 
@@ -860,10 +869,13 @@ def imagined_transition_to_gvf_item(
         else jnp.ravel(jnp.asarray(cumulants, dtype=jnp.float32))
     )
     return DreamGVFTrainingItem(
-        observations=transition.observation,
-        cumulants=cumulant_array,
-        next_observations=transition.next_observation,
-        discounts=jnp.reshape(jnp.asarray(transition.discount, dtype=jnp.float32), (1,)),
+        observations=_neutralize_invalid(transition.observation, transition.valid),
+        cumulants=_neutralize_invalid(cumulant_array, transition.valid),
+        next_observations=_neutralize_invalid(transition.next_observation, transition.valid),
+        discounts=_neutralize_invalid(
+            jnp.reshape(jnp.asarray(transition.discount, dtype=jnp.float32), (1,)),
+            transition.valid,
+        ),
         weights=jnp.reshape(jnp.asarray(transition.valid, dtype=jnp.float32), (1,)),
     )
 
@@ -880,10 +892,14 @@ def imagined_rollout_to_gvf_items(
         else jnp.asarray(cumulants, dtype=jnp.float32)
     )
     return DreamGVFTrainingItem(
-        observations=transitions.observation,
-        cumulants=cumulant_array,
-        next_observations=transitions.next_observation,
-        discounts=jnp.asarray(transitions.discount, dtype=jnp.float32),
+        observations=_neutralize_invalid(transitions.observation, transitions.valid),
+        cumulants=_neutralize_invalid(cumulant_array, transitions.valid),
+        next_observations=_neutralize_invalid(
+            transitions.next_observation, transitions.valid
+        ),
+        discounts=_neutralize_invalid(
+            jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
+        ),
         weights=jnp.asarray(transitions.valid, dtype=jnp.float32),
     )
 
@@ -904,12 +920,18 @@ def imagined_rollout_to_sarsa_items(
         next_actions = jnp.concatenate([actions[1:], bootstrap], axis=0)
         weights = jnp.asarray(transitions.valid, dtype=jnp.float32)
     return DreamSARSATrainingItem(
-        observations=transitions.observation,
-        actions=actions,
-        rewards=jnp.asarray(transitions.reward, dtype=jnp.float32),
-        next_observations=transitions.next_observation,
-        discounts=jnp.asarray(transitions.discount, dtype=jnp.float32),
-        next_actions=next_actions,
+        observations=_neutralize_invalid(transitions.observation, transitions.valid),
+        actions=_neutralize_invalid(actions, transitions.valid),
+        rewards=_neutralize_invalid(
+            jnp.asarray(transitions.reward, dtype=jnp.float32), transitions.valid
+        ),
+        next_observations=_neutralize_invalid(
+            transitions.next_observation, transitions.valid
+        ),
+        discounts=_neutralize_invalid(
+            jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
+        ),
+        next_actions=_neutralize_invalid(next_actions, transitions.valid),
         weights=weights,
     )
 

--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -711,7 +711,20 @@ def dream_one_step(
         dtype=jnp.float32,
     )
     terminated = jnp.logical_or(world_prediction.terminated, discount_terminal)
-    valid = jnp.logical_and(rollout_state.active, jnp.logical_and(confidence_ok, error_ok))
+    # A non-finite model prediction can never be a valid imagined step: it would
+    # otherwise ship to the control learner with full weight and poison every
+    # later step of the rollout through the carried observation.
+    finite = (
+        jnp.all(jnp.isfinite(world_prediction.next_observation))
+        & jnp.all(jnp.isfinite(world_prediction.reward))
+        & jnp.all(jnp.isfinite(world_prediction.discount))
+        & jnp.all(jnp.isfinite(world_prediction.confidence))
+        & jnp.all(jnp.isfinite(world_prediction.model_error))
+    )
+    valid = jnp.logical_and(
+        rollout_state.active,
+        jnp.logical_and(finite, jnp.logical_and(confidence_ok, error_ok)),
+    )
     next_active = jnp.logical_and(valid, jnp.logical_not(terminated))
     if not cfg.stop_on_terminal:
         next_active = valid

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -235,10 +235,13 @@ def test_nonfinite_world_prediction_marks_the_dream_step_invalid_and_stops() -> 
     chex.assert_trees_all_close(gvf_items.weights, jnp.zeros((3,), dtype=jnp.float32))
     sarsa_items = imagined_rollout_to_sarsa_items(rollout)
     chex.assert_trees_all_close(sarsa_items.weights, jnp.zeros((3,), dtype=jnp.float32))
-    item = imagined_transition_to_supervised_item(
-        jax.tree.map(lambda leaf: leaf[0], rollout.transitions)
-    )
+    transition = jax.tree.map(lambda leaf: leaf[0], rollout.transitions)
+    item = imagined_transition_to_supervised_item(transition)
+    gvf_item = imagined_transition_to_gvf_item(transition)
     assert float(item.weights) == 0.0
+    for converted in (item, gvf_item, gvf_items, sarsa_items):
+        for leaf in jax.tree.leaves(converted):
+            assert bool(jnp.all(jnp.isfinite(leaf)))
 
 
 @pytest.mark.parametrize("field", ["reward", "discount", "confidence", "model_error"])

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import Any
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.dreaming import (
     DreamBehaviorModelPrediction,
@@ -206,6 +209,56 @@ def test_model_confidence_gating_marks_invalid_and_stops_rollout() -> None:
     )
     gvf_items = imagined_rollout_to_gvf_items(rollout)
     chex.assert_trees_all_close(gvf_items.weights, jnp.zeros((3,), dtype=jnp.float32))
+
+
+def test_nonfinite_world_prediction_marks_the_dream_step_invalid_and_stops() -> None:
+    """A NaN/inf model prediction must not become a valid, weight-1.0 imagined transition."""
+    world = MockWorldModel()
+    behavior = DeterministicBehaviorModel()
+    world_state = MockWorldState(
+        drift=jnp.array([jnp.nan, 0.0], dtype=jnp.float32),
+        reward_bias=jnp.array(0.25, dtype=jnp.float32),
+        confidence=jnp.array(1.0, dtype=jnp.float32),
+        model_error=jnp.array(0.0, dtype=jnp.float32),
+    )
+    behavior_state = DeterministicBehaviorState(action=jnp.array(0, dtype=jnp.int32))
+    config = DreamRolloutConfig(rollout_horizon=3, confidence_threshold=0.5, max_model_error=1.0)
+    anchor = jnp.array([1.0, 1.0], dtype=jnp.float32)
+    initial = init_dream_rollout_state(anchor, jr.key(11))
+
+    rollout = dream_rollout(world, world_state, behavior, behavior_state, initial, config)
+
+    assert not bool(jnp.any(rollout.transitions.valid))
+    assert not bool(rollout.state.active)
+    chex.assert_trees_all_close(rollout.state.observation, anchor)
+    gvf_items = imagined_rollout_to_gvf_items(rollout)
+    chex.assert_trees_all_close(gvf_items.weights, jnp.zeros((3,), dtype=jnp.float32))
+    sarsa_items = imagined_rollout_to_sarsa_items(rollout)
+    chex.assert_trees_all_close(sarsa_items.weights, jnp.zeros((3,), dtype=jnp.float32))
+    item = imagined_transition_to_supervised_item(
+        jax.tree.map(lambda leaf: leaf[0], rollout.transitions)
+    )
+    assert float(item.weights) == 0.0
+
+
+@pytest.mark.parametrize("field", ["reward", "discount", "confidence", "model_error"])
+def test_nonfinite_scalar_channels_mark_the_dream_step_invalid(field: str) -> None:
+    class ScalarNaNWorldModel(MockWorldModel):
+        def predict(self, state, observation, action, key):  # type: ignore[no-untyped-def]
+            prediction = super().predict(state, observation, action, key)
+            return dataclasses.replace(prediction, **{field: jnp.array(jnp.nan, dtype=jnp.float32)})
+
+    initial = init_dream_rollout_state(jnp.array([1.0, 1.0], dtype=jnp.float32), jr.key(3))
+    config = DreamRolloutConfig(rollout_horizon=2, confidence_threshold=0.5, max_model_error=1.0)
+    rollout = dream_rollout(
+        ScalarNaNWorldModel(),
+        _world_state(),
+        DeterministicBehaviorModel(),
+        DeterministicBehaviorState(action=jnp.array(1, dtype=jnp.int32)),
+        initial,
+        config,
+    )
+    assert not bool(jnp.any(rollout.transitions.valid))
 
 
 def test_training_item_conversions_have_expected_targets() -> None:


### PR DESCRIPTION
## Scope

Fixes the fail-open dream path where a nonfinite world-model prediction could be marked usable and poison subsequent learning.

`dream_one_step` now requires finite next observation, reward, discount, confidence, and model error. Rejected transitions stop the rollout and preserve the carried observation. In addition, every supervised, GVF, rollout-GVF, and SARSA converter replaces rejected data fields with finite neutral zeros before downstream weighted arithmetic. This closes the `0 * NaN` contamination path while keeping rejected weights at zero.

Finite valid predictions retain their prior behavior. This is transaction hardening only; it does not create or promote evidence, and no `outputs/` path changed.

## Verification

Exact head `cd3b9916074722cb72e311c264e152e94f98e496`:

- direct dreaming suite: 10 passed, including finite neutral payload checks across all converters
- focused Ruff: passed
- strict mypy on `core/dreaming.py`: passed
- diff check: clean
- the original 265-test adjacent Step 9/Prototype panel passed at the preceding implementation head; fresh repository CI is running for this repaired head

<!-- evidence-head:cd3b9916074722cb72e311c264e152e94f98e496 -->