### PR TITLE
fix(forager): reject non-integer analysis horizon

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_final_analysis.py
+++ b/alberta_framework/benchmarks/forager_matched_final_analysis.py
@@ -2198,7 +2198,7 @@ def _validate_evaluation_snapshot(
         != qualification_manifest_sha256
         or executor_manifest.get("qualification_manifest_sha256")
         != qualification_manifest_sha256
-        or plan.get("horizon") != sealed_protocol.horizon
+        or not _json_exact_equal(plan.get("horizon"), sealed_protocol.horizon)
         or type(plan_active_seeds) is not list
         or not _json_exact_equal(plan_active_seeds, list(sealed_protocol.active_seeds))
         or type(plan_candidate_order) is not list

--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -2484,6 +2484,7 @@ def test_source_projection_and_command_templates_are_exact(
         )
 
     malformed_plan_cases: tuple[tuple[str, Any], ...] = (
+        ("horizon", float(seal_content.sealed_protocol.horizon)),
         ("active_seeds", None),
         (
             "active_seeds",


### PR DESCRIPTION
Closes #483.

## What changed

Fifth instance of the same bug class as #450/#460/#466/#471: `_validate_evaluation_snapshot` accepted a JSON float horizon when its numeric value matched the sealed protocol horizon (`499712.0 == 499712` is true in Python), letting an invalid execution-plan schema value cross the final-analysis closure boundary. Notably, this file already defines and uses `_json_exact_equal` for the sibling `active_seeds` field a few lines below the fixed line — `horizon` was simply the one field that got missed.

confirmed directly before touching the source, using a real fixture-derived plan with only `horizon` changed from the sealed integer to its float alias:

```text
BUG: accepted horizon=499712.0 (float); expected exact int 499712
```

fix: use the file's own existing `_json_exact_equal` helper for the horizon comparison, matching the pattern already applied to `active_seeds` in the same function — a one-line change reusing established infrastructure rather than introducing anything new.

## Reachability

`_validate_evaluation_snapshot` is invoked by `_load_from_open_root` and by the final-analysis creation flow — both confirmed directly. The public module API exports `load_final_analysis_content`, `create_forager_matched_final_analysis_bundle`, and `authenticate_final_analysis_content` in `__all__` — confirmed directly — each leads to final-analysis content loading/validation with externally-supplied execution-plan content.

## Verification

macOS note: this test file's fixtures require the atomic no-replace publication primitives (`renameat2`, Linux-only) already documented as unavailable on this dev platform in #467/#472. I independently re-ran the full suite using the same test-only monkeypatch shim that swaps those primitives for plain `os.rename` during fixture setup — confirmed the shim only touches publication-primitive plumbing (`_publish_verified_no_replace`, `_rename_no_replace`, `_publish_bytes`), never anything related to the horizon check under test, before trusting it.

```text
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p asi46_pytest_shim tests/test_forager_matched_final_analysis.py -q -o addopts=""
33 passed in 176.57s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_final_analysis.py tests/test_forager_matched_final_analysis.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New coverage: `("horizon", float(seal_content.sealed_protocol.horizon))` added to the existing `malformed_plan_cases` table inside `test_source_projection_and_command_templates_are_exact`, which already exercises the analogous `active_seeds` and `candidate_order` malformed-value cases.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_final_analysis.py`, kept the test), reran the parametrized test — failed with the float alias silently passing the horizon check and continuing on to an unrelated later assertion (`AssertionError: Regex pattern did not match. Expected: "execution-plan closure drifted" / Actual: "evaluation receipt-index header closure drifted"`), proving the float alias crossed the intended validation boundary undetected. restored the fix, green again.

## Evidence

<!-- evidence-head -->
1d7daa1a4490fd917e091fe31c7909046008ace1

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p asi46_pytest_shim tests/test_forager_matched_final_analysis.py -q -o addopts="" -k test_source_projection_and_command_templates_are_exact
FAILED - AssertionError: Regex pattern did not match.
Expected regex: 'execution-plan closure drifted'
Actual message: 'evaluation receipt-index header closure drifted'
1 failed, 32 deselected in 4.45s

green (fix restored):
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p asi46_pytest_shim tests/test_forager_matched_final_analysis.py -q -o addopts="" -k test_source_projection_and_command_templates_are_exact
1 passed, 32 deselected in 4.39s
```

<!-- evidence-row:domain-artifact -->
```text
BUG: accepted horizon=499712.0 (float); expected exact int 499712
```
independently reran the full touched test file (33 tests, using the documented macOS publication shim), ruff, and mypy myself; independently inspected the shim's source to confirm it only patches unrelated publication-primitive plumbing, not anything touching the fix under test; independently confirmed both real call sites and the `__all__` export chain before writing the reachability claim; did my own revert-and-confirm-red mutation check with the correct (parametrized-table, not separately-named) test target.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file using the same macOS compatibility shim after independently auditing what it patches, ruff, and mypy myself, independently confirmed both real call sites and the export chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
