### PR TITLE
fix(streams): validate float params of Abrupt/Cyclic/PeriodicChangeStream

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -8,6 +8,7 @@ All streams use JAX-compatible pure functions that work with jax.lax.scan.
 """
 
 import math
+from numbers import Real
 from typing import Any
 
 import chex
@@ -54,6 +55,20 @@ def _require_normal_float32_scale(name: str, value: float) -> float:
         raise ValueError(message)
     narrowed = float(np.float32(normalized))
     if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
+        raise ValueError(message)
+    return narrowed
+
+
+def _require_finite_nonnegative_float32(name: str, value: object) -> float:
+    """Require a finite non-negative float32 execution value."""
+    message = f"{name} must be a finite non-negative float32 value"
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(message)
+    try:
+        narrowed = float(np.float32(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(narrowed) or narrowed < 0.0:
         raise ValueError(message)
     return narrowed
 
@@ -306,10 +321,10 @@ class AbruptChangeStream:
             noise_std: Std dev of target noise
             feature_std: Std dev of feature values
         """
-        self._feature_dim = feature_dim
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
         self._change_interval = _require_positive_int("change_interval", change_interval)
-        self._noise_std = noise_std
-        self._feature_std = feature_std
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
+        self._feature_std = _require_finite_nonnegative_float32("feature_std", feature_std)
 
     @property
     def feature_dim(self) -> int:
@@ -562,13 +577,13 @@ class CyclicStream:
             noise_std: Std dev of target noise
             feature_std: Std dev of feature values
         """
-        self._feature_dim = feature_dim
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
         self._cycle_length = _require_positive_int("cycle_length", cycle_length)
         self._num_configurations = _require_positive_int(
             "num_configurations", num_configurations
         )
-        self._noise_std = noise_std
-        self._feature_std = feature_std
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
+        self._feature_std = _require_finite_nonnegative_float32("feature_std", feature_std)
 
     @property
     def feature_dim(self) -> int:
@@ -678,11 +693,11 @@ class PeriodicChangeStream:
             noise_std: Std dev of target noise
             feature_std: Std dev of feature values
         """
-        self._feature_dim = feature_dim
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
         self._period = _require_positive_int("period", period)
-        self._amplitude = amplitude
-        self._noise_std = noise_std
-        self._feature_std = feature_std
+        self._amplitude = _require_finite_nonnegative_float32("amplitude", amplitude)
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
+        self._feature_std = _require_finite_nonnegative_float32("feature_std", feature_std)
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -95,6 +95,16 @@ class TestRandomWalkStream:
 class TestAbruptChangeStream:
     """Tests for the AbruptChangeStream class."""
 
+    def test_rejects_non_finite_or_negative_float_params(self):
+        """Should reject NaN/inf/negative noise_std and feature_std."""
+        for name, value in (
+            ("noise_std", float("nan")),
+            ("noise_std", float("inf")),
+            ("feature_std", -1.0),
+        ):
+            with pytest.raises(ValueError, match=name):
+                AbruptChangeStream(feature_dim=4, **{name: value})
+
     @pytest.mark.parametrize("compiled", [False, True], ids=["eager", "jit"])
     def test_initial_weights_last_for_first_full_segment(self, rng_key, compiled):
         """Initialized weights govern exactly one complete change interval."""
@@ -173,6 +183,16 @@ class TestSuttonExperiment1Stream:
 class TestCyclicStream:
     """Tests for the CyclicStream class."""
 
+    def test_rejects_non_finite_or_negative_float_params(self):
+        """Should reject NaN/inf/negative noise_std and feature_std."""
+        for name, value in (
+            ("noise_std", float("nan")),
+            ("noise_std", float("inf")),
+            ("feature_std", -1.0),
+        ):
+            with pytest.raises(ValueError, match=name):
+                CyclicStream(feature_dim=4, **{name: value})
+
     def test_cycles_through_configurations(self, rng_key):
         """Should cycle through configurations."""
         stream = CyclicStream(
@@ -228,6 +248,17 @@ class TestCyclicStream:
 
 class TestPeriodicChangeStream:
     """Tests for the PeriodicChangeStream class."""
+
+    def test_rejects_non_finite_or_negative_float_params(self):
+        """Should reject NaN/inf/negative amplitude, noise_std, feature_std."""
+        for name, value in (
+            ("amplitude", float("nan")),
+            ("amplitude", float("inf")),
+            ("noise_std", -0.5),
+            ("feature_std", float("nan")),
+        ):
+            with pytest.raises(ValueError, match=name):
+                PeriodicChangeStream(feature_dim=4, **{name: value})
 
     def test_init_creates_valid_state(self, rng_key):
         """Stream init should create valid state with correct shapes."""


### PR DESCRIPTION
Fixes #509.

Adds finite non-negative float32 validation for `noise_std` and `feature_std` (and `amplitude` for `PeriodicChangeStream`) alongside the existing `_require_positive_int` checks, plus regression tests. Note: re-defines `_require_finite_nonnegative_float32` locally so this PR is self-contained against main. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).