### PR TITLE
fix(step10): bound STOMP dimensions to int32

### DIFF
--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -210,6 +210,7 @@ def _require_int(
     value: object,
     *,
     minimum: int | None = None,
+    maximum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral):
@@ -221,17 +222,27 @@ def _require_int(
         if minimum == 0:
             raise ValueError(f"{name} must be non-negative, got {value!r}")
         raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     if exclusive_maximum is not None and number >= exclusive_maximum:
         raise ValueError(f"{name} must be smaller than int32 max, got {value!r}")
     return number
 
 
 def _validate_stomp_facade_config(config: Step10STOMPConfig) -> None:
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
+    # Observation dimensions and action indices flow into int32 JAX sinks;
+    # bounding both keeps every feature_index (< observation_dim) in range.
+    observation_dim = _require_int(
+        "observation_dim",
+        config.observation_dim,
+        minimum=1,
+        maximum=_INT32_MAX,
+    )
     n_primitive_actions = _require_int(
         "n_primitive_actions",
         config.n_primitive_actions,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     option_planning_backups_per_step = _require_int(
         "option_planning_backups_per_step",

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -180,6 +180,7 @@ _INVALID_STEP10_FIELDS: tuple[tuple[str, Any], ...] = (
     ("observation_dim", -1),
     ("observation_dim", 1.5),
     ("observation_dim", "4"),
+    ("observation_dim", 2**31),
     ("observation_dim", None),
     ("n_primitive_actions", True),
     ("n_primitive_actions", False),
@@ -188,6 +189,7 @@ _INVALID_STEP10_FIELDS: tuple[tuple[str, Any], ...] = (
     ("n_primitive_actions", 1.5),
     ("n_primitive_actions", "2"),
     ("n_primitive_actions", None),
+    ("n_primitive_actions", 2**31),
     ("option_planning_backups_per_step", True),
     ("option_planning_backups_per_step", False),
     ("option_planning_backups_per_step", -1),
@@ -300,6 +302,36 @@ def _config_with(**overrides: Any) -> Step10STOMPConfig:
 def test_step10_stomp_fields_reject_invalid_inputs(field: str, value: object) -> None:
     with pytest.raises(ValueError, match=field):
         _config_with(**{field: value})
+
+
+@pytest.mark.unit
+def test_step10_stomp_int_dimensions_stay_within_int32() -> None:
+    int32_max = 2**31 - 1
+    upper = Step10STOMPConfig(
+        subtask_specs=(_SPEC1,),
+        observation_dim=int32_max,
+        n_primitive_actions=int32_max,
+    )
+    assert upper.observation_dim == int32_max
+    assert upper.n_primitive_actions == int32_max
+    with pytest.raises(ValueError, match="observation_dim"):
+        Step10STOMPConfig(subtask_specs=(_SPEC1,), observation_dim=int32_max + 1)
+    with pytest.raises(ValueError, match="n_primitive_actions"):
+        Step10STOMPConfig(subtask_specs=(_SPEC1,), n_primitive_actions=int32_max + 1)
+
+
+@pytest.mark.unit
+def test_step10_stomp_feature_index_stays_within_int32() -> None:
+    # An out-of-int32 feature_index can only pass the observation_dim bound
+    # check if observation_dim itself escapes int32, so both must reject.
+    with pytest.raises(ValueError, match="observation_dim"):
+        Step10STOMPConfig(
+            subtask_specs=(SubtaskSpec(feature_index=2**35),),
+            observation_dim=2**40,
+        )
+    spec = SubtaskSpec(feature_index=2**31 - 2)
+    cfg = Step10STOMPConfig(subtask_specs=(spec,), observation_dim=2**31 - 1)
+    assert cfg.subtask_specs[0].feature_index == 2**31 - 2
 
 
 def test_step10_stomp_rejects_non_tuple_subtask_specs() -> None:


### PR DESCRIPTION
Fixes #367

## Context

Most of issue #367 was already resolved on `main` by the shared step-facade float32 hardening (`alberta_framework/steps/_float32_validation.py` + `alberta_framework/_float32.py`): exact `Fraction` inputs now round once to binary32 (the issue's midpoint repro stores `nextafter(float32(1.0), 2.0)`), float32 overflows (`1e100`) are rejected as non-finite, strictly positive fields reject float32 underflow (`option_importance_clip=1e-50`, `SubtaskSpec.threshold=1e-50`), and `option_planning_backups_per_step` / `max_option_steps` already carry int32 guards. All of those were re-verified against the issue's reproduction before this change.

What remained: `observation_dim` and `n_primitive_actions` had no upper bound, so out-of-int32 dimensions — and with them out-of-int32 `feature_index` values, which are only checked against `observation_dim` — passed validation.

## Changes

- `alberta_framework/steps/step10.py`: add an inclusive `maximum` guard to `_require_int` (matching the Step 9 facade style) and bound `observation_dim` and `n_primitive_actions` to signed int32 max (`2**31 - 1`). Bounding `observation_dim` transitively bounds every `feature_index`.
- `tests/test_step10_production.py`: failing-first `unit`-lane tests — `2**31` added to the invalid-field matrix for both dimensions, plus endpoint tests asserting `2**31 - 1` stays constructible and out-of-int32 `feature_index`/`observation_dim` pairs reject.

## Validation

- `.venv/bin/python -m pytest tests/test_step10_production.py -q` — 162 passed (new tests confirmed failing before the fix: 4 failed)
- `.venv/bin/python -m pytest tests/test_step_float32_validation.py -q` — 103 passed
- `.venv/bin/python -m ruff check .` — All checks passed
- `.venv/bin/python -m mypy` — Success: no issues found in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)