### PR TITLE
fix(streams): validate polynomial stream configuration

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -26,7 +26,9 @@ or tanh feature bank:
   compositional DAG that builds features-of-features can.
 """
 
+from fractions import Fraction
 from numbers import Real
+from typing import cast
 
 import chex
 import jax.numpy as jnp
@@ -39,8 +41,40 @@ from alberta_framework._fixed_count_selection import (
     require_positive_builtin_int,
     stable_smallest_mask,
 )
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import (
+    round_real_to_float32,
+    round_real_to_float32_with_ratio,
+)
 from alberta_framework.core.types import TimeStep
+
+_FLOAT32_MULTIPLIER_MAX = float(np.sqrt(np.finfo(np.float32).max))
+_INT32_MAX = int(np.iinfo(np.int32).max)
+_SUPPORTED_NUMPY_REAL_SCALAR_TYPES = frozenset(
+    {
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.longlong,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.ulonglong,
+        np.float16,
+        np.float32,
+        np.float64,
+        np.longdouble,
+    }
+)
+
+
+def _is_supported_real_scalar(value: object) -> bool:
+    """Return whether ``value`` has an exact trusted host scalar type."""
+    actual_type = type(value)
+    if actual_type in (int, float, Fraction):
+        return True
+    return actual_type in _SUPPORTED_NUMPY_REAL_SCALAR_TYPES
 
 
 def _require_positive_float32(value: object, name: str) -> float:
@@ -56,6 +90,40 @@ def _require_positive_float32(value: object, name: str) -> float:
     if not np.isfinite(converted) or converted <= np.float32(0.0):
         raise ValueError(f"{name} must be a positive finite float32 value")
     return converted
+
+
+def _require_finite_float32_multiplier(
+    value: object,
+    *,
+    name: str,
+    nonnegative: bool = False,
+) -> float:
+    """Return a canonical finite multiplier with conservative float32 headroom."""
+    message = f"{name} must be a finite real in the safe float32 multiplier range"
+    if not _is_supported_real_scalar(value):
+        raise ValueError(message)
+    try:
+        numerator, _, narrowed = round_real_to_float32_with_ratio(cast(Real, value))
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(message) from error
+    if nonnegative and numerator < 0:
+        raise ValueError(message)
+    if not np.isfinite(narrowed) or abs(narrowed) > _FLOAT32_MULTIPLIER_MAX:
+        raise ValueError(message)
+    return narrowed
+
+
+def _require_safe_float32_product(*values: float, names: str) -> None:
+    """Reject configured multiplier products that consume float32 headroom."""
+    product = np.float32(1.0)
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        for value in values:
+            product = np.float32(product * np.float32(value))
+    if not np.isfinite(product) or abs(product) > _FLOAT32_MULTIPLIER_MAX:
+        raise ValueError(
+            f"{names} must stay within the safe combined float32 multiplier range"
+        )
+
 
 # =============================================================================
 # OutOfClassPolynomialStream -- degree-3 polynomial targets
@@ -132,18 +200,45 @@ class OutOfClassPolynomialStream:
                 indices (``x_i^2 * x_j``, ``x_i^3``).  Default False, so
                 the oracle uses strict ``i < j < l`` triples only.
         """
+        feature_dim = require_positive_builtin_int(feature_dim, name="feature_dim")
         if feature_dim < 3:
             raise ValueError("feature_dim must be at least 3")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
-        if context_length < 1:
-            raise ValueError("context_length must be positive")
+        n_tasks = require_positive_builtin_int(n_tasks, name="n_tasks")
+        n_contexts = require_positive_builtin_int(n_contexts, name="n_contexts")
+        context_length = require_positive_builtin_int(context_length, name="context_length")
+        if context_length > _INT32_MAX:
+            raise ValueError("context_length must be at most int32 max")
         active_triples_per_context = require_positive_builtin_int(
             active_triples_per_context,
             name="active_triples_per_context",
         )
