### PR TITLE
fix(dreaming): validate DreamingConfig scalars against NaN and type stand-ins

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Any, Literal, Protocol, cast
 
 import chex
@@ -43,6 +44,29 @@ from alberta_framework.core.world_model import (
 from alberta_framework.core.world_model import (
     WorldModelPrediction as ActionWorldModelPrediction,
 )
+
+
+def _require_exact_int(value: object, name: str, *, minimum: int) -> None:
+    """Reject bools, floats, and other non-int scalars for count fields."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{name} must be an int >= {minimum}")
+
+
+def _require_finite_nonnegative(value: object, name: str) -> None:
+    """Reject NaN, infinities, negatives, and non-real scalars."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(value)
+        or value < 0.0
+    ):
+        raise ValueError(f"{name} must be finite and non-negative")
+
+
+def _require_bool(value: object, name: str) -> None:
+    """Reject truthy stand-ins for exact bools."""
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a bool")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -72,6 +96,20 @@ class DreamingConfig:
     max_model_error: float = 1.0e30
     discount_floor: float = 0.0
     stop_on_terminal: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate scalar configuration, rejecting NaN and type stand-ins."""
+        _require_exact_int(self.warmup_steps, "warmup_steps", minimum=0)
+        _require_finite_nonnegative(self.max_model_error_ema, "max_model_error_ema")
+        _require_finite_nonnegative(self.max_uncertainty, "max_uncertainty")
+        _require_finite_nonnegative(self.min_discount, "min_discount")
+        if self.max_discount is not None:
+            _require_finite_nonnegative(self.max_discount, "max_discount")
+        _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1)
+        _require_finite_nonnegative(self.confidence_threshold, "confidence_threshold")
+        _require_finite_nonnegative(self.max_model_error, "max_model_error")
+        _require_finite_nonnegative(self.discount_floor, "discount_floor")
+        _require_bool(self.stop_on_terminal, "stop_on_terminal")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -184,16 +222,20 @@ class GuardedDreamer:
     def __init__(self, config: DreamingConfig | None = None):
         """Initialize a guarded dream proposer."""
         self._config = config or DreamingConfig()
-        if self._config.warmup_steps < 0:
-            raise ValueError("warmup_steps must be non-negative")
-        if self._config.max_model_error_ema < 0.0:
-            raise ValueError("max_model_error_ema must be non-negative")
-        if self._config.max_uncertainty < 0.0:
-            raise ValueError("max_uncertainty must be non-negative")
-        if self._config.min_discount < 0.0:
-            raise ValueError("min_discount must be non-negative")
-        if self._config.max_discount is not None and self._config.max_discount < 0.0:
-            raise ValueError("max_discount must be non-negative")
+        # DreamingConfig.__post_init__ validates on construction; re-validate here
+        # so instances mutated through object.__setattr__ (or crafted subclasses)
+        # cannot smuggle NaN or type stand-ins past the guard.
+        _require_exact_int(self._config.warmup_steps, "warmup_steps", minimum=0)
+        _require_finite_nonnegative(self._config.max_model_error_ema, "max_model_error_ema")
+        _require_finite_nonnegative(self._config.max_uncertainty, "max_uncertainty")
+        _require_finite_nonnegative(self._config.min_discount, "min_discount")
+        if self._config.max_discount is not None:
+            _require_finite_nonnegative(self._config.max_discount, "max_discount")
+        _require_exact_int(self._config.rollout_horizon, "rollout_horizon", minimum=1)
+        _require_finite_nonnegative(self._config.confidence_threshold, "confidence_threshold")
+        _require_finite_nonnegative(self._config.max_model_error, "max_model_error")
+        _require_finite_nonnegative(self._config.discount_floor, "discount_floor")
+        _require_bool(self._config.stop_on_terminal, "stop_on_terminal")
 
     @property
     def config(self) -> DreamingConfig:
@@ -509,15 +551,12 @@ class DreamRolloutConfig:
     stop_on_terminal: bool = True
 
     def __post_init__(self) -> None:
-        """Validate scalar configuration."""
-        if self.rollout_horizon < 1:
-            raise ValueError("rollout_horizon must be positive")
-        if self.confidence_threshold < 0.0:
-            raise ValueError("confidence_threshold must be non-negative")
-        if self.max_model_error < 0.0:
-            raise ValueError("max_model_error must be non-negative")
-        if self.discount_floor < 0.0:
-            raise ValueError("discount_floor must be non-negative")
+        """Validate scalar configuration, rejecting NaN and type stand-ins."""
+        _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1)
+        _require_finite_nonnegative(self.confidence_threshold, "confidence_threshold")
+        _require_finite_nonnegative(self.max_model_error, "max_model_error")
+        _require_finite_nonnegative(self.discount_floor, "discount_floor")
+        _require_bool(self.stop_on_terminal, "stop_on_terminal")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -11,8 +11,10 @@ import pytest
 
 from alberta_framework.core.dreaming import (
     DreamBehaviorModelPrediction,
+    DreamingConfig,
     DreamRolloutConfig,
     DreamWorldModelPrediction,
+    GuardedDreamer,
     dream_one_step,
     dream_rollout,
     imagined_rollout_to_gvf_items,
@@ -318,3 +320,119 @@ def test_rollout_to_sarsa_items_shift_actions_and_mask_last_without_bootstrap() 
         jnp.array(1, dtype=jnp.int32),
     )
     chex.assert_trees_all_close(bootstrapped.weights, rollout.transitions.valid.astype(jnp.float32))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field",
+    [
+        "max_model_error_ema",
+        "max_uncertainty",
+        "min_discount",
+        "max_discount",
+        "confidence_threshold",
+        "max_model_error",
+        "discount_floor",
+    ],
+)
+def test_dreaming_config_rejects_nonfinite_float_fields(field: str) -> None:
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match=field):
+            DreamingConfig(**{field: bad})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_model_error_ema", -0.5),
+        ("max_uncertainty", -0.5),
+        ("min_discount", -0.5),
+        ("max_discount", -0.5),
+        ("confidence_threshold", -0.5),
+        ("max_model_error", -0.5),
+        ("discount_floor", -0.5),
+    ],
+)
+def test_dreaming_config_rejects_negative_float_fields(field: str, value: float) -> None:
+    with pytest.raises(ValueError, match=field):
+        DreamingConfig(**{field: value})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0, -1, True, False, 1.0, 2.5, float("nan")])
+def test_dreaming_config_rejects_invalid_rollout_horizon(bad: object) -> None:
+    with pytest.raises(ValueError, match="rollout_horizon"):
+        DreamingConfig(rollout_horizon=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [-1, True, False, 0.0, 1.5, float("nan")])
+def test_dreaming_config_rejects_invalid_warmup_steps(bad: object) -> None:
+    with pytest.raises(ValueError, match="warmup_steps"):
+        DreamingConfig(warmup_steps=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0, 1, "yes", None, 1.0])
+def test_dreaming_config_rejects_non_bool_stop_on_terminal(bad: object) -> None:
+    with pytest.raises(ValueError, match="stop_on_terminal"):
+        DreamingConfig(stop_on_terminal=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_dreaming_config_accepts_valid_boundaries() -> None:
+    config = DreamingConfig(
+        warmup_steps=0,
+        max_model_error_ema=0.0,
+        max_uncertainty=0.0,
+        min_discount=0.0,
+        max_discount=0.0,
+        rollout_horizon=1,
+        confidence_threshold=0.0,
+        max_model_error=0.0,
+        discount_floor=0.0,
+        stop_on_terminal=False,
+    )
+    assert config.rollout_horizon == 1
+    assert config.max_discount == 0.0
+    assert DreamingConfig(max_discount=None).max_discount is None
+
+
+@pytest.mark.unit
+def test_guarded_dreamer_rejects_nan_confidence_threshold_config() -> None:
+    with pytest.raises(ValueError, match="confidence_threshold"):
+        GuardedDreamer(DreamingConfig(confidence_threshold=float("nan")))
+
+
+@pytest.mark.unit
+def test_dreaming_config_from_config_revalidates() -> None:
+    payload = DreamingConfig().to_config()
+    payload["confidence_threshold"] = float("nan")
+    with pytest.raises(ValueError, match="confidence_threshold"):
+        DreamingConfig.from_config(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field",
+    ["confidence_threshold", "max_model_error", "discount_floor"],
+)
+def test_dream_rollout_config_rejects_nonfinite_float_fields(field: str) -> None:
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match=field):
+            DreamRolloutConfig(**{field: bad})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0, -1, True, False, 1.0, 2.5, float("nan")])
+def test_dream_rollout_config_rejects_invalid_rollout_horizon(bad: object) -> None:
+    with pytest.raises(ValueError, match="rollout_horizon"):
+        DreamRolloutConfig(rollout_horizon=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0, 1, "yes", None, 1.0])
+def test_dream_rollout_config_rejects_non_bool_stop_on_terminal(bad: object) -> None:
+    with pytest.raises(ValueError, match="stop_on_terminal"):
+        DreamRolloutConfig(stop_on_terminal=bad)  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #526

## Changes

- `alberta_framework/core/dreaming.py`: added three shared module-level validators (`_require_exact_int`, `_require_finite_nonnegative`, `_require_bool`) and applied them at every dreaming config trust boundary:
  - `DreamingConfig` gains a `__post_init__` that validates all ten scalar fields, so `NaN`/`inf` values, negative values, bool/float stand-ins for `warmup_steps`/`rollout_horizon`, and non-bool `stop_on_terminal` are rejected at construction (covering `from_config` round-trips too).
  - `GuardedDreamer.__init__` re-validates the full config with `math.isfinite`-hardened checks, replacing the bare `< 0.0` comparisons that `NaN` passed, and now also checks the previously unchecked `rollout_horizon`, `confidence_threshold`, `max_model_error`, `discount_floor`, and `stop_on_terminal`.
  - `DreamRolloutConfig.__post_init__` (same field set, consumed by `dream_one_step`/`dream_rollout`, where a `NaN` `confidence_threshold` makes `confidence_ok` uniformly false) is hardened identically and now validates `stop_on_terminal`.
- `tests/test_dreaming.py`: added `@pytest.mark.unit` regression tests (failing-test-first) covering NaN/inf/negative rejection for every float field, bool/float/zero/negative rejection for `rollout_horizon` and `warmup_steps`, exact-bool enforcement for `stop_on_terminal`, `from_config` re-validation, the issue's `GuardedDreamer(DreamingConfig(confidence_threshold=float("nan")))` reproduction, and boundary acceptance of valid configs.

## Validation

- `.venv/bin/python -m pytest tests/test_dreaming.py -q` — 60 passed (46 of the new cases failed before the fix, confirming the defect).
- `.venv/bin/python -m pytest tests/test_prototype_agent.py tests/test_prototype_dream_isolation.py -q` — 102 passed (direct `DreamingConfig`/`GuardedDreamer` consumers).
- `.venv/bin/python -m ruff check .` — all checks passed.
- `.venv/bin/python -m mypy` — success, no issues in 165 source files.
- `alberta-evidence-status` — reports `invalid` for all five claims both on this branch and on an untouched `main` checkout in this environment; `core/dreaming.py` is not in the registered source inventory (`evaluation/evidence_manifest.py`), so this PR does not change evidence validity. Not silenced per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
