### PR TITLE
fix(associative-memory): reject out-of-vocabulary labels instead of clipping them

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -26,6 +26,7 @@ from jaxtyping import Bool, Float, Int
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
+    safe_discrete_action,
     select_transaction,
 )
 
@@ -667,7 +668,10 @@ class AssociativeMemoryLearner:
     ) -> AssociativeMemoryUpdateResult:
         """Predict, then update active associative rows."""
         prediction = self.predict(state, context)
-        label = jnp.clip(label.astype(jnp.int32), 0, self._config.vocab_size - 1)
+        # An out-of-vocabulary, fractional, or non-finite label is a rejected
+        # transaction, never a substituted class: clipping would train and
+        # score a class the stream did not observe with update_applied=True.
+        label, label_valid = safe_discrete_action(label, self._config.vocab_size)
         loss = _cross_entropy_from_logits(prediction.logits, label)
         accuracy = (jnp.argmax(prediction.logits) == label).astype(jnp.float32)
         next_state = state.replace(  # type: ignore[attr-defined]
@@ -781,7 +785,8 @@ class AssociativeMemoryLearner:
             dtype=jnp.float32,
         )
         update_applied = (
-            floating_tree_is_finite(state)
+            label_valid
+            & floating_tree_is_finite(state)
             & floating_tree_is_finite(prediction)
             & jnp.isfinite(loss)
             & floating_tree_is_finite(next_state)

--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -20,13 +20,13 @@ from typing import Any, Literal, cast
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
-    safe_discrete_action,
     select_transaction,
 )
 
@@ -659,7 +659,6 @@ class AssociativeMemoryLearner:
             next_state.replace(budget_logit=budget_logit),  # type: ignore[attr-defined]
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
         state: AssociativeMemoryState,
@@ -667,11 +666,49 @@ class AssociativeMemoryLearner:
         label: Int[Array, ""],
     ) -> AssociativeMemoryUpdateResult:
         """Predict, then update active associative rows."""
+        safe_label, label_valid = self._prepare_label(label)
+        return cast(
+            AssociativeMemoryUpdateResult,
+            self._update(state, context, safe_label, label_valid),
+        )
+
+    def _prepare_label(self, label: object) -> tuple[Array, Array]:
+        """Validate a discrete label before JAX can narrow or reshape it."""
+        actual_type = type(label)
+        if issubclass(actual_type, jax.core.Tracer):
+            array = jnp.asarray(label)
+            valid_type = jnp.issubdtype(array.dtype, jnp.integer) and array.shape == ()
+            return array, jnp.asarray(valid_type, dtype=jnp.bool_)
+
+        allowed = (
+            actual_type is int
+            or issubclass(actual_type, np.integer)
+            or actual_type is np.ndarray
+            or issubclass(actual_type, jax.Array)
+        )
+        if not allowed:
+            return jnp.asarray(0, dtype=jnp.int32), jnp.asarray(False)
+        try:
+            host = np.asarray(label)
+        except (OverflowError, TypeError, ValueError):
+            return jnp.asarray(0, dtype=jnp.int32), jnp.asarray(False)
+        if host.shape != () or host.dtype.kind not in ("i", "u"):
+            return jnp.asarray(0, dtype=jnp.int32), jnp.asarray(False)
+        value = int(host.item())
+        if value < 0 or value >= self._config.vocab_size:
+            return jnp.asarray(0, dtype=jnp.int32), jnp.asarray(False)
+        return jnp.asarray(value, dtype=jnp.int32), jnp.asarray(True)
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _update(
+        self,
+        state: AssociativeMemoryState,
+        context: Int[Array, " block_size"],
+        label: Int[Array, ""],
+        label_valid: Bool[Array, ""],
+    ) -> AssociativeMemoryUpdateResult:
+        """Execute one already-domain-checked associative transaction."""
         prediction = self.predict(state, context)
