### PR TITLE
fix(step10): reject class-spoofed non-integer config fields

### DIFF
--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -208,9 +208,10 @@ def _require_int(
     maximum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(value)
+    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -332,6 +332,34 @@ def test_step10_stomp_feature_index_stays_within_int32() -> None:
     spec = SubtaskSpec(feature_index=2**31 - 2)
     cfg = Step10STOMPConfig(subtask_specs=(spec,), observation_dim=2**31 - 1)
     assert cfg.subtask_specs[0].feature_index == 2**31 - 2
+class _SpoofedInt:
+    """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return int
+
+    def __int__(self) -> int:
+        return 3
+
+    def __index__(self) -> int:
+        return 3
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_dim", "n_primitive_actions", "option_planning_backups_per_step"],
+)
+def test_step10_stomp_fields_reject_class_spoofed_integers(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: _SpoofedInt()})
+
+
+# Note: SubtaskSpec.feature_index/max_option_steps also route through this
+# module's _require_int, but SubtaskSpec.__post_init__ (core/options.py) runs
+# its own unguarded `< 0`/`< 1` comparison first and raises a raw TypeError
+# on a spoofed object before this module's helper is ever reached. That is a
+# separate, out-of-scope gap in a different file/function - not fixed here.
 
 
 def test_step10_stomp_rejects_non_tuple_subtask_specs() -> None:


### PR DESCRIPTION
Closes #562.

Replaces conflicting #563 by replaying the reviewed fix on current `main` while preserving the newer Step 10 int32-boundary coverage.

Verification: `pytest tests/test_step10_production.py -q -o addopts=''` (full module passed); `ruff check alberta_framework tests`.