### PR TITLE
fix(step9): enforce remaining int32 facade bounds

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -248,8 +248,12 @@ def _require_bool(name: str, value: object) -> bool:
 
 
 def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
-    observation_dim = _require_int("observation_dim", config.observation_dim, minimum=1)
-    n_actions = _require_int("n_actions", config.n_actions, minimum=1)
+    observation_dim = _require_int(
+        "observation_dim", config.observation_dim, minimum=1, maximum=_INT32_MAX
+    )
+    n_actions = _require_int(
+        "n_actions", config.n_actions, minimum=1, maximum=_INT32_MAX
+    )
     if config.control.n_actions != n_actions:
         raise ValueError(
             f"control.n_actions ({config.control.n_actions}) must equal "
@@ -261,7 +265,7 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
             f"{config.model_hidden_sizes!r}"
         )
     model_hidden_sizes = tuple(
-        _require_int("model_hidden_sizes", size, minimum=1)
+        _require_int("model_hidden_sizes", size, minimum=1, maximum=_INT32_MAX)
         for size in config.model_hidden_sizes
     )
     model_step_size = _require_nonneg_real("model_step_size", config.model_step_size)
@@ -294,11 +298,14 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         "behavior_model_step_size",
         config.behavior_model_step_size,
     )
-    planning_budget = _require_int("planning_budget", config.planning_budget, minimum=0)
+    planning_budget = _require_int(
+        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+    )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
+        maximum=_INT32_MAX,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
@@ -810,7 +817,8 @@ def run_step9_smoke(
     seed: int = 0,
 ) -> Step9SmokeResult:
     """Run a tiny deterministic Step 9 dreaming integration probe."""
-    steps = _require_int("steps", steps, minimum=1)
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
     cfg = config or Step9DreamingConfig()
     agent, model, buffer = make_step9_components(cfg)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -425,6 +425,22 @@ def test_step9_count_fields_preserve_int32_upper_endpoints() -> None:
     json.dumps(config.to_dict(), allow_nan=False)
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_dim",
+        "n_actions",
+        "model_hidden_sizes",
+        "planning_budget",
+        "dream_rollout_horizon",
+    ],
+)
+def test_step9_remaining_fields_enforce_int32_upper_bound(field: str) -> None:
+    value: object = (2**31,) if field == "model_hidden_sizes" else 2**31
+    with pytest.raises(ValueError, match=field):
+        _config_with(**{field: value})
+
+
 # ---------------------------------------------------------------------------
 # Factory and init tests
 # ---------------------------------------------------------------------------
@@ -830,6 +846,20 @@ def test_step9_smoke_rejects_class_spoofed_integer_steps() -> None:
 
     with pytest.raises(ValueError, match="steps must be an integer"):
         run_step9_smoke(steps=_SpoofedInt())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"steps": 2**31}, "steps"),
+        ({"seed": -1}, "seed"),
+        ({"seed": 2**31}, "seed"),
+        ({"seed": True}, "seed"),
+    ],
+)
+def test_step9_smoke_enforces_int32_inputs(kwargs: dict[str, object], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_step9_smoke(**kwargs)  # type: ignore[arg-type]
 
 
 def test_step9_smoke_linear_model() -> None:


### PR DESCRIPTION
Closes #385.

Conflict-resolved successor to #389. Current `main` already contains the original PR's exact-rational float32 rounding, overflow/underflow rejection, and several count bounds through the shared validation helpers. This retains the still-missing signed-int32 guards for observation/model dimensions, planning budget, rollout horizon, and `run_step9_smoke` inputs without replaying stale duplicate setters or weakening newer boolean contracts.

The original contributor remains the commit author.

Verification:
- `pytest tests/test_step9_production.py -q -o addopts=''` — 178 passed
- focused post-rebase regression selection — 9 passed
- `ruff check alberta_framework/steps/step9.py tests/test_step9_production.py`