### PR TITLE
fix(ipmnist): require paired seeds when merging shards

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -8393,7 +8393,12 @@ def merge_shards(
     control_name: str = "upgd_w_control",
     slope_window: int = 15,
 ) -> dict[str, Any]:
-    """Merge shards into a ranked screening summary with paired comparisons."""
+    """Merge shards into a ranked screening summary with paired comparisons.
+
+    Every config must carry exactly the same seed set. The headline ranking
+    and every comparison against the control are therefore computed over the
+    same paired runs; an incomplete worker batch is rejected before ranking.
+    """
     normalized_paths = [Path(path) for path in paths]
     input_bindings = _artifact_file_bindings(
         normalized_paths, context="screening shard input"
@@ -8461,11 +8466,31 @@ def merge_shards(
             f"(present: {sorted(by_config)}); a summary without its control "
             "would silently carry no paired_vs_control blocks"
         )
+    for name, per_seed in sorted(by_config.items()):
+        _validate_screening_arm_contract(name, per_seed)
     control = by_config[control_name]
+    control_seeds = sorted(control)
+    for name, per_seed in sorted(by_config.items()):
+        seeds = sorted(per_seed)
+        if name != control_name and not any(seed in control for seed in seeds):
+            raise ValueError(
+                f"config {name!r} shares no seeds with control {control_name!r} "
+                f"(seeds {seeds} vs {control_seeds}); refusing to rank an "
+                "unpaired entry in the summary"
+            )
+    seed_sets = {
+        name: tuple(sorted(per_seed))
+        for name, per_seed in sorted(by_config.items())
+    }
+    if len(set(seed_sets.values())) != 1:
+        raise ValueError(
+            f"seed sets differ across configs: {seed_sets}; "
+            "merge_shards ranks configs on paired seeds only"
+        )
+
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):
         seeds = sorted(per_seed)
-        _validate_screening_arm_contract(name, per_seed)
         wall_clock_total = _finite_wall_clock_total(
             [per_seed[s]["wall_clock_seconds"] for s in seeds],
             context=f"config {name!r}",
@@ -8501,16 +8526,6 @@ def merge_shards(
             "wall_clock_seconds_total": round(wall_clock_total, 2),
         }
         common = [s for s in seeds if s in control]
-        if name != control_name and not common:
-            # Every comparison in this campaign is paired on shared seeds; an
-            # arm with no seed in common with the control would still rank in
-            # the summary by raw mean with no paired_vs_control block and
-            # nothing marking it unpaired (issue #49).  Refuse instead.
-            raise ValueError(
-                f"config {name!r} shares no seeds with control {control_name!r} "
-                f"(seeds {seeds} vs {sorted(control)}); refusing to rank an "
-                "unpaired entry in the summary"
-            )
         if name != control_name and common:
             control_avg = np.asarray(
                 [

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -1093,21 +1093,20 @@ class TestShardsAndMerge:
         ):
             merge_shards(paths, control_name="upgd_w_control", slope_window=2)
 
-    def test_merge_pairs_on_partial_seed_overlap(self, tmp_path, small_data):
-        """Partial overlap keeps merging and pairs on the intersection, which
-        the block records visibly — the zero-overlap refusal must not
-        over-reach into this legitimate case."""
+    def test_merge_rejects_partial_seed_overlap(self, tmp_path):
+        """A ranked summary must compare every arm on exactly paired seeds."""
         paths = [
-            self._make_shard(tmp_path, small_data, "upgd_w_control", 0),
-            self._make_shard(tmp_path, small_data, "upgd_w_control", 1),
-            self._make_shard(tmp_path, small_data, "upgd_l2init", 1),
-            self._make_shard(tmp_path, small_data, "upgd_l2init", 2),
+            self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.40),
+            self._write_inband_shard(tmp_path, "upgd_w_control", 1, 0.60),
+            self._write_inband_shard(tmp_path, "upgd_l2init", 1, 0.55),
+            self._write_inband_shard(tmp_path, "upgd_l2init", 2, 0.90),
         ]
-        summary = merge_shards(paths, control_name="upgd_w_control", slope_window=2)
-        l2 = next(e for e in summary["results"] if e["config_name"] == "upgd_l2init")
-        assert l2["seeds"] == [1, 2]
-        assert l2["paired_vs_control"]["seeds"] == [1]
-        assert len(l2["paired_vs_control"]["per_seed_diff"]) == 1
+
+        with pytest.raises(
+            ValueError,
+            match=r"seed sets differ across configs.*ranks configs on paired seeds only",
+        ):
+            merge_shards(paths, control_name="upgd_w_control", slope_window=2)
 
     def _write_inband_shard(self, tmp_path, config_name, seed, accuracy):
         """Write a structurally valid shard with controlled accuracy."""
@@ -1439,12 +1438,10 @@ class TestShardsAndMerge:
             merge_shards(paths, control_name="upgd_w_control", slope_window=2)
 
     def test_confirmation_candidate_requires_two_paired_seeds(self, tmp_path):
-        """One lucky shared seed cannot authorize a confirmation wave."""
+        """One paired seed cannot authorize a confirmation wave."""
         paths = [
             self._write_inband_shard(tmp_path, "upgd_w_control", 0, 0.50),
             self._write_inband_shard(tmp_path, "upgd_l2init", 0, 0.56),
-            self._write_inband_shard(tmp_path, "upgd_l2init", 1, 0.56),
-            self._write_inband_shard(tmp_path, "upgd_l2init", 2, 0.56),
         ]
         summary = merge_shards(paths, control_name="upgd_w_control", slope_window=2)
         result = next(


### PR DESCRIPTION
Closes #445.

`merge_shards` now requires every configuration to have the identical validated seed set before it computes means, paired differences, ranks, or a confirmation candidate. The existing specific zero-overlap diagnostic is retained. Equal-seed v1/v2 inputs, deterministic ordering, and the minimum-two-paired-seeds confirmation gate keep their prior schema and behavior.

Failing-first evidence: the issue reproduction (control seeds {0,1}, competing arm {1,2}, competing arm losing on the only shared seed) was ranked on the parent instead of raising. The retained regression now fails closed.

Validation:
- independent merge/shard review: 81 tests;
- screening provenance: 52 tests;
- local prereg stage/confirmation: 8 tests;
- prereg summary reconstruction: 2 tests;
- broader implementation panels: 461 pre-rebase and 229 post-rebase tests;
- final current-main selector: 2 passed;
- Ruff and strict mypy: clean.

No outputs changed. The five-claim evidence registry retains its inherited fail-closed invalid status from unrelated registered-source drift; neither changed file is a registered five-claim source. This screening source remains correctly bound by its own development provenance.