### PR TITLE
fix(step4): reject non-boolean layer norm flags

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -223,6 +223,10 @@ def _validate_sarsa_config(config: Step4SARSAConfig) -> None:
     meta_step_size = _require_nonnegative_real("meta_step_size", config.meta_step_size)
     bounder_kappa = _require_positive_real("bounder_kappa", config.bounder_kappa)
     sparsity = _require_unit_interval("sparsity", config.sparsity)
+    if type(config.use_layer_norm) is not bool:
+        raise ValueError(
+            f"use_layer_norm must be a boolean, got {config.use_layer_norm!r}"
+        )
     object.__setattr__(config, "n_actions", n_actions)
     object.__setattr__(config, "hidden_sizes", hidden_sizes)
     object.__setattr__(config, "gamma", gamma)

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -205,6 +205,12 @@ def test_step4_sarsa_scalars_reject_invalid_inputs(field: str, value: object) ->
         _config_with(**{field: value})
 
 
+@pytest.mark.parametrize("value", [0, 1, "false", None])
+def test_step4_sarsa_config_requires_exact_boolean_layer_norm(value: object) -> None:
+    with pytest.raises(ValueError, match="use_layer_norm must be a boolean"):
+        _config_with(use_layer_norm=value)
+
+
 def test_step4_sarsa_scalars_preserve_legal_boundaries() -> None:
     config = Step4SARSAConfig(
         n_actions=1,


### PR DESCRIPTION
Closes #493.

## What changed

Same bug class as #490 (`Step3HordeConfig`), in the sibling Step 4 SARSA facade: `Step4SARSAConfig.use_layer_norm` is annotated `bool`, but `_validate_sarsa_config` never validated it. A JSON-like caller passing the string `"false"` had it accepted and forwarded unchanged to `SARSAAgent`/`HordeLearner` — Python treats that non-empty string as truthy, so an input that appears to disable layer normalization instead enables the layer-normalized learner path, silently changing measured algorithm behavior instead of being rejected.

confirmed directly before touching the source:

```text
input=False stored=False truthy=False agent_flag=False
input='false' stored='false' truthy=True agent_flag='false'
```

fix: require `type(config.use_layer_norm) is bool` in `_validate_sarsa_config`, rejecting integer aliases (`0`/`1`), strings, and `None` as well — not just the specific string that triggered the reproduction.

## Reachability

`Step4SARSAConfig` is exported from `alberta_framework/steps/__init__.py` — confirmed directly. `Step4SARSAConfig.from_dict` accepts deserialized configuration mappings; `AlbertaPipelineConfig.from_dict` calls it for the external `control` payload in `alberta_framework/pipeline.py`; pipeline construction passes the config to `make_step4_sarsa_agent`, which forwards `cfg.use_layer_norm` to `SARSAAgent` and thereby selects the learner architecture — all confirmed directly in source.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_step4_production.py -q -o addopts=""
61 passed in 3.60s

$ .venv/bin/python -m ruff check alberta_framework/steps/step4.py tests/test_step4_production.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New test: `test_step4_sarsa_config_requires_exact_boolean_layer_norm`, parametrized over `0`, `1`, `"false"`, `None`, asserting `ValueError` matching `"use_layer_norm must be a boolean"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/steps/step4.py`, kept the test), reran — all 4 cases failed with `DID NOT RAISE ValueError`, confirming every alias previously crossed validation and would have silently selected the layer-normalized learner path. restored the fix, 61/61 green again.

## Evidence

<!-- evidence-head -->
93bb0bf1156f3888c846d95a6fcddf6d63b58854

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_step4_production.py -q -o addopts="" -k test_step4_sarsa_config_requires_exact_boolean_layer_norm
FAILED [0] - Failed: DID NOT RAISE ValueError
FAILED [1] - Failed: DID NOT RAISE ValueError
FAILED [false] - Failed: DID NOT RAISE ValueError
FAILED [None] - Failed: DID NOT RAISE ValueError
4 failed, 57 deselected in 0.48s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_step4_production.py -q -o addopts=""
61 passed in 3.55s
```

<!-- evidence-row:domain-artifact -->
```text
input=False stored=False truthy=False agent_flag=False
input='false' stored='false' truthy=True agent_flag='false'
```
independently reran the full touched test file, ruff, and mypy myself; independently confirmed `cfg.use_layer_norm` flows through `make_step4_sarsa_agent` → `SARSAAgent` and the full pipeline-config reachability chain before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the full touched test file, ruff, and mypy myself, independently confirmed the reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
