### PR TITLE
fix(off-policy TD): skip unused infinite traces at zero decay

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -391,18 +391,6 @@ class OffPolicyTDLinearLearner:
             [squared_td, td_error, rho_clipped, alpha, mean_e],
             dtype=jnp.float32,
         )
-        new_state = jax.lax.cond(
-            update_applied,
-            lambda: proposed_state,
-            lambda: state,
-        )
-
-        squared_td = td_error**2
-        mean_e = jnp.mean(jnp.abs(new_state.eligibility_traces))
-        metrics = jnp.array(
-            [squared_td, td_error, rho_clipped, alpha, mean_e],
-            dtype=jnp.float32,
-        )
 
         return OffPolicyTDUpdateResult(  # type: ignore[call-arg]
             state=new_state,

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -70,6 +70,11 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 
+
+def _zero_if_unused(scale: Array, value: Array) -> Array:
+    """Sanitize leftover inf only in the finite-state check when unused."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+
 # =============================================================================
 # State / result types
 # =============================================================================
@@ -365,10 +370,26 @@ class OffPolicyTDLinearLearner:
             & jnp.isfinite(gamma_s)
             & jnp.isfinite(rho_s)
         )
+        previous_checked = state.replace(  # type: ignore[attr-defined]
+            eligibility_traces=_zero_if_unused(decay, state.eligibility_traces),
+            bias_eligibility_trace=_zero_if_unused(decay, state.bias_eligibility_trace),
+        )
         update_applied = (
             inputs_valid
-            & _floating_tree_is_finite(state)
+            & _floating_tree_is_finite(previous_checked)
             & _floating_tree_is_finite(proposed_state)
+        )
+        new_state = jax.lax.cond(
+            update_applied,
+            lambda: proposed_state,
+            lambda: state,
+        )
+
+        squared_td = td_error**2
+        mean_e = jnp.mean(jnp.abs(new_state.eligibility_traces))
+        metrics = jnp.array(
+            [squared_td, td_error, rho_clipped, alpha, mean_e],
+            dtype=jnp.float32,
         )
         new_state = jax.lax.cond(
             update_applied,
@@ -518,7 +539,9 @@ class ETDLinearLearner:
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
         follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
-        emphasis = lam * interest_s + (1.0 - lam) * follow_on
+        emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(
+            1.0 - lam, follow_on
+        )
 
         trace_decay = gamma_s * lam
         new_e = rho_s * (
@@ -547,9 +570,16 @@ class ETDLinearLearner:
             & jnp.isfinite(rho_s)
             & jnp.isfinite(interest_s)
         )
+        previous_checked = state.replace(  # type: ignore[attr-defined]
+            eligibility_traces=_zero_if_unused(trace_decay, state.eligibility_traces),
+            bias_eligibility_trace=_zero_if_unused(
+                trace_decay, state.bias_eligibility_trace
+            ),
+            follow_on_trace=_zero_if_unused(gamma_s, state.follow_on_trace),
+        )
         update_applied = (
             inputs_valid
-            & _floating_tree_is_finite(state)
+            & _floating_tree_is_finite(previous_checked)
             & _floating_tree_is_finite(proposed_state)
         )
         new_state = jax.lax.cond(
@@ -742,9 +772,14 @@ class GradientTDLinearLearner:
             & jnp.isfinite(gamma_s)
             & jnp.isfinite(rho_s)
         )
+        previous_checked = state.replace(  # type: ignore[attr-defined]
+            eligibility_traces=_zero_if_unused(
+                gamma_s * lam, state.eligibility_traces
+            ),
+        )
         update_applied = (
             inputs_valid
-            & _floating_tree_is_finite(state)
+            & _floating_tree_is_finite(previous_checked)
             & _floating_tree_is_finite(proposed_state)
         )
         new_state = jax.lax.cond(

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -796,3 +796,68 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         assert bool(result.update_applied)
         chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
         chex.assert_tree_all_finite(result.state.weights)
+
+    def test_off_policy_td_does_not_multiply_inf_traces(self) -> None:
+        """gamma*lam=0 drops leftover traces; 0 * inf must not freeze."""
+        learner = OffPolicyTDLinearLearner(step_size=0.1, trace_decay=0.9)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            eligibility_traces=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            bias_eligibility_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.array([0.5, -0.25], dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state.eligibility_traces)
+        assert bool(jnp.isfinite(result.state.bias_eligibility_trace))
+
+    def test_etd_does_not_multiply_inf_follow_on(self) -> None:
+        """gamma=0 drops leftover F; 0 * inf must not freeze the ETD step."""
+        learner = ETDLinearLearner(step_size=0.1, trace_decay=0.4)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            follow_on_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            eligibility_traces=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            bias_eligibility_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.array([0.5, -0.25], dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        assert bool(jnp.isfinite(result.state.follow_on_trace))
+        chex.assert_tree_all_finite(result.state.eligibility_traces)
+
+    def test_gradient_td_does_not_multiply_inf_traces(self) -> None:
+        """gamma*lam=0 drops leftover GTD traces; 0 * inf must not freeze."""
+        learner = GradientTDLinearLearner(step_size=0.1, trace_decay=0.9)
+        state = learner.init(2).replace(  # type: ignore[attr-defined]
+            eligibility_traces=jnp.full(3, jnp.inf, dtype=jnp.float32),
+        )
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.isfinite(raw))
+
+        result = learner.update(
+            state,
+            jnp.array([0.5, -0.25], dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+            jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array(1.0, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        chex.assert_tree_all_finite(result.state.eligibility_traces)


### PR DESCRIPTION
Supersedes #561 and preserves its numerical fix while removing the duplicated update and metric block called out in review. Retrace TD, ETD(lambda), and GTD sanitize only trace and follow-on fields that are mathematically unused when their scale is zero; live rollback state remains unchanged. Verification: the focused off-policy TD suite passed 32 tests, Ruff passed, and diff-check is clean.