### PR TITLE
fix(core): reject non-vector cumulant shapes in AverageRewardHordeLearner

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -919,6 +919,12 @@ class AverageRewardHordeLearner:
         next_observation: Array,
     ) -> AverageRewardHordeUpdateResult:
         """Apply one shared-trunk differential Horde update."""
+        cumulants = jnp.asarray(cumulants)
+        expected_shape = (self._n_demons,)
+        if cumulants.shape != expected_shape:
+            raise ValueError(
+                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
+            )
         next_predictions = self._learner.predict(state.learner_state, next_observation)
         # NaN remains the inactive-head sentinel. Other non-finite cumulants
         # are rejected per head and reported separately from inactivity.

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -186,6 +186,25 @@ def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
     assert bool(jnp.all(recovered.head_updates_applied))
 
 
+def test_average_reward_horde_rejects_scalar_cumulant() -> None:
+    """A scalar cumulant must not broadcast to every demon head."""
+    learner = AverageRewardHordeLearner(
+        n_demons=3,
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        use_layer_norm=False,
+    )
+    state = learner.init(3, jr.key(11))
+    obs = jnp.ones(3, dtype=jnp.float32)
+    nxt = jnp.ones(3, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="cumulants must have shape"):
+        learner.update(state, obs, jnp.array(1.0, dtype=jnp.float32), nxt)
+
+    with pytest.raises(ValueError, match="cumulants must have shape"):
+        learner.update(state, obs, jnp.array([1.0], dtype=jnp.float32), nxt)
+
+
 def test_differential_td_scan_shapes_and_finite_metrics() -> None:
     learner = DifferentialTDLearner(DifferentialTDConfig(trace_decay=0.2))
     state = learner.init(2)


### PR DESCRIPTION
Fixes #515.

`AverageRewardHordeLearner.update` accepted a scalar or `(1,)` cumulant that broadcast to every demon head; now it requires shape `(n_demons,)` exactly as `HordeLearner` does. The single-head actor-critic caller already passes `atleast_1d`. Regression test added. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).