### PR TITLE
fix(streams): validate out-of-class scale parameters

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -489,8 +489,16 @@ class FrequencyMismatchStream:
         self._context_length = context_length
         self._omega_min = omega_min_float32
         self._omega_max = omega_max_float32
-        self._amplitude_scale = amplitude_scale
-        self._noise_std = noise_std
+        self._amplitude_scale = _require_finite_float32_multiplier(
+            amplitude_scale,
+            name="amplitude_scale",
+            nonnegative=True,
+        )
+        self._noise_std = _require_finite_float32_multiplier(
+            noise_std,
+            name="noise_std",
+            nonnegative=True,
+        )
 
     @property
     def feature_dim(self) -> int:
@@ -706,7 +714,27 @@ class CompositionalStream:
             raise ValueError("n_contexts must be positive")
         if context_length < 1:
             raise ValueError("context_length must be positive")
+        feature_std_float32 = _require_finite_float32_multiplier(
+            feature_std,
+            name="feature_std",
+            nonnegative=True,
+        )
         weight_scale_float32 = _require_compositional_weight_scale_float32(weight_scale)
+        amplitude_scale_float32 = _require_finite_float32_multiplier(
+            amplitude_scale,
+            name="amplitude_scale",
+            nonnegative=True,
+        )
+        noise_std_float32 = _require_finite_float32_multiplier(
+            noise_std,
+            name="noise_std",
+            nonnegative=True,
+        )
+        _require_safe_float32_product(
+            feature_std_float32,
+            weight_scale_float32,
+            names="feature_std and weight_scale",
+        )
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks
@@ -714,10 +742,10 @@ class CompositionalStream:
         self._outer_components = outer_components
         self._n_contexts = n_contexts
         self._context_length = context_length
-        self._feature_std = feature_std
+        self._feature_std = feature_std_float32
         self._weight_scale = weight_scale_float32
-        self._amplitude_scale = amplitude_scale
-        self._noise_std = noise_std
+        self._amplitude_scale = amplitude_scale_float32
+        self._noise_std = noise_std_float32
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -643,6 +643,36 @@ class TestOutOfClassPolynomialStream:
 class TestFrequencyMismatchStream:
     """Tests for the trigonometric out-of-class stream."""
 
+    @pytest.mark.parametrize("field", ["amplitude_scale", "noise_std"])
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), -1.0, -Fraction(1, 2**200)],
+    )
+    def test_scale_parameters_reject_nonfinite_or_negative_exact_reals(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            FrequencyMismatchStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["amplitude_scale", "noise_std"])
+    def test_scale_parameters_reject_untrusted_real_subclasses(self, field: str) -> None:
+        with pytest.raises(ValueError, match=field):
+            FrequencyMismatchStream(  # type: ignore[arg-type]
+                **{field: _PositiveRatioFloat(-0.5)}
+            )
+
+    def test_scale_parameters_are_canonical_float32_values(self) -> None:
+        stream = FrequencyMismatchStream(
+            amplitude_scale=Fraction(1, 3),
+            noise_std=np.float64(0.2),
+        )
+        assert type(stream._amplitude_scale) is float  # noqa: SLF001
+        assert type(stream._noise_std) is float  # noqa: SLF001
+        assert stream._amplitude_scale == float(np.float32(1 / 3))  # noqa: SLF001
+        assert stream._noise_std == float(np.float32(0.2))  # noqa: SLF001
+
     @pytest.mark.parametrize(
         ("omega_min", "omega_max"),
         [(float("nan"), 3.0), (0.5, float("inf")), (float("inf"), float("inf"))],
@@ -846,6 +876,39 @@ class TestFrequencyMismatchStream:
 
 class TestCompositionalStream:
     """Tests for the 2-hidden-layer compositional out-of-class stream."""
+
+    @pytest.mark.parametrize("field", ["feature_std", "amplitude_scale", "noise_std"])
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), -1.0, -Fraction(1, 2**200)],
+    )
+    def test_scale_parameters_reject_nonfinite_or_negative_exact_reals(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            CompositionalStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["feature_std", "amplitude_scale", "noise_std"])
+    def test_scale_parameters_reject_untrusted_real_subclasses(self, field: str) -> None:
+        with pytest.raises(ValueError, match=field):
+            CompositionalStream(**{field: _PositiveRatioFloat(-0.5)})  # type: ignore[arg-type]
+
+    def test_scale_parameters_are_canonical_float32_values(self) -> None:
+        stream = CompositionalStream(
+            feature_std=Fraction(1, 3),
+            amplitude_scale=np.float64(0.2),
+            noise_std=np.float32(0.1),
+        )
+        assert type(stream._feature_std) is float  # noqa: SLF001
+        assert type(stream._amplitude_scale) is float  # noqa: SLF001
+        assert type(stream._noise_std) is float  # noqa: SLF001
+
+    def test_feature_and_weight_scale_reject_unsafe_float32_product(self) -> None:
+        safe = float(np.sqrt(np.finfo(np.float32).max, dtype=np.float32))
+        with pytest.raises(ValueError, match="feature_std and weight_scale"):
+            CompositionalStream(feature_std=safe, weight_scale=safe)
 
     @pytest.mark.parametrize("weight_scale", [float("nan"), float("inf"), float("-inf")])
     def test_weight_scale_must_be_finite(self, weight_scale: float) -> None:


### PR DESCRIPTION
Supersedes #535 and #538. FrequencyMismatchStream and CompositionalStream now validate and canonicalize nonnegative scale parameters through the existing trusted exact-ratio float32 multiplier boundary instead of duplicating a weaker helper. The compositional feature and weight scales also must have a safe combined float32 product. Adversarial real subclasses, exact negative fractions, overflow, and canonical storage are covered. Verification: 240 out-of-class stream tests passed; Ruff passed; diff-check clean. Fixes #510. Fixes #511.