### PR TITLE
Skip off-policy Horde 0*inf utilities and replacing traces

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -39,6 +39,11 @@ from alberta_framework.core.update_safety import (
 )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _report_demon_values(
     values: Array,
     requested: Array,
@@ -411,7 +416,31 @@ class OffPolicyHordeLearner:
         )
         td_targets = cumulants + discounts * bootstrap_predictions
         requested_mask = ~jnp.isnan(cumulants)
-        source_state_finite = _floating_tree_is_finite(state)
+        checked_state = state
+        if self._utility_decay == 0.0:
+            checked_state = checked_state.replace(  # type: ignore[attr-defined]
+                hidden_unit_utilities=tuple(
+                    jnp.zeros_like(utility) for utility in state.hidden_unit_utilities
+                )
+            )
+        if replacing:
+            checked_state = checked_state.replace(  # type: ignore[attr-defined]
+                trunk_traces=tuple(jnp.zeros_like(trace) for trace in state.trunk_traces),
+            )
+        lamdas = self._horde_spec.lamdas
+        head_decay_unused = jnp.all(
+            (discounts == 0.0) | (jnp.asarray(lamdas, dtype=jnp.float32) == 0.0)
+        )
+        checked_state = checked_state.replace(  # type: ignore[attr-defined]
+            head_traces=tuple(
+                (
+                    jnp.where(head_decay_unused, jnp.zeros_like(old_w), old_w),
+                    jnp.where(head_decay_unused, jnp.zeros_like(old_b), old_b),
+                )
+                for old_w, old_b in state.head_traces
+            )
+        )
+        source_state_finite = _floating_tree_is_finite(checked_state)
         global_inputs_valid = jnp.all(jnp.isfinite(observation))
         next_observation_valid = jnp.all(jnp.isfinite(next_observation))
         head_inputs_valid = (
@@ -514,7 +543,7 @@ class OffPolicyHordeLearner:
             )
             utility_signal = jnp.abs(activations[i] * trunk_bias_grads[i])
             new_hidden_unit_utilities.append(
-                utility_decay * old_utility
+                _skip_zero_scale(utility_decay, old_utility)
                 + (1.0 - utility_decay) * utility_signal
             )
 
@@ -528,7 +557,7 @@ class OffPolicyHordeLearner:
             w_grad_i = trunk_weight_grads[i]
             old_w_trace = state.trunk_traces[2 * i]
             if replacing:
-                new_w_trace = jnp.where(w_grad_i != 0.0, w_grad_i, old_w_trace * 0.0)
+                new_w_trace = jnp.where(w_grad_i != 0.0, w_grad_i, jnp.zeros_like(old_w_trace))
             else:
                 new_w_trace = w_grad_i
             new_trunk_traces.append(new_w_trace)
@@ -547,7 +576,7 @@ class OffPolicyHordeLearner:
             b_grad_i = trunk_bias_grads[i]
             old_b_trace = state.trunk_traces[2 * i + 1]
             if replacing:
-                new_b_trace = jnp.where(b_grad_i != 0.0, b_grad_i, old_b_trace * 0.0)
+                new_b_trace = jnp.where(b_grad_i != 0.0, b_grad_i, jnp.zeros_like(old_b_trace))
             else:
                 new_b_trace = b_grad_i
             new_trunk_traces.append(new_b_trace)
@@ -621,16 +650,16 @@ class OffPolicyHordeLearner:
                 new_w_trace = jnp.where(
                     w_grad != 0.0,
                     w_grad,
-                    head_gl * old_w_trace,
+                    _skip_zero_scale(head_gl, old_w_trace),
                 )
                 new_b_trace = jnp.where(
                     b_grad != 0.0,
                     b_grad,
-                    head_gl * old_b_trace,
+                    _skip_zero_scale(head_gl, old_b_trace),
                 )
             else:
-                new_w_trace = head_gl * old_w_trace + w_grad
-                new_b_trace = head_gl * old_b_trace + b_grad
+                new_w_trace = _skip_zero_scale(head_gl, old_w_trace) + w_grad
+                new_b_trace = _skip_zero_scale(head_gl, old_b_trace) + b_grad
 
             error_i = masked_td_errors[i]
             w_step, new_w_opt, w_update_applied = (

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -15,7 +15,7 @@ from alberta_framework.core.off_policy_horde import (
     run_off_policy_horde_learning_loop,
 )
 from alberta_framework.core.optimizers import LMS, ObGDBounding
-from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec, create_horde_spec
+from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec, TraceMode, create_horde_spec
 
 
 def _spec(
@@ -583,3 +583,61 @@ def test_nonlinear_shared_gtd_zero_discount_does_not_multiply_inf_next() -> None
     chex.assert_tree_all_finite(result.state)
     chex.assert_trees_all_close(result.td_targets, jnp.array([3.0], dtype=jnp.float32))
     chex.assert_tree_all_finite(result.correction_norms)
+
+
+def test_zero_utility_decay_does_not_multiply_inf_utility() -> None:
+    """utility_decay=0 times leftover inf hidden-unit utility is NaN."""
+    learner = OffPolicyHordeLearner(
+        _spec(gammas=(0.0, 0.0)),
+        hidden_sizes=(4,),
+        optimizer=LMS(step_size=0.01),
+        utility_decay=0.0,
+        sparsity=0.0,
+    )
+    state = learner.init(3, jax.random.key(0))
+    state = state.replace(  # type: ignore[attr-defined]
+        hidden_unit_utilities=tuple(
+            jnp.full_like(utility, jnp.inf) for utility in state.hidden_unit_utilities
+        )
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = learner.update_with_ratios(
+        state,
+        jnp.array([0.2, -0.1, 0.4], dtype=jnp.float32),
+        jnp.array([1.0, -0.5], dtype=jnp.float32),
+        jnp.array([0.0, 0.1, 0.2], dtype=jnp.float32),
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    for utility in result.state.hidden_unit_utilities:
+        chex.assert_tree_all_finite(utility)
+
+
+def test_replacing_zero_grad_does_not_multiply_inf_trunk_trace() -> None:
+    """Replacing traces used old * 0.0 on silent coordinates, which is 0*inf."""
+    learner = OffPolicyHordeLearner(
+        _spec(gammas=(0.0, 0.0)),
+        hidden_sizes=(3,),
+        optimizer=LMS(step_size=0.01),
+        trace_mode=TraceMode.REPLACING,
+        sparsity=0.0,
+    )
+    state = learner.init(2, jax.random.key(1))
+    state = state.replace(  # type: ignore[attr-defined]
+        trunk_traces=tuple(jnp.full_like(trace, jnp.inf) for trace in state.trunk_traces)
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = learner.update_with_ratios(
+        state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([0.5, -0.25], dtype=jnp.float32),
+        jnp.zeros(2, dtype=jnp.float32),
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    for trace in result.state.trunk_traces:
+        chex.assert_tree_all_finite(trace)


### PR DESCRIPTION
## Summary
- Off-policy Horde still formed utility_decay * old_utility and replacing-trace old * 0.0, so leftover inf trackers became NaN and blocked a finite transition.
- Zero decay now skips those products. Head-trace decay uses the same skip when gamma*lambda is 0.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_off_policy_horde.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/off_policy_horde.py tests/test_off_policy_horde.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).