### PR TITLE
fix(step10): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -212,9 +212,10 @@ def _require_int(
     minimum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -302,6 +302,36 @@ def test_step10_stomp_fields_reject_invalid_inputs(field: str, value: object) ->
         _config_with(**{field: value})
 
 
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_dim", "n_primitive_actions", "option_planning_backups_per_step"],
+)
+def test_step10_stomp_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: _SpoofedInt()})
+
+
+# Note: SubtaskSpec.feature_index/max_option_steps also route through this
+# module's _require_int, but SubtaskSpec.__post_init__ (core/options.py) runs
+# its own unguarded `< 0`/`< 1` comparison first and raises a raw TypeError
+# on a spoofed object before this module's helper is ever reached. That is a
+# separate, out-of-scope gap in a different file/function - not fixed here.
+
+
 def test_step10_stomp_rejects_non_tuple_subtask_specs() -> None:
     with pytest.raises(ValueError, match="subtask_specs"):
         Step10STOMPConfig(subtask_specs=[_SPEC1])  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #562.

## What changed

Same pattern as #400, #502, #504, #544, #547, #552, #556, #559: `_require_int` in `step10.py` used `isinstance(value, bool) or not isinstance(value, Integral)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `int` passes `isinstance(value, Integral)` even though `type(value) is not int`.

`_validate_stomp_facade_config`, called unconditionally from `Step10STOMPConfig.__post_init__`, routes `observation_dim`, `n_primitive_actions`, `option_planning_backups_per_step`, `feature_index`, and `max_option_steps` through this helper.

## Reachability

`Step10STOMPConfig` is exported from `alberta_framework.steps.__init__`'s `__all__`, and its `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED observation_dim ACCEPTED: 3 <class 'int'>
```

- new test `test_step10_stomp_fields_reject_class_spoofed_integers`, parametrized over `observation_dim`/`n_primitive_actions`/`option_planning_backups_per_step`, added next to the existing `test_step10_stomp_fields_reject_invalid_inputs`.
- `feature_index`/`max_option_steps` (the `SubtaskSpec`-nested fields also routed through this helper) are intentionally **not** covered by the new spoof test: `SubtaskSpec.__post_init__` in `core/options.py` runs its own unguarded comparison first and raises a raw `TypeError` on a spoofed object before this module's `_require_int` is ever reached - confirmed while writing this test. That's a separate, out-of-scope gap in a different file/function; noted in the closing issue rather than folded into this fix.
- mutation check: reverted just the source fix, reran the new test -> all 3 fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `161 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
