### PR TITLE
fix(benchmarks): reject int/bool aliases in EMNIST plan/shard intake

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -98,7 +98,7 @@ import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import chex
 import jax
@@ -878,6 +878,33 @@ def _strict_json_object(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _validated_float_hyperparameters(
+    value: object, learner: str, *, context: str
+) -> dict[str, float]:
+    """Require every hyperparameter to be an exact finite ``float``.
+
+    Python's ``0 == 0.0`` and ``True == 1.0`` make ``float(v)`` coercion and
+    dict ``==`` alias-tolerant, so an int/bool-aliased arm could slip through
+    intake and be measured under a different hyperparameter vector than the
+    registered one. Mirror ``ipmnist_screening``'s strict gate instead:
+    ``type(...) is float`` (rejecting bool, the int subclass, and every other
+    alias) plus finiteness, before any comparison.
+    """
+    if not isinstance(value, dict):
+        raise ValueError(f"{context}: {learner} hyperparameters must be an object")
+    invalid = sorted(
+        str(name)
+        for name, entry in value.items()
+        if type(entry) is not float or not math.isfinite(entry)
+    )
+    if invalid:
+        raise ValueError(
+            f"{context}: {learner} hyperparameters must be finite floats "
+            f"(int/bool aliases are forbidden); invalid field(s): {invalid}"
+        )
+    return {str(name): cast(float, entry) for name, entry in value.items()}
+
+
 def load_plan(path: Path) -> dict[str, Any]:
     """Load and structurally validate a v1 plan file."""
     payload = _strict_json_object(path)
@@ -901,12 +928,16 @@ def load_plan(path: Path) -> dict[str, Any]:
     if sorted(body["hyperparameters"]) != sorted(learner_ids):
         raise ValueError(f"{path}: hyperparameter learner keys differ from learner_ids")
     for learner in learner_ids:
-        resolved = resolve_hyperparameters(
-            learner,
-            {k: float(v) for k, v in body["hyperparameters"][learner].items()},
+        provided = _validated_float_hyperparameters(
+            body["hyperparameters"][learner], learner, context=str(path)
         )
-        if resolved != {k: float(v) for k, v in body["hyperparameters"][learner].items()}:
-            raise ValueError(f"{path}: {learner} hyperparameters have unknown keys")
+        resolved = resolve_hyperparameters(learner, provided)
+        if sorted(resolved) != sorted(provided) or any(
+            resolved[name].hex() != provided[name].hex() for name in provided
+        ):
+            raise ValueError(
+                f"{path}: {learner} hyperparameters must list the complete arm"
+            )
     raw_seeds = body.get("seed_ids")
     if not isinstance(raw_seeds, list):
         raise ValueError(f"{path}: plan seed_ids must be a list")
@@ -954,7 +985,15 @@ def _validated_partial(path: Path, plan: dict[str, Any]) -> dict[str, Any]:
     learner = payload.get("learner")
     if learner not in body["learner_ids"]:
         raise ValueError(f"{path}: learner {learner!r} is not planned")
-    if payload.get("hyperparameters") != body["hyperparameters"][learner]:
+    shard_hp = _validated_float_hyperparameters(
+        payload.get("hyperparameters"), str(learner), context=str(path)
+    )
+    planned_hp = _validated_float_hyperparameters(
+        body["hyperparameters"][learner], str(learner), context=f"{path}: plan"
+    )
+    if sorted(shard_hp) != sorted(planned_hp) or any(
+        shard_hp[name].hex() != planned_hp[name].hex() for name in shard_hp
+    ):
         raise ValueError(f"{path}: hyperparameters differ from the plan")
     seed = require_jax_seed(payload.get("seed_id"), name=f"{path}: seed_id")
     if seed not in body["seed_ids"]:

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -607,3 +607,107 @@ class TestPlanShardMergeAccounting:
             assert entry["reproduction_gap_flagged"] is (
                 abs(entry["gap"]) > comparison["gap_threshold"]
             )
+
+
+@pytest.mark.unit
+class TestPlanShardFloatAliasIntake:
+    """Issue #525: int/bool aliases of float hyperparameters must be rejected.
+
+    Python's ``0 == 0.0`` and ``True == 1.0`` make ``float(v)`` coercion and
+    dict ``==`` alias-tolerant, so an aliased arm could pass the plan and shard
+    gates while the sibling ``ipmnist_screening`` lane stays strict.
+    """
+
+    def _write_plan(self, tmp_path, mutate=None):
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+        payload = build_plan_payload(TINY, [0, 1], DATASET_META)
+        if mutate is not None:
+            mutate(payload["plan"])
+            payload["plan_sha256"] = upgd_label_emnist.canonical_json_sha256(
+                payload["plan"]
+            )
+        path = tmp_path / "plan.json"
+        atomic_write_new_json(path, payload)
+        return path
+
+    def test_plan_rejects_int_alias_hyperparameter(self, tmp_path):
+        def mutate(body):
+            assert body["hyperparameters"]["adamw"]["beta1"] == 0.0
+            body["hyperparameters"]["adamw"]["beta1"] = 0
+
+        path = self._write_plan(tmp_path, mutate)
+        with pytest.raises(ValueError, match="finite floats"):
+            load_plan(path)
+
+    def test_plan_rejects_bool_alias_hyperparameter(self, tmp_path):
+        def mutate(body):
+            assert body["hyperparameters"]["upgd_w"]["weight_decay"] == 0.0
+            body["hyperparameters"]["upgd_w"]["weight_decay"] = False
+
+        path = self._write_plan(tmp_path, mutate)
+        with pytest.raises(ValueError, match="finite floats"):
+            load_plan(path)
+
+    def test_plan_rejects_non_numeric_hyperparameter(self, tmp_path):
+        def mutate(body):
+            body["hyperparameters"]["upgd_w"]["lr"] = "0.01"
+
+        path = self._write_plan(tmp_path, mutate)
+        with pytest.raises(ValueError, match="finite floats"):
+            load_plan(path)
+
+    def test_plan_rejects_incomplete_hyperparameter_arm(self, tmp_path):
+        def mutate(body):
+            del body["hyperparameters"]["upgd_w"]["noise_std"]
+
+        path = self._write_plan(tmp_path, mutate)
+        with pytest.raises(ValueError, match="complete"):
+            load_plan(path)
+
+    def test_plan_still_accepts_exact_float_hyperparameters(self, tmp_path):
+        path = self._write_plan(tmp_path)
+        loaded = load_plan(path)
+        for learner, hp in loaded["plan"]["hyperparameters"].items():
+            assert all(type(v) is float for v in hp.values()), learner
+
+    def test_shard_rejects_int_alias_hyperparameter(self, tmp_path):
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+        plan = build_plan_payload(TINY, [0, 1], DATASET_META)
+        x, y = _tiny_data()
+        result = run_label_emnist(x, y, "adamw", seeds=[0], config=TINY)
+        payload = partial_payload(result, plan["plan_sha256"])
+        assert payload["hyperparameters"]["beta1"] == 0.0
+        payload["hyperparameters"] = dict(payload["hyperparameters"], beta1=0)
+        path = tmp_path / "aliased_int.json"
+        atomic_write_new_json(path, payload)
+        with pytest.raises(ValueError, match="finite floats"):
+            merge_partials(plan, [path], allow_incomplete=True)
+
+    def test_shard_rejects_bool_alias_hyperparameter(self, tmp_path):
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+        plan = build_plan_payload(TINY, [0, 1], DATASET_META)
+        x, y = _tiny_data()
+        result = run_label_emnist(x, y, "upgd_w", seeds=[0], config=TINY)
+        payload = partial_payload(result, plan["plan_sha256"])
+        assert payload["hyperparameters"]["weight_decay"] == 0.0
+        payload["hyperparameters"] = dict(payload["hyperparameters"], weight_decay=False)
+        path = tmp_path / "aliased_bool.json"
+        atomic_write_new_json(path, payload)
+        with pytest.raises(ValueError, match="finite floats"):
+            merge_partials(plan, [path], allow_incomplete=True)
+
+    def test_shard_rejects_unequal_float_hyperparameter(self, tmp_path):
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+        plan = build_plan_payload(TINY, [0, 1], DATASET_META)
+        x, y = _tiny_data()
+        result = run_label_emnist(x, y, "adamw", seeds=[0], config=TINY)
+        payload = partial_payload(result, plan["plan_sha256"])
+        payload["hyperparameters"] = dict(payload["hyperparameters"], lr=2e-4)
+        path = tmp_path / "unregistered.json"
+        atomic_write_new_json(path, payload)
+        with pytest.raises(ValueError, match="differ from the plan"):
+            merge_partials(plan, [path], allow_incomplete=True)


### PR DESCRIPTION
Fixes #525

## Changes

- Added `_validated_float_hyperparameters` to `alberta_framework/benchmarks/upgd_label_emnist.py`: every plan/shard hyperparameter must satisfy `type(...) is float` and be finite, mirroring `ipmnist_screening._validated_registered_hyperparameters`. Bool (an int subclass) and int aliases such as `0`, `false`, and `true` are rejected before any comparison.
- Plan gate (`load_plan`): replaced the `float(v)`-coerced comparison — which only ever checked key completeness and accepted arbitrary aliased values — with the strict helper, followed by a complete-arm check (`sorted` key equality plus exact `hex()` bit match against the resolved arm).
- Shard gate (`_validated_partial`): replaced the alias-tolerant dict `==` (`0 == 0.0`, `True == 1.0`) with strict float validation of both shard and planned vectors plus an exact `hex()` bit match, so an unregistered aliased arm can no longer pass as the planned one.
- Added `TestPlanShardFloatAliasIntake` (marker lane `unit`, CI-cheap) to `tests/test_upgd_label_emnist.py`: int/bool/string alias rejection and incomplete-arm rejection at the plan gate, int/bool alias and unequal-float rejection at the shard gate, and an exact-float acceptance regression guard. All alias tests fail on `main`, reproducing the defect.

No `outputs/` paths were touched; `upgd_label_emnist.py` is not in the registered evidence source inventory (`evaluation/evidence_manifest.py`).

## Validation

- `.venv/bin/python -m pytest tests/test_upgd_label_emnist.py tests/test_strict_json_finite_numbers.py -q` — 101 passed
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)