### PR TITLE
fix(step3): reject non-boolean learner flags

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -234,6 +234,12 @@ def _require_positive_int(name: str, value: object) -> int:
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
+
+
 def _validate_horde_config(config: Step3HordeConfig) -> None:
     if len(config.gammas) == 0:
         raise ValueError("Step 3 Horde must have at least one demon")
@@ -251,12 +257,16 @@ def _validate_horde_config(config: Step3HordeConfig) -> None:
     hidden_sizes = tuple(
         _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
     )
+    use_obgd = _require_bool("use_obgd", config.use_obgd)
+    use_layer_norm = _require_bool("use_layer_norm", config.use_layer_norm)
     object.__setattr__(config, "gammas", gammas)
     object.__setattr__(config, "lamdas", lamdas)
     object.__setattr__(config, "hidden_sizes", hidden_sizes)
     object.__setattr__(config, "step_size", step_size)
     object.__setattr__(config, "sparsity", sparsity)
     object.__setattr__(config, "obgd_kappa", obgd_kappa)
+    object.__setattr__(config, "use_obgd", use_obgd)
+    object.__setattr__(config, "use_layer_norm", use_layer_norm)
 
 
 def make_step3_normalizer(

--- a/tests/test_step3_production.py
+++ b/tests/test_step3_production.py
@@ -177,6 +177,15 @@ def test_step3_config_validation() -> None:
         run_step3_smoke(steps=4, final_window=8)
 
 
+@pytest.mark.parametrize("field", ("use_obgd", "use_layer_norm"))
+def test_step3_config_rejects_non_boolean_algorithm_flags(field: str) -> None:
+    payload = Step3HordeConfig().to_dict()
+    payload[field] = "false"
+
+    with pytest.raises(ValueError, match=rf"{field} must be a boolean"):
+        Step3HordeConfig.from_dict(payload)
+
+
 def _config_with(**overrides: Any) -> Step3HordeConfig:
     payload: dict[str, Any] = {
         "gammas": (0.0,),


### PR DESCRIPTION
Closes #490.

## What changed

`Step3HordeConfig` validated its numerical and dimensional fields but accepted arbitrary objects for `use_obgd` and `use_layer_norm`. Python truthiness selects the measured learner behavior at these two flags — a deserialized JSON string `"false"` is truthy in Python, so it was stored unchanged and evaluated as true, silently enabling ObGD bounding (and likewise layer normalization) instead of rejecting the malformed configuration.

confirmed directly before touching the source, through the learner's supported `to_config()` surface: a config deserialized with `use_obgd: "false"` produced a horde config with `'bounder': {'type': 'ObGDBounding', ...}` — the string selected `ObGDBounding` instead of being rejected.

fix: a new `_require_bool` validator (`type(value) is bool`, mirroring the existing `_require_positive_int` pattern already used for numerical fields in the same function), applied to both algorithm-selection flags during `Step3HordeConfig`'s post-init validation.

## Reachability

`alberta_framework.__init__` exports `AlbertaPipelineConfig`, `make_alberta_pipeline`, and `run_pipeline_smoke` — confirmed directly. `AlbertaPipelineConfig.from_dict()` passes `payload["horde"]` to `Step3HordeConfig.from_dict()`; pipeline construction then calls `make_step3_horde(self._config.horde)`, which uses `cfg.use_obgd` directly to select `ObGDBounding(kappa=cfg.obgd_kappa) if cfg.use_obgd else None` — confirmed directly in source. A malformed truthy value previously changed measured behavior through this real, publicly-reachable configuration path, not a hardcoded-safe internal call.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_step3_production.py -q -o addopts=""
42 passed in 2.69s

$ .venv/bin/python -m ruff check alberta_framework/steps/step3.py tests/test_step3_production.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_step3_config_rejects_non_boolean_algorithm_flags`, parametrized over `use_obgd` and `use_layer_norm`, deserializing a config with the field set to the string `"false"` and asserting `ValueError` matching `"{field} must be a boolean"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/steps/step3.py`, kept the test), reran — both cases failed with `DID NOT RAISE ValueError`, confirming the string alias previously crossed validation and would have silently selected `ObGDBounding`. restored the fix, 42/42 green again.

## Evidence

<!-- evidence-head -->
fd97cc8fae10b68815daa8b6bcae1a2b91490006

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_step3_production.py -q -o addopts="" -k test_step3_config_rejects_non_boolean_algorithm_flags
FAILED [use_obgd] - Failed: DID NOT RAISE ValueError
FAILED [use_layer_norm] - Failed: DID NOT RAISE ValueError
2 failed, 40 deselected in 0.45s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_step3_production.py -q -o addopts=""
42 passed in 2.59s
```

<!-- evidence-row:domain-artifact -->
```text
stored use_obgd: 'false'
horde config: {... 'bounder': {'type': 'ObGDBounding', 'kappa': 2.0}, ...}
```
independently reran the full touched test file, ruff, and mypy myself; independently confirmed `cfg.use_obgd` is used directly as a truthy gate in `make_step3_horde` and the full pipeline-config reachability chain before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the truthy-gate usage and reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
