### PR TITLE
fix(streams): reject class-spoofed non-real scalars in pavlovian gates

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import math
 from numbers import Real
+from typing import cast
 
 import chex
 import jax
@@ -64,10 +65,11 @@ def _require_finite_real(
     nonnegative: bool = False,
 ) -> float:
     """Return a finite real, rejecting bools, NaN, and infinities."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a finite real, got {value!r}")
     try:
-        number = float(value)
+        number = float(cast(Real, value))
     except (OverflowError, ValueError) as error:
         raise ValueError(f"{name} must be a finite real, got {value!r}") from error
     if not math.isfinite(number):
@@ -84,12 +86,14 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     below the float32 subnormal range are accepted as exact zero, matching the
     noise-free trajectory they produce in the stream's float32 arithmetic.
     """
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
-    if value < 0:
+    real_value = cast(Real, value)
+    if real_value < 0:
         raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
     try:
-        narrowed = round_real_to_float32(value)
+        narrowed = round_real_to_float32(real_value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(
             f"{name} must remain finite when rounded to float32, got {value!r}"
@@ -103,9 +107,10 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
 
 def _require_unit_interval(value: object, *, name: str) -> float:
     """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    number = float(value)
+    number = float(cast(Real, value))
     if not math.isfinite(number) or not 0.0 <= number <= 1.0:
         raise ValueError(f"{name} must be in [0, 1], got {value!r}")
     return number

--- a/tests/test_pavlovian_validation.py
+++ b/tests/test_pavlovian_validation.py
@@ -1,0 +1,107 @@
+"""Unit tests for the pavlovian stream's scalar validation gates.
+
+Locks the type gates in ``_require_finite_real``,
+``_require_nonnegative_float32``, and ``_require_unit_interval`` against
+``__class__``-spoofed non-real scalars (issue #600). ``isinstance`` consults
+the overridable ``__class__`` attribute, so an object whose ``__class__``
+property returns ``float`` used to sail through validation into
+``ClassicalConditioningStream``'s internal state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.streams.pavlovian import (
+    ClassicalConditioningStream,
+    PavlovianPhase,
+    partial_reinforcement_scenario,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _FloatSpoof:
+    """Not a Real at all, but reports ``float`` through ``__class__``."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return self._value
+
+
+class _RaisingFloatSpoof:
+    """A ``__class__`` spoof whose ``__float__`` hook raises when trusted."""
+
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        raise RuntimeError("untrusted __float__ hook executed")
+
+
+def _valid_phase(**overrides: object) -> PavlovianPhase:
+    fields: dict[str, object] = {
+        "name": "acq",
+        "n_steps": 10,
+        "cs_active": (0,),
+        "compound_index": -1,
+        "cs_us_contingency": 1.0,
+    }
+    fields.update(overrides)
+    return PavlovianPhase(**fields)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("spoof", [_FloatSpoof(0.5), _RaisingFloatSpoof()])
+def test_construct_rejects_class_spoofed_distractor_prob(spoof: object) -> None:
+    """An in-domain host value must not smuggle a non-Real type past the gate."""
+    with pytest.raises(ValueError, match="distractor_prob must be in"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            distractor_prob=spoof,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("spoof", [_FloatSpoof(0.05), _RaisingFloatSpoof()])
+def test_construct_rejects_class_spoofed_noise_std(spoof: object) -> None:
+    """The local noise_std gate must reject spoofs itself, not lean on float32 rounding."""
+    with pytest.raises(ValueError, match="noise_std must be a non-negative finite real"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(),),
+            noise_std=spoof,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("spoof", [_FloatSpoof(1.0), _RaisingFloatSpoof()])
+def test_construct_rejects_class_spoofed_phase_contingency(spoof: object) -> None:
+    """A spoofed cs_us_contingency on a phase must fail stream construction."""
+    with pytest.raises(ValueError, match="cs_us_contingency must be in"):
+        ClassicalConditioningStream(
+            phases=(_valid_phase(cs_us_contingency=spoof),),
+        )
+
+
+@pytest.mark.parametrize("spoof", [_FloatSpoof(0.5), _RaisingFloatSpoof()])
+def test_partial_reinforcement_rejects_class_spoofed_p(spoof: object) -> None:
+    """The partial-reinforcement helper shares the same hardened unit-interval gate."""
+    with pytest.raises(ValueError, match="p must be in"):
+        partial_reinforcement_scenario(p=spoof)  # type: ignore[arg-type]
+
+
+def test_spoofed_scalars_never_leak_the_raw_float_hook_exception() -> None:
+    """A spoof with a raising ``__float__`` must surface the documented ValueError."""
+    for kwargs in (
+        {"distractor_prob": _RaisingFloatSpoof()},
+        {"noise_std": _RaisingFloatSpoof()},
+    ):
+        with pytest.raises(ValueError):
+            ClassicalConditioningStream(
+                phases=(_valid_phase(),),
+                **kwargs,  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
Fixes #600

## Changes

- `alberta_framework/streams/pavlovian.py`: switched the type gates in `_require_finite_real`, `_require_nonnegative_float32`, and `_require_unit_interval` from `isinstance(value, Real)` (consults the overridable `__class__` attribute) to the non-spoofable `type(value)` slot with `issubclass(actual_type, bool | np.bool_) or not issubclass(actual_type, Real)`, matching the pattern already merged for `core/recurrent_latent_world_model_ensemble.py` (#592) and `core/dual_replay.py`. Post-gate conversions use `cast(Real, value)`.
- `tests/test_pavlovian_validation.py` (new, `unit` marker lane, CI-cheap): failing-test-first coverage locking rejection of `__class__`-spoofed non-real scalars for `distractor_prob`, `noise_std`, per-phase `cs_us_contingency`, and `partial_reinforcement_scenario`'s `p`, including a raising-`__float__` spoof that must surface the documented `ValueError` rather than leak its raw exception. All 9 tests reproduce the defect on unpatched code.

## Validation

- `pytest tests/test_pavlovian_validation.py -q` — 9 passed
- `pytest tests/test_pavlovian_validation.py tests/test_pavlovian_stream.py tests/test_pavlovian_learning.py -q` — 105 passed, 2 failed; both failures (`test_construct_narrows_original_noise_real_once`, `test_construct_rejects_negative_real_that_rounds_to_zero`) fail identically on unmodified `origin/main` on this machine (Apple Silicon: `np.longdouble` is float64, so the tests' own precondition asserts fail) — pre-existing, unrelated to this change
- `ruff check .` — all checks passed
- `mypy` — success, no issues in 165 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
