### PR TITLE
fix(step8): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -134,9 +134,10 @@ def _require_nonnegative_real(name: str, value: object) -> float:
 
 
 def _require_int(name: str, value: object, *, minimum: int | None = None) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -225,6 +225,24 @@ def test_step8_bool_fields_accept_exact_bools() -> None:
     core = config.to_core_config()
     assert core.use_layer_norm is False
     assert core.predict_delta is True
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize("field", ["observation_dim", "n_actions", "action_dim"])
+def test_step8_world_model_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        make_step8_world_model(_config_with(**{field: _SpoofedInt()}))
 
 
 def test_step8_world_model_rejects_nonpositive_vector_action_dim() -> None:


### PR DESCRIPTION
Closes #543.

Replaces conflicting #544 by replaying the reviewed fix on current `main` while preserving the newer Step 8 boolean-validation coverage.

Verification: `pytest tests/test_step8_production.py -q -o addopts=''` (69 passed); `ruff check alberta_framework tests`.