### PR TITLE
fix(core): correct post-review validation regressions

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
+from numbers import Integral
 from typing import Any, Literal, Protocol, cast
 
 import chex
@@ -31,6 +31,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.behavior_model import (
     BehaviorModel,
     BehaviorModelState,
@@ -46,33 +47,32 @@ from alberta_framework.core.world_model import (
 )
 
 
-def _require_exact_int(value: object, name: str, *, minimum: int) -> None:
-    """Reject bools, floats, and other non-int scalars for count fields."""
-    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
-        raise ValueError(f"{name} must be an int >= {minimum}")
+def _require_exact_int(value: object, name: str, *, minimum: int) -> int:
+    """Return one canonical signed-int32 count from a trusted integer type."""
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+        raise ValueError(f"{name} must be an int in [{minimum}, {2**31 - 1}]")
+    canonical = int(cast(Integral, value))
+    if not minimum <= canonical <= 2**31 - 1:
+        raise ValueError(f"{name} must be an int in [{minimum}, {2**31 - 1}]")
+    return canonical
 
 
-def _require_finite_nonnegative(value: object, name: str) -> None:
-    """Reject NaN, infinities, negatives, and non-real scalars."""
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, int | float)
-        or not math.isfinite(value)
-        or value < 0.0
-    ):
-        raise ValueError(f"{name} must be finite and non-negative")
+def _require_finite_nonnegative(value: object, name: str) -> float:
+    """Return a canonical finite float32-domain non-negative scalar."""
+    return validated_float32_scalar(name, value, lower=0.0)
 
 
-def _require_finite(value: object, name: str) -> None:
-    """Reject NaN, infinities, and non-real scalars (sign-agnostic)."""
-    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
-        raise ValueError(f"{name} must be finite")
+def _require_finite(value: object, name: str) -> float:
+    """Return a canonical finite float32-domain scalar."""
+    return validated_float32_scalar(name, value)
 
 
-def _require_bool(value: object, name: str) -> None:
+def _require_bool(value: object, name: str) -> bool:
     """Reject truthy stand-ins for exact bools."""
-    if not isinstance(value, bool):
+    if type(value) is not bool:
         raise ValueError(f"{name} must be a bool")
+    return value
 
 
 @dataclasses.dataclass(frozen=True)
@@ -105,17 +105,32 @@ class DreamingConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar configuration, rejecting NaN and type stand-ins."""
-        _require_exact_int(self.warmup_steps, "warmup_steps", minimum=0)
-        _require_finite_nonnegative(self.max_model_error_ema, "max_model_error_ema")
-        _require_finite_nonnegative(self.max_uncertainty, "max_uncertainty")
-        _require_finite_nonnegative(self.min_discount, "min_discount")
+        object.__setattr__(
+            self, "warmup_steps", _require_exact_int(self.warmup_steps, "warmup_steps", minimum=0)
+        )
+        for name in (
+            "max_model_error_ema",
+            "max_uncertainty",
+            "min_discount",
+            "confidence_threshold",
+            "max_model_error",
+            "discount_floor",
+        ):
+            object.__setattr__(self, name, _require_finite_nonnegative(getattr(self, name), name))
         if self.max_discount is not None:
-            _require_finite_nonnegative(self.max_discount, "max_discount")
-        _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1)
-        _require_finite_nonnegative(self.confidence_threshold, "confidence_threshold")
-        _require_finite_nonnegative(self.max_model_error, "max_model_error")
-        _require_finite_nonnegative(self.discount_floor, "discount_floor")
-        _require_bool(self.stop_on_terminal, "stop_on_terminal")
+            object.__setattr__(
+                self,
+                "max_discount",
+                _require_finite_nonnegative(self.max_discount, "max_discount"),
+            )
+        object.__setattr__(
+            self,
+            "rollout_horizon",
+            _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1),
+        )
+        object.__setattr__(
+            self, "stop_on_terminal", _require_bool(self.stop_on_terminal, "stop_on_terminal")
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -184,15 +199,20 @@ class DreamSelectionConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar configuration, rejecting NaN and type stand-ins."""
-        _require_exact_int(self.max_items, "max_items", minimum=1)
-        _require_finite(self.surprise_weight, "surprise_weight")
-        _require_finite(self.utility_weight, "utility_weight")
-        _require_finite(self.confidence_weight, "confidence_weight")
-        _require_finite(self.model_error_weight, "model_error_weight")
-        _require_finite(self.min_surprise, "min_surprise")
-        _require_finite(self.min_utility, "min_utility")
-        _require_finite_nonnegative(self.min_confidence, "min_confidence")
-        _require_finite_nonnegative(self.max_model_error, "max_model_error")
+        object.__setattr__(
+            self, "max_items", _require_exact_int(self.max_items, "max_items", minimum=1)
+        )
+        for name in (
+            "surprise_weight",
+            "utility_weight",
+            "confidence_weight",
+            "model_error_weight",
+            "min_surprise",
+            "min_utility",
+        ):
+            object.__setattr__(self, name, _require_finite(getattr(self, name), name))
+        for name in ("min_confidence", "max_model_error"):
+            object.__setattr__(self, name, _require_finite_nonnegative(getattr(self, name), name))
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -457,10 +477,10 @@ class RecentObservationBuffer:
 
     def __init__(self, capacity: int, observation_dim: int):
         """Initialize the buffer shape."""
