### PR TITLE
fix(core): gate SARSAAgent.update on a valid last_action

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -519,12 +519,28 @@ class SARSAAgent:
 
         # Build cumulants: NaN for all except last_action gets sarsa_target
         cumulants = jnp.full(self._horde.n_demons, jnp.nan, dtype=jnp.float32)
-        # Only update the head corresponding to the action we took at s_t
-        cumulants = cumulants.at[state.last_action].set(sarsa_target)
+        # Only update the head corresponding to the action we took at s_t.
+        # An update before select_action leaves last_action == -1, which
+        # modular-indexes to the last head; gate it out instead so no control
+        # head learns from a premature update.
+        action_valid = (state.last_action >= 0) & (state.last_action < n_actions)
+        safe_last_action = jnp.clip(
+            state.last_action,
+            0,
+            n_actions - 1,
+        )
+        updated_cumulants = cumulants.at[safe_last_action].set(sarsa_target)
+        cumulants = jnp.where(action_valid, updated_cumulants, cumulants)
 
         # Add prediction demon cumulants if any
         if prediction_cumulants is not None:
-            cumulants = cumulants.at[n_actions:].set(prediction_cumulants)
+            cumulants = cumulants.at[n_actions:].set(
+                jnp.where(
+                    action_valid,
+                    prediction_cumulants,
+                    jnp.full_like(prediction_cumulants, jnp.nan),
+                )
+            )
 
         # Horde update: learns from (s_t, cumulants, s'). Control heads use
         # zero transition discounts (the SARSA target above already contains
@@ -563,8 +579,8 @@ class SARSAAgent:
             new_learner_state = new_learner_state.replace(head_traces=tuple(head_traces))
 
         # TD error for the taken action
-        q_old = q_previous[state.last_action]
-        td_error = sarsa_target - q_old
+        q_old = q_previous[safe_last_action]
+        td_error = jnp.where(action_valid, sarsa_target - q_old, 0.0)
 
         # Epsilon decay
         cfg = self._sarsa_config

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -214,6 +214,44 @@ class TestSARSAUpdate:
         chex.assert_shape(result.td_error, ())
         assert result.reward == 1.0
 
+    def test_update_before_select_action_trains_no_head(self):
+        """last_action == -1 must not wrap to the last control head."""
+        agent = _make_agent(n_actions=4, epsilon_start=0.0)
+        state = agent.init(feature_dim=4, key=jr.key(3))
+        next_obs = jnp.ones(4, dtype=jnp.float32) * 2.0
+
+        # No select_action was called, so last_action == -1.
+        assert int(state.last_action) == -1
+        result = agent.update(
+            state,
+            reward=jnp.array(1.0),
+            observation=next_obs,
+            terminated=jnp.array(0.0),
+            next_action=jnp.array(0, dtype=jnp.int32),
+        )
+
+        assert float(result.td_error) == 0.0
+        chex.assert_trees_all_close(
+            result.state.learner_state.trunk_params.weights,
+            state.learner_state.trunk_params.weights,
+            atol=0.0,
+        )
+        chex.assert_trees_all_close(
+            result.state.learner_state.trunk_params.biases,
+            state.learner_state.trunk_params.biases,
+            atol=0.0,
+        )
+        chex.assert_trees_all_close(
+            result.state.learner_state.head_params.weights,
+            state.learner_state.head_params.weights,
+            atol=0.0,
+        )
+        chex.assert_trees_all_close(
+            result.state.learner_state.head_params.biases,
+            state.learner_state.head_params.biases,
+            atol=0.0,
+        )
+
     def test_terminated_no_bootstrap(self):
         """At terminal state, target = r (no bootstrapping)."""
         agent = _make_agent(n_actions=2, gamma=0.99, epsilon_start=0.0)


### PR DESCRIPTION
Fixes #518.

`SARSAAgent.update` with `last_action == -1` (update before `select_action`) modular-indexed to the last control head and silently trained it. Now the update is neutralized — all cumulants NaN and TD error zero — unless `last_action` is in range, mirroring `AverageRewardHordeActorCritic`. Regression test added. Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).