### PR TITLE
Reject non-finite prototype-memory hyperparameters at construction

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -18,6 +18,7 @@ the packaged Step 2 retained-view memory
 from __future__ import annotations
 
 import functools
+import math
 from typing import Any, cast
 
 import chex
@@ -119,11 +120,11 @@ def _validate_config(config: PrototypeMemoryConfig) -> None:
         raise ValueError("n_classes must be at least 2")
     if config.slots_per_class < 1:
         raise ValueError("slots_per_class must be positive")
-    if not 0.0 < config.update_rate <= 1.0:
+    if not 0.0 < config.update_rate <= 1.0 or not math.isfinite(config.update_rate):
         raise ValueError("update_rate must be in (0, 1]")
-    if config.novelty_threshold < 0.0:
+    if config.novelty_threshold < 0.0 or not math.isfinite(config.novelty_threshold):
         raise ValueError("novelty_threshold must be non-negative")
-    if config.bandwidth <= 0.0:
+    if config.bandwidth <= 0.0 or not math.isfinite(config.bandwidth):
         raise ValueError("bandwidth must be positive")
 
 

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -4,6 +4,7 @@
 import chex
 import jax
 import jax.numpy as jnp
+import pytest
 
 from alberta_framework.core.prototype_memory import (
     PrototypeMemoryConfig,
@@ -153,3 +154,39 @@ def test_config_roundtrip() -> None:
 
     assert PrototypeMemoryConfig.from_config(config.to_config()) == config
     assert PrototypeMemoryLearner.from_config(learner.to_config()).config == config
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"bandwidth": float("inf")}, "bandwidth"),
+        ({"bandwidth": float("nan")}, "bandwidth"),
+        ({"novelty_threshold": float("inf")}, "novelty_threshold"),
+        ({"novelty_threshold": float("nan")}, "novelty_threshold"),
+        ({"update_rate": float("nan")}, "update_rate"),
+    ],
+)
+def test_config_rejects_nonfinite_floats(kwargs: dict[str, float], match: str) -> None:
+    """Non-finite kernel hyperparameters must fail closed at construction."""
+    with pytest.raises(ValueError, match=match):
+        PrototypeMemoryLearner(
+            PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=1, **kwargs)
+        )
+
+
+def test_infinite_observation_prediction_stays_nonfinite() -> None:
+    """Inf observations corrupt logits; predict must stay fail-visible, not a uniform simplex."""
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=3, slots_per_class=2)
+    )
+    state = learner.init()
+    target = jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32)
+    state = learner.update(
+        state, jnp.asarray([0.25, 0.75], dtype=jnp.float32), target
+    ).state
+    obs = jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32)
+
+    logits = learner.class_logits(state, obs)
+    assert not bool(jnp.all(jnp.isfinite(logits)))
+    prediction = learner.predict(state, obs)
+    assert not bool(jnp.all(jnp.isfinite(prediction)))


### PR DESCRIPTION
## Summary
- Relands the useful part of #195: `PrototypeMemoryConfig` now rejects non-finite `bandwidth`, `novelty_threshold`, and `update_rate`.
- Does not rewrite inf-observation softmax into a uniform simplex. Public `predict` stays fail-visible when logits are corrupted, matching the close reason on #195.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_prototype_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/prototype_memory.py tests/test_prototype_memory.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)