+        feature_std = _require_finite_float32_multiplier(
+            feature_std,
+            name="feature_std",
+            nonnegative=True,
+        )
+        linear_scale = _require_finite_float32_multiplier(
+            linear_scale,
+            name="linear_scale",
+        )
+        noise_std = _require_finite_float32_multiplier(
+            noise_std,
+            name="noise_std",
+            nonnegative=True,
+        )
+        _require_safe_float32_product(
+            feature_std,
+            feature_std,
+            feature_std,
+            names="feature_std cubed",
+        )
+        _require_safe_float32_product(
+            linear_scale,
+            feature_std,
+            names="linear_scale and feature_std",
+        )
+        if type(include_squares) is not bool:
+            raise ValueError(f"include_squares must be a bool, got {include_squares!r}")
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -222,12 +222,19 @@ class OutOfClassPolynomialStream:
         n_tasks = require_positive_builtin_int(n_tasks, name="n_tasks")
         n_contexts = require_positive_builtin_int(n_contexts, name="n_contexts")
         context_length = require_positive_builtin_int(context_length, name="context_length")
-        if context_length > _INT32_MAX:
-            raise ValueError("context_length must be at most int32 max")
         active_triples_per_context = require_positive_builtin_int(
             active_triples_per_context,
             name="active_triples_per_context",
         )
+        for name, value in (
+            ("feature_dim", feature_dim),
+            ("n_tasks", n_tasks),
+            ("n_contexts", n_contexts),
+            ("context_length", context_length),
+            ("active_triples_per_context", active_triples_per_context),
+        ):
+            if value > _INT32_MAX:
+                raise ValueError(f"{name} must be at most int32 max")
         feature_std = _require_finite_float32_multiplier(
             feature_std,
             name="feature_std",

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -254,7 +254,7 @@ class OutOfClassPolynomialStream:
             names="linear_scale and feature_std",
         )
         if type(include_squares) is not bool:
-            raise ValueError(f"include_squares must be a bool, got {include_squares!r}")
+            raise ValueError("include_squares must be a built-in bool")
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -49,32 +49,49 @@ from alberta_framework.core.types import TimeStep
 
 _FLOAT32_MULTIPLIER_MAX = float(np.sqrt(np.finfo(np.float32).max))
 _INT32_MAX = int(np.iinfo(np.int32).max)
-_SUPPORTED_NUMPY_REAL_SCALAR_TYPES = frozenset(
-    {
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.longlong,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.ulonglong,
-        np.float16,
-        np.float32,
-        np.float64,
-        np.longdouble,
-    }
+_SUPPORTED_NUMPY_REAL_SCALAR_TYPES: tuple[type[object], ...] = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.longdouble,
 )
 
 
-def _is_supported_real_scalar(value: object) -> bool:
-    """Return whether ``value`` has an exact trusted host scalar type."""
+def _trusted_multiplier_real(value: object, message: str) -> Real:
+    """Return a hook-free concrete real for Polynomial stream multipliers."""
     actual_type = type(value)
-    if actual_type in (int, float, Fraction):
-        return True
-    return actual_type in _SUPPORTED_NUMPY_REAL_SCALAR_TYPES
+    if actual_type is int or actual_type is float:
+        return cast(Real, value)
+    for supported_type in _SUPPORTED_NUMPY_REAL_SCALAR_TYPES:
+        if actual_type is supported_type:
+            return cast(Real, value)
+    if actual_type is not Fraction:
+        raise ValueError(message)
+
+    fraction = cast(Fraction, value)
+    try:
+        numerator: object = object.__getattribute__(fraction, "_numerator")
+        denominator: object = object.__getattribute__(fraction, "_denominator")
+    except Exception as error:
+        raise ValueError(message) from error
+    if type(numerator) is not int or type(denominator) is not int:
+        raise ValueError(message)
+    if denominator <= 0:
+        raise ValueError(message)
+    try:
+        return Fraction(numerator, denominator)
+    except Exception as error:
+        raise ValueError(message) from error
 
 
 def _require_positive_float32(value: object, name: str) -> float:
