### PR TITLE
fix(stacked-horde): validate float32 step-size domain

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -82,6 +82,19 @@ _NUMPY_STEP_SIZE_TYPES = frozenset(
 )
 
 
+def _snapshot_exact_fraction(value: Fraction) -> Fraction:
+    """Copy a structurally canonical exact Fraction without conversion hooks."""
+    numerator = value.numerator
+    denominator = value.denominator
+    if (
+        type(numerator) is not int
+        or type(denominator) is not int
+        or denominator <= 0
+    ):
+        raise ValueError(_STEP_SIZE_ERROR)
+    return Fraction(numerator, denominator)
+
+
 def _require_positive_normal_float32_step_size(value: object) -> float:
     """Return a JSON-safe scalar whose float32 execution value is usable.
 
@@ -89,15 +102,21 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
     positive host value whose binary32 sink is zero or subnormal can create a
     Horde that reports applied updates while its weights never move. Only
     exact trusted scalar families are admitted, so user subclasses are
-    refused before conversion hooks can run. Exact-ratio conversion prevents
-    overloaded host comparisons from hiding a negative value and avoids
-    double-rounding supported third-party reals.
+    refused before conversion hooks can run. Exact Fractions additionally
+    require exact builtin-integer components and are copied before shared
+    conversion. Exact-ratio conversion prevents overloaded host comparisons
+    from hiding a negative value and avoids double-rounding supported
+    third-party reals.
     """
     value_type = type(value)
     preserve_builtin_float = value_type is float
     if value_type not in (int, float, Fraction) and value_type not in _NUMPY_STEP_SIZE_TYPES:
         raise ValueError(_STEP_SIZE_ERROR)
-    real = cast(Real, value)
+    real = (
+        _snapshot_exact_fraction(cast(Fraction, value))
+        if value_type is Fraction
+        else cast(Real, value)
+    )
     try:
         numerator, _, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -38,13 +38,16 @@ the NaN-masking convention of the loop-based hordes.
 
 import math
 from dataclasses import dataclass
