### PR TITLE
fix(core): validate per_head_gamma_lamda in MultiHeadMLPLearner

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -20,6 +20,7 @@ import functools
 import math
 import time
 from collections.abc import Mapping
+from numbers import Real
 from typing import Any
 
 import chex
@@ -399,6 +400,23 @@ class MultiHeadMLPLearner:
                 f"trace decay with a shared trunk."
             )
             raise ValueError(msg)
+        if per_head_gamma_lamda is not None:
+            if len(per_head_gamma_lamda) != self._n_heads:
+                raise ValueError(
+                    f"per_head_gamma_lamda must have length n_heads ({self._n_heads}), "
+                    f"got {len(per_head_gamma_lamda)}"
+                )
+            for head_index, gl in enumerate(per_head_gamma_lamda):
+                if not isinstance(gl, Real) or isinstance(gl, bool):
+                    raise ValueError(
+                        f"per_head_gamma_lamda[{head_index}] must be a real number, "
+                        f"got {gl!r}"
+                    )
+                if not math.isfinite(float(gl)) or not 0.0 <= float(gl) <= 1.0:
+                    raise ValueError(
+                        f"per_head_gamma_lamda[{head_index}] must be finite and in "
+                        f"[0, 1], got {gl}"
+                    )
 
     @property
     def n_heads(self) -> int:

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -281,6 +281,33 @@ class TestMultiHeadUpdateAllActive:
 # =============================================================================
 
 
+class TestMultiHeadConstructorValidation:
+    """``per_head_gamma_lamda`` values must be finite and in [0, 1]."""
+
+    def test_rejects_wrong_length_per_head_gamma_lamda(self):
+        """The tuple must have exactly one value per head."""
+        with pytest.raises(ValueError, match="length n_heads"):
+            MultiHeadMLPLearner(
+                n_heads=2,
+                hidden_sizes=(),
+                sparsity=0.0,
+                step_size=0.01,
+                per_head_gamma_lamda=(0.5,),
+            )
+
+    @pytest.mark.parametrize("gl", [float("nan"), float("inf"), -0.1, 1.5, True, "0.5"])
+    def test_rejects_non_finite_or_out_of_range_values(self, gl):
+        """Each per-head trace decay must be a finite real in [0, 1]."""
+        with pytest.raises(ValueError, match=r"per_head_gamma_lamda\[1\]"):
+            MultiHeadMLPLearner(
+                n_heads=2,
+                hidden_sizes=(),
+                sparsity=0.0,
+                step_size=0.01,
+                per_head_gamma_lamda=(0.5, gl),  # type: ignore[arg-type]
+            )
+
+
 class TestMultiHeadUpdateValidation:
     """``update`` must reject targets that are not one value per head.
 


### PR DESCRIPTION
Fixes #516.

`per_head_gamma_lamda` was stored raw; NaN values silently poisoned that head's eligibility traces and out-of-range values expanded instead of decaying them. Now requires length equal to `n_heads` and every value finite in `[0, 1]`, mirroring how trunk `gamma`/`lamda` are constrained. Regression tests added. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).