### PR TITLE
fix(associative-memory): reject out-of-vocabulary traced labels at runtime

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -27,6 +27,7 @@ from jaxtyping import Bool, Float, Int
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
+    safe_discrete_action,
     select_transaction,
 )
 
@@ -677,8 +678,11 @@ class AssociativeMemoryLearner:
         actual_type = type(label)
         if issubclass(actual_type, jax.core.Tracer):
             array = jnp.asarray(label)
-            valid_type = jnp.issubdtype(array.dtype, jnp.integer) and array.shape == ()
-            return array, jnp.asarray(valid_type, dtype=jnp.bool_)
+            if not (jnp.issubdtype(array.dtype, jnp.integer) and array.shape == ()):
+                return jnp.asarray(0, dtype=jnp.int32), jnp.asarray(False)
+            # Static checks cannot see traced values, so the vocabulary-domain
+            # verdict must be a runtime predicate folded into update_applied.
+            return safe_discrete_action(array, self._config.vocab_size)
 
         allowed = (
             actual_type is int

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -343,6 +343,64 @@ def test_update_rejects_labels_outside_the_vocabulary_instead_of_clipping(
     chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
 
 
+@pytest.mark.parametrize("label", [-1, 4, 9999])
+def test_scan_update_rejects_out_of_vocabulary_traced_labels(label: int) -> None:
+    """A traced out-of-vocabulary label is a rejected transaction, not a substituted class."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    contexts = jnp.asarray([[1, 2, 3], [2, 3, 0]], dtype=jnp.int32)
+    labels = jnp.full((2,), label, dtype=jnp.int32)
+
+    result = run_associative_memory_arrays(learner, state, contexts, labels)
+
+    chex.assert_trees_all_equal(
+        result.updates_applied,
+        jnp.zeros((contexts.shape[0],), dtype=jnp.bool_),
+    )
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(result.predictions, jnp.zeros_like(result.predictions))
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
+
+
+def test_scan_update_applies_only_the_valid_labels_of_a_mixed_stream() -> None:
+    """Valid labels in a mixed stream keep training while invalid steps are neutralized."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    contexts = jnp.asarray([[1, 2, 3], [1, 2, 3], [1, 2, 3]], dtype=jnp.int32)
+    labels = jnp.asarray([1, 4, 1], dtype=jnp.int32)
+
+    result = run_associative_memory_arrays(learner, state, contexts, labels)
+
+    chex.assert_trees_all_equal(
+        result.updates_applied,
+        jnp.asarray([True, False, True], dtype=jnp.bool_),
+    )
+    assert float(result.state.prior[1]) > 0.0
+    chex.assert_trees_all_equal(result.metrics[1], jnp.zeros_like(result.metrics[1]))
+
+
+def test_all_invalid_label_stream_does_not_report_perfect_accuracy() -> None:
+    """A stream whose every label is out of range must not publish trained-looking metrics."""
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
+    )
+    state = learner.init()
+    steps = 20
+    contexts = jnp.tile(jnp.asarray([[1, 2, 3]], dtype=jnp.int32), (steps, 1))
+    labels = jnp.full((steps,), 4, dtype=jnp.int32)
+
+    result = run_associative_memory_arrays(learner, state, contexts, labels)
+
+    assert not bool(result.updates_applied.any())
+    chex.assert_trees_all_equal(result.state, state)
+    assert float(result.metrics[-10:, 1].mean()) == 0.0
+    assert float(result.metrics[-10:, 0].mean()) == 0.0
+
+
 def test_update_accepts_every_in_vocabulary_label() -> None:
     learner = AssociativeMemoryLearner(
         AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)


### PR DESCRIPTION
Fixes #458

## Summary

PR #459 hardened the eager `AssociativeMemoryLearner.update` wrapper against out-of-domain labels, but the traced branch of `_prepare_label` performed only a static dtype/shape check — traced values are invisible to static checks, so no runtime vocabulary verdict existed. Inside `jax.lax.scan` (`run_associative_memory_arrays`, the Step 2 smoke path) an out-of-range integer label still passed `label_valid=True`:

- `label=-1` wrapped via negative indexing and trained the last class,
- `label=4`/`9999` had their scatter writes silently dropped while loss was computed against a clipped class,
- every such step reported `update_applied=True`,

so a stream whose every label is out of range still published all-`True` `updates_applied` and trained-looking metrics through `Step2AssociativeSmokeResult` — the residual surface of the defect in #458.

## Changes

- `alberta_framework/core/associative_memory.py`: the traced branch of `_prepare_label` now folds `safe_discrete_action(label, vocab_size)` (the existing fail-closed helper in `core/update_safety.py`, exactly as the issue prescribes) into the returned `(safe_label, label_valid)` pair, so the vocabulary-domain verdict is a runtime predicate that flows into `update_applied`. An invalid traced label is a rejected, neutralized transaction: state unchanged, predictions/logits/metrics zeroed, `update_applied=False`. A traced non-integer or non-scalar label now also returns a safe `int32` zero code instead of the raw array. In-vocabulary labels are unchanged.
- `tests/test_associative_memory.py`: failing-test-first unit tests (CI-cheap, `unit` lane) covering traced labels `-1`/`4`/`9999` rejected atomically through the scan runner, a mixed valid/invalid stream applying only the valid steps, and the all-invalid-stream symptom (no step applied, state unchanged, final-10 accuracy/loss zeroed instead of trained-looking).

## Validation

- `.venv/bin/python -m pytest tests/test_associative_memory.py -q` — 47 passed (the 5 new tests all failed before the fix, all pass after)
- `.venv/bin/python -m pytest tests/test_pipeline.py tests/test_step2_theory_invariants.py -q` — 25 passed
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files
- `alberta_framework/core/associative_memory.py` is not in the evidence registry's registered source inventory (`evaluation/evidence_manifest.py`), so no persisted evidence claim is invalidated by this change; nothing under `outputs/` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)