-from typing import Any
+from numbers import Real
+from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
+
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 __all__ = [
     "StackedHordeConfig",
@@ -53,6 +56,34 @@ __all__ = [
     "StackedLinearHorde",
     "nexting_spec",
 ]
+
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
+_STEP_SIZE_ERROR = "step_size must be positive"
+
+
+def _require_positive_normal_float32_step_size(value: object) -> float:
+    """Return a JSON-safe scalar whose float32 execution value is usable.
+
+    JAX CPU execution flushes float32 subnormals to zero, so accepting a
+    positive host value whose binary32 sink is zero or subnormal can create a
+    Horde that reports applied updates while its weights never move.  The
+    exact-ratio conversion also prevents overloaded host comparisons from
+    hiding a negative value and avoids double-rounding third-party reals.
+    """
+    actual_type = type(value)
+    preserve_builtin_float = actual_type is float
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(_STEP_SIZE_ERROR)
+    real = cast(Real, value)
+    try:
+        numerator, _, narrowed = round_real_to_float32_with_ratio(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError):
+        raise ValueError(_STEP_SIZE_ERROR) from None
+    if numerator <= 0 or not math.isfinite(narrowed) or narrowed < _FLOAT32_MIN_NORMAL:
+        raise ValueError(_STEP_SIZE_ERROR)
+    # Preserve an already JSON-safe builtin float for payload compatibility.
+    # Every other accepted Real is stored as the validated binary32 value.
+    return cast(float, value) if preserve_builtin_float else narrowed
 
 
 @dataclass(frozen=True)
@@ -66,7 +97,9 @@ class StackedHordeConfig:
         lamdas: Per-demon trace decays, length ``n_demons``.
         cumulant_indices: Per-demon index into the cumulant-source vector
             handed to :meth:`StackedLinearHorde.update`.
-        step_size: Shared TD step-size alpha.
+        step_size: Shared TD step-size alpha. Its float32 execution value must
+            be finite, positive, and normal; accepted non-builtin reals are
+            canonicalized to a JSON-safe builtin float.
     """
 
     n_demons: int
@@ -93,8 +126,11 @@ class StackedHordeConfig:
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
-        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
+        object.__setattr__(
+            self,
+            "step_size",
+            _require_positive_normal_float32_step_size(self.step_size),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this config to a dictionary."""

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -38,12 +38,14 @@ the NaN-masking convention of the loop-based hordes.
 
 import math
 from dataclasses import dataclass
+from fractions import Fraction
 from numbers import Real
 from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -59,6 +61,25 @@ __all__ = [
 
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _STEP_SIZE_ERROR = "step_size must be positive"
+_NUMPY_STEP_SIZE_TYPES = frozenset(
+    np.dtype(dtype_code).type
+    for dtype_code in (
+        "b",
+        "B",
+        "h",
+        "H",
+        "i",
+        "I",
+        "l",
+        "L",
+        "q",
+        "Q",
+        "e",
+        "f",
+        "d",
+        "g",
+    )
+)
 
 
 def _require_positive_normal_float32_step_size(value: object) -> float:
@@ -66,13 +87,15 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
     JAX CPU execution flushes float32 subnormals to zero, so accepting a
     positive host value whose binary32 sink is zero or subnormal can create a
-    Horde that reports applied updates while its weights never move.  The
-    exact-ratio conversion also prevents overloaded host comparisons from
-    hiding a negative value and avoids double-rounding third-party reals.
+    Horde that reports applied updates while its weights never move. Only
+    exact trusted scalar families are admitted, so user subclasses are
+    refused before conversion hooks can run. Exact-ratio conversion prevents
+    overloaded host comparisons from hiding a negative value and avoids
+    double-rounding supported third-party reals.
     """
-    actual_type = type(value)
-    preserve_builtin_float = actual_type is float
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    value_type = type(value)
+    preserve_builtin_float = value_type is float
+    if value_type not in (int, float, Fraction) and value_type not in _NUMPY_STEP_SIZE_TYPES:
         raise ValueError(_STEP_SIZE_ERROR)
     real = cast(Real, value)
     try:
@@ -98,8 +121,8 @@ class StackedHordeConfig:
         cumulant_indices: Per-demon index into the cumulant-source vector
             handed to :meth:`StackedLinearHorde.update`.
         step_size: Shared TD step-size alpha. Its float32 execution value must
-            be finite, positive, and normal; accepted non-builtin reals are
-            canonicalized to a JSON-safe builtin float.
+            be finite, positive, and normal; accepted supported non-builtin
+            reals are canonicalized to a JSON-safe builtin float.
     """
 
     n_demons: int

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -61,7 +61,7 @@ __all__ = [
 
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _STEP_SIZE_ERROR = "step_size must be positive"
-_NUMPY_STEP_SIZE_TYPES = frozenset(
+_NUMPY_STEP_SIZE_TYPES = tuple(
     np.dtype(dtype_code).type
     for dtype_code in (
         "b",
@@ -80,12 +80,16 @@ _NUMPY_STEP_SIZE_TYPES = frozenset(
         "g",
     )
 )
+_TRUSTED_STEP_SIZE_TYPES = (int, float, Fraction, *_NUMPY_STEP_SIZE_TYPES)
 
 
 def _snapshot_exact_fraction(value: Fraction) -> Fraction:
     """Copy a structurally canonical exact Fraction without conversion hooks."""
-    numerator = value.numerator
-    denominator = value.denominator
+    try:
+        numerator = value.numerator
+        denominator = value.denominator
+    except AttributeError:
+        raise ValueError(_STEP_SIZE_ERROR) from None
     if (
         type(numerator) is not int
         or type(denominator) is not int
@@ -110,7 +114,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
     """
     value_type = type(value)
     preserve_builtin_float = value_type is float
-    if value_type not in (int, float, Fraction) and value_type not in _NUMPY_STEP_SIZE_TYPES:
+    if not any(value_type is trusted_type for trusted_type in _TRUSTED_STEP_SIZE_TYPES):
         raise ValueError(_STEP_SIZE_ERROR)
     real = (
         _snapshot_exact_fraction(cast(Fraction, value))

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -198,6 +198,77 @@ class TestConfig:
 
         assert calls == []
 
+    @pytest.mark.parametrize("component", ["numerator", "denominator"])
+    @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
+    def test_step_size_rejects_hooks_laundered_through_an_exact_fraction(
+        self, serialized: bool, component: str
+    ) -> None:
+        calls: list[str] = []
+
+        class IntegerSpoof(int):
+            def __int__(self) -> int:
+                calls.append("int")
+                return 1
+
+        class Carrier(Fraction):
+            @property
+            def numerator(self) -> int:
+                return IntegerSpoof(-1) if component == "numerator" else 1
+
+            @property
+            def denominator(self) -> int:
+                return IntegerSpoof(-4) if component == "denominator" else 4
+
+        step_size = Fraction(Carrier(1, 4))
+        assert type(step_size) is Fraction
+        assert step_size.numerator < 0 or step_size.denominator < 0
+
+        with pytest.raises(ValueError, match="step_size"):
+            if serialized:
+                payload = _simple_config().to_config()
+                payload["step_size"] = step_size
+                StackedLinearHorde.from_config(
+                    {"type": "StackedLinearHorde", "config": payload}
+                )
+            else:
+                _simple_config(step_size=step_size)
+
+        assert calls == []
+
+    @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
+    def test_step_size_rejects_exact_fraction_with_zero_denominator(
+        self, serialized: bool
+    ) -> None:
+        property_calls: list[str] = []
+
+        class Carrier(Fraction):
+            @property
+            def numerator(self) -> int:
+                property_calls.append("numerator")
+                return 1
+
+            @property
+            def denominator(self) -> int:
+                property_calls.append("denominator")
+                return 0
+
+        step_size = Fraction(Carrier(1, 1))
+        assert type(step_size) is Fraction
+        assert step_size.denominator == 0
+        calls_after_construction = tuple(property_calls)
+
+        with pytest.raises(ValueError, match="step_size"):
+            if serialized:
+                payload = _simple_config().to_config()
+                payload["step_size"] = step_size
+                StackedLinearHorde.from_config(
+                    {"type": "StackedLinearHorde", "config": payload}
+                )
+            else:
+                _simple_config(step_size=step_size)
+
+        assert tuple(property_calls) == calls_after_construction
+
     @pytest.mark.parametrize(
         "step_size",
         [1.0e100, Fraction(1, 2**149), Decimal("0.1"), jnp.asarray(0.1)],

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -198,6 +198,92 @@ class TestConfig:
 
         assert calls == []
 
+    @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
+    @pytest.mark.parametrize(
+        "attack",
+        ["equality-spoof", "raising-equality", "raising-hash"],
+    )
+    def test_step_size_rejects_hostile_metaclasses_without_hooks(
+        self, serialized: bool, attack: str
+    ) -> None:
+        calls: list[str] = []
+
+        class EqualitySpoofMeta(type):
+            def __eq__(cls, other: object) -> bool:
+                del cls, other
+                calls.append("equality")
+                return True
+
+            def __hash__(cls) -> int:
+                calls.append("hash")
+                return type.__hash__(cls)
+
+        class RaisingEqualityMeta(type):
+            def __eq__(cls, other: object) -> bool:
+                del cls, other
+                calls.append("raising-equality")
+                raise RuntimeError("metaclass equality hook must not run")
+
+            def __hash__(cls) -> int:
+                calls.append("hash")
+                return type.__hash__(cls)
+
+        class RaisingHashMeta(type):
+            def __hash__(cls) -> int:
+                del cls
+                calls.append("raising-hash")
+                raise RuntimeError("metaclass hash hook must not run")
+
+        class EqualitySpoof(float, metaclass=EqualitySpoofMeta):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                calls.append("ratio")
+                return (1, 2)
+
+        class RaisingEquality(float, metaclass=RaisingEqualityMeta):
+            pass
+
+        class RaisingHash(float, metaclass=RaisingHashMeta):
+            pass
+
+        step_sizes = {
+            "equality-spoof": EqualitySpoof(-1.0),
+            "raising-equality": RaisingEquality(0.5),
+            "raising-hash": RaisingHash(0.5),
+        }
+
+        with pytest.raises(ValueError, match="step_size"):
+            if serialized:
+                payload = _simple_config().to_config()
+                payload["step_size"] = step_sizes[attack]
+                StackedLinearHorde.from_config(
+                    {"type": "StackedLinearHorde", "config": payload}
+                )
+            else:
+                _simple_config(step_size=step_sizes[attack])
+
+        assert calls == []
+
+    @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
+    @pytest.mark.parametrize("missing_slot", ["numerator", "denominator"])
+    def test_step_size_rejects_exact_fraction_with_missing_slot(
+        self, serialized: bool, missing_slot: str
+    ) -> None:
+        step_size = object.__new__(Fraction)
+        if missing_slot == "numerator":
+            object.__setattr__(step_size, "_denominator", 2)
+        else:
+            object.__setattr__(step_size, "_numerator", 1)
+
+        with pytest.raises(ValueError, match="step_size"):
+            if serialized:
+                payload = _simple_config().to_config()
+                payload["step_size"] = step_size
+                StackedLinearHorde.from_config(
+                    {"type": "StackedLinearHorde", "config": payload}
+                )
+            else:
+                _simple_config(step_size=step_size)
+
     @pytest.mark.parametrize("component", ["numerator", "denominator"])
     @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
     def test_step_size_rejects_hooks_laundered_through_an_exact_fraction(

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -65,9 +65,13 @@ class TestConfig:
         "step_size",
         [
             1,
+            np.int8(1),
+            np.int64(1),
+            np.uint64(1),
+            np.float16(0.5),
             np.float32(0.5),
             np.float64(0.5),
-            np.int64(1),
+            np.longdouble(0.5),
             Fraction(1, 2),
         ],
     )
@@ -143,6 +147,56 @@ class TestConfig:
 
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=NegativeSpoof())
+
+    @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
+    def test_step_size_rejects_numeric_subclasses_before_conversion_hooks(
+        self, serialized: bool
+    ) -> None:
+        calls: list[str] = []
+
+        class RatioSpoof(float):
+            def __new__(cls) -> "RatioSpoof":
+                return super().__new__(cls, -0.25)
+
+            def as_integer_ratio(self) -> tuple[int, int]:
+                calls.append("ratio")
+                return (1, 4)
+
+        class IntegerSpoof(int):
+            def __new__(cls) -> "IntegerSpoof":
+                return super().__new__(cls, -1)
+
+            def __int__(self) -> int:
+                calls.append("int")
+                return 1
+
+        class FractionSpoof(Fraction):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                calls.append("fraction-ratio")
+                return (1, 4)
+
+        class ExplodingRatio(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                calls.append("exploding")
+                raise RuntimeError("conversion hook must not run")
+
+        for step_size in (
+            RatioSpoof(),
+            IntegerSpoof(),
+            FractionSpoof(-1, 4),
+            ExplodingRatio(0.25),
+        ):
+            with pytest.raises(ValueError, match="step_size"):
+                if serialized:
+                    payload = _simple_config().to_config()
+                    payload["step_size"] = step_size
+                    StackedLinearHorde.from_config(
+                        {"type": "StackedLinearHorde", "config": payload}
+                    )
+                else:
+                    _simple_config(step_size=step_size)
+
+        assert calls == []
 
     @pytest.mark.parametrize(
         "step_size",

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -11,10 +11,14 @@ the same workload, with a ~144 s compile; see the scaling notes in
 docs/evidence/methodology.md).
 """
 
+import json
 import math
 import time
+from decimal import Decimal
+from fractions import Fraction
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -56,6 +60,121 @@ class TestConfig:
     def test_step_size_must_be_finite_and_positive(self, step_size: float) -> None:
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=step_size)
+
+    @pytest.mark.parametrize(
+        "step_size",
+        [
+            1,
+            np.float32(0.5),
+            np.float64(0.5),
+            np.int64(1),
+            Fraction(1, 2),
+        ],
+    )
+    def test_step_size_supported_reals_canonicalize_for_json(
+        self, step_size: object
+    ) -> None:
+        cfg = _simple_config(step_size=step_size)
+        payload = cfg.to_config()
+
+        assert type(cfg.step_size) is float
+        json.dumps(payload, allow_nan=False)
+        assert StackedHordeConfig.from_config(payload) == cfg
+
+    def test_builtin_float_step_size_preserves_compatible_payload(self) -> None:
+        cfg = _simple_config(step_size=0.1)
+
+        assert type(cfg.step_size) is float
+        assert cfg.step_size == 0.1
+
+    def test_fraction_step_size_rounds_directly_to_float32(self) -> None:
+        above_half_midpoint = (
+            Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
+        )
+        expected = float(np.nextafter(np.float32(0.5), np.float32(1.0)))
+
+        cfg = _simple_config(step_size=above_half_midpoint)
+
+        assert cfg.step_size == expected
+
+    @pytest.mark.parametrize(
+        "step_size",
+        [
+            True,
+            np.bool_(True),
+            Decimal("0.1"),
+            jnp.asarray(0.1),
+            jnp.asarray(1),
+        ],
+    )
+    def test_step_size_rejects_non_real_or_array_scalars(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            _simple_config(step_size=step_size)
+
+    @pytest.mark.parametrize(
+        "step_size",
+        [
+            1.0e100,
+            Fraction(1, 2**150),
+            Fraction(1, 2**149),
+            float(np.nextafter(np.finfo(np.float32).tiny, np.float32(0.0))),
+        ],
+    )
+    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(
+        self, step_size: object
+    ) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            _simple_config(step_size=step_size)
+
+    def test_step_size_accepts_float32_normal_boundaries(self) -> None:
+        minimum = float(np.finfo(np.float32).tiny)
+        maximum = float(np.finfo(np.float32).max)
+
+        assert _simple_config(step_size=minimum).step_size == minimum
+        assert _simple_config(step_size=maximum).step_size == maximum
+
+    def test_step_size_comparison_spoof_cannot_hide_negative_value(self) -> None:
+        class NegativeSpoof(float):
+            def __new__(cls) -> "NegativeSpoof":
+                return super().__new__(cls, -0.25)
+
+            def __le__(self, other: object) -> bool:
+                return False
+
+        with pytest.raises(ValueError, match="step_size"):
+            _simple_config(step_size=NegativeSpoof())
+
+    @pytest.mark.parametrize(
+        "step_size",
+        [1.0e100, Fraction(1, 2**149), Decimal("0.1"), jnp.asarray(0.1)],
+    )
+    def test_invalid_serialized_step_size_is_refused_before_runtime(
+        self, step_size: object
+    ) -> None:
+        payload = _simple_config().to_config()
+        payload["step_size"] = step_size
+
+        with pytest.raises(ValueError, match="step_size"):
+            StackedLinearHorde.from_config(
+                {"type": "StackedLinearHorde", "config": payload}
+            )
+
+    def test_minimum_normal_step_size_survives_jit_execution(self) -> None:
+        minimum = float(np.finfo(np.float32).tiny)
+        horde = StackedLinearHorde(_simple_config(n_demons=1, step_size=minimum))
+        state = horde.init()
+        update = jax.jit(horde.update)
+
+        result = update(
+            state,
+            jnp.array([1.0, 0.0, 0.0]),
+            jnp.zeros((3,)),
+            jnp.array([1.0]),
+        )
+
+        assert bool(result.update_applied)
+        assert int(result.state.step_count) == 1
+        assert float(result.state.weights[0, 0]) == minimum
 
     def test_roundtrip(self):
         cfg = _simple_config()


### PR DESCRIPTION
Closes #498.

The original #479 merge only rejected host non-finites. This follow-up closes the complete execution-domain and trust-boundary contract for `StackedLinearHordeConfig.step_size`:

- exact-ratio, single-round binary32 conversion with ties-to-even;
- positive finite normal float32 requirement, rejecting overflow, zero, and CPU/XLA-flushed subnormals;
- JSON-safe canonical storage for accepted non-builtin reals while preserving valid builtin-float payloads;
- exact trusted built-in, Fraction, and concrete NumPy scalar admission;
- identity-only type checks, so hostile subclass/metaclass equality/hash/conversion hooks never run;
- structurally certified and snapshotted exact Fraction components, with malformed/missing slots normalized to ValueError;
- identical enforcement through direct construction and `from_config`.

Failing-test-first work was independently audited in two rounds. Exact rebased-head gates:

- stacked-horde + shared float32 suites: **75 passed**;
- repository Ruff: clean;
- strict mypy: **165 source files** clean;
- current-main rebase/composition: clean;
- direct JIT update at the minimum accepted normal endpoint: green.

No output artifact or five-claim registered evidence source changes. The registry remains inherited-invalid from unrelated existing source drift.