### PR TITLE
fix(associative-memory): reset an evicted row before a new key writes into it

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -687,8 +687,11 @@ class AssociativeMemoryLearner:
             existing_slot = indices[0]
             replacement_slot, used_empty = self._replacement_slot(carry)
             slot = jnp.where(found_scalar, existing_slot, replacement_slot)
-            old_row = carry.values[slot]
-            old_utility = carry.utility[slot]
+            # A slot allocated or reused for a new key starts empty: the values,
+            # utility, and count of an evicted occupant must not be inherited.
+            slot_values = carry.values[slot]
+            old_row = jnp.where(found_scalar, slot_values, jnp.zeros_like(slot_values))
+            old_utility = jnp.where(found_scalar, carry.utility[slot], 0.0)
             row_logits = self._config.logit_scale * old_row
             feature_loss = jnp.where(
                 found_scalar,
@@ -732,7 +735,9 @@ class AssociativeMemoryLearner:
                 ),
                 counts=jnp.where(
                     active_bool,
-                    carry.counts.at[slot].add(1.0),
+                    carry.counts.at[slot].set(
+                        jnp.where(found_scalar, carry.counts[slot] + 1.0, 1.0)
+                    ),
                     carry.counts,
                 ),
                 last_update=jnp.where(

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -307,6 +307,38 @@ def test_associative_memory_respects_fixed_budget() -> None:
     assert int(result.state.replacements) > 0
 
 
+def test_evicted_row_is_reset_before_a_new_key_writes_into_it() -> None:
+    """A slot reused by eviction must not carry the evicted key's values, utility, or counts."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=2,
+            suffix_length=2,
+            feature_family="position_token",
+            max_features=2,
+        )
+    )
+    state = learner.init()
+    context_a = jnp.asarray([0, 1], dtype=jnp.int32)
+    context_b = jnp.asarray([2, 3], dtype=jnp.int32)
+    for _ in range(30):
+        state = learner.update(state, context_a, jnp.asarray(3, dtype=jnp.int32)).state
+    assert int(state.replacements) == 0
+
+    state = learner.update(state, context_b, jnp.asarray(1, dtype=jnp.int32)).state
+    assert int(state.replacements) > 0
+    prediction = learner.predict(state, context_b)
+    found = prediction.found > 0
+    assert int(jnp.sum(found)) >= 1
+    slots = prediction.indices[found]
+    rows = state.values[slots]
+    # B was written exactly once with label 1: no mass at A's label 3, one write's worth at 1
+    chex.assert_trees_all_close(rows[:, 3], jnp.zeros((rows.shape[0],), dtype=jnp.float32))
+    assert bool(jnp.all(rows[:, 1] > 0.0))
+    assert int(jnp.argmax(prediction.logits)) == 1
+    chex.assert_trees_all_close(state.counts[slots], jnp.ones((rows.shape[0],), dtype=jnp.float32))
+
+
 def test_associative_adaptive_family_scope_prefers_useful_pairs() -> None:
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(


### PR DESCRIPTION
Closes #456.

## Issue

`row_step` overwrote only the key of a slot reused by eviction; the evicted occupant's values, utility, and count were carried over, so a freshly allocated key predicted the previous key's label at high confidence for several writes and every budget ablation below the default table size scored below chance (`acc=0.000` at `max_features=2/4` on a periodic 4-class stream).

## New state

When the key is not found, `row_step` starts from an empty row (`zeros`), zero utility, and a count of `1.0`; found keys keep decaying/accumulating exactly as before. Allocation and replacement counters, `last_update`, and the found-key path are unchanged.

Failing-test-first: `test_evicted_row_is_reset_before_a_new_key_writes_into_it` (30 writes of A@3, one write of B@1 evicting A → B's found rows carry no mass at class 3, argmax is 1, counts are 1) fails on `main` and passes here.

## Evidence

Steady-state stream from #456 at this head:

```text
max_features=  2  steady-state acc=0.250  loss=1.054  replacements=279
max_features=  4  steady-state acc=0.500  loss=0.703  replacements=199
max_features=  8  steady-state acc=1.000  loss=0.000  replacements=0
```

Verification at `a0090c5777f641dc690814e75949b1d989914506`:

```text
.venv/bin/python -m pytest tests/test_associative_memory.py tests/test_step2*.py tests/test_pipeline*.py -q -o addopts=""   -> 54 passed
.venv/bin/python -m ruff check .                                                                                     -> All checks passed!
.venv/bin/python -m mypy                                                                                             -> Success: no issues found in 164 source files
```

Composes cleanly with open #449 (`git merge-tree` clean; #449 edits config validation, this edits the write path). `core/associative_memory.py` is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:a0090c5777f641dc690814e75949b1d989914506 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
