### PR TITLE
Skip adaptive ObGD 0*inf second-moment mixes when beta2 is 0

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -1307,7 +1307,7 @@ def adaptive_obgd_update(
     epsilon_array = jnp.asarray(epsilon, dtype=signal.dtype)
     proposed_second_moment = jax.tree_util.tree_map(
         lambda previous, trace: (
-            beta * previous
+            jnp.where(beta == 0.0, jnp.zeros_like(previous), beta * previous)
             + (1.0 - beta) * jnp.square(signal * trace)
         ),
         second_moment,
@@ -1342,6 +1342,10 @@ def adaptive_obgd_update(
     )
     alpha_array = jnp.asarray(alpha, dtype=signal.dtype)
     kappa_array = jnp.asarray(kappa, dtype=signal.dtype)
+    checked_second_moment = jax.tree_util.tree_map(
+        lambda previous: jnp.where(beta == 0.0, jnp.zeros_like(previous), previous),
+        second_moment,
+    )
     update_applied = (
         jnp.isfinite(signal)
         & jnp.isfinite(alpha_array)
@@ -1354,7 +1358,7 @@ def adaptive_obgd_update(
         & jnp.isfinite(epsilon_array)
         & (epsilon_array > 0.0)
         & _floating_tree_is_finite(traces)
-        & _floating_tree_is_finite(second_moment)
+        & _floating_tree_is_finite(checked_second_moment)
         & _floating_tree_is_finite(proposed_second_moment)
         & _floating_tree_is_finite(proposed_updates)
         & jnp.isfinite(step_size)

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -708,6 +708,38 @@ def test_adaptive_obgd_infinite_signal_keeps_finite_updates() -> None:
     chex.assert_trees_all_close(zeroed.second_moment, second_moment)
 
 
+def test_adaptive_obgd_zero_beta2_does_not_multiply_inf_moments() -> None:
+    """beta2=0 drops leftover v; 0 * inf must not freeze the update."""
+    traces = {
+        "first": jnp.asarray((2.0, -1.0), dtype=jnp.float32),
+        "second": jnp.asarray((0.5,), dtype=jnp.float32),
+    }
+    second_moment = {
+        "first": jnp.full((2,), jnp.inf, dtype=jnp.float32),
+        "second": jnp.full((1,), jnp.inf, dtype=jnp.float32),
+    }
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    signal = jnp.asarray(-3.0, dtype=jnp.float32)
+    result = adaptive_obgd_update(
+        traces,
+        second_moment,
+        signal,
+        alpha=0.2,
+        kappa=2.0,
+        beta2=0.0,
+        epsilon=1e-4,
+        step=4,
+    )
+    assert bool(result.update_applied)
+    expected = jax.tree_util.tree_map(
+        lambda trace: jnp.square(signal * trace),
+        traces,
+    )
+    chex.assert_trees_all_close(result.second_moment, expected)
+
+
 def test_adaptive_obgd_matches_memorax_second_moment_formula() -> None:
     traces = {
         "first": jnp.asarray((2.0, -1.0), dtype=jnp.float32),


### PR DESCRIPTION
## Summary
- Adaptive stream-AC ObGD mixes leftover second moments with `beta2 * v`. Config allows `beta2=0`, which is IEEE `0 * inf` when `v` is infinite, so the fail-closed update froze unused state.
- Skip the product when `beta2` is 0 and sanitize leftover moments only in the finite-state check. Live rollback state is unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_recurrent_trace_actor_critic.py::test_adaptive_obgd_infinite_signal_keeps_finite_updates tests/test_recurrent_trace_actor_critic.py::test_adaptive_obgd_zero_beta2_does_not_multiply_inf_moments tests/test_recurrent_trace_actor_critic.py::test_adaptive_obgd_matches_memorax_second_moment_formula -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/recurrent_trace_actor_critic.py tests/test_recurrent_trace_actor_critic.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)