### PR TITLE
fix(streams): validate CompositionalStream feature_std, amplitude_scale, noise_std

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -57,6 +57,21 @@ def _require_positive_float32(value: object, name: str) -> float:
         raise ValueError(f"{name} must be a positive finite float32 value")
     return converted
 
+
+def _require_nonnegative_float32(value: object, name: str) -> float:
+    """Return a finite non-negative value representable in the stream execution dtype."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite non-negative float32 value")
+    try:
+        converted = round_real_to_float32(value)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"{name} must be a finite non-negative float32 value"
+        ) from error
+    if not np.isfinite(converted) or converted < np.float32(0.0):
+        raise ValueError(f"{name} must be a finite non-negative float32 value")
+    return converted
+
 # =============================================================================
 # OutOfClassPolynomialStream -- degree-3 polynomial targets
 # =============================================================================
@@ -596,10 +611,10 @@ class CompositionalStream:
         self._outer_components = outer_components
         self._n_contexts = n_contexts
         self._context_length = context_length
-        self._feature_std = feature_std
+        self._feature_std = _require_nonnegative_float32(feature_std, "feature_std")
         self._weight_scale = weight_scale_float32
-        self._amplitude_scale = amplitude_scale
-        self._noise_std = noise_std
+        self._amplitude_scale = _require_nonnegative_float32(amplitude_scale, "amplitude_scale")
+        self._noise_std = _require_nonnegative_float32(noise_std, "noise_std")
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -473,6 +473,26 @@ class TestFrequencyMismatchStream:
 class TestCompositionalStream:
     """Tests for the 2-hidden-layer compositional out-of-class stream."""
 
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("feature_std", float("nan")),
+            ("feature_std", float("inf")),
+            ("feature_std", -1.0),
+            ("amplitude_scale", float("nan")),
+            ("amplitude_scale", float("inf")),
+            ("amplitude_scale", -0.5),
+            ("noise_std", float("nan")),
+            ("noise_std", float("inf")),
+            ("noise_std", -1.0),
+        ],
+    )
+    def test_rejects_non_finite_or_negative_scale_params(
+        self, name: str, value: float
+    ) -> None:
+        with pytest.raises(ValueError, match="float32"):
+            CompositionalStream(**{name: value})  # type: ignore[arg-type]
+
     @pytest.mark.parametrize("weight_scale", [float("nan"), float("inf"), float("-inf")])
     def test_weight_scale_must_be_finite(self, weight_scale: float) -> None:
         with pytest.raises(ValueError, match="weight_scale must be finite"):


### PR DESCRIPTION
Fixes #511.

Validates `feature_std`, `amplitude_scale`, and `noise_std` as finite non-negative float32, matching the existing `weight_scale` check, plus regression tests. Note: re-defines `_require_nonnegative_float32` locally so the PR is self-contained against main. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).