### PR TITLE
fix(experiments): stabilize extracted coordinate keys

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -58,7 +58,71 @@ _NUMPY_COORDINATE_TYPES = frozenset(
         "U",
     )
 )
-_PYTHON_NUMERIC_COORDINATE_TYPES = (bool, int, float, complex, Decimal, Fraction)
+
+
+class _CanonicalFractionCoordinate(tuple[int, int]):
+    """An intrinsically immutable rational key with Fraction hash semantics."""
+
+    __slots__ = ()
+
+    def __new__(
+        cls,
+        numerator: int,
+        denominator: int,
+    ) -> "_CanonicalFractionCoordinate":
+        if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
+            raise ValueError("canonical Fraction coordinates require builtin integer components")
+        normalized = Fraction(numerator, denominator)
+        return tuple.__new__(cls, (normalized.numerator, normalized.denominator))
+
+    @property
+    def numerator(self) -> int:
+        return self[0]
+
+    @property
+    def denominator(self) -> int:
+        return self[1]
+
+    def _as_fraction(self) -> Fraction:
+        return Fraction(self.numerator, self.denominator)
+
+    def __hash__(self) -> int:
+        return hash(self._as_fraction())
+
+    def __eq__(self, other: object) -> bool:
+        other_type = type(other)
+        if other_type is _CanonicalFractionCoordinate:
+            coordinate = cast(_CanonicalFractionCoordinate, other)
+            return (
+                self.numerator == coordinate.numerator
+                and self.denominator == coordinate.denominator
+            )
+        if other_type in (bool, int, float, complex, Decimal, Fraction):
+            return bool(self._as_fraction() == other)
+        return False
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    def __repr__(self) -> str:
+        return repr(self._as_fraction())
+
+    def __str__(self) -> str:
+        return str(self._as_fraction())
+
+    def __getnewargs__(self) -> tuple[int, int]:
+        return (self.numerator, self.denominator)
+
+
+_PYTHON_NUMERIC_COORDINATE_TYPES = (
+    bool,
+    int,
+    float,
+    complex,
+    Decimal,
+    Fraction,
+    _CanonicalFractionCoordinate,
+)
 _STRING_COORDINATE_TYPES = (str, np.str_)
 _BYTES_COORDINATE_TYPES = (bytes, np.bytes_)
 _MAX_HYPERPARAMETER_COORDINATE_NESTING = 32
