### PR TITLE
fix(step7): reject class-spoofed non-integer planning fields

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -165,9 +165,10 @@ def _require_unit_interval(name: str, value: object) -> float:
 
 
 def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -183,6 +183,34 @@ def test_step7_planning_fields_reject_invalid_inputs(field: str, value: object) 
         _config_with(**{field: value})
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "planning_steps",
+        "planning_rollout_depth",
+        "planning_warmup_steps",
+        "planning_memory_size",
+    ],
+)
+def test_step7_planning_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: _SpoofedInt()})
+
+
 def test_step7_planning_fields_preserve_legal_endpoints() -> None:
     config = Step7DynaConfig(
         control=Step6DifferentialSARSAConfig(n_actions=N_ACTIONS),


### PR DESCRIPTION
Closes #550.

## What changed

Same pattern as #400, #502, #504, #544, #547: `_require_int` in `step7.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`_validate_planning_config`, called unconditionally from `Step7DynaConfig.__post_init__`, routes `planning_steps`, `planning_rollout_depth`, `planning_warmup_steps`, and `planning_memory_size` through this helper.

## Reachability

`Step7DynaConfig` is exported from `alberta_framework.steps.__init__`'s `__all__`, and its `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED planning_steps ACCEPTED: 3 <class 'int'>
```

- new test `test_step7_planning_fields_reject_class_spoofed_integers`, parametrized over all 4 affected fields, added next to the existing `test_step7_planning_fields_reject_invalid_inputs`.
- mutation check: reverted just the source fix, reran the new test -> all 4 fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `95 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
