### PR TITLE
fix(features): bias-correct EMA utility outputs

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -33,6 +33,8 @@ from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
 from alberta_framework.core.future_utility import (
+    bias_correct_future_utility,
+    canonical_float32_ema_decay,
     contribution_trace_output_loss_reduction,
     normalize_future_utility_signal,
     trace_output_loss_reduction,
@@ -1036,8 +1038,11 @@ class CompositionalFeatureLearner:
             raise ValueError("n_tasks must be positive")
         if candidate_count < 0:
             raise ValueError("candidate_count must be non-negative")
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        utility_decay_config = utility_decay
+        utility_decay = canonical_float32_ema_decay(
+            "utility_decay",
+            utility_decay,
+        )
         if replacement_interval < 0:
             raise ValueError("replacement_interval must be non-negative")
         if not 0.0 <= promotion_blend <= 1.0:
@@ -1133,8 +1138,11 @@ class CompositionalFeatureLearner:
             and candidate_selector_exploration <= 0.0
         ):
             raise ValueError("exp3 candidate_selector requires positive exploration")
-        if not 0.0 <= retention_slow_utility_decay < 1.0:
-            raise ValueError("retention_slow_utility_decay must be in [0, 1)")
+        retention_slow_utility_decay_config = retention_slow_utility_decay
+        retention_slow_utility_decay = canonical_float32_ema_decay(
+            "retention_slow_utility_decay",
+            retention_slow_utility_decay,
+        )
         if retention_tanh_min_count < 0:
             raise ValueError("retention_tanh_min_count must be non-negative")
         if retention_product_min_count < 0:
@@ -1178,6 +1186,7 @@ class CompositionalFeatureLearner:
         self._step_size_output = step_size_output
         self._step_size_theta = step_size_theta
         self._utility_decay = utility_decay
+        self._utility_decay_config = utility_decay_config
         self._replacement_interval = replacement_interval
         self._min_feature_age = min_feature_age
         self._candidate_min_age = candidate_min_age
@@ -1223,6 +1232,9 @@ class CompositionalFeatureLearner:
             )
         )
         self._retention_slow_utility_decay = retention_slow_utility_decay
+        self._retention_slow_utility_decay_config = (
+            retention_slow_utility_decay_config
+        )
         self._retention_tanh_min_count = retention_tanh_min_count
         self._retention_product_min_count = retention_product_min_count
         self._operation_prior = operation_prior
@@ -1284,7 +1296,7 @@ class CompositionalFeatureLearner:
             "candidate_count": self._candidate_count,
             "step_size_output": self._step_size_output,
             "step_size_theta": self._step_size_theta,
-            "utility_decay": self._utility_decay,
+            "utility_decay": self._utility_decay_config,
             "replacement_interval": self._replacement_interval,
             "min_feature_age": self._min_feature_age,
             "candidate_min_age": self._candidate_min_age,
@@ -1327,7 +1339,9 @@ class CompositionalFeatureLearner:
                 self._candidate_selector_learning_rate
             ),
             "candidate_selector_exploration": self._candidate_selector_exploration,
