### PR TITLE
fix(step8): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -134,9 +134,10 @@ def _require_nonnegative_real(name: str, value: object) -> float:
 
 
 def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -190,6 +190,26 @@ def test_step8_world_model_fields_reject_invalid_inputs(field: str, value: objec
         make_step8_world_model(_config_with(**{field: value}))
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize("field", ["observation_dim", "n_actions", "action_dim"])
+def test_step8_world_model_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_step8_world_model(_config_with(**{field: _SpoofedInt()}))
+
+
 def test_step8_world_model_rejects_nonpositive_vector_action_dim() -> None:
     with pytest.raises(ValueError, match="action_dim"):
         make_step8_world_model(_config_with(n_actions=None, action_dim=0))


### PR DESCRIPTION
Closes #543.

## What changed

Same pattern as #400 (step12), #502 (step9), #504 (step11): `_require_int` in `step8.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`_validate_world_model_config` - called unconditionally from `Step8WorldModelConfig.__post_init__` - routes `observation_dim`, `n_actions`, `action_dim`, and each `hidden_sizes` entry through this helper.

## Reachability

`Step8WorldModelConfig` is exported from `alberta_framework.steps.__init__`'s `__all__`, and its own `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED observation_dim ACCEPTED: 3 <class 'int'>
```

- new test `test_step8_world_model_fields_reject_class_spoofed_integers`, parametrized over `observation_dim`/`n_actions`/`action_dim`, added next to the existing `test_step8_world_model_fields_reject_invalid_inputs`.
- mutation check: reverted just the source fix, reran the new test -> all 3 fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `56 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
