### PR TITLE
fix(stacked-horde): validate cumulant source bounds

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -81,6 +81,31 @@ _NUMPY_STEP_SIZE_TYPES = tuple(
     )
 )
 _TRUSTED_STEP_SIZE_TYPES = (int, float, Fraction, *_NUMPY_STEP_SIZE_TYPES)
+_CUMULANT_SOURCE_RANK_ERROR = "cumulant_source must be a rank-one array"
+_CUMULANT_SOURCE_INDEX_ERROR = (
+    "cumulant_source does not contain every configured cumulant index"
+)
+
+
+def _require_cumulant_source_shape(
+    source: Array,
+    *,
+    maximum_index: int,
+    batched: bool = False,
+) -> Array:
+    """Return an array whose final axis covers every configured cumulant."""
+    concrete = jnp.asarray(source)
+    expected_rank = 2 if batched else 1
+    if concrete.ndim != expected_rank:
+        message = (
+            "cumulant_sources must be a rank-two array"
+            if batched
+            else _CUMULANT_SOURCE_RANK_ERROR
+        )
+        raise ValueError(message)
+    if concrete.shape[-1] <= maximum_index:
+        raise ValueError(_CUMULANT_SOURCE_INDEX_ERROR)
+    return concrete
 
 
 def _snapshot_exact_fraction(value: Fraction) -> Fraction:
