### PR TITLE
fix(world-model): integrate unclipped diagnostic scoring

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -138,19 +138,10 @@ class ActionConditionedWorldModelState:
 
 @chex.dataclass(frozen=True)
 class WorldModelPrediction:
-    """Decoded world-model prediction.
-
-    ``reward`` is the value published to dream rollouts: clipped into the
-    observed reward range (plus guard margin) once bounds exist, for models
-    that apply such a guard. ``raw_reward`` is the same head's decoded
-    output *before* that guard, so callers scoring the model itself (rather
-    than the guard) do not have their diagnostic saturate at the guard's
-    margin. Models with no reward guard set ``raw_reward == reward``.
-    """
+    """Decoded world-model prediction."""
 
     next_observation: Float[Array, " observation_dim"]
     reward: Float[Array, ""]
-    raw_reward: Float[Array, ""]
     raw_predictions: Float[Array, " model_heads"]
     discount: Float[Array, ""]
 
@@ -466,14 +457,12 @@ class ActionConditionedWorldModel:
         discount_target = jnp.reshape(jnp.asarray(discount, dtype=jnp.float32), (1,))
         return jnp.concatenate([normalized_delta, reward_target, discount_target], axis=0)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
+    def _prediction_and_raw_diagnostics(
         self,
         state: ActionConditionedWorldModelState,
         observation: Array,
         action: Array,
-    ) -> WorldModelPrediction:
-        """Predict the next observation, reward, and discount."""
+    ) -> tuple[WorldModelPrediction, Array, Array]:
         inputs, inputs_valid, safe_obs = self._safe_input_features(
             observation,
             action,
@@ -486,7 +475,7 @@ class ActionConditionedWorldModel:
             -self._config.max_delta_scale,
             self._config.max_delta_scale,
         )
-        next_observation = jnp.where(
+        decoded_next_observation = jnp.where(
             self._config.predict_delta,
             safe_obs + normalized_delta * obs_scale,
             normalized_delta * obs_scale,
@@ -495,8 +484,10 @@ class ActionConditionedWorldModel:
         has_bounds = state.step_count > 0
         low = state.observation_min - self._config.observation_clip_margin
         high = state.observation_max + self._config.observation_clip_margin
-        clipped_next = jnp.clip(next_observation, low, high)
-        next_observation = jnp.where(has_bounds, clipped_next, next_observation)
+        clipped_next = jnp.clip(decoded_next_observation, low, high)
+        next_observation = jnp.where(
+            has_bounds, clipped_next, decoded_next_observation
+        )
 
         raw_reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
         reward_low = state.reward_min - self._config.observation_clip_margin
@@ -519,6 +510,11 @@ class ActionConditionedWorldModel:
             invalid_observation,
         )
         reward = jnp.where(inputs_valid, reward, invalid_scalar)
+        decoded_next_observation = jnp.where(
+            inputs_valid,
+            decoded_next_observation,
+            invalid_observation,
+        )
         raw_reward = jnp.where(inputs_valid, raw_reward, invalid_scalar)
         discount = jnp.where(inputs_valid, discount, invalid_scalar)
         raw_predictions = jnp.where(
@@ -527,13 +523,29 @@ class ActionConditionedWorldModel:
             invalid_raw,
         )
 
-        return WorldModelPrediction(
-            next_observation=next_observation,
-            reward=reward,
-            raw_reward=raw_reward,
-            raw_predictions=raw_predictions,
-            discount=discount,
+        return (
+            WorldModelPrediction(
+                next_observation=next_observation,
+                reward=reward,
+                raw_predictions=raw_predictions,
+                discount=discount,
+            ),
+            decoded_next_observation,
+            raw_reward,
         )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def predict(
+        self,
+        state: ActionConditionedWorldModelState,
+        observation: Array,
+        action: Array,
+    ) -> WorldModelPrediction:
+        """Predict the guarded next observation, reward, and discount."""
+        prediction, _, _ = self._prediction_and_raw_diagnostics(
+            state, observation, action
+        )
+        return prediction
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def update(
@@ -583,24 +595,19 @@ class ActionConditionedWorldModel:
             inputs_valid, next_obs, jnp.zeros_like(next_obs)
         )
 
-        prediction = self.predict(state, safe_obs, safe_action)
+        prediction, decoded_next_observation, decoded_reward = (
+            self._prediction_and_raw_diagnostics(state, safe_obs, safe_action)
+        )
         targets = self.targets(
             safe_obs, safe_reward, safe_discount, safe_next_obs
         )
         inputs = self.input_features(safe_obs, safe_action)
         learner_result = self._learner.update(state.learner_state, inputs, targets)
 
-        observation_mse = jnp.mean(
-            (prediction.next_observation - safe_next_obs) ** 2
-        )
-        # Score the model's own decoded reward, not the guard published to dream
-        # rollouts: once bounds exist, `prediction.reward` is clipped into the
-        # observed reward range (+/- observation_clip_margin) and pins
-        # `reward_error` at exactly that margin regardless of the reward head's
-        # actual error (see #391).
-        reward_error = prediction.raw_reward - safe_reward
+        next_observation_errors = decoded_next_observation - safe_next_obs
+        observation_mse = jnp.mean(next_observation_errors**2)
+        reward_error = decoded_reward - safe_reward
         discount_error = prediction.discount - safe_discount
-        next_observation_errors = prediction.next_observation - safe_next_obs
         prediction_error = observation_mse + reward_error**2 + discount_error**2
 
         error_decay = jnp.asarray(self._config.error_decay, dtype=jnp.float32)
@@ -649,7 +656,6 @@ class ActionConditionedWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
-            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),
@@ -1031,7 +1037,6 @@ class OneStepWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
-            raw_reward=reward,
             raw_predictions=raw_predictions,
             discount=jnp.array(jnp.nan, dtype=jnp.float32),
         )
