### PR TITLE
fix(learners): honour the normalizer's fail-closed verdict in LinearLearner

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -240,10 +240,14 @@ class LinearLearner:
         """
         new_normalizer_state = state.normalizer_state
         obs = observation
+        normalizer_update_applied = jnp.asarray(True, dtype=jnp.bool_)
         if self._normalizer is not None and state.normalizer_state is not None:
-            obs, new_normalizer_state = self._normalizer.normalize(
+            normalizer_result = self._normalizer.normalize_with_diagnostics(
                 state.normalizer_state, observation
             )
+            obs = normalizer_result.normalized
+            new_normalizer_state = normalizer_result.state
+            normalizer_update_applied = normalizer_result.update_applied
 
         prediction = self.predict(
             LearnerState(
@@ -300,6 +304,7 @@ class LinearLearner:
         update_applied = (
             floating_tree_is_finite(state)
             & inputs_valid
+            & normalizer_update_applied
             & opt_update.update_applied
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(prediction))

--- a/tests/test_learners.py
+++ b/tests/test_learners.py
@@ -19,12 +19,65 @@ from alberta_framework import (
     RandomWalkStream,
     StepSizeHistory,
     StepSizeTrackingConfig,
+    WelfordNormalizer,
     agent_age_s,
     agent_uptime_s,
     metrics_to_dicts,
     run_learning_loop,
     run_learning_loop_batched,
 )
+
+
+class TestLinearLearnerNormalizerVeto:
+    """LinearLearner must honour the normalizer's fail-closed verdict like MLPLearner does."""
+
+    @staticmethod
+    def _fail_stopped_welford_state(learner: LinearLearner, feature_dim: int):
+        state = learner.init(feature_dim)
+        boundary = 2**24
+        normalizer_state = state.normalizer_state.replace(  # type: ignore[union-attr]
+            sample_count=jnp.asarray(boundary, dtype=jnp.int32),
+            sample_count_words=jnp.asarray((0, boundary), dtype=jnp.uint32),
+            mean=jnp.full(feature_dim, 100.0, dtype=jnp.float32),
+            var=jnp.full(feature_dim, 4.0, dtype=jnp.float32),
+            p=jnp.full(feature_dim, 4.0 * (boundary - 1), dtype=jnp.float32),
+        )
+        return state.replace(normalizer_state=normalizer_state)  # type: ignore[attr-defined]
+
+    def test_fail_stopped_normalizer_rejects_the_linear_update(self) -> None:
+        normalizer = WelfordNormalizer()
+        learner = LinearLearner(optimizer=LMS(0.1), normalizer=normalizer)
+        state = self._fail_stopped_welford_state(learner, 3)
+        observation = jnp.ones(3, dtype=jnp.float32)
+        diagnostics = normalizer.normalize_with_diagnostics(state.normalizer_state, observation)
+        assert not bool(diagnostics.update_applied)
+
+        result = learner.update(state, observation, jnp.asarray(1.0, dtype=jnp.float32))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_mismatched_ema_config_rejects_the_linear_update(self) -> None:
+        normalizer = EMANormalizer(decay=0.99)
+        learner = LinearLearner(optimizer=LMS(0.1), normalizer=normalizer)
+        state = learner.init(3)
+        persisted = state.normalizer_state.replace(  # type: ignore[union-attr]
+            decay=jnp.asarray(0.5, dtype=jnp.float32)
+        )
+        state = state.replace(normalizer_state=persisted)  # type: ignore[attr-defined]
+        assert not bool(normalizer.counter_status(persisted).counter_valid)
+
+        result = learner.update(state, jnp.ones(3, dtype=jnp.float32), jnp.asarray(1.0))
+
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, state)
+
+    def test_healthy_normalizer_still_applies(self) -> None:
+        learner = LinearLearner(optimizer=LMS(0.1), normalizer=WelfordNormalizer())
+        state = learner.init(3)
+        result = learner.update(state, jnp.ones(3, dtype=jnp.float32), jnp.asarray(1.0))
+        assert bool(result.update_applied)
+        assert int(result.state.step_count) == 1
 
 
 class TestLinearLearner:


### PR DESCRIPTION
Closes #464.

## Issue

`LinearLearner.update` used the thin `normalize()` wrapper, which drops `NormalizerUpdateResult.update_applied`, so a fail-stopped Welford count or a checkpoint whose persisted decay disagreed with the configured normalizer still trained on frozen or identity statistics and reported `update_applied=True`; `MLPLearner` already refuses.

## New state

`LinearLearner.update` calls `normalize_with_diagnostics` and ANDs `normalizer_update_applied` into `update_applied` — the same gate `MLPLearner.update` uses — so those steps become rejected, state-preserving transactions. Healthy normalizers, `normalizer=None`, and every metric are unchanged.

Failing-test-first: `TestLinearLearnerNormalizerVeto::test_fail_stopped_normalizer_rejects_the_linear_update` and `::test_mismatched_ema_config_rejects_the_linear_update` fail on `main` and pass here; `::test_healthy_normalizer_still_applies` pins the accepted path.

## Evidence

Verification at `cd101c7310312218cf53784a6b8df947ce0a3ef9`:

```text
.venv/bin/python -m pytest tests/test_learners.py tests/test_normalizers.py tests/test_utils_smoke.py -q -o addopts=""   -> all passed (102 + new)
(step1/pipeline suites unchanged; the 3 failures in tests/test_step11_production.py / test_step12_production.py reproduce identically on pristine main on this macOS arm64 host — np.longdouble is float64 here — and are unrelated)
.venv/bin/python -m ruff check .                                                                                       -> All checks passed!
.venv/bin/python -m mypy                                                                                               -> Success: no issues found in 164 source files
```

`core/learners.py` is imported by the robot track and stays importable (public API unchanged); it is not a registered evidence source; no benchmark lane, seeds, or `outputs/` artifacts were touched; no `CHANGELOG.md` edit (maintainer-recorded).

CLI sessions cannot mint GitHub attachment URLs, so the run output above is inline rather than attached.

<!-- evidence-head:cd101c7310312218cf53784a6b8df947ce0a3ef9 -->
<!-- evidence-row:logs -->
- [x] logs: inline above (focused pytest, ruff, mypy, falsifier output at the evidence head)

Provider/model/client: anthropic / claude-fable-5 / Claude Code 2.1.233 (contribute-to-asi skill revision 72e4239e).
