### PR TITLE
fix(forager-matched): reject numeric aliases in raw bindings

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -1201,7 +1201,7 @@ def _validate_raw_binding(
         raw_sha,
         raw_size,
     )
-    if payload != expected:
+    if canonical_json_bytes(payload) != canonical_json_bytes(expected):
         raise ForagerMatchedCampaignError("raw archive binding differs from actual opaque file")
     return payload, digest
 

--- a/tests/test_forager_matched_campaign.py
+++ b/tests/test_forager_matched_campaign.py
@@ -946,6 +946,39 @@ def test_bound_raw_corruption_fails_before_any_oci_call(tmp_path: Path) -> None:
     assert oci_called is False
 
 
+def test_raw_binding_rejects_equal_valued_float_size_alias(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    candidate_id = context.rebuilt.candidate_ids[0]
+    seed = context.rebuilt.protocol.active_seeds[0]
+    run_cell, _completion = campaign._cell_paths(context.root, candidate_id, seed)
+    attempt = run_cell / "attempt-000001"
+    attempt.mkdir(parents=True)
+    raw_path = attempt / "raw-output.tar"
+    raw_path.write_bytes(b"opaque-raw-content")
+    raw_sha256, raw_size = campaign._stable_file_hash(
+        raw_path,
+        "test opaque raw archive",
+        maximum=1024,
+    )
+    binding = campaign._raw_binding(
+        context,
+        candidate_id,
+        seed,
+        attempt.name,
+        raw_sha256,
+        raw_size,
+    )
+    cast(dict[str, Any], binding["raw_archive"])["size_bytes"] = float(raw_size)
+    binding_bytes = campaign.canonical_json_bytes(binding)
+    (attempt / "raw-binding.json").write_bytes(binding_bytes)
+    (attempt / "raw-binding.json.sha256").write_text(
+        hashlib.sha256(binding_bytes).hexdigest() + "\n"
+    )
+
+    with pytest.raises(campaign.ForagerMatchedCampaignError, match="raw archive binding"):
+        campaign._validate_raw_binding(context, candidate_id, seed, attempt)
+
+
 def test_completed_bundle_without_pointer_repairs_only_the_pointer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #488.

## What changed

Sixth instance of the same bug class as #450/#460/#466/#471/#483: `_validate_raw_binding` loaded a canonical, sidecar-hashed raw archive binding and compared the resulting Python mapping to the expected binding with ordinary mapping equality. Python considers equal-valued integers and floats equal, so an external binding declaring `"size_bytes": 19.0` was accepted as an exact match for a real 19-byte archive — weakening a persisted provenance/measurement boundary that claims the binding differs unless it exactly describes the opaque file.

confirmed directly before touching the source:

```text
actual_size=19 declared=19.0 declared_type=float
RESULT: accepted equal-valued float alias
```

fix: compare the raw binding through its canonical JSON bytes (`canonical_json_bytes`, already defined in this module) rather than Python mapping equality — distinguishes JSON integer `19` from JSON float `19.0` without adding a new schema or abstraction.

## Reachability

The validator is reached with persisted, non-hardcoded-safe campaign data via the installed `alberta-forager-matched-campaign` console script — confirmed directly in `pyproject.toml` — → `main` → `verify_open_tuning_campaign`/`campaign_status` → `_load_context_and_status` → `_scan_all_cells` → `_scan_cell` → `_validate_raw_binding`. `load_completed_open_tuning_campaign` also calls `_scan_all_cells`, so programmatic completed-bundle loading reaches the same check.

## Verification

macOS note (same as #472/#486): fixtures for this test file need Linux-only file primitives (`O_TMPFILE` for anonymous-inode publication). I independently re-ran the full suite using a test-only shim that swaps `_publish_bytes`/`_rename_no_replace` for portable equivalents during fixture setup, after reading its source myself to confirm it only touches publication plumbing, never the fix under test. The shim correctly excludes the one test (`test_anonymous_publication_failure_leaves_no_visible_partial`) that specifically needs the real platform-specific failure mode.

```text
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p fix47_pytest_shim tests/test_forager_matched_campaign.py -q -o addopts="" -k "not open_campaign_v2_golden_byte_contract and not anonymous_publication_failure_leaves_no_visible_partial"
36 passed, 2 deselected in 4.10s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_campaign.py tests/test_forager_matched_campaign.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_raw_binding_rejects_equal_valued_float_size_alias`, creating a real opaque archive with a self-consistent canonical binding/sidecar, changing only `raw_archive.size_bytes` to an equal-valued float, and asserting production binding validation fails closed.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_campaign.py`, kept the test), reran — failed with `DID NOT RAISE ForagerMatchedCampaignError`, confirming the float alias previously crossed validation undetected. restored the fix, green again.

**Note on excluded `test_open_campaign_v2_golden_byte_contract`:** independently confirmed this failure is pre-existing and unrelated — reproduced it identically (same three mismatched hashes: `open-protocol.json`, `execution-schedule.json`, `campaign.json`) on an unmodified checkout via `git stash` before writing this PR. Stale golden hashes in the test fixture versus current `origin/main` output, not caused by this change.

## Evidence

<!-- evidence-head -->
ea1628e3b84dd013f14cd829ef5fcd14b0ecff9f

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p fix47_pytest_shim tests/test_forager_matched_campaign.py -q -o addopts="" -k test_raw_binding_rejects_equal_valued_float_size_alias
FAILED - Failed: DID NOT RAISE ForagerMatchedCampaignError
1 failed, 37 deselected in 0.15s

green (fix restored):
$ PYTHONPATH=<shim-dir> .venv/bin/python -m pytest -p fix47_pytest_shim tests/test_forager_matched_campaign.py -q -o addopts="" -k test_raw_binding_rejects_equal_valued_float_size_alias
1 passed, 37 deselected in 0.04s
```

<!-- evidence-row:domain-artifact -->
```text
actual_size=19 declared=19.0 declared_type=float
RESULT: accepted equal-valued float alias
```
independently reran the full touched-file suite (using the audited shim), ruff, and mypy myself; independently confirmed the golden-byte-contract failure is pre-existing by reproducing it on an unmodified checkout; independently confirmed both real call sites and the console entry point; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched-file suite using the audited macOS shim, ruff, and mypy myself, independently confirmed the unrelated golden-hash failure is pre-existing, verified the reachability chain and console entry point, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
