### PR TITLE
fix(stacked-horde): reject non-finite step sizes

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -36,6 +36,7 @@ inactive for that step (its trace still decays; its weights freeze), matching
 the NaN-masking convention of the loop-based hordes.
 """
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -92,7 +93,7 @@ class StackedHordeConfig:
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
-        if self.step_size <= 0.0:
+        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
             raise ValueError("step_size must be positive")
 
     def to_config(self) -> dict[str, Any]:

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -11,6 +11,7 @@ the same workload, with a ~144 s compile; see the scaling notes in
 docs/evidence/methodology.md).
 """
 
+import math
 import time
 
 import chex
@@ -50,6 +51,11 @@ class TestConfig:
             _simple_config(gammas=(1.5, 0.9))
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=0.0)
+
+    @pytest.mark.parametrize("step_size", [math.nan, math.inf, -math.inf])
+    def test_step_size_must_be_finite_and_positive(self, step_size: float) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            _simple_config(step_size=step_size)
 
     def test_roundtrip(self):
         cfg = _simple_config()


### PR DESCRIPTION
Closes #478.

## What changed

`StackedHordeConfig` now rejects non-finite `step_size` values before they can be serialized into a Horde that silently rolls back every update.

The table-driven regression covers NaN and both infinities. Existing zero/negative rejection, legal finite positive values, the default `0.05`, TD(λ) equations, and runtime transaction guards remain unchanged.

## Scope

- `alberta_framework/core/stacked_horde.py`
- `tests/test_stacked_horde.py`

## Verification

Exact candidate head: `4acc03eefc6338d0976cd6d43395bfd7de4e6a2a`  
Base: `bffd66c0524eba231e87da1f2a217e7be016d412`

- concrete reproduction before the fix:
  - NaN and positive-infinite step sizes construct successfully;
  - the next valid update rolls back, leaves finite zero weights, and does not advance the step count;
- tests-first config baseline: **2 failed, 4 passed**;
- final config suite: **6 passed**;
- full stacked-Horde suite: **15 passed**;
- full Ruff: **all checks passed**;
- strict mypy: **no issues in 165 source files**;
- `git diff --check`: clean;
- clean candidate worktree with one authored commit;
- rebased onto current `origin/main` (`bffd66c0524eba231e87da1f2a217e7be016d412`);
- exact-head proof rerun after rebase: full stacked-Horde suite **15 passed**;
- live path ownership refresh: no open ASI PR touches either target file; PR #470 owns the separate `core/horde.py` pair.

## Scientific integrity

This is fail-closed constructor validation only. It does not change equations, thresholds, defaults, TD traces, update behavior for legal configs, RNG schedules, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
