### PR TITLE
fix(core): reject class-spoofed non-real gamma/lamda in GVFSpec

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -668,7 +668,8 @@ class TraceMode(enum.Enum):
 def _normalized_gvf_probability(name: str, value: object) -> float:
     """Return one static GVF probability with stable float32 semantics."""
     message = f"{name} must be a real non-boolean scalar in [0, 1]"
-    if not isinstance(value, Real) or isinstance(value, (bool, np.bool_)):
+    actual_type = type(value)
+    if issubclass(actual_type, (bool, np.bool_)) or not issubclass(actual_type, Real):
         raise ValueError(message)
     try:
         comparable = cast(Any, value)
@@ -676,7 +677,7 @@ def _normalized_gvf_probability(name: str, value: object) -> float:
             raise ValueError(message)
         if comparable != 0 and comparable < _FLOAT32_TINY:
             raise ValueError(f"{name} must be zero or a normal float32 value in [0, 1]")
-        normalized = float(value)
+        normalized = float(comparable)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
     if not math.isfinite(normalized) or not 0.0 <= normalized <= 1.0:

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -173,6 +173,45 @@ class TestGVFSpec:
         with pytest.raises(ValueError, match=field):
             GVFSpec.from_config(config)
 
+    @pytest.mark.parametrize("field", ["gamma", "lamda"])
+    def test_discount_and_trace_decay_reject_class_spoofed_float(self, field):
+        class _SpoofedFloat:
+            """Mimics ``float`` via ``__class__`` to defeat ``isinstance``."""
+
+            @property
+            def __class__(self) -> type:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                return 0.5
+
+            def __lt__(self, other: object) -> bool:
+                return 0.5 < other  # type: ignore[operator]
+
+            def __gt__(self, other: object) -> bool:
+                return 0.5 > other  # type: ignore[operator]
+
+            def __eq__(self, other: object) -> bool:
+                return 0.5 == other
+
+            def __ne__(self, other: object) -> bool:
+                return 0.5 != other
+
+            def __hash__(self) -> int:
+                return hash(0.5)
+
+        kwargs = {
+            "name": "invalid",
+            "demon_type": DemonType.PREDICTION,
+            "gamma": 0.9,
+            "lamda": 0.8,
+            "cumulant_index": 0,
+        }
+        kwargs[field] = _SpoofedFloat()
+
+        with pytest.raises(ValueError, match=field):
+            GVFSpec(**kwargs)
+
     def test_discount_and_trace_decay_normalize_supported_real_scalars(self):
         spec = GVFSpec(
             name="boundary",


### PR DESCRIPTION
Closes #573.

## What changed

Same isinstance-spoofing class as the `_require_int` family and the `representation_gradient_mixer`/`partner_policy_fusion` fixes (#569, #571): `_normalized_gvf_probability` in `types.py` used `not isinstance(value, Real) or isinstance(value, (bool, np.bool_))`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passes `isinstance(value, Real)` even though `type(value) is not float`.

`GVFSpec.__post_init__` routes `gamma` and `lamda` through this helper.

## Reachability

`GVFSpec` is exported at package root and constructed directly by Horde/GVF facades throughout the codebase - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED gamma ACCEPTED: 0.5 <class 'float'>
```
this one is worse than a bare rejection failure: the spoofed object is silently *canonicalized* into a genuine `float(0.5)` and stored on the frozen dataclass, indistinguishable from a legitimate input downstream.

- new test `test_discount_and_trace_decay_reject_class_spoofed_float`, parametrized over `gamma`/`lamda`, added next to the existing `test_discount_and_trace_decay_require_concrete_float32_reals` in `TestGVFSpec`.
- mutation check: reverted just the source fix, reran the new test -> both fields fail with `DID NOT RAISE ValueError`. restored -> passes.
- full file: `47 passed`.
- collateral check: `types.py` is imported by 33 other modules, so also ran `test_horde.py`, `test_off_policy_horde.py`, `test_mixed_horde.py`, `test_independent_demon_horde.py` (75 tests) - all pass, no collateral breakage.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, collateral spot-check, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