-        _require_exact_int(capacity, "capacity", minimum=1)
-        _require_exact_int(observation_dim, "observation_dim", minimum=1)
-        self._capacity = capacity
-        self._observation_dim = observation_dim
+        self._capacity = _require_exact_int(capacity, "capacity", minimum=1)
+        self._observation_dim = _require_exact_int(
+            observation_dim, "observation_dim", minimum=1
+        )
 
     @property
     def capacity(self) -> int:
@@ -559,11 +579,16 @@ class DreamRolloutConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar configuration, rejecting NaN and type stand-ins."""
-        _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1)
-        _require_finite_nonnegative(self.confidence_threshold, "confidence_threshold")
-        _require_finite_nonnegative(self.max_model_error, "max_model_error")
-        _require_finite_nonnegative(self.discount_floor, "discount_floor")
-        _require_bool(self.stop_on_terminal, "stop_on_terminal")
+        object.__setattr__(
+            self,
+            "rollout_horizon",
+            _require_exact_int(self.rollout_horizon, "rollout_horizon", minimum=1),
+        )
+        for name in ("confidence_threshold", "max_model_error", "discount_floor"):
+            object.__setattr__(self, name, _require_finite_nonnegative(getattr(self, name), name))
+        object.__setattr__(
+            self, "stop_on_terminal", _require_bool(self.stop_on_terminal, "stop_on_terminal")
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -957,15 +957,10 @@ class ExperientialMemory:
             _saturating_increment(entries.recency_ages),
             entries.recency_ages,
         )
-        utility_decay = jnp.asarray(self._config.utility_decay, dtype=jnp.float32)
-        decayed_utilities = jax.lax.select(
-            utility_decay == 0.0,
-            jnp.zeros_like(entries.utilities),
-            entries.utilities * utility_decay,
-        )
         utilities = jnp.where(
             valid,
-            decayed_utilities,
+            entries.utilities
+            * jnp.asarray(self._config.utility_decay, dtype=jnp.float32),
             entries.utilities,
         )
         return ExperientialMemoryState(

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -20,7 +20,6 @@ import functools
 import math
 import time
 from collections.abc import Mapping
-from numbers import Real
 from typing import Any
 
 import chex
@@ -29,6 +28,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
 from alberta_framework.core.normalizers import (
@@ -406,17 +406,15 @@ class MultiHeadMLPLearner:
                     f"per_head_gamma_lamda must have length n_heads ({self._n_heads}), "
                     f"got {len(per_head_gamma_lamda)}"
                 )
-            for head_index, gl in enumerate(per_head_gamma_lamda):
-                if not isinstance(gl, Real) or isinstance(gl, bool):
-                    raise ValueError(
-                        f"per_head_gamma_lamda[{head_index}] must be a real number, "
-                        f"got {gl!r}"
-                    )
-                if not math.isfinite(float(gl)) or not 0.0 <= float(gl) <= 1.0:
-                    raise ValueError(
-                        f"per_head_gamma_lamda[{head_index}] must be finite and in "
-                        f"[0, 1], got {gl}"
-                    )
+            self._per_head_gl = tuple(
+                validated_float32_scalar(
+                    f"per_head_gamma_lamda[{head_index}]",
+                    gl,
+                    lower=0.0,
+                    upper=1.0,
+                )
+                for head_index, gl in enumerate(per_head_gamma_lamda)
+            )
 
     @property
     def n_heads(self) -> int:

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -14,10 +14,8 @@ trustworthy — the "selective" part of selective model-based updates.
 from __future__ import annotations
 
 import functools
-import math
-from dataclasses import dataclass
-from numbers import Real
-from typing import Any, cast
+from dataclasses import dataclass, replace
+from typing import Any
 
 import chex
 import jax
@@ -25,16 +23,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
 
-
-def _finite_real(name: str, value: object) -> float:
-    """Return a finite real configuration value without accepting booleans."""
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number")
-    concrete = float(cast(Real, value))
-    if not math.isfinite(concrete):
-        raise ValueError(f"{name} must be finite")
-    return concrete
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -111,8 +100,7 @@ class RLSRewardModel:
 
     def __init__(self, config: RLSRewardModelConfig):
         """Initialize the model."""
-        self._validate_config(config)
-        self._config = config
+        self._config = self._validated_config(config)
 
     @property
     def config(self) -> RLSRewardModelConfig:
@@ -235,18 +223,22 @@ class RLSRewardModel:
             update_applied=update_applied,
         )
 
-    def _validate_config(self, config: RLSRewardModelConfig) -> None:
+    def _validated_config(self, config: RLSRewardModelConfig) -> RLSRewardModelConfig:
         if type(config.feature_dim) is not int or config.feature_dim <= 0:
             raise ValueError("feature_dim must be a positive builtin integer")
-        forgetting = _finite_real("forgetting", config.forgetting)
-        if not 0.0 < forgetting <= 1.0:
-            raise ValueError("forgetting must be in (0, 1]")
-        ridge = _finite_real("ridge", config.ridge)
-        if ridge <= 0.0:
-            raise ValueError("ridge must be positive")
-        error_decay = _finite_real("error_decay", config.error_decay)
-        if not 0.0 <= error_decay < 1.0:
-            raise ValueError("error_decay must be in [0, 1)")
+        forgetting = validated_float32_scalar(
+            "forgetting", config.forgetting, positive=True, upper=1.0
+        )
+        ridge = validated_float32_scalar("ridge", config.ridge, positive=True)
+        error_decay = validated_float32_scalar(
+            "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        return replace(
+            config,
+            forgetting=forgetting,
+            ridge=ridge,
+            error_decay=error_decay,
+        )
 
 
 __all__ = [

--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -20,9 +20,8 @@ Reference: Sutton & Barto 2018, Section 10.1 (Episodic Semi-gradient SARSA)
 
 import dataclasses
 import functools
-import math
 import time
-from numbers import Integral, Real
+from numbers import Integral
 from typing import Any
 
 import chex
@@ -32,7 +31,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Float, Int
 
-from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.horde import HordeLearner
 from alberta_framework.core.multi_head_learner import (
     MULTI_HEAD_MLP_STATE_SCHEMA,
@@ -77,7 +76,7 @@ class SARSAConfig:
     epsilon_decay_steps: int = 0
 
     def __post_init__(self) -> None:
-        """Reject invalid host configuration before it reaches JAX indexing."""
+        """Validate and canonicalize host configuration before JAX use."""
         actual_actions_type = type(self.n_actions)
         if (
             issubclass(actual_actions_type, bool)
@@ -92,26 +91,18 @@ class SARSAConfig:
             or self.epsilon_decay_steps < 0
         ):
             raise ValueError("epsilon_decay_steps must be a non-negative integer")
-        for name, value in (
-            ("gamma", self.gamma),
-            ("epsilon_start", self.epsilon_start),
-            ("epsilon_end", self.epsilon_end),
-        ):
-            actual_type = type(value)
-            if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-                raise ValueError(f"{name} must be a finite real in [0, 1]")
-            try:
-                numerator, denominator, narrowed = round_real_to_float32_with_ratio(value)
-            except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
-                raise ValueError(f"{name} must be a finite real in [0, 1]") from exc
-            if (
-                not math.isfinite(narrowed)
-                or numerator < 0
-                or numerator > denominator
-                or narrowed < 0.0
-                or narrowed > 1.0
-            ):
-                raise ValueError(f"{name} must be a finite real in [0, 1]")
+        gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
+        epsilon_start = validated_float32_scalar(
+            "epsilon_start", self.epsilon_start, lower=0.0, upper=1.0
+        )
+        epsilon_end = validated_float32_scalar(
+            "epsilon_end", self.epsilon_end, lower=0.0, upper=1.0
+        )
+        if self.epsilon_decay_steps > 0 and epsilon_end > epsilon_start:
+            raise ValueError("epsilon_end must not exceed epsilon_start when decaying")
+        object.__setattr__(self, "gamma", gamma)
+        object.__setattr__(self, "epsilon_start", epsilon_start)
+        object.__setattr__(self, "epsilon_end", epsilon_end)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""
@@ -643,6 +634,7 @@ class SARSAAgent:
             rng_key=state.rng_key,
             step_count=new_step_count,
         )
+        new_state = jax.lax.cond(action_valid, lambda: new_state, lambda: state)
 
         return SARSAUpdateResult(  # type: ignore[call-arg]
             state=new_state,

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
 import dataclasses
+from fractions import Fraction
 from typing import Any
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.dreaming import (
     DreamBehaviorModelPrediction,
     DreamingConfig,
     DreamRolloutConfig,
+    DreamSelectionConfig,
     DreamWorldModelPrediction,
     GuardedDreamer,
+    RecentObservationBuffer,
     dream_one_step,
     dream_rollout,
     imagined_rollout_to_gvf_items,
@@ -24,6 +28,75 @@ from alberta_framework.core.dreaming import (
     init_dream_rollout_state,
     slice_imagined_transition,
 )
+
+
+class _ClassSpoof:
+    def __init__(self, reported_type: type[object]) -> None:
+        self._reported_type = reported_type
+
+    @property
+    def __class__(self) -> type[object]:  # type: ignore[override]
+        return self._reported_type
+
+    def __float__(self) -> float:
+        raise RuntimeError("must not convert")
+
+    def __int__(self) -> int:
+        raise RuntimeError("must not convert")
+
+
+def test_dream_configs_reject_class_spoofs_before_conversion() -> None:
+    with pytest.raises(ValueError, match="warmup_steps"):
+        DreamingConfig(warmup_steps=_ClassSpoof(int))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="max_model_error"):
+        DreamingConfig(max_model_error=_ClassSpoof(float))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="stop_on_terminal"):
+        DreamRolloutConfig(stop_on_terminal=_ClassSpoof(bool))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="capacity"):
+        RecentObservationBuffer(_ClassSpoof(int), 2)  # type: ignore[arg-type]
+
+
+def test_dream_configs_validate_and_canonicalize_float32_sink_values() -> None:
+    selection = DreamSelectionConfig(
+        surprise_weight=np.float32(-0.5),
+        utility_weight=Fraction(1, 4),
+        min_confidence=np.float64(0.25),
+    )
+    assert selection.surprise_weight == -0.5
+    assert selection.utility_weight == 0.25
+    assert selection.min_confidence == 0.25
+    assert all(
+        type(value) is float
+        for value in (
+            selection.surprise_weight,
+            selection.utility_weight,
+            selection.min_confidence,
+        )
+    )
+    with pytest.raises(ValueError, match="surprise_weight"):
+        DreamSelectionConfig(surprise_weight=1e100)
+    with pytest.raises(ValueError, match="min_confidence"):
+        DreamSelectionConfig(min_confidence=Fraction(-1, 10**50))
+
+
+@pytest.mark.parametrize("value", [2**31, True, 1.5])
+def test_dream_count_fields_reject_non_int32_values(value: object) -> None:
+    with pytest.raises(ValueError, match="max_items"):
+        DreamSelectionConfig(max_items=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="capacity"):
+        RecentObservationBuffer(value, 2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observation_dim"):
+        RecentObservationBuffer(2, value)  # type: ignore[arg-type]
+
+
+def test_dream_count_fields_accept_int32_endpoint_and_numpy_ints() -> None:
+    selection = DreamSelectionConfig(max_items=np.int32(3))
+    buffer = RecentObservationBuffer(np.int32(2), np.int64(4))
+    endpoint = DreamSelectionConfig(max_items=2**31 - 1)
+    assert type(selection.max_items) is int
+    assert type(buffer.capacity) is int
+    assert type(buffer.observation_dim) is int
+    assert endpoint.max_items == 2**31 - 1
 
 
 def _assert_rollout_state_close(left, right) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -751,23 +751,6 @@ def test_same_size_wrong_shapes_and_dtype_aliases_are_rejected_before_tracing() 
         )
 
 
-def test_zero_utility_decay_does_not_multiply_inf_utilities() -> None:
-    """utility_decay=0 drops leftover eviction utility; 0 * inf must not freeze."""
-    memory = ExperientialMemory(_config(utility_decay=0.0))
-    state = _write(memory, memory.init(), _entry(1, utility=2.0))
-    poisoned = state.replace(
-        entries=state.entries.replace(
-            utilities=jnp.where(state.entries.valid, jnp.inf, 0.0)
-        )
-    )
-    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
-    assert not bool(jnp.isfinite(raw))
-
-    advanced = memory._advance(poisoned)
-    chex.assert_tree_all_finite(advanced.entries.utilities)
-    assert bool(jnp.all(advanced.entries.utilities >= 0.0))
-
-
 def test_dynamic_state_corruption_makes_query_abstain_and_mutations_exact_noops() -> None:
     memory = ExperientialMemory(_config())
     original = memory.init()

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -6,6 +6,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -306,6 +307,36 @@ class TestMultiHeadConstructorValidation:
                 step_size=0.01,
                 per_head_gamma_lamda=(0.5, gl),  # type: ignore[arg-type]
             )
+
+    def test_rejects_class_spoof_without_invoking_float_hook(self):
+        class Spoof:
+            @property
+            def __class__(self) -> type[float]:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match=r"per_head_gamma_lamda\[1\]"):
+            MultiHeadMLPLearner(
+                n_heads=2,
+                hidden_sizes=(),
+                sparsity=0.0,
+                step_size=0.01,
+                per_head_gamma_lamda=(0.5, Spoof()),  # type: ignore[arg-type]
+            )
+
+    def test_canonicalizes_numpy_per_head_values(self):
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+            step_size=0.01,
+            per_head_gamma_lamda=(np.float32(0.25), np.float64(0.5)),
+        )
+
+        values = learner.to_config()["per_head_gamma_lamda"]
+        assert all(type(value) is float for value in values)
 
 
 class TestMultiHeadUpdateValidation:

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -127,6 +127,42 @@ def test_rls_reward_model_rejects_non_real_or_non_finite_scalars(
         RLSRewardModel(RLSRewardModelConfig.from_config(payload))
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("forgetting", 1e-50),
+        ("ridge", 1e-50),
+        ("ridge", 1e50),
+        ("error_decay", 1.0 - 1e-10),
+    ],
+)
+def test_rls_reward_model_rejects_values_invalid_after_float32_narrowing(
+    field: str,
+    value: float,
+) -> None:
+    payload = RLSRewardModelConfig(feature_dim=1).to_config()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        RLSRewardModel(RLSRewardModelConfig.from_config(payload))
+
+
+def test_rls_reward_model_canonicalizes_numpy_scalars() -> None:
+    model = RLSRewardModel(
+        RLSRewardModelConfig(
+            feature_dim=1,
+            forgetting=np.float32(0.75),
+            ridge=np.float32(0.5),
+            error_decay=np.float32(0.25),
+        )
+    )
+
+    assert type(model.config.forgetting) is float
+    assert type(model.config.ridge) is float
+    assert type(model.config.error_decay) is float
+    assert RLSRewardModel.from_config(model.to_config()).to_config() == model.to_config()
+
+
 def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     """Inf reward * a silent feature's zero gain is 0*inf = NaN."""
     model = RLSRewardModel(

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -100,6 +100,28 @@ class TestSARSAConfigValidation:
         with pytest.raises(ValueError, match="gamma"):
             SARSAConfig(n_actions=2, gamma=SpoofedFloat())  # type: ignore[arg-type]
 
+    def test_accepts_gamma_one_and_canonicalizes_numpy_scalars(self) -> None:
+        config = SARSAConfig(
+            n_actions=2,
+            gamma=np.float32(1.0),
+            epsilon_start=np.float32(0.25),
+            epsilon_end=np.float64(0.1),
+        )
+
+        assert config.gamma == 1.0
+        assert type(config.gamma) is float
+        assert type(config.epsilon_start) is float
+        assert type(config.epsilon_end) is float
+
+    def test_rejects_inverted_decay_schedule(self) -> None:
+        with pytest.raises(ValueError, match="epsilon_end"):
+            SARSAConfig(
+                n_actions=2,
+                epsilon_start=0.3,
+                epsilon_end=0.5,
+                epsilon_decay_steps=10,
+            )
+
 
 class TestSARSAInit:
     """Tests for SARSAAgent initialization."""
@@ -303,6 +325,40 @@ class TestSARSAUpdate:
             state.learner_state.head_params.biases,
             atol=0.0,
         )
