### PR TITLE
fix(core): validate SARSAConfig hyperparameters

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -20,7 +20,9 @@ Reference: Sutton & Barto 2018, Section 10.1 (Episodic Semi-gradient SARSA)
 
 import dataclasses
 import functools
+import math
 import time
+from numbers import Real
 from typing import Any
 
 import chex
@@ -72,6 +74,32 @@ class SARSAConfig:
     epsilon_start: float = 0.1
     epsilon_end: float = 0.01
     epsilon_decay_steps: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate SARSA hyperparameters at construction time."""
+        if self.n_actions < 1:
+            raise ValueError("n_actions must be at least 1")
+        if not isinstance(self.gamma, Real) or isinstance(self.gamma, bool):
+            raise ValueError("gamma must be a real number")
+        if not math.isfinite(self.gamma) or not 0.0 <= self.gamma < 1.0:
+            raise ValueError("gamma must be a finite value in [0, 1)")
+        for name, value in (
+            ("epsilon_start", self.epsilon_start),
+            ("epsilon_end", self.epsilon_end),
+        ):
+            if not isinstance(value, Real) or isinstance(value, bool):
+                raise ValueError(f"{name} must be a real number")
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be a finite value in [0, 1]")
+        if self.epsilon_decay_steps < 0:
+            raise ValueError("epsilon_decay_steps must be non-negative")
+        if (
+            self.epsilon_decay_steps > 0
+            and self.epsilon_end > self.epsilon_start
+        ):
+            raise ValueError(
+                "epsilon_end must not exceed epsilon_start when decaying"
+            )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -49,6 +49,36 @@ def _make_agent(
 # =============================================================================
 
 
+class TestSARSAConfigValidation:
+    """``SARSAConfig`` must reject invalid hyperparameters at construction."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"n_actions": 0},
+            {"n_actions": -2},
+            {"gamma": 1.0},
+            {"gamma": -0.1},
+            {"gamma": float("nan")},
+            {"gamma": float("inf")},
+            {"gamma": True},
+            {"epsilon_start": 1.5},
+            {"epsilon_start": float("nan")},
+            {"epsilon_end": -0.1},
+            {"epsilon_end": 2.0},
+            {"epsilon_decay_steps": -1},
+            {"epsilon_start": 0.3, "epsilon_end": 0.5, "epsilon_decay_steps": 10},
+        ],
+    )
+    def test_rejects_invalid_config(self, kwargs):
+        with pytest.raises(ValueError):
+            SARSAConfig(n_actions=kwargs.pop("n_actions", 2), **kwargs)
+
+    def test_accepts_valid_config(self):
+        config = SARSAConfig(n_actions=2, gamma=0.99, epsilon_start=0.1, epsilon_end=0.01)
+        assert config.n_actions == 2
+
+
 class TestSARSAInit:
     """Tests for SARSAAgent initialization."""
 


### PR DESCRIPTION
Fixes #519.

`SARSAConfig` stored `n_actions`, `gamma`, and the epsilon values unchecked: NaN gamma silently poisoned every SARSA target, and an inverted decay range (`epsilon_end` > `epsilon_start`) produced constant exploration instead of a decay schedule. Values are now validated at construction time via `__post_init__`. Regression tests added.

Contribution provenance: AI-assisted implementation (provider: Anthropic, model: claude-sonnet-4).