### PR TITLE
fix(benchmarks): reject bool aliases in open-screen probe intake

### DIFF
--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -18,7 +18,7 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
-from typing import Any, NoReturn, cast
+from typing import Any, NoReturn, TypeGuard, cast
 
 _SOURCE_ROOT = Path("/opt/foragax-agents")
 _PROTOCOL_ROOT = Path("/protocol")
@@ -88,6 +88,37 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _is_exact_int(value: Any) -> TypeGuard[int]:
+    """True only for exact ints; bool is an int subclass and must not alias 0/1."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_task_intake(protocol: dict[str, Any]) -> tuple[dict[str, Any], int, list[int]]:
+    task = protocol.get("task")
+    if not isinstance(task, dict):
+        _fail("protocol task must be an object")
+    horizon = task.get("steps_per_seed", task.get("steps"))
+    seeds = task.get("seeds")
+    if not _is_exact_int(horizon) or horizon <= 0:
+        _fail("protocol horizon is invalid")
+    if not isinstance(seeds, list) or not seeds or not all(_is_exact_int(v) for v in seeds):
+        _fail("protocol seeds are invalid")
+    return task, horizon, cast(list[int], seeds)
+
+
+def _validate_ppo_schedule(
+    rollout: Any,
+    updates: Any,
+    horizon: int,
+    relative: str,
+) -> tuple[int, int]:
+    if not _is_exact_int(rollout) or not _is_exact_int(updates):
+        _fail(f"PPO schedule is not explicit: {relative}")
+    if rollout * updates != horizon:
+        _fail(f"PPO schedule does not equal the frozen horizon: {relative}")
+    return rollout, updates
 
 
 def _relative_path(value: Any, label: str) -> str:
@@ -274,16 +305,7 @@ def _validate_configurations(
     from ml_instrumentation.metadata import attach_metadata
     from PyExpUtils.results.tools import getParamsAsDict
 
-    task = protocol.get("task")
-    if not isinstance(task, dict):
-        _fail("protocol task must be an object")
-    horizon = task.get("steps_per_seed", task.get("steps"))
-    seeds = task.get("seeds")
-    if not isinstance(horizon, int) or horizon <= 0:
-        _fail("protocol horizon is invalid")
-    if not isinstance(seeds, list) or not seeds or not all(isinstance(v, int) for v in seeds):
-        _fail("protocol seeds are invalid")
-    typed_seeds = cast(list[int], seeds)
+    task, horizon, typed_seeds = _validate_task_intake(protocol)
 
     raw_configs = protocol.get("configurations")
     if not isinstance(raw_configs, list) or not raw_configs:
@@ -333,12 +355,12 @@ def _validate_configurations(
         if not isinstance(agent, str) or not agent:
             _fail(f"configuration agent is invalid: {relative}")
         if agent.startswith("PPO"):
-            rollout = hypers.get("rollout_steps")
-            updates = hypers.get("num_updates")
-            if not isinstance(rollout, int) or not isinstance(updates, int):
-                _fail(f"PPO schedule is not explicit: {relative}")
-            if rollout * updates != horizon:
-                _fail(f"PPO schedule does not equal the frozen horizon: {relative}")
+            rollout, updates = _validate_ppo_schedule(
+                hypers.get("rollout_steps"),
+                hypers.get("num_updates"),
+                horizon,
+                relative,
+            )
             entrypoint = "src/rtu_ppo.py"
             effective = [
                 stored_seed + int(experiment.get_hypers(seed).get("seed_offset", 0))

--- a/tests/test_foragax_open_screen.py
+++ b/tests/test_foragax_open_screen.py
@@ -18,6 +18,7 @@ from typing import Any, BinaryIO, cast
 import numpy as np
 import pytest
 
+from alberta_framework.benchmarks import _foragax_open_screen_probe as probe
 from alberta_framework.benchmarks import _foragax_open_screen_scorer as image_scorer
 from alberta_framework.benchmarks import _foragax_open_screen_scorer_v3 as image_scorer_v3
 from alberta_framework.benchmarks import foragax_open_screen as screen
@@ -1170,3 +1171,64 @@ def test_mocked_screen_preserves_initial_diagnostics_rescores_and_validates_comm
     sidecar.write_text(hashlib.sha256(manifest_bytes).hexdigest() + "\n", encoding="ascii")
     with pytest.raises(screen.ScreenError, match="attempt projection or host command drift"):
         screen.validate_screen(_BASELINE_V3, output, docker="mock-docker")
+
+
+def test_probe_exact_int_rejects_bool_and_non_int_aliases() -> None:
+    assert probe._is_exact_int(1)
+    assert probe._is_exact_int(0)
+    assert not probe._is_exact_int(True)
+    assert not probe._is_exact_int(False)
+    assert not probe._is_exact_int(1.0)
+    assert not probe._is_exact_int("1")
+    assert not probe._is_exact_int(None)
+
+
+def test_probe_task_intake_accepts_exact_int_horizon_and_seeds() -> None:
+    protocol = {"task": {"steps_per_seed": 4, "seeds": [1, 2, 3]}}
+    task, horizon, seeds = probe._validate_task_intake(protocol)
+    assert task is protocol["task"]
+    assert horizon == 4
+    assert seeds == [1, 2, 3]
+    fallback = {"task": {"steps": 6, "seeds": [0]}}
+    _, fallback_horizon, fallback_seeds = probe._validate_task_intake(fallback)
+    assert fallback_horizon == 6
+    assert fallback_seeds == [0]
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        {"steps_per_seed": True, "seeds": [1, 2]},
+        {"steps": True, "seeds": [1, 2]},
+        {"steps_per_seed": 0, "seeds": [1, 2]},
+        {"steps_per_seed": -3, "seeds": [1, 2]},
+        {"steps_per_seed": 4.0, "seeds": [1, 2]},
+        {"seeds": [1, 2]},
+    ],
+)
+def test_probe_task_intake_rejects_invalid_horizon(task: dict[str, Any]) -> None:
+    with pytest.raises(RuntimeError, match="protocol horizon is invalid"):
+        probe._validate_task_intake({"task": task})
+
+
+@pytest.mark.parametrize(
+    "seeds",
+    [[True, 2, 3], [1, False], [1.0], ["1"], [], None],
+)
+def test_probe_task_intake_rejects_invalid_seeds(seeds: Any) -> None:
+    with pytest.raises(RuntimeError, match="protocol seeds are invalid"):
+        probe._validate_task_intake({"task": {"steps_per_seed": 4, "seeds": seeds}})
+
+
+def test_probe_task_intake_rejects_non_object_task() -> None:
+    with pytest.raises(RuntimeError, match="protocol task must be an object"):
+        probe._validate_task_intake({"task": [1]})
+
+
+def test_probe_ppo_schedule_rejects_bool_rollout_and_updates() -> None:
+    assert probe._validate_ppo_schedule(4, 8, 32, "configs/demo.json") == (4, 8)
+    for rollout, updates in ((True, 32), (32, True), (False, 1), (1.0, 32), (None, 32)):
+        with pytest.raises(RuntimeError, match="PPO schedule is not explicit"):
+            probe._validate_ppo_schedule(rollout, updates, 32, "configs/demo.json")
+    with pytest.raises(RuntimeError, match="PPO schedule does not equal the frozen horizon"):
+        probe._validate_ppo_schedule(4, 4, 32, "configs/demo.json")


### PR DESCRIPTION
Fixes #524

## Problem

The frozen-protocol intake in `alberta_framework/benchmarks/_foragax_open_screen_probe.py` used plain `isinstance(value, int)` for the horizon (`steps_per_seed`/`steps`), each entry of `seeds`, and the PPO `rollout_steps`/`num_updates`. Since `bool` is an `int` subclass, a protocol with `"steps_per_seed": true` or `"seeds": [true]` was accepted and silently treated as horizon 1 / seed 1, defeating the probe's exact frozen-protocol intake.

## Changes

- Add `_is_exact_int` (`TypeGuard[int]`, rejects `bool`) to `_foragax_open_screen_probe.py`, matching the strict int checks in `forager_matched_protocol.py`.
- Extract the task intake checks into `_validate_task_intake` and the PPO schedule checks into `_validate_ppo_schedule`, both now using the exact-int guard; `_validate_configurations` calls the helpers with unchanged failure messages and semantics for valid protocols.
- Add unit-lane intake tests in `tests/test_foragax_open_screen.py` covering bool horizon, bool seeds, bool PPO `rollout_steps`/`num_updates`, plus the existing nonpositive/empty/type rejections and the accepted exact-int paths (failing-test-first; the new tests fail on `main`).

No probe/benchmark execution and no `outputs/` paths touched; the probe snapshot hash is computed live at run time, so no pinned artifact is invalidated.

## Validation

- `.venv/bin/python -m pytest tests/test_foragax_open_screen.py -q` — 36 passed
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
