### PR TITLE
fix(step2): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -168,10 +168,11 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
     try:
-        number = int(value)
+        number = int(cast(Integral, value))
     except (OverflowError, TypeError, ValueError):
         raise ValueError(f"{name} must be an integer, got {value!r}") from None
     if minimum is not None and number < minimum:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -513,6 +513,39 @@ def test_step2_kernel_fields_reject_invalid_inputs(field: str, value: object) ->
         Step2KernelConfig(**{field: value})
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "field"),
+    [
+        (Step2KernelConfig, "feature_dim"),
+        (Step2KernelConfig, "n_heads"),
+        (Step2KernelConfig, "context_length"),
+        (Step2StrictDigitReadoutConfig, "n_heads"),
+        (Step2MemoryConfig, "feature_dim"),
+        (Step2MemoryConfig, "n_classes"),
+        (Step2MemoryConfig, "slots_per_class"),
+    ],
+)
+def test_step2_configs_reject_class_spoofed_integer_fields(
+    config_cls: type, field: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        config_cls(**{field: _SpoofedInt()})
+
+
 _INVALID_STEP2_MEMORY_FIELDS: tuple[tuple[str, Any], ...] = (
     ("feature_dim", 0),
     ("feature_dim", -1),


### PR DESCRIPTION
Closes #546.

## What changed

Same pattern as #400 (step12), #502 (step9), #504 (step11), #544 (step8): `_require_int` in `step2.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

This one helper backs three config validators: `_validate_step2_kernel_config` (`Step2KernelConfig`: `feature_dim`, `n_heads`, each `hidden_sizes` entry, `context_length`), `_validate_step2_strict_digit_config` (`Step2StrictDigitReadoutConfig`: `n_heads`), and `_validate_step2_memory_config` (`Step2MemoryConfig`: `feature_dim`, `n_classes`, `slots_per_class`).

## Reachability

All three config classes are exported from `alberta_framework.steps.__init__`'s `__all__`, and each runs the vulnerable check on every construction via `__post_init__` - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED feature_dim ACCEPTED: 3 <class 'int'>
```

- new test `test_step2_configs_reject_class_spoofed_integer_fields`, parametrized across all three config classes and their `_require_int`-backed fields (7 cases), added next to the existing `test_step2_kernel_fields_reject_invalid_inputs`.
- mutation check: reverted just the source fix, reran the new test -> all 7 cases fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `313 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
