### PR TITLE
fix(streams): reject class-spoofed non-real Pavlovian scalars

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import math
 from numbers import Real
+from typing import Any, cast
 
 import chex
 import jax
@@ -64,10 +65,11 @@ def _require_finite_real(
     nonnegative: bool = False,
 ) -> float:
     """Return a finite real, rejecting bools, NaN, and infinities."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a finite real, got {value!r}")
     try:
-        number = float(value)
+        number = float(cast(Any, value))
     except (OverflowError, ValueError) as error:
         raise ValueError(f"{name} must be a finite real, got {value!r}") from error
     if not math.isfinite(number):
@@ -84,12 +86,13 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     below the float32 subnormal range are accepted as exact zero, matching the
     noise-free trajectory they produce in the stream's float32 arithmetic.
     """
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
-    if value < 0:
+    if cast(Any, value) < 0:
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
     try:
-        narrowed = round_real_to_float32(value)
+        narrowed = round_real_to_float32(cast(Any, value))
     except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
@@ -103,9 +106,10 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
 
 def _require_unit_interval(value: object, *, name: str) -> float:
     """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    number = float(value)
+    number = float(cast(Any, value))
     if not math.isfinite(number) or not 0.0 <= number <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return number

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 from fractions import Fraction
+from numbers import Real
 
 import chex
 import jax
@@ -581,6 +582,52 @@ def test_construct_rejects_illegal_distractor_prob(value: object) -> None:
             phases=(_valid_phase(),),
             distractor_prob=value,  # type: ignore[arg-type]
         )
+
+
+class _SpoofedFloat:
+    """Mimics ``float`` via ``__class__`` to defeat ``isinstance``."""
+
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+    def __lt__(self, other: object) -> bool:
+        return 0.5 < other  # type: ignore[operator]
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        return (1, 2)
+
+
+def test_construct_rejects_class_spoofed_distractor_prob() -> None:
+    """A ``__class__``-spoofed non-``Real`` must not defeat ``distractor_prob``.
+
+    ``isinstance()`` consults the overridable ``__class__`` attribute rather
+    than the real type slot, so an object whose ``__class__`` property
+    returns ``float`` passes ``isinstance(value, Real)`` even though its
+    actual type has no relationship to ``numbers.Real``.
+    """
+    fake = _SpoofedFloat()
+    assert isinstance(fake, Real)
+    assert not issubclass(type(fake), Real)
+
+    with pytest.raises(ValueError, match="distractor_prob"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            distractor_prob=fake,  # type: ignore[arg-type]
+        )
+
+
+def test_construct_rejects_class_spoofed_cs_us_contingency() -> None:
+    """A ``__class__``-spoofed non-``Real`` must not defeat ``cs_us_contingency``."""
+    fake = _SpoofedFloat()
+    assert isinstance(fake, Real)
+    assert not issubclass(type(fake), Real)
+
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        ClassicalConditioningStream(phases=(_valid_phase(cs_us_contingency=fake),))
 
 
 @pytest.mark.parametrize("value", [True, False])


### PR DESCRIPTION
Closes #600.

## What changed

Same isinstance-spoofing class as the `_require_int` family (#400, #502,
#504, #544, #547, #552, #556, #559, #563), `representation_gradient_mixer.py`
(#570), `partner_policy_fusion.py` (#572), `types.py` GVFSpec (#574),
`associative_memory.py` (#577), and `closed_loop.py` (#581) — all currently
open. `_require_finite_real`, `_require_nonnegative_float32`, and
`_require_unit_interval` in `alberta_framework/streams/pavlovian.py` used
`isinstance(value, bool) or not isinstance(value, Real)`. `isinstance()`
consults `__class__`, which is overridable via a `@property`, so an object
whose `__class__` property returns `float` passes `isinstance(value, Real)`
even though `type(value)` has no real relationship to `numbers.Real`.

`ClassicalConditioningStream.__init__` routes `distractor_prob` and every
phase's `cs_us_contingency` through `_require_unit_interval` before use.
`_require_unit_interval` is directly exploitable end-to-end: it narrows via
plain `float(value)`, which succeeds on anything implementing `__float__`,
so a spoofed object sails through unvalidated into the stream's internal
float state. `noise_std` routes through `_require_nonnegative_float32`,
which has the same unsound gate but happens to be masked end-to-end today
because the downstream `round_real_to_float32()` call
(`alberta_framework/_float32.py`) performs its own `type()`-based check and
raises `TypeError`, which gets converted to `ValueError`. I hardened it
anyway for defense-in-depth and consistency — the local gate itself should
do its job rather than relying on an unrelated function's incidental
protection. `_require_finite_real` is currently dead code (no call sites)
but shares the same gate, so it's hardened too rather than left as a latent
trap for the next caller.

`ClassicalConditioningStream` is a public class in
`alberta_framework/streams/pavlovian.py`, constructed directly with
ordinary keyword arguments — no special access required.

Fix: switch the type gate in all three helpers to `type()`-based
`issubclass` checks, which read the real, non-spoofable type slot instead of
the overridable `__class__` attribute. Downstream uses of `value` after the
gate are wrapped in `cast(Any, value)` to preserve mypy's prior narrowing
(mypy narrows on `isinstance(value, Real)` but not on
`issubclass(type(value), Real)`).

## Reachability

```python
from numbers import Real
from alberta_framework.streams.pavlovian import ClassicalConditioningStream, PavlovianPhase

class SpoofedFloat:
    @property
    def __class__(self):
        return float
    def __float__(self):
        return 0.5

fake = SpoofedFloat()
print(isinstance(fake, Real))          # True  (spoofed)
print(issubclass(type(fake), Real))    # False (actual type)

phase = PavlovianPhase(name="acq", n_steps=10, cs_active=(0,), compound_index=-1, cs_us_contingency=1.0)
stream = ClassicalConditioningStream(phases=(phase,), distractor_prob=fake)
print(stream._distractor_prob)  # 0.5 -- constructs successfully on unpatched main, no ValueError
```

Confirmed live against the unpatched code in an interactive
`.venv/bin/python` session before writing the fix (same result for
`cs_us_contingency=fake` on a phase).

## Verification

- New tests `test_construct_rejects_class_spoofed_distractor_prob` and
  `test_construct_rejects_class_spoofed_cs_us_contingency` added next to the
  existing `test_construct_rejects_illegal_distractor_prob` /
  `test_construct_rejects_bool_phase_contingency` in
  `tests/test_pavlovian_stream.py`.
- Mutation check: `git stash push -- alberta_framework/streams/pavlovian.py`
  (source only, tests kept), reran the two new tests → both fail with
  `Failed: DID NOT RAISE ValueError`, reproducing the original symptom.
  `git stash pop` restored the fix → both pass.
- `.venv/bin/python -m pytest tests/test_pavlovian_stream.py -q -o addopts="" -m ""` → `98 passed` (140.87s; file is `@pytest.mark.slow`).
- `.venv/bin/python -m pytest tests/test_pavlovian_learning.py -q -o addopts="" -m ""` (downstream caller of the stream) → `2 passed`.
- `.venv/bin/python -m ruff check .` → `All checks passed!`
- `.venv/bin/python -m mypy` (full project, strict) → `Success: no issues found in 165 source files`.
- `git diff --check` → clean, no whitespace errors.
- `.venv/bin/alberta-evidence-status` → `overall_status: invalid`, unchanged
  by this PR. `pavlovian.py` is not a registered source for any of the 5
  evidence claims (confirmed via `grep -rn pavlovian alberta_framework/evaluation/evidence_manifest.py`,
  no matches), and the registry already reports `invalid` on an unmodified
  clean `main` checkout in this environment — a pre-existing, unrelated
  condition, not caused by this change.

## Provenance

AI-assisted (Claude Code, `claude-sonnet-5`, provider Anthropic). Spoofing
behavior reproduced empirically against the unpatched code before writing
the fix. All verification above (mutation testing, full-file test run,
lint/typecheck, reachability trace, evidence-registry check) performed and
observed directly before opening this PR.

Receipt signing deferred — handled centrally by the orchestrating session
for this contribution cycle.
