### PR TITLE
Do not form 0*inf TD bootstraps at gamma 0

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -75,6 +75,12 @@ from alberta_framework.core.update_safety import (
 )
 from alberta_framework.streams.base import ScanStream
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip a collapsed 0*inf product before it becomes NaN."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 # Type variable for TD stream state
 StateT = TypeVar("StateT")
 
@@ -1795,9 +1801,10 @@ class TDLinearLearner:
         next_prediction = self.predict(state, next_observation)
 
         gamma_scalar = jnp.squeeze(gamma)
+        next_value = jnp.squeeze(next_prediction)
         td_error = (
             jnp.squeeze(reward)
-            + gamma_scalar * jnp.squeeze(next_prediction)
+            + _skip_zero_scale(gamma_scalar, next_value)
             - jnp.squeeze(prediction)
         )
 
@@ -1833,7 +1840,7 @@ class TDLinearLearner:
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(reward))
-            & jnp.all(jnp.isfinite(next_observation))
+            & (jnp.all(jnp.isfinite(next_observation)) | (gamma_scalar == 0.0))
             & jnp.all(jnp.isfinite(gamma))
         )
         update_applied = (
@@ -1944,13 +1951,20 @@ class TrueOnlineTDLearner:
 
         value = jnp.squeeze(self.predict(state, observation))
         next_value = jnp.squeeze(self.predict(state, next_observation))
-        td_error = jnp.squeeze(reward) + gamma_scalar * next_value - value
+        td_error = jnp.squeeze(reward) + _skip_zero_scale(gamma_scalar, next_value) - value
 
         trace_dot = jnp.dot(state.eligibility_traces, observation)
         trace_dot = trace_dot + state.bias_eligibility_trace
-        trace_scale = 1.0 - alpha * gamma_scalar * lamda * trace_dot
-        new_traces = gamma_scalar * lamda * state.eligibility_traces + trace_scale * observation
-        new_bias_trace = gamma_scalar * lamda * state.bias_eligibility_trace + trace_scale
+        decay_scale = jnp.where(
+            (gamma_scalar == 0.0) | (lamda == 0.0),
+            jnp.zeros_like(gamma_scalar),
+            gamma_scalar * lamda,
+        )
+        trace_scale = 1.0 - alpha * _skip_zero_scale(decay_scale, trace_dot)
+        new_traces = (
+            _skip_zero_scale(decay_scale, state.eligibility_traces) + trace_scale * observation
+        )
+        new_bias_trace = _skip_zero_scale(decay_scale, state.bias_eligibility_trace) + trace_scale
 
         correction = value - state.v_old
         update_scale = alpha * (td_error + correction)
@@ -1984,7 +1998,7 @@ class TrueOnlineTDLearner:
         inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.isfinite(jnp.squeeze(reward))
-            & jnp.all(jnp.isfinite(next_observation))
+            & (jnp.all(jnp.isfinite(next_observation)) | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
         )
         proposed_finite = (
@@ -2018,7 +2032,7 @@ class TrueOnlineTDLearner:
             ),
             next_prediction=jnp.where(
                 update_applied,
-                jnp.atleast_1d(next_value),
+                jnp.atleast_1d(jnp.where(jnp.isfinite(next_value), next_value, 0.0)),
                 jnp.zeros_like(jnp.atleast_1d(next_value)),
             ),
             td_error=jnp.where(

--- a/tests/test_td_learners.py
+++ b/tests/test_td_learners.py
@@ -387,6 +387,36 @@ class TestRunTDLearningLoop:
         chex.assert_tree_all_finite(state.optimizer_state.h_traces)
         chex.assert_tree_all_finite(metrics)
 
+    def test_zero_gamma_does_not_multiply_inf_next_observation(self) -> None:
+        """gamma=0 must skip V(s') so an unused inf next observation can still commit."""
+        learner = TDLinearLearner()
+        state = learner.init(2)
+        observation = jnp.array([1.0, 0.0], dtype=jnp.float32)
+        reward = jnp.array(0.5, dtype=jnp.float32)
+        next_observation = jnp.array([jnp.inf, 0.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            observation,
+            reward,
+            next_observation,
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state.weights)
+        chex.assert_tree_all_finite(result.td_error)
+        finite_next = learner.update(
+            state,
+            observation,
+            reward,
+            jnp.zeros_like(next_observation),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        chex.assert_trees_all_close(result.state.weights, finite_next.state.weights)
+        chex.assert_trees_all_close(result.td_error, finite_next.td_error)
+
 
 class TestTDLearnerWithDifferentOptimizers:
     """Integration tests comparing TDIDBD and AutoTDIDBD in learning loops."""

--- a/tests/test_true_online_td.py
+++ b/tests/test_true_online_td.py
@@ -78,6 +78,36 @@ class TestInit:
         assert bool(jnp.all(jnp.isfinite(result.prediction)))
         assert bool(jnp.all(jnp.isfinite(result.next_prediction)))
 
+    def test_zero_gamma_does_not_multiply_inf_next_observation(self) -> None:
+        """gamma=0 must skip V(s') so an unused inf next observation can still commit."""
+        learner = TrueOnlineTDLearner(step_size=0.1, trace_decay=0.5)
+        state = learner.init(2)
+        observation = jnp.array([1.0, 0.0], dtype=jnp.float32)
+        reward = jnp.array(0.25, dtype=jnp.float32)
+        next_observation = jnp.array([jnp.inf, 0.0], dtype=jnp.float32)
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            observation,
+            reward,
+            next_observation,
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state.weights)
+        chex.assert_tree_all_finite(result.td_error)
+        finite_next = learner.update(
+            state,
+            observation,
+            reward,
+            jnp.zeros_like(next_observation),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        chex.assert_trees_all_close(result.state.weights, finite_next.state.weights)
+        chex.assert_trees_all_close(result.td_error, finite_next.td_error)
+
 
 # =============================================================================
 # TD(0) equivalence to supervised LMS for one-step gamma=0 supervision


### PR DESCRIPTION
## Summary
- `TDLinearLearner` and `TrueOnlineTDLearner` now skip `gamma * V(s')` (and True Online's `gamma * lambda` trace decay) before the product, so gamma 0 cannot turn an unused inf next observation into NaN.
- The optimizer layer already allowed this; the learner wrappers still required a finite next observation and formed the 0*inf bootstrap.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_td_learners.py tests/test_true_online_td.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/learners.py tests/test_td_learners.py tests/test_true_online_td.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)