### PR TITLE
fix(core): reject class-spoofed non-real scalars in normalizers

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -241,7 +241,8 @@ class Normalizer[
         Args:
             epsilon: Small constant added to std for numerical stability
         """
-        if isinstance(epsilon, bool) or not isinstance(epsilon, Real):
+        epsilon_type = type(epsilon)
+        if issubclass(epsilon_type, bool) or not issubclass(epsilon_type, Real):
             raise TypeError("epsilon must be a finite real number")
         if not math.isfinite(epsilon) or epsilon <= 0.0:
             raise ValueError("epsilon must be finite and positive")
@@ -441,7 +442,8 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
                 prior-regularized moments with no exponential forgetting.
         """
         super().__init__(epsilon=epsilon)
-        if isinstance(decay, bool) or not isinstance(decay, Real):
+        decay_type = type(decay)
+        if issubclass(decay_type, bool) or not issubclass(decay_type, Real):
             raise TypeError("decay must be a finite real number")
         if not math.isfinite(decay):
             raise ValueError("decay must be finite")
@@ -730,7 +732,8 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
     def __init__(self, epsilon: float = 1e-5, momentum: float = 0.99):
         """Initialize the streaming BatchNorm-style normalizer."""
         super().__init__(epsilon=epsilon)
-        if isinstance(momentum, bool) or not isinstance(momentum, Real):
+        momentum_type = type(momentum)
+        if issubclass(momentum_type, bool) or not issubclass(momentum_type, Real):
             raise TypeError("momentum must be a finite real number")
         if not math.isfinite(momentum):
             raise ValueError("momentum must be finite")

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -588,3 +588,106 @@ class TestNormalizerABC:
         out = normalizer.normalize_only(state, jnp.array([max_f32], dtype=jnp.float32))
         assert not bool(jnp.isfinite(out[0]))
         assert float(out[0]) != 0.0
+
+
+class _FloatSpoof:
+    """Not a Real at all, but reports ``float`` through ``__class__``."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return self._value
+
+
+class _RaisingFloatSpoof:
+    """A ``__class__`` spoof whose ``__float__`` hook raises when trusted."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        raise RuntimeError("untrusted __float__ hook executed")
+
+
+class TestNormalizerScalarSpoofRejection:
+    """``epsilon``/``decay``/``momentum`` must reject ``__class__``-spoofed reals.
+
+    ``isinstance(value, Real)`` consults the overridable ``__class__``
+    attribute, so an object that only lies about its class via a
+    ``__class__`` property previously passed validation even though its
+    actual type is not a registered ``Real``.
+    """
+
+    @pytest.mark.parametrize(
+        ("ctor", "field"),
+        [
+            (EMANormalizer, "epsilon"),
+            (EMANormalizer, "decay"),
+            (StreamingBatchNormalizer, "epsilon"),
+            (StreamingBatchNormalizer, "momentum"),
+            (WelfordNormalizer, "epsilon"),
+        ],
+        ids=[
+            "ema-epsilon",
+            "ema-decay",
+            "streaming-epsilon",
+            "streaming-momentum",
+            "welford-epsilon",
+        ],
+    )
+    def test_rejects_class_spoofed_real_field(self, ctor, field) -> None:
+        """A well-behaved ``__class__``-spoofed real must not be accepted."""
+        in_domain = {"epsilon": 1e-6, "decay": 0.5, "momentum": 0.5}[field]
+        with pytest.raises(TypeError, match="must be a finite real number"):
+            ctor(**{field: _FloatSpoof(in_domain)})
+
+    @pytest.mark.parametrize(
+        ("ctor", "field"),
+        [
+            (EMANormalizer, "epsilon"),
+            (EMANormalizer, "decay"),
+            (StreamingBatchNormalizer, "epsilon"),
+            (StreamingBatchNormalizer, "momentum"),
+            (WelfordNormalizer, "epsilon"),
+        ],
+        ids=[
+            "ema-epsilon",
+            "ema-decay",
+            "streaming-epsilon",
+            "streaming-momentum",
+            "welford-epsilon",
+        ],
+    )
+    def test_raising_spoofed_field_stays_a_type_error(self, ctor, field) -> None:
+        """A spoof with a raising ``__float__`` must not leak its raw exception."""
+        with pytest.raises(TypeError, match="must be a finite real number"):
+            ctor(**{field: _RaisingFloatSpoof()})
+
+    def test_rejects_bool_epsilon(self) -> None:
+        with pytest.raises(TypeError, match="epsilon must be a finite real number"):
+            EMANormalizer(epsilon=True)
+
+    def test_rejects_bool_decay(self) -> None:
+        with pytest.raises(TypeError, match="decay must be a finite real number"):
+            EMANormalizer(decay=False)
+
+    def test_rejects_bool_momentum(self) -> None:
+        with pytest.raises(TypeError, match="momentum must be a finite real number"):
+            StreamingBatchNormalizer(momentum=True)
+
+    def test_accepts_genuine_numpy_scalar_decay(self) -> None:
+        """A real (non-spoofed) numpy scalar type must remain accepted."""
+        np = pytest.importorskip("numpy")
+        normalizer = EMANormalizer(decay=np.float64(0.75))
+        assert normalizer._decay == pytest.approx(0.75)
+
+    def test_accepts_genuine_int_momentum(self) -> None:
+        """A real (non-spoofed) int must remain accepted and coerced to float."""
+        normalizer = StreamingBatchNormalizer(momentum=1)
+        assert normalizer._momentum == 1.0


### PR DESCRIPTION
Closes #607.

## What changed

`Normalizer.__init__` (`epsilon`), `EMANormalizer.__init__` (`decay`), and
`StreamingBatchNormalizer.__init__` (`momentum`) in
`alberta_framework/core/normalizers.py` each guarded their scalar
hyperparameter with:

```python
if isinstance(value, bool) or not isinstance(value, Real):
    raise TypeError(f"{name} must be a finite real number")
```

`isinstance()`/`issubclass()` against `numbers.Real` consults an object's
`__class__` attribute, which is overridable via a `@property`. An object
whose `__class__` property lies about its type (reports `float`) passes this
check even though its true type (`type(value)`) is not a registered `Real`.

Two concrete consequences on unpatched `main`:

1. A well-behaved `__class__`-spoofed real is silently accepted past
   validation. The unguarded arithmetic that follows it (e.g.
   `0.0 <= decay <= 1.0`, `epsilon <= 0.0`) then raises a raw, undocumented
   `TypeError` from Python's comparison protocol (e.g. `'<=' not supported
   between instances of 'float' and 'FloatSpoof'`) instead of the module's
   own documented `TypeError("... must be a finite real number")`.
2. A spoofed object whose `__float__` hook raises leaks that **raw
   exception** (e.g. `RuntimeError`) out of the constructor instead of the
   documented `TypeError`.

Fix: switch all three checks to read the real, non-spoofable type slot via
`type(value)` + `issubclass`, matching the pattern already used to fix the
same bug class elsewhere in this repository (`representation_gradient_mixer.py`,
`partner_policy_fusion.py`, `recurrent_latent_world_model_ensemble.py` /
commit `b93e60e`).

## Reachability

`EMANormalizer`, `StreamingBatchNormalizer`, and `Normalizer` are exported at
package root (`alberta_framework.__init__`) and constructed by the Step 1
facade (`alberta_framework/steps/step1.py::make_step1_normalizer`) from
caller-supplied `config.ema_decay` / `config.streaming_batch_momentum`, and
by `alberta_framework/steps/step3.py::make_step3_normalizer` — ordinary
public config fields, not internal-only state. They are also directly
constructible by any caller of the public API regardless of any facade-level
validation.

(Note: `step1.py`'s own `_require_unit_interval` facade helper has the
identical spoofable pattern independently, but `step1.py` is out of scope
for this change — it is untouched here and appears to already be covered by
other in-flight validation work in this repository. This PR hardens
`normalizers.py` itself, which remains reachable directly regardless of
upstream facade behavior.)

## Verification

Exact head this fix is built on: `f1599e3db3e2627f855447fc3c07c33ea0b5e05e`
(branch rebased clean onto `origin/main`, zero divergence, one commit ahead).

```text
$ .venv/bin/python -m pytest tests/test_normalizers.py -q -o addopts=""
71 passed in 16.47s

$ .venv/bin/python -m pytest tests -q -m "not slow and not package" -k "normalizer or step1 or step3 or gymnasium" -o addopts=""
764 passed, 7563 deselected in 573.36s (0:09:33)

$ .venv/bin/python -m ruff check alberta_framework/core/normalizers.py tests/test_normalizers.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 165 source files

$ git diff --check
(clean, no output)
```

New tests (failing-test-first; all 10 spoofing-parametrized cases confirmed
red before the source fix, 5 acceptance/bool-rejection cases were already
green since those checks predate this fix):

- `test_rejects_class_spoofed_real_field` (EMA epsilon, EMA decay, streaming
  epsilon, streaming momentum, Welford epsilon)
- `test_raising_spoofed_field_stays_a_type_error` (same five fields,
  `__float__` raises)
- `test_rejects_bool_epsilon` / `test_rejects_bool_decay` /
  `test_rejects_bool_momentum`
- `test_accepts_genuine_numpy_scalar_decay` /
  `test_accepts_genuine_int_momentum` (regression guard: legitimate numpy
  scalar types and plain `int` must remain accepted)

Mutation check: reverted only `alberta_framework/core/normalizers.py`
(`git stash push -- alberta_framework/core/normalizers.py`, kept the new
tests) — all 10 spoofing tests failed with the exact pre-fix symptoms
(raw `TypeError`/`RuntimeError` leaking instead of the documented
`TypeError`). Restored the fix — all 71 green again.

**Environment note:** this machine has no functioning CUDA/GPU driver for
the installed `jaxlib` CUDA plugin (`cuInit(0) failed: Unknown CUDA error
303`); JAX transparently falls back to CPU and every command above executed
and passed on CPU. This is a host limitation, not something this change
touches.

## Evidence

<!-- evidence-head:3a8ae7b30eb99178c3f5df2e2aeafcc8a29e2268 -->

<!-- evidence-row:logs -->
- [x] logs:
```text
red (source fix reverted, new tests kept):
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_rejects_class_spoofed_real_field[ema-epsilon]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_rejects_class_spoofed_real_field[ema-decay]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_rejects_class_spoofed_real_field[streaming-epsilon]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_rejects_class_spoofed_real_field[streaming-momentum]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_rejects_class_spoofed_real_field[welford-epsilon]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_raising_spoofed_field_stays_a_type_error[ema-epsilon]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_raising_spoofed_field_stays_a_type_error[ema-decay]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_raising_spoofed_field_stays_a_type_error[streaming-epsilon]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_raising_spoofed_field_stays_a_type_error[streaming-momentum]
FAILED tests/test_normalizers.py::TestNormalizerScalarSpoofRejection::test_raising_spoofed_field_stays_a_type_error[welford-epsilon]
10 failed, 5 passed, 56 deselected in 2.03s

green (fix restored):
tests/test_normalizers.py ....................................................................... [100%]
71 passed in 16.47s
```
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact:
```text
SPOOFED decay ACCEPTED (pre-fix): 0.5 <class 'float'>  [n._decay after EMANormalizer(decay=FloatSpoof(0.5))]
LEAKED comparison TypeError (pre-fix): "'<=' not supported between instances of 'float' and 'FloatSpoof'"
LEAKED raw exception (pre-fix): RuntimeError('untrusted __float__ hook executed')
POST-FIX: EMANormalizer(decay=FloatSpoof(0.5)) -> TypeError: decay must be a finite real number
POST-FIX: EMANormalizer(decay=RaisingFloatSpoof()) -> TypeError: decay must be a finite real number
POST-FIX regression guard: EMANormalizer(decay=numpy.float64(0.7))._decay == 0.7 (accepted)
POST-FIX regression guard: StreamingBatchNormalizer(momentum=1)._momentum == 1.0 (accepted)
```

## Provenance

AI provider/model: anthropic / claude-sonnet-5.
Client / agent tooling: Claude Code, lane `rama0x1-asi-claude-worker`.
Attribution status: self-reported. All verification above (mutation
testing, full test-file and cross-module runs, lint/typecheck, reachability
trace, live reproduction of the bug before writing the fix) was performed by
me in this session.

Receipt signing deferred — operator handling centrally for this pipeline;
not attempted from this session.
