### PR TITLE
fix(pipeline): complete facade domain validation

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -35,6 +35,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.associative_memory import (
     AssociativeFeatureFamily,
     AssociativeMemoryConfig,
@@ -228,15 +229,24 @@ class Step2FeatureConfig:
         include_raw = _require_bool("include_raw", self.include_raw)
         include_ema = _require_bool("include_ema", self.include_ema)
         include_delta = _require_bool("include_delta", self.include_delta)
-        _require_bool("include_phase_products", self.include_phase_products)
+        include_phase_products = _require_bool(
+            "include_phase_products",
+            self.include_phase_products,
+        )
         if not (include_raw or include_ema or include_delta):
             msg = "at least one of include_raw/include_ema/include_delta is required"
             raise ValueError(msg)
         ema_decay = _require_half_open_zero_one_interval("ema_decay", self.ema_decay)
+        if type(self.periods) is not tuple:
+            raise ValueError(f"periods must be a tuple, got {self.periods!r}")
         canonical_periods = tuple(
             _require_positive_real("period", p) for p in self.periods
         )
         object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "include_raw", include_raw)
+        object.__setattr__(self, "include_ema", include_ema)
+        object.__setattr__(self, "include_delta", include_delta)
+        object.__setattr__(self, "include_phase_products", include_phase_products)
         object.__setattr__(self, "ema_decay", ema_decay)
         object.__setattr__(self, "periods", canonical_periods)
 
@@ -446,12 +456,14 @@ class Step2AssociativePipelineConfig:
         max_features = _require_int(
             "max_features", self.max_features, minimum=1, maximum=_INT32_MAX
         )
-        write_lr = _require_nonnegative_real("write_lr", self.write_lr)
+        write_lr = _require_positive_real("write_lr", self.write_lr)
         retention = _require_unit_interval("retention", self.retention)
         utility_lr = _require_nonnegative_real("utility_lr", self.utility_lr)
         utility_decay = _require_unit_interval("utility_decay", self.utility_decay)
-        min_weight = _require_nonnegative_real("min_weight", self.min_weight)
+        min_weight = _require_positive_real("min_weight", self.min_weight)
         max_weight = _require_positive_real("max_weight", self.max_weight)
+        if max_weight < min_weight:
+            raise ValueError("max_weight must be >= min_weight")
         logit_scale = _require_positive_real("logit_scale", self.logit_scale)
         feature_family = _require_str_choice(
             "feature_family",
@@ -1338,7 +1350,7 @@ def run_pipeline_smoke(
 ) -> AlbertaPipelineSmokeResult:
     """Run a deterministic Step 1-4 pipeline smoke probe."""
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
-    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    seed = require_jax_seed(seed, name="seed")
     cfg = config or AlbertaPipelineConfig()
     pipeline = make_alberta_pipeline(cfg)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -586,6 +586,7 @@ _INVALID_PIPELINE_FEATURE_FIELDS: tuple[tuple[str, object], ...] = (
     ("periods", (1e100,)),
     ("periods", (float("nan"),)),
     ("periods", (True,)),
+    ("periods", [32.0]),
 )
 
 
@@ -642,6 +643,7 @@ _INVALID_PIPELINE_ASSOCIATIVE_FIELDS: tuple[tuple[str, object], ...] = (
     ("max_features", 2**31),
     ("max_features", True),
     ("write_lr", -0.1),
+    ("write_lr", 0.0),
     ("write_lr", 1e100),
     ("write_lr", True),
     ("retention", -0.1),
@@ -656,6 +658,7 @@ _INVALID_PIPELINE_ASSOCIATIVE_FIELDS: tuple[tuple[str, object], ...] = (
     ("utility_decay", 1e100),
     ("utility_decay", True),
     ("min_weight", -0.01),
+    ("min_weight", 0.0),
     ("min_weight", 1e100),
     ("min_weight", True),
     ("max_weight", 0.0),
@@ -739,13 +742,27 @@ def test_pipeline_horde_ac_fields_reject_invalid_inputs(field: str, value: objec
         ({"steps": True}, "steps"),
         ({"steps": "24"}, "steps"),
         ({"seed": -1}, "seed"),
-        ({"seed": 2**31}, "seed"),
+        ({"seed": 2**32}, "seed"),
         ({"seed": True}, "seed"),
     ],
 )
 def test_pipeline_smoke_rejects_invalid_inputs(kwargs: dict[str, object], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         run_pipeline_smoke(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("seed", [2**31, 2**32 - 1])
+def test_pipeline_smoke_accepts_full_uint32_seed_domain(seed: int) -> None:
+    result = run_pipeline_smoke(steps=2, seed=seed)
+    assert result.seed == seed
+
+
+def test_pipeline_associative_requires_ordered_weight_bounds() -> None:
+    with pytest.raises(ValueError, match="max_weight must be >= min_weight"):
+        Step2AssociativePipelineConfig(min_weight=2.0, max_weight=1.0)
+
+    config = Step2AssociativePipelineConfig(min_weight=1.0, max_weight=1.0)
+    assert config.min_weight == config.max_weight == 1.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Corrective follow-up to #438.

This completes the pipeline facade contract by requiring an actual periods tuple, rejecting zero write rates and zero minimum weights that cannot satisfy the downstream update semantics, enforcing max_weight >= min_weight, and accepting the full uint32 seed domain through require_jax_seed. The tests cover the illegal endpoints, the legal equal-weight endpoint, and both high uint32 seed boundaries.

Verification:
- pytest tests/test_pipeline.py -q -o addopts='' (162 passed)
- ruff check on changed source/tests
- mypy alberta_framework/pipeline.py
- git diff --check