### PR TITLE
fix(horde): reject malformed head vectors

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -389,6 +389,13 @@ class HordeLearner:
             HordeUpdateResult with updated state, predictions, TD errors,
             TD targets, and per-demon metrics
         """
+        cumulants = jnp.asarray(cumulants)
+        expected_shape = (self.n_demons,)
+        if cumulants.shape != expected_shape:
+            raise ValueError(
+                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
+            )
+
         # 1. Compute V(s') for bootstrapping
         next_preds = self._learner.predict(state, next_observation)
 
@@ -466,8 +473,19 @@ class HordeLearner:
         Returns:
             HordeUpdateResult with updated state and TD metrics.
         """
-        next_preds = self._learner.predict(state, next_observation)
+        cumulants = jnp.asarray(cumulants)
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
+        expected_shape = (self.n_demons,)
+        if cumulants.shape != expected_shape:
+            raise ValueError(
+                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
+            )
+        if discounts.shape != expected_shape:
+            raise ValueError(
+                f"discounts must have shape {expected_shape}, got {discounts.shape}"
+            )
+
+        next_preds = self._learner.predict(state, next_observation)
         bootstrap = jnp.where(discounts == 0.0, 0.0, discounts * next_preds)
         targets = cumulants + bootstrap
         requested = ~jnp.isnan(cumulants)

--- a/tests/test_horde.py
+++ b/tests/test_horde.py
@@ -3,6 +3,7 @@
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework import (
     Autostep,
@@ -13,6 +14,7 @@ from alberta_framework import (
     HordeLearner,
     HordeLearningResult,
     MultiHeadMLPLearner,
+    MultiHeadMLPState,
     ObGDBounding,
     create_horde_spec,
     run_horde_learning_loop,
@@ -29,6 +31,70 @@ def _make_all_gamma0_spec(n: int) -> list[GVFSpec]:
         )
         for i in range(n)
     ]
+
+
+def _shape_contract_horde() -> tuple[HordeLearner, MultiHeadMLPState]:
+    horde = HordeLearner(
+        horde_spec=create_horde_spec(_make_all_gamma0_spec(3)),
+        hidden_sizes=(4,),
+        sparsity=0.0,
+    )
+    return horde, horde.init(5, jr.key(0))
+
+
+@pytest.mark.parametrize(
+    "cumulants",
+    [
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones((1,), dtype=jnp.float32),
+        jnp.ones((3, 1), dtype=jnp.float32),
+    ],
+)
+def test_horde_update_rejects_wrong_cumulant_shape(cumulants: jnp.ndarray) -> None:
+    horde, state = _shape_contract_horde()
+    with pytest.raises(ValueError, match=r"cumulants must have shape \(3,\)"):
+        horde.update(
+            state,
+            jnp.ones((5,), dtype=jnp.float32),
+            cumulants,
+            jnp.zeros((5,), dtype=jnp.float32),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "cumulants", "discounts"),
+    [
+        (
+            "cumulants",
+            jnp.ones((1,), dtype=jnp.float32),
+            jnp.ones((3,), dtype=jnp.float32),
+        ),
+        (
+            "discounts",
+            jnp.ones((3,), dtype=jnp.float32),
+            jnp.asarray(0.9, dtype=jnp.float32),
+        ),
+        (
+            "discounts",
+            jnp.ones((3,), dtype=jnp.float32),
+            jnp.ones((3, 1), dtype=jnp.float32),
+        ),
+    ],
+)
+def test_horde_update_with_discounts_rejects_wrong_head_vector_shape(
+    field: str,
+    cumulants: jnp.ndarray,
+    discounts: jnp.ndarray,
+) -> None:
+    horde, state = _shape_contract_horde()
+    with pytest.raises(ValueError, match=rf"{field} must have shape \(3,\)"):
+        horde.update_with_discounts(
+            state,
+            jnp.ones((5,), dtype=jnp.float32),
+            cumulants,
+            jnp.zeros((5,), dtype=jnp.float32),
+            discounts,
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #463.

`HordeLearner.update` now requires cumulants to have exactly one value per demon. `update_with_discounts` applies the same exact cumulant contract and requires an exact per-demon discount vector. Both checks run before prediction/target arithmetic, replacing broadcast-dependent low-level JAX failures with a field-specific `ValueError`.

Failing-first evidence on the parent: six retained scalar, singleton, and `(n_demons, 1)` cumulant/discount cases all failed with the old opaque errors or no exception. The repaired selector is 6/6 green.

Validation:
- full `tests/test_horde.py`: 28 passed;
- mixed Horde + forward-view equivalence + SARSA adjacency: 65 passed;
- final rebased boundary selector: 6 passed;
- Ruff: clean;
- strict mypy: 165 source files clean;
- diff check: clean.

No outputs or registered evidence sources changed. The current evidence registry remains in its inherited fail-closed invalid state from unrelated registered-source drift.