-            "retention_slow_utility_decay": self._retention_slow_utility_decay,
+            "retention_slow_utility_decay": (
+                self._retention_slow_utility_decay_config
+            ),
             "retention_tanh_min_count": self._retention_tanh_min_count,
             "retention_product_min_count": self._retention_product_min_count,
             "operation_prior": (
@@ -2032,6 +2046,16 @@ class CompositionalFeatureLearner:
         decay = jnp.asarray(self._retention_slow_utility_decay, dtype=jnp.float32)
         return decay * previous_slow_utility + (1.0 - decay) * utility_signal
 
+    def _utility_update(self, previous_utility: Array, utility_signal: Array) -> Array:
+        """Update the raw utility EMA with one float32 decay/complement pair."""
+        if self._utility_decay == 0.0:
+            return utility_signal
+        decay = jnp.asarray(self._utility_decay, dtype=jnp.float32)
+        return (
+            decay * previous_utility
+            + (jnp.asarray(1.0, dtype=jnp.float32) - decay) * utility_signal
+        )
+
     def _retention_score(
         self,
         fast_utility: Array,
@@ -2041,6 +2065,20 @@ class CompositionalFeatureLearner:
         if self._retention_slow_utility_decay == 0.0:
             return fast_utility
         return jnp.maximum(fast_utility, slow_utility)
+
+    def _ranking_utility(
+        self,
+        raw_utility: Array,
+        ages: Array,
+        decay: float,
+    ) -> Array:
+        """Return curation/report scores without changing serialized EMA state."""
+        mode = (
+            self._future_utility_normalization
+            if self._future_utility_mix > 0.0
+            else "none"
+        )
+        return bias_correct_future_utility(raw_utility, ages, decay, mode)
 
     def _energy_normalized_residual_score(
         self,
@@ -2236,6 +2274,12 @@ class CompositionalFeatureLearner:
             utilities = jnp.ones_like(existing_depth, dtype=jnp.float32)
         else:
             utilities = existing_utilities
+            if existing_ages is not None:
+                utilities = self._ranking_utility(
+                    utilities,
+                    existing_ages,
+                    self._utility_decay,
+                )
         parent_logits = self._parent_logits(
             eligible,
             utilities,
@@ -2396,9 +2440,14 @@ class CompositionalFeatureLearner:
             depth_ok = depth_c + 1 <= self._max_depth
             eligible = alive & depth_ok
             any_eligible = jnp.any(eligible)
+            ranking_utils = self._ranking_utility(
+                utils_c,
+                ages_c,
+                self._utility_decay,
+            )
             logits = self._parent_logits(
                 eligible,
-                utils_c,
+                ranking_utils,
                 feature_values=feature_values,
                 feature_credit=feature_credit,
                 depth=depth_c,
@@ -2408,7 +2457,7 @@ class CompositionalFeatureLearner:
             partner_logits = self._partner_logits(
                 eligible,
                 depth_c,
-                utils_c,
+                ranking_utils,
                 ages=ages_c,
                 parent_mode=parent_mode,
             )
@@ -2662,13 +2711,7 @@ class CompositionalFeatureLearner:
                 state.feature_score_residual_trace,
                 state.feature_score_energy_trace,
             )
-        if self._utility_decay == 0.0:
-            new_utilities = utility_signal
-        else:
-            new_utilities = (
-                self._utility_decay * state.utilities
-                + (1.0 - self._utility_decay) * utility_signal
-            )
+        new_utilities = self._utility_update(state.utilities, utility_signal)
         retention_slow_utilities = self._retention_slow_utility(
             state.retention_slow_utilities,
             utility_signal,
@@ -2785,13 +2828,10 @@ class CompositionalFeatureLearner:
                     )
                 )
                 candidate_signal = candidate_signal * novelty_gate
-            if self._utility_decay == 0.0:
-                new_candidate_utilities = candidate_signal
-            else:
-                new_candidate_utilities = (
-                    self._utility_decay * state.candidate_utilities
-                    + (1.0 - self._utility_decay) * candidate_signal
-                )
+            new_candidate_utilities = self._utility_update(
+                state.candidate_utilities,
+                candidate_signal,
+            )
         candidate_retention_slow_utilities = self._retention_slow_utility(
             state.candidate_retention_slow_utilities,
             candidate_signal if self._candidate_count > 0 else new_candidate_utilities,
@@ -2829,6 +2869,26 @@ class CompositionalFeatureLearner:
         )
         ages = state.ages + 1
         candidate_ages = state.candidate_ages + 1
+        ranking_utilities = self._ranking_utility(
+            new_utilities,
+            ages,
+            self._utility_decay,
+        )
+        ranking_retention_slow_utilities = self._ranking_utility(
+            retention_slow_utilities,
+            ages,
+            self._retention_slow_utility_decay,
+        )
+        ranking_candidate_utilities = self._ranking_utility(
+            new_candidate_utilities,
+            candidate_ages,
+            self._utility_decay,
+        )
+        ranking_candidate_retention_slow_utilities = self._ranking_utility(
+            candidate_retention_slow_utilities,
+            candidate_ages,
+            self._retention_slow_utility_decay,
+        )
         step_count = state.step_count + 1
         key, decision_key, curation_key = jr.split(state.key, 3)
         proposal_key, cascade_key = compositional_curation_keys(curation_key)
@@ -2911,8 +2971,8 @@ class CompositionalFeatureLearner:
             & (~product_quota_protected)
         )
         active_replacement_score = self._retention_score(
-            new_utilities,
-            retention_slow_utilities,
+            ranking_utilities,
+            ranking_retention_slow_utilities,
         )
         retention_bonus = (
             jnp.asarray(self._retention_depth_bonus, dtype=jnp.float32)
@@ -3014,8 +3074,8 @@ class CompositionalFeatureLearner:
                 compatible_active_by_candidate, axis=1
             )
             candidate_promotion_scores = self._retention_score(
-                new_candidate_utilities,
-                candidate_retention_slow_utilities,
+                ranking_candidate_utilities,
+                ranking_candidate_retention_slow_utilities,
             )
             candidate_selector_state = FiniteCandidateSelectorState(
                 log_weights=candidate_selector_log_weights,
@@ -3053,7 +3113,7 @@ class CompositionalFeatureLearner:
                 candidate_selector_action_counts = selector_result.state.action_counts
             has_refresh_candidate = jnp.any(eligible_candidates)
             refresh_scores = jnp.where(
-                eligible_candidates, new_candidate_utilities, jnp.inf
+                eligible_candidates, ranking_candidate_utilities, jnp.inf
             )
             worst_candidate = jnp.argmin(refresh_scores).astype(jnp.int32)
             compatible_active = compatible_active_by_candidate[best_candidate]
@@ -3143,9 +3203,18 @@ class CompositionalFeatureLearner:
                         can_promote, cand_depth_after, depth_a[promotion_slot]
                     ).astype(jnp.int32)
                 )
+                promoted_utility = (
+                    jnp.array(0.0, dtype=jnp.float32)
+                    if (
+                        self._future_utility_mix > 0.0
+                        and self._future_utility_normalization
+                        in {"age", "uncertainty_age"}
+                    )
+                    else cutil_a[best_candidate]
+                )
                 util_b = util_a.at[promotion_slot].set(
                     jnp.where(
-                        can_promote, cutil_a[best_candidate], util_a[promotion_slot]
+                        can_promote, promoted_utility, util_a[promotion_slot]
                     )
                 )
                 age_b = age_a.at[promotion_slot].set(
@@ -3663,7 +3732,11 @@ class CompositionalFeatureLearner:
                 eligible = in_range & depth_ok
                 logits = self._parent_logits(
                     eligible,
-                    util_x,
+                    self._ranking_utility(
+                        util_x,
+                        age_x,
+                        self._utility_decay,
+                    ),
                     feature_values=feature_values,
                     feature_credit=feature_credit,
                     depth=depth_x,
@@ -3673,7 +3746,11 @@ class CompositionalFeatureLearner:
                 partner_logits = self._partner_logits(
                     eligible,
                     depth_x,
-                    util_x,
+                    self._ranking_utility(
+                        util_x,
+                        age_x,
+                        self._utility_decay,
+                    ),
                     ages=age_x,
                     parent_mode=parent_mode,
                 )
@@ -3977,6 +4054,15 @@ class CompositionalFeatureLearner:
             promoted_retention_slow_utility = candidate_retention_slow_utilities[
                 safe_best_candidate
             ]
+            if (
+                self._future_utility_mix > 0.0
+                and self._future_utility_normalization
+                in {"age", "uncertainty_age"}
+            ):
+                promoted_retention_slow_utility = jnp.array(
+                    0.0,
+                    dtype=jnp.float32,
+                )
         else:
             promoted_contribution_trace = jnp.zeros(
                 (self._n_tasks,), dtype=jnp.float32
@@ -4112,12 +4198,23 @@ class CompositionalFeatureLearner:
             reset_candidate_traces, 0.0, candidate_selector_action_counts
         )
 
+        ranking_utilities = self._ranking_utility(
+            new_utilities,
+            ages,
+            self._utility_decay,
+        )
+        ranking_candidate_utilities = self._ranking_utility(
+            new_candidate_utilities,
+            candidate_ages,
+            self._utility_decay,
+        )
+
         generator_resource_state = state.generator_resource_state
         if self._learn_generator_resources:
             policy_scores, policy_finite = self._generator_policy_scores(
-                new_utilities,
+                ranking_utilities,
                 feature_generator_policy,
-                new_candidate_utilities,
+                ranking_candidate_utilities,
                 candidate_generator_policy,
             )
             if self._generator_resource_promotion_credit > 0.0:
@@ -4127,7 +4224,7 @@ class CompositionalFeatureLearner:
                         self._generator_resource_promotion_credit,
                         dtype=jnp.float32,
                     )
-                    * jnp.maximum(jnp.max(new_candidate_utilities), 0.0)
+                    * jnp.maximum(jnp.max(ranking_candidate_utilities), 0.0)
                 )
                 policy_ids = jnp.arange(
                     self._generator_resource_manager.n_policies,
@@ -4235,7 +4332,7 @@ class CompositionalFeatureLearner:
         loss = jnp.sum(errors**2) / active_count
         mean_abs_error = jnp.sum(jnp.abs(errors)) / active_count
         max_candidate_utility = (
-            jnp.max(new_candidate_utilities)
+            jnp.max(ranking_candidate_utilities)
             if self._candidate_count > 0
             else jnp.array(0.0, dtype=jnp.float32)
         )
@@ -4244,8 +4341,8 @@ class CompositionalFeatureLearner:
             [
                 loss,
                 mean_abs_error,
-                jnp.mean(new_utilities),
-                jnp.min(new_utilities),
+                jnp.mean(ranking_utilities),
+                jnp.min(ranking_utilities),
                 max_candidate_utility,
                 replacement_flag,
                 bounding_scale,

--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -33,6 +33,8 @@ from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
 from alberta_framework.core.future_utility import (
+    bias_correct_future_utility,
+    canonical_float32_ema_decay,
     contribution_trace_output_loss_reduction,
     normalize_future_utility_signal,
     one_step_output_loss_reduction,
@@ -278,8 +280,11 @@ class FixedBudgetFeatureLearner:
             raise ValueError("n_tasks must be positive")
         if candidate_count < 0:
             raise ValueError("candidate_count must be non-negative")
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        utility_decay_config = utility_decay
+        utility_decay = canonical_float32_ema_decay(
+            "utility_decay",
+            utility_decay,
+        )
         if replacement_interval < 0:
             raise ValueError("replacement_interval must be non-negative")
         if not 0.0 <= promotion_blend <= 1.0:
@@ -317,12 +322,16 @@ class FixedBudgetFeatureLearner:
             raise ValueError("future_utility_normalization_decay must be in [0, 1)")
         if future_utility_rare_task_power < 0.0:
             raise ValueError("future_utility_rare_task_power must be non-negative")
-        if utility_retention_decay is not None and not (
-            utility_decay <= utility_retention_decay < 1.0
-        ):
-            raise ValueError(
-                "utility_retention_decay must be in [utility_decay, 1) when set"
+        utility_retention_decay_config = utility_retention_decay
+        if utility_retention_decay is not None:
+            utility_retention_decay = canonical_float32_ema_decay(
+                "utility_retention_decay",
+                utility_retention_decay,
             )
+            if utility_retention_decay < utility_decay:
+                raise ValueError(
+                    "utility_retention_decay must be in [utility_decay, 1) when set"
+                )
 
         mix = jnp.array(generator_mix, dtype=jnp.float32)
         if mix.shape != (3,):
@@ -356,6 +365,7 @@ class FixedBudgetFeatureLearner:
         self._step_size_output = step_size_output
         self._step_size_feature = step_size_feature
         self._utility_decay = utility_decay
+        self._utility_decay_config = utility_decay_config
         self._replacement_interval = replacement_interval
         self._min_feature_age = min_feature_age
         self._candidate_count = candidate_count
@@ -374,6 +384,7 @@ class FixedBudgetFeatureLearner:
         self._future_utility_normalization_decay = future_utility_normalization_decay
         self._future_utility_rare_task_power = future_utility_rare_task_power
         self._utility_retention_decay = utility_retention_decay
+        self._utility_retention_decay_config = utility_retention_decay_config
         self._init_scale = init_scale
         self._mutation_scale = mutation_scale
         self._use_obgd = use_obgd
@@ -406,7 +417,7 @@ class FixedBudgetFeatureLearner:
             "n_tasks": self._n_tasks,
             "step_size_output": self._step_size_output,
             "step_size_feature": self._step_size_feature,
-            "utility_decay": self._utility_decay,
+            "utility_decay": self._utility_decay_config,
             "replacement_interval": self._replacement_interval,
             "min_feature_age": self._min_feature_age,
             "candidate_count": self._candidate_count,
@@ -426,7 +437,7 @@ class FixedBudgetFeatureLearner:
                 self._future_utility_normalization_decay
             ),
             "future_utility_rare_task_power": self._future_utility_rare_task_power,
-            "utility_retention_decay": self._utility_retention_decay,
+            "utility_retention_decay": self._utility_retention_decay_config,
             "init_scale": self._init_scale,
             "mutation_scale": self._mutation_scale,
             "use_obgd": self._use_obgd,
@@ -778,9 +789,10 @@ class FixedBudgetFeatureLearner:
 
     def _utility_update(self, old_utilities: Array, utility_signal: Array) -> Array:
         """Update utility, optionally retaining recurrent-context peaks longer."""
+        decay = jnp.asarray(self._utility_decay, dtype=jnp.float32)
         ema = (
             _skip_zero_scale(self._utility_decay, old_utilities)
-            + (1.0 - self._utility_decay) * utility_signal
+            + (jnp.asarray(1.0, dtype=jnp.float32) - decay) * utility_signal
         )
         if self._utility_retention_decay is None:
             return ema
@@ -988,6 +1000,11 @@ class FixedBudgetFeatureLearner:
             state.task_activity_ema, active_mask
         )
         generator_mix = jnp.asarray(self._generator_mix, dtype=jnp.float32)
+        future_utility_ranking_mode = (
+            self._future_utility_normalization
+            if self._future_utility_mix > 0.0
+            else "none"
+        )
         plasticity_weights = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32)
         if self._learn_feature_resources:
             generator_mix = self._resource_weights(state.generator_log_weights)
@@ -1183,6 +1200,18 @@ class FixedBudgetFeatureLearner:
         )
         ages = state.ages + 1
         candidate_ages = state.candidate_ages + 1
+        ranking_utilities = bias_correct_future_utility(
+            new_utilities,
+            ages,
+            self._utility_decay,
+            future_utility_ranking_mode,
+        )
+        ranking_candidate_utilities = bias_correct_future_utility(
+            new_candidate_utilities,
+            candidate_ages,
+            self._utility_decay,
+            future_utility_ranking_mode,
+        )
         step_count = state.step_count + 1
         key, replacement_key = jr.split(state.key)
 
@@ -1213,25 +1242,27 @@ class FixedBudgetFeatureLearner:
             )
 
         eligible_active = ages >= self._min_feature_age
