### PR TITLE
fix(core): validate world-model config scalar finiteness and update discount bounds (fixes #419)

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Any, cast
 
 import chex
@@ -637,6 +638,7 @@ class LatentWorldModel:
             & action_valid
             & jnp.all(jnp.isfinite(reward_arr))
             & jnp.all(jnp.isfinite(discount_arr))
+            & jnp.all((discount_arr >= 0.0) & (discount_arr <= 1.0))
             & jnp.all(jnp.isfinite(next_observation_arr))
         )
         safe_observation = jnp.where(
@@ -800,43 +802,121 @@ class LatentWorldModel:
         )
 
     def _validate_config(self, config: LatentWorldModelConfig) -> None:
-        if config.observation_dim <= 0:
+        if (
+            isinstance(config.observation_dim, bool)
+            or not isinstance(config.observation_dim, int)
+            or config.observation_dim <= 0
+        ):
             raise ValueError("observation_dim must be positive")
-        if config.n_actions <= 0:
+        if (
+            isinstance(config.n_actions, bool)
+            or not isinstance(config.n_actions, int)
+            or config.n_actions <= 0
+        ):
             raise ValueError("n_actions must be positive")
-        if config.latent_dim <= 0:
+        if (
+            isinstance(config.latent_dim, bool)
+            or not isinstance(config.latent_dim, int)
+            or config.latent_dim <= 0
+        ):
             raise ValueError("latent_dim must be positive")
-        if not 0.0 <= config.gamma <= 1.0:
-            raise ValueError("gamma must be in [0, 1]")
+        if not math.isfinite(config.gamma) or not 0.0 <= config.gamma <= 1.0:
+            raise ValueError("gamma must be finite and in [0, 1]")
         if config.observation_scale is not None:
             if len(config.observation_scale) != config.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
-            if any(scale <= 0.0 for scale in config.observation_scale):
-                raise ValueError("observation_scale values must be positive")
-        if config.reward_scale <= 0.0:
-            raise ValueError("reward_scale must be positive")
-        if config.encoder_scale <= 0.0:
-            raise ValueError("encoder_scale must be positive")
-        if config.encoder_bias_scale < 0.0:
-            raise ValueError("encoder_bias_scale must be non-negative")
-        if any(size <= 0 for size in config.hidden_sizes):
+            if any(
+                isinstance(scale, bool)
+                or not isinstance(scale, (int, float))
+                or not math.isfinite(scale)
+                or scale <= 0.0
+                for scale in config.observation_scale
+            ):
+                raise ValueError("observation_scale values must be positive and finite")
+        if (
+            isinstance(config.reward_scale, bool)
+            or not isinstance(config.reward_scale, (int, float))
+            or not math.isfinite(config.reward_scale)
+            or config.reward_scale <= 0.0
+        ):
+            raise ValueError("reward_scale must be positive and finite")
+        if (
+            isinstance(config.encoder_scale, bool)
+            or not isinstance(config.encoder_scale, (int, float))
+            or not math.isfinite(config.encoder_scale)
+            or config.encoder_scale <= 0.0
+        ):
+            raise ValueError("encoder_scale must be positive and finite")
+        if (
+            isinstance(config.encoder_bias_scale, bool)
+            or not isinstance(config.encoder_bias_scale, (int, float))
+            or not math.isfinite(config.encoder_bias_scale)
+            or config.encoder_bias_scale < 0.0
+        ):
+            raise ValueError("encoder_bias_scale must be non-negative and finite")
+        if any(
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size <= 0
+            for size in config.hidden_sizes
+        ):
             raise ValueError("hidden_sizes must contain only positive widths")
