### PR TITLE
fix(options): validate SubtaskSpec threshold finiteness and pseudo_reward_scale

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -69,8 +69,10 @@ class SubtaskSpec:
     Args:
         feature_index: Index of the observation feature the option drives toward.
         threshold: Pseudo-reward value at which the option is considered
-            complete.  Must be positive; choose relative to the feature scale.
+            complete.  Must be finite and positive; choose relative to the
+            feature scale.
         pseudo_reward_scale: Multiplicative scale for the pseudo-reward signal.
+            Must be finite and positive.
         max_option_steps: Hard cap on option duration to prevent infinite loops.
     """
 
@@ -83,8 +85,10 @@ class SubtaskSpec:
         """Validate subtask specification."""
         if self.feature_index < 0:
             raise ValueError("feature_index must be non-negative")
-        if self.threshold <= 0.0:
-            raise ValueError("threshold must be positive")
+        if not math.isfinite(self.threshold) or self.threshold <= 0.0:
+            raise ValueError("threshold must be finite and positive")
+        if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
+            raise ValueError("pseudo_reward_scale must be finite and positive")
         if self.max_option_steps < 1:
             raise ValueError("max_option_steps must be at least 1")
 

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -172,11 +172,6 @@ class Step10STOMPConfig:
 _INT32_MAX = 2**31 - 1
 
 
-def _require_real(name: str, value: object) -> float:
-    real, _, _, narrowed = finite_real_and_float32(name, value)
-    return canonical_float32_storage(real, narrowed)
-
-
 def _require_unit_interval(name: str, value: object) -> float:
     real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
@@ -253,7 +248,7 @@ def _validate_stomp_facade_config(config: Step10STOMPConfig) -> None:
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
             )
         threshold = _require_positive_real("threshold", spec.threshold)
-        pseudo_reward_scale = _require_real(
+        pseudo_reward_scale = _require_positive_real(
             "pseudo_reward_scale",
             spec.pseudo_reward_scale,
         )

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -260,7 +260,7 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
             )
         threshold = _require_positive_real("threshold", spec.threshold)
-        pseudo_reward_scale = _require_real(
+        pseudo_reward_scale = _require_positive_real(
             "pseudo_reward_scale",
             spec.pseudo_reward_scale,
         )

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -240,7 +240,7 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
                 f"feature_index must be < observation_dim, got {spec.feature_index!r}"
             )
         threshold = _require_positive_real("threshold", spec.threshold)
-        pseudo_reward_scale = _require_real(
+        pseudo_reward_scale = _require_positive_real(
             "pseudo_reward_scale",
             spec.pseudo_reward_scale,
         )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -27,6 +27,28 @@ N_PRIMITIVE = 2
 N_OPTIONS = 2
 
 
+@pytest.mark.unit
+class TestSubtaskSpecValidation:
+    """SubtaskSpec must reject non-finite thresholds and degenerate scales."""
+
+    def test_valid_spec_accepted(self) -> None:
+        spec = SubtaskSpec(feature_index=0, threshold=0.5, pseudo_reward_scale=2.0)
+        assert spec.threshold == 0.5
+        assert spec.pseudo_reward_scale == 2.0
+
+    @pytest.mark.parametrize("threshold", [float("nan"), float("inf"), 0.0, -1.0])
+    def test_rejects_bad_threshold(self, threshold: float) -> None:
+        with pytest.raises(ValueError, match="threshold"):
+            SubtaskSpec(feature_index=0, threshold=threshold)
+
+    @pytest.mark.parametrize(
+        "scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0]
+    )
+    def test_rejects_bad_pseudo_reward_scale(self, scale: float) -> None:
+        with pytest.raises(ValueError, match="pseudo_reward_scale"):
+            SubtaskSpec(feature_index=0, pseudo_reward_scale=scale)
+
+
 def _agent() -> STOMPAgent:
     return STOMPAgent(
         STOMPConfig(

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -353,7 +353,7 @@ def test_step10_stomp_fields_preserve_legal_endpoints() -> None:
             SubtaskSpec(
                 feature_index=0,
                 threshold=1e-12,
-                pseudo_reward_scale=0.0,
+                pseudo_reward_scale=1e-12,
                 max_option_steps=1,
             ),
         ),
@@ -396,7 +396,7 @@ def test_step10_stomp_fields_preserve_legal_endpoints() -> None:
     assert restored.option_importance_clip == 1e-12
     assert restored.subtask_specs[0].feature_index == 0
     assert restored.subtask_specs[0].threshold == 1e-12
-    assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert restored.subtask_specs[0].pseudo_reward_scale == 1e-12
     assert restored.subtask_specs[0].max_option_steps == 1
     assert agent.config.option_gamma == 0.0
 

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -335,7 +335,7 @@ def test_step11_oak_fields_preserve_legal_endpoints() -> None:
             SubtaskSpec(
                 feature_index=0,
                 threshold=1e-12,
-                pseudo_reward_scale=0.0,
+                pseudo_reward_scale=1e-12,
                 max_option_steps=1,
             ),
         ),
@@ -378,7 +378,7 @@ def test_step11_oak_fields_preserve_legal_endpoints() -> None:
     assert restored.curation_threshold == 0.0
     assert restored.subtask_specs[0].feature_index == 0
     assert restored.subtask_specs[0].threshold == float(np.float32(1e-12))
-    assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert restored.subtask_specs[0].pseudo_reward_scale == float(np.float32(1e-12))
     assert restored.subtask_specs[0].max_option_steps == 1
     assert agent.config.stomp.option_gamma == 0.0
 
@@ -417,6 +417,13 @@ def test_step11_oak_rejects_float32_underflow_for_positive_fields() -> None:
     with pytest.raises(ValueError, match="threshold"):
         Step11OaKConfig(
             subtask_specs=(SubtaskSpec(feature_index=0, threshold=1e-46),),
+            observation_dim=4,
+        )
+    with pytest.raises(ValueError, match="pseudo_reward_scale"):
+        Step11OaKConfig(
+            subtask_specs=(
+                SubtaskSpec(feature_index=0, pseudo_reward_scale=1e-50),
+            ),
             observation_dim=4,
         )
 
@@ -525,13 +532,13 @@ def test_step11_fraction_float32_overflow_midpoint_is_exact() -> None:
 
 def test_step11_oak_preserves_float32_boundaries() -> None:
     f32_max = float(np.finfo(np.float32).max)
-    f32_min = float(np.finfo(np.float32).min)
+    f32_tiny = float(np.finfo(np.float32).tiny)
     config = Step11OaKConfig(
         subtask_specs=(
             SubtaskSpec(
                 feature_index=0,
                 threshold=f32_max,
-                pseudo_reward_scale=f32_min,
+                pseudo_reward_scale=f32_tiny,
                 max_option_steps=10,
             ),
         ),
@@ -541,7 +548,7 @@ def test_step11_oak_preserves_float32_boundaries() -> None:
     )
     agent = make_step11_oak_agent(config)
     assert agent.config.stomp.subtask_specs[0].threshold == f32_max
-    assert agent.config.stomp.subtask_specs[0].pseudo_reward_scale == f32_min
+    assert agent.config.stomp.subtask_specs[0].pseudo_reward_scale == f32_tiny
     assert config.curation_threshold == f32_max
     assert config.base_step_size == f32_max
 

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -352,7 +352,7 @@ def test_step12_ia_fields_preserve_legal_endpoints() -> None:
             SubtaskSpec(
                 feature_index=0,
                 threshold=1e-12,
-                pseudo_reward_scale=0.0,
+                pseudo_reward_scale=1e-12,
                 max_option_steps=1,
             ),
         ),
@@ -383,7 +383,7 @@ def test_step12_ia_fields_preserve_legal_endpoints() -> None:
     assert restored.utility_ema_decay == 0.0
     assert restored.subtask_specs[0].feature_index == 0
     assert restored.subtask_specs[0].threshold == float(np.float32(1e-12))
-    assert restored.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert restored.subtask_specs[0].pseudo_reward_scale == float(np.float32(1e-12))
     assert restored.subtask_specs[0].max_option_steps == 1
     assert agent.config.cortex.stomp.option_gamma == 0.0
 
@@ -473,26 +473,34 @@ def test_step12_rejects_values_that_overflow_float32(field: str) -> None:
 
 @pytest.mark.parametrize("value", [1.0e100, -1.0e100])
 def test_step12_rejects_pseudo_reward_scale_that_overflows_float32(value: float) -> None:
-    spec = SubtaskSpec(feature_index=0, pseudo_reward_scale=value)
     with pytest.raises(ValueError, match="pseudo_reward_scale"):
-        _config_with(subtask_specs=(spec,))
+        _config_with(
+            subtask_specs=(SubtaskSpec(feature_index=0, pseudo_reward_scale=value),),
+        )
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("field", "value", "expected"),
     [
-        ("cerebellum_step_size", 1.0e-50),
+        ("cerebellum_step_size", 1.0e-50, "cerebellum_step_size"),
         (
             "subtask_specs",
             (SubtaskSpec(feature_index=0, threshold=1.0e-50),),
+            "threshold",
+        ),
+        (
+            "subtask_specs",
+            (SubtaskSpec(feature_index=0, pseudo_reward_scale=1.0e-50),),
+            "pseudo_reward_scale",
         ),
     ],
+    ids=("cerebellum_step_size", "threshold", "pseudo_reward_scale"),
 )
 def test_step12_strict_positive_fields_reject_float32_zero_collapse(
     field: str,
     value: object,
+    expected: str,
 ) -> None:
-    expected = "threshold" if field == "subtask_specs" else field
     with pytest.raises(ValueError, match=expected):
         _config_with(**{field: value})
 
@@ -501,7 +509,7 @@ def test_step12_float32_underflow_and_finite_boundaries_are_canonical() -> None:
     spec = SubtaskSpec(
         feature_index=0,
         threshold=_FLOAT32_MIN_SUBNORMAL,
-        pseudo_reward_scale=-1.0e-50,
+        pseudo_reward_scale=_FLOAT32_MIN_SUBNORMAL,
     )
     config = _config_with(
         subtask_specs=(spec,),
@@ -515,14 +523,14 @@ def test_step12_float32_underflow_and_finite_boundaries_are_canonical() -> None:
     assert config.base_avg_reward_step_size == 0.0
     assert config.option_step_size == 0.0
     assert config.subtask_specs[0].threshold == _FLOAT32_MIN_SUBNORMAL
-    assert config.subtask_specs[0].pseudo_reward_scale == 0.0
+    assert config.subtask_specs[0].pseudo_reward_scale == _FLOAT32_MIN_SUBNORMAL
 
     maximum = _config_with(
         subtask_specs=(
             SubtaskSpec(
                 feature_index=0,
                 threshold=_FLOAT32_MAX,
-                pseudo_reward_scale=-_FLOAT32_MAX,
+                pseudo_reward_scale=_FLOAT32_MAX,
             ),
         ),
         cerebellum_step_size=_FLOAT32_MAX,
@@ -533,7 +541,7 @@ def test_step12_float32_underflow_and_finite_boundaries_are_canonical() -> None:
     assert maximum.cerebellum_step_size == _FLOAT32_MAX
     assert maximum.base_step_size == _FLOAT32_MAX
     assert maximum.subtask_specs[0].threshold == _FLOAT32_MAX
-    assert maximum.subtask_specs[0].pseudo_reward_scale == -_FLOAT32_MAX
+    assert maximum.subtask_specs[0].pseudo_reward_scale == _FLOAT32_MAX
 
 
 def test_step12_int32_counter_boundaries_match_core_sinks() -> None:


### PR DESCRIPTION
Fixes #517

## Problem

`SubtaskSpec.__post_init__` let non-finite thresholds through (`NaN <= 0.0` is `False`, and `inf` passes a pure positivity check) and never validated `pseudo_reward_scale`. A `NaN` threshold makes the option-complete comparison uniformly false so the option never terminates on its completion signal, and a zero/negative/non-finite scale silently zeroes or corrupts the pseudo-reward that drives option selection.

## Changes

- `alberta_framework/core/options.py`: `SubtaskSpec.__post_init__` now requires `threshold` to be finite and positive, and validates `pseudo_reward_scale` as finite and positive (matching the `threshold` domain and the `STOMPConfig.option_gamma` finite-and-range house style). Docstrings updated.
- `alberta_framework/steps/{step10,step11,step12}.py`: the step kernels' `pseudo_reward_scale` narrowing now goes through `_require_positive_real` (same validator as `threshold`), so float32 underflow-to-zero is rejected instead of silently canonicalized to `0.0`; the now-unused `_require_real` helper in step10 is removed.
- `tests/test_options.py`: new `unit`-marked `TestSubtaskSpecValidation` class covering NaN/inf/zero/negative rejection for both fields (failing-test-first against the old code).
- `tests/test_step{10,11,12}_production.py`: legal-endpoint, float32-boundary, underflow, and zero-collapse cases moved into the positive `pseudo_reward_scale` domain, with new underflow-rejection coverage for `pseudo_reward_scale` in steps 11 and 12.

## Validation

- `.venv/bin/python -m pytest tests/test_options.py tests/test_stomp_extended_action_mask.py -q` — 30 passed.
- `.venv/bin/python -m pytest tests/test_step10_production.py tests/test_step11_production.py tests/test_step12_production.py tests/test_step_float32_validation.py tests/test_options.py -q` — 623 passed, 3 failed: `test_step11_oak_validates_original_real_domain_before_narrowing`, `test_step11_oak_narrows_the_original_real_once`, `test_step12_narrows_original_real_directly_without_double_rounding` fail identically on `origin/main` on this machine (macOS arm64, where `np.longdouble` is float64), i.e. pre-existing platform-dependent failures unrelated to this change.
- Broader sweep of all 29 SubtaskSpec-touching test files (`-m "not slow and not package"`) — 860 passed with only the failures addressed/explained above.
- `.venv/bin/python -m ruff check .` — all checks passed.
- `.venv/bin/python -m mypy` — no issues in 165 source files.

Note: `alberta_framework/core/options.py` is a registered source for the `continual_intelligence_amplification` evidence claim. The evidence registry already reports `invalid` from prior source drift on main (as noted in the issue); this change does not alter that status, and per the repo's fail-closed rules it is working-as-designed, not silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)