### PR TITLE
fix(step9): reject class-spoofed non-integer steps in _require_int

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -226,9 +226,10 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -814,6 +814,24 @@ def test_step9_smoke_rejects_non_integer_steps(steps: object) -> None:
         run_step9_smoke(steps=steps)  # type: ignore[arg-type]
 
 
+def test_step9_smoke_rejects_class_spoofed_integer_steps() -> None:
+    class _SpoofedInt:
+        """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+        @property
+        def __class__(self) -> type:  # type: ignore[override]
+            return int
+
+        def __int__(self) -> int:
+            return 3
+
+        def __index__(self) -> int:
+            return 3
+
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step9_smoke(steps=_SpoofedInt())  # type: ignore[arg-type]
+
+
 def test_step9_smoke_linear_model() -> None:
     """Linear (hidden_sizes=()) world model should work identically."""
     cfg = Step9DreamingConfig(


### PR DESCRIPTION
Closes #501.

## What changed

Same pattern as #400 (step12), and matching the pattern already correct in `step1.py`/`step6.py`: `_require_int` in `step9.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`run_step9_smoke` and `_validate_dreaming_config` route `steps`/`observation_dim`/`n_actions`/etc. through this same helper - both publicly reachable via `alberta_framework.steps.__all__`.

## Reachability

`run_step9_smoke` is exported from `alberta_framework.steps.__init__`'s `__all__` - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live before fixing:
```text
SPOOFED steps ACCEPTED, result.steps = 3 <class 'int'>
```
a spoofed object was silently accepted and converted via its own `__int__`, rather than rejected.

- new test `test_step9_smoke_rejects_class_spoofed_integer_steps` added next to the existing `test_step9_smoke_rejects_non_integer_steps`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `169 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session before writing the fix; all verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
