### PR TITLE
fix(streams): Step 1 & Step 2 benchmark streams parameter validation and signed int32 bounds

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import struct
 from numbers import Integral, Real
+from typing import cast
 
 
 def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
@@ -38,43 +39,92 @@ def _float32_from_ratio(
     else:
         exponent = magnitude.bit_length() - denominator.bit_length()
         if exponent >= 0:
-            if magnitude < denominator << exponent:
-                exponent -= 1
-        elif magnitude << -exponent < denominator:
+            scaled_numerator = magnitude
+            scaled_denominator = denominator << exponent
+        else:
+            scaled_numerator = magnitude << (-exponent)
+            scaled_denominator = denominator
+        if scaled_numerator < scaled_denominator:
             exponent -= 1
+        elif scaled_numerator >= (scaled_denominator << 1):
+            exponent += 1
 
-        if exponent > 127:
-            bits = sign_bits | 0x7F800000
-        elif exponent >= -126:
+        unbiased_exponent = exponent
+        if unbiased_exponent > 127:
+            raise OverflowError("value overflows IEEE 754 binary32")
+
+        if unbiased_exponent >= -126:
             shift = 23 - exponent
             if shift >= 0:
-                significand = _round_quotient_ties_to_even(
-                    magnitude << shift,
-                    denominator,
-                )
+                scaled_num = magnitude << shift
+                scaled_den = denominator
             else:
-                significand = _round_quotient_ties_to_even(
-                    magnitude,
-                    denominator << -shift,
-                )
-            if significand == 1 << 24:
-                significand >>= 1
-                exponent += 1
-            if exponent > 127:
-                bits = sign_bits | 0x7F800000
-            else:
-                bits = (
-                    sign_bits
-                    | ((exponent + 127) << 23)
-                    | (significand - (1 << 23))
-                )
+                scaled_num = magnitude
+                scaled_den = denominator << (-shift)
+            significand_full = _round_quotient_ties_to_even(scaled_num, scaled_den)
+            if significand_full == 1 << 24:
+                unbiased_exponent += 1
+                if unbiased_exponent > 127:
+                    raise OverflowError("value overflows IEEE 754 binary32")
+                significand_full >>= 1
+            biased_exponent = unbiased_exponent + 127
+            significand_bits = significand_full & ((1 << 23) - 1)
+            bits = sign_bits | (biased_exponent << 23) | significand_bits
         else:
-            significand = _round_quotient_ties_to_even(
-                magnitude << 149,
-                denominator,
-            )
-            bits = sign_bits | significand
+            scaled_num = magnitude << 149
+            scaled_den = denominator
+            significand = _round_quotient_ties_to_even(scaled_num, scaled_den)
+            if significand >= (1 << 23):
+                bits = sign_bits | (1 << 23)
+            else:
+                bits = sign_bits | significand
     return float(struct.unpack("!f", bits.to_bytes(4, byteorder="big"))[0])
+
+
+def _real_ratio(value: Real) -> tuple[int, int, bool]:
+    """Return one normalized exact ratio and its zero-sign metadata."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise TypeError("value must be an actual non-bool real")
+    if issubclass(actual_type, Integral):
+        ratio: object = (int(cast(Integral, value)), 1)
+    else:
+        ratio_method = getattr(actual_type, "as_integer_ratio", None)
+        if not callable(ratio_method):
+            raise TypeError("real value must expose as_integer_ratio")
+        ratio = ratio_method(value)
+    if type(ratio) is not tuple or len(ratio) != 2:
+        raise TypeError("as_integer_ratio must return an integer pair")
+    numerator_raw, denominator_raw = ratio
+    num_type = type(numerator_raw)
+    den_type = type(denominator_raw)
+    if (
+        issubclass(num_type, bool)
+        or not issubclass(num_type, Integral)
+        or issubclass(den_type, bool)
+        or not issubclass(den_type, Integral)
+    ):
+        raise TypeError("as_integer_ratio must return an integer pair")
+    numerator = int(numerator_raw)
+    denominator = int(denominator_raw)
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if denominator == 0:
+        raise ValueError("ratio denominator must be nonzero")
+    negative_zero = numerator == 0 and math.copysign(1.0, float(value)) < 0.0
+    return numerator, denominator, negative_zero
+
+
+def round_real_to_float32_with_ratio(value: Real) -> tuple[int, int, float]:
+    """Read one exact ratio and return it with its binary32 rounding."""
+    numerator, denominator, negative_zero = _real_ratio(value)
+    narrowed = _float32_from_ratio(
+        numerator,
+        denominator,
+        negative_zero=negative_zero,
+    )
+    return numerator, denominator, narrowed
 
 
 def round_real_to_float32(value: Real) -> float:
@@ -85,35 +135,7 @@ def round_real_to_float32(value: Real) -> float:
     conversion. Real implementations that cannot expose an exact ratio are
     rejected instead of being silently double-rounded.
     """
-    if isinstance(value, bool):
-        raise TypeError("real value must not be a bool")
-    if isinstance(value, Integral):
-        ratio: object = (int(value), 1)
-    else:
-        ratio_method = getattr(value, "as_integer_ratio", None)
-        if not callable(ratio_method):
-            raise TypeError("real value must expose as_integer_ratio")
-        ratio = ratio_method()
-    if not isinstance(ratio, tuple) or len(ratio) != 2:
-        raise TypeError("as_integer_ratio must return an integer pair")
-    numerator_raw, denominator_raw = ratio
-    if (
-        isinstance(numerator_raw, bool)
-        or not isinstance(numerator_raw, Integral)
-        or isinstance(denominator_raw, bool)
-        or not isinstance(denominator_raw, Integral)
-    ):
-        raise TypeError("as_integer_ratio must return an integer pair")
-    numerator = int(numerator_raw)
-    denominator = int(denominator_raw)
-    negative_zero = (
-        numerator == 0 and math.copysign(1.0, float(value)) < 0.0
-    )
-    return _float32_from_ratio(
-        numerator,
-        denominator,
-        negative_zero=negative_zero,
-    )
+    return round_real_to_float32_with_ratio(value)[2]
 
 
-__all__ = ["round_real_to_float32"]
+__all__ = ["round_real_to_float32", "round_real_to_float32_with_ratio"]

--- a/alberta_framework/streams/alberta_plan_step1.py
+++ b/alberta_framework/streams/alberta_plan_step1.py
@@ -21,13 +21,88 @@ protocol and are JIT-friendly (no Python control flow on traced values).
 Reference: Sutton et al., "The Alberta Plan for AI Research", Step 1.
 """
 
+import math
+from numbers import Integral, Real
+from typing import cast
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.types import TimeStep
+
+_INT32_MAX = 2**31 - 1
+
+
+def _finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def _canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return _canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return _canonical_float32_storage(real, narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(Integral, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
 
 
 @chex.dataclass(frozen=True)
@@ -102,21 +177,24 @@ class AlbertaPlanStep1Stream:
             ValueError: If ``num_relevant > feature_dim`` or either is
                 non-positive.
         """
-        if feature_dim <= 0:
-            raise ValueError(f"feature_dim must be positive, got {feature_dim}")
-        if num_relevant <= 0:
-            raise ValueError(f"num_relevant must be positive, got {num_relevant}")
-        if num_relevant > feature_dim:
+        feature_dim_val = _require_int("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX)
+        num_relevant_val = _require_int("num_relevant", num_relevant, minimum=1, maximum=_INT32_MAX)
+        if num_relevant_val > feature_dim_val:
             raise ValueError(
-                f"num_relevant ({num_relevant}) must not exceed "
-                f"feature_dim ({feature_dim})"
+                f"num_relevant ({num_relevant_val}) must not exceed "
+                f"feature_dim ({feature_dim_val})"
             )
-        self._feature_dim = feature_dim
-        self._num_relevant = num_relevant
-        self._drift_rate_w = drift_rate_w
-        self._drift_rate_b = drift_rate_b
-        self._noise_std = noise_std
-        self._feature_std = feature_std
+        drift_rate_w_val = _require_nonnegative_real("drift_rate_w", drift_rate_w)
+        drift_rate_b_val = _require_nonnegative_real("drift_rate_b", drift_rate_b)
+        noise_std_val = _require_nonnegative_real("noise_std", noise_std)
+        feature_std_val = _require_positive_real("feature_std", feature_std)
+
+        self._feature_dim = feature_dim_val
+        self._num_relevant = num_relevant_val
+        self._drift_rate_w = drift_rate_w_val
+        self._drift_rate_b = drift_rate_b_val
+        self._noise_std = noise_std_val
+        self._feature_std = feature_std_val
 
     @property
     def feature_dim(self) -> int:
@@ -127,6 +205,26 @@ class AlbertaPlanStep1Stream:
     def num_relevant(self) -> int:
         """Return the number of relevant input dimensions."""
         return self._num_relevant
+
+    @property
+    def drift_rate_w(self) -> float:
+        """Return the weight drift rate."""
+        return self._drift_rate_w
+
+    @property
+    def drift_rate_b(self) -> float:
+        """Return the bias drift rate."""
+        return self._drift_rate_b
+
+    @property
+    def noise_std(self) -> float:
+        """Return the target noise standard deviation."""
+        return self._noise_std
+
+    @property
+    def feature_std(self) -> float:
+        """Return the feature standard deviation."""
+        return self._feature_std
 
     def init(self, key: Array) -> AlbertaPlanStep1State:
         """Initialize stream state.
@@ -272,30 +370,40 @@ class XDistShiftStream:
                 ``scale_min >= scale_max``, ``scale_change_interval <= 0``, or
                 if ``feature_dim`` / ``num_relevant`` are non-positive.
         """
-        if feature_dim <= 0:
-            raise ValueError(f"feature_dim must be positive, got {feature_dim}")
-        if num_relevant <= 0:
-            raise ValueError(f"num_relevant must be positive, got {num_relevant}")
-        if num_relevant > feature_dim:
+        feature_dim_val = _require_int("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX)
+        num_relevant_val = _require_int("num_relevant", num_relevant, minimum=1, maximum=_INT32_MAX)
+        if num_relevant_val > feature_dim_val:
             raise ValueError(
-                f"num_relevant ({num_relevant}) must not exceed "
-                f"feature_dim ({feature_dim})"
+                f"num_relevant ({num_relevant_val}) must not exceed "
+                f"feature_dim ({feature_dim_val})"
             )
-        if scale_change_interval <= 0:
+        noise_std_val = _require_nonnegative_real("noise_std", noise_std)
+        scale_change_interval_val = _require_int(
+            "scale_change_interval",
+            scale_change_interval,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
+        scale_min_val = _require_positive_real("scale_min", scale_min)
+        scale_max_val = _require_positive_real("scale_max", scale_max)
+        if scale_min_val >= scale_max_val:
             raise ValueError(
-                f"scale_change_interval must be positive, got {scale_change_interval}"
+                f"scale_min ({scale_min_val}) must be less than scale_max ({scale_max_val})"
             )
-        if scale_min >= scale_max:
-            raise ValueError(
-                f"scale_min ({scale_min}) must be less than scale_max ({scale_max})"
+        if isinstance(noise_in_target, (bool, np.bool_)):
+            noise_in_target_val = bool(noise_in_target)
+        else:
+            raise TypeError(
+                f"noise_in_target must be a boolean, got {noise_in_target!r}"
             )
-        self._feature_dim = feature_dim
-        self._num_relevant = num_relevant
-        self._noise_std = noise_std
-        self._scale_change_interval = scale_change_interval
-        self._scale_min = scale_min
-        self._scale_max = scale_max
-        self._noise_in_target = noise_in_target
+
+        self._feature_dim = feature_dim_val
+        self._num_relevant = num_relevant_val
+        self._noise_std = noise_std_val
+        self._scale_change_interval = scale_change_interval_val
+        self._scale_min = scale_min_val
+        self._scale_max = scale_max_val
+        self._noise_in_target = noise_in_target_val
 
     @property
     def feature_dim(self) -> int:
@@ -306,6 +414,31 @@ class XDistShiftStream:
     def num_relevant(self) -> int:
         """Return the number of relevant input dimensions."""
         return self._num_relevant
+
+    @property
+    def noise_std(self) -> float:
+        """Return the target noise standard deviation."""
+        return self._noise_std
+
+    @property
+    def scale_change_interval(self) -> int:
+        """Return the scale change interval."""
+        return self._scale_change_interval
+
+    @property
+    def scale_min(self) -> float:
+        """Return the minimum scale."""
+        return self._scale_min
+
+    @property
+    def scale_max(self) -> float:
+        """Return the maximum scale."""
+        return self._scale_max
+
+    @property
+    def noise_in_target(self) -> bool:
+        """Return whether target noise is enabled."""
+        return self._noise_in_target
 
     def init(self, key: Array) -> XDistShiftState:
         """Initialize stream state.

--- a/alberta_framework/streams/feature_discovery.py
+++ b/alberta_framework/streams/feature_discovery.py
@@ -13,11 +13,14 @@ minimal representation lies outside a one-layer feature bank — is probed by
 :mod:`alberta_framework.streams.out_of_class`.
 """
 
-from typing import Any
+import math
+from numbers import Integral, Real
+from typing import Any, cast
 
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
@@ -25,7 +28,77 @@ from alberta_framework._fixed_count_selection import (
     require_positive_builtin_int,
     stable_smallest_mask,
 )
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.types import TimeStep
+
+_INT32_MAX = 2**31 - 1
+
+
+def _finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
+    """Return the original real, exact ratio, and finite binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number, got {value!r}")
+    real = cast(Real, value)
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+    return real, numerator, denominator, narrowed
+
+
+def _canonical_float32_storage(value: Real, narrowed: float) -> float:
+    if not isinstance(value, (int, float, np.floating)):
+        return narrowed
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return narrowed
+    if not math.isfinite(number):
+        raise ValueError("scalar must be finite")
+    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
+        renarrowed = np.asarray(number, dtype=np.float32)
+    if not bool(np.array_equal(narrowed, renarrowed)):
+        number = float(narrowed)
+    return number
+
+
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
+    if real < 0.0 or numerator < 0 or narrowed < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return _canonical_float32_storage(real, narrowed)
+
+
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
+    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return _canonical_float32_storage(real, narrowed)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(Integral, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
 
 
 @chex.dataclass(frozen=True)
@@ -108,29 +181,34 @@ class NonlinearFeatureDiscoveryStream:
             linear_scale: Scale of the direct linear target component.
             noise_std: Standard deviation of target noise.
         """
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if n_latents < 1:
-            raise ValueError("n_latents must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
-        if context_length < 1:
-            raise ValueError("context_length must be positive")
-        if active_latents_per_context < 1:
-            raise ValueError("active_latents_per_context must be positive")
+        feature_dim_val = _require_int("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX)
+        n_tasks_val = _require_int("n_tasks", n_tasks, minimum=1, maximum=_INT32_MAX)
+        n_latents_val = _require_int("n_latents", n_latents, minimum=1, maximum=_INT32_MAX)
+        n_contexts_val = _require_int("n_contexts", n_contexts, minimum=1, maximum=_INT32_MAX)
+        context_length_val = _require_int(
+            "context_length", context_length, minimum=1, maximum=_INT32_MAX
+        )
+        active_latents_per_context_val = _require_int(
+            "active_latents_per_context",
+            active_latents_per_context,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
+        feature_std_val = _require_positive_real("feature_std", feature_std)
+        latent_scale_val = _require_positive_real("latent_scale", latent_scale)
+        linear_scale_val = _require_nonnegative_real("linear_scale", linear_scale)
+        noise_std_val = _require_nonnegative_real("noise_std", noise_std)
 
-        self._feature_dim = feature_dim
-        self._n_tasks = n_tasks
-        self._n_latents = n_latents
-        self._n_contexts = n_contexts
-        self._context_length = context_length
-        self._active_latents_per_context = active_latents_per_context
-        self._feature_std = feature_std
-        self._latent_scale = latent_scale
-        self._linear_scale = linear_scale
-        self._noise_std = noise_std
+        self._feature_dim = feature_dim_val
+        self._n_tasks = n_tasks_val
+        self._n_latents = n_latents_val
+        self._n_contexts = n_contexts_val
+        self._context_length = context_length_val
+        self._active_latents_per_context = active_latents_per_context_val
+        self._feature_std = feature_std_val
+        self._latent_scale = latent_scale_val
+        self._linear_scale = linear_scale_val
+        self._noise_std = noise_std_val
 
     @property
     def feature_dim(self) -> int:
@@ -143,9 +221,49 @@ class NonlinearFeatureDiscoveryStream:
         return self._n_tasks
 
     @property
+    def n_tasks(self) -> int:
+        """Return the number of supervised tasks."""
+        return self._n_tasks
+
+    @property
     def n_latents(self) -> int:
         """Return the number of hidden oracle features."""
         return self._n_latents
+
+    @property
+    def n_contexts(self) -> int:
+        """Return the number of recurring relevance contexts."""
+        return self._n_contexts
+
+    @property
+    def context_length(self) -> int:
+        """Return the context length."""
+        return self._context_length
+
+    @property
+    def active_latents_per_context(self) -> int:
+        """Return the active latents per context."""
+        return self._active_latents_per_context
+
+    @property
+    def feature_std(self) -> float:
+        """Return the feature standard deviation."""
+        return self._feature_std
+
+    @property
+    def latent_scale(self) -> float:
+        """Return the latent scale."""
+        return self._latent_scale
+
+    @property
+    def linear_scale(self) -> float:
+        """Return the linear scale."""
+        return self._linear_scale
+
+    @property
+    def noise_std(self) -> float:
+        """Return the noise standard deviation."""
+        return self._noise_std
 
     def init(self, key: Array) -> NonlinearFeatureDiscoveryState:
         """Initialize stream state."""
@@ -231,6 +349,12 @@ def collect_feature_discovery_stream(
     """
     import jax
 
+    num_steps = _require_int("num_steps", num_steps, minimum=1, maximum=_INT32_MAX)
+    if not hasattr(stream, "init") or not callable(stream.init):
+        raise TypeError("stream must provide a callable init method")
+    if not hasattr(stream, "step") or not callable(stream.step):
+        raise TypeError("stream must provide a callable step method")
+
     state = stream.init(key)
 
     def step_fn(
@@ -286,28 +410,37 @@ class InteractionFeatureDiscoveryStream:
             noise_std: Standard deviation of target noise.
             include_squares: Whether to include ``x_i * x_i`` oracle features.
         """
-        if feature_dim < 2:
-            raise ValueError("feature_dim must be at least 2")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
-        if context_length < 1:
-            raise ValueError("context_length must be positive")
-        active_pairs_per_context = require_positive_builtin_int(
+        feature_dim_val = _require_int("feature_dim", feature_dim, minimum=2, maximum=_INT32_MAX)
+        n_tasks_val = _require_int("n_tasks", n_tasks, minimum=1, maximum=_INT32_MAX)
+        n_contexts_val = _require_int("n_contexts", n_contexts, minimum=1, maximum=_INT32_MAX)
+        context_length_val = _require_int(
+            "context_length", context_length, minimum=1, maximum=_INT32_MAX
+        )
+        active_pairs_per_context_val = require_positive_builtin_int(
             active_pairs_per_context,
             name="active_pairs_per_context",
         )
+        if active_pairs_per_context_val > _INT32_MAX:
+            raise ValueError(f"active_pairs_per_context must be <= {_INT32_MAX}")
+        feature_std_val = _require_positive_real("feature_std", feature_std)
+        linear_scale_val = _require_nonnegative_real("linear_scale", linear_scale)
+        noise_std_val = _require_nonnegative_real("noise_std", noise_std)
+        if isinstance(include_squares, (bool, np.bool_)):
+            include_squares_val = bool(include_squares)
+        else:
+            raise TypeError(
+                f"include_squares must be a boolean, got {include_squares!r}"
+            )
 
-        self._feature_dim = feature_dim
-        self._n_tasks = n_tasks
-        self._n_contexts = n_contexts
-        self._context_length = context_length
-        self._active_pairs_per_context = active_pairs_per_context
-        self._feature_std = feature_std
-        self._linear_scale = linear_scale
-        self._noise_std = noise_std
-        self._include_squares = include_squares
+        self._feature_dim = feature_dim_val
+        self._n_tasks = n_tasks_val
+        self._n_contexts = n_contexts_val
+        self._context_length = context_length_val
+        self._active_pairs_per_context = active_pairs_per_context_val
+        self._feature_std = feature_std_val
+        self._linear_scale = linear_scale_val
+        self._noise_std = noise_std_val
+        self._include_squares = include_squares_val
 
     @property
     def feature_dim(self) -> int:
@@ -318,6 +451,46 @@ class InteractionFeatureDiscoveryStream:
     def target_dim(self) -> int:
         """Return the number of supervised tasks."""
         return self._n_tasks
+
+    @property
+    def n_tasks(self) -> int:
+        """Return the number of supervised tasks."""
+        return self._n_tasks
+
+    @property
+    def n_contexts(self) -> int:
+        """Return the number of recurring relevance contexts."""
+        return self._n_contexts
+
+    @property
+    def context_length(self) -> int:
+        """Return the context length."""
+        return self._context_length
+
+    @property
+    def active_pairs_per_context(self) -> int:
+        """Return the active pairs per context."""
+        return self._active_pairs_per_context
+
+    @property
+    def feature_std(self) -> float:
+        """Return the feature standard deviation."""
+        return self._feature_std
+
+    @property
+    def linear_scale(self) -> float:
+        """Return the linear scale."""
+        return self._linear_scale
+
+    @property
+    def noise_std(self) -> float:
+        """Return the noise standard deviation."""
+        return self._noise_std
+
+    @property
+    def include_squares(self) -> bool:
+        """Return whether square interactions are included."""
+        return self._include_squares
 
     def _pairs(self) -> tuple[Array, Array]:
         pairs = []

--- a/tests/test_alberta_plan_step1_streams.py
+++ b/tests/test_alberta_plan_step1_streams.py
@@ -7,6 +7,8 @@ eta_t`` with non-stationarity in either the target functions or the input
 distribution.
 """
 
+from typing import Any
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -15,13 +17,12 @@ import pytest
 
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.alberta_plan_step1 import (
+    _INT32_MAX,
     AlbertaPlanStep1State,
     AlbertaPlanStep1Stream,
     XDistShiftState,
     XDistShiftStream,
 )
-
-pytestmark = pytest.mark.slow
 
 # -----------------------------------------------------------------------------
 # AlbertaPlanStep1Stream
@@ -40,6 +41,7 @@ def _collect_step1_targets(
     return jnp.stack(targets)
 
 
+@pytest.mark.slow
 class TestAlbertaPlanStep1Stream:
     """Tests for :class:`AlbertaPlanStep1Stream`."""
 
@@ -176,6 +178,7 @@ class TestAlbertaPlanStep1Stream:
 # -----------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestXDistShiftStream:
     """Tests for :class:`XDistShiftStream`."""
 
@@ -320,3 +323,148 @@ class TestXDistShiftStream:
         stream = XDistShiftStream(feature_dim=8, num_relevant=2)
         state = stream.init(jr.key(0))
         assert isinstance(state, XDistShiftState)
+
+
+class TestStep1StreamsValidation:
+    """Comprehensive validation tests for Step 1 streams."""
+
+    def test_alberta_plan_step1_stream_properties_and_boundaries(self) -> None:
+        stream = AlbertaPlanStep1Stream(
+            feature_dim=_INT32_MAX,
+            num_relevant=_INT32_MAX,
+            drift_rate_w=0.005,
+            drift_rate_b=0.002,
+            noise_std=0.5,
+            feature_std=2.0,
+        )
+        assert stream.feature_dim == _INT32_MAX
+        assert stream.num_relevant == _INT32_MAX
+        assert stream.drift_rate_w == 0.005
+        assert stream.drift_rate_b == 0.002
+        assert stream.noise_std == 0.5
+        assert stream.feature_std == 2.0
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"feature_dim": 0}, "feature_dim"),
+            ({"feature_dim": -1}, "feature_dim"),
+            ({"feature_dim": _INT32_MAX + 1}, "feature_dim"),
+            ({"feature_dim": True}, "feature_dim"),
+            ({"feature_dim": "20"}, "feature_dim"),
+            ({"num_relevant": 0}, "num_relevant"),
+            ({"num_relevant": -1}, "num_relevant"),
+            ({"num_relevant": _INT32_MAX + 1}, "num_relevant"),
+            ({"num_relevant": True}, "num_relevant"),
+            ({"drift_rate_w": -0.01}, "drift_rate_w"),
+            ({"drift_rate_b": -0.01}, "drift_rate_b"),
+            ({"noise_std": -0.01}, "noise_std"),
+            ({"feature_std": 0.0}, "feature_std"),
+            ({"feature_std": -1.0}, "feature_std"),
+            ({"feature_std": "1.0"}, "feature_std"),
+        ],
+    )
+    def test_alberta_plan_step1_stream_rejects_malformed_inputs(
+        self, kwargs: dict[str, Any], match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            AlbertaPlanStep1Stream(**kwargs)
+
+    @pytest.mark.parametrize(
+        "ratio",
+        [
+            pytest.param((-1, 1), id="negative-ratio"),
+            pytest.param((-1, 2**200), id="negative-subnormal-ratio"),
+        ],
+    )
+    def test_alberta_plan_step1_rejects_adversarial_ratio_drift(
+        self, ratio: tuple[int, int]
+    ) -> None:
+        class HiddenBoundaryFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return ratio
+
+        with pytest.raises(ValueError, match="drift_rate_w must be non-negative"):
+            AlbertaPlanStep1Stream(drift_rate_w=HiddenBoundaryFloat(0.5))
+
+    def test_alberta_plan_step1_rejects_spoofed_int_class(self) -> None:
+        class SpoofedIntFloat(float):
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        with pytest.raises(ValueError, match="drift_rate_w must be non-negative"):
+            AlbertaPlanStep1Stream(drift_rate_w=SpoofedIntFloat(0.5))
+
+    def test_alberta_plan_step1_rejects_spoofed_ratio_components(self) -> None:
+        class SpoofedComponent:
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def __int__(self) -> int:
+                return 1
+
+        class BadRatioFloat(float):
+            def as_integer_ratio(self) -> tuple[Any, Any]:
+                return (SpoofedComponent(), 2)
+
+        with pytest.raises(ValueError, match="must narrow to a finite float32"):
+            AlbertaPlanStep1Stream(drift_rate_w=BadRatioFloat(0.5))
+
+    def test_xdist_shift_stream_properties_and_boundaries(self) -> None:
+        stream = XDistShiftStream(
+            feature_dim=10,
+            num_relevant=4,
+            noise_std=0.2,
+            scale_change_interval=1000,
+            scale_min=0.5,
+            scale_max=5.0,
+            noise_in_target=False,
+        )
+        assert stream.feature_dim == 10
+        assert stream.num_relevant == 4
+        assert stream.noise_std == 0.2
+        assert stream.scale_change_interval == 1000
+        assert stream.scale_min == 0.5
+        assert stream.scale_max == 5.0
+        assert not stream.noise_in_target
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"feature_dim": 0}, "feature_dim"),
+            ({"num_relevant": 0}, "num_relevant"),
+            ({"num_relevant": 15}, "num_relevant"),
+            ({"scale_change_interval": 0}, "scale_change_interval"),
+            ({"scale_change_interval": -5}, "scale_change_interval"),
+            ({"scale_change_interval": _INT32_MAX + 1}, "scale_change_interval"),
+            ({"scale_min": 0.0}, "scale_min"),
+            ({"scale_min": -1.0}, "scale_min"),
+            ({"scale_max": 0.0}, "scale_max"),
+            ({"scale_min": 5.0, "scale_max": 2.0}, "scale_min"),
+            ({"noise_std": -0.1}, "noise_std"),
+        ],
+    )
+    def test_xdist_shift_stream_rejects_malformed_inputs(
+        self, kwargs: dict[str, Any], match: str
+    ) -> None:
+        base: dict[str, Any] = {"feature_dim": 10, "num_relevant": 3}
+        base.update(kwargs)
+        with pytest.raises(ValueError, match=match):
+            XDistShiftStream(**base)
+
+    def test_xdist_shift_stream_rejects_non_bool_noise_in_target(self) -> None:
+        with pytest.raises(TypeError, match="noise_in_target must be a boolean"):
+            XDistShiftStream(feature_dim=10, num_relevant=3, noise_in_target=1)  # type: ignore[arg-type]
+
+    def test_xdist_shift_rejects_adversarial_ratio(self) -> None:
+        class HiddenBoundaryFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        with pytest.raises(ValueError, match="noise_std must be non-negative"):
+            XDistShiftStream(feature_dim=10, num_relevant=3, noise_std=HiddenBoundaryFloat(0.5))

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -2970,3 +2970,164 @@ class TestReplaceFractionRemoval:
         restored = FixedBudgetFeatureLearner.from_config(legacy)
 
         assert restored.to_config() == learner.to_config()
+
+
+class TestFeatureDiscoveryStreamsValidation:
+    """Comprehensive validation tests for Step 2 feature-discovery streams."""
+
+    def test_nonlinear_properties_and_boundaries(self) -> None:
+        stream = NonlinearFeatureDiscoveryStream(
+            feature_dim=16,
+            n_tasks=3,
+            n_latents=64,
+            n_contexts=4,
+            context_length=200,
+            active_latents_per_context=8,
+            feature_std=1.5,
+            latent_scale=0.8,
+            linear_scale=0.02,
+            noise_std=0.05,
+        )
+        assert stream.feature_dim == 16
+        assert stream.target_dim == 3
+        assert stream.n_tasks == 3
+        assert stream.n_latents == 64
+        assert stream.n_contexts == 4
+        assert stream.context_length == 200
+        assert stream.active_latents_per_context == 8
+        assert stream.feature_std == 1.5
+        assert stream.latent_scale == 0.8
+        assert stream.linear_scale == 0.02
+        assert stream.noise_std == 0.05
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"feature_dim": 0}, "feature_dim"),
+            ({"feature_dim": -1}, "feature_dim"),
+            ({"feature_dim": 2**31}, "feature_dim"),
+            ({"feature_dim": True}, "feature_dim"),
+            ({"n_tasks": 0}, "n_tasks"),
+            ({"n_latents": 0}, "n_latents"),
+            ({"n_contexts": 0}, "n_contexts"),
+            ({"context_length": 0}, "context_length"),
+            ({"active_latents_per_context": 0}, "active_latents_per_context"),
+            ({"feature_std": 0.0}, "feature_std"),
+            ({"feature_std": -1.0}, "feature_std"),
+            ({"latent_scale": 0.0}, "latent_scale"),
+            ({"latent_scale": -1.0}, "latent_scale"),
+            ({"linear_scale": -0.01}, "linear_scale"),
+            ({"noise_std": -0.01}, "noise_std"),
+        ],
+    )
+    def test_nonlinear_rejects_malformed_inputs(
+        self, kwargs: dict[str, Any], match: str
+    ) -> None:
+        base: dict[str, Any] = {"feature_dim": 8}
+        base.update(kwargs)
+        with pytest.raises(ValueError, match=match):
+            NonlinearFeatureDiscoveryStream(**base)
+
+    def test_nonlinear_rejects_adversarial_ratio(self) -> None:
+        class HiddenBoundaryFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        with pytest.raises(ValueError, match="linear_scale must be non-negative"):
+            NonlinearFeatureDiscoveryStream(feature_dim=8, linear_scale=HiddenBoundaryFloat(0.5))
+
+    def test_nonlinear_rejects_spoofed_int_class(self) -> None:
+        class SpoofedIntFloat(float):
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        with pytest.raises(ValueError, match="noise_std must be non-negative"):
+            NonlinearFeatureDiscoveryStream(feature_dim=8, noise_std=SpoofedIntFloat(0.5))
+
+    def test_nonlinear_rejects_spoofed_ratio_components(self) -> None:
+        class SpoofedComponent:
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def __int__(self) -> int:
+                return 1
+
+        class BadRatioFloat(float):
+            def as_integer_ratio(self) -> tuple[Any, Any]:
+                return (SpoofedComponent(), 2)
+
+        with pytest.raises(ValueError, match="must narrow to a finite float32"):
+            NonlinearFeatureDiscoveryStream(feature_dim=8, noise_std=BadRatioFloat(0.5))
+
+    def test_interaction_properties_and_boundaries(self) -> None:
+        stream = InteractionFeatureDiscoveryStream(
+            feature_dim=12,
+            n_tasks=5,
+            n_contexts=6,
+            context_length=300,
+            active_pairs_per_context=10,
+            feature_std=1.2,
+            linear_scale=0.03,
+            noise_std=0.04,
+            include_squares=True,
+        )
+        assert stream.feature_dim == 12
+        assert stream.target_dim == 5
+        assert stream.n_tasks == 5
+        assert stream.n_contexts == 6
+        assert stream.context_length == 300
+        assert stream.active_pairs_per_context == 10
+        assert stream.feature_std == 1.2
+        assert stream.linear_scale == 0.03
+        assert stream.noise_std == 0.04
+        assert stream.include_squares
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"feature_dim": 1}, "feature_dim"),
+            ({"feature_dim": 0}, "feature_dim"),
+            ({"feature_dim": 2**31}, "feature_dim"),
+            ({"n_tasks": 0}, "n_tasks"),
+            ({"n_contexts": 0}, "n_contexts"),
+            ({"context_length": 0}, "context_length"),
+            ({"active_pairs_per_context": 0}, "active_pairs_per_context"),
+            ({"feature_std": 0.0}, "feature_std"),
+            ({"linear_scale": -0.01}, "linear_scale"),
+            ({"noise_std": -0.01}, "noise_std"),
+        ],
+    )
+    def test_interaction_rejects_malformed_inputs(
+        self, kwargs: dict[str, Any], match: str
+    ) -> None:
+        base: dict[str, Any] = {"feature_dim": 6}
+        base.update(kwargs)
+        with pytest.raises(ValueError, match=match):
+            InteractionFeatureDiscoveryStream(**base)
+
+    def test_interaction_rejects_non_bool_include_squares(self) -> None:
+        with pytest.raises(TypeError, match="include_squares must be a boolean"):
+            InteractionFeatureDiscoveryStream(feature_dim=6, include_squares=1)  # type: ignore[arg-type]
+
+    def test_interaction_rejects_adversarial_ratio(self) -> None:
+        class HiddenBoundaryFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        with pytest.raises(ValueError, match="linear_scale must be non-negative"):
+            InteractionFeatureDiscoveryStream(feature_dim=6, linear_scale=HiddenBoundaryFloat(0.5))
+
+    def test_collect_feature_discovery_stream_validation(self) -> None:
+        stream = NonlinearFeatureDiscoveryStream(feature_dim=4)
+        key = jr.key(0)
+        with pytest.raises(ValueError, match="num_steps"):
+            collect_feature_discovery_stream(stream, 0, key)
+        with pytest.raises(ValueError, match="num_steps"):
+            collect_feature_discovery_stream(stream, -1, key)
+        with pytest.raises(TypeError, match="init"):
+            collect_feature_discovery_stream(object(), 10, key)


### PR DESCRIPTION
Closes #475

### Summary of Changes
- **Step 1 Streams (`alberta_framework/streams/alberta_plan_step1.py`):**
  - Added strict signed int32 validation (`[1, 2**31 - 1]`) for `feature_dim`, `num_relevant`, and `scale_change_interval`.
  - Added exact-ratio float32 domain validation on `drift_rate_w`, `drift_rate_b`, `noise_std`, `feature_std`, `scale_min`, `scale_max`.
  - Added strict boolean checking for `noise_in_target`.
  - Exposed complete read-only properties for all stream configuration parameters.
- **Step 2 Feature Discovery Streams (`alberta_framework/streams/feature_discovery.py`):**
  - Added signed int32 bounds checking for `feature_dim`, `n_tasks`, `n_latents`, `n_contexts`, `context_length`, `active_latents_per_context`, `active_pairs_per_context`, and `num_steps` in `collect_feature_discovery_stream`.
  - Added exact-ratio float32 validation for `feature_std`, `latent_scale`, `linear_scale`, `noise_std`.
  - Added strict boolean checking for `include_squares`.
  - Added duck-typing validation for `stream` argument in `collect_feature_discovery_stream`.
  - Exposed configuration properties on all stream classes.
- **Testing (`tests/test_alberta_plan_step1_streams.py`, `tests/test_feature_discovery.py`):**
  - Added `TestStep1StreamsValidation` and `TestFeatureDiscoveryStreamsValidation` covering parameter boundaries, illegal type rejections, class-spoofed floats, adversarial exact ratios, and property getters.