### PR TITLE
fix(ipmnist): close remaining screening input-validation gaps

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7261,8 +7261,15 @@ def _validated_ipmnist_data(
     *,
     input_dim: int | None,
     n_classes: int | None,
+    min_length: int | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
-    return validated_ipmnist_data(data_x, data_y, input_dim=input_dim, n_classes=n_classes)
+    return validated_ipmnist_data(
+        data_x,
+        data_y,
+        input_dim=input_dim,
+        n_classes=n_classes,
+        min_length=min_length,
+    )
 
 
 def ipmnist_permutation_sha256(permutation: np.ndarray | Array) -> str:
@@ -7699,14 +7706,15 @@ def run_screening_config(
         noise_mode,
         noise_pool_steps if noise_mode == "pool" else None,
     )
-    data_x = jnp.asarray(data_x, dtype=jnp.float32)
-    data_y = jnp.asarray(data_y, dtype=jnp.int32)
-    if data_x.ndim != 2 or data_x.shape[1] != config.input_dim:
-        raise ValueError(
-            f"data_x must have shape (n_train, {config.input_dim}), got {data_x.shape}"
-        )
-    if data_y.shape != (data_x.shape[0],):
-        raise ValueError("data_y must be (n_train,) aligned with data_x")
+    resolved_x, resolved_y = _validated_ipmnist_data(
+        data_x,
+        data_y,
+        input_dim=config.input_dim,
+        n_classes=config.n_classes,
+        min_length=config.task_length,
+    )
+    data_x = jnp.asarray(resolved_x, dtype=jnp.float32)
+    data_y = jnp.asarray(resolved_y, dtype=jnp.int32)
     n_train = int(data_x.shape[0])
 
     init_fn, step_fn = spec.factory(spec.hyperparameters)

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -399,23 +399,46 @@ def init_mlp_params(key: Array, config: IPMNISTConfig) -> dict[str, Array]:
     return params
 
 
+_REAL_NUMERIC_DTYPE_KINDS = frozenset({"i", "u", "f"})
+"""Concrete dtype kinds admitted as ``data_x``: signed/unsigned integers and floats.
+
+An allowlist is load-bearing here: ``np.issubdtype(np.timedelta64, np.number)``
+is true, and a ``NaT`` timedelta casts to a *finite* float32 sentinel, so a
+``number``-based check would let non-finite-in-spirit data through the finite
+gate.  Kind codes exclude bool (``b``), complex (``c``), timedelta (``m``),
+datetime (``M``), and every non-numeric kind.
+"""
+
+
 def validated_ipmnist_data(
     data_x: np.ndarray | Array,
     data_y: np.ndarray | Array,
     *,
     input_dim: int | None,
     n_classes: int | None,
+    min_length: int | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return ``(data_x, data_y)`` as finite float32 / int32 arrays inside the protocol domain.
 
     JAX gathers clamp out-of-range indices instead of raising, so a label at
     or above ``n_classes`` would silently be scored and trained as the last
     class, and a non-finite input would still yield an in-range accuracy.
-    Every runner that indexes the softmax by label must go through here.
+    Every runner that indexes the softmax by label must go through here
+    before touching any hyperparameter resolver or learner factory.
+
+    Args:
+        data_x: Candidate ``(n_train, input_dim)`` example matrix.
+        data_y: Candidate ``(n_train,)`` integer label vector.
+        input_dim: Required example width (``None`` = any).
+        n_classes: Exclusive label upper bound (``None`` = any).
+        min_length: Required minimum row count -- pass ``config.task_length``
+            so per-task sampling without replacement is feasible
+            (``None`` = any).
 
     Raises:
         ValueError: If ``data_x`` is not a finite ``(n_train, input_dim)``
-            matrix or ``data_y`` is not an aligned vector of integer labels in
+            matrix of a real numeric dtype kind with at least ``min_length``
+            rows, or ``data_y`` is not an aligned vector of integer labels in
             ``[0, n_classes)``.
     """
     raw_x = np.asarray(jax.device_get(data_x))
@@ -426,11 +449,11 @@ def validated_ipmnist_data(
         raise ValueError(f"data_x must have shape (n_train, {input_dim})")
     if raw_y.shape != (raw_x.shape[0],):
         raise ValueError("data_y must be (n_train,) aligned with data_x")
-    if (
-        np.issubdtype(raw_x.dtype, np.bool_)
-        or np.issubdtype(raw_x.dtype, np.complexfloating)
-        or not np.issubdtype(raw_x.dtype, np.number)
-    ):
+    if min_length is not None and raw_x.shape[0] < min_length:
+        raise ValueError(
+            "dataset smaller than task_length; cannot sample without replacement"
+        )
+    if raw_x.dtype.kind not in _REAL_NUMERIC_DTYPE_KINDS:
         raise ValueError("data_x must use a real numeric, non-boolean dtype")
     if raw_y.dtype.kind not in {"i", "u"}:
         raise ValueError("data_y must contain integer class labels")
@@ -781,7 +804,11 @@ def run_ipmnist(
     if noise_mode == "pool" and noise_pool_steps < 2:
         raise ValueError(f"noise_pool_steps must be >= 2, got {noise_pool_steps}")
     resolved_x, resolved_y = validated_ipmnist_data(
-        data_x, data_y, input_dim=config.input_dim, n_classes=config.n_classes
+        data_x,
+        data_y,
+        input_dim=config.input_dim,
+        n_classes=config.n_classes,
+        min_length=config.task_length,
     )
     hp = resolve_hyperparameters(learner, hyperparameters)
     init_fn, step_fn = _LEARNER_FACTORIES[learner](hp)
@@ -791,8 +818,6 @@ def run_ipmnist(
     data_x = jnp.asarray(resolved_x, dtype=jnp.float32)
     data_y = jnp.asarray(resolved_y, dtype=jnp.int32)
     n_train = int(data_x.shape[0])
-    if n_train < config.task_length:
-        raise ValueError("dataset smaller than task_length; cannot sample without replacement")
 
     seeds_array = jnp.asarray(seed_tuple, dtype=jnp.uint32)
 

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -482,7 +482,11 @@ def run_label_emnist(
     if config is None:
         config = LabelEMNISTConfig()
     resolved_x, resolved_y = validated_ipmnist_data(
-        data_x, data_y, input_dim=config.input_dim, n_classes=config.n_classes
+        data_x,
+        data_y,
+        input_dim=config.input_dim,
+        n_classes=config.n_classes,
+        min_length=config.task_length,
     )
     hp = resolve_hyperparameters(learner, hyperparameters)
     init_fn, step_fn = _FULL_STEP_FACTORIES[learner](hp)
@@ -490,8 +494,6 @@ def run_label_emnist(
     data_x = jnp.asarray(resolved_x, dtype=jnp.float32)
     data_y = jnp.asarray(resolved_y, dtype=jnp.int32)
     n_train = int(data_x.shape[0])
-    if n_train < config.task_length:
-        raise ValueError("dataset smaller than task_length; cannot sample without replacement")
 
     seeds_array = jnp.asarray(seed_tuple, dtype=jnp.uint32)
     initialization_config = IPMNISTConfig(**config.to_config())

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -368,6 +368,49 @@ class TestControlParity:
         )
 
 
+@pytest.mark.unit
+class TestScreeningInputDomain:
+    """Issue #527: run_screening_config must refuse out-of-domain data before the factory."""
+
+    @staticmethod
+    def _boom_factory(hyperparameters):
+        del hyperparameters
+        raise AssertionError("out-of-domain data reached the learner factory")
+
+    @pytest.mark.parametrize("noise_mode", ["step", "pool"])
+    @pytest.mark.parametrize(
+        ("mutate", "message"),
+        [
+            (lambda x, y: (x, y + 100), "must be smaller than"),
+            (lambda x, y: (x, y - 1), "non-negative"),
+            (lambda x, y: (x, y.astype(np.float32) + 0.9), "integer class labels"),
+            (lambda x, y: (x.at[0, 0].set(np.inf), y), "finite"),
+            (lambda x, y: (x.at[3, 1].set(np.nan), y), "finite"),
+            (
+                lambda x, y: (np.full(np.shape(x), np.timedelta64("NaT", "s")), y),
+                "real numeric",
+            ),
+            (
+                lambda x, y: (
+                    x[: SMALL.task_length - 1],
+                    y[: SMALL.task_length - 1],
+                ),
+                "task_length",
+            ),
+        ],
+    )
+    def test_rejects_before_learner_factory(
+        self, small_data, noise_mode: str, mutate, message: str
+    ) -> None:
+        x, y = small_data
+        x, y = mutate(jnp.asarray(x), jnp.asarray(y))
+        spec = replace(screening_spec("upgd_w_control"), factory=self._boom_factory)
+        with pytest.raises(ValueError, match=message):
+            run_screening_config(
+                x, y, spec, seed=0, config=SMALL, noise_mode=noise_mode
+            )
+
+
 class TestIDBDCombo:
     def test_meta_zero_reduces_to_lean_upgd(self):
         """With meta=0 and initial alpha = published lr, IDBD == lean UPGD-W."""

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -167,6 +167,52 @@ class TestInputDomain:
             run_ipmnist(x, y, "adamw", seeds=[0], config=TINY)
 
 
+@pytest.mark.unit
+class TestInputDomainBoundary:
+    """Issue #527: the shared validator is the single gate ahead of learner setup."""
+
+    @staticmethod
+    def _unexpected_setup(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("out-of-domain data reached learner setup")
+
+    def test_run_rejects_timedelta_inputs_before_setup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        x = np.full((N_TRAIN, TINY.input_dim), np.timedelta64("NaT", "s"))
+        y = np.zeros(N_TRAIN, dtype=np.int32)
+        monkeypatch.setattr(upgd_ipmnist, "resolve_hyperparameters", self._unexpected_setup)
+        with pytest.raises(ValueError, match="real numeric"):
+            run_ipmnist(x, y, "adamw", seeds=[0], config=TINY)
+
+    def test_run_rejects_short_dataset_before_setup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        x, y = _synthetic_dataset(0, TINY.task_length - 1, TINY.input_dim, TINY.n_classes)
+        monkeypatch.setattr(upgd_ipmnist, "resolve_hyperparameters", self._unexpected_setup)
+        with pytest.raises(ValueError, match="task_length"):
+            run_ipmnist(x, y, "adamw", seeds=[0], config=TINY)
+
+    @pytest.mark.parametrize("kind", ["timedelta64[s]", "datetime64[s]", "bool"])
+    def test_validator_rejects_non_real_dtype_kinds(self, kind: str) -> None:
+        x = np.zeros((4, TINY.input_dim), dtype=kind)
+        y = np.zeros(4, dtype=np.int32)
+        with pytest.raises(ValueError, match="real numeric"):
+            upgd_ipmnist.validated_ipmnist_data(
+                x, y, input_dim=TINY.input_dim, n_classes=TINY.n_classes
+            )
+
+    def test_validator_enforces_min_length(self) -> None:
+        x, y = _synthetic_dataset(0, 5, TINY.input_dim, TINY.n_classes)
+        with pytest.raises(ValueError, match="task_length"):
+            upgd_ipmnist.validated_ipmnist_data(
+                x, y, input_dim=TINY.input_dim, n_classes=TINY.n_classes, min_length=6
+            )
+        upgd_ipmnist.validated_ipmnist_data(
+            x, y, input_dim=TINY.input_dim, n_classes=TINY.n_classes, min_length=5
+        )
+
+
 class TestSeedBoundary:
     @pytest.mark.parametrize(
         "seeds",

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -338,6 +338,38 @@ def test_run_label_emnist_rejects_out_of_domain_inputs(
         run_label_emnist(x, y, "adamw", seeds=[0], config=TINY)
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda x, y: (np.full(x.shape, np.timedelta64("NaT", "s")), y),
+            "real numeric",
+        ),
+        (
+            lambda x, y: (
+                x[: TINY.task_length - 1],
+                y[: TINY.task_length - 1],
+            ),
+            "task_length",
+        ),
+    ],
+)
+def test_run_label_emnist_rejects_boundary_gaps_before_setup(
+    monkeypatch: pytest.MonkeyPatch, mutate, message: str
+) -> None:
+    """Issue #527: timedelta inputs and short datasets must fail before setup."""
+
+    def unexpected_setup(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("out-of-domain data reached learner setup")
+
+    x, y = mutate(*_tiny_data())
+    monkeypatch.setattr(upgd_label_emnist, "resolve_hyperparameters", unexpected_setup)
+    with pytest.raises(ValueError, match=message):
+        run_label_emnist(x, y, "adamw", seeds=[0], config=TINY)
+
+
 @pytest.fixture(scope="class")
 def debug_run():
     """Run the shared tiny diagnostic once for this test module."""


### PR DESCRIPTION
Fixes #527

Closes the three screening-path validation gaps that remained after #448, keeping the shared validator as the single trust boundary ahead of any hyperparameter resolver or learner factory.

## Changes

- `validated_ipmnist_data` (`alberta_framework/benchmarks/upgd_ipmnist.py`) now checks `data_x` against a concrete dtype-kind allowlist (`{"i", "u", "f"}`, module constant `_REAL_NUMERIC_DTYPE_KINDS`) instead of `np.issubdtype(..., np.number)`. This rejects `timedelta64` — whose `NaT` previously cast to a finite float32 sentinel and slipped past the non-finite gate — plus `datetime64`, bool, complex, and every non-numeric kind, with the same error text as before.
- `validated_ipmnist_data` gains a keyword-only `min_length` parameter so a shape-aligned dataset shorter than `task_length` is rejected at the validation boundary, before learner setup. `run_ipmnist` and `run_label_emnist` pass `min_length=config.task_length` and drop their post-factory length checks (same error message, earlier point of failure).
- `run_screening_config` (`alberta_framework/benchmarks/ipmnist_screening.py`) now routes through `_validated_ipmnist_data` (with `input_dim`, `n_classes`, and `min_length=config.task_length`) before `spec.factory` in both `noise_mode="step"` and `noise_mode="pool"`, replacing the inline shape-only checks that let invalid labels and non-finite inputs reach the learner factory. The `_validated_ipmnist_data` wrapper forwards the new `min_length` keyword; other call sites (sentinel/retention paths) are unchanged, preserving valid-trajectory and provenance compatibility.
- Failing-test-first unit coverage (marker `unit`, synthetic data only, no benchmark executions): `TestScreeningInputDomain` pins `run_screening_config` rejection before the factory for label overflow/underflow, float labels, non-finite inputs, all-`NaT` timedelta inputs, and short datasets in both noise modes; `TestInputDomainBoundary` and the new `run_label_emnist` parametrized test pin the timedelta and short-dataset rejections before setup plus the validator's dtype-kind allowlist and `min_length` contract.

## Validation

- `.venv/bin/python -m pytest tests/test_upgd_ipmnist.py tests/test_upgd_label_emnist.py tests/test_ipmnist_screening.py -q` — 446 passed in 621.56s
- New tests reproduced every gap on the pre-fix tree first: 20 failed as expected, then all pass with the fix
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues found in 165 source files

No `outputs/` paths touched; no benchmark executions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
