### PR TITLE
fix(step1): reject class-spoofed non-integer config and smoke counts

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
+from numbers import Real
 from typing import Any, Literal, cast
 
 import jax.numpy as jnp
@@ -123,6 +123,15 @@ def _require_positive_real(name: str, value: object) -> float:
     return number
 
 
+# Exact trusted integer scalar types, compared by identity in _require_int.
+# ``longlong``/``ulonglong`` are listed via their dtype codes because they can
+# be distinct types from the fixed-width aliases on some platforms.
+_TRUSTED_INT_TYPES: tuple[type, ...] = (
+    int,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
+)
+
+
 def _require_int(
     name: str,
     value: object,
@@ -130,9 +139,13 @@ def _require_int(
     minimum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
+    # Identity-only admission: an actual ``int`` subclass can override
+    # ``__int__``/``__index__``/``__repr__`` with hostile hooks, so anything
+    # that is not an exact trusted builtin/NumPy integer scalar type is
+    # rejected before conversion, without interpolating the untrusted value.
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
-        raise ValueError(f"{name} must be an integer, got {value!r}")
+    if not any(actual_type is trusted_type for trusted_type in _TRUSTED_INT_TYPES):
+        raise ValueError(f"{name} must be an integer of an exact trusted type")
     number: int = int(cast(Any, value))
     if minimum is not None and number < minimum:
         if minimum == 1:

--- a/tests/test_step1_int_validation.py
+++ b/tests/test_step1_int_validation.py
@@ -1,0 +1,133 @@
+"""Unit tests for the Step 1 integer trust boundary (issue #499).
+
+The Step 1 facade must admit only exact builtin/NumPy integer scalar types.
+An actual ``int`` subclass can override ``__int__`` (or ``__repr__``) with
+hostile hooks, so subclasses are rejected by identity comparison before any
+conversion runs, and the invalid-type error never interpolates the value.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.steps import Step1KernelConfig, run_step1_smoke
+
+pytestmark = pytest.mark.unit
+
+_INT_FIELDS = ("steps", "final_window")
+_CONFIG_INT_FIELDS = ("feature_dim", "num_relevant")
+
+
+class _LyingIntSubclass(int):
+    """An actual ``int`` subclass whose conversion hook rewrites the value."""
+
+    def __int__(self) -> int:
+        return 2
+
+    def __index__(self) -> int:
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    """An actual ``int`` subclass whose conversion hook raises."""
+
+    def __int__(self) -> int:
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    """A non-integer whose ``__repr__`` hook raises if the error path runs it."""
+
+    def __repr__(self) -> str:
+        raise RuntimeError("repr hook must not run")
+
+
+def _smoke_kwargs(field: str, value: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {"steps": 4, "final_window": 2}
+    kwargs[field] = value
+    return kwargs
+
+
+@pytest.mark.parametrize("field", _INT_FIELDS)
+def test_step1_smoke_rejects_int_subclass_with_lying_conversion_hook(field: str) -> None:
+    value = _LyingIntSubclass(-1)
+    assert isinstance(value, int)
+
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        run_step1_smoke(**_smoke_kwargs(field, value))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _INT_FIELDS)
+def test_step1_smoke_rejects_int_subclass_without_running_raising_hook(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        run_step1_smoke(**_smoke_kwargs(field, _RaisingIntSubclass(4)))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _INT_FIELDS)
+def test_step1_smoke_invalid_type_error_does_not_run_repr_hook(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        run_step1_smoke(**_smoke_kwargs(field, _RaisingRepr()))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _CONFIG_INT_FIELDS)
+def test_step1_config_rejects_int_subclass_with_lying_conversion_hook(field: str) -> None:
+    value = _LyingIntSubclass(-1)
+
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        Step1KernelConfig(**{field: value})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _CONFIG_INT_FIELDS)
+def test_step1_config_rejects_int_subclass_without_running_raising_hook(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        Step1KernelConfig(**{field: _RaisingIntSubclass(4)})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _CONFIG_INT_FIELDS)
+def test_step1_config_invalid_type_error_does_not_run_repr_hook(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        Step1KernelConfig(**{field: _RaisingRepr()})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.uint8,
+        np.int16,
+        np.uint16,
+        np.int32,
+        np.uint32,
+        np.int64,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ],
+)
+def test_step1_config_canonicalizes_exact_numpy_integer_scalars(np_type: type) -> None:
+    config = Step1KernelConfig(
+        feature_dim=np_type(10),  # type: ignore[arg-type]
+        num_relevant=np_type(3),  # type: ignore[arg-type]
+    )
+
+    assert type(config.feature_dim) is int
+    assert type(config.num_relevant) is int
+    assert config.feature_dim == 10
+    assert config.num_relevant == 3
+
+
+@pytest.mark.parametrize("field", _CONFIG_INT_FIELDS)
+@pytest.mark.parametrize("value", [True, np.bool_(True), 4.0, np.float64(4.0), "4", None])
+def test_step1_config_still_rejects_non_integer_scalars(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be an integer"):
+        Step1KernelConfig(**{field: value})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _INT_FIELDS)
+def test_step1_smoke_bounds_errors_still_name_the_field(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be positive"):
+        run_step1_smoke(**_smoke_kwargs(field, 0))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Fixes #499

PR #368's `_require_int` in `alberta_framework/steps/step1.py` still admitted actual `int` subclasses through `issubclass(type(value), Integral)` and then ran their user-controlled `__int__` during conversion, so `run_step1_smoke(steps=LieInt(-1), ...)` and `Step1KernelConfig(num_relevant=LieInt(-1))` were accepted and canonicalized to the hook's value, a raising `__int__` leaked its raw exception out of validation, and the invalid-type error path executed untrusted `__repr__` hooks via `{value!r}` interpolation.

## Changes

- `alberta_framework/steps/step1.py`: `_require_int` now admits only exact trusted integer scalar types via identity comparison against `_TRUSTED_INT_TYPES` — builtin `int` plus the NumPy integer scalar types for dtype codes `b B h H i I l L q Q` (covering `longlong`/`ulonglong` even where they are distinct from the fixed-width aliases). Subclasses are rejected before any conversion runs, and the invalid-type message no longer interpolates the untrusted value. `bool` stays rejected (it is never an exact trusted type) and NumPy integer canonicalization to builtin `int` is retained. Covers both smoke counts (`steps`, `final_window`) and the shared config fields (`feature_dim`, `num_relevant`), which all flow through `_require_int`.
- `tests/test_step1_int_validation.py`: new `unit`-marked, CI-cheap tests reproducing the defect failing-first: lying `__int__` subclass rejection, raising-hook subclass rejection without leaking `RuntimeError`, raising-`__repr__` invalid-type path, exact NumPy scalar canonicalization across all ten integer scalar types, and regression coverage for bool/float/string rejection and bounds messages.

## Validation

- `.venv/bin/python -m pytest tests/test_step1_int_validation.py -q` — 36 passed (12 of these failed before the fix, reproducing the issue's spoof, raising-hook, and raising-repr paths)
- `.venv/bin/python -m pytest tests/test_production_steps.py tests/test_step1_stream_factory.py -q` — 309 passed
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

No `outputs/` artifacts touched; `steps/step1.py` is not a registered evidence source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
