### PR TITLE
fix(forager): reject non-integer plan horizons

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -595,6 +595,7 @@ def _validate_execution_plan_snapshot(
         _require_int(item, "execution plan seed")
         for item in _require_array(value["active_seeds"], "execution plan active seeds")
     )
+    horizon = _require_int(value["horizon"], "execution plan horizon", minimum=1)
     candidate_order = tuple(
         _require_identifier(item, "execution plan candidate")
         for item in _require_array(value["candidate_order"], "execution plan candidate order")
@@ -616,7 +617,7 @@ def _validate_execution_plan_snapshot(
         value["protocol_sha256"] != open_protocol.protocol_sha256
         or qualification_digest != scores.qualification_manifest_sha256
         or active_seeds != open_protocol.active_seeds
-        or value["horizon"] != open_protocol.horizon
+        or horizon != open_protocol.horizon
         or candidate_order
         != tuple(item.candidate_id for item in scores.candidate_scores)
         or _canonical_sha256(source_manifest) != source_digest

--- a/tests/test_forager_matched_seal.py
+++ b/tests/test_forager_matched_seal.py
@@ -537,6 +537,26 @@ def test_qualification_manifest_cross_carrier_tampering_fails_closed(
         )
 
 
+@pytest.mark.parametrize("invalid_horizon", [499_712.0, True])
+def test_execution_plan_rejects_non_integer_horizon(
+    tmp_path: Path,
+    invalid_horizon: object,
+) -> None:
+    completed, _ = _completed_campaign(tmp_path)
+    plan_payload = seal._decode_canonical(
+        completed.plan.canonical_bytes,
+        "test execution plan",
+    )
+    plan_payload["horizon"] = invalid_horizon
+
+    with pytest.raises(seal.ForagerMatchedSealError, match="horizon must be an integer"):
+        seal._validate_execution_plan_snapshot(
+            plan_payload,
+            completed.protocol,
+            completed.score_evidence,
+        )
+
+
 def test_literal_v1_qualification_carriers_and_seal_manifest_are_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #466.

## What changed

Third instance of the same bug class as #450/#460: `_validate_execution_plan_snapshot` validated every `active_seeds` element with the module's exact built-in-integer helper, but validated the execution plan's `horizon` only with bare equality against the protocol horizon. Python considers an integral float equal to the corresponding integer, so a canonical JSON plan containing `499712.0` crosses the validation boundary and receives a plan digest even though the protocol contract carries an integer horizon.

confirmed directly before touching the source, using a real completed-campaign fixture with only the decoded plan horizon changed:

```text
protocol horizon: 499712 (int)
payload horizon: 499712.0 (float)
accepted digest: e875ab2134426598896fd5da93599de91da40cdbb10649352868f8393ffa95da
exit_code=0
```

fix: route `value["horizon"]` through the existing `_require_int(..., minimum=1)` helper before comparing against the protocol horizon, matching the exact-type policy already used for execution-plan seeds in the same function.

## Reachability

The validator is called both when creating a new seal bundle (`create_forager_matched_seal_bundle` → decode completed `open_execution_plan` → `_validate_execution_plan_snapshot`) and when replaying a persisted one — confirmed both call sites directly in source. These paths consume canonical JSON artifacts, not hardcoded-safe values. Publicly reachable through the installed `alberta-forager-matched-sealed-evaluation` console entry point — confirmed in `pyproject.toml`.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_seal.py -q -o addopts="" -k execution_plan_rejects_non_integer_horizon
2 passed, 26 deselected in 1.23s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_seal.py tests/test_forager_matched_seal.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_execution_plan_rejects_non_integer_horizon`, parametrized over `499_712.0` and `True`, asserting `ForagerMatchedSealError` matching `"horizon must be an integer"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_seal.py`, kept the test), reran — 2/2 failed (the float case was silently accepted; the bool case raised a *different* error, `"open execution plan closure drifted"`, since `True`'s value happens not to coincide with the expected horizon in this fixture — same honest nuance pattern as #451, doesn't weaken the float-alias finding). restored the fix, 2/2 green again.

**Note on the full-file test run:** the touched test file has 14 pre-existing failures unrelated to this change (`ForagerMatchedSealError: renameat2 is required for seal publication` — a Linux-only syscall requirement, this is a macOS dev environment). Independently confirmed all 14 reproduce identically on an unmodified checkout (via `git stash`, rerunning against the pre-existing source) before writing this PR — same count, same failures, not introduced by this fix.

## Evidence

<!-- evidence-head -->
16013fff80cb9a4c53aa95ffcfddcd323dc7b771

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_forager_matched_seal.py -q -o addopts="" -k execution_plan_rejects_non_integer_horizon
FAILED [499712.0] - Failed: DID NOT RAISE ForagerMatchedSealError
FAILED [True] - AssertionError: Regex pattern did not match. Actual message: 'open execution plan closure drifted'
2 failed, 26 deselected in 1.79s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_forager_matched_seal.py -q -o addopts="" -k execution_plan_rejects_non_integer_horizon
2 passed, 26 deselected in 1.08s
```

<!-- evidence-row:domain-artifact -->
```text
protocol horizon: 499712 (int)
payload horizon: 499712.0 (float)
accepted digest: e875ab2134426598896fd5da93599de91da40cdbb10649352868f8393ffa95da
exit_code=0
```
independently reran the focused suite, ruff, and mypy myself; independently confirmed the 14 unrelated full-file failures are pre-existing by reproducing them on an unmodified checkout; independently confirmed both real call sites and the console entry point before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, ruff, and mypy myself, independently confirmed the pre-existing unrelated failures reproduce on an unmodified checkout, verified both real call sites and the console entry point, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
