### PR TITLE
fix(streams): integrate float32-safe scale bounds

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -9,7 +9,7 @@ All streams use JAX-compatible pure functions that work with jax.lax.scan.
 
 import math
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax.numpy as jnp
@@ -18,6 +18,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
+from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -40,21 +41,26 @@ def _require_positive_int(name: str, value: object) -> int:
     return value
 
 
-def _require_normal_float32_scale(name: str, value: float) -> float:
+def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[Real, float]:
+    """Return an actual real together with its single exact binary32 rounding."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(message)
+    real = cast(Real, value)
+    try:
+        narrowed = round_real_to_float32(real)
+    except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(narrowed):
+        raise ValueError(message)
+    return real, narrowed
+
+
+def _require_normal_float32_scale(name: str, value: object) -> float:
     """Return a positive bound with stable JAX float32 logarithm semantics."""
     message = f"{name} must be finite, positive, and representable as a normal float32 value"
-    try:
-        normalized = float(value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
-    if (
-        not math.isfinite(normalized)
-        or normalized < _FLOAT32_TINY
-        or normalized > _FLOAT32_MAX
-    ):
-        raise ValueError(message)
-    narrowed = float(np.float32(normalized))
-    if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
+    real, narrowed = _narrow_real_to_float32(name, value, message)
+    if real <= 0 or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
         raise ValueError(message)
     return narrowed
 
@@ -70,6 +76,12 @@ def _require_finite_nonnegative_float32(name: str, value: object) -> float:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed) or narrowed < 0.0:
         raise ValueError(message)
+
+
+def _require_finite_float32_log_scale(name: str, value: object) -> float:
+    """Return a clip bound that stays finite once JAX narrows it to float32."""
+    message = f"{name} must be finite and remain finite once narrowed to float32"
+    _, narrowed = _narrow_real_to_float32(name, value, message)
     return narrowed
 
 
@@ -1138,13 +1150,10 @@ class ScaleDriftStream:
         self._feature_dim = feature_dim
         self._weight_drift_rate = weight_drift_rate
         self._scale_drift_rate = scale_drift_rate
-        for name, bound in (("min_log_scale", min_log_scale), ("max_log_scale", max_log_scale)):
-            if isinstance(bound, bool) or not isinstance(bound, Real) or not math.isfinite(bound):
-                raise ValueError(f"{name} must be finite")
-        if min_log_scale > max_log_scale:
+        self._min_log_scale = _require_finite_float32_log_scale("min_log_scale", min_log_scale)
+        self._max_log_scale = _require_finite_float32_log_scale("max_log_scale", max_log_scale)
+        if self._min_log_scale > self._max_log_scale:
             raise ValueError("min_log_scale must be <= max_log_scale")
-        self._min_log_scale = min_log_scale
-        self._max_log_scale = max_log_scale
         self._noise_std = noise_std
 
     @property

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -991,8 +991,10 @@ class DynamicScaleShiftStream:
         self._weight_change_interval = _require_positive_int(
             "weight_change_interval", weight_change_interval
         )
-        self._min_scale = min_scale
-        self._max_scale = max_scale
+        self._min_scale = _require_normal_float32_scale("min_scale", min_scale)
+        self._max_scale = _require_normal_float32_scale("max_scale", max_scale)
+        if self._min_scale > self._max_scale:
+            raise ValueError("min_scale must be <= max_scale")
         self._noise_std = noise_std
 
     @property
@@ -1136,6 +1138,11 @@ class ScaleDriftStream:
         self._feature_dim = feature_dim
         self._weight_drift_rate = weight_drift_rate
         self._scale_drift_rate = scale_drift_rate
+        for name, bound in (("min_log_scale", min_log_scale), ("max_log_scale", max_log_scale)):
+            if isinstance(bound, bool) or not isinstance(bound, Real) or not math.isfinite(bound):
+                raise ValueError(f"{name} must be finite")
+        if min_log_scale > max_log_scale:
+            raise ValueError("min_log_scale must be <= max_log_scale")
         self._min_log_scale = min_log_scale
         self._max_log_scale = max_log_scale
         self._noise_std = noise_std

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -76,6 +76,7 @@ def _require_finite_nonnegative_float32(name: str, value: object) -> float:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed) or narrowed < 0.0:
         raise ValueError(message)
+    return narrowed
 
 
 def _require_finite_float32_log_scale(name: str, value: object) -> float:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -595,6 +595,21 @@ class TestMakeScaleRange:
 class TestDynamicScaleShiftStream:
     """Tests for the DynamicScaleShiftStream class."""
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"min_scale": 0.0},
+            {"min_scale": -1.0},
+            {"min_scale": float("nan")},
+            {"max_scale": float("inf")},
+            {"min_scale": 10.0, "max_scale": 1.0},
+        ],
+    )
+    def test_rejects_nonpositive_nonfinite_or_reversed_scale_bounds(self, kwargs):
+        """These bounds produced NaN/inf observations or an inverted log-uniform range."""
+        with pytest.raises(ValueError, match="scale"):
+            DynamicScaleShiftStream(feature_dim=4, **kwargs)
+
     def test_init_creates_valid_state(self, rng_key):
         """Stream init should create valid state with correct shapes."""
         stream = DynamicScaleShiftStream(feature_dim=10)
@@ -680,6 +695,27 @@ class TestDynamicScaleShiftStream:
 
 class TestScaleDriftStream:
     """Tests for the ScaleDriftStream class."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            (
