### PR TITLE
fix(dreaming): gate dream steps on finite anchor observation and action

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -711,11 +711,16 @@ def dream_one_step(
         dtype=jnp.float32,
     )
     terminated = jnp.logical_or(world_prediction.terminated, discount_terminal)
-    # A non-finite model prediction can never be a valid imagined step: it would
-    # otherwise ship to the control learner with full weight and poison every
-    # later step of the rollout through the carried observation.
+    # A non-finite imagined step can never be valid: it would otherwise ship to
+    # the control learner with full weight and poison every later step of the
+    # rollout through the carried observation. The anchor observation and the
+    # sampled action are gated alongside the model prediction because both are
+    # copied verbatim into the emitted transition (mirroring the one-step
+    # guard's REJECT_NONFINITE, which also requires a finite anchor).
     finite = (
-        jnp.all(jnp.isfinite(world_prediction.next_observation))
+        jnp.all(jnp.isfinite(jnp.asarray(rollout_state.observation, dtype=jnp.float32)))
+        & jnp.all(jnp.isfinite(jnp.asarray(behavior_prediction.action, dtype=jnp.float32)))
+        & jnp.all(jnp.isfinite(world_prediction.next_observation))
         & jnp.all(jnp.isfinite(world_prediction.reward))
         & jnp.all(jnp.isfinite(world_prediction.discount))
         & jnp.all(jnp.isfinite(world_prediction.confidence))

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -244,6 +244,91 @@ def test_nonfinite_world_prediction_marks_the_dream_step_invalid_and_stops() -> 
             assert bool(jnp.all(jnp.isfinite(leaf)))
 
 
+class FiniteWorldModel:
+    """World model that returns finite predictions regardless of the anchor."""
+
+    def predict(
+        self,
+        state: Any,
+        observation: jnp.ndarray,
+        action: jnp.ndarray,
+        key: Any,
+    ) -> DreamWorldModelPrediction:
+        del state, action, key
+        return DreamWorldModelPrediction(
+            next_observation=jnp.zeros_like(observation),
+            reward=jnp.array(1.0, dtype=jnp.float32),
+            discount=jnp.array(0.9, dtype=jnp.float32),
+            terminated=jnp.array(False),
+            confidence=jnp.array(1.0, dtype=jnp.float32),
+            model_error=jnp.array(0.0, dtype=jnp.float32),
+        )
+
+
+@pytest.mark.unit
+def test_nonfinite_anchor_observation_marks_the_dream_step_invalid_and_stops() -> None:
+    """A non-finite anchor observation must not ship as a valid, weight-1.0 item.
+
+    ``GuardedDreamer.propose`` rejects a non-finite anchor observation with
+    ``REJECT_NONFINITE``; the rollout path must mirror that gate even when the
+    world model itself returns finite predictions, because the anchor is copied
+    verbatim into ``ImaginedTransition.observation``.
+    """
+    behavior = DeterministicBehaviorModel()
+    behavior_state = DeterministicBehaviorState(action=jnp.array(0, dtype=jnp.int32))
+    config = DreamRolloutConfig(rollout_horizon=3, confidence_threshold=0.5, max_model_error=1.0)
+    anchor = jnp.array([jnp.nan, 1.0], dtype=jnp.float32)
+    initial = init_dream_rollout_state(anchor, jr.key(5))
+
+    rollout = dream_rollout(FiniteWorldModel(), None, behavior, behavior_state, initial, config)
+
+    assert not bool(jnp.any(rollout.transitions.valid))
+    assert not bool(rollout.state.active)
+    gvf_items = imagined_rollout_to_gvf_items(rollout)
+    chex.assert_trees_all_close(gvf_items.weights, jnp.zeros((3,), dtype=jnp.float32))
+    sarsa_items = imagined_rollout_to_sarsa_items(rollout)
+    chex.assert_trees_all_close(sarsa_items.weights, jnp.zeros((3,), dtype=jnp.float32))
+    transition = jax.tree.map(lambda leaf: leaf[0], rollout.transitions)
+    item = imagined_transition_to_supervised_item(transition)
+    gvf_item = imagined_transition_to_gvf_item(transition)
+    assert float(item.weights) == 0.0
+    for converted in (item, gvf_item, gvf_items, sarsa_items):
+        for leaf in jax.tree.leaves(converted):
+            assert bool(jnp.all(jnp.isfinite(leaf)))
+
+
+@pytest.mark.unit
+def test_nonfinite_imagined_action_marks_the_dream_step_invalid() -> None:
+    """A non-finite sampled action must not ship as a valid training input."""
+
+    class NaNActionBehaviorModel:
+        def sample_action(
+            self,
+            state: Any,
+            observation: jnp.ndarray,
+            key: Any,
+        ) -> DreamBehaviorModelPrediction:
+            del state, observation, key
+            return DreamBehaviorModelPrediction(
+                action=jnp.array([jnp.nan], dtype=jnp.float32),
+                action_probability=jnp.array(1.0, dtype=jnp.float32),
+                log_probability=jnp.array(0.0, dtype=jnp.float32),
+            )
+
+    config = DreamRolloutConfig(rollout_horizon=2, confidence_threshold=0.5, max_model_error=1.0)
+    initial = init_dream_rollout_state(jnp.array([1.0, 1.0], dtype=jnp.float32), jr.key(9))
+
+    rollout = dream_rollout(
+        FiniteWorldModel(), None, NaNActionBehaviorModel(), None, initial, config
+    )
+
+    assert not bool(jnp.any(rollout.transitions.valid))
+    sarsa_items = imagined_rollout_to_sarsa_items(rollout)
+    chex.assert_trees_all_close(sarsa_items.weights, jnp.zeros((2,), dtype=jnp.float32))
+    for leaf in jax.tree.leaves(sarsa_items):
+        assert bool(jnp.all(jnp.isfinite(leaf)))
+
+
 @pytest.mark.parametrize("field", ["reward", "discount", "confidence", "model_error"])
 def test_nonfinite_scalar_channels_mark_the_dream_step_invalid(field: str) -> None:
     class ScalarNaNWorldModel(MockWorldModel):


### PR DESCRIPTION
Fixes #454

## Context

The core defect in #454 (non-finite world-model predictions passing the rollout gate with `valid=True`, weight 1.0) was fixed on main by #455 (`6263368`) plus converter neutralization (`cd3b991`), but the issue remained open and a residual gap survived: the rollout's finiteness gate covered only the world-model prediction fields. `GuardedDreamer.propose` (`REJECT_NONFINITE`) also requires a finite anchor observation; `dream_one_step` did not. Since the anchor is copied verbatim into `ImaginedTransition.observation` (and the sampled action into `ImaginedTransition.action`), a generic `DreamWorldModel` returning finite predictions from a non-finite anchor — or a behavior model emitting a non-finite action — still shipped NaN training inputs to the GVF/SARSA/supervised converters at full weight 1.0, with the rollout reporting a fully valid horizon.

## Changes

- `alberta_framework/core/dreaming.py`: extend `dream_one_step`'s `finite` conjunction to require a finite anchor observation and a finite sampled action alongside the prediction fields (pure `jnp.isfinite` masks — jit/vmap-safe, no Python branches on traced values). Invalid steps keep the carried observation at its previous value and deactivate the rollout, as before.
- `tests/test_dreaming.py`: two failing-first `unit`-marked tests — `test_nonfinite_anchor_observation_marks_the_dream_step_invalid_and_stops` and `test_nonfinite_imagined_action_marks_the_dream_step_invalid` — asserting `valid` is all-False, the rollout deactivates, and every converter (`supervised`, `gvf`, `sarsa`) emits weight 0.0 with fully finite payloads.

## Validation

- `pytest tests/test_dreaming.py -q` — 12 passed (both new tests failed before the fix, pass after)
- `pytest tests/test_dreaming.py tests/test_differential_sarsa_discounts.py tests/test_step9_production.py tests/test_step9_rng.py tests/test_action_conditioned_world_model.py -q` (all consumers of `dream_one_step`/`dream_rollout`) — 206 passed
- `ruff check .` — all checks passed
- `mypy` — success, no issues in 165 source files
- `alberta_framework/core/dreaming.py` is not a registered evidence source (`evaluation/evidence_manifest.py`), so no persisted evidence claim is invalidated by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)