### PR TITLE
fix(core): reject class-spoofed non-real scalars in latent WM ensemble config

### DIFF
--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -91,9 +91,10 @@ def _finite_float32(
     positive: bool = False,
     nonnegative: bool = False,
 ) -> float:
-    if not isinstance(value, Real) or isinstance(value, (bool, np.bool_)):
+    actual_type = type(value)
+    if issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real non-boolean scalar")
-    canonical = float(value)
+    canonical = float(cast(Real, value))
     lower_ok = canonical > 0.0 if positive else canonical >= 0.0 if nonnegative else True
     if not math.isfinite(canonical) or not lower_ok or abs(canonical) > _FLOAT32_MAX:
         qualifier = "positive " if positive else "nonnegative " if nonnegative else ""

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -159,6 +159,75 @@ def test_initialization_is_distinct_fixed_width_and_exactly_accounted() -> None:
     assert budget.replay_capacity == 0
 
 
+_REAL_SCALAR_FIELDS = (
+    "learning_rate",
+    "variance_floor",
+    "max_variance",
+    "initialization_scale",
+    "gradient_clip_norm",
+    "max_raw_gradient_norm",
+    "max_input_magnitude",
+    "max_parameter_magnitude",
+    "max_prediction_magnitude",
+    "max_loss_magnitude",
+    "bootstrap_probability",
+)
+
+_IN_DOMAIN_SCALARS = {
+    "learning_rate": 0.01,
+    "variance_floor": 1.0e-3,
+    "max_variance": 100.0,
+    "initialization_scale": 0.2,
+    "gradient_clip_norm": 10.0,
+    "max_raw_gradient_norm": 100_000.0,
+    "max_input_magnitude": 1_000.0,
+    "max_parameter_magnitude": 10_000.0,
+    "max_prediction_magnitude": 10_000.0,
+    "max_loss_magnitude": 100_000_000.0,
+    "bootstrap_probability": 0.8,
+}
+
+
+class _FloatSpoof:
+    """Not a Real at all, but reports ``float`` through ``__class__``."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return self._value
+
+
+class _RaisingFloatSpoof:
+    """A ``__class__`` spoof whose ``__float__`` hook raises when trusted."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        raise RuntimeError("untrusted __float__ hook executed")
+
+
+@pytest.mark.parametrize("field", _REAL_SCALAR_FIELDS)
+def test_config_rejects_objects_that_only_spoof_float_through_class(field: str) -> None:
+    """An in-domain host value must not smuggle a non-Real type past validation."""
+    spoof = _FloatSpoof(_IN_DOMAIN_SCALARS[field])
+    with pytest.raises(ValueError, match="real non-boolean"):
+        _config(**{field: spoof})
+
+
+@pytest.mark.parametrize("field", _REAL_SCALAR_FIELDS)
+def test_config_raising_spoofed_scalar_stays_a_value_error(field: str) -> None:
+    """A spoof with a raising ``__float__`` must not leak its raw exception."""
+    with pytest.raises(ValueError, match="real non-boolean"):
+        _config(**{field: _RaisingFloatSpoof()})
+
+
 def test_config_rejects_an_initial_variance_bias_outside_the_parameter_bound() -> None:
     """The deterministic variance-head initializer must fit inside max_parameter_magnitude."""
     expected = (


### PR DESCRIPTION
Fixes #575.

## Changes

- `alberta_framework/core/recurrent_latent_world_model_ensemble.py` — `_finite_float32` guarded against `bool`/non-`Real` values with `isinstance(value, Real) or isinstance(value, (bool, np.bool_))`. `isinstance()` consults an object's `__class__` attribute, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passed the check even though `type(value)` is not a registered `Real`. All eleven real-scalar config fields routed through this helper (`learning_rate`, `variance_floor`, `max_variance`, `initialization_scale`, `gradient_clip_norm`, `max_raw_gradient_norm`, `max_input_magnitude`, `max_parameter_magnitude`, `max_prediction_magnitude`, `max_loss_magnitude`, `bootstrap_probability`) accepted spoofed non-real objects, and a spoof whose `__float__` hook raises leaked its raw exception out of `RecurrentLatentWorldModelEnsembleConfig.__post_init__` instead of the documented `ValueError`. The check now reads the real, non-spoofable type slot via `type(value)` + `issubclass(actual_type, bool | np.bool_) / issubclass(actual_type, Real)`, matching the pattern already established in `core/dual_replay.py`, `_float32.py`, and `steps/_float32_validation.py`. A `cast(Real, value)` keeps the subsequent `float(...)` conversion strict-mypy clean.
- `tests/test_recurrent_latent_world_model_ensemble.py` — new `unit`-lane tests (CI-cheap, no benchmark execution): `test_config_rejects_objects_that_only_spoof_float_through_class` and `test_config_raising_spoofed_scalar_stays_a_value_error`, each parametrized over all eleven affected fields (22 cases). Failing-test-first: all 22 were confirmed red against the unpatched source (silent acceptance for the well-behaved spoof, raw `RuntimeError` leaking for the raising spoof), then green after the one-hunk fix.

Direct reproduction of the issue scenario after the fix:

```text
REJECTED: learning_rate must be a real non-boolean scalar
```

## Validation

```text
$ .venv/bin/python -m pytest tests/test_recurrent_latent_world_model_ensemble.py -q -o addopts=""
54 passed in 58.45s

$ .venv/bin/python -m pytest tests/test_latent_world_model.py tests/test_recurrent_latent_world_model_ensemble.py -q -o addopts=""
72 passed in 113.70s

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ git diff --check
(clean)
```

Red-before-fix evidence: with only the tests applied, `-k spoof` reported `22 failed, 32 deselected`; after the source fix, `22 passed, 32 deselected`.

Evidence registry note: `alberta-evidence-status` reports `invalid` on this branch, but the mismatches are exclusively FTL source-hash drifts (`core/ftl_world_model.py`, `evaluation/ftl_decision_{artifact,cli,fidelity}.py`) that pre-exist on `origin/main` and are untouched by this PR. `recurrent_latent_world_model_ensemble.py` is not a registered evidence source; no `outputs/` artifact was created, edited, or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