@@ -1095,7 +1100,6 @@ class OneStepWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
-            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -138,10 +138,19 @@ class ActionConditionedWorldModelState:
 
 @chex.dataclass(frozen=True)
 class WorldModelPrediction:
-    """Decoded world-model prediction."""
+    """Decoded world-model prediction.
+
+    ``reward`` is the value published to dream rollouts: clipped into the
+    observed reward range (plus guard margin) once bounds exist, for models
+    that apply such a guard. ``raw_reward`` is the same head's decoded
+    output *before* that guard, so callers scoring the model itself (rather
+    than the guard) do not have their diagnostic saturate at the guard's
+    margin. Models with no reward guard set ``raw_reward == reward``.
+    """
 
     next_observation: Float[Array, " observation_dim"]
     reward: Float[Array, ""]
+    raw_reward: Float[Array, ""]
     raw_predictions: Float[Array, " model_heads"]
     discount: Float[Array, ""]
 
@@ -489,11 +498,11 @@ class ActionConditionedWorldModel:
         clipped_next = jnp.clip(next_observation, low, high)
         next_observation = jnp.where(has_bounds, clipped_next, next_observation)
 
-        reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
+        raw_reward = raw_predictions[self._config.observation_dim] * self._config.reward_scale
         reward_low = state.reward_min - self._config.observation_clip_margin
         reward_high = state.reward_max + self._config.observation_clip_margin
-        clipped_reward = jnp.clip(reward, reward_low, reward_high)
-        reward = jnp.where(has_bounds, clipped_reward, reward)
+        clipped_reward = jnp.clip(raw_reward, reward_low, reward_high)
+        reward = jnp.where(has_bounds, clipped_reward, raw_reward)
 
         discount = jnp.clip(
             raw_predictions[self._config.observation_dim + 1],
@@ -510,6 +519,7 @@ class ActionConditionedWorldModel:
             invalid_observation,
         )
         reward = jnp.where(inputs_valid, reward, invalid_scalar)
+        raw_reward = jnp.where(inputs_valid, raw_reward, invalid_scalar)
         discount = jnp.where(inputs_valid, discount, invalid_scalar)
         raw_predictions = jnp.where(
             inputs_valid,
@@ -520,6 +530,7 @@ class ActionConditionedWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
+            raw_reward=raw_reward,
             raw_predictions=raw_predictions,
             discount=discount,
         )
@@ -582,7 +593,12 @@ class ActionConditionedWorldModel:
         observation_mse = jnp.mean(
             (prediction.next_observation - safe_next_obs) ** 2
         )
-        reward_error = prediction.reward - safe_reward
+        # Score the model's own decoded reward, not the guard published to dream
+        # rollouts: once bounds exist, `prediction.reward` is clipped into the
+        # observed reward range (+/- observation_clip_margin) and pins
+        # `reward_error` at exactly that margin regardless of the reward head's
+        # actual error (see #391).
+        reward_error = prediction.raw_reward - safe_reward
         discount_error = prediction.discount - safe_discount
         next_observation_errors = prediction.next_observation - safe_next_obs
         prediction_error = observation_mse + reward_error**2 + discount_error**2
@@ -633,6 +649,7 @@ class ActionConditionedWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
+            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),
@@ -1014,6 +1031,7 @@ class OneStepWorldModel:
         return WorldModelPrediction(
             next_observation=next_observation,
             reward=reward,
+            raw_reward=reward,
             raw_predictions=raw_predictions,
             discount=jnp.array(jnp.nan, dtype=jnp.float32),
         )