-        if not 0.0 <= config.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= config.surprise_decay < 1.0:
-            raise ValueError("surprise_decay must be in [0, 1)")
-        if not 0.0 <= config.collapse_decay < 1.0:
-            raise ValueError("collapse_decay must be in [0, 1)")
-        if config.min_latent_std < 0.0:
-            raise ValueError("min_latent_std must be non-negative")
-        if config.max_latent_delta <= 0.0:
-            raise ValueError("max_latent_delta must be positive")
-        if config.encoder_step_size <= 0.0:
-            raise ValueError("encoder_step_size must be positive")
-        if config.max_encoder_update <= 0.0:
-            raise ValueError("max_encoder_update must be positive")
-        if not 0.0 <= config.encoder_collapse_gate_threshold <= 1.0:
-            raise ValueError("encoder_collapse_gate_threshold must be in [0, 1]")
+        if (
+            isinstance(config.utility_decay, bool)
+            or not isinstance(config.utility_decay, (int, float))
+            or not math.isfinite(config.utility_decay)
+            or not 0.0 <= config.utility_decay < 1.0
+        ):
+            raise ValueError("utility_decay must be finite and in [0, 1)")
+        if (
+            isinstance(config.surprise_decay, bool)
+            or not isinstance(config.surprise_decay, (int, float))
+            or not math.isfinite(config.surprise_decay)
+            or not 0.0 <= config.surprise_decay < 1.0
+        ):
+            raise ValueError("surprise_decay must be finite and in [0, 1)")
+        if (
+            isinstance(config.collapse_decay, bool)
+            or not isinstance(config.collapse_decay, (int, float))
+            or not math.isfinite(config.collapse_decay)
+            or not 0.0 <= config.collapse_decay < 1.0
+        ):
+            raise ValueError("collapse_decay must be finite and in [0, 1)")
+        if (
+            isinstance(config.min_latent_std, bool)
+            or not isinstance(config.min_latent_std, (int, float))
+            or not math.isfinite(config.min_latent_std)
+            or config.min_latent_std < 0.0
+        ):
+            raise ValueError("min_latent_std must be non-negative and finite")
+        if (
+            isinstance(config.max_latent_delta, bool)
+            or not isinstance(config.max_latent_delta, (int, float))
+            or not math.isfinite(config.max_latent_delta)
+            or config.max_latent_delta <= 0.0
+        ):
+            raise ValueError("max_latent_delta must be positive and finite")
+        if (
+            isinstance(config.encoder_step_size, bool)
+            or not isinstance(config.encoder_step_size, (int, float))
+            or not math.isfinite(config.encoder_step_size)
+            or config.encoder_step_size <= 0.0
+        ):
+            raise ValueError("encoder_step_size must be positive and finite")
+        if (
+            isinstance(config.max_encoder_update, bool)
+            or not isinstance(config.max_encoder_update, (int, float))
+            or not math.isfinite(config.max_encoder_update)
+            or config.max_encoder_update <= 0.0
+        ):
+            raise ValueError("max_encoder_update must be positive and finite")
+        if (
+            isinstance(config.encoder_collapse_gate_threshold, bool)
+            or not isinstance(config.encoder_collapse_gate_threshold, (int, float))
+            or not math.isfinite(config.encoder_collapse_gate_threshold)
+            or not 0.0 <= config.encoder_collapse_gate_threshold <= 1.0
+        ):
+            raise ValueError("encoder_collapse_gate_threshold must be finite and in [0, 1]")
 
 
 def run_latent_world_model_learning_loop(

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Any, cast
 
 import chex
@@ -557,6 +558,7 @@ class ActionConditionedWorldModel:
             & action_valid
             & jnp.all(jnp.isfinite(reward_arr))
             & jnp.all(jnp.isfinite(discount_arr))
+            & jnp.all((discount_arr >= 0.0) & (discount_arr <= 1.0))
             & jnp.all(jnp.isfinite(next_obs))
         )
         safe_obs = jnp.where(inputs_valid, obs, jnp.zeros_like(obs))
@@ -654,29 +656,73 @@ class ActionConditionedWorldModel:
         )
 
     def _validate_config(self, config: ActionConditionedWorldModelConfig) -> None:
-        if config.observation_dim <= 0:
+        if (
+            isinstance(config.observation_dim, bool)
+            or not isinstance(config.observation_dim, int)
+            or config.observation_dim <= 0
+        ):
             raise ValueError("observation_dim must be positive")
-        if config.n_actions <= 0:
+        if (
+            isinstance(config.n_actions, bool)
+            or not isinstance(config.n_actions, int)
+            or config.n_actions <= 0
+        ):
             raise ValueError("n_actions must be positive")
-        if not 0.0 <= config.gamma <= 1.0:
-            raise ValueError("gamma must be in [0, 1]")
+        if not math.isfinite(config.gamma) or not 0.0 <= config.gamma <= 1.0:
+            raise ValueError("gamma must be finite and in [0, 1]")
         if config.observation_scale is not None:
             if len(config.observation_scale) != config.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
