### PR TITLE
fix(core): reject class-spoofed non-real scalars in partner policy fusion

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -84,9 +84,10 @@ def _strict_float32(
 ) -> float:
     """Return a finite normal float32-compatible configuration scalar."""
 
-    if not isinstance(value, Real) or isinstance(value, bool):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real scalar, not boolean")
-    normalized = float(value)
+    normalized = float(cast(Real, value))
     if not math.isfinite(normalized) or abs(normalized) > _FLOAT32_MAX:
         raise ValueError(f"{name} must be finite and float32-compatible")
     if positive and (normalized < 0.0 or (not allow_zero and normalized == 0.0)):

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -207,6 +207,32 @@ def test_config_rejects_invalid_values(field: str, value: Any) -> None:
         PartnerPolicyFusionConfig(**kwargs)
 
 
+class _SpoofedFloat:
+    """Mimics ``float`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["learning_rate", "max_abs_weight", "communication_cost_weight"],
+)
+def test_config_rejects_class_spoofed_float_fields(field: str) -> None:
+    kwargs: dict[str, Any] = {
+        "max_partners": 2,
+        "context_dim": 2,
+        "n_actions": 3,
+        field: _SpoofedFloat(),
+    }
+    with pytest.raises(ValueError, match=field):
+        PartnerPolicyFusionConfig(**kwargs)
+
+
 def test_strict_config_roundtrip_and_l0_status() -> None:
     fusion = _fusion()
     restored = PartnerPolicyFusion.from_config(fusion.to_config())


### PR DESCRIPTION
Closes #571.

## What changed

Same isinstance-spoofing class as the `_require_int` family and the `representation_gradient_mixer` fix (#569): `_strict_float32` in `partner_policy_fusion.py` used `not isinstance(value, Real) or isinstance(value, bool)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passes `isinstance(value, Real)` even though `type(value) is not float`.

`PartnerPolicyFusionConfig.__post_init__` routes `learning_rate`, `max_abs_weight`, `max_abs_context`, `max_communication_cost`, `assistance_value_bound`, `max_abs_declared_score`, `communication_cost_weight`, `base_blend_weight`, `option_blend_weight`, `partner_blend_weight`, and more through this helper.

## Reachability

`PartnerPolicyFusionConfig` is exported from both `alberta_framework.core.__init__` and package-root `__all__`, and its `__post_init__` runs the vulnerable check on every construction - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED learning_rate ACCEPTED: <FakeFloat object> <class 'FakeFloat'>
```

- new test `test_config_rejects_class_spoofed_float_fields`, parametrized over `learning_rate`/`max_abs_weight`/`communication_cost_weight`, added next to the existing `test_config_rejects_invalid_values`.
- mutation check: reverted just the source fix, reran the new test -> all 3 fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `60 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
