### PR TITLE
fix(forager-matched-qualification): reject numeric-alias authority/boundary records

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -4925,25 +4925,29 @@ def load_matched_current_qualification_bundle(
         or manifest.get("promotion_authorized") is not False
         or manifest.get("performance_claim") is not False
         or manifest.get("external_verification_required") is not True
-        or authority
-        != {
-            "identity": MATCHED_CURRENT_AUTHORITY_IDENTITY,
-            "content_only": True,
-            "externally_endorsed": False,
-            "external_signature_created": False,
-            "trust_profile_created": False,
-        }
-        or boundary
-        != {
-            "qualification_seed": PUBLIC_QUALIFICATION_SEED,
-            "qualification_seed_class": "public_nonbenchmark_seed",
-            "tuning_seeds_used": [],
-            "evaluation_seeds_used": [],
-            "environment_resets": len(builder.MATCHED_CURRENT_CANDIDATE_IDS),
-            "environment_transitions": 0,
-            "reward_arrays_read": 0,
-            "result_archives_opened": 0,
-        }
+        or not _json_exact_equal(
+            authority,
+            {
+                "identity": MATCHED_CURRENT_AUTHORITY_IDENTITY,
+                "content_only": True,
+                "externally_endorsed": False,
+                "external_signature_created": False,
+                "trust_profile_created": False,
+            },
+        )
+        or not _json_exact_equal(
+            boundary,
+            {
+                "qualification_seed": PUBLIC_QUALIFICATION_SEED,
+                "qualification_seed_class": "public_nonbenchmark_seed",
+                "tuning_seeds_used": [],
+                "evaluation_seeds_used": [],
+                "environment_resets": len(builder.MATCHED_CURRENT_CANDIDATE_IDS),
+                "environment_transitions": 0,
+                "reward_arrays_read": 0,
+                "result_archives_opened": 0,
+            },
+        )
     ):
         raise ForagerMatchedQualificationError("qualification authority boundary drifted")
     candidate_order = manifest.get("candidate_order")

