### PR TITLE
fix(step7): require exact bool for planning_apply_importance_correction

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -177,6 +177,12 @@ def _require_int(name: str, value: object, *, minimum: int | None = None) -> int
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a bool, got {value!r}")
+    return value
+
+
 def _validate_planning_config(config: Step7DynaConfig) -> None:
     planning_steps = _require_int("planning_steps", config.planning_steps, minimum=0)
     planning_rollout_depth = _require_int(
@@ -205,6 +211,10 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     utility_step = _require_unit_interval(
         "planning_utility_step_size",
         config.planning_utility_step_size,
+    )
+    _require_bool(
+        "planning_apply_importance_correction",
+        config.planning_apply_importance_correction,
     )
     if config.planning_strategy not in (
         "random",

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -93,6 +93,12 @@ _INVALID_STEP7_FIELDS: tuple[tuple[str, Any], ...] = (
     ("planning_utility_step_size", 1.1),
     ("planning_utility_step_size", "0.2"),
     ("planning_utility_step_size", None),
+    ("planning_apply_importance_correction", 1),
+    ("planning_apply_importance_correction", 0),
+    ("planning_apply_importance_correction", 1.0),
+    ("planning_apply_importance_correction", "yes"),
+    ("planning_apply_importance_correction", ""),
+    ("planning_apply_importance_correction", None),
 )
 
 
@@ -227,6 +233,17 @@ def test_step7_planning_fields_preserve_legal_endpoints() -> None:
     smoke = run_step7_smoke(config, steps=4, seed=0)
     assert smoke.finite
     assert smoke.planning_td_errors_shape == (4, 0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("flag", [True, False])
+def test_step7_importance_correction_accepts_exact_bool(flag: bool) -> None:
+    config = _config_with(planning_apply_importance_correction=flag)
+    assert config.planning_apply_importance_correction is flag
+    payload = config.to_dict()
+    assert type(payload["planning_apply_importance_correction"]) is bool
+    restored = Step7DynaConfig.from_dict(payload)
+    assert restored.planning_apply_importance_correction is flag
 
 
 def test_step7_planning_fields_canonicalize_nonbuiltin_numbers() -> None:


### PR DESCRIPTION
Fixes #522

## Changes

- `alberta_framework/steps/step7.py`: added a `_require_bool` helper (mirroring the strict boolean check in `steps/step9.py`) and wired it into `_validate_planning_config`, so `Step7DynaConfig` now rejects non-boolean `planning_apply_importance_correction` values (`1`, `0`, `1.0`, `"yes"`, `""`, `None`) instead of silently treating them as truthy and toggling importance correction.
- `tests/test_step7_production.py`: extended the `_INVALID_STEP7_FIELDS` parametrized rejection table with six non-bool `planning_apply_importance_correction` cases (written failing-first against main), and added a unit-marked positive test asserting exact `True`/`False` are preserved through `to_dict`/`from_dict`.

## Validation

- `.venv/bin/python -m pytest tests/test_step7_production.py tests/test_step7_rng.py -q` — 111 passed
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

New rejection tests were confirmed to fail before the fix (6 failed on main's validator) and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)