-            if any(scale <= 0.0 for scale in config.observation_scale):
-                raise ValueError("observation_scale values must be positive")
-        if config.reward_scale <= 0.0:
-            raise ValueError("reward_scale must be positive")
-        if any(size <= 0 for size in config.hidden_sizes):
+            if any(
+                isinstance(scale, bool)
+                or not isinstance(scale, (int, float))
+                or not math.isfinite(scale)
+                or scale <= 0.0
+                for scale in config.observation_scale
+            ):
+                raise ValueError("observation_scale values must be positive and finite")
+        if (
+            isinstance(config.reward_scale, bool)
+            or not isinstance(config.reward_scale, (int, float))
+            or not math.isfinite(config.reward_scale)
+            or config.reward_scale <= 0.0
+        ):
+            raise ValueError("reward_scale must be positive and finite")
+        if any(
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size <= 0
+            for size in config.hidden_sizes
+        ):
             raise ValueError("hidden_sizes must contain only positive widths")
-        if not 0.0 <= config.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= config.error_decay < 1.0:
-            raise ValueError("error_decay must be in [0, 1)")
-        if config.observation_clip_margin < 0.0:
-            raise ValueError("observation_clip_margin must be non-negative")
-        if config.max_delta_scale <= 0.0:
-            raise ValueError("max_delta_scale must be positive")
+        if (
+            isinstance(config.utility_decay, bool)
+            or not isinstance(config.utility_decay, (int, float))
+            or not math.isfinite(config.utility_decay)
+            or not 0.0 <= config.utility_decay < 1.0
+        ):
+            raise ValueError("utility_decay must be finite and in [0, 1)")
+        if (
+            isinstance(config.error_decay, bool)
+            or not isinstance(config.error_decay, (int, float))
+            or not math.isfinite(config.error_decay)
+            or not 0.0 <= config.error_decay < 1.0
+        ):
+            raise ValueError("error_decay must be finite and in [0, 1)")
+        if (
+            isinstance(config.observation_clip_margin, bool)
+            or not isinstance(config.observation_clip_margin, (int, float))
+            or not math.isfinite(config.observation_clip_margin)
+            or config.observation_clip_margin < 0.0
+        ):
+            raise ValueError("observation_clip_margin must be non-negative and finite")
+        if (
+            isinstance(config.max_delta_scale, bool)
+            or not isinstance(config.max_delta_scale, (int, float))
+            or not math.isfinite(config.max_delta_scale)
+            or config.max_delta_scale <= 0.0
+        ):
+            raise ValueError("max_delta_scale must be positive and finite")
 
 
 def run_action_conditioned_world_model_learning_loop(

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -458,3 +458,60 @@ def test_trainable_encoder_config_validation_fails_closed(
     )
     with pytest.raises(ValueError):
         LatentWorldModel(config)
+
+
+def test_latent_world_model_config_finiteness() -> None:
+    # Valid config
+    cfg = LatentWorldModelConfig(observation_dim=2, n_actions=2)
+    model = LatentWorldModel(cfg)
+    assert model.config.observation_dim == 2
+
+    # Non-finite scalars
+    with pytest.raises(ValueError, match="min_latent_std"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, min_latent_std=float("nan"))
+        )
+    with pytest.raises(ValueError, match="min_latent_std"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, min_latent_std=float("inf"))
+        )
+    with pytest.raises(ValueError, match="max_latent_delta"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, max_latent_delta=float("nan"))
+        )
+    with pytest.raises(ValueError, match="encoder_step_size"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, encoder_step_size=float("nan"))
+        )
+    with pytest.raises(ValueError, match="max_encoder_update"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, max_encoder_update=float("nan"))
+        )
+    with pytest.raises(ValueError, match="encoder_scale"):
+        LatentWorldModel(
+            LatentWorldModelConfig(observation_dim=2, n_actions=2, encoder_scale=float("nan"))
+        )
+
+
+def test_latent_world_model_rejects_out_of_range_discount() -> None:
+    cfg = LatentWorldModelConfig(observation_dim=2, n_actions=2)
+    model = LatentWorldModel(cfg)
+    state = model.init(jr.key(0))
+
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    action = jnp.int32(0)
+    reward = jnp.float32(1.0)
+    next_obs = jnp.array([0.5, 0.5], dtype=jnp.float32)
+
+    # Valid discount in [0, 1]
+    res_valid = model.update(state, obs, action, reward, jnp.float32(0.9), next_obs)
+    assert bool(res_valid.update_applied)
+
+    # Discount > 1.0 must not apply
+    res_high = model.update(state, obs, action, reward, jnp.float32(5.0), next_obs)
+    assert not bool(res_high.update_applied)
+
+    # Negative discount must not apply
+    res_neg = model.update(state, obs, action, reward, jnp.float32(-1.0), next_obs)
+    assert not bool(res_neg.update_applied)
+

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -6,6 +6,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
@@ -173,3 +174,87 @@ def test_world_model_learns_action_conditional_deterministic_transition() -> Non
     assert float(last_mse) < float(first_mse)
     assert float(pred_a1.reward - pred_a0.reward) > 0.25
     assert float(pred_a1.next_observation[0] - pred_a0.next_observation[0]) > 0.5