--- a/tests/test_forager_matched_qualification.py
+++ b/tests/test_forager_matched_qualification.py
@@ -1907,6 +1907,106 @@ def test_probe_result_accepts_only_reward_blind_unendorsed_payload(tmp_path: Pat
     assert caught.value.__cause__ is overflow
 
 
+def _minimal_qualification_manifest() -> dict[str, Any]:
+    """Build the smallest manifest that reaches the authority/boundary gate.
+
+    Every field ahead of ``load_matched_current_qualification_bundle``'s
+    authority/reward-blind-boundary comparison (schema/status/candidate_order
+    consistency) is populated with its exact expected value; every field the
+    loader only inspects *after* that gate is populated with a placeholder,
+    since a manifest that fails the gate under test must never reach them.
+    """
+    candidate_order = list(builder.MATCHED_CURRENT_CANDIDATE_IDS)
+    return {
+        "schema_version": qualification.MATCHED_CURRENT_QUALIFICATION_SCHEMA_VERSION,
+        "classification": "content_only_unendorsed_nonpromoting",
+        "status": "structurally_qualified_external_trust_resolution_required",
+        "promotion_authorized": False,
+        "performance_claim": False,
+        "external_verification_required": True,
+        "authority": {
+            "identity": qualification.MATCHED_CURRENT_AUTHORITY_IDENTITY,
+            "content_only": True,
+            "externally_endorsed": False,
+            "external_signature_created": False,
+            "trust_profile_created": False,
+        },
+        "reward_blind_boundary": {
+            "qualification_seed": qualification.PUBLIC_QUALIFICATION_SEED,
+            "qualification_seed_class": "public_nonbenchmark_seed",
+            "tuning_seeds_used": [],
+            "evaluation_seeds_used": [],
+            "environment_resets": len(candidate_order),
+            "environment_transitions": 0,
+            "reward_arrays_read": 0,
+            "result_archives_opened": 0,
+        },
+        "runtime_qualification": {},
+        "qualification_probe": {},
+        "resource_accounting_semantics": {},
+        "executor_qualification_roots": {},
+        "frozen_executor_qualification_artifacts": {},
+        "candidate_order": candidate_order,
+        "sources": {},
+        "candidates": {},
+        "open_protocol_sha256": "",
+    }
+
+
+def _write_qualification_manifest(root: Path, manifest: dict[str, Any]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_raw = qualification._canonical_json_bytes(manifest)  # noqa: SLF001
+    (root / "manifest.json").write_bytes(manifest_raw)
+    digest = hashlib.sha256(manifest_raw).hexdigest()
+    (root / "manifest.json.sha256").write_bytes(f"{digest}\n".encode("ascii"))
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "alias"),
+    [
+        ("authority", "content_only", 1),
+        ("authority", "externally_endorsed", 0),
+        ("reward_blind_boundary", "environment_transitions", False),
+        ("reward_blind_boundary", "reward_arrays_read", 0.0),
+    ],
+)
+def test_manifest_rejects_wrong_type_numeric_aliases_in_authority_boundary(
+    tmp_path: Path,
+    section: str,
+    field: str,
+    alias: object,
+) -> None:
+    manifest = _minimal_qualification_manifest()
+    manifest[section][field] = alias
+    root = tmp_path / "qualification"
+    _write_qualification_manifest(root, manifest)
+
+    with pytest.raises(
+        qualification.ForagerMatchedQualificationError,
+        match="qualification authority boundary drifted",
+    ):
+        qualification.load_matched_current_qualification_bundle(root)
+
+
+def test_manifest_with_true_types_reaches_past_authority_boundary_gate(
+    tmp_path: Path,
+) -> None:
+    """A byte-identical, correctly-typed manifest must not trip this gate.
+
+    It is still rejected further down (placeholder executor/source/candidate
+    fields), proving the gate under test is not merely rejecting everything.
+    """
+    manifest = _minimal_qualification_manifest()
+    root = tmp_path / "qualification"
+    _write_qualification_manifest(root, manifest)
+
+    with pytest.raises(
+        qualification.ForagerMatchedQualificationError,
+        match="runtime qualification drifted",
+    ):
+        qualification.load_matched_current_qualification_bundle(root)
+
+
 @pytest.mark.parametrize(
     ("section", "field", "alias"),
     [


### PR DESCRIPTION
Fixes #497.

## What changed

`load_matched_current_qualification_bundle` in
`alberta_framework/benchmarks/forager_matched_qualification.py` compared the
persisted manifest's `authority` and `reward_blind_boundary` records with
plain Python `!=`. JSON numeric aliases cross that boundary because
`1 == True`, `0 == False`, and `0.0 == 0` in Python, so an authority record
with `"content_only": 1` (instead of `true`) satisfied the equality check
and passed the gate. This is the fifth instance of the bug class documented
in #450/#460/#466/#471; PR #472 already hardened the **probe** side of this
same file with the `_json_exact_equal` helper (canonical-JSON byte
comparison that preserves the int/float/bool distinction) — the **manifest**
side (lines 4928-4946 at this PR's base) was the one path still using the
weaker comparison, exactly as #497 describes.

Fix: reuse `_json_exact_equal` for both the `authority` and
`reward_blind_boundary` record comparisons, matching the pattern already
used elsewhere in the same function/file (e.g. the probe's own
`authority`/`reward_blind_boundary` check a few hundred lines above).

## Confirmed directly (before touching the source)

```text
attacker authority = {"identity": "content_only_unendorsed_v1", "content_only": 1,
                      "externally_endorsed": 0, "external_signature_created": 0,
                      "trust_profile_created": 0}
plain != says attacker differs? False
current gate would ACCEPT attacker: True
_json_exact_equal (fixed) says equal? False
```

## Reachability

`load_matched_current_qualification_bundle` loads the persisted qualification
manifest and feeds `forager_matched_campaign.py` and
`forager_matched_sealed_evaluation_campaign.py`; it is publicly reachable
through the installed `alberta-forager-matched-qualification` console
script family, same as documented in #471/#497.

## Verification

Commit under test: `a9d54ae076d89885d382ba039749ce34ac36c3ca`

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_qualification.py -q -o addopts=""
112 passed in 4.27s

$ .venv/bin/python -m pytest tests/test_forager_matched_campaign.py tests/test_forager_matched_sealed_evaluation_campaign.py tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py tests/test_forager_matched_qualification_integration.py tests/test_forager_matched_final_analysis.py -q -o addopts="" -m "not slow"
82 passed, 34 deselected in 20.93s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/forager_matched_qualification.py tests/test_forager_matched_qualification.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

New tests (failing-test-first): `test_manifest_rejects_wrong_type_numeric_aliases_in_authority_boundary`
(4 parametrized alias cases mirroring PR #472's
`test_persisted_probe_rejects_wrong_type_numeric_aliases`) and
`test_manifest_with_true_types_reaches_past_authority_boundary_gate` (control:
a correctly-typed manifest is not rejected by *this* gate — it is only
rejected further down by the test's intentionally-placeholder fields, proving
the gate isn't just rejecting everything).

Mutation-resistance verified independently: reverted just the source fix
(`git stash push -- alberta_framework/benchmarks/forager_matched_qualification.py`,
kept the tests), reran:

```text
$ .venv/bin/python -m pytest tests/test_forager_matched_qualification.py -q -o addopts="" -k "manifest_rejects_wrong_type_numeric_aliases_in_authority_boundary or manifest_with_true_types_reaches_past_authority_boundary_gate"
4 failed, 1 passed, 107 deselected in 3.92s
```

All 4 alias cases failed — each one now trips the *next* check instead
(`runtime qualification drifted`), proving they slip past the vulnerable
gate on unpatched `main`. The control case still passed, confirming the test
targets the specific gate and not some downstream check. Restored the fix
(`git stash pop`) and reran: 112/112 green again.

## Environment note

Local JAX has no usable CUDA runtime in this container (`cuInit` fails on
plugin load); JAX falls back to CPU and every executed test still passes.
This does not affect the change — it touches only Python-level JSON
comparison logic with no JAX involvement.

## Scope

Only the two manifest record comparisons this issue names
(`authority`, `reward_blind_boundary` at `load_matched_current_qualification_bundle`,
lines 4928-4946). Other plain-`!=` dict comparisons in the file that #497
explicitly marks out of scope (`qualification_probe` at line 4560, `runtime`
at line 4732 — both string-only records) are untouched.

Receipt signing deferred — operator handling centrally.



---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05WJ79A9SDXFFKQ6ZSWRSJE","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T18:15:24.715Z","completed_at":"2026-08-16T18:15:50.496Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f378fb0fd9f241d6247d6195bb36277330d52319a7dae35a354e80593f8d68c7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"cc703874-697c-43d9-94cb-e5fde9e9bb78","object_id":"sha256:f378fb0fd9f241d6247d6195bb36277330d52319a7dae35a354e80593f8d68c7","sha256":"f378fb0fd9f241d6247d6195bb36277330d52319a7dae35a354e80593f8d68c7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"6PtvSOz2-KVsescB6Z710YaXH3HfwogJBi9JLI2LpAHUiFlQRh5GU1tsZOBRuGmbUm82i2pGSgA7wrRf0OFyDQ"}} -->
