### PR TITLE
fix(export): reject nonfinite display summaries

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -21,7 +21,7 @@ from alberta_framework._seed_validation import require_unique_jax_seeds
 if TYPE_CHECKING:
     import pandas as pd
 
-    from alberta_framework.utils.experiments import AggregatedResults
+    from alberta_framework.utils.experiments import AggregatedResults, MetricSummary
     from alberta_framework.utils.statistics import SignificanceResult
 
 
@@ -266,6 +266,23 @@ def export_to_json(
     _write_text_atomically(filepath, payload)
 
 
+def _finite_table_summaries(
+    results: dict[str, "AggregatedResults"],
+    metric: str,
+) -> dict[str, "MetricSummary"]:
+    """Return display summaries only after validating their rendered statistics."""
+    if not results:
+        raise ValueError("table results must be non-empty")
+
+    summaries: dict[str, MetricSummary] = {}
+    for name, aggregate in results.items():
+        summary = aggregate.summary[metric]
+        mean = float(_exported_number(summary.mean))
+        std = float(_exported_number(summary.std))
+        summaries[name] = summary._replace(mean=mean, std=std)
+    return summaries
+
+
 def generate_latex_table(
     results: dict[str, "AggregatedResults"],
     significance_results: dict[tuple[str, str], "SignificanceResult"] | None = None,
@@ -300,14 +317,14 @@ def generate_latex_table(
     lines.append(r"\midrule")
 
     # Find best result
-    summaries = {name: agg.summary[metric] for name, agg in results.items()}
+    summaries = _finite_table_summaries(results, metric)
     if lower_is_better:
         best_name = min(summaries.keys(), key=lambda k: summaries[k].mean)
     else:
         best_name = max(summaries.keys(), key=lambda k: summaries[k].mean)
 
-    for name, agg in results.items():
-        summary = agg.summary[metric]
+    for name in results:
+        summary = summaries[name]
         mean_str = f"{summary.mean:.4f}"
         std_str = f"{summary.std:.4f}"
 
@@ -395,14 +412,14 @@ def generate_markdown_table(
     lines.append("|--------|-------------------------|-------|")
 
     # Find best result
-    summaries = {name: agg.summary[metric] for name, agg in results.items()}
+    summaries = _finite_table_summaries(results, metric)
     if lower_is_better:
         best_name = min(summaries.keys(), key=lambda k: summaries[k].mean)
     else:
         best_name = max(summaries.keys(), key=lambda k: summaries[k].mean)
 
-    for name, agg in results.items():
-        summary = agg.summary[metric]
+    for name in results:
+        summary = summaries[name]
         mean_str = f"{summary.mean:.4f}"
         std_str = f"{summary.std:.4f}"
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -480,6 +480,44 @@ def test_atomic_publish_failure_preserves_destination_and_removes_temporary_file
     assert list(tmp_path.iterdir()) == [path]
 
 
+@pytest.mark.parametrize("field", ["mean", "std"])
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_display_tables_reject_nonfinite_summaries(field: str, value: float) -> None:
+    result = _constant_result("invalid")
+    summary = result.summary[_METRIC]._replace(**{field: value})
+    results = {"invalid": result._replace(summary={_METRIC: summary})}
+
+    for render in (generate_latex_table, generate_markdown_table):
+        with pytest.raises(ValueError, match="non-finite"):
+            render(results)
+
+
+@pytest.mark.parametrize("field", ["mean", "std"])
+def test_display_tables_render_the_same_canonical_float_they_validate(field: str) -> None:
+    class InfiniteFloatWithFiniteCoercion(float):
+        def __float__(self) -> float:
+            return 0.0
+
+    value = InfiniteFloatWithFiniteCoercion(math.inf)
+    assert float(value) == 0.0
+    assert format(value, ".4f") == "inf"
+
+    result = _constant_result("candidate", 1.0)
+    summary = result.summary[_METRIC]._replace(**{field: value})
+    results = {"candidate": result._replace(summary={_METRIC: summary})}
+
+    for render in (generate_latex_table, generate_markdown_table):
+        table = render(results)
+        assert "inf" not in table
+        assert "0.0000" in table
+
+
+def test_display_tables_reject_empty_results() -> None:
+    for render in (generate_latex_table, generate_markdown_table):
+        with pytest.raises(ValueError, match="non-empty"):
+            render({})
+
+
 def test_display_only_tables_keep_four_decimal_presentation() -> None:
     results = {"candidate": _constant_result("candidate", 0.12345678901234566)}
 


### PR DESCRIPTION
Closes #473.

## What changed

LaTeX and Markdown result-table generation now share a narrow display-summary preflight that:

- rejects an empty result mapping with a boundary-specific error;
- converts each rendered mean and standard deviation exactly once to a finite built-in `float`;
- returns canonical `MetricSummary` values so validation, best-result ranking, and four-decimal rendering consume the same numeric payload.

This closes the polymorphic-float gap identified during review: a `float` subclass could store `+inf`, override `__float__()` to return `0.0`, pass the old preflight, and then render the original object as `inf`. The regression covers this behavior independently for both `mean` and `std` across both table renderers.

Finite ranking, significance markers, four-decimal presentation, and the deeper machine-readable CSV/JSON preflight remain unchanged.

## Requested-change follow-up

Addressed the review on exact prior head `1988f75c7775eb2ec9b0e89e369c805a003fc1a6`:

- reproduced `float(value) == 0.0` while `format(value, ".4f") == "inf"` for an adversarial `float` subclass;
- canonicalized each mean/std value once after finite validation;
- changed both ranking and rendering paths to use those canonical built-in values;
- added mean and std regressions that require both LaTeX and Markdown to render `0.0000` and never `inf`.

## Scope

- `alberta_framework/utils/export.py`
- `tests/test_export.py`

## Verification

Exact candidate head: `bd7ba47d8650dabdf6ebcc81ce9b42632c543b2c`  
Base: `a5e8e7390d9bf45390a42dc3dc60f30e218aeaa7`

- original tests-first focused baseline: **7 failed, 92 passed**;
- requested-change reproduction confirmed on prior exact head `1988f75c7775eb2ec9b0e89e369c805a003fc1a6`;
- complete export suite after the review repair: **101 passed**;
- full Ruff: **all checks passed**;
- strict mypy: **no issues in 165 source files**;
- `git diff --check`: clean;
- clean candidate worktree with one authored commit;
- rebased onto current `origin/main` (`a5e8e7390d9bf45390a42dc3dc60f30e218aeaa7`);
- exact-head proof recorded after rebase: complete export suite **101 passed**;
- live path ownership refresh: only this PR touches either target file among open ASI PRs.

## Scientific integrity

This is fail-closed formatting-boundary validation. It does not change aggregation, statistics, significance calculations, metric values, registered evidence sources, frozen protocols, seeds, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->