### PR TITLE
Skip leftover inf independent-Horde traces when gamma*lamda is 0

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -614,6 +614,12 @@ class IndependentDemonHorde:
         # Inf error zeros the ObGD step, then error * step is 0*inf=NaN.
         # Treat that the same as an inactive demon: keep previous finite
         # params, traces, and optimizer states.
+        previous_checked = demon_state.replace(
+            traces=tuple(
+                jnp.where(gamma_lamda == 0.0, jnp.zeros_like(trace), trace)
+                for trace in demon_state.traces
+            )
+        )
         proposed_finite = (
             _floating_tree_is_finite(new_params)
             & _floating_tree_is_finite(tuple(new_traces))
@@ -623,7 +629,7 @@ class IndependentDemonHorde:
             active
             & jnp.all(jnp.isfinite(observation))
             & jnp.isfinite(error)
-            & _floating_tree_is_finite(demon_state)
+            & _floating_tree_is_finite(previous_checked)
             & proposed_finite
             & normalizer_update_applied
             & jnp.all(jnp.stack(optimizer_updates_applied))
@@ -775,10 +781,23 @@ class IndependentDemonHorde:
 
         # 3. NaN means inactive; other non-finite values are rejected heads.
         requested_mask = ~jnp.isnan(cumulants)
+        checked_demon_states = tuple(
+            demon_state.replace(
+                traces=tuple(
+                    jnp.where(
+                        (gammas[i] == 0.0) | (lamdas[i] == 0.0),
+                        jnp.zeros_like(trace),
+                        trace,
+                    )
+                    for trace in demon_state.traces
+                )
+            )
+            for i, demon_state in enumerate(state.demon_states)
+        )
         global_inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(next_observation))
-            & _floating_tree_is_finite(state)
+            & _floating_tree_is_finite(state.replace(demon_states=checked_demon_states))
         )
         active_mask = (
             requested_mask

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -257,6 +257,42 @@ class TestZeroGammaBootstrap:
         for w in result.state.demon_states[0].params.weights:  # type: ignore[attr-defined]
             assert bool(jnp.all(jnp.isfinite(w)))
 
+    def test_zero_gamma_does_not_multiply_inf_traces(self) -> None:
+        """gamma*lamda=0 drops leftover traces; 0 * inf must not freeze."""
+        spec = create_horde_spec(
+            [
+                GVFSpec(
+                    name="d0",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=0.0,
+                    lamda=0.9,
+                    cumulant_index=0,
+                )
+            ]
+        )
+        horde = IndependentDemonHorde(
+            horde_spec=spec,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+        state = horde.init(2, jr.key(0))
+        ds = state.demon_states[0]
+        ds = ds.replace(traces=tuple(jnp.full_like(trace, jnp.inf) for trace in ds.traces))
+        state = state.replace(demon_states=(ds,))
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = horde.update(
+            state,
+            jnp.asarray([0.5, -0.25], dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            jnp.asarray([0.0, 0.0], dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_trees_all_equal(result.head_updates_applied, jnp.array([True]))
+        for trace in result.state.demon_states[0].traces:  # type: ignore[attr-defined]
+            assert bool(jnp.all(jnp.isfinite(trace)))
+
 
 # =============================================================================
 # gamma*lamda > 0 with hidden layers must NOT raise (the point of this class)


### PR DESCRIPTION
## Summary
- IndependentDemonHorde already skips `gamma * lamda * z` when that product is 0, but leftover infinite traces still failed the fail-closed finite-state checks on the demon and the whole Horde.
- Sanitize unused traces only in those checks. Live rollback state is unchanged.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_independent_demon_horde.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/independent_demon_horde.py tests/test_independent_demon_horde.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)