### PR TITLE
fix(streams): reject non-finite SwitchingTwoStateMDP payoffs

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -203,6 +203,8 @@ class SwitchingTwoStateMDP:
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
             if payoff.shape != (_TWO_STATE_N, _TWO_STATE_ACTIONS):
                 raise ValueError(f"{name} must be 2x2 (state x action), got shape {payoff.shape}")
+            if not np.all(np.isfinite(payoff)):
+                raise ValueError(f"{name} must contain only finite values, got {payoff.tolist()}")
             phase_payoffs.append(payoff)
         payoffs = np.stack(phase_payoffs)
         self._config = config

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -151,6 +151,28 @@ class TestSwitchingTwoStateDynamics:
                 SwitchingTwoStateConfig(payoffs_a=((0.0, 1.0, 2.0),) * 2)  # type: ignore[arg-type]
             )
 
+    @pytest.mark.parametrize(
+        "payoffs_a",
+        [
+            ((float("nan"), 0.0), (0.0, 1.0)),
+            ((float("inf"), 0.0), (0.0, 1.0)),
+            ((-1.0, 0.0), (0.0, float("-inf"))),
+        ],
+    )
+    def test_non_finite_payoffs_raise(self, payoffs_a):
+        """Payoff matrices must contain only finite values."""
+        with pytest.raises(ValueError, match="finite"):
+            SwitchingTwoStateMDP(SwitchingTwoStateConfig(payoffs_a=payoffs_a))
+
+    def test_non_finite_payoffs_b_raise(self):
+        """payoffs_b is validated like payoffs_a."""
+        with pytest.raises(ValueError, match="finite"):
+            SwitchingTwoStateMDP(
+                SwitchingTwoStateConfig(
+                    payoffs_b=((0.0, float("nan")), (1.0, 0.0))  # type: ignore[arg-type]
+                )
+            )
+
 
 # =============================================================================
 # Switching two-state MDP: analytic helpers


### PR DESCRIPTION
Fixes #512.

Adds a finiteness check on `payoffs_a`/`payoffs_b` alongside the existing shape check in `SwitchingTwoStateMDP.__init__`, plus regression tests. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).