+
+
+def test_action_conditioned_world_model_config_finiteness() -> None:
+    from alberta_framework.core.world_model import (
+        ActionConditionedWorldModel,
+        ActionConditionedWorldModelConfig,
+    )
+
+    # Valid config constructs
+    cfg = ActionConditionedWorldModelConfig(observation_dim=2, n_actions=2)
+    model = ActionConditionedWorldModel(cfg)
+    assert model.config.observation_dim == 2
+
+    # Non-finite / invalid scalars
+    with pytest.raises(ValueError, match="observation_clip_margin"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, observation_clip_margin=float("nan")
+            )
+        )
+    with pytest.raises(ValueError, match="max_delta_scale"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, max_delta_scale=float("nan")
+            )
+        )
+    with pytest.raises(ValueError, match="max_delta_scale"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, max_delta_scale=float("inf")
+            )
+        )
+    with pytest.raises(ValueError, match="reward_scale"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, reward_scale=float("nan")
+            )
+        )
+    with pytest.raises(ValueError, match="reward_scale"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, reward_scale=float("inf")
+            )
+        )
+    with pytest.raises(ValueError, match="observation_scale"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(
+                observation_dim=2, n_actions=2, observation_scale=(float("nan"), 1.0)
+            )
+        )
+    with pytest.raises(ValueError, match="gamma"):
+        ActionConditionedWorldModel(
+            ActionConditionedWorldModelConfig(observation_dim=2, n_actions=2, gamma=float("nan"))
+        )
+
+
+def test_action_conditioned_world_model_rejects_out_of_range_discount() -> None:
+    from alberta_framework.core.world_model import (
+        ActionConditionedWorldModel,
+        ActionConditionedWorldModelConfig,
+    )
+
+    cfg = ActionConditionedWorldModelConfig(observation_dim=2, n_actions=2)
+    model = ActionConditionedWorldModel(cfg)
+    state = model.init(jr.key(0))
+
+    obs = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    action = jnp.int32(0)
+    reward = jnp.float32(1.0)
+    next_obs = jnp.array([0.5, 0.5], dtype=jnp.float32)
+
+    # Valid discount in [0, 1]
+    res_valid = model.update(state, obs, action, reward, jnp.float32(0.9), next_obs)
+    assert bool(res_valid.update_applied)
+
+    # Discount > 1.0 must not apply
+    res_high = model.update(state, obs, action, reward, jnp.float32(5.0), next_obs)
+    assert not bool(res_high.update_applied)
+
+    # Negative discount must not apply
+    res_neg = model.update(state, obs, action, reward, jnp.float32(-1.0), next_obs)
+    assert not bool(res_neg.update_applied)
+
+


### PR DESCRIPTION
Closes #419.

### Problem
1. In `ActionConditionedWorldModel._validate_config` and `LatentWorldModel._validate_config`, scalar hyperparameter validation used bare comparisons (such as `<= 0.0` or `< 0.0`), which allowed `NaN` to silently pass through unchecked (`NaN <= 0.0` is `False`), and allowed `inf` to pass positive checks.
2. In `ActionConditionedWorldModel.update` and `LatentWorldModel.update`, the `inputs_valid` transition guard checked only `isfinite(discount_arr)`, allowing negative discounts and discounts `> 1.0` to apply updates.

### Fix
- Add explicit `math.isfinite` checks and strict bounds validation for all scalar configuration parameters across `ActionConditionedWorldModelConfig` and `LatentWorldModelConfig`.
- Enforce `0.0 <= discount <= 1.0` in `inputs_valid` in both world model `update()` methods.
- Add regression tests in `tests/test_world_model.py` and `tests/test_latent_world_model.py`.