### PR TITLE
fix(experiential-memory): record policy access recency

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -132,7 +132,12 @@ class ExperientialMemoryEntry:
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryEntries:
-    """Fixed-capacity structure-of-arrays for persistent exemplars."""
+    """Fixed-capacity structure-of-arrays for persistent exemplars.
+
+    ``ages`` is the exemplar's chronological age. ``recency_ages`` is local
+    time since its last accepted retrieval: zero on write and on access, then
+    incremented once per later memory step while the slot remains valid.
+    """
 
     observations: Float[Array, "capacity observation_dim"]
     keys: Float[Array, "capacity key_dim"]
@@ -1106,7 +1111,9 @@ class ExperientialMemory:
                 ),
                 valid=current_entries.valid.at[slot].set(True),
                 ages=current_entries.ages.at[slot].set(entry.age),
-                recency_ages=current_entries.recency_ages.at[slot].set(entry.age),
+                # Recency is time since this memory last retrieved the
+                # exemplar, not the exemplar's imported chronological age.
+                recency_ages=current_entries.recency_ages.at[slot].set(0),
                 provenance_ids=current_entries.provenance_ids.at[slot].set(entry.provenance_id),
                 source_ids=current_entries.source_ids.at[slot].set(entry.source_id),
                 retrieval_counts=current_entries.retrieval_counts.at[slot].set(0),