+                {"min_log_scale": 4.0, "max_log_scale": -4.0},
+                "min_log_scale must be <= max_log_scale",
+            ),
+            ({"min_log_scale": float("nan")}, "min_log_scale must be finite"),
+            ({"max_log_scale": float("inf")}, "max_log_scale must be finite"),
+        ],
+    )
+    def test_rejects_reversed_or_nonfinite_log_scale_bounds(self, kwargs, message):
+        """Reversed clip bounds pin every scale to max_log_scale: a stationary stream."""
+        with pytest.raises(ValueError, match=message):
+            ScaleDriftStream(feature_dim=4, **kwargs)
+
+    def test_equal_log_scale_bounds_are_accepted(self, rng_key):
+        stream = ScaleDriftStream(feature_dim=4, min_log_scale=0.0, max_log_scale=0.0)
+        timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
+        chex.assert_tree_all_finite(timestep.observation)
 
     def test_init_creates_valid_state(self, rng_key):
         """Stream init should create valid state with correct shapes."""

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,5 +1,7 @@
 """Tests for experience streams."""
 
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -603,12 +605,31 @@ class TestDynamicScaleShiftStream:
             {"min_scale": float("nan")},
             {"max_scale": float("inf")},
             {"min_scale": 10.0, "max_scale": 1.0},
+            {"max_scale": 1e39},
+            {"max_scale": Fraction(10**400)},
+            {"min_scale": True},
+            {"max_scale": True},
+            {"min_scale": 1e-40},
         ],
     )
     def test_rejects_nonpositive_nonfinite_or_reversed_scale_bounds(self, kwargs):
         """These bounds produced NaN/inf observations or an inverted log-uniform range."""
         with pytest.raises(ValueError, match="scale"):
             DynamicScaleShiftStream(feature_dim=4, **kwargs)
