### PR TITLE
fix(associative-memory): reject class-spoofed non-real config scalars

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -171,9 +171,10 @@ class AssociativeMemoryLearningResult:
 
 
 def _finite_real(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number")
-    number = float(value)
+    number = float(cast(Real, value))
     if not math.isfinite(number):
         raise ValueError(f"{name} must be finite")
     return number
@@ -229,12 +230,13 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     )
     if not 0.0 < initial_budget_fraction <= 1.0:
         raise ValueError("initial_budget_fraction must be in (0, 1]")
-    if isinstance(config.min_effective_budget, bool) or not isinstance(
-        config.min_effective_budget,
+    min_effective_budget_type = type(config.min_effective_budget)
+    if issubclass(min_effective_budget_type, bool) or not issubclass(
+        min_effective_budget_type,
         Integral,
     ):
         raise ValueError("min_effective_budget must be an integer")
-    min_effective_budget = int(config.min_effective_budget)
+    min_effective_budget = int(cast(Integral, config.min_effective_budget))
     if min_effective_budget < 1:
         raise ValueError("min_effective_budget must be positive")
     if min_effective_budget > config.max_features:

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -87,6 +87,96 @@ def test_config_rejects_invalid_adaptive_scalars(
             AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
 
 
+class _SpoofedFloat:
+    """Mimics ``float`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+
+class _RaisingSpoofedFloat:
+    """Mimics ``float`` via ``__class__`` but raises when actually converted."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        raise RuntimeError("untrusted __float__ hook executed")
+
+
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 1
+
+
+class _RaisingSpoofedInt:
+    """Mimics ``int`` via ``__class__`` but raises when actually converted."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        raise RuntimeError("untrusted __int__ hook executed")
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["scope_lr", "budget_lr", "initial_budget_fraction", "scope_logit_clip"],
+)
+def test_config_rejects_class_spoofed_real_fields(field: str) -> None:
+    base = AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2)
+    payload = base.to_config()
+    payload[field] = _SpoofedFloat()
+
+    with pytest.raises(ValueError, match=field):
+        AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["scope_lr", "budget_lr", "initial_budget_fraction", "scope_logit_clip"],
+)
+def test_config_raising_spoofed_real_field_stays_a_value_error(field: str) -> None:
+    """A spoofed real whose ``__float__`` raises must not leak a raw exception."""
+    base = AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2)
+    payload = base.to_config()
+    payload[field] = _RaisingSpoofedFloat()
+
+    with pytest.raises(ValueError, match=field):
+        AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
+
+
+def test_config_rejects_class_spoofed_min_effective_budget() -> None:
+    base = AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2)
+    payload = base.to_config()
+    payload["min_effective_budget"] = _SpoofedInt()
+
+    with pytest.raises(ValueError, match="min_effective_budget"):
+        AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
+
+
+def test_config_raising_spoofed_min_effective_budget_stays_a_value_error() -> None:
+    """A spoofed int whose ``__int__`` raises must not leak a raw exception."""
+    base = AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2)
+    payload = base.to_config()
+    payload["min_effective_budget"] = _RaisingSpoofedInt()
+
+    with pytest.raises(ValueError, match="min_effective_budget"):
+        AssociativeMemoryLearner(AssociativeMemoryConfig.from_config(payload))
+
+
 def test_silent_feature_does_not_turn_inf_value_into_nan() -> None:
     """Weight 0 times an inf stored row is 0*inf = NaN in the evidence sum."""
     learner = AssociativeMemoryLearner(


### PR DESCRIPTION
Closes #576.

## What changed

`_finite_real` in `alberta_framework/core/associative_memory.py` guarded against `bool`/non-`Real` values with `isinstance(value, bool) or not isinstance(value, Real)`, and the inline `min_effective_budget` check used the identical spoofable pattern against `Integral`. `isinstance()` consults an object's `__class__` attribute, which is overridable via a `@property`, so an object whose `__class__` property lies about its type passes the check even though its true type is not an actual registered `Real`/`Integral`.

Two concrete consequences on unpatched `main`:

1. A well-behaved `__class__`-spoofed real is silently accepted and stored **unconverted** in the frozen `AssociativeMemoryConfig` (not the documented `float`).
2. A `__class__`-spoofed object whose `__float__`/`__int__` raises leaks that **raw exception** out of `AssociativeMemoryLearner.__init__` instead of the documented `ValueError`.

Fix: switch both checks to read the real, non-spoofable type slot via `type(value)` + `issubclass`, matching the pattern already used to fix the same bug class elsewhere in this repository (`representation_gradient_mixer.py`, `partner_policy_fusion.py`).

## Reachability

`AssociativeMemoryConfig`/`AssociativeMemoryLearner` are exported at package root (`alberta_framework.__init__`) and constructed by the Step 2 facade (`alberta_framework/steps/step2.py::make_step2_associative_learner`) from caller-supplied scalars for `scope_lr`, `budget_lr`, `initial_budget_fraction`, `scope_logit_clip`, and `min_effective_budget` — ordinary public config fields, not internal-only state.

## Verification

Exact head this fix is built on: `bdf8ce2b4974e14f3dc37b5858030a59f5a2182b` (branch rebased clean onto `origin/main`, no divergence).

```text
$ .venv/bin/python -m pytest tests/test_associative_memory.py -q -o addopts=""
52 passed in 39.40s

$ .venv/bin/python -m pytest tests/test_step2_production.py tests/test_step2_pretraining.py tests/test_associative_memory.py -q -o addopts=""
61 passed in 36.24s

$ .venv/bin/python -m ruff check alberta_framework/core/associative_memory.py tests/test_associative_memory.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ git diff --check
(clean, no output)
```

New tests (failing-test-first, all 10 parametrized/individual cases confirmed red before the source fix):

- `test_config_rejects_class_spoofed_real_fields` (scope_lr, budget_lr, initial_budget_fraction, scope_logit_clip)
- `test_config_raising_spoofed_real_field_stays_a_value_error` (same four fields, `__float__` raises)
- `test_config_rejects_class_spoofed_min_effective_budget`
- `test_config_raising_spoofed_min_effective_budget_stays_a_value_error` (`__int__` raises)

Mutation check: reverted only `alberta_framework/core/associative_memory.py` (`git stash push -- alberta_framework/core/associative_memory.py`, kept the new tests) — all 10 new tests failed with the exact pre-fix symptoms (silent "DID NOT RAISE ValueError" for the well-behaved spoof, raw `RuntimeError` leaking through for the raising spoof). Restored the fix — all 10 green again.

Also ran the broader fast lane touching this module and its neighbors: `pytest tests -q -m "not slow and not package" -k "associative or step2 or pipeline"` → `89 passed, 8033 deselected`.

**Environment note:** this machine has no functioning CUDA/GPU driver for the installed `jaxlib` CUDA plugin (`cuInit(0) failed: Unknown CUDA error 303`); JAX transparently falls back to CPU and every test above executed and passed on CPU. This is a host limitation, not something this change touches.

## Evidence

<!-- evidence-head -->
bdf8ce2b4974e14f3dc37b5858030a59f5a2182b

<!-- evidence-row:logs -->
```text
red (source fix reverted, tests kept):
FAILED tests/test_associative_memory.py::test_config_rejects_class_spoofed_real_fields[scope_lr]
FAILED tests/test_associative_memory.py::test_config_rejects_class_spoofed_real_fields[budget_lr]
FAILED tests/test_associative_memory.py::test_config_rejects_class_spoofed_real_fields[initial_budget_fraction]
FAILED tests/test_associative_memory.py::test_config_rejects_class_spoofed_real_fields[scope_logit_clip]
FAILED tests/test_associative_memory.py::test_config_raising_spoofed_real_field_stays_a_value_error[scope_lr]
FAILED tests/test_associative_memory.py::test_config_raising_spoofed_real_field_stays_a_value_error[budget_lr]
FAILED tests/test_associative_memory.py::test_config_raising_spoofed_real_field_stays_a_value_error[initial_budget_fraction]
FAILED tests/test_associative_memory.py::test_config_raising_spoofed_real_field_stays_a_value_error[scope_logit_clip]
FAILED tests/test_associative_memory.py::test_config_rejects_class_spoofed_min_effective_budget
FAILED tests/test_associative_memory.py::test_config_raising_spoofed_min_effective_budget_stays_a_value_error
10 failed, 42 deselected in 1.85s

green (fix restored):
tests/test_associative_memory.py .................................................... [100%]
52 passed in 39.40s
```

<!-- evidence-row:domain-artifact -->
```text
SPOOFED scope_lr ACCEPTED (pre-fix): <__main__.SpoofedFloat object at 0x71beedf8a660> <class '__main__.SpoofedFloat'>
LEAKED raw exception (pre-fix): RuntimeError('boom - untrusted __float__ hook executed')
LEAKED raw exception (pre-fix): RuntimeError('boom - untrusted __int__ hook executed')
```

## Provenance

AI provider/model: anthropic / claude-sonnet-5.
Client / agent tooling: Claude Code, lane `rama0x1-asi-claude-worker`.
Attribution status: self-reported. All verification above (mutation testing, full test-file and cross-module runs, lint/typecheck, reachability trace, live reproduction of the bug before writing the fix) was performed by me in this session.

Receipt signing deferred — operator handling centrally for this pipeline; not attempted from this session.



---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05ZDA5QB6RB0R02MG7DHD5A","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T19:05:09.560Z","completed_at":"2026-08-16T19:05:35.201Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1850d989e2a9f442d016349dfef3c8a1eaf45cb723b1830cb8210dcafe3ad814","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"06bb0861-5e3c-4482-bd08-6fdc7298dc40","object_id":"sha256:1850d989e2a9f442d016349dfef3c8a1eaf45cb723b1830cb8210dcafe3ad814","sha256":"1850d989e2a9f442d016349dfef3c8a1eaf45cb723b1830cb8210dcafe3ad814"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"k2eFLLchCBIVaVVsnRUCegrQmIaqoZrYLdGh9uiUffvOe6MDZz1AN7OXARAf-exaLMRzReBO6hUHfMTIAiv7CQ"}} -->
