### PR TITLE
Skip working-memory trace mixes when decay or the gate is 0

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -318,7 +318,13 @@ class WorkingMemoryFeaturizer:
             return traces
         decay = jnp.asarray(decay_rates, dtype=jnp.float32)[:, None]
         update_rate = (1.0 - decay) * gate
-        return traces + update_rate * (value[None, :] - traces)
+        persist = 1.0 - update_rate
+        delta_update = traces + update_rate * (value[None, :] - traces)
+        return jnp.where(
+            persist == 0.0,
+            jnp.broadcast_to(value[None, :], traces.shape),
+            jnp.where(update_rate == 0.0, traces, delta_update),
+        )
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def features(
@@ -427,9 +433,22 @@ class WorkingMemoryFeaturizer:
             step_count=state.step_count + 1,
             last_gate=jnp.stack([observation_gate, action_gate, reward_gate]),
         )
+        previous_checked = state
+        if cfg.observation_decay_rates and all(rate == 0.0 for rate in cfg.observation_decay_rates):
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
+                observation_traces=jnp.zeros_like(state.observation_traces),
+            )
+        if cfg.action_decay_rates and all(rate == 0.0 for rate in cfg.action_decay_rates):
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
+                action_traces=jnp.zeros_like(state.action_traces),
+            )
+        if cfg.reward_decay_rates and all(rate == 0.0 for rate in cfg.reward_decay_rates):
+            previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
+                reward_traces=jnp.zeros_like(state.reward_traces),
+            )
         update_applied = (
             inputs_valid
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate)
         )
         return WorkingMemoryUpdateResult(

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -451,3 +451,31 @@ def test_legal_finite_decay_endpoints_still_construct_and_update() -> None:
     )
     assert bool(checked.update_applied)
     chex.assert_tree_all_finite(checked.state)
+
+
+def test_zero_decay_does_not_multiply_inf_traces() -> None:
+    """decay=0 is a full replace; inf leftover traces must not become NaN."""
+    memory = WorkingMemoryFeaturizer(
+        _minimal_config(observation_decay_rates=(0.0,), gated_update=False)
+    )
+    obs = jnp.asarray([1.0, -2.0], dtype=jnp.float32)
+    state = memory.update_checked(
+        memory.init(),
+        obs,
+        memory.zero_action(),
+        memory.zero_reward(),
+    ).state
+    state = state.replace(  # type: ignore[attr-defined]
+        observation_traces=jnp.full_like(state.observation_traces, jnp.inf),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = memory.update_checked(
+        state,
+        obs,
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    assert bool(result.update_applied)
+    chex.assert_trees_all_close(result.state.observation_traces, obs[None, :])


### PR DESCRIPTION
## Summary
- Working-memory banks with decay 0 still used traces + (x - traces), which is inf-inf when leftover traces are infinite, then refused a finite observation.
- Zero-decay (and zero-gate) rows now skip that mix. Finite-input overflow of a nonzero persist mix still fails closed.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_working_memory.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/working_memory.py tests/test_working_memory.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).