### PR TITLE
test(step6): lock int32 bounds and scalar canonicalization coverage

### DIFF
--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -280,6 +280,10 @@ def test_step6_smoke_rejects_non_integral_dimensions(field: str, value: Any) -> 
         ("seed", -1),
         ("seed", 2**31),
         ("seed", True),
+        ("steps", np.int64(2**31)),
+        ("feature_dim", np.int64(2**31)),
+        ("seed", np.int64(2**31)),
+        ("seed", np.int64(-1)),
     ],
 )
 def test_step6_smoke_rejects_out_of_range_dimensions_and_seed(
@@ -290,7 +294,7 @@ def test_step6_smoke_rejects_out_of_range_dimensions_and_seed(
         run_step6_smoke(**{field: value})
 
 
-@pytest.mark.parametrize("feature_dim", [0, 2**31, True])
+@pytest.mark.parametrize("feature_dim", [0, 2**31, True, np.int64(2**31)])
 def test_init_step6_state_rejects_invalid_feature_dim(feature_dim: Any) -> None:
     agent = make_step6_differential_sarsa_agent()
 
@@ -437,6 +441,34 @@ def test_step6_fields_canonicalize_nonbuiltin_numbers() -> None:
     assert type(payload["epsilon_start"]) is float
     assert type(payload["epsilon_end"]) is float
     assert agent.config.n_actions == 3
+
+
+def test_step6_fields_canonicalize_longdouble_and_fraction_scalars() -> None:
+    config = Step6DifferentialSARSAConfig(
+        q_step_size=np.longdouble("0.05"),
+        average_reward_step_size=np.longdouble("0.01"),
+        trace_decay=Fraction(1, 3),
+        epsilon_start=Fraction(1, 10),
+        epsilon_end=np.longdouble("0.01"),
+    )
+    fields = (
+        "q_step_size",
+        "average_reward_step_size",
+        "trace_decay",
+        "epsilon_start",
+        "epsilon_end",
+    )
+    for field in fields:
+        assert type(getattr(config, field)) is float, field
+    assert config.q_step_size == float(np.float32(0.05))
+    assert config.trace_decay == float(np.float32(1.0 / 3.0))
+    assert config.epsilon_start == float(np.float32(0.1))
+    payload = config.to_dict()
+    json.dumps(payload, allow_nan=False)
+    for field in fields:
+        assert type(payload[field]) is float, field
+    restored = Step6DifferentialSARSAConfig.from_dict(payload)
+    assert restored == config
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #378

## Summary

Issue #378 reported that the Step 6 differential SARSA facade lacked signed int32 upper bounds on `feature_dim`, `steps`, and `seed` in `run_step6_smoke` / `init_step6_state`, that `_narrow_float32` leaked `np.float32` instances for non-standard scalars (`np.longdouble`, `Fraction`), and that `Step6DifferentialSARSAConfig.to_dict` needed explicit `int`/`float` conversion.

The code-level fixes have all since landed on `main` (`3f2f25c`, `d822484`, `b8035bf`, `440f35c`, `a49414a`, `233ecb1`): `run_step6_smoke` and `init_step6_state` bound `steps`/`feature_dim`/`seed` at `2**31 - 1` via the shared bool-rejecting `_require_int` helper, the old `_narrow_float32` was replaced by `finite_real_and_float32` (which returns builtin Python `float`), and `to_dict` converts every field through `int(...)`/`float(...)`. I re-verified each reported reproduction on `origin/main` (`06b0fbd`): `steps=2**31`, `feature_dim=2**31`, `seed=2**31`, `seed=-1`, `steps=True`, and `np.int64(2**31)` all raise a clean `ValueError` at the facade boundary, and `np.longdouble` / `Fraction` config scalars are stored and serialized as builtin `float`.

What remained unresolved was the issue's test bullet: the exact surfaces it names had no regression coverage. This PR pins them so the boundary cannot silently regress.

## Changes

- `tests/test_step5_step6_production.py`
  - Extend `test_step6_smoke_rejects_out_of_range_dimensions_and_seed` with `np.int64` out-of-range params (`steps`/`feature_dim`/`seed` at `2**31`, `seed` at `-1`) so the int32 bound is exercised through NumPy `Integral` types, not just builtin `int`.
  - Extend `test_init_step6_state_rejects_invalid_feature_dim` with `np.int64(2**31)`.
  - Add `test_step6_fields_canonicalize_longdouble_and_fraction_scalars`: `np.longdouble` and `Fraction` config scalars must be stored as builtin Python `float` with a single binary32 rounding, `to_dict` must emit builtin `float` values that are JSON-serializable (`allow_nan=False`) and round-trip through `from_dict`.

No library code changed; no `outputs/` artifact is touched.

## Validation

```
$ PYTHONPATH=<worktree> .venv/bin/python -m pytest tests/test_step5_step6_production.py -q
178 passed in 46.19s

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files
```

The 17 tests touched by this PR (`-k "longdouble or out_of_range or init_step6_state_rejects"`) pass in 1.76s — CI-cheap, default fast lane, no benchmark executions inside pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
