### PR TITLE
fix(forager-matched): reject numeric aliases in completion summary

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_sealed_evaluation_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_sealed_evaluation_campaign.py
@@ -723,7 +723,9 @@ def _summary_validator(inputs: _SealedInputs) -> _SummaryValidator:
             score_evidence,
             request,
         )
-        if campaign._plain(summary) != expected:
+        if campaign.canonical_json_bytes(campaign._plain(summary)) != campaign.canonical_json_bytes(
+            expected
+        ):
             raise ForagerMatchedSealedEvaluationCampaignError(
                 "sealed completion summary differs from its exact v2 schema"
             )

--- a/tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py
+++ b/tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py
@@ -980,6 +980,11 @@ def test_completion_summary_rejects_false_authority_and_closure(tmp_path: Path) 
         with pytest.raises(ValueError, match="closure|exact v2 schema"):
             validator(context, receipt, scores, request, changed)
 
+    numeric_alias = dict(valid)
+    numeric_alias["candidate_count"] = float(numeric_alias["candidate_count"])
+    with pytest.raises(ValueError, match="exact v2 schema"):
+        validator(context, receipt, scores, request, numeric_alias)
+
 
 def test_partial_final_artifacts_fail_closed_without_repair(
     tmp_path: Path,


### PR DESCRIPTION
Closes #495.

## What changed

Seventh instance of the same bug class as #450/#460/#466/#471/#483/#488: `_summary_validator` compared the supplied completion summary with the rebuilt exact v2 summary using ordinary Python equality. A numeric alias such as `6.0` compares equal to the expected integer `6`, so a non-canonical JSON value could cross the sealed completion schema boundary.

confirmed directly before touching the source, mutating `candidate_count` from integer `6` to float `6.0`: the mutated summary was silently accepted instead of raising.

fix: compare canonical JSON bytes (via the already-shared `forager_matched_campaign.canonical_json_bytes` helper, imported as `campaign` — the same helper the sibling PRs #489/#486 use) for the normalized supplied summary and expected summary, rather than Python equality.

## Reachability

`_summary_validator` is used by `prepare_sealed_evaluation_campaign`, `run_sealed_evaluation_campaign`, and `verify_sealed_evaluation_campaign_content` — all confirmed exported in this module's `__all__` and reached from the module CLI operations. They validate externally supplied persisted completion summaries against rebuilt sealed campaign content.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py -q -o addopts="" -k test_completion_summary_rejects_false_authority_and_closure
1 passed, 21 deselected in 1.43s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_sealed_evaluation_campaign.py tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New coverage: a `candidate_count` numeric-alias assertion added to the existing `test_completion_summary_rejects_false_authority_and_closure`, asserting `ValueError` matching `"exact v2 schema"`.

mutation-resistance verified independently: reverted just the source fix (`git stash push -- alberta_framework/benchmarks/forager_matched_sealed_evaluation_campaign.py`, kept the test), reran — failed with `DID NOT RAISE ValueError`, confirming the float alias previously crossed validation undetected. restored the fix, green again.

**Note on the full-file test run:** this test file has 5 pre-existing failures and 4 pre-existing errors unrelated to this change — the same macOS `O_TMPFILE`/`renameat2`-unavailable publication-primitive limitation already documented on sibling PRs #489/#486. Independently confirmed the exact same 5 failures + 4 errors (same test names) reproduce identically on an unmodified checkout before writing this PR.

## Evidence

<!-- evidence-head -->
e1a63395ba88b93893a7d58ccc14037515d3d46f

<!-- evidence-row:logs -->
```text
red (source fix reverted, test kept):
$ .venv/bin/python -m pytest tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py -q -o addopts="" -k test_completion_summary_rejects_false_authority_and_closure
FAILED - Failed: DID NOT RAISE ValueError
1 failed, 21 deselected in 1.12s

green (fix restored):
$ .venv/bin/python -m pytest tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py -q -o addopts="" -k test_completion_summary_rejects_false_authority_and_closure
1 passed, 21 deselected in 0.94s
```

<!-- evidence-row:domain-artifact -->
```text
candidate_count: int 6 -> float 6.0
before fix: accepted (no error)
after fix:  ForagerMatchedSealedEvaluationCampaignError: sealed completion summary differs from its exact v2 schema
```
independently reran the full touched-file test target, ruff, and mypy myself; independently confirmed the 5 failures + 4 errors in the full-file run are pre-existing by reproducing them (same test names) on an unmodified checkout; independently confirmed the reachability chain (`__all__` exports, three real call sites) before writing the reachability claim; did my own revert-and-confirm-red mutation check.

## Provenance

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the touched-file test target, ruff, and mypy myself, independently confirmed the pre-existing unrelated failures, verified the reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Attribution status: self-reported