@@ -172,6 +197,10 @@ class StackedHordeConfig:
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
+        if any(type(index) is not int or index < 0 for index in self.cumulant_indices):
+            raise ValueError(
+                "every cumulant_indices entry must be a nonnegative builtin integer"
+            )
         object.__setattr__(
             self,
             "step_size",
@@ -279,6 +308,7 @@ class StackedLinearHorde:
         self._gammas = jnp.asarray(config.gammas, dtype=jnp.float32)
         self._lamdas = jnp.asarray(config.lamdas, dtype=jnp.float32)
         self._cumulant_idx = jnp.asarray(config.cumulant_indices, dtype=jnp.int32)
+        self._maximum_cumulant_index = max(config.cumulant_indices)
 
     @property
     def config(self) -> StackedHordeConfig:
@@ -336,6 +366,10 @@ class StackedLinearHorde:
             TD errors (TD errors are NaN for inactive demons).
         """
         cfg = self._config
+        cumulant_source = _require_cumulant_source_shape(
+            cumulant_source,
+            maximum_index=self._maximum_cumulant_index,
+        )
         cumulants = cumulant_source[self._cumulant_idx]  # (n_demons,)
         requested = ~jnp.isnan(cumulants)
         active = jnp.isfinite(cumulants)
@@ -464,6 +498,11 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
+    cumulant_sources = _require_cumulant_source_shape(
+        cumulant_sources,
+        maximum_index=max(horde.config.cumulant_indices),
+        batched=True,
+    )
     num_steps = features.shape[0]
     if rhos is None:
         rhos = jnp.ones((num_steps,), dtype=jnp.float32)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -399,6 +399,82 @@ class TestConfig:
         assert cfg.cumulant_indices == (0, 0, 2, 2)
         assert cfg.gammas == (0.0, 0.9, 0.0, 0.9)
 
+    @pytest.mark.parametrize("index", [-1, True, np.int64(0)])
+    def test_cumulant_indices_must_be_nonnegative_builtin_integers(
+        self, index: object
+    ) -> None:
+        with pytest.raises(ValueError, match="cumulant_indices"):
+            _simple_config(cumulant_indices=(0, index))
+
+
+class TestCumulantSourceValidation:
+    @staticmethod
+    def _indexed_horde() -> StackedLinearHorde:
+        return StackedLinearHorde(
+            StackedHordeConfig(
+                n_demons=2,
+                feature_dim=3,
+                gammas=(0.0, 0.0),
+                lamdas=(0.0, 0.0),
+                cumulant_indices=(0, 2),
+                step_size=0.5,
+            )
+        )
+
+    @pytest.mark.parametrize("compiled", [False, True], ids=("direct", "jit"))
+    def test_update_rejects_source_without_every_configured_index(
+        self, compiled: bool
+    ) -> None:
+        horde = self._indexed_horde()
+        state = horde.init()
+        update = jax.jit(horde.update) if compiled else horde.update
+
+        with pytest.raises(ValueError, match="configured cumulant index"):
+            update(
+                state,
+                jnp.array([1.0, 0.0, 0.0]),
+                jnp.zeros((3,)),
+                jnp.array([1.0, 99.0]),
+            )
+
+        chex.assert_trees_all_equal(state, horde.init())
+
+    def test_update_uses_the_requested_channel_when_source_is_wide_enough(self) -> None:
+        horde = self._indexed_horde()
+        state = horde.init()
+
+        result = horde.update(
+            state,
+            jnp.array([1.0, 0.0, 0.0]),
+            jnp.zeros((3,)),
+            jnp.array([1.0, 99.0, 4.0]),
+        )
+
+        np.testing.assert_allclose(np.asarray(result.td_errors), [1.0, 4.0])
+        np.testing.assert_allclose(
+            np.asarray(result.state.weights),
+            [[0.5, 0.0, 0.0], [2.0, 0.0, 0.0]],
+        )
+
+    def test_update_rejects_non_vector_cumulant_source(self) -> None:
+        horde = self._indexed_horde()
+
+        with pytest.raises(ValueError, match="rank-one"):
+            horde.update(
+                horde.init(),
+                jnp.array([1.0, 0.0, 0.0]),
+                jnp.zeros((3,)),
+                jnp.array([[1.0, 99.0, 4.0]]),
+            )
+
+    def test_scan_rejects_source_without_every_configured_index(self) -> None:
+        horde = self._indexed_horde()
+        features = jnp.eye(3, dtype=jnp.float32)
+        sources = jnp.asarray([[1.0, 99.0]] * 3, dtype=jnp.float32)
+
+        with pytest.raises(ValueError, match="configured cumulant index"):
+            run_stacked_horde_scan(horde, horde.init(), features, sources)
+
 
 class TestExactSemantics:
     def test_hand_computed_two_step(self):


### PR DESCRIPTION
Fixes #579.

## What changed

`StackedLinearHorde` now validates the complete cumulant-source shape before JAX gathers configured channels:

- every `cumulant_indices` entry must be a nonnegative exact built-in integer;
- one-step `cumulant_source` inputs must be rank one;
- scan `cumulant_sources` inputs must be rank two;
- the source's final axis must contain the maximum configured cumulant index before any gather or state update;
- the same static-shape checks apply to direct, `jax.jit(...)`, and `jax.lax.scan` paths.

This prevents JAX's positive out-of-range gather clipping from silently training a demon on the final available channel. Negative indices no longer wrap, and booleans / NumPy integer aliases no longer become configuration channels.

Valid TD(lambda) equations, state layout, update masking, serialization keys, and nexting behavior are unchanged.

## Reproduction

On the pre-change implementation:

```text
cumulant_indices=(0, 2)
source=[1, 99, 4] -> td_errors=[1, 4]
source=[1, 99]    -> td_errors=[1, 99]  # index 2 silently clips to channel 1
```

The failing-first focused run produced **6 failures and 61 passes**. The failures demonstrated acceptance of negative/boolean/NumPy indices, silent one-step and scan clipping, and a later broadcast failure for a rank-two one-step source instead of a boundary error.

## Verification

Final base: `80f1ace55108d38b9a25e6339e1efecf3f45c95c`

Exact head: `c82b915fc0577f5880f0ba66ad8c7a3ba72cd071`

- focused module: **68 passed**;
- direct and JIT short-source rejection: passed;
- valid wide-source channel-selection proof: passed;
- one-step rank validation: passed;
- scan short-source validation: passed;
- Ruff on changed source and tests: passed;
- strict mypy on changed production source: passed;
- `git diff --check origin/main...HEAD`: clean;
- exact-head factory proof: recorded green for `c82b915fc`.

## Ownership and scientific integrity

A complete current scan covered **61 open ASI PRs / 182 changed-file rows** with zero overlap on either target path. A separate scan covered **57 open issues** and matching claim comments; only #579 claims Stacked Horde cumulant-source bounds.

No `outputs/**` file, frozen protocol, benchmark threshold, seed, scientific claim, or registered five-claim evidence source changed. `alberta-evidence-status` remains inherited-invalid from unrelated source-hash drift already present on `main`; this PR does not suppress, regenerate, revalidate, or promote any evidence.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
- Attribution status: self-reported

— [sol-stacked-horde-cumulant-bounds]
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