+
+    def test_update_before_select_action_is_exact_noop_with_nonzero_traces(self):
+        agent = _make_agent(
+            n_actions=2,
+            hidden_sizes=(),
+            gamma=0.9,
+            epsilon_start=0.2,
+            epsilon_decay_steps=10,
+            lamda=0.8,
+        )
+        state = agent.init(feature_dim=3, key=jr.key(9))
+        learner_state = state.learner_state.replace(
+            head_traces=jax.tree.map(jnp.ones_like, state.learner_state.head_traces)
+        )
+        state = state.replace(learner_state=learner_state)
+
+        result = agent.update(
+            state,
+            reward=jnp.array(1.0),
+            observation=jnp.ones(3),
+            terminated=jnp.array(0.0),
+            next_action=jnp.array(0, dtype=jnp.int32),
+        )
+
+        # birth_timestamp is host-only static PyTree metadata and is not a
+        # meaningful transaction field inside a jitted comparison.
+        actual = result.state.replace(
+            learner_state=result.state.learner_state.replace(birth_timestamp=0.0)
+        )
+        expected = state.replace(
+            learner_state=state.learner_state.replace(birth_timestamp=0.0)
+        )
+        chex.assert_trees_all_equal(actual, expected)
+        assert float(result.td_error) == 0.0
 
     def test_terminated_no_bootstrap(self):
         """At terminal state, target = r (no bootstrapping)."""


### PR DESCRIPTION
Corrects defects found by deep review after concurrent merges:\n\n- make invalid pre-action SARSA updates preserve complete persistent state, including nonzero traces and counters;\n- canonicalize SARSA probabilities and reward-model scalars through the shared exact host + float32 sink validator;\n- harden per-head trace decay scalars against class spoofing and canonicalize them;\n- restore experiential-memory fail-closed behavior for manually corrupted nonfinite state instead of selectively sanitizing a private helper path;\n- repair the newly merged dreaming validators with actual-type Integral/bool gates, signed-int32 count bounds, exact float32 sink validation, canonical JSON-safe storage, and hostile/NumPy/overflow regressions.\n\nValidation: 230 focused core tests and 112 dreaming/transaction tests passed; Ruff clean; strict mypy clean on changed dreaming source and prior full changed-source run; git diff --check clean.