### PR TITLE
fix(core): validate SARSA configuration exactly

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -20,7 +20,9 @@ Reference: Sutton & Barto 2018, Section 10.1 (Episodic Semi-gradient SARSA)
 
 import dataclasses
 import functools
+import math
 import time
+from numbers import Integral, Real
 from typing import Any
 
 import chex
@@ -30,6 +32,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Float, Int
 
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.horde import HordeLearner
 from alberta_framework.core.multi_head_learner import (
     MULTI_HEAD_MLP_STATE_SCHEMA,
@@ -72,6 +75,43 @@ class SARSAConfig:
     epsilon_start: float = 0.1
     epsilon_end: float = 0.01
     epsilon_decay_steps: int = 0
+
+    def __post_init__(self) -> None:
+        """Reject invalid host configuration before it reaches JAX indexing."""
+        actual_actions_type = type(self.n_actions)
+        if (
+            issubclass(actual_actions_type, bool)
+            or not issubclass(actual_actions_type, Integral)
+            or self.n_actions < 1
+        ):
+            raise ValueError("n_actions must be a positive integer")
+        actual_decay_type = type(self.epsilon_decay_steps)
+        if (
+            issubclass(actual_decay_type, bool)
+            or not issubclass(actual_decay_type, Integral)
+            or self.epsilon_decay_steps < 0
+        ):
+            raise ValueError("epsilon_decay_steps must be a non-negative integer")
+        for name, value in (
+            ("gamma", self.gamma),
+            ("epsilon_start", self.epsilon_start),
+            ("epsilon_end", self.epsilon_end),
+        ):
+            actual_type = type(value)
+            if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+                raise ValueError(f"{name} must be a finite real in [0, 1]")
+            try:
+                numerator, denominator, narrowed = round_real_to_float32_with_ratio(value)
+            except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
+                raise ValueError(f"{name} must be a finite real in [0, 1]") from exc
+            if (
+                not math.isfinite(narrowed)
+                or numerator < 0
+                or numerator > denominator
+                or narrowed < 0.0
+                or narrowed > 1.0
+            ):
+                raise ValueError(f"{name} must be a finite real in [0, 1]")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -49,6 +49,58 @@ def _make_agent(
 # =============================================================================
 
 
+class TestSARSAConfigValidation:
+    @pytest.mark.parametrize("n_actions", [0, -1, True, 2.0])
+    def test_rejects_invalid_action_count(self, n_actions):
+        with pytest.raises(ValueError, match="n_actions"):
+            SARSAConfig(n_actions=n_actions)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("epsilon_decay_steps", [-1, True, 2.0])
+    def test_rejects_invalid_decay_steps(self, epsilon_decay_steps):
+        with pytest.raises(ValueError, match="epsilon_decay_steps"):
+            SARSAConfig(n_actions=2, epsilon_decay_steps=epsilon_decay_steps)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("name", ["gamma", "epsilon_start", "epsilon_end"])
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), -0.1, 1.1, True, "0.5"]
+    )
+    def test_rejects_invalid_probability(self, name, value):
+        with pytest.raises(ValueError, match=name):
+            SARSAConfig(n_actions=2, **{name: value})
+
+    @pytest.mark.parametrize("value", [0.0, 1.0])
+    def test_accepts_probability_endpoints(self, value):
+        config = SARSAConfig(
+            n_actions=2,
+            gamma=value,
+            epsilon_start=value,
+            epsilon_end=value,
+        )
+        assert config.gamma == value
+
+    def test_rejects_class_spoofed_scalars(self):
+        class SpoofedInt:
+            @property
+            def __class__(self):
+                return int
+
+            def __int__(self):
+                return 2
+
+        class SpoofedFloat:
+            @property
+            def __class__(self):
+                return float
+
+            def __float__(self):
+                return 0.5
+
+        with pytest.raises(ValueError, match="n_actions"):
+            SARSAConfig(n_actions=SpoofedInt())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="gamma"):
+            SARSAConfig(n_actions=2, gamma=SpoofedFloat())  # type: ignore[arg-type]
+
+
 class TestSARSAInit:
     """Tests for SARSAAgent initialization."""
 


### PR DESCRIPTION
Closes #519. Replaces closed #567 while preserving contributor authorship. The earlier branch rejected the valid gamma=1 endpoint and imposed an unrequested epsilon ordering constraint. This version implements the issue contract exactly, validates at the float32 sink, and rejects bool/class-spoof aliases.\n\nValidation: 69 SARSA tests; ruff; strict mypy.