### PR TITLE
fix(step3): reject class-spoofed non-integer hidden_sizes entries

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -224,9 +224,10 @@ def _require_positive_real(name: str, value: object) -> float:
 
 
 def _require_positive_int(name: str, value: object) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be a positive integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if number < 1:
         raise ValueError(f"{name} must be positive, got {value!r}")
     if number > _INT32_MAX:

--- a/tests/test_step3_production.py
+++ b/tests/test_step3_production.py
@@ -201,6 +201,25 @@ def test_step3_horde_scalars_reject_invalid_inputs(field: str, value: object) ->
         make_step3_horde(_config_with(**{field: value}))
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+def test_step3_horde_hidden_sizes_rejects_class_spoofed_integers() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        make_step3_horde(_config_with(hidden_sizes=(_SpoofedInt(),)))
+
+
 def test_step3_horde_scalars_preserve_legal_boundaries() -> None:
     config = Step3HordeConfig(
         gammas=(0.0, 1.0),


### PR DESCRIPTION
Closes #554.

## What changed

Same pattern as #400, #502, #504, #544, #547, #552: `_require_positive_int` in `step3.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`_validate_horde_config`, called unconditionally from `Step3HordeConfig.__post_init__`, routes each `hidden_sizes` entry through this helper.

## Reachability

`Step3HordeConfig` is exported from `alberta_framework.steps.__init__`'s `__all__`, and its `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED hidden_sizes ACCEPTED: (3,) [<class 'int'>]
```

- new test `test_step3_horde_hidden_sizes_rejects_class_spoofed_integers` added next to the existing `test_step3_horde_scalars_reject_invalid_inputs`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `43 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