+
+    def test_scale_bounds_are_narrowed_once_and_compared_after_narrowing(self, rng_key):
+        """Exact-ratio inputs round straight to float32; equal narrowed bounds are accepted."""
+        midpoint = Fraction(1) + Fraction(1, 2**24)
+        stream = DynamicScaleShiftStream(feature_dim=4, min_scale=midpoint, max_scale=midpoint)
+        assert stream._min_scale == 1.0
+        assert stream._max_scale == 1.0
+        assert type(stream._min_scale) is float
+        max_finite = float(np.finfo(np.float32).max)
+        stream = DynamicScaleShiftStream(feature_dim=4, min_scale=1.0, max_scale=max_finite)
+        assert stream._max_scale == max_finite
+        stream = DynamicScaleShiftStream(feature_dim=4, min_scale=0.5, max_scale=0.5)
+        timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
+        chex.assert_tree_all_finite(timestep.observation)
 
     def test_init_creates_valid_state(self, rng_key):
         """Stream init should create valid state with correct shapes."""
@@ -705,6 +726,11 @@ class TestScaleDriftStream:
             ),
             ({"min_log_scale": float("nan")}, "min_log_scale must be finite"),
             ({"max_log_scale": float("inf")}, "max_log_scale must be finite"),
+            ({"min_log_scale": -1e100, "max_log_scale": 1e100}, "min_log_scale must be finite"),
+            ({"max_log_scale": 1e39}, "max_log_scale must be finite"),
+            ({"max_log_scale": Fraction(10**400)}, "max_log_scale must be finite"),
+            ({"min_log_scale": True}, "min_log_scale must be finite"),
+            ({"max_log_scale": False}, "max_log_scale must be finite"),
         ],
     )
     def test_rejects_reversed_or_nonfinite_log_scale_bounds(self, kwargs, message):
@@ -716,6 +742,33 @@ class TestScaleDriftStream:
         stream = ScaleDriftStream(feature_dim=4, min_log_scale=0.0, max_log_scale=0.0)
         timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
         chex.assert_tree_all_finite(timestep.observation)
+
+    def test_log_scale_bounds_are_narrowed_once_before_comparison(self, rng_key):
+        """A Fraction midpoint rounds once (ties-to-even) to the float32 clip bound."""
+        midpoint = Fraction(1) + Fraction(1, 2**24)
+        stream = ScaleDriftStream(feature_dim=4, min_log_scale=midpoint, max_log_scale=1.0)
+        assert stream._min_log_scale == 1.0
+        assert stream._max_log_scale == 1.0
+        assert type(stream._min_log_scale) is float
+        max_finite = float(np.finfo(np.float32).max)
+        stream = ScaleDriftStream(
+            feature_dim=4, min_log_scale=-max_finite, max_log_scale=max_finite
+        )
+        assert stream._max_log_scale == max_finite
+        timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
+        chex.assert_tree_all_finite(timestep.observation)
+
+    def test_clip_bounds_stay_finite_at_execution(self, rng_key):
+        """The stored bounds are exactly what jnp.clip receives, so the walk is bounded."""
+        stream = ScaleDriftStream(
+            feature_dim=4, scale_drift_rate=10.0, min_log_scale=-1.0, max_log_scale=1.0
+        )
+        state = stream.init(rng_key)
+        for step in range(50):
+            _, state = stream.step(state, jnp.array(step))
+        assert bool(jnp.all(jnp.isfinite(state.log_scales)))
+        assert bool(jnp.all(state.log_scales >= -1.0))
+        assert bool(jnp.all(state.log_scales <= 1.0))
 
     def test_init_creates_valid_state(self, rng_key):
         """Stream init should create valid state with correct shapes."""


### PR DESCRIPTION
Supersedes conflicting #422 while preserving its contributor commits and final repaired behavior on current `main`.

Both `ScaleDriftStream` and `DynamicScaleShiftStream` validate exact host values and their binary32 execution sinks, reject class-spoofed/non-finite/overflowing values, compare canonicalized bounds, and store the values JAX actually consumes. The integration retains newer synthetic-stream validation already on main.

Validation: `tests/test_streams.py` — 164 passed; Ruff clean. No outputs or evidence artifacts changed.

Closes #421.

AI assistance: OpenAI GPT-5.6 Codex desktop. Attribution: self-reported.