-        # An out-of-vocabulary, fractional, or non-finite label is a rejected
-        # transaction, never a substituted class: clipping would train and
-        # score a class the stream did not observe with update_applied=True.
-        label, label_valid = safe_discrete_action(label, self._config.vocab_size)
         loss = _cross_entropy_from_logits(prediction.logits, label)
         accuracy = (jnp.argmax(prediction.logits) == label).astype(jnp.float32)
         next_state = state.replace(  # type: ignore[attr-defined]

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -307,6 +307,34 @@ def test_associative_memory_respects_fixed_budget() -> None:
     assert int(result.state.replacements) > 0
 
 
+@pytest.mark.parametrize("label", [-1, 4, 9999, 1.9, float("nan"), float("inf")])
+def test_update_rejects_labels_outside_the_vocabulary_instead_of_clipping(label: float) -> None:
+    """An out-of-domain label must be a rejected transaction, not a substituted class."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    result = learner.update(
+        state, jnp.asarray([1, 2, 3], dtype=jnp.int32), jnp.asarray(label, dtype=jnp.float32)
+    )
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
+
+
+def test_update_accepts_every_in_vocabulary_label() -> None:
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    for label in range(4):
+        result = learner.update(
+            state, jnp.asarray([1, 2, 3], dtype=jnp.int32), jnp.asarray(label, dtype=jnp.int32)
+        )
+        assert bool(result.update_applied)
+        assert float(result.state.prior[label]) > float(state.prior[label])
+
+
 def test_evicted_row_is_reset_before_a_new_key_writes_into_it() -> None:
     """A slot reused by eviction must not carry the evicted key's values, utility, or counts."""
     learner = AssociativeMemoryLearner(

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -5,6 +5,7 @@ import math
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.associative_memory import (
@@ -307,15 +308,35 @@ def test_associative_memory_respects_fixed_budget() -> None:
     assert int(result.state.replacements) > 0
 
 
-@pytest.mark.parametrize("label", [-1, 4, 9999, 1.9, float("nan"), float("inf")])
-def test_update_rejects_labels_outside_the_vocabulary_instead_of_clipping(label: float) -> None:
+@pytest.mark.parametrize(
+    "label",
+    [
+        -1,
+        4,
+        9999,
+        1.9,
+        float("nan"),
+        float("inf"),
+        1 + 2j,
+        True,
+        np.uint64(2**32),
+        np.float64(1.00000001),
+        np.asarray([1], dtype=np.int32),
+        2**100,
+    ],
+)
+def test_update_rejects_labels_outside_the_vocabulary_instead_of_clipping(
+    label: object,
+) -> None:
     """An out-of-domain label must be a rejected transaction, not a substituted class."""
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
     )
     state = learner.init()
     result = learner.update(
-        state, jnp.asarray([1, 2, 3], dtype=jnp.int32), jnp.asarray(label, dtype=jnp.float32)
+        state,
+        jnp.asarray([1, 2, 3], dtype=jnp.int32),
+        label,  # type: ignore[arg-type]
     )
     assert not bool(result.update_applied)
     chex.assert_trees_all_equal(result.state, state)


### PR DESCRIPTION
## Scope

Rejects associative-memory labels outside the exact discrete vocabulary domain before JAX can narrow, truncate, reshape, or overflow them. Invalid labels produce an atomic refused transaction: state is unchanged, outputs and metrics are neutral, and update_applied is false.

The public wrapper now validates concrete Python, NumPy, and JAX scalar integer inputs before entering the compiled update. Traced scan inputs retain static scalar/integer validation plus the runtime vocabulary check. Complex values, booleans, fractional aliases, uint overflow aliases, singleton arrays, and huge integers all fail closed.

Finite in-vocabulary integer labels retain their prior behavior. This is transaction hardening only; no registered evidence source or outputs artifact changed.

## Verification

Exact head 626d47b7788e6536771d7a5f07062025d41466cb:

- associative-memory suite: 42 passed
- Step 2 and pipeline downstream suite: 25 passed
- focused Ruff: passed
- strict mypy on associative_memory.py: passed
- diff check: clean

<!-- evidence-head:626d47b7788e6536771d7a5f07062025d41466cb -->