### PR TITLE
fix(swifttd): validate finite configuration

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -42,10 +42,11 @@ A Fast and Robust Algorithm for Temporal Difference Learning." RLJ/RLC 2024.
 """
 
 import math
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -63,6 +64,52 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 
 # Paper default for the step-size floor: eta_min = e^-15.
 _DEFAULT_ETA_MIN = math.exp(-15.0)
+
+_SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
+    int,
+    float,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.longdouble,
+)
+
+
+def _require_finite_config_float(
+    value: object,
+    name: str,
+    *,
+    minimum: float,
+    minimum_inclusive: bool,
+    maximum: float | None = None,
+) -> float:
+    """Return one trusted finite configuration scalar inside its host domain."""
+    message = f"{name} must be a finite real scalar in its documented range"
+    actual_type = type(value)
+    if not any(actual_type is supported_type for supported_type in _SUPPORTED_CONFIG_REAL_TYPES):
+        raise ValueError(message)
+    try:
+        concrete = float(cast(Any, value))
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(message) from error
+    minimum_valid = concrete >= minimum if minimum_inclusive else concrete > minimum
+    if (
+        not math.isfinite(concrete)
+        or not minimum_valid
+        or (maximum is not None and concrete > maximum)
+    ):
+        raise ValueError(message)
+    return concrete
 
 
 @chex.dataclass(frozen=True)
@@ -172,22 +219,44 @@ class SwiftTD:
         Raises:
             ValueError: If a hyperparameter is outside its valid range
         """
