### PR TITLE
fix(core): reject class-spoofed non-real scalars in gradient mixer

### DIFF
--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -44,9 +44,10 @@ def _strict_float32_scalar(
 ) -> float:
     """Validate a finite nonnegative scalar with a stable float32 encoding."""
 
-    if not isinstance(value, Real) or isinstance(value, bool):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{label} must be a real scalar")
-    normalized = float(value)
+    normalized = float(cast(Real, value))
     if not math.isfinite(normalized) or normalized < 0.0:
         raise ValueError(f"{label} must be finite and non-negative")
     if not allow_zero and normalized == 0.0:

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -99,6 +99,29 @@ def test_config_rejects_nonfinite_negative_or_unknown_rules(
         RepresentationGradientMixerConfig(**kwargs)  # type: ignore[arg-type]
 
 
+class _SpoofedFloat:
+    """Mimics ``float`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["behavior_weight", "grounded_world_weight", "normalization_epsilon"],
+)
+def test_config_rejects_class_spoofed_float_fields(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        RepresentationGradientMixerConfig(
+            representation_dim=2,
+            **{field: _SpoofedFloat()},  # type: ignore[arg-type]
+        )
+
+
 def test_full_mode_matches_disclosed_weighted_algebra() -> None:
     config = RepresentationGradientMixerConfig(
         representation_dim=3,


### PR DESCRIPTION
Closes #569.

## What changed

Same isinstance-spoofing class as the `_require_int` family (#400, #502, #504, #544, #547, #552, #556, #559, #563) and the npz-import `ewm_decay` fix (#424): `_strict_float32_scalar` in `representation_gradient_mixer.py` used `not isinstance(value, Real) or isinstance(value, bool)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passes `isinstance(value, Real)` even though `type(value) is not float`.

`RepresentationGradientMixerConfig.__post_init__` routes `behavior_weight`, `grounded_world_weight`, `normalization_epsilon`, `behavior_clip_norm`, `grounded_world_clip_norm`, and `final_clip_norm` through this helper.

## Reachability

`RepresentationGradientMixerConfig` is exported from both `alberta_framework.core.__init__` and package-root `__all__`, and its `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED behavior_weight ACCEPTED: <FakeFloat object> <class 'FakeFloat'>
```

notably worse than the `_require_int` family: `_strict_float32_scalar` computes a canonicalized return value, but no call site in `__post_init__` captures it - so the raw spoofed object (or, on a legitimate non-builtin `Real`, the raw un-canonicalized input) is what actually ends up stored on the frozen config. That's a separate, likely pre-existing bug (validated data silently discarded); disclosed in the closing issue rather than folded into this fix's scope.

- new test `test_config_rejects_class_spoofed_float_fields`, parametrized over `behavior_weight`/`grounded_world_weight`/`normalization_epsilon`, added next to the existing `test_config_rejects_nonfinite_negative_or_unknown_rules`.
- mutation check: reverted just the source fix, reran the new test -> all 3 fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `30 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