@@ -1077,6 +1095,7 @@ class OneStepWorldModel:
                 update_applied, prediction.next_observation
             ),
             reward=neutralize_array(update_applied, prediction.reward),
+            raw_reward=neutralize_array(update_applied, prediction.raw_reward),
             raw_predictions=neutralize_array(
                 update_applied, prediction.raw_predictions
             ),

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -64,17 +64,11 @@ def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     chex.assert_tree_all_finite(result.prediction_error)
 
 
-def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
+def test_diagnostics_reflect_true_decodes_not_guard_clips() -> None:
     """Regression test for #391.
 
-    ``predict()`` clips the reward into ``[reward_min, reward_max] +/-
-    observation_clip_margin`` before ``update()`` scores it, so once bounds
-    exist ``reward_error`` saturates at ``observation_clip_margin`` no matter
-    how wrong the reward head is: a head biased by 0.05 and one biased by 45
-    both reported the same ``|reward_error| == 0.05`` on `main`. The fix
-    scores ``update()``'s diagnostics against the unclipped decoded
-    prediction (``WorldModelPrediction.raw_reward``) while leaving the
-    guarded ``prediction.reward`` published to dream rollouts unchanged.
+    The public prediction remains guarded for dream rollouts, while update
+    diagnostics score both decoded observation and reward before those guards.
     """
     config = ActionConditionedWorldModelConfig(
         observation_dim=1,
@@ -87,15 +81,21 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     init_state = model.init(jr.key(0))
     reward_head = config.observation_dim  # heads: [obs deltas..., reward, discount]
 
-    def warmed_state_with_reward_bias(bias: float) -> ActionConditionedWorldModelState:
-        """Zero the reward head's weight and fix its bias, with bounds warmed to 5.0."""
+    def warmed_state_with_biases(
+        observation_bias: float, reward_bias: float
+    ) -> ActionConditionedWorldModelState:
         head_params = init_state.learner_state.head_params
         new_weights = tuple(
-            jnp.zeros_like(w) if i == reward_head else w
+            jnp.zeros_like(w) if i in (0, reward_head) else w
             for i, w in enumerate(head_params.weights)
         )
         new_biases = tuple(
-            jnp.full_like(b, bias) if i == reward_head else b
+            jnp.full_like(
+                b,
+                observation_bias if i == 0 else reward_bias,
+            )
+            if i in (0, reward_head)
+            else b
             for i, b in enumerate(head_params.biases)
         )
         learner_state = dataclasses.replace(
@@ -119,8 +119,8 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     true_reward = jnp.array(5.0, dtype=jnp.float32)
     discount = jnp.array(0.9, dtype=jnp.float32)
 
-    near_state = warmed_state_with_reward_bias(5.05)
-    far_state = warmed_state_with_reward_bias(50.0)
+    near_state = warmed_state_with_biases(0.05, 5.05)
+    far_state = warmed_state_with_biases(50.0, 50.0)
 
     near_result = model.update(near_state, obs, action, true_reward, discount, obs)
     far_result = model.update(far_state, obs, action, true_reward, discount, obs)
@@ -132,15 +132,23 @@ def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
     # reward range +/- the margin, unchanged by this fix.
     assert float(far_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
     assert float(near_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
-
-    # The unclipped decode is exposed and used for the diagnostic.
-    assert float(far_result.prediction.raw_reward) == pytest.approx(50.0, abs=1e-3)
-    assert float(near_result.prediction.raw_reward) == pytest.approx(5.05, abs=1e-3)
+    assert float(far_result.prediction.next_observation[0]) == pytest.approx(
+        0.05, abs=1e-4
+    )
+    assert float(near_result.prediction.next_observation[0]) == pytest.approx(
+        0.05, abs=1e-4
+    )
 
     # reward_error must separate a badly wrong head from a nearly-correct one
     # instead of both saturating at observation_clip_margin.
     assert float(near_result.reward_error) == pytest.approx(0.05, abs=1e-3)
     assert float(far_result.reward_error) == pytest.approx(45.0, abs=1e-3)
+    assert float(near_result.next_observation_errors[0]) == pytest.approx(
+        0.05, abs=1e-3
+    )
+    assert float(far_result.next_observation_errors[0]) == pytest.approx(
+        config.max_delta_scale, abs=1e-3
+    )
 
 
 def test_action_conditioned_world_model_config_roundtrip() -> None:

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 from fractions import Fraction
 
@@ -26,6 +27,7 @@ from alberta_framework.core.dreaming import (
 from alberta_framework.core.world_model import (
     ActionConditionedWorldModel,
     ActionConditionedWorldModelConfig,
+    ActionConditionedWorldModelState,
     WorldModelPrediction,
     run_action_conditioned_world_model_learning_loop,
 )
@@ -60,6 +62,85 @@ def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     assert int(result.state.step_count) == 1
     chex.assert_tree_all_finite(result.prediction.raw_predictions)
     chex.assert_tree_all_finite(result.prediction_error)
+
+
+def test_reward_error_reflects_true_model_error_not_the_guard_clip() -> None:
+    """Regression test for #391.
+
+    ``predict()`` clips the reward into ``[reward_min, reward_max] +/-
+    observation_clip_margin`` before ``update()`` scores it, so once bounds
+    exist ``reward_error`` saturates at ``observation_clip_margin`` no matter
+    how wrong the reward head is: a head biased by 0.05 and one biased by 45
+    both reported the same ``|reward_error| == 0.05`` on `main`. The fix
+    scores ``update()``'s diagnostics against the unclipped decoded
+    prediction (``WorldModelPrediction.raw_reward``) while leaving the
+    guarded ``prediction.reward`` published to dream rollouts unchanged.
+    """
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        hidden_sizes=(),
+        sparsity=0.0,
+        observation_clip_margin=0.05,
+    )
+    model = ActionConditionedWorldModel(config)
+    init_state = model.init(jr.key(0))
+    reward_head = config.observation_dim  # heads: [obs deltas..., reward, discount]
+
+    def warmed_state_with_reward_bias(bias: float) -> ActionConditionedWorldModelState:
+        """Zero the reward head's weight and fix its bias, with bounds warmed to 5.0."""
+        head_params = init_state.learner_state.head_params
+        new_weights = tuple(
+            jnp.zeros_like(w) if i == reward_head else w
+            for i, w in enumerate(head_params.weights)
+        )
+        new_biases = tuple(
+            jnp.full_like(b, bias) if i == reward_head else b
+            for i, b in enumerate(head_params.biases)
+        )
+        learner_state = dataclasses.replace(
+            init_state.learner_state,
+            head_params=dataclasses.replace(
+                head_params, weights=new_weights, biases=new_biases
+            ),
+        )
+        return dataclasses.replace(
+            init_state,
+            learner_state=learner_state,
+            observation_min=jnp.array([0.0], dtype=jnp.float32),
+            observation_max=jnp.array([0.0], dtype=jnp.float32),
+            reward_min=jnp.array(5.0, dtype=jnp.float32),
+            reward_max=jnp.array(5.0, dtype=jnp.float32),
+            step_count=jnp.array(1, dtype=jnp.int32),
+        )
+
+    obs = jnp.array([0.0], dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+    true_reward = jnp.array(5.0, dtype=jnp.float32)
+    discount = jnp.array(0.9, dtype=jnp.float32)
+
+    near_state = warmed_state_with_reward_bias(5.05)
+    far_state = warmed_state_with_reward_bias(50.0)
+
+    near_result = model.update(near_state, obs, action, true_reward, discount, obs)
+    far_result = model.update(far_state, obs, action, true_reward, discount, obs)
+
+    assert bool(near_result.update_applied)
+    assert bool(far_result.update_applied)
+
+    # The guard published to dream rollouts stays clipped to the observed
+    # reward range +/- the margin, unchanged by this fix.
+    assert float(far_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
+    assert float(near_result.prediction.reward) == pytest.approx(5.05, abs=1e-4)
+
+    # The unclipped decode is exposed and used for the diagnostic.
+    assert float(far_result.prediction.raw_reward) == pytest.approx(50.0, abs=1e-3)
+    assert float(near_result.prediction.raw_reward) == pytest.approx(5.05, abs=1e-3)
+
+    # reward_error must separate a badly wrong head from a nearly-correct one
+    # instead of both saturating at observation_clip_margin.
+    assert float(near_result.reward_error) == pytest.approx(0.05, abs=1e-3)
+    assert float(far_result.reward_error) == pytest.approx(45.0, abs=1e-3)
 
 
 def test_action_conditioned_world_model_config_roundtrip() -> None:


### PR DESCRIPTION
Supersedes #436 after the merged world-model validation refactor made that branch conflict.

This preserves guarded predictions for dream rollouts while scoring observation and reward diagnostics from the private pre-guard decode, without changing the public `WorldModelPrediction` schema. It retains #436 contributor authorship in the cherry-picked commits and resolves the integration conflict with #420.

Validation on the integrated current-main branch:
- 139 passed: action-conditioned, latent, dreaming, and world-model suites
- Ruff clean
- focused strict mypy clean

No outputs or evidence artifacts changed.

Closes #391.

AI assistance: OpenAI GPT-5.6 Codex desktop. Attribution: self-reported.