### PR TITLE
fix(step11): reject class-spoofed non-integer steps in _require_int

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from numbers import Integral, Real
-from typing import Any
+from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
@@ -219,9 +219,10 @@ def _require_int(
     minimum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1034,6 +1034,24 @@ def test_run_step11_smoke_rejects_non_integer_steps(steps: object) -> None:
         run_step11_smoke(steps=steps)  # type: ignore[arg-type]
 
 
+def test_run_step11_smoke_rejects_class_spoofed_integer_steps() -> None:
+    class _SpoofedInt:
+        """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+        @property
+        def __class__(self) -> type:  # type: ignore[override]
+            return int
+
+        def __int__(self) -> int:
+            return 3
+
+        def __index__(self) -> int:
+            return 3
+
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step11_smoke(steps=_SpoofedInt())  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # Long-horizon fineness
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #503.

## What changed

Same pattern as #400 (step12) and #502 (step9): `_require_int` in `step11.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`run_step11_smoke` and the OaK config validator route `steps`/`observation_dim`/`n_primitive_actions`/etc. through this same helper - both publicly reachable via `alberta_framework.steps.__all__`.

## Reachability

`run_step11_smoke` is exported from `alberta_framework.steps.__init__`'s `__all__` - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED steps ACCEPTED, result.steps = 3 <class 'int'>
```

- new test `test_run_step11_smoke_rejects_class_spoofed_integer_steps` added next to the existing `test_run_step11_smoke_rejects_non_integer_steps`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `173 passed`, 2 pre-existing failures (`test_step11_oak_validates_original_real_domain_before_narrowing`, `test_step11_oak_narrows_the_original_real_once`) - independently reproduced on unmodified main, unrelated `_require_real`/longdouble narrowing code path, not touched by this change.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix; the two pre-existing failures were independently reproduced against unmodified main before being excluded. All verification above performed and confirmed by me before pushing.

Attribution status: self-reported.
