### PR TITLE
fix(streams): reject non-finite feature_scales in ScaledStreamWrapper

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -798,6 +798,8 @@ class ScaledStreamWrapper:
                 f"feature_scales shape ({self._feature_scales.shape}) "
                 f"must match inner stream's feature_dim ({inner_stream.feature_dim})"
             )
+        if not bool(jnp.all(jnp.isfinite(self._feature_scales))):
+            raise ValueError("feature_scales must contain only finite float32 values")
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -367,6 +367,16 @@ class TestScaledStreamWrapper:
         with pytest.raises(ValueError, match="must match"):
             ScaledStreamWrapper(inner, feature_scales=scales)
 
+    def test_rejects_non_finite_scales(self):
+        """Should raise error if scales contain NaN or infinity."""
+        inner = RandomWalkStream(feature_dim=5)
+        for scales in (
+            jnp.array([1.0, float("nan"), 2.0, 3.0, 4.0]),
+            jnp.array([1.0, float("inf"), 2.0, 3.0, 4.0]),
+        ):
+            with pytest.raises(ValueError, match="finite"):
+                ScaledStreamWrapper(inner, feature_scales=scales)
+
     def test_works_with_different_streams(self, rng_key):
         """Should work with any stream implementing the protocol."""
         scales = jnp.array([0.01, 0.1, 1.0, 10.0, 100.0])


### PR DESCRIPTION
Fixes #507.

Adds a finiteness check on `feature_scales` in `ScaledStreamWrapper.__init__`, alongside the existing shape check, plus a regression test. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).