### PR TITLE
Skip behavior-model diagnostic EMAs when decay is disabled

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -537,20 +537,27 @@ class BehaviorModel:
 
         decay = jnp.asarray(cfg.diagnostic_decay, dtype=jnp.float32)
         first = state.step_count == 0
+        carried_nll = jnp.where(decay == 0.0, jnp.zeros_like(state.nll_ema), decay * state.nll_ema)
+        carried_accuracy = jnp.where(
+            decay == 0.0, jnp.zeros_like(state.accuracy_ema), decay * state.accuracy_ema
+        )
+        carried_confidence = jnp.where(
+            decay == 0.0, jnp.zeros_like(state.confidence_ema), decay * state.confidence_ema
+        )
         nll_ema = jnp.where(
             first,
             loss,
-            decay * state.nll_ema + (1.0 - decay) * loss,
+            carried_nll + (1.0 - decay) * loss,
         )
         accuracy_ema = jnp.where(
             first,
             correct,
-            decay * state.accuracy_ema + (1.0 - decay) * correct,
+            carried_accuracy + (1.0 - decay) * correct,
         )
         confidence_ema = jnp.where(
             first,
             confidence,
-            decay * state.confidence_ema + (1.0 - decay) * confidence,
+            carried_confidence + (1.0 - decay) * confidence,
         )
 
         new_state = state.replace(  # type: ignore[attr-defined]
@@ -563,12 +570,18 @@ class BehaviorModel:
         )
         # Inf observation makes softmax NaN and logit_error * x = 0*inf = NaN
         # on silent features. Hold the previous finite state.
+        diagnostics_required = jnp.asarray(cfg.diagnostic_decay != 0.0, dtype=jnp.bool_)
         source_finite = (
             jnp.all(jnp.isfinite(state.weights))
             & jnp.all(jnp.isfinite(state.bias))
-            & jnp.isfinite(state.nll_ema)
-            & jnp.isfinite(state.accuracy_ema)
-            & jnp.isfinite(state.confidence_ema)
+            & (
+                (~diagnostics_required)
+                | (
+                    jnp.isfinite(state.nll_ema)
+                    & jnp.isfinite(state.accuracy_ema)
+                    & jnp.isfinite(state.confidence_ema)
+                )
+            )
         )
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -119,6 +119,33 @@ def test_infinite_observation_does_not_poison_weights() -> None:
     assert bool(recovered.update_applied)
 
 
+def test_zero_diagnostic_decay_does_not_multiply_inf_ema() -> None:
+    """decay=0 times an infinite diagnostic EMA is NaN and would reject a finite sample."""
+    model = BehaviorModel(
+        BehaviorModelConfig(n_actions=2, step_size=0.1, diagnostic_decay=0.0)
+    )
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    obs = jnp.array([0.5, -0.25], dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+    state = model.update(state, obs, action).state
+    state = state.replace(  # type: ignore[attr-defined]
+        nll_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        accuracy_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        confidence_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = model.update(state, obs, action)
+    assert bool(result.update_applied)
+    chex.assert_tree_all_finite(result.state.nll_ema)
+    chex.assert_tree_all_finite(result.state.accuracy_ema)
+    chex.assert_tree_all_finite(result.state.confidence_ema)
+    chex.assert_trees_all_close(result.state.nll_ema, result.loss)
+    chex.assert_trees_all_close(result.state.accuracy_ema, result.correct)
+    chex.assert_trees_all_close(result.state.confidence_ema, result.confidence)
+
+
 def test_infinite_observation_marks_input_loss_gradient_invalid() -> None:
     """The state-builder bridge returns a neutral payload with a false verdict.
 


### PR DESCRIPTION
## Summary
- `diagnostic_decay` is allowed to be 0, but the nll/accuracy/confidence EMAs still formed `decay * previous`. An inf leftover tracker became NaN and blocked a finite supervised sample.
- Zero decay now skips those products and no longer requires the unused diagnostic EMAs to be finite.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_behavior_model.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/behavior_model.py tests/test_behavior_model.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)