### PR TITLE
fix(step4): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -188,9 +188,10 @@ def _require_positive_real(name: str, value: object) -> float:
 
 
 def _require_positive_int(name: str, value: object) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be a positive integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if number < 1:
         raise ValueError(f"{name} must be positive, got {value!r}")
     if number > _INT32_MAX:
@@ -199,9 +200,10 @@ def _require_positive_int(name: str, value: object) -> int:
 
 
 def _require_nonneg_int(name: str, value: object) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if number < 0:
         raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
     if number > _INT32_MAX:

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -205,6 +205,31 @@ def test_step4_sarsa_scalars_reject_invalid_inputs(field: str, value: object) ->
         _config_with(**{field: value})
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize("field", ["n_actions", "epsilon_decay_steps"])
+def test_step4_sarsa_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: _SpoofedInt()})
+
+
+def test_step4_sarsa_hidden_sizes_rejects_class_spoofed_integers() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        _config_with(hidden_sizes=(_SpoofedInt(),))
+
+
 @pytest.mark.parametrize("value", [0, 1, "false", None])
 def test_step4_sarsa_config_requires_exact_boolean_layer_norm(value: object) -> None:
     with pytest.raises(ValueError, match="use_layer_norm must be a boolean"):


### PR DESCRIPTION
Closes #558.

## What changed

Same pattern as #400, #502, #504, #544, #547, #552, #556: `_require_positive_int` and `_require_nonneg_int` in `step4.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`Step4SARSAConfig.__post_init__` routes `n_actions`, each `hidden_sizes` entry, and `epsilon_decay_steps` through these two helpers.

## Reachability

`Step4SARSAConfig` is exported from `alberta_framework.steps.__init__`'s `__all__`, and its `__post_init__` runs the vulnerable checks on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED ACCEPTED dict_keys(['n_actions'])
SPOOFED ACCEPTED dict_keys(['n_actions', 'epsilon_decay_steps'])
```

- new tests `test_step4_sarsa_fields_reject_class_spoofed_integers` (parametrized over `n_actions`/`epsilon_decay_steps`) and `test_step4_sarsa_hidden_sizes_rejects_class_spoofed_integers`, added next to the existing `test_step4_sarsa_scalars_reject_invalid_inputs`.
- mutation check: reverted just the source fix, reran the new tests -> all 3 cases fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `64 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
