### PR TITLE
fix(off-policy): apply each ratio once in TD traces

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -9,12 +9,12 @@ Theoretical background:
     to TD with FA). Several remedies exist:
 
     1. Per-decision importance sampling (Precup, Sutton, Singh 2000):
-       multiply each step's update by rho_t = pi(a_t|s_t) / b(a_t|s_t)
-       so that on average we are simulating the on-policy distribution.
-       Variance can be very large.
-    2. Retrace ratio clipping (Munos et al. 2016): use
-       rho_clipped = min(c, rho_t). Convergent for c <= 1; for c > 1 it
-       trades bias for variance reduction.
+       include each rho_t = pi(a_t|s_t) / b(a_t|s_t) once in the
+       eligibility-trace recursion so that on average we are simulating the
+       on-policy distribution. Variance can be very large.
+    2. Retrace-style ratio clipping (Munos et al. 2016): use
+       rho_clipped = min(c, rho_t) to trade variance for bias. Clipping is
+       not by itself a convergence guarantee for linear off-policy TD.
     3. Gradient-TD (TDC, GQ-lambda) (Sutton, Maei, et al. 2009-2010):
        gradient descent on the projected Bellman error.
     4. Emphatic TD (Sutton, Mahmood, White 2016): emphasis traces F_t
@@ -82,8 +82,8 @@ class OffPolicyTDState:
     Attributes:
         weights: Weight vector for linear value approximation
         bias: Bias term
-        eligibility_traces: Per-feature eligibility trace
-        bias_eligibility_trace: Bias eligibility trace
+        eligibility_traces: Per-feature importance-sampling trace ``z_t``
+        bias_eligibility_trace: Bias importance-sampling trace
         step_count: Number of updates applied
         birth_timestamp: Wall-clock seconds at init
         uptime_s: Cumulative wall-clock seconds spent in update calls
@@ -224,13 +224,13 @@ class OffPolicyTDLinearLearner:
         rho_t = pi(a_t|s_t) / b(a_t|s_t)               (provided externally)
         rho_clipped = min(c, rho_t)                     (Retrace clipping)
         delta_t = R_{t+1} + gamma_t * V(s_{t+1}) - V(s_t)
-        e_t = gamma_t * lambda_t * rho_clipped * e_{t-1} + phi_t
-        w_{t+1} = w_t + alpha * delta_t * rho_clipped * e_t
+        z_t = rho_clipped * (gamma_t * lambda_t * z_{t-1} + phi_t)
+        w_{t+1} = w_t + alpha * delta_t * z_t
 
     Setting ``retrace_clip = inf`` recovers naive per-decision IS.
-    Setting ``retrace_clip = 1.0`` gives the Retrace-c=1 update which is
-    convergent under standard conditions. Setting ``rho_t = 1`` always
-    recovers on-policy semi-gradient TD(lambda).
+    Setting ``retrace_clip = 1.0`` clips every ratio in the trace recursion
+    to one. Setting ``rho_t = 1`` always recovers on-policy semi-gradient
+    TD(lambda).
 
     Attributes:
         step_size: Learning rate alpha
@@ -249,9 +249,8 @@ class OffPolicyTDLinearLearner:
         Args:
             step_size: Learning rate alpha (scalar)
             trace_decay: Eligibility trace decay lambda in [0, 1]
