### PR TITLE
fix(reward-model): validate scalar config types

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -14,7 +14,9 @@ trustworthy — the "selective" part of selective model-based updates.
 from __future__ import annotations
 
 import functools
+import math
 from dataclasses import dataclass
+from numbers import Real
 from typing import Any
 
 import chex
@@ -22,6 +24,16 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
+
+
+def _finite_real(name: str, value: object) -> float:
+    """Return a finite real configuration value without accepting booleans."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number")
+    concrete = float(value)
+    if not math.isfinite(concrete):
+        raise ValueError(f"{name} must be finite")
+    return concrete
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -223,13 +235,16 @@ class RLSRewardModel:
         )
 
     def _validate_config(self, config: RLSRewardModelConfig) -> None:
-        if config.feature_dim <= 0:
-            raise ValueError("feature_dim must be positive")
-        if not 0.0 < config.forgetting <= 1.0:
+        if type(config.feature_dim) is not int or config.feature_dim <= 0:
+            raise ValueError("feature_dim must be a positive builtin integer")
+        forgetting = _finite_real("forgetting", config.forgetting)
+        if not 0.0 < forgetting <= 1.0:
             raise ValueError("forgetting must be in (0, 1]")
-        if config.ridge <= 0.0:
+        ridge = _finite_real("ridge", config.ridge)
+        if ridge <= 0.0:
             raise ValueError("ridge must be positive")
-        if not 0.0 <= config.error_decay < 1.0:
+        error_decay = _finite_real("error_decay", config.error_decay)
+        if not 0.0 <= error_decay < 1.0:
             raise ValueError("error_decay must be in [0, 1)")
 
 

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -17,7 +17,7 @@ import functools
 import math
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax
@@ -28,9 +28,10 @@ from jaxtyping import Bool, Float
 
 def _finite_real(name: str, value: object) -> float:
     """Return a finite real configuration value without accepting booleans."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a real number")
-    concrete = float(value)
+    concrete = float(cast(Real, value))
     if not math.isfinite(concrete):
         raise ValueError(f"{name} must be finite")
     return concrete

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import chex
 import jax.numpy as jnp
-
+import numpy as np
+import pytest
 from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
 
 
@@ -67,6 +68,48 @@ def test_rls_reward_model_rejects_invalid_config() -> None:
             pass
         else:
             raise AssertionError(f"expected ValueError for {config}")
+
+
+@pytest.mark.parametrize("value", [True, 1.0, "1", np.int64(1)])
+def test_rls_reward_model_rejects_non_builtin_feature_dim(value: object) -> None:
+    """Dimensions must not accept bool or integer-like aliases."""
+    payload = RLSRewardModelConfig(feature_dim=1).to_config()
+    payload["feature_dim"] = value
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModel(RLSRewardModelConfig.from_config(payload))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("forgetting", True),
+        ("forgetting", "0.5"),
+        ("forgetting", float("nan")),
+        ("forgetting", float("inf")),
+        ("forgetting", float("-inf")),
+        ("ridge", True),
+        ("ridge", "1.0"),
+        ("ridge", float("nan")),
+        ("ridge", float("inf")),
+        ("ridge", float("-inf")),
+        ("error_decay", True),
+        ("error_decay", "0.5"),
+        ("error_decay", float("nan")),
+        ("error_decay", float("inf")),
+        ("error_decay", float("-inf")),
+    ],
+)
+def test_rls_reward_model_rejects_non_real_or_non_finite_scalars(
+    field: str,
+    value: object,
+) -> None:
+    """Serialized config must reject booleans, objects, NaN, and infinities."""
+    payload = RLSRewardModelConfig(feature_dim=1).to_config()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        RLSRewardModel(RLSRewardModelConfig.from_config(payload))
 
 
 def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -6,6 +6,7 @@ import chex
 import jax.numpy as jnp
 import numpy as np
 import pytest
+
 from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
 
 
@@ -80,6 +81,17 @@ def test_rls_reward_model_rejects_non_builtin_feature_dim(value: object) -> None
         RLSRewardModel(RLSRewardModelConfig.from_config(payload))
 
 
+class _FloatSpoof:
+    """Non-real object that spoofs ``float`` through ``__class__``."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -98,6 +110,9 @@ def test_rls_reward_model_rejects_non_builtin_feature_dim(value: object) -> None
         ("error_decay", float("nan")),
         ("error_decay", float("inf")),
         ("error_decay", float("-inf")),
+        ("forgetting", _FloatSpoof()),
+        ("ridge", _FloatSpoof()),
+        ("error_decay", _FloatSpoof()),
     ],
 )
 def test_rls_reward_model_rejects_non_real_or_non_finite_scalars(


### PR DESCRIPTION
Fixes #605.

## What changed

`RLSRewardModel` now validates its runtime configuration before any JAX array construction:

- `feature_dim` must be a positive exact built-in integer, so booleans, floats, strings, and NumPy integer aliases cannot become array dimensions;
- `forgetting`, `ridge`, and `error_decay` must be non-boolean real numbers;
- every scalar must be finite before its documented interval is checked;
- valid RLS initialization, update equations, serialization keys, and fail-closed update behavior are unchanged.

## Reproduction

The failing-first focused run produced **11 failures / 13 passes**.

Confirmed pre-change behavior included:

```text
feature_dim=True       -> constructs as a one-dimensional model
feature_dim="1"        -> incidental TypeError during comparison
ridge=True             -> constructs with ridge=1
ridge=NaN              -> constructs with non-finite covariance
ridge=+inf             -> constructs with zero covariance and zero learning gain
```

The existing chained range guards already rejected non-finite `forgetting` and `error_decay`; this patch preserves those intervals while making their type/finiteness contract explicit and field-specific.

## Verification

Final base: `4be199e69c8031b483f1d2558ddaccf40cd9dd44`

Exact head: `10b6c93b8ee858a99f115cadb9938b8da3818765`

- tests-first baseline: **11 failed / 13 passed**;
- focused final module: **24 passed**;
- serialized malformed-type / NaN / infinity matrix: passed;
- valid config roundtrip and deterministic RLS learning regression: passed;
- Ruff on changed source and tests: passed;
- strict mypy on changed production source: passed;
- `git diff --check origin/main...HEAD`: clean;
- exact-head factory proof: recorded green for `10b6c93b8`.

## Ownership and scientific integrity

A complete current scan covered **63 open ASI PRs / 195 changed-file rows** with zero overlap on either target path. A separate scan covered **56 open issues** and matching claim comments; only #605 claims reward-model configuration validation. #419 is a separate world-model validator issue, while #184 and #188 are scientific preregistrations rather than this library boundary fix.

No `outputs/**` file, frozen protocol, benchmark threshold, seed, scientific claim, or registered five-claim evidence source changed. `alberta-evidence-status` remains inherited-invalid from unrelated registered-source hash drift already present on `main`; this PR does not suppress, regenerate, revalidate, or promote any evidence.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
- Attribution status: self-reported

— [sol-reward-model-config]
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
