### PR TITLE
fix(streams): validate RandomWalkStream constructor inputs

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -8,6 +8,7 @@ All streams use JAX-compatible pure functions that work with jax.lax.scan.
 """
 
 import math
+from numbers import Real
 from typing import Any
 
 import chex
@@ -58,6 +59,20 @@ def _require_normal_float32_scale(name: str, value: float) -> float:
     return narrowed
 
 
+def _require_finite_nonnegative_float32(name: str, value: object) -> float:
+    """Require a finite non-negative float32 execution value."""
+    message = f"{name} must be a finite non-negative float32 value"
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        narrowed = float(np.float32(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(narrowed) or narrowed < 0.0:
+        raise ValueError(message)
+    return narrowed
+
+
 @chex.dataclass(frozen=True)
 class RandomWalkState:
     """State for RandomWalkStream.
@@ -101,10 +116,10 @@ class RandomWalkStream:
             noise_std: Std dev of target noise
             feature_std: Std dev of feature values
         """
-        self._feature_dim = feature_dim
-        self._drift_rate = drift_rate
-        self._noise_std = noise_std
-        self._feature_std = feature_std
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
+        self._drift_rate = _require_finite_nonnegative_float32("drift_rate", drift_rate)
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
+        self._feature_std = _require_finite_nonnegative_float32("feature_std", feature_std)
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -34,6 +34,24 @@ class TestRandomWalkStream:
         assert state.key is not None
         chex.assert_shape(state.true_weights, (10,))
 
+    def test_rejects_invalid_feature_dim(self):
+        """Should reject non-positive, bool, or non-integer feature_dim."""
+        for feature_dim in (0, -1, True, 2.5):
+            with pytest.raises(ValueError, match="feature_dim"):
+                RandomWalkStream(feature_dim=feature_dim)
+
+    def test_rejects_non_finite_or_negative_float_params(self):
+        """Should reject NaN/inf/negative drift_rate, noise_std, feature_std."""
+        for name, value in (
+            ("drift_rate", float("nan")),
+            ("drift_rate", float("inf")),
+            ("drift_rate", -1.0),
+            ("noise_std", float("nan")),
+            ("feature_std", -0.5),
+        ):
+            with pytest.raises(ValueError, match=name):
+                RandomWalkStream(feature_dim=4, **{name: value})
+
     def test_step_produces_valid_timestep(self, rng_key):
         """Step should produce valid observation and target."""
         stream = RandomWalkStream(feature_dim=10)


### PR DESCRIPTION
Fixes #508.

`RandomWalkStream` performed no constructor validation. Now `feature_dim` must be a positive int and `drift_rate`/`noise_std`/`feature_std` finite non-negative float32, matching the sibling streams' validation. Adds `_require_finite_nonnegative_float32` helper plus regression tests. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).