### PR TITLE
fix(step1): forward XDist target-noise magnitude

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -326,6 +326,7 @@ def make_step1_stream(
         return XDistShiftStream(
             feature_dim=config.feature_dim,
             num_relevant=config.num_relevant,
+            noise_std=config.noise_std,
             noise_in_target=config.noise_std > 0.0,
         )
     msg = f"unknown Step 1 stream {config.stream!r}"

--- a/tests/test_step1_stream_factory.py
+++ b/tests/test_step1_stream_factory.py
@@ -1,0 +1,31 @@
+"""Fast contracts for the production Step 1 stream factory."""
+
+import numpy as np
+import pytest
+
+from alberta_framework.steps import Step1KernelConfig, make_step1_stream
+from alberta_framework.streams.alberta_plan_step1 import XDistShiftStream
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("noise_std", "noise_in_target"),
+    [(0.0, False), (0.25, True), (7.0, True)],
+)
+def test_xdist_factory_forwards_noise_configuration(
+    noise_std: float,
+    noise_in_target: bool,
+) -> None:
+    config = Step1KernelConfig(
+        feature_dim=4,
+        num_relevant=2,
+        stream="xdist_shift",
+        noise_std=noise_std,
+    )
+
+    stream = make_step1_stream(config)
+
+    assert isinstance(stream, XDistShiftStream)
+    assert stream._noise_std == float(np.float32(noise_std))  # noqa: SLF001
+    assert stream._noise_in_target is noise_in_target  # noqa: SLF001


### PR DESCRIPTION
Closes #481.

## What changed

The Step 1 production factory now forwards the validated `noise_std` magnitude into `XDistShiftStream` instead of forwarding only whether noise is enabled.

A fast table-driven regression covers zero, a fractional non-default magnitude, and a large non-default magnitude. Zero still disables target noise; positive values preserve both the requested magnitude and enabled state.

## Why

Before this patch, every positive `Step1KernelConfig(stream="xdist_shift", noise_std=...)` silently ran with the stream default `0.1`. The serialized configuration and generated trajectory therefore disagreed.

## Scope

- `alberta_framework/steps/step1.py`
- `tests/test_step1_stream_factory.py`

No stream equation, RNG schedule, scientific evidence source, frozen artifact, benchmark result, or changelog entry changed.

## Verification

Exact candidate head: `fd0272af032dc2b31c3fc59b38906e2e32f0daaf`  
Base: `9e0719f8a92639fe8f78d08cb2fe267bf8ca1089`

- tests-first baseline on the original `origin/main` `ca9aaaf`: **3 failed**;
- exact-head focused regression: **3 passed**;
- exact-head affected Step 1 panel: **321 passed** (`test_step1_stream_factory.py`, `test_production_steps.py`, and `test_alberta_plan_step1_streams.py`);
- affected-file Ruff: **all checks passed**;
- strict Step 1 source mypy: **passed**;
- `git diff --check`: clean;
- clean candidate worktree with one authored commit;
- rebased onto current `origin/main` (`9e0719f8a92639fe8f78d08cb2fe267bf8ca1089`);
- exact-head proofs recorded for `fd0272af032dc2b31c3fc59b38906e2e32f0daaf`;
- live ownership refresh: no open PR implements this factory-forwarding defect; PRs #368 and #426 touch disjoint integer/config-validation hunks in `steps/step1.py`, and PR #476 owns the direct stream implementation files.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Claude Code via CLIProxyAPI
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
