### PR TITLE
test(reward-model): stabilize xdist parameter ids

### DIFF
--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -110,9 +110,9 @@ class _FloatSpoof:
         ("error_decay", float("nan")),
         ("error_decay", float("inf")),
         ("error_decay", float("-inf")),
-        ("forgetting", _FloatSpoof()),
-        ("ridge", _FloatSpoof()),
-        ("error_decay", _FloatSpoof()),
+        pytest.param("forgetting", _FloatSpoof(), id="forgetting-class-spoof"),
+        pytest.param("ridge", _FloatSpoof(), id="ridge-class-spoof"),
+        pytest.param("error_decay", _FloatSpoof(), id="error-decay-class-spoof"),
     ],
 )
 def test_rls_reward_model_rejects_non_real_or_non_finite_scalars(


### PR DESCRIPTION
Follow-up to #606.

The three `_FloatSpoof()` parameter values used default repr-based pytest IDs containing process-specific addresses. Under the repository xdist lane, workers therefore collected different node IDs and aborted before execution. Assign explicit stable IDs to those three cases.

Validation:
- `pytest tests/test_reward_model.py -q -o addopts= -n 2 --dist loadfile` — 27 passed
- scoped ruff — passed
- `git diff --check` — clean

No outputs or evidence artifacts changed.