-        active_scores = jnp.where(eligible_active, new_utilities, jnp.inf)
+        active_scores = jnp.where(eligible_active, ranking_utilities, jnp.inf)
         worst_active = jnp.argmin(active_scores).astype(jnp.int32)
         has_active_slot = jnp.any(eligible_active)
 
         if self._candidate_count > 0:
             eligible_candidates = candidate_ages >= self._candidate_min_age
             candidate_scores = jnp.where(
-                eligible_candidates, new_candidate_utilities, -jnp.inf
+                eligible_candidates, ranking_candidate_utilities, -jnp.inf
             )
             best_candidate = jnp.argmax(candidate_scores).astype(jnp.int32)
-            worst_candidate = jnp.argmin(new_candidate_utilities).astype(jnp.int32)
+            worst_candidate = jnp.argmin(ranking_candidate_utilities).astype(
+                jnp.int32
+            )
             has_candidate = jnp.any(eligible_candidates)
             should_promote = (
                 should_try_replace
                 & has_active_slot
                 & has_candidate
                 & (
-                    new_candidate_utilities[best_candidate]
-                    > promotion_margin * new_utilities[worst_active]
+                    ranking_candidate_utilities[best_candidate]
+                    > promotion_margin * ranking_utilities[worst_active]
                 )
             )
 