@@ -100,11 +117,10 @@ def _require_finite_float32_multiplier(
 ) -> float:
     """Return a canonical finite multiplier with conservative float32 headroom."""
     message = f"{name} must be a finite real in the safe float32 multiplier range"
-    if not _is_supported_real_scalar(value):
-        raise ValueError(message)
     try:
-        numerator, _, narrowed = round_real_to_float32_with_ratio(cast(Real, value))
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        trusted_value = _trusted_multiplier_real(value, message)
+        numerator, _, narrowed = round_real_to_float32_with_ratio(trusted_value)
+    except Exception as error:
         raise ValueError(message) from error
     if nonnegative and numerator < 0:
         raise ValueError(message)

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -181,6 +181,84 @@ class TestOutOfClassPolynomialStream:
         with pytest.raises(ValueError, match=field):
             OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
 
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    def test_scientific_scalars_do_not_hash_or_compare_untrusted_actual_types(
+        self,
+        field: str,
+    ) -> None:
+        calls: list[str] = []
+
+        class HostileNumericMeta(type):
+            def __hash__(cls) -> int:
+                calls.append("hash")
+                raise RuntimeError("untrusted metaclass hash hook executed")
+
+            def __eq__(cls, other: object) -> bool:
+                del other
+                calls.append("eq")
+                raise RuntimeError("untrusted metaclass equality hook executed")
+
+        class HostileFloat(float, metaclass=HostileNumericMeta):
+            pass
+
+        calls.clear()
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(  # type: ignore[arg-type]
+                **{field: HostileFloat(1.0)}
+            )
+
+        assert calls == []
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize("slot", ["_numerator", "_denominator"])
+    def test_scientific_scalars_reject_poisoned_exact_fraction_components_without_hooks(
+        self,
+        field: str,
+        slot: str,
+    ) -> None:
+        calls = 0
+
+        class ExplodingInt(int):
+            def __int__(self) -> int:
+                nonlocal calls
+                calls += 1
+                raise RuntimeError("untrusted Fraction component hook executed")
+
+        value = Fraction(1, 4)
+        component = ExplodingInt(1 if slot == "_numerator" else 4)
+        object.__setattr__(value, slot, component)
+
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+        assert calls == 0
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize("slot", ["_numerator", "_denominator"])
+    def test_scientific_scalars_normalize_missing_exact_fraction_slots(
+        self,
+        field: str,
+        slot: str,
+    ) -> None:
+        value = Fraction(1, 4)
+        object.__delattr__(value, slot)
+
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize("denominator", [0, -4])
+    def test_scientific_scalars_reject_nonpositive_exact_fraction_denominators(
+        self,
+        field: str,
+        denominator: int,
+    ) -> None:
+        value = Fraction(1, 4)
+        object.__setattr__(value, "_denominator", denominator)
+
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
     @pytest.mark.parametrize(
         "scalar_type",
         [
@@ -214,6 +292,19 @@ class TestOutOfClassPolynomialStream:
         assert stream._feature_std == 1.0  # noqa: SLF001
         assert stream._linear_scale == 1.0  # noqa: SLF001
         assert stream._noise_std == 1.0  # noqa: SLF001
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize("scalar_type", [np.longlong, np.ulonglong])
+    def test_scientific_scalars_preserve_distinct_numpy_long_integer_types(
+        self,
+        field: str,
+        scalar_type: type[np.generic],
+    ) -> None:
+        stream = OutOfClassPolynomialStream(  # type: ignore[arg-type]
+            **{field: scalar_type(1)}
+        )
+
+        assert getattr(stream, f"_{field}") == 1.0
 
     @pytest.mark.parametrize("field", ["feature_std", "noise_std"])
     @pytest.mark.parametrize("value", [-1.0, -Fraction(1, 2**200)])

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -402,6 +402,20 @@ class TestOutOfClassPolynomialStream:
         with pytest.raises(ValueError, match="include_squares"):
             OutOfClassPolynomialStream(include_squares=value)  # type: ignore[arg-type]
 
+    def test_include_squares_rejects_invalid_type_without_calling_repr(self) -> None:
+        repr_calls = 0
+
+        class ExplodingRepr:
+            def __repr__(self) -> str:
+                nonlocal repr_calls
+                repr_calls += 1
+                raise RuntimeError("untrusted repr hook executed")
+
+        with pytest.raises(ValueError, match="include_squares"):
+            OutOfClassPolynomialStream(include_squares=ExplodingRepr())  # type: ignore[arg-type]
+
+        assert repr_calls == 0
+
     def test_legal_scalar_endpoints_remain_supported(self) -> None:
         stream = OutOfClassPolynomialStream(
             feature_dim=3,

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -11,6 +11,7 @@ import json
 import math
 from decimal import Decimal
 from fractions import Fraction
+from numbers import Real
 
 import chex
 import jax
@@ -31,6 +32,27 @@ class _FloatCoercible:
 
     def __float__(self) -> float:
         return 0.5
+
+
+class _PositiveRatioFloat(float):
+    """Negative float subclass whose ratio hook reports a positive value."""
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (1, 4)
+
+
+class _PositiveInt(int):
+    """Negative int subclass whose conversion hook reports a positive value."""
+
+    def __int__(self) -> int:
+        return 1
+
+
+class _ExplodingRatioFloat(float):
+    """Float subclass whose ratio hook must never execute during validation."""
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("untrusted ratio hook executed")
 
 
 def _scan_collect(stream, num_steps: int, key) -> tuple[jnp.ndarray, jnp.ndarray]:
@@ -68,6 +90,243 @@ class TestOutOfClassPolynomialStream:
                 feature_dim=4,
                 active_triples_per_context=active_count,  # type: ignore[arg-type]
             )
+
+    @pytest.mark.parametrize(
+        "field",
+        ["feature_dim", "n_tasks", "n_contexts", "context_length"],
+    )
+    @pytest.mark.parametrize("value", [True, False, 1.0, np.int64(3), "3", None])
+    def test_dimensions_require_positive_builtin_ints(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("feature_dim", 2),
+            ("n_tasks", 0),
+            ("n_contexts", 0),
+            ("context_length", 0),
+        ],
+    )
+    def test_dimensions_enforce_minimums(self, field: str, value: int) -> None:
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    def test_context_length_rejects_values_above_the_step_int32_domain(self) -> None:
+        with pytest.raises(ValueError, match="context_length.*int32 max"):
+            OutOfClassPolynomialStream(context_length=2**31)
+
+    def test_context_length_accepts_int32_max_and_runs_eager_and_jit_step(self) -> None:
+        maximum = int(np.iinfo(np.int32).max)
+        stream = OutOfClassPolynomialStream(
+            feature_dim=3,
+            n_tasks=1,
+            n_contexts=1,
+            context_length=maximum,
+            active_triples_per_context=1,
+            noise_std=0.0,
+        )
+        state = stream.init(jr.key(98))
+        step_index = jnp.array(0, dtype=jnp.int32)
+
+        eager_timestep, _ = stream.step(state, step_index)
+        jit_timestep, _ = jax.jit(stream.step)(state, step_index)
+
+        assert stream._context_length == maximum  # noqa: SLF001
+        chex.assert_tree_all_finite((eager_timestep, jit_timestep))
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            True,
+            np.bool_(True),
+            "0.5",
+            Decimal("0.5"),
+            _FloatCoercible(),
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            1e100,
+        ],
+    )
+    def test_scientific_scalars_require_safe_finite_float32_reals(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            _PositiveRatioFloat(-0.25),
+            _PositiveInt(-1),
+            _ExplodingRatioFloat(0.5),
+        ],
+        ids=("forged-float-ratio", "forged-int-conversion", "raising-float-ratio"),
+    )
+    def test_scientific_scalars_reject_untrusted_real_subclasses(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "scalar_type",
+        [
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.longlong,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.ulonglong,
+            np.float16,
+            np.float32,
+            np.float64,
+            np.longdouble,
+        ],
+    )
+    def test_scientific_scalars_accept_supported_numpy_types(
+        self,
+        scalar_type: type[np.generic],
+    ) -> None:
+        value = scalar_type(1)
+        stream = OutOfClassPolynomialStream(
+            feature_std=value,
+            linear_scale=value,
+            noise_std=value,
+        )
+
+        assert stream._feature_std == 1.0  # noqa: SLF001
+        assert stream._linear_scale == 1.0  # noqa: SLF001
+        assert stream._noise_std == 1.0  # noqa: SLF001
+
+    @pytest.mark.parametrize("field", ["feature_std", "noise_std"])
+    @pytest.mark.parametrize("value", [-1.0, -Fraction(1, 2**200)])
+    def test_standard_deviations_reject_negative_exact_reals(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+    def test_noise_std_rejects_non_real_with_a_real_class_facade(self) -> None:
+        class RealFacade:
+            @property
+            def __class__(self) -> type[float]:
+                return float
+
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (1, 2)
+
+        value = RealFacade()
+        assert isinstance(value, Real)
+        assert not issubclass(type(value), Real)
+
+        with pytest.raises(ValueError, match="noise_std"):
+            OutOfClassPolynomialStream(noise_std=value)  # type: ignore[arg-type]
+
+    def test_noise_std_rejects_ratio_component_with_an_integral_class_facade(
+        self,
+    ) -> None:
+        class IntegralFacade:
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def __int__(self) -> int:
+                return 1
+
+        class MalformedRatioFloat(float):
+            def as_integer_ratio(self) -> tuple[object, int]:
+                return (IntegralFacade(), 2)
+
+        with pytest.raises(ValueError, match="noise_std"):
+            OutOfClassPolynomialStream(noise_std=MalformedRatioFloat(0.5))
+
+    def test_noise_std_rejects_negative_exact_ratio_from_float_subclass(self) -> None:
+        class NegativeRatioFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (-1, 2**200)
+
+        value = NegativeRatioFloat(0.5)
+        assert value >= 0.0
+        assert value.as_integer_ratio()[0] < 0
+
+        with pytest.raises(ValueError, match="noise_std"):
+            OutOfClassPolynomialStream(noise_std=value)
+
+    @pytest.mark.parametrize("field", ["feature_std", "linear_scale", "noise_std"])
+    @pytest.mark.parametrize(
+        ("offset", "expected"),
+        [
+            (Fraction(-1, 2**60), float(np.float32(1.0))),
+            (Fraction(0), float(np.float32(1.0))),
+            (
+                Fraction(1, 2**60),
+                float(np.nextafter(np.float32(1.0), np.float32(2.0))),
+            ),
+        ],
+        ids=("below", "tie-to-even", "above"),
+    )
+    def test_scientific_scalars_round_exact_midpoints_once(
+        self,
+        field: str,
+        offset: Fraction,
+        expected: float,
+    ) -> None:
+        value = Fraction(1) + Fraction(1, 2**24) + offset
+        stream = OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
+
+        assert getattr(stream, f"_{field}") == expected
+
+    def test_multiplier_products_retain_float32_headroom(self) -> None:
+        multiplier_max = float(np.sqrt(np.finfo(np.float32).max))
+
+        with pytest.raises(ValueError, match="feature_std cubed"):
+            OutOfClassPolynomialStream(feature_std=3_000_000.0)
+        with pytest.raises(ValueError, match="linear_scale and feature_std"):
+            OutOfClassPolynomialStream(
+                feature_std=2.0,
+                linear_scale=multiplier_max,
+            )
+
+    @pytest.mark.parametrize("value", [0, 1, "yes", np.bool_(True)])
+    def test_include_squares_requires_strict_bool(self, value: object) -> None:
+        with pytest.raises(ValueError, match="include_squares"):
+            OutOfClassPolynomialStream(include_squares=value)  # type: ignore[arg-type]
+
+    def test_legal_scalar_endpoints_remain_supported(self) -> None:
+        stream = OutOfClassPolynomialStream(
+            feature_dim=3,
+            n_tasks=1,
+            n_contexts=1,
+            context_length=1,
+            feature_std=0.0,
+            linear_scale=-0.0,
+            noise_std=0.0,
+            include_squares=False,
+        )
+
+        assert stream.feature_dim == 3
+        assert math.copysign(1.0, stream._linear_scale) == -1.0  # noqa: SLF001
+        timestep, _ = stream.step(stream.init(jr.key(97)), jnp.array(0))
+        chex.assert_tree_all_finite((timestep.observation, timestep.target))
 
     def test_active_triple_count_caps_at_available_triples(self) -> None:
         stream = OutOfClassPolynomialStream(

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -117,9 +117,19 @@ class TestOutOfClassPolynomialStream:
         with pytest.raises(ValueError, match=field):
             OutOfClassPolynomialStream(**{field: value})  # type: ignore[arg-type]
 
-    def test_context_length_rejects_values_above_the_step_int32_domain(self) -> None:
-        with pytest.raises(ValueError, match="context_length.*int32 max"):
-            OutOfClassPolynomialStream(context_length=2**31)
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "feature_dim",
+            "n_tasks",
+            "n_contexts",
+            "context_length",
+            "active_triples_per_context",
+        ],
+    )
+    def test_dimensions_reject_values_above_the_int32_domain(self, field: str) -> None:
+        with pytest.raises(ValueError, match=rf"{field}.*int32 max"):
+            OutOfClassPolynomialStream(**{field: 2**31})  # type: ignore[arg-type]
 
     def test_context_length_accepts_int32_max_and_runs_eager_and_jit_step(self) -> None:
         maximum = int(np.iinfo(np.int32).max)


