### PR TITLE
fix(core): fail closed on non-finite inputs in NonlinearSharedGTDHordeLearner

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -150,6 +150,8 @@ class NonlinearSharedGTDHordeUpdateResult:
     clipped_rhos: Float[Array, " n_demons"]
     correction_norms: Float[Array, " n_demons"]
     secondary_norms: Float[Array, " n_demons"]
+    head_updates_applied: Bool[Array, " n_demons"]
+    update_applied: Bool[Array, ""]
 
 
 @chex.dataclass(frozen=True)
@@ -986,7 +988,18 @@ class NonlinearSharedGTDHordeLearner:
         )
         td_targets = cumulants + discounts * bootstrap_predictions
         td_errors = td_targets - predictions
-        active_mask = ~jnp.isnan(td_targets)
+        requested = ~jnp.isnan(cumulants)
+        active_mask = (
+            requested
+            & jnp.isfinite(cumulants)
+            & jnp.isfinite(rhos)
+            & jnp.isfinite(discounts)
+            & jnp.isfinite(td_targets)
+        )
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
+            jnp.isfinite(next_observation)
+        )
+        head_updates_applied = active_mask & inputs_valid
         safe_td_errors = jnp.where(active_mask, td_errors, 0.0)
         clipped_rhos = jnp.minimum(
             jnp.maximum(jnp.asarray(rhos, dtype=jnp.float32), 0.0),
@@ -1031,7 +1044,7 @@ class NonlinearSharedGTDHordeLearner:
             # importance sampling, Sutton & Barto 2nd ed., Section 11.7;
             # GQ(0) with e = rho grad, Maei & Sutton 2010).  Inactive demons
             # (NaN cumulant) contribute nothing this step.
-            masked_rho = jnp.where(active_mask[i], clipped_rhos[i], 0.0)
+            masked_rho = jnp.where(head_updates_applied[i], clipped_rhos[i], 0.0)
             terminated_i = discounts[i] == 0.0
             rho_dot = jnp.where(
                 terminated_i,
@@ -1073,7 +1086,7 @@ class NonlinearSharedGTDHordeLearner:
                 primary_alpha * (rho_delta * grad_head_b - correction_head_b)
             )
 
-            masked_beta = jnp.where(active_mask[i], secondary_beta, 0.0)
+            masked_beta = jnp.where(head_updates_applied[i], secondary_beta, 0.0)
             sec_trunk_w = state.secondary_trunk_w[i] + masked_beta * (
                 rho_delta * grad_trunk_w - secondary_dot * grad_trunk_w
             )
@@ -1107,7 +1120,7 @@ class NonlinearSharedGTDHordeLearner:
                 )
             )
 
-        new_state = state.replace(  # type: ignore[attr-defined]
+        proposed_state = state.replace(  # type: ignore[attr-defined]
             trunk_w=state.trunk_w + trunk_w_step,
             trunk_b=state.trunk_b + trunk_b_step,
             head_w=state.head_w + head_w_step,
@@ -1117,6 +1130,12 @@ class NonlinearSharedGTDHordeLearner:
             secondary_head_w=jnp.stack(new_secondary_head_w),
             secondary_head_b=jnp.stack(new_secondary_head_b),
             step_count=state.step_count + 1,
+        )
+        update_applied = inputs_valid & (jnp.any(active_mask) | jnp.all(~requested))
+        new_state = jax.lax.cond(
+            update_applied,
+            lambda: proposed_state,
+            lambda: state,
         )
         return NonlinearSharedGTDHordeUpdateResult(  # type: ignore[call-arg]
             state=new_state,
@@ -1129,6 +1148,8 @@ class NonlinearSharedGTDHordeLearner:
             clipped_rhos=clipped_rhos,
             correction_norms=jnp.stack(correction_norms),
             secondary_norms=jnp.stack(secondary_norms),
+            head_updates_applied=head_updates_applied,
+            update_applied=update_applied,
         )
 
 

--- a/tests/test_offpolicy_horde_rho.py
+++ b/tests/test_offpolicy_horde_rho.py
@@ -273,3 +273,59 @@ def test_gtd_backend_masks_nan_cumulants() -> None:
     assert float(jnp.linalg.norm(result.state.head_w[1] - warm.state.head_w[1])) > 0.0
     assert bool(jnp.isnan(result.td_errors[0]))
     assert bool(jnp.isfinite(result.correction_norms[0]))
+
+
+def test_gtd_backend_rejects_non_finite_cumulant() -> None:
+    """An inf (not NaN) cumulant must reject that head without poisoning it."""
+    learner = NonlinearSharedGTDHordeLearner(
+        _spec(gammas=(0.8, 0.8)),
+        hidden_size=4,
+        primary_step_size=0.01,
+        secondary_step_size=0.01,
+        ratio_clip=10.0,
+    )
+    state = learner.init(2, jax.random.key(7))
+    obs = jnp.array([1.0, 0.2], dtype=jnp.float32)
+    next_obs = jnp.array([-0.4, 1.0], dtype=jnp.float32)
+    rhos = jnp.array([1.5, 1.5], dtype=jnp.float32)
+    discounts = jnp.array([0.8, 0.8], dtype=jnp.float32)
+
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        obs,
+        jnp.array([jnp.inf, 1.0], dtype=jnp.float32),
+        next_obs,
+        rhos,
+        discounts,
+    )
+
+    chex.assert_tree_all_finite(result.state)
+    assert not bool(result.head_updates_applied[0])
+    assert bool(result.head_updates_applied[1])
+    assert bool(result.update_applied)
+    assert float(jnp.linalg.norm(result.state.head_w[1] - state.head_w[1])) > 0.0
+    assert float(jnp.linalg.norm(result.state.head_w[0] - state.head_w[0])) == 0.0
+
+
+def test_gtd_backend_rejects_non_finite_observation() -> None:
+    """A NaN observation must fail closed and leave the state untouched."""
+    learner = NonlinearSharedGTDHordeLearner(
+        _spec(gammas=(0.8,)),
+        hidden_size=4,
+        primary_step_size=0.01,
+        secondary_step_size=0.01,
+        ratio_clip=10.0,
+    )
+    state = learner.init(2, jax.random.key(9))
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        jnp.array([jnp.nan, 0.2], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array([-0.4, 1.0], dtype=jnp.float32),
+        jnp.array([1.5], dtype=jnp.float32),
+        jnp.array([0.8], dtype=jnp.float32),
+    )
+
+    chex.assert_trees_all_close(result.state.trunk_w, state.trunk_w, atol=0.0)
+    chex.assert_trees_all_close(result.state.head_w, state.head_w, atol=0.0)
+    assert not bool(result.update_applied)


### PR DESCRIPTION
Fixes #514.

`update_with_ratios_and_discounts` gated only on `~isnan(td_targets)`, so inf cumulants/rhos/discounts/observations poisoned the shared trunk and the state was committed unconditionally. It now rejects non-finite inputs per head (`head_updates_applied`), commits the state transactionally (`update_applied`, no-op on invalid inputs), and reports both on the result. Mirrors `HordeLearner`/`OffPolicyHordeLearner`. Regression tests added. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).