@@ -452,17 +516,21 @@ def extract_hyperparameter_results(
             from a config name. Accepted scalar coordinates are exact ``None``,
             ``bool``, ``int``, finite ``float`` or ``complex``, finite ``Decimal``,
             ``Fraction``, ``str``, ``bytes``, and the corresponding supported exact
-            NumPy scalar types. Exact tuples and frozensets may compose them to at
-            most 32 nested container levels. Across configurations, Python numeric
-            types form one coherent family, while a NumPy numeric scalar is
-            compatible only with the same exact NumPy scalar type. Coordinate pairs
-            are certified recursively; incompatible container or scalar families
-            fail closed before dictionary equality is invoked. Enums, UUIDs,
-            datetimes, named-tuple subclasses, and other user-defined or noncanonical
-            immutable keys are not accepted.
+            NumPy scalar types. Fraction leaves are normalized into private immutable
+            rational keys with the same Python-numeric equality, hash, representation,
+            and lookup behavior; their input object identity is not retained. Exact
+            tuples and frozensets may compose scalar coordinates to at most 32 nested
+            container levels. Across configurations, Python numeric types form one
+            coherent family, while a NumPy numeric scalar is compatible only with the
+            same exact NumPy scalar type. Coordinate pairs are certified recursively;
+            incompatible container or scalar families fail closed before dictionary
+            equality is invoked. Enums, UUIDs, datetimes, named-tuple subclasses, and
+            other user-defined or noncanonical immutable keys are not accepted.
 
     Returns:
-        Dictionary mapping param value to (mean, std) tuple
+        Dictionary mapping each canonical parameter value to its (mean, std) tuple.
+        Non-Fraction coordinates retain their original key objects; Fraction leaves
+        use immutable, numerically equivalent snapshots.
 
     Raises:
         ValueError: If ``param_extractor`` returns a coordinate outside the
@@ -550,15 +618,40 @@ def _require_hyperparameter_coordinate(
                 f"{_MAX_HYPERPARAMETER_COORDINATE_NESTING} nested "
                 "tuple/frozenset levels"
             )
-        for component in cast(tuple[object, ...] | frozenset[object], value):
+        components = cast(tuple[object, ...] | frozenset[object], value)
+        canonical_components = tuple(
             _require_hyperparameter_coordinate(
                 component,
                 name=name,
                 nesting_depth=nesting_depth + 1,
             )
-        return value
+            for component in components
+        )
+        if all(
+            canonical is original
+            for canonical, original in zip(canonical_components, components, strict=True)
+        ):
+            return value
+        if value_type is tuple:
+            return canonical_components
+        canonical_set = frozenset(canonical_components)
+        if len(canonical_set) != len(components):
+            reject()
+        return canonical_set
 
-    if value is None or value_type in (bool, int, str, bytes, Fraction):
+    if value_type is Fraction:
+        fraction = cast(Fraction, value)
+        numerator = fraction.numerator
+        denominator = fraction.denominator
+        if (
+            type(numerator) is not int
+            or type(denominator) is not int
+            or denominator <= 0
+        ):
+            reject()
+        return _CanonicalFractionCoordinate(numerator, denominator)
+
+    if value is None or value_type in (bool, int, str, bytes):
         return value
 
     if value_type is float:

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -15,7 +15,7 @@ Two conventions matter for downstream analysis:
 """
 
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from decimal import Decimal
 from fractions import Fraction
 from typing import Any, NamedTuple, NoReturn, cast
@@ -60,6 +60,14 @@ _NUMPY_COORDINATE_TYPES = frozenset(
 )
 
 
+def _type_identity_in(
+    value_type: type[object],
+    candidates: Iterable[type[object]],
+) -> bool:
+    """Match an untrusted runtime type without metaclass equality or hashing."""
+    return any(value_type is candidate for candidate in candidates)
+
+
 class _CanonicalFractionCoordinate(tuple[int, int]):
     """An intrinsically immutable rational key with Fraction hash semantics."""
 
@@ -97,7 +105,7 @@ class _CanonicalFractionCoordinate(tuple[int, int]):
                 self.numerator == coordinate.numerator
                 and self.denominator == coordinate.denominator
             )
-        if other_type in (bool, int, float, complex, Decimal, Fraction):
+        if _type_identity_in(other_type, (bool, int, float, complex, Decimal, Fraction)):
             return bool(self._as_fraction() == other)
         return False
 
@@ -597,8 +605,9 @@ def _require_hyperparameter_coordinate(
     Accepted coordinates are exact immutable Python scalar types, ``Decimal``,
     ``Fraction``, supported exact NumPy scalar types, and exact ``tuple`` or
     ``frozenset`` compositions of those types. User-defined subclasses and keys
-    are deliberately excluded because calling their conversion, equality, or hash
-    methods cannot establish a durable dictionary-key contract.
+    are deliberately excluded with identity-only type matching because calling
+    their metaclass, conversion, equality, or hash hooks cannot establish a durable
+    dictionary-key contract.
     """
 
     def reject() -> NoReturn:
@@ -610,7 +619,7 @@ def _require_hyperparameter_coordinate(
         )
 
     value_type = type(value)
-    if value_type in (tuple, frozenset):
+    if _type_identity_in(value_type, (tuple, frozenset)):
         if nesting_depth >= _MAX_HYPERPARAMETER_COORDINATE_NESTING:
             raise ValueError(
                 "param_extractor returned an over-nested coordinate for "
@@ -641,8 +650,11 @@ def _require_hyperparameter_coordinate(
 
     if value_type is Fraction:
         fraction = cast(Fraction, value)
-        numerator = fraction.numerator
-        denominator = fraction.denominator
+        try:
+            numerator = fraction.numerator
+            denominator = fraction.denominator
+        except AttributeError:
+            reject()
         if (
             type(numerator) is not int
             or type(denominator) is not int
@@ -651,7 +663,7 @@ def _require_hyperparameter_coordinate(
             reject()
         return _CanonicalFractionCoordinate(numerator, denominator)
 
-    if value is None or value_type in (bool, int, str, bytes):
+    if value is None or _type_identity_in(value_type, (bool, int, str, bytes)):
         return value
 
     if value_type is float:
@@ -670,7 +682,7 @@ def _require_hyperparameter_coordinate(
             reject()
         return value
 
-    if value_type in _NUMPY_COORDINATE_TYPES:
+    if _type_identity_in(value_type, _NUMPY_COORDINATE_TYPES):
         if np.dtype(value_type).kind in ("f", "c") and not bool(
             np.isfinite(cast(Any, value))
         ):
@@ -692,11 +704,13 @@ def _require_coordinate_hash(value: object, *, name: str) -> int:
 
 
 def _is_python_numeric_coordinate_type(value_type: type[object]) -> bool:
-    return value_type in _PYTHON_NUMERIC_COORDINATE_TYPES
+    return _type_identity_in(value_type, _PYTHON_NUMERIC_COORDINATE_TYPES)
 
 
 def _is_numpy_numeric_coordinate_type(value_type: type[object]) -> bool:
-    return value_type in _NUMPY_COORDINATE_TYPES and np.dtype(value_type).kind in (
+    return _type_identity_in(value_type, _NUMPY_COORDINATE_TYPES) and np.dtype(
+        value_type
+    ).kind in (
         "b",
         "i",
         "u",
@@ -727,7 +741,9 @@ def _coordinate_pair_is_compatible(left: object, right: object) -> bool:
             for right_item in right_set
         )
 
-    if left_type in (tuple, frozenset) or right_type in (tuple, frozenset):
+    if _type_identity_in(left_type, (tuple, frozenset)) or _type_identity_in(
+        right_type, (tuple, frozenset)
+    ):
         return False
 
     if left_type is right_type:
@@ -778,9 +794,13 @@ def _coordinate_values_equal(left: object, right: object) -> bool:
                 return False
         return True
 
-    if left_type in _STRING_COORDINATE_TYPES and right_type in _STRING_COORDINATE_TYPES:
+    if _type_identity_in(left_type, _STRING_COORDINATE_TYPES) and _type_identity_in(
+        right_type, _STRING_COORDINATE_TYPES
+    ):
         return bool(left == right)
-    if left_type in _BYTES_COORDINATE_TYPES and right_type in _BYTES_COORDINATE_TYPES:
+    if _type_identity_in(left_type, _BYTES_COORDINATE_TYPES) and _type_identity_in(
+        right_type, _BYTES_COORDINATE_TYPES
+    ):
         return bool(left == right)
     if left_type is right_type or (
         _is_python_numeric_coordinate_type(left_type)

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -58,6 +58,10 @@ _NUMPY_COORDINATE_TYPES = frozenset(
         "U",
     )
 )
+_PYTHON_NUMERIC_COORDINATE_TYPES = (bool, int, float, complex, Decimal, Fraction)
+_STRING_COORDINATE_TYPES = (str, np.str_)
+_BYTES_COORDINATE_TYPES = (bytes, np.bytes_)
+_MAX_HYPERPARAMETER_COORDINATE_NESTING = 32
 
 
 class ExperimentConfig(NamedTuple):
@@ -448,36 +452,78 @@ def extract_hyperparameter_results(
             from a config name. Accepted scalar coordinates are exact ``None``,
             ``bool``, ``int``, finite ``float`` or ``complex``, finite ``Decimal``,
             ``Fraction``, ``str``, ``bytes``, and the corresponding supported exact
-            NumPy scalar types. Exact tuples and frozensets may compose them.
+            NumPy scalar types. Exact tuples and frozensets may compose them to at
+            most 32 nested container levels. Across configurations, Python numeric
+            types form one coherent family, while a NumPy numeric scalar is
+            compatible only with the same exact NumPy scalar type. Coordinate pairs
+            are certified recursively; incompatible container or scalar families
+            fail closed before dictionary equality is invoked. Enums, UUIDs,
+            datetimes, named-tuple subclasses, and other user-defined or noncanonical
+            immutable keys are not accepted.
 
     Returns:
         Dictionary mapping param value to (mean, std) tuple
 
     Raises:
         ValueError: If ``param_extractor`` returns a coordinate outside the
-            canonical immutable-key contract or maps more than one configuration
-            to the same value; a sensitivity curve built from a silently truncated,
-            insertion-order-dependent subset is not a measurement.
+            canonical immutable-key contract, exceeds the nesting limit, mixes
+            mutually incompatible coordinate families, or maps more than one
+            configuration to the same value; a sensitivity curve built from a
+            silently truncated, insertion-order-dependent subset is not a measurement.
     """
     performance = get_final_performance(results, metric)
 
     if param_extractor is None:
         return {k: v for k, v in performance.items()}
 
-    names_by_value: dict[Any, list[str]] = {}
+    coordinate_entries: list[tuple[str, object, int]] = []
     for name in performance:
         coordinate = _require_hyperparameter_coordinate(param_extractor(name), name=name)
-        names_by_value.setdefault(coordinate, []).append(name)
-    collisions = {value: names for value, names in names_by_value.items() if len(names) > 1}
+        coordinate_hash = _require_coordinate_hash(coordinate, name=name)
+        coordinate_entries.append((name, coordinate, coordinate_hash))
+
+    for left_index, (left_name, left, left_hash) in enumerate(coordinate_entries):
+        for right_name, right, right_hash in coordinate_entries[left_index + 1 :]:
+            if not _coordinate_pair_is_compatible(left, right):
+                raise ValueError(
+                    "param_extractor must return mutually compatible canonical coordinate "
+                    f"families; configurations {left_name!r} and {right_name!r} do not"
+                )
+            if _coordinate_values_equal(left, right) and left_hash != right_hash:
+                raise ValueError(
+                    "param_extractor returned equal coordinates with different hashes for "
+                    f"configurations {left_name!r} and {right_name!r}"
+                )
+
+    coordinate_groups: list[tuple[object, list[str]]] = []
+    for name, coordinate, _ in coordinate_entries:
+        for representative, names in coordinate_groups:
+            if _coordinate_values_equal(representative, coordinate):
+                names.append(name)
+                break
+        else:
+            coordinate_groups.append((coordinate, [name]))
+
+    collisions = [(value, names) for value, names in coordinate_groups if len(names) > 1]
     if collisions:
-        described = "; ".join(f"{value!r} <- {names}" for value, names in collisions.items())
+        described = "; ".join(f"{value!r} <- {names}" for value, names in collisions)
         raise ValueError(
             f"param_extractor maps several configurations to one value: {described}"
         )
-    return {value: performance[names[0]] for value, names in names_by_value.items()}
+    try:
+        return {value: performance[names[0]] for value, names in coordinate_groups}
+    except Exception as exc:
+        raise ValueError(
+            "param_extractor coordinates could not maintain the canonical dictionary-key contract"
+        ) from exc
 
 
-def _require_hyperparameter_coordinate(value: object, *, name: str) -> Any:
+def _require_hyperparameter_coordinate(
+    value: object,
+    *,
+    name: str,
+    nesting_depth: int = 0,
+) -> Any:
     """Require one coordinate whose finiteness and hash semantics are intrinsic.
 
     Accepted coordinates are exact immutable Python scalar types, ``Decimal``,
@@ -497,8 +543,19 @@ def _require_hyperparameter_coordinate(value: object, *, name: str) -> Any:
 
     value_type = type(value)
     if value_type in (tuple, frozenset):
+        if nesting_depth >= _MAX_HYPERPARAMETER_COORDINATE_NESTING:
+            raise ValueError(
+                "param_extractor returned an over-nested coordinate for "
+                f"configuration {name!r}; coordinates support at most "
+                f"{_MAX_HYPERPARAMETER_COORDINATE_NESTING} nested "
+                "tuple/frozenset levels"
+            )
         for component in cast(tuple[object, ...] | frozenset[object], value):
-            _require_hyperparameter_coordinate(component, name=name)
+            _require_hyperparameter_coordinate(
+                component,
+                name=name,
+                nesting_depth=nesting_depth + 1,
+            )
         return value
 
     if value is None or value_type in (bool, int, str, bytes, Fraction):
@@ -528,3 +585,113 @@ def _require_hyperparameter_coordinate(value: object, *, name: str) -> Any:
         return value
 
     reject()
+
+
+def _require_coordinate_hash(value: object, *, name: str) -> int:
+    """Hash a validated coordinate without allowing raw runtime errors to escape."""
+    try:
+        return hash(value)
+    except Exception as exc:
+        raise ValueError(
+            "param_extractor returned a coordinate that cannot be hashed for "
+            f"configuration {name!r}"
+        ) from exc
+
+
+def _is_python_numeric_coordinate_type(value_type: type[object]) -> bool:
+    return value_type in _PYTHON_NUMERIC_COORDINATE_TYPES
+
+
+def _is_numpy_numeric_coordinate_type(value_type: type[object]) -> bool:
+    return value_type in _NUMPY_COORDINATE_TYPES and np.dtype(value_type).kind in (
+        "b",
+        "i",
+        "u",
+        "f",
+        "c",
+    )
+
+
+def _coordinate_pair_is_compatible(left: object, right: object) -> bool:
+    """Certify that equality between two validated coordinates cannot narrow."""
+    left_type = type(left)
+    right_type = type(right)
+
+    if left_type is tuple and right_type is tuple:
+        left_tuple = cast(tuple[object, ...], left)
+        right_tuple = cast(tuple[object, ...], right)
+        return all(
+            _coordinate_pair_is_compatible(left_item, right_item)
+            for left_item, right_item in zip(left_tuple, right_tuple, strict=False)
+        )
+
+    if left_type is frozenset and right_type is frozenset:
+        left_set = cast(frozenset[object], left)
+        right_set = cast(frozenset[object], right)
+        return all(
+            _coordinate_pair_is_compatible(left_item, right_item)
+            for left_item in left_set
+            for right_item in right_set
+        )
+
+    if left_type in (tuple, frozenset) or right_type in (tuple, frozenset):
+        return False
+
+    if left_type is right_type:
+        return True
+    if _is_python_numeric_coordinate_type(left_type) and _is_python_numeric_coordinate_type(
+        right_type
+    ):
+        return True
+    if _is_numpy_numeric_coordinate_type(left_type) and _is_numpy_numeric_coordinate_type(
+        right_type
+    ):
+        return False
+    if (
+        _is_python_numeric_coordinate_type(left_type)
+        and _is_numpy_numeric_coordinate_type(right_type)
+    ) or (
+        _is_numpy_numeric_coordinate_type(left_type)
+        and _is_python_numeric_coordinate_type(right_type)
+    ):
+        return False
+    return True
+
+
+def _coordinate_values_equal(left: object, right: object) -> bool:
+    """Compare a pair after :func:`_coordinate_pair_is_compatible` accepts it."""
+    left_type = type(left)
+    right_type = type(right)
+
+    if left_type is tuple and right_type is tuple:
+        left_tuple = cast(tuple[object, ...], left)
+        right_tuple = cast(tuple[object, ...], right)
+        return len(left_tuple) == len(right_tuple) and all(
+            _coordinate_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left_tuple, right_tuple, strict=True)
+        )
+
+    if left_type is frozenset and right_type is frozenset:
+        left_items = list(cast(frozenset[object], left))
+        unmatched_right = list(cast(frozenset[object], right))
+        if len(left_items) != len(unmatched_right):
+            return False
+        for left_item in left_items:
+            for right_index, right_item in enumerate(unmatched_right):
+                if _coordinate_values_equal(left_item, right_item):
+                    unmatched_right.pop(right_index)
+                    break
+            else:
+                return False
+        return True
+
+    if left_type in _STRING_COORDINATE_TYPES and right_type in _STRING_COORDINATE_TYPES:
+        return bool(left == right)
+    if left_type in _BYTES_COORDINATE_TYPES and right_type in _BYTES_COORDINATE_TYPES:
+        return bool(left == right)
+    if left_type is right_type or (
+        _is_python_numeric_coordinate_type(left_type)
+        and _is_python_numeric_coordinate_type(right_type)
+    ):
+        return bool(left == right)
+    return False

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -663,6 +663,113 @@ def test_extract_hyperparameter_results_snapshots_fraction_before_private_mutati
     assert extracted[expected_coordinates[1]] == (2.0, 0.0)
 
 
+def test_extract_hyperparameter_results_rejects_delayed_hash_metaclass_spoof() -> None:
+    metaclass_calls: list[str] = []
+
+    class NumpyIntegerSpoof(type):
+        def __hash__(cls) -> int:
+            metaclass_calls.append("hash")
+            return hash(np.int64)
+
+        def __eq__(cls, other: object) -> bool:
+            metaclass_calls.append("eq")
+            return other is np.int64
+
+    class DelayedHash(metaclass=NumpyIntegerSpoof):
+        def __init__(self) -> None:
+            self.hash_calls = 0
+
+        def __hash__(self) -> int:
+            self.hash_calls += 1
+            return 100 + self.hash_calls
+
+        def __eq__(self, other: object) -> bool:
+            return self is other
+
+    coordinate = DelayedHash()
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: coordinate,
+        )
+
+    assert metaclass_calls == []
+    assert coordinate.hash_calls == 0
+
+
+@pytest.mark.parametrize("nesting", ["scalar", "tuple", "frozenset"])
+def test_extract_hyperparameter_results_rejects_raising_metaclass_without_hooks(
+    nesting: str,
+) -> None:
+    metaclass_calls: list[str] = []
+
+    class RaisingMetaclass(type):
+        def __hash__(cls) -> int:
+            metaclass_calls.append("hash")
+            raise RuntimeError("metaclass hash must not run")
+
+        def __eq__(cls, other: object) -> bool:
+            metaclass_calls.append("eq")
+            raise RuntimeError("metaclass equality must not run")
+
+    class Coordinate(metaclass=RaisingMetaclass):
+        pass
+
+    coordinate = _nested_fraction_coordinate(Coordinate(), nesting)
+    metaclass_calls.clear()
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: coordinate,
+        )
+
+    assert metaclass_calls == []
+
+
+def test_canonical_fraction_comparison_does_not_run_hostile_metaclass_equality() -> None:
+    metaclass_calls: list[str] = []
+
+    class RaisingMetaclass(type):
+        def __eq__(cls, other: object) -> bool:
+            metaclass_calls.append("eq")
+            raise RuntimeError("metaclass equality must not run")
+
+    class Coordinate(metaclass=RaisingMetaclass):
+        pass
+
+    extracted = extract_hyperparameter_results(
+        {"candidate": _flat_trace("candidate", 1.0)},
+        param_extractor=lambda _: Fraction(1, 2),
+    )
+    canonical_fraction = next(iter(extracted))
+    hostile = Coordinate()
+
+    assert (canonical_fraction == hostile) is False
+    assert (hostile == canonical_fraction) is False
+    assert (canonical_fraction != hostile) is True
+    assert (hostile != canonical_fraction) is True
+    assert metaclass_calls == []
+
+
+@pytest.mark.parametrize("nesting", ["scalar", "tuple", "frozenset"])
+@pytest.mark.parametrize("component", ["numerator", "denominator"])
+def test_extract_hyperparameter_results_normalizes_missing_fraction_slots(
+    nesting: str,
+    component: str,
+) -> None:
+    fraction = Fraction(1, 2)
+    coordinate = _nested_fraction_coordinate(fraction, nesting)
+    object.__delattr__(fraction, f"_{component}")
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: coordinate,
+        )
+
+
 @pytest.mark.parametrize(
     "coordinates",
     [

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -475,7 +475,14 @@ def test_extract_hyperparameter_results_keeps_canonical_coordinate_families(
     )
 
     assert len(extracted) == 1
-    assert next(iter(extracted)) is coordinate
+    returned_coordinate = next(iter(extracted))
+    if type(coordinate) is Fraction:
+        assert returned_coordinate is not coordinate
+        assert returned_coordinate == coordinate
+        assert hash(returned_coordinate) == hash(coordinate)
+        assert repr(returned_coordinate) == repr(coordinate)
+    else:
+        assert returned_coordinate is coordinate
 
 
 class _NonfiniteFloatThatConvertsFinite(float):
@@ -515,7 +522,145 @@ def test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates(
     )
 
     assert len(extracted) == 1
-    assert next(iter(extracted)) is coordinate
+    returned_coordinate = next(iter(extracted))
+    if type(coordinate) is Fraction:
+        assert returned_coordinate is not coordinate
+        assert returned_coordinate == coordinate
+        assert hash(returned_coordinate) == hash(coordinate)
+    else:
+        assert returned_coordinate is coordinate
+
+
+def _nested_fraction_coordinate(value: object, nesting: str) -> object:
+    if nesting == "scalar":
+        return value
+    if nesting == "tuple":
+        return ("fraction", value)
+    assert nesting == "frozenset"
+    return frozenset(("fraction", value))
+
+
+@pytest.mark.parametrize("nesting", ["scalar", "tuple", "frozenset"])
+@pytest.mark.parametrize("poisoned_first", [True, False], ids=("poisoned-first", "poisoned-last"))
+def test_extract_hyperparameter_results_rejects_hidden_fraction_integer_hooks(
+    nesting: str,
+    poisoned_first: bool,
+) -> None:
+    calls: list[str] = []
+    hooks_armed = False
+
+    def record_hook(name: str) -> None:
+        calls.append(name)
+        if hooks_armed:
+            raise RuntimeError(f"unsafe Fraction component hook: {name}")
+
+    class HookedInt(int):
+        def __hash__(self) -> int:
+            record_hook("hash")
+            return int.__hash__(self)
+
+        def __eq__(self, other: object) -> bool:
+            record_hook("eq")
+            result = int.__eq__(self, other)
+            return False if result is NotImplemented else result
+
+        def __int__(self) -> int:
+            record_hook("int")
+            return int.__int__(self)
+
+        def __index__(self) -> int:
+            record_hook("index")
+            return int.__index__(self)
+
+    class Carrier(Fraction):
+        @property
+        def numerator(self) -> int:
+            return HookedInt(1)
+
+        @property
+        def denominator(self) -> int:
+            return HookedInt(2)
+
+    poisoned = Fraction(Carrier(1, 2))
+    assert type(poisoned) is Fraction
+    assert type(poisoned.numerator) is HookedInt
+    poisoned_coordinate = _nested_fraction_coordinate(poisoned, nesting)
+    safe_coordinate = _nested_fraction_coordinate(Fraction(3, 4), nesting)
+    calls.clear()
+    hooks_armed = True
+    coordinates = (
+        (poisoned_coordinate, safe_coordinate)
+        if poisoned_first
+        else (safe_coordinate, poisoned_coordinate)
+    )
+    coordinate_iterator = iter(coordinates)
+    results = {
+        "candidate_0": _flat_trace("candidate_0", 1.0),
+        "candidate_1": _flat_trace("candidate_1", 2.0),
+    }
+
+    with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+        extract_hyperparameter_results(
+            results,
+            param_extractor=lambda _: next(coordinate_iterator),
+        )
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("nesting", ["scalar", "tuple", "frozenset"])
+@pytest.mark.parametrize("reverse", [False, True], ids=("forward", "reverse"))
+def test_extract_hyperparameter_results_snapshots_fraction_before_private_mutation(
+    nesting: str,
+    reverse: bool,
+) -> None:
+    fractions = [Fraction(1, 3), Fraction(2, 3)]
+    if reverse:
+        fractions.reverse()
+    expected_coordinates = tuple(
+        _nested_fraction_coordinate(Fraction(value.numerator, value.denominator), nesting)
+        for value in fractions
+    )
+    calls = 0
+
+    def extract_and_mutate(_: str) -> object:
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return _nested_fraction_coordinate(fractions[0], nesting)
+        object.__setattr__(fractions[0], "_numerator", fractions[1].numerator)
+        object.__setattr__(fractions[0], "_denominator", fractions[1].denominator)
+        calls += 1
+        return _nested_fraction_coordinate(fractions[1], nesting)
+
+    extracted = extract_hyperparameter_results(
+        {
+            "candidate_0": _flat_trace("candidate_0", 1.0),
+            "candidate_1": _flat_trace("candidate_1", 2.0),
+        },
+        param_extractor=extract_and_mutate,
+    )
+
+    assert tuple(extracted) == expected_coordinates
+    assert extracted[expected_coordinates[0]] == (1.0, 0.0)
+    assert extracted[expected_coordinates[1]] == (2.0, 0.0)
+
+    returned_coordinate = next(iter(extracted))
+    if nesting == "scalar":
+        returned_fraction = returned_coordinate
+    elif nesting == "tuple":
+        returned_fraction = returned_coordinate[1]
+    else:
+        returned_fraction = next(
+            component for component in returned_coordinate if component != "fraction"
+        )
+    with pytest.raises((AttributeError, TypeError)):
+        object.__setattr__(returned_fraction, "_numerator", 99)
+
+    object.__setattr__(fractions[0], "_numerator", 7)
+    object.__setattr__(fractions[1], "_numerator", 11)
+    assert extracted[expected_coordinates[0]] == (1.0, 0.0)
+    assert extracted[expected_coordinates[1]] == (2.0, 0.0)
 
 
 @pytest.mark.parametrize(
@@ -605,7 +750,43 @@ def test_extract_hyperparameter_results_keeps_coherent_python_numeric_families()
     )
 
     assert tuple(extracted) == coordinates
-    assert all(actual is expected for actual, expected in zip(extracted, coordinates, strict=True))
+    assert all(
+        actual is not expected if type(expected) is Fraction else actual is expected
+        for actual, expected in zip(extracted, coordinates, strict=True)
+    )
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        (Fraction(1, 2), 0.5),
+        (0.5, Fraction(1, 2)),
+        (("value", Fraction(1, 2)), ("value", Decimal("0.5"))),
+        (("value", Decimal("0.5")), ("value", Fraction(1, 2))),
+        (
+            frozenset(("value", Fraction(1, 2))),
+            frozenset(("value", Decimal("0.5"))),
+        ),
+        (
+            frozenset(("value", Decimal("0.5"))),
+            frozenset(("value", Fraction(1, 2))),
+        ),
+    ],
+)
+def test_extract_hyperparameter_results_preserves_fraction_numeric_collisions(
+    coordinates: tuple[object, object],
+) -> None:
+    coordinate_iterator = iter(coordinates)
+    results = {
+        "candidate_0": _flat_trace("candidate_0", 1.0),
+        "candidate_1": _flat_trace("candidate_1", 2.0),
+    }
+
+    with pytest.raises(ValueError, match=r"maps several configurations to one value"):
+        extract_hyperparameter_results(
+            results,
+            param_extractor=lambda _: next(coordinate_iterator),
+        )
 
 
 class _DelayedHashDrift:

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -518,6 +518,96 @@ def test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates(
     assert next(iter(extracted)) is coordinate
 
 
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        (Decimal(0), np.int64(0)),
+        (np.int64(0), Decimal(0)),
+        (5e-324, np.float16(0.0)),
+        (np.float16(0.0), 5e-324),
+    ],
+)
+def test_extract_hyperparameter_results_rejects_incompatible_numeric_families(
+    coordinates: tuple[object, object],
+) -> None:
+    """Cross-family aliases must fail before dict equality or hashing can narrow."""
+    coordinate_iterator = iter(coordinates)
+    results = {
+        "candidate_0": _flat_trace("candidate_0", 1.0),
+        "candidate_1": _flat_trace("candidate_1", 2.0),
+    }
+
+    with pytest.raises(ValueError, match=r"mutually compatible canonical coordinate families"):
+        extract_hyperparameter_results(
+            results,
+            param_extractor=lambda _: next(coordinate_iterator),
+        )
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        (("value", Decimal(0)), ("value", np.int64(0))),
+        (
+            frozenset(("value", Decimal(0))),
+            frozenset(("value", np.int64(0))),
+        ),
+    ],
+)
+def test_extract_hyperparameter_results_rejects_nested_incompatible_families(
+    coordinates: tuple[object, object],
+) -> None:
+    coordinate_iterator = iter(coordinates)
+    results = {
+        "candidate_0": _flat_trace("candidate_0", 1.0),
+        "candidate_1": _flat_trace("candidate_1", 2.0),
+    }
+
+    with pytest.raises(ValueError, match=r"mutually compatible canonical coordinate families"):
+        extract_hyperparameter_results(
+            results,
+            param_extractor=lambda _: next(coordinate_iterator),
+        )
+
+
+def test_extract_hyperparameter_results_bounds_coordinate_nesting() -> None:
+    within_limit: object = 0
+    beyond_limit: object = 0
+    for _ in range(32):
+        within_limit = (within_limit,)
+    for _ in range(33):
+        beyond_limit = (beyond_limit,)
+
+    extracted = extract_hyperparameter_results(
+        {"candidate": _flat_trace("candidate", 1.0)},
+        param_extractor=lambda _: within_limit,
+    )
+    assert next(iter(extracted)) is within_limit
+
+    with pytest.raises(ValueError, match=r"at most 32 nested tuple/frozenset levels"):
+        extract_hyperparameter_results(
+            {"candidate": _flat_trace("candidate", 1.0)},
+            param_extractor=lambda _: beyond_limit,
+        )
+
+
+def test_extract_hyperparameter_results_keeps_coherent_python_numeric_families() -> None:
+    coordinates = (1, 2.0, Decimal(3), Fraction(4, 1), complex(5, 0))
+    coordinate_iterator = iter(coordinates)
+    results = {
+        f"candidate_{index}": _flat_trace(f"candidate_{index}", float(index))
+        for index in range(len(coordinates))
+    }
+
+    extracted = extract_hyperparameter_results(
+        results,
+        param_extractor=lambda _: next(coordinate_iterator),
+    )
+
+    assert tuple(extracted) == coordinates
+    assert all(actual is expected for actual, expected in zip(extracted, coordinates, strict=True))
+
+
 class _DelayedHashDrift:
     def __init__(self) -> None:
         self.hash_calls = 0


### PR DESCRIPTION
Closes #505.

PR #415 added scalar preflight, but relational collisions, mutable Fraction internals, metaclass-spoofed type checks, malformed Fraction slots, and unbounded nesting could still produce unstable mappings or leak implementation exceptions.

This follow-up:

- certifies all coordinates and pairwise equality/hash relationships before dict insertion;
- uses identity-only trusted-type admission without invoking hostile metaclass hooks;
- snapshots valid Fraction leaves into an immutable tuple-backed numeric key while preserving numeric equality, hash, repr, lookup, and ordering behavior;
- bounds nested tuple/frozenset coordinates and normalizes ordinary failures to ValueError;
- preserves all non-Fraction coordinate identities and existing ordinary output order.

Failing-test-first repair stack was independently reviewed. Exact rebased-head gates:

- `tests/test_experiments_validation.py`: 98 passed;
- affected/adjacent review panel: 343 passed;
- repository Ruff: clean;
- strict mypy: 165 source files clean;
- current-main composition: conflict-free.

No outputs or registered five-claim evidence sources change. The evidence registry remains inherited-invalid from unrelated source drift.