### PR DESCRIPTION
Closes #484.

## What changed

`OutOfClassPolynomialStream` now validates and canonicalizes its complete public constructor configuration before JAX work:

- dimensions/counts require exact built-in integers and signed-int32-safe bounds;
- scientific multipliers admit only exact trusted built-in, `Fraction`, and concrete NumPy real scalar families;
- subclasses, class/metaclass spoofing, malformed or poisoned Fraction internals, and conversion hooks are rejected before hooks run;
- exact ratios round directly to binary32 ties-to-even, with sign, finite, overflow, individual-headroom, cubic-headroom, and interacting-product checks;
- accepted values are JSON-safe built-in floats, and `include_squares` is an exact built-in boolean;
- invalid boolean errors do not interpolate untrusted objects, so hostile `__repr__` hooks cannot escape the validation boundary.

Target construction, recurrence, sparse triple selection, RNG splitting, and valid default behavior are unchanged.

## Review repairs

This head incorporates all requested repairs after the original contribution: identity-only trusted-type dispatch; complete NumPy signed/unsigned integer coverage; safe Fraction snapshotting; zero metaclass/equality/conversion hooks; and a constant boolean error message. An independent fresh review found no remaining blocker.

## Verification

Exact head: `b2d3ac1a28b92fd8f8511d46a427f567e887637a`

- failing-first hostile-`repr` regression: failed on the prior repaired head, then passed with zero repr calls;
- full out-of-class module: **212 passed/**;
- independent 86-case adversarial type/hook matrix: passed;
- 37-step default trajectory: bit-for-bit identical to the pre-change implementation;
- repository Ruff: clean;
- strict mypy: **165 source files** clean;
- `git diff --check`: clean;
- current-main composition: conflict-free, with the same 208 tests green.

No `outputs/**` artifact or five-claim registered evidence source changes. The evidence registry remains inherited-invalid from unrelated existing source drift; this PR does not revalidate or promote any claim.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Codex
- Attribution status: self-reported