### PR TITLE
fix(streams): reject class-spoofed non-real RiverSwim probabilities

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -67,11 +67,12 @@ _FLOAT32_TINY_RATIO = _FLOAT32_TINY.as_integer_ratio()
 def _exact_real_ratio(name: str, value: object) -> tuple[int, int]:
     """Return the exact ratio of a supported concrete real scalar."""
     message = f"{name} must be finite, positive, and a normal float32 probability"
-    if not isinstance(value, Real) or isinstance(value, (bool, np.bool_)):
+    actual_type = type(value)
+    if issubclass(actual_type, (bool, np.bool_)) or not issubclass(actual_type, Real):
         raise ValueError(message)
     try:
-        if isinstance(value, Integral):
-            ratio = (int(value), 1)
+        if issubclass(actual_type, Integral):
+            ratio = (int(cast(Any, value)), 1)
         else:
             ratio = cast(Any, value).as_integer_ratio()
         numerator, denominator = ratio

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -1,6 +1,7 @@
 """Tests for the closed-loop micro-MDPs (actions affect observations)."""
 
 from fractions import Fraction
+from numbers import Real
 
 import chex
 import jax
@@ -413,6 +414,30 @@ class TestRiverSwim:
         kwargs = {field: value}
         with pytest.raises(ValueError, match=field):
             RiverSwimMDP(RiverSwimConfig(**kwargs))
+
+    @pytest.mark.parametrize("field", ["p_right_up", "p_right_down"])
+    def test_transition_probabilities_reject_class_spoofed_reals(self, field):
+        """``__class__``-spoofed non-``Real`` objects must not defeat validation."""
+
+        class _SpoofedFloat:
+            """Mimics ``float`` via ``__class__`` to defeat ``isinstance``."""
+
+            @property
+            def __class__(self) -> type:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                return 0.3
+
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (3, 10)
+
+        assert isinstance(_SpoofedFloat(), Real)
+        assert not issubclass(type(_SpoofedFloat()), Real)
+
+        kwargs = {field: _SpoofedFloat()}
+        with pytest.raises(ValueError, match=field):
+            RiverSwimMDP(RiverSwimConfig(**kwargs))  # type: ignore[arg-type]
 
     def test_transition_probabilities_preserve_real_scalars_and_normalize_runtime(self):
         env = RiverSwimMDP(


### PR DESCRIPTION
Closes #580.

## What changed

Same isinstance-spoofing class as the `_require_int` family (#400, #502,
#504, #544, #547, #552, #556, #559, #563) and the recently-fixed
`representation_gradient_mixer.py` (#570), `partner_policy_fusion.py`
(#572), `types.py` GVFSpec (#574), and `associative_memory.py` (#577):
`_exact_real_ratio` in `alberta_framework/streams/closed_loop.py` used
`not isinstance(value, Real) or isinstance(value, (bool, np.bool_))`.
`isinstance()` consults `__class__`, which is overridable via a
`@property`, so an object whose `__class__` property returns `float`
passes `isinstance(value, Real)` even though `type(value)` has no real
relationship to `numbers.Real`.

`RiverSwimMDP.__init__` routes `RiverSwimConfig.p_right_up` and
`p_right_down` through this helper before narrowing them to float32
probabilities in `_normalized_positive_float32_probability`. Both
`RiverSwimConfig` and `RiverSwimMDP` are exported from
`alberta_framework.streams`, so this is publicly reachable with an
ordinary concrete config.

Fix: switch the type gate, and the `Integral` branch inside the same
function, to `type()`-based `issubclass` checks, which read the real,
non-spoofable type slot instead of the overridable `__class__` attribute.

## Reachability

```python
class SpoofedProbability:
    @property
    def __class__(self):
        return float
    def __float__(self):
        return 0.3
    def as_integer_ratio(self):
        return (3, 10)

fake = SpoofedProbability()
print(isinstance(fake, Real))          # True  (spoofed)
print(issubclass(type(fake), Real))    # False (actual type)

cfg = RiverSwimConfig(p_right_up=fake, p_right_down=0.05)
RiverSwimMDP(cfg)   # constructs successfully on unpatched main
```

## Verification

- Confirmed the bug live against the unpatched code before writing the fix
  (output above, reproduced in an interactive `.venv/bin/python` session).
- New test `test_transition_probabilities_reject_class_spoofed_reals`,
  parametrized over `p_right_up`/`p_right_down`, added next to the existing
  `test_transition_probabilities_require_positive_float32_reals`.
- Mutation check: reverted just the source fix (`git stash` on
  `closed_loop.py` only), reran the new test → both parametrizations fail
  with `Failed: DID NOT RAISE ValueError`. Restored → both pass.
- `.venv/bin/python -m pytest tests/test_closed_loop_env.py -q -o addopts=""` → `52 passed`.
- `.venv/bin/python -m pytest tests/test_closed_loop_env.py tests/test_ia_amplification.py -q -o addopts="" -m "not slow"` (downstream caller of `closed_loop.py` via `continual_ia.py`) → `52 passed, 7 deselected`.
- `.venv/bin/python -m ruff check alberta_framework/streams/closed_loop.py tests/test_closed_loop_env.py` → `All checks passed!`
- `.venv/bin/python -m mypy` (full project, strict) → `Success: no issues found in 165 source files`.
- `git diff --check` → clean.

### Evidence-registry note (environment limitation, not caused by this change)

`alberta_framework/streams/closed_loop.py` is a registered source file for
the `continual_intelligence_amplification` claim. `.venv/bin/alberta-evidence-status`
exits `2` (invalid) both **before and after** this change on this checkout —
I confirmed this by stashing just the two touched files and re-running the
status command against unmodified `main`: all 5 claims already report
`"status": "invalid"` / `"valid": false` on a clean worktree in this
environment, before any edit of mine. The only diff the status report shows
between before/after is the (expected) updated source hash for
`closed_loop.py` and `worktree_dirty` flags. I'm not attempting to fix the
pre-existing registry-wide invalid state here — it's out of scope for this
narrow change and predates it.

## Provenance

AI-assisted (Claude Code, `claude-sonnet-5`, provider Anthropic). Spoofing
behavior reproduced empirically against the unpatched code before writing
the fix. All verification above (mutation testing, full-suite run,
lint/typecheck, reachability trace, evidence-registry check) performed and
observed directly before opening this PR.

Receipt signing deferred — handled centrally by the orchestrating session
for this contribution cycle.


---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-claude-worker]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M05YZQXCSX8RPNYE2JRP15N6","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-16T18:57:44.876Z","completed_at":"2026-08-16T18:58:09.814Z","skill_sha256":"b5830ca463d0956bb515e50cb8726cfe4c4e499d2fe205bab617da08026e5424","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d8329e4e93cb1f6fdce46659817cd371a2a25f0900b473f0a8341b76508acbe2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c996ebc4-f838-452f-8626-c112374407fd","object_id":"sha256:d8329e4e93cb1f6fdce46659817cd371a2a25f0900b473f0a8341b76508acbe2","sha256":"d8329e4e93cb1f6fdce46659817cd371a2a25f0900b473f0a8341b76508acbe2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"bJQp8RksSm31gU6jlzfftfj4KCsCpOFqWpzaONYBVP42lK__gKFAZPxtj5rHGjKUfnG31sDoOCzKahp6EnbRAg"}} -->
