### PR TITLE
fix(streams): reject non-finite RiverSwim rewards and non-integer initial_state

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -421,6 +421,21 @@ class RiverSwimMDP:
             raise ValueError(
                 f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
             )
+        if isinstance(config.initial_state, bool) or not isinstance(
+            config.initial_state, Integral
+        ):
+            raise ValueError(
+                "initial_state must be an integer, got "
+                f"{config.initial_state!r}"
+            )
+        if not np.isfinite(config.reward_left):
+            raise ValueError(
+                f"reward_left must be finite, got {config.reward_left}"
+            )
+        if not np.isfinite(config.reward_right):
+            raise ValueError(
+                f"reward_right must be finite, got {config.reward_right}"
+            )
         config = config.replace(  # type: ignore[attr-defined]
             p_right_up=p_right_up,
             p_right_down=p_right_down,

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -273,6 +273,24 @@ class TestSwitchingScanRollout:
 class TestRiverSwim:
     """Dynamics, rewards, and analytic helpers of the stochastic variant."""
 
+    @pytest.mark.parametrize("reward_left", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_reward_left_raises(self, reward_left):
+        """reward_left must be finite."""
+        with pytest.raises(ValueError, match="reward_left must be finite"):
+            RiverSwimMDP(RiverSwimConfig(reward_left=reward_left))
+
+    @pytest.mark.parametrize("reward_right", [float("nan"), float("inf")])
+    def test_non_finite_reward_right_raises(self, reward_right):
+        """reward_right must be finite."""
+        with pytest.raises(ValueError, match="reward_right must be finite"):
+            RiverSwimMDP(RiverSwimConfig(reward_right=reward_right))
+
+    @pytest.mark.parametrize("initial_state", [1.5, True, 2.0])
+    def test_non_integer_initial_state_raises(self, initial_state):
+        """initial_state must be a canonical integer in range."""
+        with pytest.raises(ValueError, match="initial_state must be an integer"):
+            RiverSwimMDP(RiverSwimConfig(initial_state=initial_state))  # type: ignore[arg-type]
+
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""
         config = RiverSwimConfig(n_states=4, p_right_up=0.3, p_right_down=0.1)


### PR DESCRIPTION
Fixes #513.

`reward_left`/`reward_right` now require finite values, and `initial_state` must be a canonical integer in range (a float like 1.5 previously passed the bare comparison and was silently truncated). Regression tests added. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).