-            retrace_clip: Maximum allowed importance ratio (default 1.0
-                is the safe Retrace-c=1 choice; pass float("inf") to
-                disable clipping).
+            retrace_clip: Maximum allowed importance ratio (default 1.0;
+                pass float("inf") to disable clipping).
         """
         if step_size <= 0:
             raise ValueError(f"step_size must be positive; got {step_size}")
@@ -335,13 +334,20 @@ class OffPolicyTDLinearLearner:
         v_next = jnp.dot(state.weights, next_observation) + state.bias
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
-        # IS-weighted accumulating eligibility trace
-        decay = gamma_s * lam * rho_clipped
-        new_e = _skip_zero_scale(decay, state.eligibility_traces) + observation
-        new_e_b = _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
+        # Canonical per-decision IS trace.  Each transition's ratio enters once:
+        # the prior ratios are already represented in the stored trace.
+        decay = gamma_s * lam
+        new_e = _skip_zero_scale(
+            rho_clipped,
+            _skip_zero_scale(decay, state.eligibility_traces) + observation
+        )
+        new_e_b = _skip_zero_scale(
+            rho_clipped,
+            _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
+        )
 
-        # Update with rho_clipped * delta * e
-        scaled_update = alpha * rho_clipped * td_error
+        # rho_clipped is already represented in the trace.
+        scaled_update = alpha * td_error
         proposed_state = OffPolicyTDState(  # type: ignore[call-arg]
             weights=state.weights + scaled_update * new_e,
             bias=state.bias + scaled_update * new_e_b,

--- a/tests/test_baird.py
+++ b/tests/test_baird.py
@@ -268,8 +268,8 @@ class TestRhoZeroInvariance:
         )
         chex.assert_trees_all_equal(result.state.weights, state.weights)
         chex.assert_trees_all_equal(result.state.bias, state.bias)
-        # rho = 0 also cuts the eligibility trace back to the current features.
-        chex.assert_trees_all_close(result.state.eligibility_traces, jnp.asarray(PHI[3]))
+        # The canonical per-decision trace z = rho * (...) vanishes.
+        chex.assert_trees_all_close(result.state.eligibility_traces, jnp.zeros(N_FEATURES))
 
     def test_etd_weights_invariant_and_follow_on_resets(self) -> None:
         learner = ETDLinearLearner(step_size=0.1, trace_decay=0.0)

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -94,6 +94,90 @@ class TestOnPolicyEquivalence:
 
 
 # =============================================================================
+# Per-decision importance sampling
+# =============================================================================
+
+
+class TestPerDecisionImportanceSampling:
+    def test_time_varying_rho_enters_each_trace_once(self) -> None:
+        """The current ratio scales the new feature; the previous ratio is retained."""
+        learner = OffPolicyTDLinearLearner(
+            step_size=0.1,
+            trace_decay=0.8,
+            retrace_clip=float("inf"),
+        )
+        state = learner.init(2)
+
+        first = learner.update(
+            state,
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+            jnp.float32(1.0),
+            jnp.zeros(2, dtype=jnp.float32),
+            jnp.float32(0.9),
+            jnp.float32(2.0),
+        )
+        second = learner.update(
+            first.state,
+            jnp.array([0.0, 1.0], dtype=jnp.float32),
+            jnp.float32(1.0),
+            jnp.zeros(2, dtype=jnp.float32),
+            jnp.float32(0.9),
+            jnp.float32(0.5),
+        )
+
+        # z_1 = 2 * phi_1.  On the next transition,
+        # z_2 = 0.5 * (0.9 * 0.8 * z_1 + phi_2) = [0.72, 0.5].
+        chex.assert_trees_all_close(
+            first.state.eligibility_traces,
+            jnp.array([2.0, 0.0], dtype=jnp.float32),
+        )
+        chex.assert_trees_all_close(
+            second.state.eligibility_traces,
+            jnp.array([0.72, 0.5], dtype=jnp.float32),
+        )
+        chex.assert_trees_all_close(
+            second.state.bias_eligibility_trace,
+            jnp.float32(1.22),
+        )
+        # delta_1 = 1 and delta_2 = 1 + 0.9*0.2 - 0.2 = 0.98.
+        chex.assert_trees_all_close(
+            second.state.weights,
+            jnp.array([0.27056, 0.049], dtype=jnp.float32),
+            atol=1e-6,
+        )
+        chex.assert_trees_all_close(second.state.bias, jnp.float32(0.31956), atol=1e-6)
+
+    def test_constant_rho_retains_prior_weight_updates(self) -> None:
+        """The canonical trace is externally equivalent to the old placement at fixed rho."""
+        learner = OffPolicyTDLinearLearner(
+            step_size=0.1,
+            trace_decay=0.8,
+            retrace_clip=float("inf"),
+        )
+        state = learner.init(2)
+
+        for observation in (
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+            jnp.array([0.0, 1.0], dtype=jnp.float32),
+        ):
+            state = learner.update(
+                state,
+                observation,
+                jnp.float32(1.0),
+                jnp.zeros(2, dtype=jnp.float32),
+                jnp.float32(0.9),
+                jnp.float32(2.0),
+            ).state
+
+        chex.assert_trees_all_close(
+            state.weights,
+            jnp.array([0.48224, 0.196], dtype=jnp.float32),
+            atol=1e-6,
+        )
+        chex.assert_trees_all_close(state.bias, jnp.float32(0.67824), atol=1e-6)
+
+
+# =============================================================================
 # ETD(lambda)
 # =============================================================================
 


### PR DESCRIPTION
Closes #462.

## What changed

`OffPolicyTDLinearLearner` now uses the canonical per-decision importance-sampling trace `z_t = rho_t * (gamma_t * lambda_t * z_{t-1} + phi_t)` and applies `alpha * delta_t * z_t`. The previous implementation put the current ratio in both the carried-trace decay and the weight-update multiplier, so time-varying ratios were applied twice.

The public state/config schema is unchanged. `rho=0` now correctly clears the current trace, constant-ratio behavior remains equivalent, and clipped/non-finite refusal behavior is retained.

## Verification

- failing-test-first: three varying-ratio regressions failed on the original base and pass here;
- independent 32-step varying-ratio oracle, constant-ratio equivalence, clipping/zero-ratio, nested JIT scan, overflow refusal, and pickle/config probes passed;
- independent focused/adjacent review: 158 passed;
- final rebased focused `test_off_policy_td + test_baird`: 36 passed;
- repository-wide Ruff: clean;
- strict mypy: 165 source files clean;
- patch-id unchanged by the final rebase onto `d06d51bb8d173f81cb5ae7093f83b97ba272520e`;
- no output or five-claim registered evidence source changed; the registry retains its pre-existing invalid source-drift state.

This is a code-correctness repair, not scientific evidence or a promoted claim.