### PR TITLE
fix(streams): bound scale drift at the float32 exponential sink

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -25,6 +25,12 @@ from alberta_framework.streams.base import ScanStream
 _INT32_MAX = 2**31 - 1
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
+_FLOAT32_EXP_SAFE_LOG_MIN = float(
+    np.nextafter(np.float32(math.log(_FLOAT32_TINY)), np.float32(math.inf))
+)
+_FLOAT32_EXP_SAFE_LOG_MAX = float(
+    np.nextafter(np.float32(math.log(_FLOAT32_MAX)), np.float32(-math.inf))
+)
 
 
 def _require_positive_int(name: str, value: object) -> int:
@@ -80,9 +86,14 @@ def _require_finite_nonnegative_float32(name: str, value: object) -> float:
 
 
 def _require_finite_float32_log_scale(name: str, value: object) -> float:
-    """Return a clip bound that stays finite once JAX narrows it to float32."""
-    message = f"{name} must be finite and remain finite once narrowed to float32"
+    """Return a clip bound whose float32 exponential stays positive and finite."""
+    message = (
+        f"{name} must be finite and remain in the float32 exp-safe interval "
+        f"[{_FLOAT32_EXP_SAFE_LOG_MIN}, {_FLOAT32_EXP_SAFE_LOG_MAX}]"
+    )
     _, narrowed = _narrow_real_to_float32(name, value, message)
+    if narrowed < _FLOAT32_EXP_SAFE_LOG_MIN or narrowed > _FLOAT32_EXP_SAFE_LOG_MAX:
+        raise ValueError(message)
     return narrowed
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -731,6 +731,8 @@ class TestScaleDriftStream:
             ({"max_log_scale": Fraction(10**400)}, "max_log_scale must be finite"),
             ({"min_log_scale": True}, "min_log_scale must be finite"),
             ({"max_log_scale": False}, "max_log_scale must be finite"),
+            ({"min_log_scale": -88.0}, "min_log_scale must be finite"),
+            ({"max_log_scale": 89.0}, "max_log_scale must be finite"),
         ],
     )
     def test_rejects_reversed_or_nonfinite_log_scale_bounds(self, kwargs, message):
@@ -743,20 +745,45 @@ class TestScaleDriftStream:
         timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
         chex.assert_tree_all_finite(timestep.observation)
 
-    def test_log_scale_bounds_are_narrowed_once_before_comparison(self, rng_key):
+    def test_log_scale_bounds_are_narrowed_once_before_comparison(self):
         """A Fraction midpoint rounds once (ties-to-even) to the float32 clip bound."""
         midpoint = Fraction(1) + Fraction(1, 2**24)
         stream = ScaleDriftStream(feature_dim=4, min_log_scale=midpoint, max_log_scale=1.0)
         assert stream._min_log_scale == 1.0
         assert stream._max_log_scale == 1.0
         assert type(stream._min_log_scale) is float
-        max_finite = float(np.finfo(np.float32).max)
-        stream = ScaleDriftStream(
-            feature_dim=4, min_log_scale=-max_finite, max_log_scale=max_finite
+
+    def test_log_scale_bounds_have_positive_finite_float32_exponentials(self):
+        """Accepted clip endpoints cannot collapse or overflow the scale factor."""
+        min_safe = float(
+            np.nextafter(
+                np.float32(np.log(np.finfo(np.float32).tiny)), np.float32(np.inf)
+            )
         )
-        assert stream._max_log_scale == max_finite
-        timestep, _ = stream.step(stream.init(rng_key), jnp.array(0))
-        chex.assert_tree_all_finite(timestep.observation)
+        max_safe = float(
+            np.nextafter(
+                np.float32(np.log(np.finfo(np.float32).max)), np.float32(-np.inf)
+            )
+        )
+        stream = ScaleDriftStream(
+            feature_dim=4, min_log_scale=min_safe, max_log_scale=max_safe
+        )
+        endpoint_scales = jnp.exp(
+            jnp.asarray([stream._min_log_scale, stream._max_log_scale], dtype=jnp.float32)
+        )
+        assert bool(jnp.all(endpoint_scales > 0.0))
+        assert bool(jnp.all(jnp.isfinite(endpoint_scales)))
+
+        with pytest.raises(ValueError, match="min_log_scale"):
+            ScaleDriftStream(
+                feature_dim=4,
+                min_log_scale=float(np.nextafter(np.float32(min_safe), np.float32(-np.inf))),
+            )
+        with pytest.raises(ValueError, match="max_log_scale"):
+            ScaleDriftStream(
+                feature_dim=4,
+                max_log_scale=float(np.nextafter(np.float32(max_safe), np.float32(np.inf))),
+            )
 
     def test_clip_bounds_stay_finite_at_execution(self, rng_key):
         """The stored bounds are exactly what jnp.clip receives, so the walk is bounded."""


### PR DESCRIPTION
Final current-main repair for #421, superseding the now-conflicting #620.

The merged bound validation still allowed finite float32 log scales whose actual `jnp.exp` sink becomes zero or infinity. This constrains stored log bounds to the exact normal-float32 exponential interval. Tests pin the accepted endpoints as positive/finite and reject each immediately adjacent float32 value, in addition to the original reversed/non-finite/exact-ratio coverage.

Validation:
- `tests/test_streams.py`: 167 passed under `-W error`
- Ruff clean
- focused strict mypy clean
- diff check clean

No outputs or evidence artifacts changed.

Closes #421.

AI assistance: OpenAI GPT-5.6 Codex desktop. Attribution: self-reported.