### PR TITLE
fix(streams): validate FrequencyMismatchStream amplitude_scale and noise_std

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -57,6 +57,21 @@ def _require_positive_float32(value: object, name: str) -> float:
         raise ValueError(f"{name} must be a positive finite float32 value")
     return converted
 
+
+def _require_nonnegative_float32(value: object, name: str) -> float:
+    """Return a finite non-negative value representable in the stream execution dtype."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite non-negative float32 value")
+    try:
+        converted = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"{name} must be a finite non-negative float32 value"
+        ) from error
+    if not np.isfinite(converted) or converted < np.float32(0.0):
+        raise ValueError(f"{name} must be a finite non-negative float32 value")
+    return converted
+
 # =============================================================================
 # OutOfClassPolynomialStream -- degree-3 polynomial targets
 # =============================================================================
@@ -371,8 +386,8 @@ class FrequencyMismatchStream:
         self._context_length = context_length
         self._omega_min = omega_min_float32
         self._omega_max = omega_max_float32
-        self._amplitude_scale = amplitude_scale
-        self._noise_std = noise_std
+        self._amplitude_scale = _require_nonnegative_float32(amplitude_scale, "amplitude_scale")
+        self._noise_std = _require_nonnegative_float32(noise_std, "noise_std")
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -270,6 +270,23 @@ class TestFrequencyMismatchStream:
     """Tests for the trigonometric out-of-class stream."""
 
     @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("amplitude_scale", float("nan")),
+            ("amplitude_scale", float("inf")),
+            ("amplitude_scale", -1.0),
+            ("noise_std", float("nan")),
+            ("noise_std", float("inf")),
+            ("noise_std", -0.5),
+        ],
+    )
+    def test_rejects_non_finite_or_negative_scale_params(
+        self, name: str, value: float
+    ) -> None:
+        with pytest.raises(ValueError, match="float32"):
+            FrequencyMismatchStream(**{name: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
         ("omega_min", "omega_max"),
         [(float("nan"), 3.0), (0.5, float("inf")), (float("inf"), float("inf"))],
     )


### PR DESCRIPTION
Fixes #510.

Validates `amplitude_scale` and `noise_std` as finite non-negative float32 (new `_require_nonnegative_float32` helper), matching the omega-bound checks, plus regression tests. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).