### PR TITLE
fix(stacked-horde): reject out-of-range cumulant reads before gather

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -172,6 +172,10 @@ class StackedHordeConfig:
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
+        # Identity-only check: bools and numpy integers are refused so a JAX
+        # gather can never wrap (negative) or reinterpret the channel.
+        if any(type(idx) is not int or idx < 0 for idx in self.cumulant_indices):
+            raise ValueError("cumulant_indices entries must be nonnegative builtin ints")
         object.__setattr__(
             self,
             "step_size",
@@ -279,6 +283,7 @@ class StackedLinearHorde:
         self._gammas = jnp.asarray(config.gammas, dtype=jnp.float32)
         self._lamdas = jnp.asarray(config.lamdas, dtype=jnp.float32)
         self._cumulant_idx = jnp.asarray(config.cumulant_indices, dtype=jnp.int32)
+        self._max_cumulant_index = max(config.cumulant_indices)
 
     @property
     def config(self) -> StackedHordeConfig:
@@ -336,6 +341,19 @@ class StackedLinearHorde:
             TD errors (TD errors are NaN for inactive demons).
         """
         cfg = self._config
+        source_shape = jnp.shape(cumulant_source)
+        # JAX clips out-of-range positive gather indices instead of raising,
+        # so a short source would silently train demons on the wrong channel.
+        # Shapes are static, so these checks also fire at jit/scan trace time.
+        if len(source_shape) != 1:
+            raise ValueError(
+                f"cumulant_source must be rank-one, got shape {source_shape}"
+            )
+        if source_shape[0] <= self._max_cumulant_index:
+            raise ValueError(
+                f"cumulant_source has {source_shape[0]} channels but "
+                f"config.cumulant_indices requires index {self._max_cumulant_index}"
+            )
         cumulants = cumulant_source[self._cumulant_idx]  # (n_demons,)
         requested = ~jnp.isnan(cumulants)
         active = jnp.isfinite(cumulants)
@@ -464,6 +482,17 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
+    sources_shape = jnp.shape(cumulant_sources)
+    if len(sources_shape) != 2:
+        raise ValueError(
+            f"cumulant_sources must be rank-two, got shape {sources_shape}"
+        )
+    max_index = max(horde.config.cumulant_indices)
+    if sources_shape[-1] <= max_index:
+        raise ValueError(
+            f"cumulant_sources has {sources_shape[-1]} channels but "
+            f"config.cumulant_indices requires index {max_index}"
+        )
     num_steps = features.shape[0]
     if rhos is None:
         rhos = jnp.ones((num_steps,), dtype=jnp.float32)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -400,6 +400,99 @@ class TestConfig:
         assert cfg.gammas == (0.0, 0.9, 0.0, 0.9)
 
 
+@pytest.mark.unit
+class TestCumulantSourceDomain:
+    """Out-of-range cumulant reads must fail closed, never clip (issue #579)."""
+
+    @staticmethod
+    def _two_channel_horde() -> StackedLinearHorde:
+        return StackedLinearHorde(
+            StackedHordeConfig(
+                n_demons=2,
+                feature_dim=3,
+                gammas=(0.0, 0.0),
+                lamdas=(0.0, 0.0),
+                cumulant_indices=(0, 2),
+                step_size=0.5,
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "bad_index",
+        [-1, True, False, np.int32(1), 1.0, "1"],
+        ids=("negative", "true", "false", "numpy-int", "float", "str"),
+    )
+    def test_config_rejects_non_builtin_or_negative_indices(self, bad_index: object) -> None:
+        with pytest.raises(ValueError, match="cumulant_indices"):
+            _simple_config(n_demons=1, gammas=(0.9,), lamdas=(0.5,), cumulant_indices=(bad_index,))
+
+    def test_from_config_rejects_invalid_serialized_indices(self) -> None:
+        payload = _simple_config().to_config()
+        payload["cumulant_indices"] = [0, -1]
+        with pytest.raises(ValueError, match="cumulant_indices"):
+            StackedHordeConfig.from_config(payload)
+
+    def test_update_rejects_source_missing_the_maximum_index(self) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        x = jnp.array([1.0, 0.0, 0.0])
+        with pytest.raises(ValueError, match="cumulant_source"):
+            horde.update(state, x, jnp.zeros(3), jnp.array([1.0, 99.0]))
+        # Nothing may have moved: the horde state is untouched by the rejection.
+        np.testing.assert_array_equal(np.asarray(state.weights), np.zeros((2, 3)))
+        assert int(state.step_count) == 0
+
+    def test_jit_update_rejects_short_source_at_trace_time(self) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        x = jnp.array([1.0, 0.0, 0.0])
+        jitted = jax.jit(horde.update)
+        with pytest.raises(ValueError, match="cumulant_source"):
+            jitted(state, x, jnp.zeros(3), jnp.array([1.0, 99.0]))
+
+    @pytest.mark.parametrize("rank", [0, 2], ids=("rank-zero", "rank-two"))
+    def test_update_rejects_non_rank_one_sources(self, rank: int) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        x = jnp.array([1.0, 0.0, 0.0])
+        source = jnp.ones((3,) * rank, dtype=jnp.float32)
+        with pytest.raises(ValueError, match="cumulant_source"):
+            horde.update(state, x, jnp.zeros(3), source)
+
+    def test_scan_rejects_non_rank_two_sources(self) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        features = jnp.zeros((3, 3), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="cumulant_sources"):
+            run_stacked_horde_scan(horde, state, features, jnp.ones((3,), dtype=jnp.float32))
+
+    def test_scan_rejects_sources_missing_the_maximum_index(self) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        features = jnp.zeros((3, 3), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="cumulant_sources"):
+            run_stacked_horde_scan(horde, state, features, jnp.ones((3, 2), dtype=jnp.float32))
+
+    def test_valid_direct_jit_and_scan_updates_are_unchanged(self) -> None:
+        horde = self._two_channel_horde()
+        state = horde.init()
+        x = jnp.array([1.0, 0.0, 0.0])
+        source = jnp.array([1.0, 99.0, 4.0])
+
+        direct = horde.update(state, x, jnp.zeros(3), source)
+        np.testing.assert_allclose(np.asarray(direct.td_errors), [1.0, 4.0], rtol=1e-6)
+        np.testing.assert_allclose(np.asarray(direct.state.weights[:, 0]), [0.5, 2.0], rtol=1e-6)
+
+        jitted = jax.jit(horde.update)(state, x, jnp.zeros(3), source)
+        np.testing.assert_allclose(np.asarray(jitted.td_errors), [1.0, 4.0], rtol=1e-6)
+
+        features = jnp.stack([x, jnp.zeros(3)])
+        sources = jnp.stack([source, source])
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
+        np.testing.assert_allclose(np.asarray(td_errors), [[1.0, 4.0]], rtol=1e-6)
+        np.testing.assert_allclose(np.asarray(final_state.weights[:, 0]), [0.5, 2.0], rtol=1e-6)
+
+
 class TestExactSemantics:
     def test_hand_computed_two_step(self):
         """Exact TD(lambda) values for one demon over two transitions."""


### PR DESCRIPTION
Fixes #579.

`StackedLinearHorde.update` gathered cumulants with a JAX array index before checking that the caller supplied every configured channel. JAX clips an out-of-range positive gather index instead of raising, so a source missing a configured channel silently trained the demon on the last available channel (e.g. `cumulant_indices=(0, 2)` with `source=[1, 99]` produced `td_errors=[1, 99]` and a first weight of `49.5` at `step_size=0.5`). Negative and boolean `cumulant_indices` were also accepted (wrapping / channel reinterpretation).

## Changes

- `StackedHordeConfig.__post_init__` requires every `cumulant_indices` entry to be a nonnegative builtin `int`, using the module's identity-only type check so bools and NumPy integers are refused before any gather can wrap or reinterpret the channel. Enforced identically through direct construction and `from_config`.
- `StackedLinearHorde.update` rejects a `cumulant_source` that is not rank-one or whose length does not cover the maximum configured index, before any gather or state update. Shapes are static, so the checks also fire at `jit`/`scan` trace time and the pre-update state is untouched by a rejection.
- `run_stacked_horde_scan` rejects `cumulant_sources` that are not rank-two or whose final axis does not cover the maximum configured index.
- Valid direct, JIT-compiled, and scan updates are unchanged (regression-tested against the issue's expected `td_errors=[1, 4]` scenario).
- New `unit`-marked test class `TestCumulantSourceDomain` in `tests/test_stacked_horde.py` (13 tests, CI-cheap) written failing-first: 13 failed on unpatched `main`, all pass after the repair.

No changes to valid TD(lambda) equations, state layout, serialization keys, thresholds, seeds, `CHANGELOG.md`, or any `outputs/**` artifact.

## Validation

- `.venv/bin/python -m pytest tests/test_stacked_horde.py -q` — **74 passed** (61 pre-existing + 13 new; the new tests reproduced the defect with 13 failures before the fix).
- `.venv/bin/python -m ruff check .` — clean.
- `.venv/bin/python -m mypy` — **165 source files**, no issues (strict, py312).
- `.venv/bin/python -m pytest tests -q -m "not slow and not package"` — **7067 passed, 66 failed, 11 skipped, 4 errors** on this macOS machine; the failures are pre-existing local-environment failures (e.g. `test_forager_matched_sealed_evaluation_campaign_adversarial.py` requires the Linux-only `renameat2` syscall for seal publication and fails identically without this diff), none in stacked-horde paths, and this diff touches only `core/stacked_horde.py` plus its test file.
- `alberta-evidence-status` — reports the same inherited `invalid` as current `main` (pre-existing registered-source drift unrelated to this change; `core/stacked_horde.py` is not a registered evidence source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