@@ -1291,15 +1322,35 @@ class FixedBudgetFeatureLearner:
                     cg,
                 ) = args
                 gen_key = replacement_key
+                parent_utilities = bias_correct_future_utility(
+                    util,
+                    age,
+                    self._utility_decay,
+                    future_utility_ranking_mode,
+                )
                 new_cw, new_cb, new_pa, new_pb, new_gen = self._generate_one(
-                    gen_key, observation, fw, fb, util, generator_mix
+                    gen_key,
+                    observation,
+                    fw,
+                    fb,
+                    parent_utilities,
+                    generator_mix,
                 )
                 fw = fw.at[worst_active].set(cw[best_candidate])
                 fb = fb.at[worst_active].set(cb[best_candidate])
                 ow = ow.at[:, worst_active].set(
                     self._promotion_blend * cow[:, best_candidate]
                 )
-                util = util.at[worst_active].set(cutil[best_candidate])
+                # Active age tracks this new lifecycle, so the raw EMA must
+                # restart with it.  Inheriting a mature candidate EMA at age
+                # zero would apply the warm-up correction twice.
+                promoted_utility = (
+                    jnp.array(0.0, dtype=jnp.float32)
+                    if future_utility_ranking_mode
+                    in {"age", "uncertainty_age"}
+                    else cutil[best_candidate]
+                )
+                util = util.at[worst_active].set(promoted_utility)
                 age = age.at[worst_active].set(0)
                 fpa = fpa.at[worst_active].set(cpa[best_candidate])
                 fpb = fpb.at[worst_active].set(cpb[best_candidate])