-        if initial_step_size <= 0.0:
-            raise ValueError(f"initial_step_size must be positive, got {initial_step_size}")
-        if eta <= 0.0:
-            raise ValueError(f"eta must be positive, got {eta}")
-        if eta_min <= 0.0:
-            raise ValueError(f"eta_min must be positive, got {eta_min}")
-        if not 0.0 < step_size_decay <= 1.0:
-            raise ValueError(f"step_size_decay must be in (0, 1], got {step_size_decay}")
-        if not 0.0 <= trace_decay <= 1.0:
-            raise ValueError(f"trace_decay must be in [0, 1], got {trace_decay}")
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
-        self._trace_decay = trace_decay
-        self._eta = eta
-        self._step_size_decay = step_size_decay
-        self._eta_min = eta_min
+        self._initial_step_size = _require_finite_config_float(
+            initial_step_size,
+            "initial_step_size",
+            minimum=0.0,
+            minimum_inclusive=False,
+        )
+        self._meta_step_size = _require_finite_config_float(
+            meta_step_size,
+            "meta_step_size",
+            minimum=0.0,
+            minimum_inclusive=True,
+        )
+        self._trace_decay = _require_finite_config_float(
+            trace_decay,
+            "trace_decay",
+            minimum=0.0,
+            minimum_inclusive=True,
+            maximum=1.0,
+        )
+        self._eta = _require_finite_config_float(
+            eta,
+            "eta",
+            minimum=0.0,
+            minimum_inclusive=False,
+        )
+        self._step_size_decay = _require_finite_config_float(
+            step_size_decay,
+            "step_size_decay",
+            minimum=0.0,
+            minimum_inclusive=False,
+            maximum=1.0,
+        )
+        self._eta_min = _require_finite_config_float(
+            eta_min,
+            "eta_min",
+            minimum=0.0,
+            minimum_inclusive=False,
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -14,6 +14,7 @@ IDBD-style step-sizes diverging to NaN (see
 """
 
 import functools
+import math
 
 import chex
 import jax
@@ -22,7 +23,12 @@ import jax.random as jr
 import numpy as np
 import pytest
 
-from alberta_framework.core import SwiftTD, SwiftTDState, TDLinearLearner
+from alberta_framework.core import (
+    SwiftTD,
+    SwiftTDState,
+    TDLinearLearner,
+    optimizer_from_config,
+)
 from alberta_framework.core.optimizers import LMS
 from alberta_framework.streams.alberta_plan_step1 import XDistShiftStream
 
@@ -151,15 +157,58 @@ class TestSwiftTDInit:
         state = optimizer.init(feature_dim=3)
         chex.assert_trees_all_close(jnp.exp(state.log_step_sizes), jnp.full(4, 0.1))
 
-    def test_invalid_hyperparameters_raise(self):
-        with pytest.raises(ValueError, match="initial_step_size"):
-            SwiftTD(initial_step_size=0.0)
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("initial_step_size", 0.0),
+            ("initial_step_size", math.nan),
+            ("initial_step_size", math.inf),
+            ("initial_step_size", -math.inf),
+            ("initial_step_size", True),
+            ("eta", -1.0),
+            ("eta", math.nan),
+            ("eta", math.inf),
+            ("eta_min", math.nan),
+            ("eta_min", math.inf),
+            ("meta_step_size", -1.0),
+            ("meta_step_size", math.nan),
+            ("meta_step_size", math.inf),
+            ("step_size_decay", 0.0),
+            ("trace_decay", 1.5),
+        ],
+    )
+    def test_invalid_hyperparameters_raise(self, field: str, value: object):
+        with pytest.raises(ValueError, match=field):
+            SwiftTD(**{field: value})  # type: ignore[arg-type]
+
+    def test_rejects_float_subclasses_without_calling_numeric_or_repr_hooks(self):
+        class HostileFloat(float):
+            def __float__(self):
+                raise AssertionError("numeric hook executed")
+
+            def __repr__(self):
+                raise AssertionError("repr hook executed")
+
         with pytest.raises(ValueError, match="eta"):
-            SwiftTD(eta=-1.0)
-        with pytest.raises(ValueError, match="step_size_decay"):
-            SwiftTD(step_size_decay=0.0)
-        with pytest.raises(ValueError, match="trace_decay"):
-            SwiftTD(trace_decay=1.5)
+            SwiftTD(eta=HostileFloat(0.1))
+
+    def test_numpy_scalars_are_canonicalized_to_builtin_floats(self):
+        config = SwiftTD(
+            initial_step_size=np.float32(0.01),
+            meta_step_size=np.float64(0.001),
+            trace_decay=np.float16(0.5),
+            eta=np.int64(1),
+        ).to_config()
+
+        assert all(type(value) is float for key, value in config.items() if key != "type")
+
+    def test_zero_meta_step_size_remains_supported(self):
+        state = SwiftTD(meta_step_size=0.0).init(feature_dim=3)
+        assert state.meta_step_size == 0.0
+
+    def test_config_factory_rejects_nonfinite_swifttd_values(self):
+        with pytest.raises(ValueError, match="initial_step_size"):
+            optimizer_from_config({"type": "SwiftTD", "initial_step_size": math.nan})
 
     def test_update_returns_correct_shapes(self):
         optimizer = SwiftTD(initial_step_size=0.01)


### PR DESCRIPTION
Closes #551.

## What changed

`SwiftTD` now validates every constructor hyperparameter at the host configuration boundary before JAX state allocation:

- accepts only built-in numeric values and concrete NumPy integer/float scalar families;
- rejects booleans and arbitrary scalar subclasses before invoking numeric, comparison, or representation hooks;
- canonicalizes accepted values once to built-in `float`;
- rejects NaN, both infinities, and values outside each documented range;
- validates the previously unchecked `meta_step_size`, preserving `0.0` as the supported no-adaptation setting.

The public `optimizer_from_config({"type": "SwiftTD", ...})` path receives the same validation. Finite update equations, reference trajectories, serialization keys, and state layout are unchanged.

## Scope

- `alberta_framework/core/swift_td.py`
- `tests/test_swift_td.py`

## Verification

Exact candidate head: `48a1866b6d13aff25b778d355cb52174962ab6cf`  
Base: `06b0fbd75467081d6f034c828d1dd8bcc18eea1a`

- tests-first baseline before the production change: **11 failed, 21 passed**;
- exact-head SwiftTD + optimizer registry + non-finite transaction suites: **112 passed**;
- Ruff on both changed files: **all checks passed**;
- strict mypy on `swift_td.py`: **no issues**;
- `git diff --check origin/main...HEAD`: clean;
- clean worktree with one authored commit rebased conflict-free onto current `origin/main`;
- complete live ownership scan: **44 open ASI PRs / 148 changed-file rows**, zero overlap with either target path.

The regressions cover NaN, both infinities, negative and boolean inputs, the legal zero meta rate, the public config factory, a hostile `float` subclass whose hooks must not execute, and canonicalization of accepted NumPy scalars.

## Scientific integrity

Neither target path is present in the five-claim registered evidence source inventory, and no `outputs/**` path is changed. `alberta-evidence-status` remains exit 2 because current `main` already has unrelated registered-source hash mismatches; this patch neither changes nor suppresses those findings. It does not modify frozen protocols, seeds, artifacts, evidence claims, benchmark results, or `CHANGELOG.md`.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Claude Code via CLIProxyAPI
- Attribution status: self-reported

<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