@@ -1249,23 +1256,13 @@ class ExperientialMemory:
             ),
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
-    def _step_jit(
+    def _step_from_retrieval(
         self,
         state: ExperientialMemoryState,
-        query_key: Array,
-        representation_version: Array,
-        query_uncertainty: Array,
-        query_uncertainty_available: Array,
+        retrieval: ExperientialMemoryRetrieval,
         entry: ExperientialMemoryEntry,
     ) -> ExperientialMemoryStepResult:
-        retrieval = self._query_jit(
-            state,
-            query_key,
-            representation_version,
-            query_uncertainty,
-            query_uncertainty_available,
-        )
+        """Age, record one already-computed pre-state query, and write once."""
 
         def apply(_: None) -> ExperientialMemoryStepResult:
             advanced = self._advance(state)
@@ -1294,6 +1291,25 @@ class ExperientialMemory:
             ExperientialMemoryStepResult,
             jax.lax.cond(self._state_is_valid(state), apply, reject, operand=None),
         )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _step_jit(
+        self,
+        state: ExperientialMemoryState,
+        query_key: Array,
+        representation_version: Array,
+        query_uncertainty: Array,
+        query_uncertainty_available: Array,
+        entry: ExperientialMemoryEntry,
+    ) -> ExperientialMemoryStepResult:
+        retrieval = self._query_jit(
+            state,
+            query_key,
+            representation_version,
+            query_uncertainty,
+            query_uncertainty_available,
+        )
+        return self._step_from_retrieval(state, retrieval, entry)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def accounting(

--- a/alberta_framework/core/experiential_memory_policy.py
+++ b/alberta_framework/core/experiential_memory_policy.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="call-arg"
-"""Non-mutating experiential-memory to discrete-policy proposal boundary.
+"""Experiential-memory to discrete-policy proposal and transaction boundary.
 
 The boundary performs a real :class:`ExperientialMemory` query internally and
 interprets the retrieved action vector only as categorical score mass, one
@@ -10,8 +10,9 @@ with positive mass.
 
 Raw mass, normalized mass, effective reliability, and retrieval provenance are
 kept separate.  None is a calibrated confidence or evidence of benefit.  The
-boundary owns no state, uses no randomness, and never mutates the supplied
-memory state.
+boundary owns no state and uses no randomness. :meth:`propose` remains
+read-only; :meth:`propose_and_step` returns a new state after exactly one
+query-before-write transaction and never mutates the supplied state.
 """
 
 from __future__ import annotations
@@ -29,8 +30,10 @@ from jaxtyping import Bool, Float, Int
 
 from alberta_framework.core.experiential_memory import (
     ExperientialMemory,
+    ExperientialMemoryEntry,
     ExperientialMemoryRetrieval,
     ExperientialMemoryState,
+    ExperientialMemoryStepResult,
 )
 
 EXPERIENTIAL_MEMORY_POLICY_SCHEMA = "alberta.experiential-memory-policy.v1"
@@ -230,6 +233,84 @@ class ExperientialMemoryPolicy:
             ExperientialMemoryPolicyProposal,
             self._interpret_jit(retrieval, hard_safety_mask),
         )
+
+    def propose_and_step(
+        self,
+        state: ExperientialMemoryState,
+        query_key: Float[Array, " key_dim"],
+        representation_version: Int[Array, ""],
+        query_uncertainty: Float[Array, ""],
+        query_uncertainty_available: Bool[Array, ""],
+        hard_safety_mask: Bool[Array, " n_actions"],
+        entry: ExperientialMemoryEntry,
+    ) -> tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult]:
+        """Propose from the pre-write state, record that access, and write once."""
+        self._memory._validate_state_static_contract(state)
+        self._memory._validate_entry_static_contract(entry)
+        _require_array(
+            query_key,
+            name="query_key",
+            shape=(self._memory.config.key_dim,),
+            dtype=jnp.float32,
+        )
+        _require_array(
+            representation_version,
+            name="representation_version",
+            shape=(),
+            dtype=jnp.int32,
+        )
+        _require_array(
+            query_uncertainty,
+            name="query_uncertainty",
+            shape=(),
+            dtype=jnp.float32,
+        )
+        _require_array(
+            query_uncertainty_available,
+            name="query_uncertainty_available",
+            shape=(),
+            dtype=jnp.bool_,
+        )
+        _require_array(
+            hard_safety_mask,
+            name="hard_safety_mask",
+            shape=(self._memory.config.action_dim,),
+            dtype=jnp.bool_,
+        )
+        return cast(
+            tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult],
+            self._propose_and_step_jit(
+                state,
+                query_key,
+                representation_version,
+                query_uncertainty,
+                query_uncertainty_available,
+                hard_safety_mask,
+                entry,
+            ),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _propose_and_step_jit(
+        self,
+        state: ExperientialMemoryState,
+        query_key: Array,
+        representation_version: Array,
+        query_uncertainty: Array,
+        query_uncertainty_available: Array,
+        hard_safety_mask: Array,
+        entry: ExperientialMemoryEntry,
+    ) -> tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult]:
+        retrieval = self._memory._query_jit(
+            state,
+            query_key,
+            representation_version,
+            query_uncertainty,
+            query_uncertainty_available,
+        )
+        proposal = self._interpret_jit(retrieval, hard_safety_mask)
+        step = self._memory._step_from_retrieval(state, retrieval, entry)
+        return proposal, step
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def _interpret_jit(

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -1553,7 +1553,12 @@ class PrototypeExperientialMemoryDiagnostics:
 
 @dataclasses.dataclass(frozen=True)
 class PrototypeExperientialMemoryResourceDeclaration:
-    """Exact persistent allocation and bounded work per required transaction."""
+    """Exact persistent allocation and bounded work per required transaction.
+
+    ``categorical_policy_queries`` is the one query shared by proposal and
+    causal access/write accounting. ``causal_step_queries`` counts only an
+    additional query and is therefore zero for the fused transaction.
+    """
 
     persistent_state_bytes: int
     categorical_policy_queries: int
@@ -2483,7 +2488,7 @@ class PrototypeAgent:
 
     @property
     def experiential_memory_policy(self) -> ExperientialMemoryPolicy | None:
-        """Return the read-only categorical memory proposal boundary."""
+        """Return the categorical memory proposal/transaction boundary."""
 
         return self._experiential_memory_policy
 
@@ -2491,14 +2496,14 @@ class PrototypeAgent:
     def experiential_memory_resource_declaration(
         self,
     ) -> PrototypeExperientialMemoryResourceDeclaration | None:
-        """Declare memory bytes and both deterministic pre-state queries."""
+        """Declare memory bytes and the single deterministic pre-state query."""
 
         policy = self._experiential_memory_policy
         if policy is None:
             return None
         policy_resources = policy.resource_declaration()
         categorical_queries = policy_resources.memory_queries_per_proposal
-        causal_queries = 1
+        causal_queries = 0
         return PrototypeExperientialMemoryResourceDeclaration(
             persistent_state_bytes=(
                 policy_resources.external_memory_persistent_state_bytes
@@ -4826,14 +4831,6 @@ class PrototypeAgent:
             memory_input.next_action_safety_mask,
             jnp.ones_like(memory_input.next_action_safety_mask),
         )
-        proposal = policy.propose(
-            memory_state,
-            decision_representation,
-            query_version,
-            query_uncertainty,
-            query_uncertainty_available,
-            safety_mask,
-        )
         entry = ExperientialMemoryEntry(
             observation=current_representation,
             key=current_representation,
@@ -4863,28 +4860,44 @@ class PrototypeAgent:
             source_id=memory_input.source_id,
         )
 
-        def apply_step(_: None) -> ExperientialMemoryStepResult:
-            return memory.step(
+        def apply_step(
+            _: None,
+        ) -> tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult]:
+            return policy.propose_and_step(
                 memory_state,
                 decision_representation,
-                memory_input.query_representation_version,
-                memory_input.query_uncertainty,
-                memory_input.query_uncertainty_available,
+                query_version,
+                query_uncertainty,
+                query_uncertainty_available,
+                safety_mask,
                 entry,
             )
 
-        def skip_step(_: None) -> ExperientialMemoryStepResult:
-            return ExperientialMemoryStepResult(
-                state=memory_state,
-                retrieval=proposal.retrieval,
-                wrote=jnp.asarray(False, dtype=jnp.bool_),
-                slot=jnp.asarray(-1, dtype=jnp.int32),
-                evicted=jnp.asarray(False, dtype=jnp.bool_),
-                evicted_provenance_id=jnp.asarray(-1, dtype=jnp.int32),
+        def skip_step(
+            _: None,
+        ) -> tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult]:
+            proposal = policy.propose(
+                memory_state,
+                decision_representation,
+                query_version,
+                query_uncertainty,
+                query_uncertainty_available,
+                safety_mask,
+            )
+            return (
+                proposal,
+                ExperientialMemoryStepResult(
+                    state=memory_state,
+                    retrieval=proposal.retrieval,
+                    wrote=jnp.asarray(False, dtype=jnp.bool_),
+                    slot=jnp.asarray(-1, dtype=jnp.int32),
+                    evicted=jnp.asarray(False, dtype=jnp.bool_),
+                    evicted_provenance_id=jnp.asarray(-1, dtype=jnp.int32),
+                ),
             )
 
-        step = cast(
-            ExperientialMemoryStepResult,
+        proposal, step = cast(
+            tuple[ExperientialMemoryPolicyProposal, ExperientialMemoryStepResult],
             jax.lax.cond(
                 transaction_required,
                 apply_step,
@@ -4936,7 +4949,7 @@ class PrototypeAgent:
             query_before_write=transaction_required & retrieval_matches,
             deterministic_prestate_query_count=jnp.where(
                 transaction_required,
-                jnp.asarray(2, dtype=jnp.int32),
+                jnp.asarray(1, dtype=jnp.int32),
                 jnp.asarray(0, dtype=jnp.int32),
             ),
             wrote=step.wrote,

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -235,6 +235,45 @@ def test_initial_allocation_and_accounting_are_exact() -> None:
     assert state.entries.outcomes.shape == (5, 1)
 
 
+def test_new_entry_recency_starts_at_zero_not_chronological_age() -> None:
+    """A freshly written exemplar has not gone ``entry.age`` steps without access."""
+    memory = ExperientialMemory(_config())
+    result = memory.write(memory.init(), _entry(17, age=500))
+
+    assert bool(result.wrote)
+    slot = int(result.slot)
+    assert int(result.state.entries.ages[slot]) == 500
+    assert int(result.state.entries.recency_ages[slot]) == 0
+
+
+def test_imported_age_does_not_override_lru_write_recency() -> None:
+    """A newly written old exemplar must not look older than prior writes."""
+    memory = ExperientialMemory(
+        _config(
+            capacity=2,
+            top_k=1,
+            eviction_utility_weight=0.0,
+            eviction_recency_weight=1.0,
+        )
+    )
+    state = _write(memory, memory.init(), _entry(10))
+    state = _write(memory, state, _entry(20))
+
+    third = memory.write(state, _entry(30, age=500))
+    assert bool(third.wrote)
+    assert int(third.evicted_provenance_id) == 10
+    fourth = memory.write(third.state, _entry(40))
+
+    assert bool(fourth.wrote)
+    assert int(fourth.evicted_provenance_id) == 20
+    retained = set(
+        np.asarray(fourth.state.entries.provenance_ids)[
+            np.asarray(fourth.state.entries.valid)
+        ].tolist()
+    )
+    assert retained == {30, 40}
+
+
 def test_empty_query_abstains_with_finite_zero_payload() -> None:
     memory = ExperientialMemory(_config())
     retrieval = memory.query(

--- a/tests/test_experiential_memory_policy.py
+++ b/tests/test_experiential_memory_policy.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="call-arg,type-var"
-"""Tests for the non-mutating experiential-memory policy proposal boundary."""
+"""Tests for experiential-memory policy proposal and transaction boundaries."""
 
 from __future__ import annotations
 
@@ -239,6 +239,89 @@ def test_valid_retrieval_is_categorical_mass_with_separate_diagnostics() -> None
     assert int(proposal.retrieval.neighbor_provenance_ids[0]) == 10
     assert bool(proposal.retrieval.neighbor_mask[0])
     _assert_trees_equal(state, before)
+
+
+def test_policy_step_matches_memory_step_and_records_each_access() -> None:
+    """The stateful policy path must query, account, age, and write exactly once."""
+    memory = ExperientialMemory(
+        _memory_config(
+            capacity=4,
+            top_k=2,
+            max_age=100,
+            eviction_utility_weight=0.0,
+            eviction_recency_weight=1.0,
+        )
+    )
+    policy = ExperientialMemoryPolicy(memory)
+    policy_state = memory.init()
+    direct_state = memory.init()
+    key = jnp.zeros((2,), dtype=jnp.float32)
+    version = jnp.asarray(1, dtype=jnp.int32)
+    uncertainty = jnp.asarray(0.1, dtype=jnp.float32)
+    uncertainty_available = jnp.asarray(True, dtype=jnp.bool_)
+    safety_mask = jnp.ones((3,), dtype=jnp.bool_)
+
+    probe_entry = _entry(99)
+    eager_probe = policy.propose_and_step(
+        policy_state,
+        key,
+        version,
+        uncertainty,
+        uncertainty_available,
+        safety_mask,
+        probe_entry,
+    )
+    compiled_probe = jax.jit(policy.propose_and_step)(
+        policy_state,
+        key,
+        version,
+        uncertainty,
+        uncertainty_available,
+        safety_mask,
+        probe_entry,
+    )
+    _assert_trees_equal(eager_probe, compiled_probe)
+
+    for index in range(12):
+        entry = _entry(100 + index)
+        proposal, policy_step = policy.propose_and_step(
+            policy_state,
+            key,
+            version,
+            uncertainty,
+            uncertainty_available,
+            safety_mask,
+            entry,
+        )
+        direct_step = memory.step(
+            direct_state,
+            key,
+            version,
+            uncertainty,
+            uncertainty_available,
+            entry,
+        )
+        _assert_trees_equal(proposal.retrieval, direct_step.retrieval)
+        _assert_trees_equal(policy_step, direct_step)
+        policy_state = policy_step.state
+        direct_state = direct_step.state
+
+    accounting = memory.accounting(policy_state)
+    assert int(accounting.queries) == 12
+    assert int(accounting.accepted_queries) == 11
+    assert int(accounting.writes) == 12
+    np.testing.assert_array_equal(
+        policy_state.entries.provenance_ids,
+        direct_state.entries.provenance_ids,
+    )
+    np.testing.assert_array_equal(
+        policy_state.entries.recency_ages,
+        direct_state.entries.recency_ages,
+    )
+    np.testing.assert_array_equal(
+        policy_state.entries.retrieval_counts,
+        direct_state.entries.retrieval_counts,
+    )
 
 
 def test_finite_action_mass_sum_cannot_overflow_into_false_abstention() -> None:

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.dreaming import DreamingConfig
+from alberta_framework.core.experiential_memory import ExperientialMemoryConfig
 from alberta_framework.core.intelligence_amplification import IAConfig
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
@@ -23,7 +24,10 @@ from alberta_framework.core.prototype_agent import (
     PrototypeAgentConfig,
     PrototypeAgentState,
     PrototypeArrayResult,
+    PrototypeExperientialMemoryInput,
+    PrototypeTransition,
     PrototypeUpdateResult,
+    _increment_decision_id,
     feature_to_subtask_specs,
     load_prototype_checkpoint,
     save_prototype_checkpoint,
@@ -395,6 +399,75 @@ class TestPrototypeAgentUpdateFull:
         chex.assert_shape(result.ia_recommendation, ())
         assert int(result.state.buffer_state.size) == 1
         assert int(result.state.world_model_state.step_count) == 1
+
+
+def test_experiential_memory_uses_one_accounted_policy_step() -> None:
+    """Prototype proposal and write must share one recorded pre-state query."""
+    memory_config = ExperientialMemoryConfig(
+        capacity=3,
+        observation_dim=OBS_DIM,
+        key_dim=OBS_DIM,
+        action_dim=N_PRIM,
+        outcome_dim=OBS_DIM + 1,
+        top_k=1,
+        min_neighbors=1,
+    )
+    agent = PrototypeAgent(
+        PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            experiential_memory=memory_config,
+        )
+    )
+    resources = agent.experiential_memory_resource_declaration
+    assert resources is not None
+    assert resources.categorical_policy_queries == 1
+    assert resources.causal_step_queries == 0
+    assert resources.total_deterministic_prestate_queries == 1
+
+    state = agent.start(agent.init(jr.key(31)), jnp.zeros(OBS_DIM, dtype=jnp.float32))
+    transition = PrototypeTransition(
+        observation=state.current_raw_observation,
+        action=state.current_action,
+        decision_id=state.current_decision_id,
+        reward=jnp.asarray(1.0, dtype=jnp.float32),
+        discount=jnp.asarray(1.0, dtype=jnp.float32),
+        terminated=jnp.asarray(False),
+        truncated=jnp.asarray(False),
+        next_observation=jnp.ones(OBS_DIM, dtype=jnp.float32),
+        next_decision_observation=jnp.ones(OBS_DIM, dtype=jnp.float32),
+    )
+    memory_input = PrototypeExperientialMemoryInput(
+        available=jnp.asarray(True),
+        current_prototype_decision_id=state.current_decision_id,
+        next_prototype_decision_id=_increment_decision_id(state.current_decision_id),
+        query_representation_version=jnp.asarray(0, dtype=jnp.int32),
+        entry_representation_version=jnp.asarray(0, dtype=jnp.int32),
+        query_uncertainty=jnp.asarray(0.0, dtype=jnp.float32),
+        query_uncertainty_available=jnp.asarray(True),
+        entry_uncertainty=jnp.asarray(0.0, dtype=jnp.float32),
+        entry_uncertainty_available=jnp.asarray(True),
+        safety_cost=jnp.asarray(0.0, dtype=jnp.float32),
+        safety_cost_available=jnp.asarray(True),
+        reliability=jnp.asarray(1.0, dtype=jnp.float32),
+        utility=jnp.asarray(1.0, dtype=jnp.float32),
+        utility_available=jnp.asarray(True),
+        provenance_id=jnp.asarray(1, dtype=jnp.int32),
+        source_id=jnp.asarray(1, dtype=jnp.int32),
+        next_action_safety_mask=jnp.ones(N_PRIM, dtype=jnp.bool_),
+    )
+
+    result = agent.update_transition(
+        state,
+        transition,
+        experiential_memory_input=memory_input,
+    )
+    diagnostics = result.experiential_memory_diagnostics
+    memory_state = agent._experiential_memory_component_state(result.state.ia_state)
+
+    assert bool(diagnostics.transaction_applied)
+    assert int(diagnostics.deterministic_prestate_query_count) == 1
+    assert int(memory_state.query_count) == 1
+    assert int(memory_state.write_count) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #432.

This adds one fused `ExperientialMemoryPolicy.propose_and_step` transaction: it queries the pre-write state once, interprets that exact retrieval, records accepted-access/accounting state, ages once, and writes once. PrototypeAgent now consumes the fused path and declares one deterministic pre-state query instead of issuing two. Fresh writes initialize retrieval recency at zero while preserving the entry chronology age, restoring true LRU semantics for imported exemplars.

Failing-first evidence on the previous code:
- stateful policy transaction was absent;
- a new entry with chronological age 500 received recency age 500 and was incorrectly evicted ahead of older writes.

Validation:
- `tests/test_experiential_memory.py` + `tests/test_experiential_memory_policy.py`: 79 passed before the live-main rebase;
- full `tests/test_prototype_agent.py`: 89 passed;
- final live-main focused composition: 82 passed;
- Ruff: clean;
- strict mypy: 165 source files clean;
- diff check: clean.

No outputs or registered evidence sources changed. The evidence registry remains in its inherited fail-closed invalid state from unrelated registered-source drift; this patch does not revalidate or promote any claim.