### PR TITLE
Skip Horde actor TD-error EMA when normalizer decay is 0

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -63,12 +63,14 @@ def _commit_scan_safe_actor_state(
     proposed: Any,
     inputs_valid: Array,
     nested_update_applied: Array,
+    previous_checked: Any | None = None,
 ) -> tuple[Any, Bool[Array, ""]]:
     """Commit one actor/critic transaction only when every component is valid."""
+    checked = previous if previous_checked is None else previous_checked
     update_applied = (
         jnp.asarray(inputs_valid, dtype=jnp.bool_)
         & jnp.asarray(nested_update_applied, dtype=jnp.bool_)
-        & _floating_tree_is_finite(previous)
+        & _floating_tree_is_finite(checked)
         & _floating_tree_is_finite(proposed)
     )
     state = jax.lax.cond(update_applied, lambda: proposed, lambda: previous)
@@ -1520,7 +1522,7 @@ class NonlinearHordeActorCriticAgent:
                 cfg.actor_td_error_normalizer_decay, dtype=jnp.float32
             )
             actor_td_error_normalizer = (
-                decay * actor_td_error_normalizer
+                _skip_zero_scale(decay, actor_td_error_normalizer)
                 + (1.0 - decay) * jnp.abs(actor_td_error)
             )
             actor_td_error = actor_td_error / jnp.maximum(
@@ -1708,11 +1710,17 @@ class NonlinearHordeActorCriticAgent:
             & critic_result.head_updates_applied[cfg.value_head_index]
             & jnp.all(jnp.stack(optimizer_updates_applied))
         )
+        previous_checked = state
+        if cfg.actor_td_error_normalizer_decay == 0.0:
+            previous_checked = state.replace(  # type: ignore[attr-defined]
+                actor_td_error_normalizer=jnp.zeros_like(state.actor_td_error_normalizer),
+            )
         new_state, update_applied = _commit_scan_safe_actor_state(
             state,
             proposed_state,
             inputs_valid,
             nested_update_applied,
+            previous_checked,
         )
         committed_critic_result = _rollback_critic_result(
             critic_result,

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -941,6 +941,37 @@ class TestNonlinearHordeActorCriticUpdate:
         result = agent.update(state, jnp.array(1.0), obs)
         assert float(result.state.actor_td_error_normalizer) > 0.0
 
+    def test_zero_td_error_normalizer_decay_does_not_multiply_inf_ema(self) -> None:
+        """decay=0 times leftover inf actor TD-error EMA is NaN."""
+        critic = HordeLearner(
+            create_horde_spec(
+                [GVFSpec(  # type: ignore[call-arg]
+                    name="v", demon_type=DemonType.PREDICTION,
+                    gamma=0.99, lamda=0.0, cumulant_index=0,
+                )]
+            ),
+            hidden_sizes=(8,),
+            step_size=0.03,
+        )
+        cfg = NonlinearHordeActorCriticConfig(
+            n_actions=N_ACTIONS,
+            hidden_sizes=(8,),
+            actor_td_error_normalizer_decay=0.0,
+        )
+        agent = NonlinearHordeActorCriticAgent(cfg, critic)
+        state = agent.init(OBS_DIM, jr.key(5))
+        obs = jr.normal(jr.key(6), (OBS_DIM,))
+        state, _, _ = agent.start(state, obs)
+        state = state.replace(  # type: ignore[attr-defined]
+            actor_td_error_normalizer=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = agent.update(state, jnp.array(1.0, dtype=jnp.float32), obs)
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state.actor_td_error_normalizer)
+
     def test_policy_sums_to_one(self) -> None:
         agent = _make_nlhac_agent()
         state = _init_nlhac(agent)


### PR DESCRIPTION
## Summary
- Nonlinear Horde actor-critic still formed decay * leftover actor TD-error EMA when actor_td_error_normalizer_decay is 0, which is allowed in [0, 1).
- Zero decay now skips that product. The unused EMA is not required to be finite, so a leftover inf tracker cannot block a finite update.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_horde_actor_critic.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/horde_actor_critic.py tests/test_horde_actor_critic.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)