@@ -1388,8 +1439,19 @@ class FixedBudgetFeatureLearner:
                     cg,
                 ) = args
                 gen_key = replacement_key
+                parent_utilities = bias_correct_future_utility(
+                    util,
+                    age,
+                    self._utility_decay,
+                    future_utility_ranking_mode,
+                )
                 new_cw, new_cb, new_pa, new_pb, new_gen = self._generate_one(
-                    gen_key, observation, fw, fb, util, generator_mix
+                    gen_key,
+                    observation,
+                    fw,
+                    fb,
+                    parent_utilities,
+                    generator_mix,
                 )
                 do_refresh = should_try_replace
                 cw = jax.lax.select(do_refresh, cw.at[worst_candidate].set(new_cw), cw)
@@ -1479,8 +1541,19 @@ class FixedBudgetFeatureLearner:
                 args: tuple[Array, Array, Array, Array, Array, Array, Array, Array],
             ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array]:
                 fw, fb, ow, util, age, fpa, fpb, fg = args
+                parent_utilities = bias_correct_future_utility(
+                    util,
+                    age,
+                    self._utility_decay,
+                    future_utility_ranking_mode,
+                )
                 new_w, new_b, new_pa, new_pb, new_gen = self._generate_one(
-                    replacement_key, observation, fw, fb, util, generator_mix
+                    replacement_key,
+                    observation,
+                    fw,
+                    fb,
+                    parent_utilities,
+                    generator_mix,
                 )
                 fw = fw.at[worst_active].set(new_w)
                 fb = fb.at[worst_active].set(new_b)
@@ -1532,10 +1605,22 @@ class FixedBudgetFeatureLearner:
         plasticity_log_weights = state.plasticity_log_weights
         plasticity_signal_ema = state.plasticity_signal_ema
         if self._learn_feature_resources:
-            generator_scores, generator_finite = self._generator_scores(
+            ranking_utilities = bias_correct_future_utility(
                 new_utilities,
-                feature_generator,
+                ages,
+                self._utility_decay,
+                future_utility_ranking_mode,
+            )
+            ranking_candidate_utilities = bias_correct_future_utility(
                 new_candidate_utilities,
+                candidate_ages,
+                self._utility_decay,
+                future_utility_ranking_mode,
+            )
+            generator_scores, generator_finite = self._generator_scores(
+                ranking_utilities,
+                feature_generator,
+                ranking_candidate_utilities,
                 candidate_generator,
             )
             generator_utility_ema = _recover_nonfinite_at_zero_scale(
@@ -1561,7 +1646,7 @@ class FixedBudgetFeatureLearner:
                 )
                 candidate_pressure_scores = jnp.where(
                     eligible_candidates_for_pressure,
-                    new_candidate_utilities,
+                    ranking_candidate_utilities,
                     -jnp.inf,
                 )
                 best_candidate_for_pressure = jnp.argmax(
@@ -1570,8 +1655,8 @@ class FixedBudgetFeatureLearner:
                 has_candidate_for_pressure = jnp.any(
                     eligible_candidates_for_pressure
                 )
-                worst_active_utility = new_utilities[worst_active]
-                best_candidate_utility = new_candidate_utilities[
+                worst_active_utility = ranking_utilities[worst_active]
+                best_candidate_utility = ranking_candidate_utilities[
                     best_candidate_for_pressure
                 ]
                 pressure_raw = (
@@ -1628,6 +1713,21 @@ class FixedBudgetFeatureLearner:
             reset_candidate_traces, 0.0, candidate_utility_signal_second_moment
         )
 
+        # Report the same bias-corrected scores used at the curation boundary,
+        # while retaining only the standard raw EMA in serializable state.
+        ranking_utilities = bias_correct_future_utility(
+            new_utilities,
+            ages,
+            self._utility_decay,
+            future_utility_ranking_mode,
+        )
+        ranking_candidate_utilities = bias_correct_future_utility(
+            new_candidate_utilities,
+            candidate_ages,
+            self._utility_decay,
+            future_utility_ranking_mode,
+        )
+
         candidate_state = FeatureDiscoveryState(
             key=key,
             feature_weights=feature_weights,
@@ -1674,7 +1774,7 @@ class FixedBudgetFeatureLearner:
         loss = jnp.sum(errors**2) / active_count
         mean_abs_error = jnp.sum(jnp.abs(errors)) / active_count
         max_candidate_utility = (
-            jnp.max(new_candidate_utilities)
+            jnp.max(ranking_candidate_utilities)
             if self._candidate_count > 0
             else jnp.array(0.0, dtype=jnp.float32)
         )
@@ -1683,8 +1783,8 @@ class FixedBudgetFeatureLearner:
             [
                 loss,
                 mean_abs_error,
-                jnp.mean(new_utilities),
-                jnp.min(new_utilities),
+                jnp.mean(ranking_utilities),
+                jnp.min(ranking_utilities),
                 max_candidate_utility,
                 replacement_flag,
                 bounding_scale,

--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -7,16 +7,34 @@ drop if a feature's output weight received the LMS update implied by the
 current residual.
 """
 
+import math
+from numbers import Real
 from typing import NamedTuple
 
 import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework._float32 import round_real_to_float32
+
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Skip ``0 * inf`` so a disabled decay does not poison the next trace."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def canonical_float32_ema_decay(name: str, value: object) -> float:
+    """Validate and canonicalize an EMA decay at its float32 execution sink."""
+    message = f"{name} must narrow to a finite float32 in [0, 1)"
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        narrowed = round_real_to_float32(value)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(message) from error
+    if not math.isfinite(narrowed) or not 0.0 <= narrowed < 1.0:
+        raise ValueError(message)
+    return narrowed
 
 
 class FutureUtilityEstimate(NamedTuple):
@@ -410,27 +428,56 @@ def normalize_future_utility_signal(
     utility_decay: float | Array,
     mode: str,
 ) -> tuple[Float[Array, " n_features"], Float[Array, " n_features"]]:
-    """Apply optional causal age/uncertainty normalization to utility signals.
+    """Apply optional causal uncertainty normalization to utility signals.
 
-    ``"age"`` debiases the current EMA warm-up so young features are compared
-    against older features on the same scale.  ``"uncertainty"`` divides by an
-    online RMS of the signal, favoring consistent usefulness over rare spikes.
-    ``"uncertainty_age"`` applies both.  The second moment is updated from the
-    current signal only, so this remains causal.
+    Age correction is deliberately *not* applied to the signal entering the
+    utility EMA.  Scaling every increment compounds correction already retained
+    in the EMA.  Call :func:`bias_correct_future_utility` on the resulting raw
+    EMA when it is ranked or reported instead.  ``"uncertainty"`` and
+    ``"uncertainty_age"`` divide the current signal by an online RMS, favoring
+    consistent usefulness over rare spikes.  The second moment is updated from
+    the current signal only, so this remains causal.
+
+    ``ages`` and ``utility_decay`` remain in this established helper surface so
+    existing callers and serialized configurations remain compatible.
     """
+    del ages, utility_decay
     decay = jnp.asarray(moment_decay, dtype=jnp.float32)
-    utility_decay_arr = jnp.asarray(utility_decay, dtype=jnp.float32)
     new_second_moment = (
         _skip_zero_scale(decay, second_moment) + (1.0 - decay) * signal**2
     )
     normalized = signal
 
-    if mode in {"age", "uncertainty_age"}:
-        age_float = jnp.maximum(ages.astype(jnp.float32), 0.0) + 1.0
-        debias = 1.0 - jnp.power(utility_decay_arr, age_float)
-        normalized = normalized / jnp.maximum(debias, 1e-3)
-
     if mode in {"uncertainty", "uncertainty_age"}:
         normalized = normalized / jnp.sqrt(new_second_moment + 1e-6)
 
     return normalized, new_second_moment
+
+
+def bias_correct_future_utility(
+    utilities: Float[Array, " n_features"],
+    ages: Array,
+    utility_decay: float | Array,
+    mode: str,
+) -> Float[Array, " n_features"]:
+    """Return rank/report scores from a standard raw utility EMA.
+
+    ``ages`` is the number of EMA updates since the slot's last reset.  For
+    age-normalized modes, dividing the accumulated EMA by
+    ``1 - utility_decay**ages`` removes only its initialization bias.  The raw
+    EMA remains in learner state, preserving the existing fixed-shape state and
+    checkpoint schemas.  Age-zero slots have no observations and retain their
+    raw value (normally zero).
+    """
+    if mode not in {"age", "uncertainty_age"}:
+        return utilities
+
+    age_count = jnp.maximum(ages.astype(jnp.float32), 0.0)
+    decay = jnp.asarray(utility_decay, dtype=utilities.dtype)
+    debias = 1.0 - jnp.power(decay, age_count)
+    safe_debias = jnp.maximum(
+        debias,
+        jnp.asarray(1e-30, dtype=utilities.dtype),
+    )
+    corrected = utilities / safe_debias
+    return jnp.where(age_count > 0.0, corrected, utilities)

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -589,6 +589,42 @@ class TestFixedBudgetFeatureLearner:
             GENERATOR_IMPRINT,
         }
 
+    def test_age_corrected_promotion_restarts_raw_utility_ema(self) -> None:
+        learner = FixedBudgetFeatureLearner(
+            n_features=1,
+            n_tasks=1,
+            step_size_output=0.0,
+            step_size_feature=0.0,
+            utility_decay=0.5,
+            replacement_interval=1,
+            min_feature_age=0,
+            candidate_count=1,
+            candidate_min_age=0,
+            promotion_margin=1.0,
+            future_utility_mix=1.0,
+            future_utility_normalization="age",
+            use_obgd=False,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(431)).replace(
+            utilities=jnp.array([0.1], dtype=jnp.float32),
+            ages=jnp.array([5], dtype=jnp.int32),
+            candidate_utilities=jnp.array([1.0], dtype=jnp.float32),
+            candidate_ages=jnp.array([5], dtype=jnp.int32),
+        )
+
+        promoted = jax.jit(learner.update)(
+            state,
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.zeros((1,), dtype=jnp.float32),
+        )
+
+        assert bool(promoted.update_applied)
+        assert int(promoted.promoted_candidate) == 0
+        assert int(promoted.state.ages[0]) == 0
+        assert float(promoted.state.utilities[0]) == 0.0
+        assert float(promoted.state.candidate_utilities[0]) == 0.0
+        chex.assert_tree_all_finite(promoted.metrics)
+
     def test_scan_loop_shapes(self) -> None:
         stream = NonlinearFeatureDiscoveryStream(
             feature_dim=4,

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -1,12 +1,18 @@
 """Tests for causal future-utility estimators."""
 
+from collections.abc import Callable
+
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
+import pytest
 
 from alberta_framework.core.compositional_features import CompositionalFeatureLearner
 from alberta_framework.core.feature_discovery import FixedBudgetFeatureLearner
 from alberta_framework.core.future_utility import (
+    bias_correct_future_utility,
     contribution_trace_output_loss_reduction,
     contribution_trace_output_loss_reduction_with_diagnostics,
     normalize_future_utility_signal,
@@ -165,6 +171,149 @@ def test_future_utility_normalization_is_finite_and_causal() -> None:
     chex.assert_tree_all_finite(normalized)
     chex.assert_tree_all_finite(second)
     assert float(second[1]) > float(second[0])
+
+
+def test_age_normalization_does_not_scale_the_ema_increment() -> None:
+    """Warm-up correction belongs after the raw EMA, not on each input."""
+    signal = jnp.ones((3,), dtype=jnp.float32)
+    normalized, _ = normalize_future_utility_signal(
+        signal,
+        ages=jnp.array([0, 10, 5_000], dtype=jnp.int32),
+        second_moment=jnp.zeros(3, dtype=jnp.float32),
+        moment_decay=0.9,
+        utility_decay=0.995,
+        mode="age",
+    )
+
+    chex.assert_trees_all_close(normalized, signal)
+
+
+def test_age_correction_reads_constant_raw_emas_on_one_scale() -> None:
+    decay = jnp.asarray(0.995, dtype=jnp.float32)
+    ages = jnp.array([1, 2, 11, 60, 301, 5_001], dtype=jnp.int32)
+    raw_emas = 1.0 - jnp.power(decay, ages.astype(jnp.float32))
+
+    correct = jax.jit(
+        lambda values: bias_correct_future_utility(
+            values,
+            ages,
+            decay,
+            "age",
+        )
+    )
+    corrected = correct(raw_emas)
+    gradients = jax.grad(lambda values: jnp.sum(correct(values)))(raw_emas)
+
+    chex.assert_trees_all_close(corrected, jnp.ones_like(corrected))
+    chex.assert_tree_all_finite(gradients)
+
+
+def test_age_zero_utility_reset_is_finite_under_jit_and_grad() -> None:
+    ages = jnp.array([0, 1], dtype=jnp.int32)
+
+    def total(values: jax.Array) -> jax.Array:
+        return jnp.sum(
+            bias_correct_future_utility(values, ages, 0.995, "uncertainty_age")
+        )
+
+    values = jnp.zeros((2,), dtype=jnp.float32)
+    corrected = jax.jit(
+        lambda value: bias_correct_future_utility(
+            value,
+            ages,
+            0.995,
+            "uncertainty_age",
+        )
+    )(values)
+    gradients = jax.jit(jax.grad(total))(values)
+
+    chex.assert_tree_all_finite(corrected)
+    chex.assert_tree_all_finite(gradients)
+
+
+def test_feature_learner_ema_and_age_correction_share_float32_decay() -> None:
+    common = dict(
+        n_features=2,
+        n_tasks=1,
+        step_size_output=0.1,
+        step_size_feature=0.0,
+        replacement_interval=0,
+        future_utility_mix=1.0,
+        future_utility_normalization="age",
+        use_obgd=False,
+    )
+    control = FixedBudgetFeatureLearner(utility_decay=0.0, **common)
+    near_one = FixedBudgetFeatureLearner(utility_decay=0.9999999, **common)
+    control_state = control.init(feature_dim=2, key=jr.key(432))
+    near_one_state = near_one.init(feature_dim=2, key=jr.key(432))
+    observation = jnp.array([0.5, -1.0], dtype=jnp.float32)
+    targets = jnp.array([1.0], dtype=jnp.float32)
+
+    control_result = jax.jit(control.update)(control_state, observation, targets)
+    near_one_result = jax.jit(near_one.update)(near_one_state, observation, targets)
+
+    chex.assert_trees_all_close(near_one_result.metrics[2:4], control_result.metrics[2:4])
+    assert near_one._utility_decay == float(np.float32(0.9999999))
+    assert near_one.to_config()["utility_decay"] == 0.9999999
+
+
+def test_compositional_ema_and_age_correction_share_float32_decay() -> None:
+    common = dict(
+        n_features=4,
+        n_tasks=1,
+        step_size_output=0.1,
+        step_size_theta=0.0,
+        replacement_interval=0,
+        future_utility_mix=1.0,
+        future_utility_normalization="age",
+        use_obgd=False,
+    )
+    control = CompositionalFeatureLearner(utility_decay=0.0, **common)
+    near_one = CompositionalFeatureLearner(utility_decay=0.9999999, **common)
+    control_state = control.init(feature_dim=2, key=jr.key(433))
+    near_one_state = near_one.init(feature_dim=2, key=jr.key(433))
+    observation = jnp.array([0.5, -1.0], dtype=jnp.float32)
+    targets = jnp.array([1.0], dtype=jnp.float32)
+
+    control_result = jax.jit(control.update)(control_state, observation, targets)
+    near_one_result = jax.jit(near_one.update)(near_one_state, observation, targets)
+
+    chex.assert_trees_all_close(near_one_result.metrics[2:4], control_result.metrics[2:4])
+    assert near_one._utility_decay == float(np.float32(0.9999999))
+    assert near_one.to_config()["utility_decay"] == 0.9999999
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            utility_decay=0.99999999,
+        ),
+        lambda: CompositionalFeatureLearner(
+            n_features=3,
+            n_tasks=1,
+            utility_decay=0.99999999,
+        ),
+        lambda: FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            utility_decay=0.5,
+            utility_retention_decay=0.99999999,
+        ),
+        lambda: CompositionalFeatureLearner(
+            n_features=3,
+            n_tasks=1,
+            retention_slow_utility_decay=0.99999999,
+        ),
+    ],
+)
+def test_utility_ema_decay_rejects_values_narrowing_to_float32_one(
+    factory: Callable[[], object],
+) -> None:
+    with pytest.raises(ValueError, match="finite float32 in \\[0, 1\\)"):
+        factory()
 
 
 def test_feature_discovery_future_utility_config_roundtrip_extended_knobs() -> None:


### PR DESCRIPTION
Closes #431

This fixes the reported EMA warm-start bias in both actual consumers of shared future-utility normalization: FixedBudgetFeatureLearner and CompositionalFeatureLearner.

The raw EMA remains in the existing state/checkpoint schema. Ranking, curation, selection, resource scores, and metrics now consume an eager/JIT/grad-safe output correction. The EMA decay and complement are canonicalized once in the float32 execution domain, and decay values that collapse to one are rejected before construction. Age-mode promotion resets both raw fast and slow utilities consistently; non-age promotion and FixedBudgetInteractionLearner compatibility remain unchanged.

Failing-first evidence reproduced the original output sequence [200.0002, 18.6409, 1.0] and a 16.1% full-learner score error near decay 0.9999999. After repair, 160 relevant tests, 92 compatibility tests, and 115 current-main composition tests passed. Full Ruff and strict mypy passed; the rebased patch ID is byte-equivalent to the independently reviewed candidate.

No outputs or registered five-claim evidence sources are changed. The existing nonpromoting slowly-changing-regression plan becomes source-stale and therefore continues to fail closed until explicitly replaced.