### PR TITLE
fix(steps): require exact bools in step8 world-model config

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -144,6 +144,12 @@ def _require_int(name: str, value: object, *, minimum: int | None = None) -> int
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a built-in bool")
+    return value
+
+
 def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
     n_actions = (
@@ -162,6 +168,8 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
         config.leaky_relu_slope,
     )
     utility_decay = _require_half_open_unit_interval("utility_decay", config.utility_decay)
+    use_layer_norm = _require_bool("use_layer_norm", config.use_layer_norm)
+    predict_delta = _require_bool("predict_delta", config.predict_delta)
     object.__setattr__(config, "observation_dim", observation_dim)
     object.__setattr__(config, "n_actions", n_actions)
     object.__setattr__(config, "action_dim", action_dim)
@@ -169,6 +177,8 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     object.__setattr__(config, "step_size", step_size)
     object.__setattr__(config, "sparsity", sparsity)
     object.__setattr__(config, "leaky_relu_slope", leaky_relu_slope)
+    object.__setattr__(config, "use_layer_norm", use_layer_norm)
+    object.__setattr__(config, "predict_delta", predict_delta)
     object.__setattr__(config, "utility_decay", utility_decay)
 
 

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -74,6 +74,16 @@ _INVALID_WORLD_MODEL_FIELDS: tuple[tuple[str, Any], ...] = (
     ("leaky_relu_slope", False),
     ("leaky_relu_slope", "0.01"),
     ("leaky_relu_slope", -0.01),
+    ("use_layer_norm", 1),
+    ("use_layer_norm", 0),
+    ("use_layer_norm", 1.0),
+    ("use_layer_norm", "yes"),
+    ("use_layer_norm", None),
+    ("predict_delta", 1),
+    ("predict_delta", 0),
+    ("predict_delta", 1.0),
+    ("predict_delta", "yes"),
+    ("predict_delta", None),
 )
 
 
@@ -188,6 +198,33 @@ def _config_with(**overrides: Any) -> Step8WorldModelConfig:
 def test_step8_world_model_fields_reject_invalid_inputs(field: str, value: object) -> None:
     with pytest.raises(ValueError, match=field):
         make_step8_world_model(_config_with(**{field: value}))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["use_layer_norm", "predict_delta"])
+def test_step8_bool_fields_reject_invalid_type_without_calling_repr(field: str) -> None:
+    repr_calls = 0
+
+    class ExplodingRepr:
+        def __repr__(self) -> str:
+            nonlocal repr_calls
+            repr_calls += 1
+            raise RuntimeError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: ExplodingRepr()})
+
+    assert repr_calls == 0
+
+
+@pytest.mark.unit
+def test_step8_bool_fields_accept_exact_bools() -> None:
+    config = _config_with(use_layer_norm=False, predict_delta=True)
+    assert config.use_layer_norm is False
+    assert config.predict_delta is True
+    core = config.to_core_config()
+    assert core.use_layer_norm is False
+    assert core.predict_delta is True
 
 
 def test_step8_world_model_rejects_nonpositive_vector_action_dim() -> None:


### PR DESCRIPTION
Fixes #521

## Changes

- `alberta_framework/steps/step8.py`: added a `_require_bool` helper and wired `use_layer_norm` and `predict_delta` through it in `_validate_world_model_config`. Both flags must now be exact built-in `bool`s — ints (`1`/`0`), floats, strings (`"yes"`), `None`, and arbitrary truthy objects are rejected with `ValueError` instead of silently steering the model onto the layer-norm or residual-delta path. The rejection message avoids `{value!r}` so an untrusted `__repr__` hook is never executed (matching the `fix(streams): avoid repr in bool validation` precedent).
- `tests/test_step8_production.py`: extended `_INVALID_WORLD_MODEL_FIELDS` with ten non-bool cases for the two flags, and added `unit`-marked tests asserting (a) rejection happens without calling `__repr__` on the invalid value and (b) exact `True`/`False` still flow through to `to_core_config()` unchanged.

## Validation

- `.venv/bin/python -m pytest tests/test_step8_production.py -q` — 66 passed (the 12 new cases fail on main, pass with the fix)
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)