### PR TITLE
fix(micro-continual): normalize hyperparameter validation exceptions

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -146,22 +146,39 @@ _STEP_DOMAIN = 303
 _BAYES_DOMAIN = 404
 
 
+def _is_registered_subclass(cls: type, abc: type) -> bool:
+    """Run one ABC subclass check, normalizing metaclass hook failures to False."""
+    try:
+        return issubclass(cls, abc)
+    except Exception:
+        # ``issubclass`` against an ABC hashes ``cls`` for its caches, so a
+        # metaclass whose ``__hash__`` raises would otherwise leak the hook's
+        # exception through the documented ValueError boundary.
+        return False
+
+
 def _require_finite_real(value: object, name: str) -> float:
-    """Return one canonical float after rejecting non-real and non-finite values."""
-    if type(value) is bool or not issubclass(type(value), Real):
-        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+    """Return one canonical float after rejecting non-real and non-finite values.
+
+    The message never formats ``value``: repr hooks on untrusted objects must
+    not run, and ordinary conversion failures normalize to ``ValueError``
+    while ``BaseException`` (e.g. ``KeyboardInterrupt``) still propagates.
+    """
+    message = f"{name} must be a finite real number"
+    if type(value) is bool or not _is_registered_subclass(type(value), Real):
+        raise ValueError(message)
     try:
         number = float(cast(Any, value))
-    except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite real number, got {value!r}") from exc
+    except Exception as exc:
+        raise ValueError(message) from exc
     if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real number, got {value!r}")
+        raise ValueError(message)
     return number
 
 
 def _freeze_micro_hyperparameters(value: object, *, context: str) -> Mapping[str, float]:
     """Copy one primitive-only hyperparameter mapping behind an immutable view."""
-    if not issubclass(type(value), Mapping):
+    if not _is_registered_subclass(type(value), Mapping):
         raise ValueError(f"{context} must be an object with non-empty string keys")
     try:
         items = list(cast(Mapping[object, object], value).items())

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -88,6 +88,41 @@ class _FloatClassSpoof:
         return 0.1
 
 
+class _ExplodingConversionFloat(float):
+    """An actual float subclass whose conversion hook raises an ordinary exception."""
+
+    def __float__(self) -> float:
+        raise RuntimeError("untrusted __float__ hook executed")
+
+
+class _InterruptingConversionFloat(float):
+    """An actual float subclass whose conversion hook raises a BaseException."""
+
+    def __float__(self) -> float:
+        raise KeyboardInterrupt
+
+
+class _ExplodingRepr:
+    """An invalid hyperparameter value whose repr hook raises."""
+
+    calls = 0
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise RuntimeError("untrusted __repr__ hook executed")
+
+
+class _ExplodingHashMeta(type):
+    """A metaclass whose hash hook raises inside ABC subclass checks."""
+
+    def __hash__(cls) -> int:
+        raise RuntimeError("untrusted metaclass __hash__ hook executed")
+
+
+class _ExplodingHashClassValue(metaclass=_ExplodingHashMeta):
+    """A value or mapping whose class cannot be hashed by issubclass caches."""
+
+
 TINY = MicroStreamConfig(
     family="input_permutation",
     n_regimes=4,
@@ -858,6 +893,46 @@ class TestShards:
             dataclasses.replace(
                 micro_arm_spec("sgd_raw"),
                 hyperparameters=hyperparameters,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize(
+        "hyperparameters",
+        [
+            {"step_size": _ExplodingConversionFloat(0.1)},
+            {"step_size": _ExplodingHashClassValue()},
+            _ExplodingHashClassValue(),
+        ],
+        ids=["conversion-hook", "metaclass-hash-value", "metaclass-hash-mapping"],
+    )
+    def test_spec_and_result_normalize_hook_failures_to_value_error(
+        self, hyperparameters: object
+    ) -> None:
+        """Ordinary hook failures surface as the documented ValueError, not the hook's type."""
+        with pytest.raises(ValueError, match="hyperparameters"):
+            dataclasses.replace(
+                micro_arm_spec("sgd_raw"),
+                hyperparameters=hyperparameters,  # type: ignore[arg-type]
+            )
+        with pytest.raises(ValueError, match="hyperparameters"):
+            dataclasses.replace(
+                self._result(),
+                hyperparameters=hyperparameters,  # type: ignore[arg-type]
+            )
+
+    def test_invalid_hyperparameter_rejection_never_calls_repr(self) -> None:
+        _ExplodingRepr.calls = 0
+        with pytest.raises(ValueError, match="hyperparameters"):
+            dataclasses.replace(
+                micro_arm_spec("sgd_raw"),
+                hyperparameters={"step_size": _ExplodingRepr()},  # type: ignore[arg-type]
+            )
+        assert _ExplodingRepr.calls == 0
+
+    def test_base_exceptions_from_conversion_hooks_still_propagate(self) -> None:
+        with pytest.raises(KeyboardInterrupt):
+            dataclasses.replace(
+                micro_arm_spec("sgd_raw"),
+                hyperparameters={"step_size": _InterruptingConversionFloat(0.1)},
             )
 
     def test_payload_rejects_an_unregistered_result_name(self):


### PR DESCRIPTION
## Summary

Fixes #500

PR #362's public hyperparameter validation boundary (`MicroArmSpec` / `MicroRunResult` construction and shard loading) could leak user-controlled exceptions instead of the documented `ValueError`:

- an actual `float` subclass whose `__float__` raises `RuntimeError` escaped `_require_finite_real` (only `OverflowError`/`TypeError`/`ValueError` were normalized)
- an invalid object whose `__repr__` raises escaped while the validator formatted `{value!r}` into the error message
- a value or mapping class with a metaclass whose `__hash__` raises escaped from the `issubclass(..., Real/Mapping)` ABC cache lookup

## Changes

- `alberta_framework/benchmarks/micro_continual.py`
  - new `_is_registered_subclass` helper wraps the `Real`/`Mapping` ABC checks, normalizing metaclass hook failures (ABC caches hash the class) to a plain rejection
  - `_require_finite_real` now uses a single message that never formats the untrusted value (no `__repr__` execution) and normalizes any ordinary `Exception` from `float(...)` conversion to `ValueError` (`from exc` preserved); `BaseException` (e.g. `KeyboardInterrupt`) still propagates
  - `_freeze_micro_hyperparameters` routes its `Mapping` check through the same hardened helper
- `tests/test_micro_continual.py` (marker lane `unit`, CI-cheap; failing-first)
  - regressions for all three hook classes on both `MicroArmSpec` and `MicroRunResult` construction (conversion hook, metaclass-hash value, metaclass-hash mapping)
  - rejection of an invalid value never calls its `__repr__` (call-counting spy, matching the #4xx `avoid repr in bool validation` house style)
  - `BaseException` from a conversion hook still propagates

The merged #362 provenance schema, registered arms, valid trajectories, and shard compatibility are untouched; no `outputs/` artifact or five-claim registered source is involved (`micro_continual.py` is not in `evaluation/evidence_manifest.py`).

## Validation

- `.venv/bin/python -m pytest tests/test_micro_continual.py -q` — 193 passed (the 4 new regressions failed before the fix, pass after)
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
