### PR TITLE
fix(core): validate SubtaskSpec threshold and pseudo_reward_scale finiteness (fixes #517)

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -81,11 +81,31 @@ class SubtaskSpec:
 
     def __post_init__(self) -> None:
         """Validate subtask specification."""
-        if self.feature_index < 0:
+        if (
+            isinstance(self.feature_index, bool)
+            or not isinstance(self.feature_index, int)
+            or self.feature_index < 0
+        ):
             raise ValueError("feature_index must be non-negative")
-        if self.threshold <= 0.0:
+        if (
+            isinstance(self.threshold, bool)
+            or not isinstance(self.threshold, (int, float))
+            or not math.isfinite(self.threshold)
+            or self.threshold <= 0.0
+        ):
             raise ValueError("threshold must be positive")
-        if self.max_option_steps < 1:
+        if (
+            isinstance(self.pseudo_reward_scale, bool)
+            or not isinstance(self.pseudo_reward_scale, (int, float))
+            or not math.isfinite(self.pseudo_reward_scale)
+            or self.pseudo_reward_scale <= 0.0
+        ):
+            raise ValueError("pseudo_reward_scale must be positive")
+        if (
+            isinstance(self.max_option_steps, bool)
+            or not isinstance(self.max_option_steps, int)
+            or self.max_option_steps < 1
+        ):
             raise ValueError("max_option_steps must be at least 1")
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -318,3 +318,49 @@ def test_semidp_q_infinite_reward_does_not_poison_weights() -> None:
     chex.assert_trees_all_close(new_rbar, rbar)
     assert float(td_error) == 0.0
     assert not bool(update_applied)
+
+
+def test_subtask_spec_validation() -> None:
+    # Valid spec
+    spec = SubtaskSpec(feature_index=0, threshold=0.5, pseudo_reward_scale=1.0, max_option_steps=8)
+    assert spec.feature_index == 0
+    assert spec.threshold == 0.5
+    assert spec.pseudo_reward_scale == 1.0
+    assert spec.max_option_steps == 8
+
+    # Invalid feature_index
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=-1)
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=True)  # type: ignore[arg-type]
+
+    # Invalid threshold
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=0.0)
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=-1.0)
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=float("nan"))
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=float("inf"))
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=True)  # type: ignore[arg-type]
+
+    # Invalid pseudo_reward_scale
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        SubtaskSpec(feature_index=0, pseudo_reward_scale=0.0)
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        SubtaskSpec(feature_index=0, pseudo_reward_scale=-2.0)
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        SubtaskSpec(feature_index=0, pseudo_reward_scale=float("nan"))
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        SubtaskSpec(feature_index=0, pseudo_reward_scale=float("inf"))
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        SubtaskSpec(feature_index=0, pseudo_reward_scale=False)  # type: ignore[arg-type]
+
+    # Invalid max_option_steps
+    with pytest.raises(ValueError, match="max_option_steps"):
+        SubtaskSpec(feature_index=0, max_option_steps=0)
+    with pytest.raises(ValueError, match="max_option_steps"):
+        SubtaskSpec(feature_index=0, max_option_steps=True)  # type: ignore[arg-type]
+


### PR DESCRIPTION
Closes #517.

### Problem
`SubtaskSpec.__post_init__` validated `threshold <= 0.0`, which allowed `NaN` to pass through unchecked (`NaN <= 0.0` is `False`). Additionally, `pseudo_reward_scale` had no validation (allowing non-finite, zero, or negative multipliers), and boolean types were not rejected for `feature_index`, `threshold`, `pseudo_reward_scale`, or `max_option_steps`.

### Fix
- Add explicit `math.isfinite` and `> 0.0` validation for `threshold` and `pseudo_reward_scale` in `SubtaskSpec.__post_init__`.
- Reject `bool` aliases for all spec fields.
- Add `test_subtask_spec_validation` covering valid specs, `NaN`, `inf`, negative/zero scales, and invalid types in `tests/test_options.py`.