### PR TITLE
Skip experiential-memory 0*inf utility decay when decay is disabled

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -957,9 +957,15 @@ class ExperientialMemory:
             _saturating_increment(entries.recency_ages),
             entries.recency_ages,
         )
+        utility_decay = jnp.asarray(self._config.utility_decay, dtype=jnp.float32)
+        decayed_utilities = jax.lax.select(
+            utility_decay == 0.0,
+            jnp.zeros_like(entries.utilities),
+            entries.utilities * utility_decay,
+        )
         utilities = jnp.where(
             valid,
-            entries.utilities * jnp.asarray(self._config.utility_decay, dtype=jnp.float32),
+            decayed_utilities,
             entries.utilities,
         )
         return ExperientialMemoryState(

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -751,6 +751,23 @@ def test_same_size_wrong_shapes_and_dtype_aliases_are_rejected_before_tracing() 
         )
 
 
+def test_zero_utility_decay_does_not_multiply_inf_utilities() -> None:
+    """utility_decay=0 drops leftover eviction utility; 0 * inf must not freeze."""
+    memory = ExperientialMemory(_config(utility_decay=0.0))
+    state = _write(memory, memory.init(), _entry(1, utility=2.0))
+    poisoned = state.replace(
+        entries=state.entries.replace(
+            utilities=jnp.where(state.entries.valid, jnp.inf, 0.0)
+        )
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    advanced = memory._advance(poisoned)
+    chex.assert_tree_all_finite(advanced.entries.utilities)
+    assert bool(jnp.all(advanced.entries.utilities >= 0.0))
+
+
 def test_dynamic_state_corruption_makes_query_abstain_and_mutations_exact_noops() -> None:
     memory = ExperientialMemory(_config())
     original = memory.init()


### PR DESCRIPTION
When `utility_decay` is configured to `0.0`, computing `entries.utilities * utility_decay` forms `0.0 * inf` when an infinite utility entry is present, resulting in IEEE-754 `NaN`.

This PR guards the decay calculation in `ExperientialMemory._advance` with `jax.lax.select`, setting the decayed utilities to zero when `utility_decay == 0.0` rather than evaluating `0 * inf`.

### Changes
- In `alberta_framework/core/experiential_memory.py`, wrap the utility decay in `jax.lax.select(utility_decay == 0.0, jnp.zeros_like(...), ...)`.
- In `tests/test_experiential_memory.py`, add `test_zero_utility_decay_does_not_multiply_inf_utilities` to verify that `utility_decay=0` produces finite zero utilities rather than NaN.