### PR TITLE
fix(cbp): validate configuration at host and float32 boundaries

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -71,9 +71,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.multi_head_learner import (
     MULTI_HEAD_MLP_STATE_SCHEMA,
@@ -116,6 +118,37 @@ class ContinualBackpropConfig:
     maturity_threshold: int = 100
     enabled: bool = True
 
+    def __post_init__(self) -> None:
+        """Validate and canonicalize configuration at its execution boundaries."""
+        decay_rate = _validated_config_float(
+            "decay_rate",
+            self.decay_rate,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        replacement_rate = _validated_config_float(
+            "replacement_rate",
+            self.replacement_rate,
+            lower=0.0,
+            upper=1.0,
+        )
+        maturity_type = type(self.maturity_threshold)
+        if maturity_type is int:
+            maturity_threshold = self.maturity_threshold
+        elif issubclass(maturity_type, np.integer):
+            maturity_threshold = int(self.maturity_threshold)
+        else:
+            raise ValueError("maturity_threshold must be an integer in the int32 domain")
+        if not 0 <= maturity_threshold <= np.iinfo(np.int32).max:
+            raise ValueError("maturity_threshold must be an integer in the int32 domain")
+        if type(self.enabled) is not bool:
+            raise ValueError("enabled must be an actual bool")
+        object.__setattr__(self, "decay_rate", decay_rate)
+        object.__setattr__(self, "replacement_rate", replacement_rate)
+        object.__setattr__(self, "maturity_threshold", maturity_threshold)
+        object.__setattr__(self, "enabled", bool(self.enabled))
+
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""
         return {
@@ -129,6 +162,29 @@ class ContinualBackpropConfig:
     def from_config(cls, config: dict[str, Any]) -> ContinualBackpropConfig:
         """Reconstruct from dict."""
         return cls(**config)
+
+
+def _validated_config_float(
+    name: str,
+    value: object,
+    *,
+    lower: float,
+    upper: float,
+    upper_inclusive: bool = True,
+) -> float:
+    """Validate trusted built-in/NumPy numerics in both host and float32 domains."""
+    actual_type = type(value)
+    if actual_type not in (int, float) and not issubclass(
+        actual_type, (np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a finite real number")
+    return validated_float32_scalar(
+        name,
+        value,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -7,6 +7,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.continual_backprop import (
@@ -681,8 +682,67 @@ class TestTrackerDataclass:
 
 
 # =============================================================================
-# Config roundtrip
+# Config validation and roundtrip
 # =============================================================================
+
+
+class TestContinualBackpropConfigValidation:
+    """Configuration rejects values that cannot be consumed safely by JAX."""
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("decay_rate", float("nan")),
+            ("decay_rate", float("inf")),
+            ("decay_rate", -0.1),
+            ("decay_rate", 1.0),
+            ("replacement_rate", float("nan")),
+            ("replacement_rate", float("inf")),
+            ("replacement_rate", -0.1),
+            ("replacement_rate", 1.1),
+            ("maturity_threshold", -1),
+            ("maturity_threshold", 1.5),
+            ("maturity_threshold", np.iinfo(np.int32).max + 1),
+            ("enabled", 1),
+        ],
+    )
+    def test_rejects_invalid_fields(self, field: str, value: object) -> None:
+        with pytest.raises(ValueError, match=field):
+            ContinualBackpropConfig(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field",
+        ["decay_rate", "replacement_rate", "maturity_threshold", "enabled"],
+    )
+    def test_rejects_class_spoofed_values(self, field: str) -> None:
+        class SpoofedScalar:
+            @property
+            def __class__(self) -> type[int]:
+                return int
+
+            def __int__(self) -> int:
+                return 1
+
+            def __float__(self) -> float:
+                return 0.5
+
+        with pytest.raises(ValueError, match=field):
+            ContinualBackpropConfig(  # type: ignore[arg-type]
+                **{field: SpoofedScalar()}
+            )
+
+    def test_canonicalizes_supported_numpy_scalars_and_roundtrips(self) -> None:
+        config = ContinualBackpropConfig(
+            decay_rate=np.float64(0.9),
+            replacement_rate=np.float32(0.25),
+            maturity_threshold=np.int64(7),
+            enabled=False,
+        )
+        assert type(config.decay_rate) is float
+        assert type(config.replacement_rate) is float
+        assert type(config.maturity_threshold) is int
+        assert type(config.enabled) is bool
+        assert ContinualBackpropConfig.from_config(config.to_config()) == config
 
 
 class TestConfigRoundtrip:


### PR DESCRIPTION
Supersedes #627 with the same useful configuration hardening plus execution-domain and adversarial coverage. Float fields use the shared exact-ratio float32 validator and canonical storage; maturity_threshold is bounded to the consumed int32 domain; actual booleans are required; trusted NumPy scalars remain supported. Added constructor, spoofing, boundary, canonicalization, and round-trip regressions. Verification: 42 focused tests passed; Ruff passed; mypy passed; diff-check clean.