### PR TITLE
fix(benchmarks): reject float RTU aperture attestations

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -1407,6 +1407,12 @@ def _require_exact_int(value: Any, path: str) -> int:
     return value
 
 
+def _require_exact_int_list(value: Any, path: str) -> list[int]:
+    if type(value) is not list:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a list")
+    return [_require_exact_int(item, f"{path}[{index}]") for index, item in enumerate(value)]
+
+
 def _verify_one_screen(
     binding: ScreeningArtifactBinding,
     protocol: Mapping[str, Any],
@@ -1963,15 +1969,27 @@ def _verify_rtu_candidate_generation(
             "rtu_schema23_screening_v1 raw and normalized matrix configurations differ"
         )
     evaluation_seeds = list(range(2_200_001, 2_200_031))
+    matrix_steps = _require_exact_int(
+        matrix.get("steps"), "rtu_schema23_screening_v1.matrix.steps"
+    )
+    matrix_seeds = _require_exact_int_list(
+        matrix.get("seeds"), "rtu_schema23_screening_v1.matrix.seeds"
+    )
+    matrix_tuning_seeds = _require_exact_int_list(
+        matrix.get("tuning_seeds"), "rtu_schema23_screening_v1.matrix.tuning_seeds"
+    )
+    matrix_evaluation_seeds = _require_exact_int_list(
+        matrix.get("evaluation_seeds"), "rtu_schema23_screening_v1.matrix.evaluation_seeds"
+    )
     if any(
         (
             matrix.get("schema_version") != "2.3",
             matrix.get("preset") != "field_of_view",
             matrix.get("stage") != "tuning",
-            matrix.get("steps") != binding.horizon_per_seed,
-            matrix.get("seeds") != list(binding.seeds),
-            matrix.get("tuning_seeds") != list(binding.seeds),
-            matrix.get("evaluation_seeds") != evaluation_seeds,
+            matrix_steps != binding.horizon_per_seed,
+            matrix_seeds != list(binding.seeds),
+            matrix_tuning_seeds != list(binding.seeds),
+            matrix_evaluation_seeds != evaluation_seeds,
             matrix.get("mode") != "vmap",
             matrix.get("source_execution_mode")
             != "content_verified_snapshot_subprocess_unsealed",
@@ -2004,19 +2022,29 @@ def _verify_rtu_candidate_generation(
     aperture_size = _require_exact_int(
         task.get("aperture_size"), "rtu_schema23_screening_v1.task.aperture_size"
     )
+    task_steps = _require_exact_int(
+        task.get("steps"), "rtu_schema23_screening_v1.task.steps"
+    )
+    task_seeds = _require_exact_int_list(
+        task.get("seeds"), "rtu_schema23_screening_v1.task.seeds"
+    )
+    future_evaluation_seeds = _require_exact_int_list(
+        future_evaluation.get("seeds"),
+        "rtu_schema23_screening_v1.future_evaluation.seeds",
+    )
     if any(
         (
             task.get("env_id") != "ForagaxTwoBiomeLarge-v1",
             task.get("observation_type") != "color",
             aperture_size != 9,
-            task.get("steps") != binding.horizon_per_seed,
-            task.get("seeds") != list(binding.seeds),
+            task_steps != binding.horizon_per_seed,
+            task_seeds != list(binding.seeds),
             protocol_matrix.get("file_sha256")
             != _artifact_raw_sha256(binding, "matrix"),
             protocol_matrix.get("normalized_config_sha256")
             != binding.normalized_matrix_sha256,
             future_evaluation.get("status") != "declared_but_unconsumed",
-            future_evaluation.get("seeds") != evaluation_seeds,
+            future_evaluation_seeds != evaluation_seeds,
         )
     ):
         raise ForagerMatchedCandidateUniverseError(
@@ -2027,9 +2055,14 @@ def _verify_rtu_candidate_generation(
             protocol.get("selection_rule"), "rtu_schema23_screening_v1.selection_rule"
         )
     )
+    advance_count = _require_exact_int(
+        protocol_rule.get("advance_count"),
+        "rtu_schema23_screening_v1.selection_rule.advance_count",
+    )
+    protocol_rule.pop("advance_count", None)
     if (
         protocol_rule.pop("selection_group", None) != "rtu_width_taylor"
-        or protocol_rule.pop("advance_count", None) != 1
+        or advance_count != 1
         or protocol_rule != matrix.get("selection_rule")
     ):
         raise ForagerMatchedCandidateUniverseError(

--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -1401,6 +1401,12 @@ def _require_false(value: Mapping[str, Any], key: str, context: str) -> None:
         raise ForagerMatchedCandidateUniverseError(f"{context}.{key} must be false")
 
 
+def _require_exact_int(value: Any, path: str) -> int:
+    if type(value) is not int:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be an integer")
+    return value
+
+
 def _verify_one_screen(
     binding: ScreeningArtifactBinding,
     protocol: Mapping[str, Any],
@@ -1995,11 +2001,14 @@ def _verify_rtu_candidate_generation(
         protocol.get("future_evaluation"),
         "rtu_schema23_screening_v1.future_evaluation",
     )
+    aperture_size = _require_exact_int(
+        task.get("aperture_size"), "rtu_schema23_screening_v1.task.aperture_size"
+    )
     if any(
         (
             task.get("env_id") != "ForagaxTwoBiomeLarge-v1",
             task.get("observation_type") != "color",
-            task.get("aperture_size") != 9,
+            aperture_size != 9,
             task.get("steps") != binding.horizon_per_seed,
             task.get("seeds") != list(binding.seeds),
             protocol_matrix.get("file_sha256")

--- a/tests/test_forager_matched_candidate_universe.py
+++ b/tests/test_forager_matched_candidate_universe.py
@@ -21,6 +21,7 @@ import json
 import shutil
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -448,6 +449,57 @@ def test_rtu_source_validator_rejects_float_alias_for_integer_aperture() -> None
         universe.ForagerMatchedCandidateUniverseError,
         match=r"task\.aperture_size must be an integer",
     ):
+        universe._verify_rtu_candidate_generation(binding, artifacts)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("artifact_role", "path", "match"),
+    [
+        ("protocol", ("task", "steps"), r"task\.steps must be an integer"),
+        ("protocol", ("task", "seeds", 0), r"task\.seeds\[0\] must be an integer"),
+        ("matrix", ("steps",), r"matrix\.steps must be an integer"),
+        ("matrix", ("seeds", 0), r"matrix\.seeds\[0\] must be an integer"),
+        ("matrix", ("tuning_seeds", 0), r"matrix\.tuning_seeds\[0\] must be an integer"),
+        (
+            "matrix",
+            ("evaluation_seeds", 0),
+            r"matrix\.evaluation_seeds\[0\] must be an integer",
+        ),
+        (
+            "protocol",
+            ("future_evaluation", "seeds", 0),
+            r"future_evaluation\.seeds\[0\] must be an integer",
+        ),
+        (
+            "protocol",
+            ("selection_rule", "advance_count"),
+            r"selection_rule\.advance_count must be an integer",
+        ),
+    ],
+)
+def test_rtu_source_validator_rejects_float_aliases_across_full_integer_contract(
+    artifact_role: str, path: tuple[object, ...], match: str
+) -> None:
+    """Reviewer-found gap on PR #461: the exact-int policy applied to
+    aperture_size alone left every adjacent integer attestation (task/matrix
+    steps and seeds, future_evaluation seeds, selection_rule advance_count)
+    still fail-open to a numeric alias via bare equality."""
+    binding = next(
+        item
+        for item in universe._LOCAL_CANDIDATE_GENERATION_BINDINGS
+        if item.screen_id == "rtu_schema23_screening_v1"
+    )
+    artifacts = {
+        artifact.role: json.loads((_REPOSITORY_ROOT / artifact.path).read_bytes())
+        for artifact in binding.artifacts
+    }
+    target: Any = artifacts[artifact_role]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = float(target[path[-1]])
+
+    with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match=match):
         universe._verify_rtu_candidate_generation(binding, artifacts)
 
 

--- a/tests/test_forager_matched_candidate_universe.py
+++ b/tests/test_forager_matched_candidate_universe.py
@@ -432,6 +432,26 @@ def test_external_screen_validator_rejects_duplicate_rank_rows() -> None:
 
 
 @pytest.mark.unit
+def test_rtu_source_validator_rejects_float_alias_for_integer_aperture() -> None:
+    binding = next(
+        item
+        for item in universe._LOCAL_CANDIDATE_GENERATION_BINDINGS
+        if item.screen_id == "rtu_schema23_screening_v1"
+    )
+    artifacts = {
+        artifact.role: json.loads((_REPOSITORY_ROOT / artifact.path).read_bytes())
+        for artifact in binding.artifacts
+    }
+    artifacts["protocol"]["task"]["aperture_size"] = 9.0
+
+    with pytest.raises(
+        universe.ForagerMatchedCandidateUniverseError,
+        match=r"task\.aperture_size must be an integer",
+    ):
+        universe._verify_rtu_candidate_generation(binding, artifacts)
+
+
+@pytest.mark.unit
 def test_external_screen_validator_reconciles_snapshot_configuration_hashes() -> None:
     binding = universe._SCREEN_BINDINGS[0]
     protocol = json.loads((_REPOSITORY_ROOT / binding.protocol_path).read_bytes())


### PR DESCRIPTION
Closes #460.

## What changed

Same bug class as #450: `_verify_rtu_candidate_generation` validates the historical RTU task aperture as the exact attested value `9` using bare numeric equality (`task.get("aperture_size") != 9`). Python treats a decoded JSON float `9.0` as equal to integer `9`, so a type-invalid external provenance field crosses the validation boundary — a sibling verifier in the same `forager_matched_*` family with the same underlying gap.

confirmed directly before touching the source:

```text
decoded type: float
ACCEPTED invalid numeric alias: 9.0
```

fix: a new `_require_exact_int` helper (`type(value) is int`) applied to `aperture_size` before comparing against the frozen value `9`, matching the sibling protocol-parsing pattern already used elsewhere in this file (and the near-identical `_integer` helper in `forager_matched_executor.py` from #451) to exclude float/bool aliases.

## Reachability

The changed private validator is reached by the public module function `verify_matched_current_candidate_universe_sources(repository_root)`, which reads bound JSON files and dispatches RTU artifacts to `_verify_rtu_candidate_generation` — confirmed directly. Production callers: `forager_matched_campaign.py` (campaign creation/resume, two call sites) and `forager_matched_sealed_evaluation_campaign.py` (rebuilding sealed evaluation content) — both confirmed directly. Inputs are real repository-bound JSON artifacts, not hardcoded-safe values.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_candidate_universe.py -q -o addopts=""
31 passed/ in 1.31s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_candidate_universe.py tests/test_forager_matched_candidate_universe.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_rtu_source_validator_rejects_float_alias_for_integer_aperture`, loading the real bound RTU artifacts and mutating the decoded `aperture_size` field to `9.0`, asserting `ForagerMatchedCandidateUniverseError` matching `"task.aperture_size must be an integer"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_candidate_universe.py`, kept the test), reran — failed with `DID NOT RAISE ForagerMatchedCandidateUniverseError`, confirming the float alias previously crossed validation undetected. restored the fix, 31/31 green/ again.

## Evidence

<!-- evidence-head -->
abbf159c400724906375dfabec8018fae3f7938f

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_forager_matched_candidate_universe.py -q -o addopts="" -k test_rtu_source_validator_rejects_float_alias_for_integer_aperture
FAILED - Failed: DID NOT RAISE ForagerMatchedCandidateUniverseError
1 failed, 22 deselected in 1.35s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_forager_matched_candidate_universe.py -q -o addopts=""
31 passed/ in 0.99s
```

<!-- evidence-row:domain-artifact -->
```text
decoded type: float
ACCEPTED invalid numeric alias: 9.0
```
independently reran the full touched test file (23 tests), ruff, and mypy myself; independently confirmed the reachability chain (`verify_matched_current_candidate_universe_sources` → `_verify_rtu_candidate_generation`, both real campaign call sites) before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported