### PR TITLE
Add focused reference transaction protocol and Prototype adapter

### DIFF
--- a/alberta_framework/prototype_reference_adapter.py
+++ b/alberta_framework/prototype_reference_adapter.py
@@ -1,0 +1,617 @@
+"""Development-only exact-dispatch adapter for the ASI transaction preview.
+
+The adapter deliberately exposes only primitive-action ``PrototypeAgent``
+configurations with no optional sidecars or Python-level curation.  It is an L0
+interoperability slice, not ``reference-dev``, a whole-life runner, an exact
+resume implementation, a safety boundary, or evidence of learning benefit.
+Each adapter instance owns its emitted state through an opaque process-local
+token; neither the adapter nor that state is a serialization or restore surface.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import Any, Literal, cast
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+from alberta_framework.core.oak import OaKState
+from alberta_framework.core.prototype_agent import (
+    PROTOTYPE_CHECKPOINT_SCHEMA,
+    PrototypeAgent,
+    PrototypeAgentConfig,
+    PrototypeAgentState,
+    PrototypeTransition,
+    PrototypeTransitionDiagnostics,
+)
+from alberta_framework.reference_agent import (
+    MAX_DECISION_INDEX,
+    REFERENCE_AGENT_MANIFEST_SCHEMA,
+    AgentCapabilities,
+    AgentManifest,
+    AuthorizationStatus,
+    Decision,
+    DecisionOwnershipError,
+    DispatchAuthorization,
+    DispatchStatus,
+    SpaceSpec,
+    Transaction,
+)
+
+PROTOTYPE_REFERENCE_ADAPTER_SCHEMA = "asi.prototype_exact_adapter.preview1"
+PROTOTYPE_REFERENCE_IMPLEMENTATION_ID = "asi.prototype_exact_adapter.preview1"
+PROTOTYPE_REFERENCE_STATE_SCHEMA = "asi.prototype_reference_state.preview1"
+PROTOTYPE_OBSERVATION_SEMANTIC_ID = "asi.prototype_raw_observation.preview1"
+PROTOTYPE_ACTION_SEMANTIC_ID = "asi.prototype_primitive_action.preview1"
+
+_LIFECYCLE_CODEC = "prototype_uint32x2_hex.preview1"
+_SCALAR_CODEC = "finite_float32_round_to_nearest.preview1"
+_LIFECYCLE_PATTERN = re.compile(r"^prototype\.([0-9a-f]{8})([0-9a-f]{8})$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PrototypeReferenceState:
+    """Process-local, adapter-owned envelope around functional Prototype state."""
+
+    schema: str
+    manifest_id: str
+    config_sha256: str
+    agent_state: PrototypeAgentState
+    lifecycle_id: str
+    decision_index: int
+    current_observation_id: str | None
+    _owner_token: object = dataclasses.field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != PROTOTYPE_REFERENCE_STATE_SCHEMA:
+            raise ValueError(
+                f"schema must be {PROTOTYPE_REFERENCE_STATE_SCHEMA!r}, got {self.schema!r}"
+            )
+        if not isinstance(self.manifest_id, str) or _SHA256_PATTERN.fullmatch(
+            self.manifest_id
+        ) is None:
+            raise ValueError("manifest_id must be a lowercase SHA-256 digest")
+        if not isinstance(self.config_sha256, str) or _SHA256_PATTERN.fullmatch(
+            self.config_sha256
+        ) is None:
+            raise ValueError("config_sha256 must be a lowercase SHA-256 digest")
+        if not isinstance(self.agent_state, PrototypeAgentState):
+            raise ValueError("agent_state must be a PrototypeAgentState")
+        if not isinstance(self.lifecycle_id, str) or _LIFECYCLE_PATTERN.fullmatch(
+            self.lifecycle_id
+        ) is None:
+            raise ValueError("lifecycle_id must use the Prototype lifecycle codec")
+        if (
+            isinstance(self.decision_index, bool)
+            or not isinstance(self.decision_index, int)
+            or self.decision_index < 0
+            or self.decision_index > MAX_DECISION_INDEX
+        ):
+            raise ValueError("decision_index must be a uint64 integer")
+        if self.current_observation_id is not None and (
+            not isinstance(self.current_observation_id, str)
+            or not self.current_observation_id.strip()
+        ):
+            raise ValueError("current_observation_id must be None or a nonempty string")
+
+    def __reduce__(self) -> Any:
+        raise TypeError(
+            "Prototype reference state is process-local and cannot be serialized; "
+            "whole-life restore is not implemented"
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PrototypeAdapterUpdate:
+    """Staged functional result for a host runner to accept or reject."""
+
+    state: PrototypeReferenceState
+    next_decision: Decision | None
+    accepted: bool
+    parameters_changed: bool
+    rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state, PrototypeReferenceState):
+            raise ValueError("state must be a PrototypeReferenceState")
+        if not isinstance(self.accepted, bool):
+            raise ValueError("accepted must be boolean")
+        if not isinstance(self.parameters_changed, bool):
+            raise ValueError("parameters_changed must be boolean")
+        if self.accepted:
+            if self.rejection_reason is not None:
+                raise ValueError("an accepted update cannot carry a rejection reason")
+        else:
+            if self.parameters_changed:
+                raise ValueError("a rejected update cannot change parameters")
+            if self.next_decision is not None:
+                raise ValueError("a rejected update cannot arm a next decision")
+            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
+                raise ValueError("a rejected update requires a nonempty reason")
+
+
+def _lifecycle_words(lifecycle_id: str) -> Array:
+    if not isinstance(lifecycle_id, str):
+        raise ValueError("lifecycle_id must use the Prototype lifecycle codec")
+    match = _LIFECYCLE_PATTERN.fullmatch(lifecycle_id)
+    if match is None:
+        raise ValueError(
+            "lifecycle_id must use 'prototype.' followed by exactly sixteen "
+            "lowercase hexadecimal digits"
+        )
+    return jnp.asarray(
+        (int(match.group(1), 16), int(match.group(2), 16)),
+        dtype=jnp.uint32,
+    )
+
+
+def _decision_index(words: Any) -> int:
+    array = np.asarray(words)
+    if array.shape != (4,) or array.dtype != np.dtype(np.uint32):
+        raise DecisionOwnershipError(
+            "Prototype decision identity must contain exactly four uint32 words"
+        )
+    return (int(array[2]) << 32) | int(array[3])
+
+
+def _bool_scalar(value: Any, *, name: str) -> bool:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype != np.dtype(np.bool_):
+        raise DecisionOwnershipError(f"{name} must be a scalar boolean")
+    return bool(array)
+
+
+def _float32_scalar(value: float, *, name: str) -> np.float32:
+    try:
+        with np.errstate(over="ignore", invalid="ignore", under="ignore"):
+            converted = np.asarray(value, dtype=np.float32)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} is not representable as a float32 scalar") from exc
+    if converted.shape != () or not bool(np.isfinite(converted)):
+        raise ValueError(f"{name} is not finitely representable as float32")
+    return np.float32(converted)
+
+
+def _tree_exactly_equal(left: Any, right: Any) -> bool:
+    left_leaves, left_structure = jax.tree_util.tree_flatten(left)
+    right_leaves, right_structure = jax.tree_util.tree_flatten(right)
+    if cast(Any, left_structure) != right_structure or len(left_leaves) != len(
+        right_leaves
+    ):
+        return False
+    return all(
+        np.asarray(left_leaf).dtype == np.asarray(right_leaf).dtype
+        and np.asarray(left_leaf).shape == np.asarray(right_leaf).shape
+        and np.array_equal(np.asarray(left_leaf), np.asarray(right_leaf))
+        for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True)
+    )
+
+
+def _parameter_tree(state: PrototypeAgentState) -> tuple[Any, Any, Any]:
+    oak_state = state.oak_state
+    if not isinstance(oak_state, OaKState):
+        raise DecisionOwnershipError(
+            "the exact Prototype adapter requires an unwrapped primitive-only OaKState"
+        )
+    base = oak_state.stomp_state.base_learner_state
+    return base.trunk_params, base.head_params, oak_state.stomp_state.base_average_reward
+
+
+def _diagnostic_rejection_reason(diagnostics: PrototypeTransitionDiagnostics) -> str:
+    names = (
+        "started",
+        "inputs_finite",
+        "action_in_range",
+        "observation_matches",
+        "action_matches",
+        "decision_id_matches",
+        "discount_valid",
+        "boundary_semantics_valid",
+        "state_consistent",
+        "post_update_finite",
+        "post_update_consistent",
+    )
+    failed = [
+        name
+        for name in names
+        if not _bool_scalar(getattr(diagnostics, name), name=f"diagnostics.{name}")
+    ]
+    detail = ", ".join(failed) if failed else "unknown invariant"
+    return f"Prototype transition rejected: {detail}"
+
+
+class PrototypeReferenceAdapter:
+    """Primitive-only, exact-dispatch bridge into the host transaction preview."""
+
+    __slots__ = ("_agent", "_config", "_manifest", "_state_owner_token")
+
+    def __init__(self, config: PrototypeAgentConfig) -> None:
+        self._validate_config(config)
+        self._config = config
+        self._agent = PrototypeAgent(config)
+        self._state_owner_token = object()
+        prototype_config = self._agent.to_config()
+        observation_dim = config.oak.observation_dim
+        action_count = config.oak.n_primitive_actions
+        self._manifest = AgentManifest.from_config(
+            schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+            implementation_id=PROTOTYPE_REFERENCE_IMPLEMENTATION_ID,
+            state_schema=PROTOTYPE_REFERENCE_STATE_SCHEMA,
+            config={
+                "adapter_schema": PROTOTYPE_REFERENCE_ADAPTER_SCHEMA,
+                "dispatch_mode": "exact_only",
+                "environment_mode": "continuing_only",
+                "lifecycle_codec": _LIFECYCLE_CODEC,
+                "prototype_agent": prototype_config,
+                "prototype_state_schema": PROTOTYPE_CHECKPOINT_SCHEMA,
+                "reward_discount_codec": _SCALAR_CODEC,
+            },
+            observation_spec=SpaceSpec.box(
+                shape=(observation_dim,),
+                dtype="float32",
+                low=None,
+                high=None,
+                semantic_id=PROTOTYPE_OBSERVATION_SEMANTIC_ID,
+            ),
+            action_spec=SpaceSpec.discrete(
+                cardinality=action_count,
+                dtype="int32",
+                semantic_id=PROTOTYPE_ACTION_SEMANTIC_ID,
+            ),
+            capabilities=AgentCapabilities(dispatch_rebinding=False),
+        )
+
+    @classmethod
+    def from_config(cls, config: PrototypeAgentConfig) -> PrototypeReferenceAdapter:
+        """Build the adapter after rejecting every unsupported Prototype lane."""
+
+        return cls(config)
+
+    @staticmethod
+    def _validate_config(config: PrototypeAgentConfig) -> None:
+        if not isinstance(config, PrototypeAgentConfig):
+            raise ValueError("config must be a PrototypeAgentConfig")
+        if config.oak.n_options != 0 or config.oak.stomp.subtask_specs:
+            raise ValueError("the adapter requires primitive-only OaK with options disabled")
+        if config.oak.stomp.option_planning_backups_per_step != 0:
+            raise ValueError("primitive-only option planning must be disabled")
+
+        unsupported = {
+            "option_search_control": config.option_search_control,
+            "world_model": config.world_model,
+            "world_model_ensemble": config.world_model_ensemble,
+            "model_replay_rehearsal": config.model_replay_rehearsal,
+            "recurrent_latent_world_model_ensemble": (
+                config.recurrent_latent_world_model_ensemble
+            ),
+            "dreaming": config.dreaming,
+            "horde_spec": config.horde_spec,
+            "ia": config.ia,
+            "partner_policy_fusion": config.partner_policy_fusion,
+            "experiential_memory": config.experiential_memory,
+            "gru_perception": config.gru_perception,
+            "state_builder": config.state_builder,
+            "representation_gradient_mixer": config.representation_gradient_mixer,
+            "gradient_joy": config.gradient_joy,
+            "prototype_feature_lifecycle": config.prototype_feature_lifecycle,
+        }
+        enabled = sorted(name for name, value in unsupported.items() if value is not None)
+        if enabled:
+            raise ValueError(
+                "unsupported Prototype lanes must be disabled: " + ", ".join(enabled)
+            )
+        if config.n_dreams_per_step != 0:
+            raise ValueError("dreaming must be disabled")
+        if config.dream_next_observation_mode != "model_prediction":
+            raise ValueError("nondefault dream observation handling is unsupported")
+        if config.learn_state_builder_from_world_model:
+            raise ValueError("state-builder learning must be disabled")
+        if config.auto_curate_every != 0:
+            raise ValueError("Python-level auto-curation must be disabled")
+
+    @property
+    def manifest(self) -> AgentManifest:
+        return self._manifest
+
+    @property
+    def config(self) -> PrototypeAgentConfig:
+        return self._config
+
+    def __reduce__(self) -> Any:
+        raise TypeError(
+            "Prototype reference adapter is process-local and cannot be serialized; "
+            "whole-life restore is not implemented"
+        )
+
+    def _require_bound_state(self, state: PrototypeReferenceState) -> None:
+        if not isinstance(state, PrototypeReferenceState):
+            raise DecisionOwnershipError("state must be a PrototypeReferenceState")
+        if state.schema != PROTOTYPE_REFERENCE_STATE_SCHEMA:
+            raise DecisionOwnershipError("state schema does not match the adapter")
+        if state.manifest_id != self.manifest.manifest_id:
+            raise DecisionOwnershipError("state manifest identity does not match the adapter")
+        if state.config_sha256 != self.manifest.config_sha256:
+            raise DecisionOwnershipError("state config digest does not match the adapter")
+        if state._owner_token is not self._state_owner_token:
+            raise DecisionOwnershipError(
+                "state owner is another PrototypeReferenceAdapter instance"
+            )
+
+    def init(self, key: Array, *, lifecycle_id: str) -> PrototypeReferenceState:
+        """Initialize complete functional agent state for one host lifecycle."""
+
+        agent_state = self._agent.init(
+            key,
+            lifecycle_id=_lifecycle_words(lifecycle_id),
+        )
+        return PrototypeReferenceState(
+            schema=PROTOTYPE_REFERENCE_STATE_SCHEMA,
+            manifest_id=self.manifest.manifest_id,
+            config_sha256=self.manifest.config_sha256,
+            agent_state=agent_state,
+            lifecycle_id=lifecycle_id,
+            decision_index=0,
+            current_observation_id=None,
+            _owner_token=self._state_owner_token,
+        )
+
+    def start(
+        self,
+        state: PrototypeReferenceState,
+        *,
+        observation_id: str,
+        observation: Any,
+    ) -> tuple[PrototypeReferenceState, Decision]:
+        """Prime a fresh Prototype state and expose its first host decision."""
+
+        self._require_bound_state(state)
+        if state.current_observation_id is not None:
+            raise DecisionOwnershipError("start requires a fresh reference state")
+        encoded = self.manifest.observation_spec.encode(observation)
+        started_agent_state = self._agent.start(
+            state.agent_state,
+            jnp.asarray(encoded.to_numpy(), dtype=jnp.float32),
+        )
+        started = dataclasses.replace(
+            state,
+            agent_state=started_agent_state,
+            current_observation_id=observation_id,
+        )
+        decision = self.current_decision(started)
+        return started, decision
+
+    def current_decision(
+        self,
+        state: PrototypeReferenceState,
+    ) -> Decision:
+        """Translate and cross-check the currently armed Prototype decision."""
+
+        self._require_bound_state(state)
+        if state.current_observation_id is None:
+            raise DecisionOwnershipError("fresh reference state has no current observation")
+        expected_lifecycle_words = np.asarray(_lifecycle_words(state.lifecycle_id))
+        try:
+            prototype_decision = self._agent.decision(state.agent_state)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise DecisionOwnershipError(
+                "Prototype state does not contain a valid current decision"
+            ) from exc
+        if not _bool_scalar(prototype_decision.armed, name="Prototype decision armed"):
+            raise DecisionOwnershipError("Prototype decision is disarmed")
+        internal_words = np.asarray(prototype_decision.decision_id)
+        if (
+            internal_words.shape != (4,)
+            or internal_words.dtype != np.dtype(np.uint32)
+            or not np.array_equal(internal_words[:2], expected_lifecycle_words)
+        ):
+            raise DecisionOwnershipError("Prototype decision belongs to another lifecycle")
+        internal_index = _decision_index(internal_words)
+        if internal_index != state.decision_index:
+            raise DecisionOwnershipError(
+                "Prototype generation/index mismatch: "
+                f"expected {state.decision_index}, got {internal_index}"
+            )
+        return self.manifest.make_decision(
+            lifecycle_id=state.lifecycle_id,
+            decision_index=state.decision_index,
+            observation_id=state.current_observation_id,
+            observation=prototype_decision.observation,
+            proposed_action=prototype_decision.action,
+            armed=True,
+        )
+
+    def _require_current_host_decision(
+        self,
+        state: PrototypeReferenceState,
+        decision: Decision,
+    ) -> None:
+        try:
+            self.manifest.validate_decision(decision)
+        except (TypeError, ValueError) as exc:
+            raise DecisionOwnershipError("decision does not match the adapter manifest") from exc
+        expected = self.current_decision(state)
+        if expected != decision:
+            raise DecisionOwnershipError(
+                "host decision does not match the Prototype observation/action cache"
+            )
+
+    def settle_dispatch(
+        self,
+        state: PrototypeReferenceState,
+        authorization: DispatchAuthorization,
+    ) -> tuple[PrototypeReferenceState, Literal[False]]:
+        """Assert exact settlement without altering agent state or credit owners."""
+
+        if not isinstance(authorization, DispatchAuthorization):
+            raise DecisionOwnershipError("settlement requires a DispatchAuthorization")
+        self._require_current_host_decision(state, authorization.decision)
+        if authorization.status is AuthorizationStatus.VETOED:
+            raise DecisionOwnershipError("a vetoed authorization cannot settle")
+        if authorization.status is not AuthorizationStatus.EXACT:
+            raise DecisionOwnershipError(
+                "the exact-only adapter cannot settle an action replacement or rebind credit"
+            )
+        if authorization.authorized_action != authorization.decision.proposed_action:
+            raise DecisionOwnershipError("exact authorization action does not match the proposal")
+        return state, False
+
+    @staticmethod
+    def _rejected(
+        state: PrototypeReferenceState,
+        reason: str,
+    ) -> PrototypeAdapterUpdate:
+        return PrototypeAdapterUpdate(
+            state=state,
+            next_decision=None,
+            accepted=False,
+            parameters_changed=False,
+            rejection_reason=reason,
+        )
+
+    def apply_outcome(
+        self,
+        state: PrototypeReferenceState,
+        transaction: Transaction,
+    ) -> PrototypeAdapterUpdate:
+        """Stage one continuing update or return an exact state-preserving rejection."""
+
+        if not isinstance(state, PrototypeReferenceState):
+            raise DecisionOwnershipError("state must be a PrototypeReferenceState")
+        try:
+            self._require_bound_state(state)
+        except DecisionOwnershipError as exc:
+            return self._rejected(state, str(exc))
+        if not isinstance(transaction, Transaction):
+            return self._rejected(state, "outcome must be a Transaction")
+        if transaction.is_boundary:
+            return self._rejected(
+                state,
+                "execution boundary is unsupported by the continuing-only Prototype adapter",
+            )
+        if transaction.next_decision_observation is None:
+            return self._rejected(state, "continuing outcome lacks a next decision observation")
+        if transaction.next_decision_observation_id is None:
+            return self._rejected(state, "continuing outcome lacks a next observation identity")
+
+        try:
+            self._require_current_host_decision(state, transaction.decision)
+            if transaction.receipt.dispatch.status is not DispatchStatus.EXACT:
+                raise DecisionOwnershipError("outcome uses a rebound dispatch")
+            if (
+                transaction.receipt.dispatch.authorization.status
+                is not AuthorizationStatus.EXACT
+            ):
+                raise DecisionOwnershipError("outcome does not use an exact authorization")
+            if transaction.receipt.effective_action != transaction.decision.proposed_action:
+                raise DecisionOwnershipError("receipt action differs from the current proposal")
+            self.manifest.action_spec.encode(transaction.receipt.effective_action)
+            self.manifest.observation_spec.encode(transaction.bootstrap_observation)
+            self.manifest.observation_spec.encode(
+                transaction.next_decision_observation
+            )
+
+            prototype_decision = self._agent.decision(state.agent_state)
+            observation = transaction.decision.observation.to_numpy()
+            action = transaction.receipt.effective_action.to_numpy()
+            bootstrap_observation = transaction.bootstrap_observation.to_numpy()
+            next_observation = transaction.next_decision_observation.to_numpy()
+            reward = _float32_scalar(transaction.reward, name="reward")
+            discount = _float32_scalar(transaction.discount, name="discount")
+            if (transaction.discount == 0.0) != (float(discount) == 0.0):
+                raise ValueError("discount changes zero/nonzero semantics in float32")
+
+            result = self._agent.update_transition(
+                state.agent_state,
+                PrototypeTransition(  # type: ignore[call-arg]
+                    observation=observation,
+                    action=action,
+                    decision_id=prototype_decision.decision_id,
+                    reward=reward,
+                    discount=discount,
+                    terminated=jnp.asarray(transaction.terminated, dtype=jnp.bool_),
+                    truncated=jnp.asarray(transaction.truncated, dtype=jnp.bool_),
+                    next_observation=bootstrap_observation,
+                    next_decision_observation=next_observation,
+                ),
+            )
+            if not _bool_scalar(
+                result.transition_diagnostics.valid,
+                name="transition diagnostics valid",
+            ):
+                return self._rejected(
+                    state,
+                    _diagnostic_rejection_reason(result.transition_diagnostics),
+                )
+
+            candidate_prototype_decision = self._agent.decision(result.state)
+            candidate_armed = _bool_scalar(
+                candidate_prototype_decision.armed,
+                name="candidate Prototype decision armed",
+            )
+            if transaction.decision.decision_index == MAX_DECISION_INDEX:
+                if candidate_armed:
+                    return self._rejected(
+                        state,
+                        "Prototype remained armed after the final host decision index",
+                    )
+                next_decision = None
+                candidate_state = dataclasses.replace(
+                    state,
+                    agent_state=result.state,
+                    current_observation_id=transaction.next_decision_observation_id,
+                )
+            else:
+                if not candidate_armed:
+                    return self._rejected(
+                        state,
+                        "Prototype disarmed before host lifecycle capacity was exhausted",
+                    )
+                candidate_state = dataclasses.replace(
+                    state,
+                    agent_state=result.state,
+                    decision_index=state.decision_index + 1,
+                    current_observation_id=transaction.next_decision_observation_id,
+                )
+                next_decision = self.current_decision(candidate_state)
+                if next_decision.observation != transaction.next_decision_observation:
+                    return self._rejected(
+                        state,
+                        "Prototype next observation does not match the host outcome",
+                    )
+
+            parameters_changed = not _tree_exactly_equal(
+                _parameter_tree(state.agent_state),
+                _parameter_tree(result.state),
+            )
+            return PrototypeAdapterUpdate(
+                state=candidate_state,
+                next_decision=next_decision,
+                accepted=True,
+                parameters_changed=parameters_changed,
+                rejection_reason=None,
+            )
+        except (
+            DecisionOwnershipError,
+            OverflowError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            return self._rejected(state, str(exc))
+
+
+__all__ = [
+    "PROTOTYPE_ACTION_SEMANTIC_ID",
+    "PROTOTYPE_OBSERVATION_SEMANTIC_ID",
+    "PROTOTYPE_REFERENCE_ADAPTER_SCHEMA",
+    "PROTOTYPE_REFERENCE_IMPLEMENTATION_ID",
+    "PROTOTYPE_REFERENCE_STATE_SCHEMA",
+    "PrototypeAdapterUpdate",
+    "PrototypeReferenceAdapter",
+    "PrototypeReferenceState",
+]

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -1,0 +1,1510 @@
+"""Versioned host-facing transaction protocol for ASI reference-agent adapters.
+
+This module provides immutable records and an in-process, single-writer
+ownership ledger. It is an L0 interoperability preview only: it does not select
+reference-dev, prove learning benefit, certify safety or robotics readiness, or
+establish exact whole-life checkpoint resume.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import json
+import math
+import re
+import threading
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+REFERENCE_AGENT_API_VERSION = "asi.reference_agent.preview1"
+REFERENCE_AGENT_MANIFEST_SCHEMA = "asi.reference_agent_manifest.preview1"
+REFERENCE_TRANSACTION_STATE_SCHEMA = "asi.reference_transaction_state.preview1"
+MAX_DECISION_INDEX = (1 << 64) - 1
+
+_SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]*$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_MAX_ID_LENGTH = 256
+_MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
+    f":{MAX_DECISION_INDEX}:authorization"
+)
+_MAX_CONFIG_BYTES = 1 << 20
+_MAX_ARRAY_RANK = 8
+_MAX_ARRAY_ELEMENTS = 1 << 20
+_SUPPORTED_DTYPES = frozenset(
+    {
+        "float16",
+        "float32",
+        "float64",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+    }
+)
+
+
+class DecisionOwnershipError(ValueError):
+    """A record does not own the current lifecycle transaction."""
+
+
+def _require_safe_id(value: str, *, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_ID_LENGTH
+        or _SAFE_ID.fullmatch(value) is None
+    ):
+        raise ValueError(
+            f"{name} must be a lowercase identifier of at most {_MAX_ID_LENGTH} "
+            "characters containing only "
+            "letters, digits, '.', '_', ':', or '-'"
+        )
+
+
+def _require_sha256(value: str, *, name: str) -> None:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase 64-character SHA-256 digest")
+
+
+def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
+    if depth > 64:
+        raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} must contain only finite JSON numbers")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{path} JSON object keys must be strings")
+            _validate_json_value(item, path=f"{path}.{key}", depth=depth + 1)
+        return
+    raise ValueError(f"{path} is not a canonical JSON value")
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    if not isinstance(value, Mapping):
+        raise ValueError("config must be a JSON mapping")
+    _validate_json_value(value, path="config")
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("config must have a finite canonical JSON encoding") from exc
+    if len(encoded) > _MAX_CONFIG_BYTES:
+        raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+    return encoded
+
+
+def canonical_config_sha256(config: Mapping[str, Any]) -> str:
+    """Return the SHA-256 of one finite, canonical JSON configuration."""
+
+    return hashlib.sha256(_canonical_json_bytes(config)).hexdigest()
+
+
+def _shape_size(shape: tuple[int, ...]) -> int:
+    size = 1
+    for dimension in shape:
+        size *= dimension
+    return size
+
+
+def _numeric_array(value: Any, *, name: str) -> np.ndarray[Any, Any]:
+    try:
+        array = np.array(value, copy=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real numeric scalar or array") from exc
+    if array.dtype.kind not in {"f", "i", "u"}:
+        raise ValueError(f"{name} must contain only real numeric values, not bool")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def _cast_representable(
+    array: np.ndarray[Any, Any],
+    *,
+    dtype: np.dtype[Any],
+    name: str,
+) -> np.ndarray[Any, Any]:
+    if dtype.kind in {"i", "u"}:
+        limits = np.iinfo(dtype)
+        integers: list[int] = []
+        for raw in array.reshape(-1):
+            if array.dtype.kind == "f":
+                floating = float(raw)
+                if not math.isfinite(floating) or not floating.is_integer():
+                    raise ValueError(
+                        f"{name} must contain integral values representable by {dtype.name}"
+                    )
+            integer = int(raw)
+            if integer < int(limits.min) or integer > int(limits.max):
+                raise ValueError(f"{name} contains a value not representable by {dtype.name}")
+            integers.append(integer)
+        return np.asarray(integers, dtype=dtype).reshape(array.shape)
+    try:
+        with np.errstate(over="ignore", invalid="ignore"):
+            cast = array.astype(dtype, copy=True)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} contains a value not representable by {dtype.name}") from exc
+    if dtype.kind == "f" and not np.all(np.isfinite(cast)):
+        raise ValueError(f"{name} contains a value not finitely representable by {dtype.name}")
+    return cast
+
+
+def _nested_tuple(value: Any) -> Any:
+    if isinstance(value, list):
+        return tuple(_nested_tuple(item) for item in value)
+    return value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ArrayValue:
+    """Exact-dtype, immutable numeric value carried by protocol records."""
+
+    semantic_id: str
+    dtype: str
+    shape: tuple[int, ...]
+    payload: bytes
+
+    def __post_init__(self) -> None:
+        _require_safe_id(self.semantic_id, name="semantic_id")
+        try:
+            dtype = np.dtype(self.dtype)
+        except TypeError as exc:
+            raise ValueError(f"unsupported dtype {self.dtype!r}") from exc
+        if dtype.name not in _SUPPORTED_DTYPES or dtype.name != self.dtype:
+            raise ValueError("ArrayValue dtype must be a portable canonical numeric dtype")
+        if not isinstance(self.shape, tuple) or any(
+            isinstance(dimension, bool)
+            or not isinstance(dimension, int)
+            or dimension <= 0
+            for dimension in self.shape
+        ):
+            raise ValueError("ArrayValue shape must be a tuple of positive dimensions or ()")
+        if not isinstance(self.payload, bytes):
+            raise ValueError("ArrayValue payload must be immutable bytes")
+        if len(self.shape) > _MAX_ARRAY_RANK:
+            raise ValueError(f"ArrayValue rank must be <= {_MAX_ARRAY_RANK}")
+        elements = _shape_size(self.shape)
+        if elements > _MAX_ARRAY_ELEMENTS:
+            raise ValueError(f"ArrayValue must contain <= {_MAX_ARRAY_ELEMENTS} elements")
+        expected = elements * dtype.itemsize
+        if len(self.payload) != expected:
+            raise ValueError(
+                f"ArrayValue payload has {len(self.payload)} bytes; expected {expected}"
+            )
+        if not np.all(np.isfinite(self.to_numpy())):
+            raise ValueError("ArrayValue payload must contain only finite values")
+
+    def to_numpy(self) -> np.ndarray[Any, Any]:
+        """Return a caller-owned NumPy copy."""
+
+        dtype = np.dtype(self.dtype)
+        storage_dtype = dtype.newbyteorder("<")
+        return (
+            np.frombuffer(self.payload, dtype=storage_dtype)
+            .astype(dtype, copy=True)
+            .reshape(self.shape)
+        )
+
+    def to_python(self) -> int | float | tuple[Any, ...]:
+        """Return a deeply immutable Python scalar or nested tuple."""
+
+        array = self.to_numpy()
+        if array.shape == ():
+            value = array.item()
+            return float(value) if array.dtype.kind == "f" else int(value)
+        frozen = _nested_tuple(array.tolist())
+        assert isinstance(frozen, tuple)
+        return frozen
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SpaceSpec:
+    """Fixed numeric observation/action codec."""
+
+    kind: str
+    shape: tuple[int, ...]
+    dtype: str
+    semantic_id: str
+    cardinality: int | None = None
+    low: tuple[float | int, ...] | None = None
+    high: tuple[float | int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        _require_safe_id(self.semantic_id, name="semantic_id")
+        if not isinstance(self.shape, tuple) or any(
+            isinstance(dimension, bool)
+            or not isinstance(dimension, int)
+            or dimension <= 0
+            for dimension in self.shape
+        ):
+            raise ValueError("shape must be a tuple of positive integer dimensions or ()")
+        try:
+            dtype = np.dtype(self.dtype)
+        except TypeError as exc:
+            raise ValueError(f"unsupported dtype {self.dtype!r}") from exc
+        if dtype.name not in _SUPPORTED_DTYPES:
+            raise ValueError("dtype must be a supported portable floating-point or integer dtype")
+        if dtype.name != self.dtype:
+            raise ValueError(f"dtype must use canonical spelling {dtype.name!r}")
+        if len(self.shape) > _MAX_ARRAY_RANK:
+            raise ValueError(f"space rank must be <= {_MAX_ARRAY_RANK}")
+        if _shape_size(self.shape) > _MAX_ARRAY_ELEMENTS:
+            raise ValueError(f"space must contain <= {_MAX_ARRAY_ELEMENTS} elements")
+
+        if self.kind == "discrete":
+            if self.shape != ():
+                raise ValueError("a discrete space must have scalar shape ()")
+            if dtype.kind not in {"i", "u"}:
+                raise ValueError("a discrete space dtype must be integer")
+            if (
+                isinstance(self.cardinality, bool)
+                or not isinstance(self.cardinality, int)
+                or self.cardinality <= 0
+            ):
+                raise ValueError("discrete cardinality must be a positive integer")
+            if self.cardinality - 1 > int(np.iinfo(dtype).max):
+                raise ValueError(
+                    f"discrete cardinality is not representable by declared dtype {dtype.name}"
+                )
+            if self.low is not None or self.high is not None:
+                raise ValueError("a discrete space cannot declare box bounds")
+            return
+
+        if self.kind != "box":
+            raise ValueError("space kind must be 'discrete' or 'box'")
+        if self.cardinality is not None:
+            raise ValueError("a box space cannot declare a cardinality")
+        if (self.low is None) != (self.high is None):
+            raise ValueError("box low and high bounds must both be present or both be absent")
+        if self.low is None:
+            return
+        assert self.high is not None
+        lows = _numeric_array(self.low, name="box low bounds")
+        highs = _numeric_array(self.high, name="box high bounds")
+        size = _shape_size(self.shape)
+        if lows.shape != (size,) or highs.shape != (size,):
+            raise ValueError("box bounds must contain one value per flattened shape entry")
+        if np.any(lows > highs):
+            raise ValueError("every box low bound must be <= its high bound")
+        cast_lows = _cast_representable(lows, dtype=dtype, name="box low bounds")
+        cast_highs = _cast_representable(highs, dtype=dtype, name="box high bounds")
+        if np.any(cast_lows > cast_highs):
+            raise ValueError("box bounds reverse in the declared dtype")
+        object.__setattr__(
+            self,
+            "low",
+            tuple(
+                float(value) if dtype.kind == "f" else int(value)
+                for value in cast_lows.tolist()
+            ),
+        )
+        object.__setattr__(
+            self,
+            "high",
+            tuple(
+                float(value) if dtype.kind == "f" else int(value)
+                for value in cast_highs.tolist()
+            ),
+        )
+
+    @classmethod
+    def discrete(
+        cls,
+        *,
+        cardinality: int,
+        dtype: str,
+        semantic_id: str,
+    ) -> SpaceSpec:
+        return cls(
+            kind="discrete",
+            shape=(),
+            dtype=dtype,
+            semantic_id=semantic_id,
+            cardinality=cardinality,
+        )
+
+    @classmethod
+    def box(
+        cls,
+        *,
+        shape: tuple[int, ...],
+        dtype: str,
+        low: Sequence[float | int] | None,
+        high: Sequence[float | int] | None,
+        semantic_id: str,
+    ) -> SpaceSpec:
+        return cls(
+            kind="box",
+            shape=tuple(shape),
+            dtype=dtype,
+            semantic_id=semantic_id,
+            low=None if low is None else tuple(low),
+            high=None if high is None else tuple(high),
+        )
+
+    def encode(self, value: Any) -> ArrayValue:
+        """Validate and encode a value without retaining caller aliases."""
+
+        if isinstance(value, ArrayValue):
+            if (
+                value.semantic_id != self.semantic_id
+                or value.dtype != self.dtype
+                or value.shape != self.shape
+            ):
+                raise ValueError("encoded value does not match the declared space codec")
+            array = value.to_numpy()
+        else:
+            declared_dtype = np.dtype(self.dtype)
+            supplied_dtype = getattr(value, "dtype", None)
+            if supplied_dtype is not None:
+                try:
+                    supplied_name = np.dtype(supplied_dtype).name
+                except TypeError as exc:
+                    raise ValueError("space value has an unsupported dtype") from exc
+                if supplied_name != self.dtype:
+                    raise ValueError(
+                        f"space value dtype must be exactly {self.dtype}, got {supplied_name}"
+                    )
+            array = _numeric_array(value, name="space value")
+            if array.shape != self.shape:
+                raise ValueError(f"space value shape must be {self.shape}, got {array.shape}")
+            if declared_dtype.kind in {"i", "u"} and array.dtype.kind == "f":
+                raise TypeError("integer space value must be supplied as an integer, not float")
+            array = _cast_representable(array, dtype=declared_dtype, name="space value")
+
+        if self.kind == "discrete":
+            if array.dtype.kind not in {"i", "u"}:
+                raise TypeError("discrete value must be an integer, not bool")
+            integer = int(array)
+            assert self.cardinality is not None
+            if integer < 0 or integer >= self.cardinality:
+                raise ValueError(
+                    f"discrete value {integer} is outside cardinality range "
+                    f"[0, {self.cardinality})"
+                )
+        elif self.low is not None:
+            assert self.high is not None
+            dtype = np.dtype(self.dtype)
+            flattened = array.reshape(-1)
+            lows = np.asarray(self.low, dtype=dtype)
+            highs = np.asarray(self.high, dtype=dtype)
+            if np.any(flattened < lows) or np.any(flattened > highs):
+                raise ValueError("box value is outside the declared bounds/range")
+
+        canonical = np.ascontiguousarray(
+            array,
+            dtype=np.dtype(self.dtype).newbyteorder("<"),
+        )
+        return ArrayValue(
+            semantic_id=self.semantic_id,
+            dtype=self.dtype,
+            shape=self.shape,
+            payload=canonical.tobytes(order="C"),
+        )
+
+    def validate_value(self, value: Any) -> None:
+        self.encode(value)
+
+    def _descriptor(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "shape": list(self.shape),
+            "dtype": self.dtype,
+            "semantic_id": self.semantic_id,
+            "cardinality": self.cardinality,
+            "low": None if self.low is None else list(self.low),
+            "high": None if self.high is None else list(self.high),
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AgentCapabilities:
+    """Mechanism disclosures, not performance claims."""
+
+    dispatch_rebinding: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.dispatch_rebinding, bool):
+            raise ValueError("dispatch_rebinding must be boolean")
+
+    def _descriptor(self) -> dict[str, Any]:
+        return {"dispatch_rebinding": self.dispatch_rebinding}
+
+
+def _manifest_digest(
+    *,
+    schema: str,
+    implementation_id: str,
+    state_schema: str,
+    config_sha256: str,
+    observation_spec: SpaceSpec,
+    action_spec: SpaceSpec,
+    capabilities: AgentCapabilities,
+) -> str:
+    payload = {
+        "api_version": REFERENCE_AGENT_API_VERSION,
+        "schema": schema,
+        "implementation_id": implementation_id,
+        "state_schema": state_schema,
+        "config_sha256": config_sha256,
+        "observation_spec": observation_spec._descriptor(),
+        "action_spec": action_spec._descriptor(),
+        "capabilities": capabilities._descriptor(),
+    }
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AgentManifest:
+    """Versioned declaration for one adapter configuration."""
+
+    schema: str
+    implementation_id: str
+    state_schema: str
+    config_sha256: str
+    manifest_id: str
+    observation_spec: SpaceSpec
+    action_spec: SpaceSpec
+    capabilities: AgentCapabilities
+    _config_json: str = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_AGENT_MANIFEST_SCHEMA:
+            raise ValueError(
+                f"schema must be {REFERENCE_AGENT_MANIFEST_SCHEMA!r}, got {self.schema!r}"
+            )
+        _require_safe_id(self.implementation_id, name="implementation_id")
+        _require_safe_id(self.state_schema, name="state_schema")
+        _require_sha256(self.config_sha256, name="config_sha256")
+        _require_sha256(self.manifest_id, name="manifest_id")
+        if not isinstance(self.observation_spec, SpaceSpec):
+            raise ValueError("observation_spec must be a SpaceSpec")
+        if not isinstance(self.action_spec, SpaceSpec):
+            raise ValueError("action_spec must be a SpaceSpec")
+        if not isinstance(self.capabilities, AgentCapabilities):
+            raise ValueError("capabilities must be AgentCapabilities")
+        try:
+            config = json.loads(self._config_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("manifest config must be canonical JSON") from exc
+        if not isinstance(config, dict):
+            raise ValueError("manifest config must be a JSON object")
+        if _canonical_json_bytes(config).decode("utf-8") != self._config_json:
+            raise ValueError("manifest config must use canonical JSON encoding")
+        if canonical_config_sha256(config) != self.config_sha256:
+            raise ValueError("manifest config_sha256 does not match config")
+        expected = _manifest_digest(
+            schema=self.schema,
+            implementation_id=self.implementation_id,
+            state_schema=self.state_schema,
+            config_sha256=self.config_sha256,
+            observation_spec=self.observation_spec,
+            action_spec=self.action_spec,
+            capabilities=self.capabilities,
+        )
+        if self.manifest_id != expected:
+            raise ValueError("manifest_id does not match the manifest fields")
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        schema: str,
+        implementation_id: str,
+        state_schema: str,
+        config: Mapping[str, Any],
+        observation_spec: SpaceSpec,
+        action_spec: SpaceSpec,
+        capabilities: AgentCapabilities,
+    ) -> AgentManifest:
+        config_bytes = _canonical_json_bytes(config)
+        config_sha256 = hashlib.sha256(config_bytes).hexdigest()
+        manifest_id = _manifest_digest(
+            schema=schema,
+            implementation_id=implementation_id,
+            state_schema=state_schema,
+            config_sha256=config_sha256,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            capabilities=capabilities,
+        )
+        return cls(
+            schema=schema,
+            implementation_id=implementation_id,
+            state_schema=state_schema,
+            config_sha256=config_sha256,
+            manifest_id=manifest_id,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            capabilities=capabilities,
+            _config_json=config_bytes.decode("utf-8"),
+        )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        config = json.loads(self._config_json)
+        assert isinstance(config, dict)
+        return config
+
+    def make_decision(
+        self,
+        *,
+        lifecycle_id: str,
+        decision_index: int,
+        observation_id: str,
+        observation: Any,
+        proposed_action: Any | None,
+        armed: bool,
+    ) -> Decision:
+        if not isinstance(armed, bool):
+            raise ValueError("armed must be boolean")
+        encoded_observation = self.observation_spec.encode(observation)
+        if armed:
+            if proposed_action is None:
+                raise ValueError("an armed decision requires a proposed_action")
+            encoded_action = self.action_spec.encode(proposed_action)
+        else:
+            if proposed_action is not None:
+                raise ValueError("a disarmed decision cannot carry a proposed_action")
+            encoded_action = None
+        return Decision(
+            manifest_id=self.manifest_id,
+            lifecycle_id=lifecycle_id,
+            decision_index=decision_index,
+            decision_id=f"{lifecycle_id}:{decision_index}",
+            observation_id=observation_id,
+            observation=encoded_observation,
+            proposed_action=encoded_action,
+            armed=armed,
+        )
+
+    def validate_decision(self, decision: Decision) -> None:
+        if not isinstance(decision, Decision):
+            raise ValueError("decision must be a Decision")
+        if decision.manifest_id != self.manifest_id:
+            raise ValueError("decision manifest identity does not match this manifest")
+        self.observation_spec.encode(decision.observation)
+        if decision.armed:
+            if decision.proposed_action is None:
+                raise ValueError("armed decision lacks a proposed action")
+            self.action_spec.encode(decision.proposed_action)
+        elif decision.proposed_action is not None:
+            raise ValueError("disarmed decision cannot carry a proposed action")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Decision:
+    """One manifest-bound decision proposal."""
+
+    manifest_id: str
+    lifecycle_id: str
+    decision_index: int
+    decision_id: str
+    observation_id: str
+    observation: ArrayValue
+    proposed_action: ArrayValue | None
+    armed: bool
+
+    def __post_init__(self) -> None:
+        _require_sha256(self.manifest_id, name="manifest_id")
+        _require_safe_id(self.lifecycle_id, name="lifecycle_id")
+        if len(self.lifecycle_id) > _MAX_LIFECYCLE_ID_LENGTH:
+            raise ValueError(
+                "lifecycle_id is too long for canonical derived transaction IDs; "
+                f"maximum length is {_MAX_LIFECYCLE_ID_LENGTH}"
+            )
+        if (
+            isinstance(self.decision_index, bool)
+            or not isinstance(self.decision_index, int)
+            or self.decision_index < 0
+            or self.decision_index > MAX_DECISION_INDEX
+        ):
+            raise ValueError(
+                f"decision_index must be a uint64 integer no greater than {MAX_DECISION_INDEX}"
+            )
+        expected_id = f"{self.lifecycle_id}:{self.decision_index}"
+        if self.decision_id != expected_id:
+            raise ValueError(f"decision_id must use canonical value {expected_id!r}")
+        _require_safe_id(self.decision_id, name="decision_id")
+        _require_safe_id(self.observation_id, name="observation_id")
+        if not isinstance(self.observation, ArrayValue):
+            raise ValueError("decision observation must be an ArrayValue")
+        if not isinstance(self.armed, bool):
+            raise ValueError("armed must be boolean")
+        if self.armed:
+            if not isinstance(self.proposed_action, ArrayValue):
+                raise ValueError("an armed decision requires an encoded proposed action")
+        elif self.proposed_action is not None:
+            raise ValueError("a disarmed decision cannot carry a proposed action")
+
+
+class AuthorizationStatus(enum.Enum):
+    EXACT = "exact"
+    REPLACED = "replaced"
+    VETOED = "vetoed"
+
+
+class DispatchStatus(enum.Enum):
+    EXACT = "exact"
+    REBOUND = "rebound"
+
+
+class TransactionPhase(enum.Enum):
+    READY = "ready"
+    ARMED = "armed"
+    AUTHORIZED = "authorized"
+    SETTLED = "settled"
+    DISPATCHED = "dispatched"
+    OUTCOME = "outcome"
+    EXHAUSTED = "exhausted"
+    HALTED = "halted"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DispatchAuthorization:
+    """Independent authority's decision-bound authorization."""
+
+    decision: Decision
+    status: AuthorizationStatus
+    authorized_action: ArrayValue | None
+    authority_id: str
+    policy_version: str
+    authorization_id: str
+    veto_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision, Decision) or not self.decision.armed:
+            raise ValueError("authorization requires an armed Decision")
+        if not isinstance(self.status, AuthorizationStatus):
+            raise ValueError("authorization status must be an AuthorizationStatus")
+        _require_safe_id(self.authority_id, name="authority_id")
+        _require_safe_id(self.policy_version, name="policy_version")
+        _require_safe_id(self.authorization_id, name="authorization_id")
+        expected_id = f"{self.decision.decision_id}:authorization"
+        if self.authorization_id != expected_id:
+            raise ValueError(f"authorization_id must use canonical value {expected_id!r}")
+        if self.status is AuthorizationStatus.VETOED:
+            if self.authorized_action is not None:
+                raise ValueError("vetoed authorization cannot carry an action")
+            if not isinstance(self.veto_reason, str) or not self.veto_reason.strip():
+                raise ValueError("vetoed authorization requires a nonempty reason")
+            return
+        if not isinstance(self.authorized_action, ArrayValue):
+            raise ValueError("non-vetoed authorization requires an encoded action")
+        if self.veto_reason is not None:
+            raise ValueError("non-vetoed authorization cannot carry a veto reason")
+        assert self.decision.proposed_action is not None
+        actions_equal = self.authorized_action == self.decision.proposed_action
+        if self.status is AuthorizationStatus.EXACT and not actions_equal:
+            raise ValueError("exact authorization action must equal the proposal")
+        if self.status is AuthorizationStatus.REPLACED and actions_equal:
+            raise ValueError("replacement authorization action must differ from the proposal")
+
+    @property
+    def lifecycle_id(self) -> str:
+        return self.decision.lifecycle_id
+
+    @property
+    def decision_id(self) -> str:
+        return self.decision.decision_id
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DispatchAck:
+    """Agent settlement of one non-vetoed authorization."""
+
+    authorization: DispatchAuthorization
+    status: DispatchStatus
+    effective_action: ArrayValue
+    settlement_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.authorization, DispatchAuthorization):
+            raise ValueError("dispatch settlement requires a DispatchAuthorization")
+        if self.authorization.status is AuthorizationStatus.VETOED:
+            raise ValueError("a vetoed authorization cannot be settled")
+        if not isinstance(self.status, DispatchStatus):
+            raise ValueError("dispatch status must be a DispatchStatus")
+        if not isinstance(self.effective_action, ArrayValue):
+            raise ValueError("dispatch effective_action must be an ArrayValue")
+        _require_safe_id(self.settlement_id, name="settlement_id")
+        expected_id = f"{self.decision_id}:settlement"
+        if self.settlement_id != expected_id:
+            raise ValueError(f"settlement_id must use canonical value {expected_id!r}")
+        assert self.authorization.authorized_action is not None
+        if self.effective_action != self.authorization.authorized_action:
+            raise ValueError("settlement action must equal the independently authorized action")
+        if (
+            self.authorization.status is AuthorizationStatus.EXACT
+            and self.status is not DispatchStatus.EXACT
+        ):
+            raise ValueError("exact authorization requires exact settlement")
+        if (
+            self.authorization.status is AuthorizationStatus.REPLACED
+            and self.status is not DispatchStatus.REBOUND
+        ):
+            raise ValueError("replacement authorization requires rebound settlement")
+
+    @property
+    def decision(self) -> Decision:
+        return self.authorization.decision
+
+    @property
+    def lifecycle_id(self) -> str:
+        return self.decision.lifecycle_id
+
+    @property
+    def decision_id(self) -> str:
+        return self.decision.decision_id
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DispatchReceipt:
+    """Host record of an executor acknowledgement for one settled action."""
+
+    dispatch: DispatchAck
+    receipt_id: str
+    executor_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.dispatch, DispatchAck):
+            raise ValueError("receipt requires a DispatchAck")
+        _require_safe_id(self.receipt_id, name="receipt_id")
+        _require_safe_id(self.executor_id, name="executor_id")
+        expected_id = f"{self.decision.decision_id}:receipt"
+        if self.receipt_id != expected_id:
+            raise ValueError(f"receipt_id must use canonical value {expected_id!r}")
+
+    @property
+    def effective_action(self) -> ArrayValue:
+        return self.dispatch.effective_action
+
+    @property
+    def decision(self) -> Decision:
+        return self.dispatch.decision
+
+
+def _finite_scalar(value: Any, *, name: str) -> float:
+    array = _numeric_array(value, name=name)
+    if array.shape != ():
+        raise ValueError(f"{name} must be a finite real scalar")
+    original = array.item()
+    try:
+        converted = float(original)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must remain finite and representable as a protocol float"
+        ) from exc
+    if not math.isfinite(converted):
+        raise ValueError(f"{name} must remain finite and representable as a protocol float")
+    if original != 0 and converted == 0.0:
+        raise ValueError(f"{name} must not underflow when represented as a protocol float")
+    return converted
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Transaction:
+    """One receipt-bound environment outcome."""
+
+    receipt: DispatchReceipt
+    reward: float
+    discount: float
+    terminated: bool
+    truncated: bool
+    autoreset: bool
+    bootstrap_observation_id: str
+    bootstrap_observation: ArrayValue
+    next_decision_observation_id: str | None
+    next_decision_observation: ArrayValue | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.receipt, DispatchReceipt):
+            raise ValueError("transaction requires a DispatchReceipt")
+        reward = _finite_scalar(self.reward, name="reward")
+        discount = _finite_scalar(self.discount, name="discount")
+        if discount < 0.0 or discount > 1.0:
+            raise ValueError("discount must be in [0, 1]")
+        for name in ("terminated", "truncated", "autoreset"):
+            if not isinstance(getattr(self, name), bool):
+                raise ValueError(f"{name} must be boolean")
+        if self.terminated and discount != 0.0:
+            raise ValueError("terminated transactions require discount == 0")
+        if not self.terminated and discount == 0.0:
+            raise ValueError("discount == 0 requires terminated=True")
+        if self.truncated and not self.terminated and discount <= 0.0:
+            raise ValueError("a truncated nonterminal transaction requires discount > 0")
+        _require_safe_id(self.bootstrap_observation_id, name="bootstrap_observation_id")
+        if not isinstance(self.bootstrap_observation, ArrayValue):
+            raise ValueError("bootstrap_observation must be an ArrayValue")
+        if self.bootstrap_observation_id == self.decision.observation_id:
+            raise ValueError("outcome observation identity must advance beyond the decision input")
+
+        if self.is_boundary:
+            if self.autoreset:
+                if self.next_decision_observation_id is None:
+                    raise ValueError("autoreset requires next_decision_observation_id")
+                if not isinstance(self.next_decision_observation, ArrayValue):
+                    raise ValueError("autoreset requires next_decision_observation")
+                _require_safe_id(
+                    self.next_decision_observation_id,
+                    name="next_decision_observation_id",
+                )
+                if self.next_decision_observation_id == self.bootstrap_observation_id:
+                    raise ValueError(
+                        "autoreset final and reset observations need distinct identities"
+                    )
+            elif (
+                self.next_decision_observation_id is not None
+                or self.next_decision_observation is not None
+            ):
+                raise ValueError(
+                    "a boundary without autoreset cannot carry a next decision observation"
+                )
+        else:
+            if self.autoreset:
+                raise ValueError("autoreset is valid only at a boundary")
+            if self.next_decision_observation_id != self.bootstrap_observation_id:
+                raise ValueError(
+                    "continuing bootstrap and next observations must share identity"
+                )
+            if self.next_decision_observation != self.bootstrap_observation:
+                raise ValueError(
+                    "continuing bootstrap and next observations must have equal values"
+                )
+
+        object.__setattr__(self, "reward", reward)
+        object.__setattr__(self, "discount", discount)
+
+    @property
+    def decision(self) -> Decision:
+        return self.receipt.decision
+
+    @property
+    def lifecycle_id(self) -> str:
+        return self.decision.lifecycle_id
+
+    @property
+    def decision_id(self) -> str:
+        return self.decision.decision_id
+
+    @property
+    def is_boundary(self) -> bool:
+        return self.terminated or self.truncated
+
+    @property
+    def is_autoreset(self) -> bool:
+        return self.autoreset
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StepResult:
+    """Outcome acceptance or fail-closed recovery result."""
+
+    transaction: Transaction
+    next_decision: Decision | None
+    transaction_accepted: bool
+    parameters_changed: bool
+    rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.transaction, Transaction):
+            raise ValueError("step result transaction must be a Transaction")
+        for name in ("transaction_accepted", "parameters_changed"):
+            if not isinstance(getattr(self, name), bool):
+                raise ValueError(f"{name} must be boolean")
+        if not self.transaction_accepted:
+            if self.parameters_changed:
+                raise ValueError("a rejected transaction cannot change parameters")
+            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
+                raise ValueError("a rejected transaction requires a nonempty rejection_reason")
+            if self.next_decision is not None:
+                raise ValueError("a rejected transaction cannot arm a next decision")
+            return
+        if self.rejection_reason is not None:
+            raise ValueError("an accepted transaction cannot carry a rejection reason")
+        if self.next_decision is None and self.life_exhausted:
+            return
+        if self.next_decision is None:
+            if not self.transaction.is_boundary or self.transaction.is_autoreset:
+                raise ValueError("a continuing/autoreset transaction must arm a next decision")
+            return
+        if not isinstance(self.next_decision, Decision):
+            raise ValueError("next_decision must be a Decision or None")
+        if not self.next_decision.armed:
+            raise DecisionOwnershipError("next decision must be armed")
+        if self.next_decision.manifest_id != self.transaction.decision.manifest_id:
+            raise DecisionOwnershipError("next decision belongs to another manifest")
+        if self.next_decision.lifecycle_id != self.transaction.lifecycle_id:
+            raise DecisionOwnershipError("next decision belongs to another lifecycle")
+        expected_index = self.transaction.decision.decision_index + 1
+        if self.next_decision.decision_index != expected_index:
+            raise DecisionOwnershipError(
+                f"next decision index must be {expected_index}"
+            )
+        if (
+            self.next_decision.observation_id
+            != self.transaction.next_decision_observation_id
+        ):
+            raise DecisionOwnershipError("next decision does not own the next observation")
+        if self.next_decision.observation != self.transaction.next_decision_observation:
+            raise DecisionOwnershipError("next decision observation value does not match")
+
+    @property
+    def event_consumed(self) -> bool:
+        return self.transaction_accepted
+
+    @property
+    def recovery_required(self) -> bool:
+        return not self.transaction_accepted
+
+    @property
+    def life_exhausted(self) -> bool:
+        return (
+            self.transaction_accepted
+            and self.next_decision is None
+            and self.transaction.decision.decision_index == MAX_DECISION_INDEX
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceTransactionState:
+    """Immutable state for one in-process transaction ledger."""
+
+    schema: str
+    manifest_id: str
+    phase: TransactionPhase
+    lifecycle_id: str | None
+    next_decision_index: int
+    decision: Decision | None = None
+    authorization: DispatchAuthorization | None = None
+    dispatch: DispatchAck | None = None
+    receipt: DispatchReceipt | None = None
+    transaction: Transaction | None = None
+    halt_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_TRANSACTION_STATE_SCHEMA:
+            raise ValueError("unsupported reference transaction state schema")
+        _require_sha256(self.manifest_id, name="manifest_id")
+        if not isinstance(self.phase, TransactionPhase):
+            raise ValueError("phase must be a TransactionPhase")
+        if self.lifecycle_id is not None:
+            _require_safe_id(self.lifecycle_id, name="lifecycle_id")
+        if (
+            isinstance(self.next_decision_index, bool)
+            or not isinstance(self.next_decision_index, int)
+            or self.next_decision_index < 0
+            or self.next_decision_index > MAX_DECISION_INDEX
+        ):
+            raise ValueError(
+                "next_decision_index must be a uint64 integer no greater than "
+                f"{MAX_DECISION_INDEX}"
+            )
+        if self.phase is TransactionPhase.HALTED:
+            if not isinstance(self.halt_reason, str) or not self.halt_reason.strip():
+                raise ValueError("halted state requires a nonempty halt_reason")
+        elif self.halt_reason is not None:
+            raise ValueError("non-halted state cannot carry halt_reason")
+
+        records = (
+            self.decision,
+            self.authorization,
+            self.dispatch,
+            self.receipt,
+            self.transaction,
+        )
+        presence = tuple(record is not None for record in records)
+        exact_presence = {
+            TransactionPhase.READY: (False, False, False, False, False),
+            TransactionPhase.ARMED: (True, False, False, False, False),
+            TransactionPhase.AUTHORIZED: (True, True, False, False, False),
+            TransactionPhase.SETTLED: (True, True, True, False, False),
+            TransactionPhase.DISPATCHED: (True, True, True, True, False),
+            TransactionPhase.OUTCOME: (True, True, True, True, True),
+            TransactionPhase.EXHAUSTED: (False, False, False, False, False),
+        }
+        if self.phase in exact_presence and presence != exact_presence[self.phase]:
+            raise ValueError(f"{self.phase.value} phase carries inconsistent transaction records")
+        if self.phase is TransactionPhase.HALTED:
+            depth = sum(presence)
+            if depth == 0 or presence != tuple(index < depth for index in range(5)):
+                raise ValueError("halted phase requires one contiguous transaction record prefix")
+
+        if self.phase is TransactionPhase.READY:
+            if self.lifecycle_id is None and self.next_decision_index != 0:
+                raise ValueError("an unstarted ready state must expect decision index 0")
+            return
+        if self.phase is TransactionPhase.EXHAUSTED:
+            if self.lifecycle_id is None or self.next_decision_index != MAX_DECISION_INDEX:
+                raise ValueError("exhausted state requires a lifecycle at the maximum index")
+            return
+        if self.lifecycle_id is None or self.decision is None:
+            raise ValueError(f"{self.phase.value} phase requires an owned lifecycle decision")
+        if not self.decision.armed:
+            raise ValueError(f"{self.phase.value} phase cannot own a disarmed decision")
+        if self.decision.manifest_id != self.manifest_id:
+            raise ValueError("state decision manifest violates the ownership chain")
+        if self.decision.lifecycle_id != self.lifecycle_id:
+            raise ValueError("state decision lifecycle violates the ownership chain")
+        if self.decision.decision_index != self.next_decision_index:
+            raise ValueError("state decision index violates the ownership chain")
+        if self.authorization is not None and self.authorization.decision != self.decision:
+            raise ValueError("authorization decision violates the ownership chain")
+        if self.dispatch is not None and self.dispatch.authorization != self.authorization:
+            raise ValueError("dispatch authorization violates the ownership chain")
+        if self.receipt is not None and self.receipt.dispatch != self.dispatch:
+            raise ValueError("receipt dispatch violates the ownership chain")
+        if self.transaction is not None and self.transaction.receipt != self.receipt:
+            raise ValueError("outcome receipt violates the ownership chain")
+        if (
+            self.authorization is not None
+            and self.authorization.status is AuthorizationStatus.VETOED
+            and self.phase is not TransactionPhase.HALTED
+        ):
+            raise ValueError("vetoed authorization is valid only in a halted state")
+
+
+class ReferenceTransactionLedger:
+    """Single-writer in-process transitions for one manifest-bound agent life.
+
+    The ledger rejects stale snapshots within this object. It is deliberately
+    not serializable and does not establish durable replay protection or exact
+    resume across process restarts; those remain responsibilities of the future
+    aggregate life runner.
+    """
+
+    __slots__ = ("_current_state", "_lock", "_manifest")
+
+    def __init__(self, manifest: AgentManifest) -> None:
+        if not isinstance(manifest, AgentManifest):
+            raise ValueError("manifest must be an AgentManifest")
+        self._manifest = manifest
+        self._current_state: ReferenceTransactionState | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def manifest(self) -> AgentManifest:
+        return self._manifest
+
+    def init(self) -> ReferenceTransactionState:
+        state = ReferenceTransactionState(
+            schema=REFERENCE_TRANSACTION_STATE_SCHEMA,
+            manifest_id=self.manifest.manifest_id,
+            phase=TransactionPhase.READY,
+            lifecycle_id=None,
+            next_decision_index=0,
+        )
+        with self._lock:
+            if self._current_state is not None:
+                raise DecisionOwnershipError(
+                    "ledger is already initialized; replay is forbidden"
+                )
+            self._current_state = state
+        return state
+
+    def __reduce__(self) -> Any:
+        raise TypeError(
+            "live reference transaction ledger cannot be serialized; "
+            "whole-life checkpoint/resume is not implemented"
+        )
+
+    def _validate_state(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        require_current: bool = True,
+    ) -> None:
+        if not isinstance(state, ReferenceTransactionState):
+            raise DecisionOwnershipError("state must be a ReferenceTransactionState")
+        if state.schema != REFERENCE_TRANSACTION_STATE_SCHEMA:
+            raise DecisionOwnershipError("state schema does not match the ledger")
+        if state.manifest_id != self.manifest.manifest_id:
+            raise DecisionOwnershipError("state manifest does not match the ledger")
+        if require_current:
+            if self._current_state is None:
+                raise DecisionOwnershipError("ledger must be initialized before use")
+            if state is not self._current_state:
+                raise DecisionOwnershipError("state is stale, replayed, or not the current state")
+
+        if state.decision is not None:
+            self.manifest.validate_decision(state.decision)
+        if state.authorization is not None:
+            action = state.authorization.authorized_action
+            if action is not None:
+                self.manifest.action_spec.encode(action)
+        if state.dispatch is not None:
+            self.manifest.action_spec.encode(state.dispatch.effective_action)
+            if (
+                state.dispatch.status is DispatchStatus.REBOUND
+                and not self.manifest.capabilities.dispatch_rebinding
+            ):
+                raise DecisionOwnershipError(
+                    "rebound settlement is not declared by the agent manifest"
+                )
+        if state.transaction is not None:
+            self.manifest.observation_spec.encode(state.transaction.bootstrap_observation)
+            if state.transaction.next_decision_observation is not None:
+                self.manifest.observation_spec.encode(
+                    state.transaction.next_decision_observation
+                )
+
+    def _commit(
+        self,
+        previous: ReferenceTransactionState,
+        next_state: ReferenceTransactionState,
+    ) -> ReferenceTransactionState:
+        self._validate_state(next_state, require_current=False)
+        with self._lock:
+            if self._current_state is not previous:
+                raise DecisionOwnershipError("state changed before commit; replay is forbidden")
+            self._current_state = next_state
+        return next_state
+
+    def _require_phase(
+        self,
+        state: ReferenceTransactionState,
+        expected: TransactionPhase,
+    ) -> None:
+        self._validate_state(state)
+        if state.phase is not expected:
+            raise DecisionOwnershipError(
+                f"transaction phase must be {expected.value}, got {state.phase.value}"
+            )
+
+    def _halt(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        reason: str,
+    ) -> ReferenceTransactionState:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("halt reason must be nonempty")
+        halted = dataclasses.replace(
+            state,
+            phase=TransactionPhase.HALTED,
+            halt_reason=reason,
+        )
+        return self._commit(state, halted)
+
+    def arm(
+        self,
+        state: ReferenceTransactionState,
+        decision: Decision,
+    ) -> ReferenceTransactionState:
+        self._require_phase(state, TransactionPhase.READY)
+        self.manifest.validate_decision(decision)
+        if not decision.armed:
+            raise DecisionOwnershipError("cannot arm a disarmed decision")
+        if decision.decision_index != state.next_decision_index:
+            raise DecisionOwnershipError(
+                f"decision index must equal expected {state.next_decision_index}"
+            )
+        if state.lifecycle_id is not None and decision.lifecycle_id != state.lifecycle_id:
+            raise DecisionOwnershipError("decision belongs to a different lifecycle")
+        lifecycle_id = decision.lifecycle_id
+        next_state = dataclasses.replace(
+            state,
+            phase=TransactionPhase.ARMED,
+            lifecycle_id=lifecycle_id,
+            decision=decision,
+            authorization=None,
+            dispatch=None,
+            receipt=None,
+            transaction=None,
+            halt_reason=None,
+        )
+        return self._commit(state, next_state)
+
+    def authorize(
+        self,
+        state: ReferenceTransactionState,
+        decision: Decision,
+        *,
+        authorized_action: Any | None,
+        authority_id: str,
+        policy_version: str,
+        authorization_id: str,
+        veto_reason: str | None = None,
+    ) -> tuple[ReferenceTransactionState, DispatchAuthorization]:
+        self._require_phase(state, TransactionPhase.ARMED)
+        if state.decision != decision:
+            raise DecisionOwnershipError("authorization does not own the armed decision")
+        self.manifest.validate_decision(decision)
+        if veto_reason is not None:
+            if authorized_action is not None:
+                raise ValueError("veto cannot carry an authorized action")
+            authorization = DispatchAuthorization(
+                decision=decision,
+                status=AuthorizationStatus.VETOED,
+                authorized_action=None,
+                authority_id=authority_id,
+                policy_version=policy_version,
+                authorization_id=authorization_id,
+                veto_reason=veto_reason,
+            )
+            halted = dataclasses.replace(
+                state,
+                phase=TransactionPhase.HALTED,
+                authorization=authorization,
+                halt_reason=f"dispatch veto: {veto_reason}",
+            )
+            return self._commit(state, halted), authorization
+
+        assert decision.proposed_action is not None
+        encoded_action = (
+            decision.proposed_action
+            if authorized_action is None
+            else self.manifest.action_spec.encode(authorized_action)
+        )
+        status = (
+            AuthorizationStatus.EXACT
+            if encoded_action == decision.proposed_action
+            else AuthorizationStatus.REPLACED
+        )
+        authorization = DispatchAuthorization(
+            decision=decision,
+            status=status,
+            authorized_action=encoded_action,
+            authority_id=authority_id,
+            policy_version=policy_version,
+            authorization_id=authorization_id,
+        )
+        next_state = dataclasses.replace(
+            state,
+            phase=TransactionPhase.AUTHORIZED,
+            authorization=authorization,
+        )
+        return self._commit(state, next_state), authorization
+
+    def settle_dispatch(
+        self,
+        state: ReferenceTransactionState,
+        authorization: DispatchAuthorization,
+        *,
+        rebinding_applied: bool,
+        settlement_id: str,
+    ) -> tuple[ReferenceTransactionState, DispatchAck | None]:
+        self._require_phase(state, TransactionPhase.AUTHORIZED)
+        if state.authorization != authorization:
+            raise DecisionOwnershipError("settlement does not own the authorization")
+        if not isinstance(rebinding_applied, bool):
+            raise ValueError("rebinding_applied must be boolean")
+        if authorization.status is AuthorizationStatus.VETOED:
+            raise DecisionOwnershipError("vetoed authorization cannot be settled")
+        assert authorization.authorized_action is not None
+
+        if authorization.status is AuthorizationStatus.REPLACED:
+            supported = self.manifest.capabilities.dispatch_rebinding
+            if not supported:
+                reason = "authorized replacement cannot rebind learning credit"
+                return self._halt(state, reason=reason), None
+            if not rebinding_applied:
+                raise ValueError("rebinding_applied=True is required for replacement")
+            status = DispatchStatus.REBOUND
+        else:
+            if rebinding_applied:
+                raise ValueError("rebinding_applied must be false for an exact authorization")
+            status = DispatchStatus.EXACT
+
+        dispatch = DispatchAck(
+            authorization=authorization,
+            status=status,
+            effective_action=authorization.authorized_action,
+            settlement_id=settlement_id,
+        )
+        next_state = dataclasses.replace(
+            state,
+            phase=TransactionPhase.SETTLED,
+            dispatch=dispatch,
+        )
+        return self._commit(state, next_state), dispatch
+
+    def record_dispatch(
+        self,
+        state: ReferenceTransactionState,
+        dispatch: DispatchAck,
+        *,
+        receipt_id: str,
+        executor_id: str,
+    ) -> tuple[ReferenceTransactionState, DispatchReceipt]:
+        self._require_phase(state, TransactionPhase.SETTLED)
+        if state.dispatch != dispatch:
+            raise DecisionOwnershipError("dispatch receipt does not own the settled dispatch")
+        receipt = DispatchReceipt(
+            dispatch=dispatch,
+            receipt_id=receipt_id,
+            executor_id=executor_id,
+        )
+        next_state = dataclasses.replace(
+            state,
+            phase=TransactionPhase.DISPATCHED,
+            receipt=receipt,
+        )
+        return self._commit(state, next_state), receipt
+
+    def record_outcome(
+        self,
+        state: ReferenceTransactionState,
+        receipt: DispatchReceipt,
+        *,
+        reward: Any,
+        discount: Any,
+        terminated: bool,
+        truncated: bool,
+        autoreset: bool,
+        bootstrap_observation_id: str,
+        bootstrap_observation: Any,
+        next_decision_observation_id: str | None,
+        next_decision_observation: Any | None,
+    ) -> tuple[ReferenceTransactionState, Transaction]:
+        self._require_phase(state, TransactionPhase.DISPATCHED)
+        if state.receipt != receipt:
+            raise DecisionOwnershipError("outcome does not own the exact dispatch receipt")
+        bootstrap = self.manifest.observation_spec.encode(bootstrap_observation)
+        next_observation = (
+            None
+            if next_decision_observation is None
+            else self.manifest.observation_spec.encode(next_decision_observation)
+        )
+        transaction = Transaction(
+            receipt=receipt,
+            reward=reward,
+            discount=discount,
+            terminated=terminated,
+            truncated=truncated,
+            autoreset=autoreset,
+            bootstrap_observation_id=bootstrap_observation_id,
+            bootstrap_observation=bootstrap,
+            next_decision_observation_id=next_decision_observation_id,
+            next_decision_observation=next_observation,
+        )
+        next_state = dataclasses.replace(
+            state,
+            phase=TransactionPhase.OUTCOME,
+            transaction=transaction,
+        )
+        return self._commit(state, next_state), transaction
+
+    def accept(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        next_decision: Decision | None,
+        parameters_changed: bool,
+    ) -> tuple[ReferenceTransactionState, StepResult]:
+        self._require_phase(state, TransactionPhase.OUTCOME)
+        if state.transaction is None:
+            raise DecisionOwnershipError("outcome phase lacks a transaction")
+        if not isinstance(parameters_changed, bool):
+            raise ValueError("parameters_changed must be boolean")
+        if next_decision is not None:
+            self.manifest.validate_decision(next_decision)
+        life_exhausted = state.next_decision_index == MAX_DECISION_INDEX
+        if life_exhausted and next_decision is not None:
+            raise DecisionOwnershipError("counter exhaustion cannot arm another decision")
+        result = StepResult(
+            transaction=state.transaction,
+            next_decision=next_decision,
+            transaction_accepted=True,
+            parameters_changed=parameters_changed,
+            rejection_reason=None,
+        )
+        if life_exhausted:
+            next_state = dataclasses.replace(
+                state,
+                phase=TransactionPhase.EXHAUSTED,
+                decision=None,
+                authorization=None,
+                dispatch=None,
+                receipt=None,
+                transaction=None,
+            )
+        elif next_decision is None:
+            next_index = state.next_decision_index + 1
+            next_state = dataclasses.replace(
+                state,
+                phase=TransactionPhase.READY,
+                next_decision_index=next_index,
+                decision=None,
+                authorization=None,
+                dispatch=None,
+                receipt=None,
+                transaction=None,
+            )
+        else:
+            next_index = state.next_decision_index + 1
+            next_state = dataclasses.replace(
+                state,
+                phase=TransactionPhase.ARMED,
+                next_decision_index=next_index,
+                decision=next_decision,
+                authorization=None,
+                dispatch=None,
+                receipt=None,
+                transaction=None,
+            )
+        return self._commit(state, next_state), result
+
+    def reject(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        reason: str,
+    ) -> tuple[ReferenceTransactionState, StepResult]:
+        self._require_phase(state, TransactionPhase.OUTCOME)
+        if state.transaction is None:
+            raise DecisionOwnershipError("outcome phase lacks a transaction")
+        result = StepResult(
+            transaction=state.transaction,
+            next_decision=None,
+            transaction_accepted=False,
+            parameters_changed=False,
+            rejection_reason=reason,
+        )
+        return self._halt(state, reason=reason), result
+
+
+__all__ = [
+    "REFERENCE_AGENT_API_VERSION",
+    "REFERENCE_AGENT_MANIFEST_SCHEMA",
+    "REFERENCE_TRANSACTION_STATE_SCHEMA",
+    "MAX_DECISION_INDEX",
+    "AgentCapabilities",
+    "AgentManifest",
+    "ArrayValue",
+    "AuthorizationStatus",
+    "Decision",
+    "DecisionOwnershipError",
+    "DispatchAck",
+    "DispatchAuthorization",
+    "DispatchReceipt",
+    "DispatchStatus",
+    "ReferenceTransactionLedger",
+    "ReferenceTransactionState",
+    "SpaceSpec",
+    "StepResult",
+    "Transaction",
+    "TransactionPhase",
+    "canonical_config_sha256",
+]

--- a/tests/test_prototype_reference_adapter.py
+++ b/tests/test_prototype_reference_adapter.py
@@ -1,0 +1,788 @@
+"""Failing-first contracts for the development-only Prototype reference adapter.
+
+This lane establishes only a primitive-action, exact-dispatch interoperability
+slice.  It does not select ``reference-dev``, prove learning benefit, or provide
+an aggregate runner, durable replay, exact whole-life resume, or safety claim.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pickle
+
+import chex
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.dreaming import DreamingConfig
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.core.prototype_agent import (
+    PrototypeAgent,
+    PrototypeAgentConfig,
+)
+from alberta_framework.prototype_reference_adapter import (
+    PROTOTYPE_REFERENCE_ADAPTER_SCHEMA,
+    PROTOTYPE_REFERENCE_STATE_SCHEMA,
+    PrototypeReferenceAdapter,
+    PrototypeReferenceState,
+)
+from alberta_framework.reference_agent import (
+    AuthorizationStatus,
+    Decision,
+    DecisionOwnershipError,
+    DispatchAck,
+    DispatchAuthorization,
+    DispatchReceipt,
+    DispatchStatus,
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    Transaction,
+    TransactionPhase,
+)
+from alberta_framework.streams.closed_loop import (
+    PHASE_A,
+    PHASE_B,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+)
+
+pytestmark = pytest.mark.unit
+
+_LIFE_A = "prototype.0000000100000002"
+_LIFE_B = "prototype.0000000300000004"
+
+
+def _config(*, base_step_size: float = 0.05) -> PrototypeAgentConfig:
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=2,
+                n_primitive_actions=2,
+                base_step_size=base_step_size,
+                epsilon_base=0.0,
+            )
+        )
+    )
+
+
+def _start(
+    adapter: PrototypeReferenceAdapter,
+    *,
+    lifecycle_id: str = _LIFE_A,
+    key_seed: int = 0,
+    observation: np.ndarray | None = None,
+) -> tuple[PrototypeReferenceState, Decision]:
+    initial_observation = (
+        np.asarray([1.0, 0.0], dtype=np.float32)
+        if observation is None
+        else observation
+    )
+    state = adapter.init(jr.key(key_seed), lifecycle_id=lifecycle_id)
+    return adapter.start(
+        state,
+        observation_id=f"{lifecycle_id}:observation:0",
+        observation=initial_observation,
+    )
+
+
+def _record_outcome(
+    adapter: PrototypeReferenceAdapter,
+    decision: Decision,
+    *,
+    agent_state: PrototypeReferenceState | None = None,
+    reward: float = 1.0,
+    discount: float = 1.0,
+    terminated: bool = False,
+    truncated: bool = False,
+    autoreset: bool = False,
+    bootstrap_observation: np.ndarray | None = None,
+) -> tuple[
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    Transaction,
+]:
+    ledger = ReferenceTransactionLedger(adapter.manifest)
+    ledger_state = ledger.arm(ledger.init(), decision)
+    ledger_state, authorization = ledger.authorize(
+        ledger_state,
+        decision,
+        authorized_action=None,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    rebinding_applied = False
+    if agent_state is not None:
+        settled_agent_state, rebinding_applied = adapter.settle_dispatch(
+            agent_state,
+            authorization,
+        )
+        assert settled_agent_state is agent_state
+    ledger_state, dispatch = ledger.settle_dispatch(
+        ledger_state,
+        authorization,
+        rebinding_applied=rebinding_applied,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    assert dispatch is not None
+    ledger_state, receipt = ledger.record_dispatch(
+        ledger_state,
+        dispatch,
+        receipt_id=f"{decision.decision_id}:receipt",
+        executor_id="tests.executor",
+    )
+    bootstrap = (
+        np.asarray([0.0, 1.0], dtype=np.float32)
+        if bootstrap_observation is None
+        else bootstrap_observation
+    )
+    boundary = terminated or truncated
+    bootstrap_id = (
+        f"{decision.lifecycle_id}:bootstrap:0"
+        if boundary
+        else f"{decision.lifecycle_id}:observation:1"
+    )
+    next_id = (
+        None
+        if boundary and not autoreset
+        else (
+            f"{decision.lifecycle_id}:observation:1"
+            if autoreset
+            else bootstrap_id
+        )
+    )
+    next_observation = None if next_id is None else bootstrap
+    ledger_state, transaction = ledger.record_outcome(
+        ledger_state,
+        receipt,
+        reward=reward,
+        discount=discount,
+        terminated=terminated,
+        truncated=truncated,
+        autoreset=autoreset,
+        bootstrap_observation_id=bootstrap_id,
+        bootstrap_observation=bootstrap,
+        next_decision_observation_id=next_id,
+        next_decision_observation=next_observation,
+    )
+    return ledger, ledger_state, transaction
+
+
+def _exact_transaction_for_decision(
+    adapter: PrototypeReferenceAdapter,
+    decision: Decision,
+    *,
+    next_observation_id: str,
+    next_observation: np.ndarray,
+    reward: float = 1.0,
+) -> Transaction:
+    """Build a structurally exact transaction without requiring a fresh index-zero ledger."""
+
+    assert decision.proposed_action is not None
+    authorization = DispatchAuthorization(
+        decision=decision,
+        status=AuthorizationStatus.EXACT,
+        authorized_action=decision.proposed_action,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    dispatch = DispatchAck(
+        authorization=authorization,
+        status=DispatchStatus.EXACT,
+        effective_action=decision.proposed_action,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    receipt = DispatchReceipt(
+        dispatch=dispatch,
+        receipt_id=f"{decision.decision_id}:receipt",
+        executor_id="tests.executor",
+    )
+    encoded_observation = adapter.manifest.observation_spec.encode(next_observation)
+    return Transaction(
+        receipt=receipt,
+        reward=reward,
+        discount=1.0,
+        terminated=False,
+        truncated=False,
+        autoreset=False,
+        bootstrap_observation_id=next_observation_id,
+        bootstrap_observation=encoded_observation,
+        next_decision_observation_id=next_observation_id,
+        next_decision_observation=encoded_observation,
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        PrototypeAgentConfig(),
+        PrototypeAgentConfig(
+            oak=OaKConfig(
+                stomp=STOMPConfig(
+                    subtask_specs=(SubtaskSpec(feature_index=0),),
+                    observation_dim=2,
+                    n_primitive_actions=2,
+                )
+            )
+        ),
+        dataclasses.replace(_config(), dreaming=DreamingConfig()),
+        dataclasses.replace(_config(), auto_curate_every=1),
+    ],
+)
+def test_adapter_rejects_options_sidecars_and_python_curation(
+    config: PrototypeAgentConfig,
+) -> None:
+    with pytest.raises(ValueError, match="primitive-only|unsupported|disabled"):
+        PrototypeReferenceAdapter.from_config(config)
+
+
+def test_manifest_binds_canonical_minimal_config_and_exact_codecs() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    manifest = adapter.manifest
+
+    assert manifest.implementation_id == "asi.prototype_exact_adapter.preview1"
+    assert manifest.state_schema == PROTOTYPE_REFERENCE_STATE_SCHEMA
+    assert manifest.config["adapter_schema"] == PROTOTYPE_REFERENCE_ADAPTER_SCHEMA
+    assert manifest.config["dispatch_mode"] == "exact_only"
+    assert manifest.config["prototype_agent"] == _config().to_config()
+    assert manifest.config["prototype_state_schema"] == "alberta.prototype_agent.v3"
+    assert not manifest.capabilities.dispatch_rebinding
+    assert manifest.observation_spec.kind == "box"
+    assert manifest.observation_spec.shape == (2,)
+    assert manifest.observation_spec.dtype == "float32"
+    assert manifest.action_spec.kind == "discrete"
+    assert manifest.action_spec.cardinality == 2
+    assert manifest.action_spec.dtype == "int32"
+
+    with pytest.raises(ValueError, match="dtype"):
+        manifest.observation_spec.encode(np.asarray([1.0, 0.0], dtype=np.float64))
+    with pytest.raises(ValueError, match="dtype"):
+        manifest.action_spec.encode(np.asarray(0, dtype=np.int64))
+
+
+def test_state_is_manifest_bound_even_when_other_config_has_identical_shapes() -> None:
+    adapter_a = PrototypeReferenceAdapter.from_config(_config(base_step_size=0.05))
+    adapter_b = PrototypeReferenceAdapter.from_config(_config(base_step_size=0.02))
+    state_b = adapter_b.init(jr.key(3), lifecycle_id=_LIFE_A)
+
+    assert isinstance(state_b, PrototypeReferenceState)
+    assert state_b.schema == PROTOTYPE_REFERENCE_STATE_SCHEMA
+    assert state_b.manifest_id == adapter_b.manifest.manifest_id
+    assert state_b.config_sha256 == adapter_b.manifest.config_sha256
+    assert state_b.lifecycle_id == _LIFE_A
+    assert state_b.decision_index == 0
+    assert state_b.current_observation_id is None
+    assert adapter_a.manifest.manifest_id != adapter_b.manifest.manifest_id
+    with pytest.raises(DecisionOwnershipError, match="manifest|config"):
+        adapter_a.start(
+            state_b,
+            observation_id=f"{_LIFE_A}:observation:0",
+            observation=np.asarray([1.0, 0.0], dtype=np.float32),
+        )
+
+    state_a, decision_a = _start(adapter_a, key_seed=7)
+    state_b, _ = adapter_b.start(
+        state_b,
+        observation_id=f"{_LIFE_A}:observation:0",
+        observation=np.asarray([1.0, 0.0], dtype=np.float32),
+    )
+    _, _, transaction_a = _record_outcome(adapter_a, decision_a)
+    rejected = adapter_a.apply_outcome(state_b, transaction_a)
+
+    assert not rejected.accepted
+    assert rejected.state is state_b
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "manifest" in rejected.rejection_reason or "config" in rejected.rejection_reason
+    assert state_a is not state_b
+
+
+def test_relabelled_learned_state_cannot_cross_adapter_configurations() -> None:
+    adapter_a = PrototypeReferenceAdapter.from_config(_config(base_step_size=0.05))
+    adapter_b = PrototypeReferenceAdapter.from_config(_config(base_step_size=0.02))
+    state_b, decision_b = _start(adapter_b, key_seed=3)
+    _, _, transaction_b = _record_outcome(
+        adapter_b,
+        decision_b,
+        agent_state=state_b,
+        reward=4.0,
+    )
+    advanced_b = adapter_b.apply_outcome(state_b, transaction_b)
+    assert advanced_b.accepted
+    assert advanced_b.next_decision is not None
+
+    relabelled_b = dataclasses.replace(
+        advanced_b.state,
+        manifest_id=adapter_a.manifest.manifest_id,
+        config_sha256=adapter_a.manifest.config_sha256,
+    )
+    b_decision = advanced_b.next_decision
+    relabelled_decision = adapter_a.manifest.make_decision(
+        lifecycle_id=b_decision.lifecycle_id,
+        decision_index=b_decision.decision_index,
+        observation_id=b_decision.observation_id,
+        observation=b_decision.observation,
+        proposed_action=b_decision.proposed_action,
+        armed=True,
+    )
+    transaction_a = _exact_transaction_for_decision(
+        adapter_a,
+        relabelled_decision,
+        next_observation_id=f"{_LIFE_A}:observation:2",
+        next_observation=np.asarray([1.0, 0.0], dtype=np.float32),
+        reward=4.0,
+    )
+
+    with pytest.raises(DecisionOwnershipError, match="owner|adapter instance"):
+        adapter_a.current_decision(relabelled_b)
+    with pytest.raises(DecisionOwnershipError, match="owner|adapter instance"):
+        adapter_a.settle_dispatch(
+            relabelled_b,
+            transaction_a.receipt.dispatch.authorization,
+        )
+    rejected = adapter_a.apply_outcome(relabelled_b, transaction_a)
+
+    assert not rejected.accepted
+    assert rejected.state is relabelled_b
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "owner" in rejected.rejection_reason or "adapter instance" in rejected.rejection_reason
+
+
+def test_equivalent_adapter_instances_do_not_share_process_local_state() -> None:
+    adapter_a = PrototypeReferenceAdapter.from_config(_config())
+    adapter_b = PrototypeReferenceAdapter.from_config(_config())
+    state_a, decision_a = _start(adapter_a)
+    assert adapter_a.manifest == adapter_b.manifest
+
+    with pytest.raises(DecisionOwnershipError, match="owner|adapter instance"):
+        adapter_b.current_decision(state_a)
+    _, _, transaction = _record_outcome(adapter_b, decision_a)
+    rejected = adapter_b.apply_outcome(state_a, transaction)
+
+    assert not rejected.accepted
+    assert rejected.state is state_a
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "owner" in rejected.rejection_reason or "adapter instance" in rejected.rejection_reason
+
+
+def test_adapter_and_reference_state_are_explicitly_nonportable() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    state = adapter.init(jr.key(0), lifecycle_id=_LIFE_A)
+
+    with pytest.raises(TypeError, match="process-local|serialize|restore"):
+        pickle.dumps(adapter)
+    with pytest.raises(TypeError, match="process-local|serialize|restore"):
+        pickle.dumps(state)
+
+
+def test_lifecycle_and_internal_generation_map_exactly_to_host_decision() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    state, decision = _start(adapter)
+
+    assert decision.lifecycle_id == _LIFE_A
+    assert decision.decision_index == 0
+    assert decision.observation_id == f"{_LIFE_A}:observation:0"
+    assert state.lifecycle_id == decision.lifecycle_id
+    assert state.decision_index == decision.decision_index
+    assert state.current_observation_id == decision.observation_id
+    assert decision.observation.to_numpy().dtype == np.dtype(np.float32)
+    assert decision.proposed_action is not None
+    assert decision.proposed_action.to_numpy().dtype == np.dtype(np.int32)
+    np.testing.assert_array_equal(
+        np.asarray(state.agent_state.current_decision_id, dtype=np.uint32),
+        np.asarray([1, 2, 0, 0], dtype=np.uint32),
+    )
+
+    with pytest.raises(ValueError, match="lifecycle"):
+        adapter.init(jr.key(1), lifecycle_id="free-form-life")
+    with pytest.raises(DecisionOwnershipError, match="index|generation"):
+        adapter.current_decision(dataclasses.replace(state, decision_index=1))
+
+
+def test_relabelled_decision_observation_id_is_rejected_without_learning() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    _, _, transaction = _record_outcome(adapter, decision)
+    relabelled_decision = dataclasses.replace(
+        transaction.decision,
+        observation_id=f"{_LIFE_A}:observation:forged",
+    )
+    relabelled_authorization = dataclasses.replace(
+        transaction.receipt.dispatch.authorization,
+        decision=relabelled_decision,
+    )
+    relabelled_dispatch = dataclasses.replace(
+        transaction.receipt.dispatch,
+        authorization=relabelled_authorization,
+    )
+    relabelled_receipt = dataclasses.replace(
+        transaction.receipt,
+        dispatch=relabelled_dispatch,
+    )
+    relabelled_transaction = dataclasses.replace(
+        transaction,
+        receipt=relabelled_receipt,
+    )
+
+    rejected = adapter.apply_outcome(agent_state, relabelled_transaction)
+
+    assert not rejected.accepted
+    assert rejected.state is agent_state
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "observation" in rejected.rejection_reason
+
+
+def test_exact_settlement_is_an_agent_state_identity_operation() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    ledger = ReferenceTransactionLedger(adapter.manifest)
+    ledger_state = ledger.arm(ledger.init(), decision)
+    ledger_state, authorization = ledger.authorize(
+        ledger_state,
+        decision,
+        authorized_action=None,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+
+    settled_agent_state, rebinding_applied = adapter.settle_dispatch(
+        agent_state,
+        authorization,
+    )
+
+    assert settled_agent_state is agent_state
+    assert rebinding_applied is False
+    ledger_state, dispatch = ledger.settle_dispatch(
+        ledger_state,
+        authorization,
+        rebinding_applied=rebinding_applied,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    assert dispatch is not None
+    assert ledger_state.phase is TransactionPhase.SETTLED
+
+
+def test_replacement_and_veto_never_mutate_the_exact_only_agent() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    assert decision.proposed_action is not None
+    proposed_action = decision.proposed_action.to_python()
+    assert isinstance(proposed_action, int)
+    replacement = np.asarray(1 - proposed_action, dtype=np.int32)
+
+    ledger = ReferenceTransactionLedger(adapter.manifest)
+    ledger_state = ledger.arm(ledger.init(), decision)
+    ledger_state, authorization = ledger.authorize(
+        ledger_state,
+        decision,
+        authorized_action=replacement,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    assert authorization.status is AuthorizationStatus.REPLACED
+    with pytest.raises(DecisionOwnershipError, match="exact|replacement|rebind"):
+        adapter.settle_dispatch(agent_state, authorization)
+    halted, dispatch = ledger.settle_dispatch(
+        ledger_state,
+        authorization,
+        rebinding_applied=False,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    assert dispatch is None
+    assert halted.phase is TransactionPhase.HALTED
+
+    other_ledger = ReferenceTransactionLedger(adapter.manifest)
+    other_state = other_ledger.arm(other_ledger.init(), decision)
+    vetoed_state, veto = other_ledger.authorize(
+        other_state,
+        decision,
+        authorized_action=None,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+        veto_reason="test veto",
+    )
+    assert vetoed_state.phase is TransactionPhase.HALTED
+    with pytest.raises(DecisionOwnershipError, match="exact|veto"):
+        adapter.settle_dispatch(agent_state, veto)
+
+    current = adapter.current_decision(agent_state)
+    assert current == decision
+
+
+def test_one_full_continuing_transaction_advances_agent_and_ledger_once() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    ledger, ledger_state, transaction = _record_outcome(
+        adapter,
+        decision,
+        agent_state=agent_state,
+    )
+
+    candidate = adapter.apply_outcome(agent_state, transaction)
+
+    assert candidate.accepted
+    assert candidate.rejection_reason is None
+    assert candidate.next_decision is not None
+    assert candidate.next_decision.decision_index == 1
+    assert candidate.next_decision.observation_id == f"{_LIFE_A}:observation:1"
+    assert int(candidate.state.agent_state.step_count) == 1
+    assert int(agent_state.agent_state.step_count) == 0
+    np.testing.assert_array_equal(
+        np.asarray(candidate.state.agent_state.current_decision_id, dtype=np.uint32),
+        np.asarray([1, 2, 0, 1], dtype=np.uint32),
+    )
+    ledger_state, step_result = ledger.accept(
+        ledger_state,
+        next_decision=candidate.next_decision,
+        parameters_changed=candidate.parameters_changed,
+    )
+    assert step_result.transaction_accepted
+    assert ledger_state.phase is TransactionPhase.ARMED
+    assert ledger_state.next_decision_index == 1
+
+
+@pytest.mark.integration
+def test_switching_two_state_exact_chain_crosses_phase_boundary() -> None:
+    """Exercise the real deterministic environment without claiming dispatch proof."""
+
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    environment = SwitchingTwoStateMDP(
+        SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    )
+    environment_state = environment.init(jr.key(7))
+    adapter_state, decision = _start(
+        adapter,
+        observation=np.asarray(environment.observe(environment_state)),
+    )
+    ledger = ReferenceTransactionLedger(adapter.manifest)
+    ledger_state = ledger.arm(ledger.init(), decision)
+    observed_phases: list[int] = []
+    observation_ids = {decision.observation_id}
+
+    for event_index in range(3):
+        phase = int(environment.phase_id(environment_state))
+        observed_phases.append(phase)
+        ledger_state, authorization = ledger.authorize(
+            ledger_state,
+            decision,
+            authorized_action=None,
+            authority_id="tests.authority",
+            policy_version="tests.policy.v1",
+            authorization_id=f"{decision.decision_id}:authorization",
+        )
+        settled_state, rebinding_applied = adapter.settle_dispatch(
+            adapter_state,
+            authorization,
+        )
+        assert settled_state is adapter_state
+        ledger_state, dispatch = ledger.settle_dispatch(
+            ledger_state,
+            authorization,
+            rebinding_applied=rebinding_applied,
+            settlement_id=f"{decision.decision_id}:settlement",
+        )
+        assert dispatch is not None
+        ledger_state, receipt = ledger.record_dispatch(
+            ledger_state,
+            dispatch,
+            receipt_id=f"{decision.decision_id}:receipt",
+            executor_id="tests.deterministic_environment",
+        )
+
+        # Validate the recorded effective action immediately before handing it
+        # to the deterministic test environment. The host receipt remains an
+        # acknowledgement, not proof of physical dispatch.
+        effective_action = adapter.manifest.action_spec.encode(
+            receipt.effective_action
+        ).to_numpy()
+        assert effective_action.shape == ()
+        assert effective_action.dtype == np.dtype(np.int32)
+        action_index = int(effective_action)
+        environment_action = jnp.asarray(effective_action, dtype=jnp.int32)
+        state_index = int(environment_state.state_index)
+        expected_reward = (
+            environment.config.payoffs_a
+            if phase == PHASE_A
+            else environment.config.payoffs_b
+        )[state_index][action_index]
+        next_observation, reward, candidate_environment_state = environment.step(
+            environment_state,
+            environment_action,
+            jr.key(event_index),
+        )
+        assert float(reward) == expected_reward
+
+        next_observation_id = f"{_LIFE_A}:observation:{event_index + 1}"
+        assert next_observation_id not in observation_ids
+        observation_ids.add(next_observation_id)
+        ledger_state, transaction = ledger.record_outcome(
+            ledger_state,
+            receipt,
+            reward=np.asarray(reward, dtype=np.float32),
+            discount=np.asarray(1.0, dtype=np.float32),
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id=next_observation_id,
+            bootstrap_observation=np.asarray(next_observation),
+            next_decision_observation_id=next_observation_id,
+            next_decision_observation=np.asarray(next_observation),
+        )
+        candidate = adapter.apply_outcome(adapter_state, transaction)
+        assert candidate.accepted, candidate.rejection_reason
+        assert candidate.next_decision is not None
+        ledger_state, result = ledger.accept(
+            ledger_state,
+            next_decision=candidate.next_decision,
+            parameters_changed=candidate.parameters_changed,
+        )
+        assert result.transaction_accepted
+
+        environment_state = candidate_environment_state
+        adapter_state = candidate.state
+        decision = candidate.next_decision
+        expected_count = event_index + 1
+        assert int(environment_state.step_count) == expected_count
+        assert int(adapter_state.agent_state.step_count) == expected_count
+        assert adapter_state.decision_index == expected_count
+        assert ledger_state.next_decision_index == expected_count
+        assert decision.decision_index == expected_count
+        assert adapter_state.current_observation_id == next_observation_id
+        assert decision.observation_id == next_observation_id
+        assert ledger_state.phase is TransactionPhase.ARMED
+
+    assert observed_phases == [PHASE_A, PHASE_A, PHASE_B]
+    assert len(observation_ids) == 4
+
+
+def test_stale_and_cross_lifecycle_outcomes_preserve_the_supplied_state() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    initial_state, decision = _start(adapter)
+    _, _, transaction = _record_outcome(adapter, decision)
+    accepted = adapter.apply_outcome(initial_state, transaction)
+    assert accepted.accepted
+
+    stale = adapter.apply_outcome(accepted.state, transaction)
+    assert not stale.accepted
+    assert stale.state is accepted.state
+    assert stale.next_decision is None
+    assert stale.rejection_reason is not None
+
+    other_state, other_decision = _start(
+        adapter,
+        lifecycle_id=_LIFE_B,
+        key_seed=4,
+    )
+    _, _, other_transaction = _record_outcome(adapter, other_decision)
+    mismatch = adapter.apply_outcome(initial_state, other_transaction)
+    assert not mismatch.accepted
+    assert mismatch.state is initial_state
+    assert mismatch.next_decision is None
+    chex.assert_trees_all_equal(initial_state.agent_state, mismatch.state.agent_state)
+    assert other_state is not initial_state
+
+    wrong_codec = dataclasses.replace(
+        transaction.bootstrap_observation,
+        semantic_id="tests.wrong_observation.preview1",
+    )
+    wrong_codec_transaction = dataclasses.replace(
+        transaction,
+        bootstrap_observation=wrong_codec,
+        next_decision_observation=wrong_codec,
+    )
+    codec_mismatch = adapter.apply_outcome(initial_state, wrong_codec_transaction)
+    assert not codec_mismatch.accepted
+    assert codec_mismatch.state is initial_state
+    assert codec_mismatch.next_decision is None
+
+
+def test_boundary_without_a_next_decision_is_rejected_before_learning() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    _, _, transaction = _record_outcome(
+        adapter,
+        decision,
+        reward=0.0,
+        discount=0.0,
+        terminated=True,
+    )
+
+    rejected = adapter.apply_outcome(agent_state, transaction)
+
+    assert not rejected.accepted
+    assert rejected.state is agent_state
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "boundary" in rejected.rejection_reason
+
+
+def test_runtime_failure_discards_the_functional_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    _, _, transaction = _record_outcome(adapter, decision)
+
+    def fail_update(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise RuntimeError("synthetic Prototype update failure")
+
+    monkeypatch.setattr(PrototypeAgent, "update_transition", fail_update)
+    rejected = adapter.apply_outcome(agent_state, transaction)
+
+    assert not rejected.accepted
+    assert rejected.state is agent_state
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason == "synthetic Prototype update failure"
+
+
+def test_premature_prototype_disarm_discards_the_functional_candidate() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    agent_state, decision = _start(adapter)
+    near_value = np.iinfo(np.int32).max - 1
+    near_counter = jnp.asarray(near_value, dtype=jnp.int32)
+    near_words = jnp.asarray([0, near_value], dtype=jnp.uint32)
+    oak_state = agent_state.agent_state.oak_state
+    stomp_state = oak_state.stomp_state
+    base_state = stomp_state.base_learner_state.replace(
+        step_count=near_counter,
+        step_words=near_words,
+    )
+    stomp_state = stomp_state.replace(
+        base_learner_state=base_state,
+        step_count=near_counter,
+        step_words=near_words,
+    )
+    oak_state = oak_state.replace(
+        stomp_state=stomp_state,
+        step_count=near_counter,
+        step_words=near_words,
+    )
+    near_limit = dataclasses.replace(
+        agent_state,
+        agent_state=agent_state.agent_state.replace(  # type: ignore[attr-defined]
+            oak_state=oak_state,
+            step_count=near_counter,
+        ),
+    )
+    _, _, transaction = _record_outcome(adapter, decision)
+
+    rejected = adapter.apply_outcome(near_limit, transaction)
+
+    assert not rejected.accepted
+    assert rejected.state is near_limit
+    assert rejected.next_decision is None
+    assert rejected.rejection_reason is not None
+    assert "disarmed" in rejected.rejection_reason or "capacity" in rejected.rejection_reason
+    assert int(rejected.state.agent_state.step_count) == np.iinfo(np.int32).max - 1

--- a/tests/test_reference_agent_protocol.py
+++ b/tests/test_reference_agent_protocol.py
@@ -1,0 +1,779 @@
+"""Failing-first tests for ASI's host-facing reference-agent transactions.
+
+These contracts establish only L0 interoperability and ownership semantics.
+They do not select ``reference-dev`` or establish learning, retention, safety,
+robotics readiness, exact whole-life resume, or scientific evidence.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError, fields, replace
+from fractions import Fraction
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import alberta_framework.reference_agent as reference_agent
+from alberta_framework.reference_agent import (
+    MAX_DECISION_INDEX,
+    REFERENCE_AGENT_API_VERSION,
+    REFERENCE_AGENT_MANIFEST_SCHEMA,
+    REFERENCE_TRANSACTION_STATE_SCHEMA,
+    AgentCapabilities,
+    AgentManifest,
+    ArrayValue,
+    AuthorizationStatus,
+    Decision,
+    DecisionOwnershipError,
+    DispatchAck,
+    DispatchAuthorization,
+    DispatchReceipt,
+    DispatchStatus,
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    SpaceSpec,
+    StepResult,
+    Transaction,
+    TransactionPhase,
+    canonical_config_sha256,
+)
+
+
+def _observation_spec() -> SpaceSpec:
+    return SpaceSpec.box(
+        shape=(3,),
+        dtype="float32",
+        low=None,
+        high=None,
+        semantic_id="tests.reference_observation.v1",
+    )
+
+
+def _action_spec() -> SpaceSpec:
+    return SpaceSpec.box(
+        shape=(2,),
+        dtype="float32",
+        low=(-1.0, -1.0),
+        high=(1.0, 1.0),
+        semantic_id="tests.normalized_action.v1",
+    )
+
+
+def _manifest(*, dispatch_rebinding: bool = False) -> AgentManifest:
+    return AgentManifest.from_config(
+        schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+        implementation_id="tests.fake_reference_adapter.v1",
+        state_schema="tests.fake_reference_state.v1",
+        config={"agent": "fake", "action_scale": 1.0, "seed": 7},
+        observation_spec=_observation_spec(),
+        action_spec=_action_spec(),
+        capabilities=AgentCapabilities(dispatch_rebinding=dispatch_rebinding),
+    )
+
+
+def _decision(
+    manifest: AgentManifest,
+    *,
+    lifecycle_id: str = "life-a",
+    decision_index: int = 0,
+    observation_id: str | None = None,
+    observation: object = (0.0, 0.0, 0.0),
+    action: object = (0.25, -0.25),
+    armed: bool = True,
+) -> Decision:
+    return manifest.make_decision(
+        lifecycle_id=lifecycle_id,
+        decision_index=decision_index,
+        observation_id=(
+            f"{lifecycle_id}:observation:{decision_index}"
+            if observation_id is None
+            else observation_id
+        ),
+        observation=observation,
+        proposed_action=action if armed else None,
+        armed=armed,
+    )
+
+
+def _armed_ledger(
+    *,
+    dispatch_rebinding: bool = False,
+) -> tuple[ReferenceTransactionLedger, ReferenceTransactionState, Decision]:
+    ledger = ReferenceTransactionLedger(_manifest(dispatch_rebinding=dispatch_rebinding))
+    state = ledger.init()
+    decision = _decision(ledger.manifest)
+    return ledger, ledger.arm(state, decision), decision
+
+
+def _authorized(
+    *,
+    dispatch_rebinding: bool = False,
+    effective_action: object | None = None,
+) -> tuple[
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    Decision,
+    DispatchAuthorization,
+]:
+    ledger, state, decision = _armed_ledger(dispatch_rebinding=dispatch_rebinding)
+    state, authorization = ledger.authorize(
+        state,
+        decision,
+        authorized_action=effective_action,
+        authority_id="tests.safety_authority.v1",
+        policy_version="tests.safety_policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    return ledger, state, decision, authorization
+
+
+def _settled(
+    *,
+    dispatch_rebinding: bool = False,
+    effective_action: object | None = None,
+) -> tuple[
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    Decision,
+    DispatchAuthorization,
+    DispatchAck,
+]:
+    ledger, state, decision, authorization = _authorized(
+        dispatch_rebinding=dispatch_rebinding,
+        effective_action=effective_action,
+    )
+    state, dispatch = ledger.settle_dispatch(
+        state,
+        authorization,
+        rebinding_applied=(effective_action is not None),
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    assert dispatch is not None
+    return ledger, state, decision, authorization, dispatch
+
+
+def _dispatched(
+    *,
+    dispatch_rebinding: bool = False,
+    effective_action: object | None = None,
+) -> tuple[
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    Decision,
+    DispatchAuthorization,
+    DispatchAck,
+    DispatchReceipt,
+]:
+    ledger, state, decision, authorization, dispatch = _settled(
+        dispatch_rebinding=dispatch_rebinding,
+        effective_action=effective_action,
+    )
+    state, receipt = ledger.record_dispatch(
+        state,
+        dispatch,
+        receipt_id=f"{decision.decision_id}:receipt",
+        executor_id="tests.environment_executor.v1",
+    )
+    return ledger, state, decision, authorization, dispatch, receipt
+
+
+def _outcome(
+    *,
+    terminated: bool = False,
+    truncated: bool = False,
+    autoreset: bool = False,
+    bootstrap_observation: object = (0.1, 0.2, 0.3),
+    bootstrap_observation_id: str = "life-a:observation:1",
+    next_decision_observation: object | None = (0.1, 0.2, 0.3),
+    next_decision_observation_id: str | None = "life-a:observation:1",
+) -> tuple[ReferenceTransactionLedger, ReferenceTransactionState, Transaction]:
+    ledger, state, _decision_value, _authorization, _dispatch, receipt = _dispatched()
+    state, transaction = ledger.record_outcome(
+        state,
+        receipt,
+        reward=1.0,
+        discount=0.0 if terminated else 0.9,
+        terminated=terminated,
+        truncated=truncated,
+        autoreset=autoreset,
+        bootstrap_observation_id=bootstrap_observation_id,
+        bootstrap_observation=bootstrap_observation,
+        next_decision_observation_id=next_decision_observation_id,
+        next_decision_observation=next_decision_observation,
+    )
+    return ledger, state, transaction
+
+
+def test_versioned_manifest_binds_canonical_config_and_state_schema() -> None:
+    assert REFERENCE_AGENT_API_VERSION == "asi.reference_agent.preview1"
+    assert REFERENCE_AGENT_MANIFEST_SCHEMA == "asi.reference_agent_manifest.preview1"
+    assert REFERENCE_TRANSACTION_STATE_SCHEMA == "asi.reference_transaction_state.preview1"
+    assert MAX_DECISION_INDEX == (1 << 64) - 1
+    assert [field.name for field in fields(AgentCapabilities)] == ["dispatch_rebinding"]
+
+    first = {"seed": 7, "nested": {"beta": 2, "alpha": 1}}
+    reordered = {"nested": {"alpha": 1, "beta": 2}, "seed": 7}
+    assert canonical_config_sha256(first) == canonical_config_sha256(reordered)
+    with pytest.raises(ValueError, match="finite|JSON"):
+        canonical_config_sha256({"invalid": math.nan})
+
+    manifest = _manifest()
+    assert manifest.state_schema == "tests.fake_reference_state.v1"
+    assert len(manifest.config_sha256) == 64
+    assert len(manifest.manifest_id) == 64
+    assert manifest.config == {"action_scale": 1.0, "agent": "fake", "seed": 7}
+    with pytest.raises(FrozenInstanceError):
+        manifest.implementation_id = "changed"  # type: ignore[misc]
+    with pytest.raises(ValueError, match="schema"):
+        AgentManifest.from_config(
+            schema="alberta.reference_agent.v0",
+            implementation_id="tests.fake_reference_adapter.v1",
+            state_schema="tests.fake_reference_state.v1",
+            config={},
+            observation_spec=_observation_spec(),
+            action_spec=_action_spec(),
+            capabilities=AgentCapabilities(dispatch_rebinding=False),
+        )
+
+
+def test_space_encoding_is_exact_dtype_bounded_and_deeply_immutable() -> None:
+    source = np.array([0.25, -0.5], dtype=np.float32)
+    encoded = _action_spec().encode(source)
+    assert isinstance(encoded, ArrayValue)
+    source[:] = 9.0
+    np.testing.assert_array_equal(encoded.to_numpy(), np.array([0.25, -0.5], np.float32))
+    assert encoded.to_python() == (0.25, -0.5)
+    with pytest.raises(FrozenInstanceError):
+        encoded.payload = b""  # type: ignore[misc]
+
+    with pytest.raises(ValueError, match="dtype|float32"):
+        _action_spec().encode(np.array([0.25, -0.5], dtype=np.float64))
+    with pytest.raises(ValueError, match="dtype|float32"):
+        _action_spec().encode(jnp.array([0.25, -0.5], dtype=jnp.float16))
+    with pytest.raises(ValueError, match="shape"):
+        _action_spec().encode((0.25,))
+    with pytest.raises(ValueError, match="finite"):
+        _action_spec().encode((0.25, math.nan))
+    with pytest.raises(ValueError, match="bounds|range"):
+        _action_spec().encode((0.25, 1.5))
+
+    discrete = SpaceSpec.discrete(
+        cardinality=4,
+        dtype="int32",
+        semantic_id="tests.discrete_action.v1",
+    )
+    assert discrete.encode(3).to_python() == 3
+    with pytest.raises((TypeError, ValueError), match="integer"):
+        discrete.encode(1.0)
+    with pytest.raises((TypeError, ValueError), match="integer|bool"):
+        discrete.encode(True)
+    with pytest.raises(ValueError, match="cardinality|range"):
+        discrete.encode(4)
+    with pytest.raises(ValueError, match="represent|int8|cardinality"):
+        SpaceSpec.discrete(
+            cardinality=300,
+            dtype="int8",
+            semantic_id="tests.too_wide.v1",
+        )
+
+
+def test_manifest_factory_binds_codec_manifest_identity_and_armed_state() -> None:
+    manifest = _manifest()
+    decision = _decision(manifest)
+    assert decision.manifest_id == manifest.manifest_id
+    assert decision.decision_id == "life-a:0"
+    assert decision.decision_index == 0
+    assert decision.observation.semantic_id == manifest.observation_spec.semantic_id
+    assert decision.proposed_action is not None
+    assert decision.proposed_action.semantic_id == manifest.action_spec.semantic_id
+    manifest.validate_decision(decision)
+
+    with pytest.raises(ValueError, match="manifest"):
+        manifest.validate_decision(replace(decision, manifest_id="0" * 64))
+    with pytest.raises(ValueError, match="canonical|decision_id"):
+        replace(decision, decision_id="life-a:reused")
+    with pytest.raises(ValueError, match="lifecycle_id|derived|length|long"):
+        _decision(
+            manifest,
+            lifecycle_id="l" * 243,
+            observation_id="tests.observation:0",
+        )
+    disarmed = _decision(manifest, armed=False)
+    assert disarmed.proposed_action is None and not disarmed.armed
+
+
+def test_authorization_settlement_and_receipt_are_distinct_owned_records() -> None:
+    ledger, state, decision, authorization = _authorized()
+    assert state.phase is TransactionPhase.AUTHORIZED
+    assert authorization.status is AuthorizationStatus.EXACT
+    assert authorization.authorized_action == decision.proposed_action
+    assert authorization.authority_id == "tests.safety_authority.v1"
+
+    state, dispatch = ledger.settle_dispatch(
+        state,
+        authorization,
+        rebinding_applied=False,
+        settlement_id="life-a:0:settlement",
+    )
+    assert state.phase is TransactionPhase.SETTLED
+    assert dispatch is not None and dispatch.status is DispatchStatus.EXACT
+    assert not hasattr(dispatch, "dispatched")
+    assert not hasattr(dispatch, "transition_expected")
+
+    state, receipt = ledger.record_dispatch(
+        state,
+        dispatch,
+        receipt_id="life-a:0:receipt",
+        executor_id="tests.environment_executor.v1",
+    )
+    assert state.phase is TransactionPhase.DISPATCHED
+    assert receipt.dispatch == dispatch
+    assert receipt.effective_action == dispatch.effective_action
+
+    with pytest.raises(DecisionOwnershipError, match="phase|dispatch"):
+        ledger.record_dispatch(
+            state,
+            dispatch,
+            receipt_id="life-a:0:duplicate-receipt",
+            executor_id="tests.environment_executor.v1",
+        )
+
+
+def test_replacement_requires_declared_and_applied_credit_rebinding() -> None:
+    ledger, state, _decision_value, authorization = _authorized(
+        dispatch_rebinding=False,
+        effective_action=(-0.5, 0.5),
+    )
+    assert authorization.status is AuthorizationStatus.REPLACED
+    halted, dispatch = ledger.settle_dispatch(
+        state,
+        authorization,
+        rebinding_applied=False,
+        settlement_id="life-a:0:settlement",
+    )
+    assert dispatch is None
+    assert halted.phase is TransactionPhase.HALTED
+    assert "rebind" in (halted.halt_reason or "")
+
+    ledger, state, _decision_value, authorization = _authorized(
+        dispatch_rebinding=True,
+        effective_action=(-0.5, 0.5),
+    )
+    with pytest.raises(ValueError, match="rebinding_applied"):
+        ledger.settle_dispatch(
+            state,
+            authorization,
+            rebinding_applied=False,
+            settlement_id="life-a:0:settlement",
+        )
+    state, dispatch = ledger.settle_dispatch(
+        state,
+        authorization,
+        rebinding_applied=True,
+        settlement_id="life-a:0:settlement",
+    )
+    assert dispatch is not None and dispatch.status is DispatchStatus.REBOUND
+
+
+def test_veto_halts_before_settlement_dispatch_or_learning() -> None:
+    ledger, state, decision = _armed_ledger()
+    halted, authorization = ledger.authorize(
+        state,
+        decision,
+        authorized_action=None,
+        authority_id="tests.safety_authority.v1",
+        policy_version="tests.safety_policy.v1",
+        authorization_id="life-a:0:authorization",
+        veto_reason="safety envelope",
+    )
+    assert authorization.status is AuthorizationStatus.VETOED
+    assert halted.phase is TransactionPhase.HALTED
+    with pytest.raises(DecisionOwnershipError, match="phase|veto"):
+        ledger.settle_dispatch(
+            halted,
+            authorization,
+            rebinding_applied=False,
+            settlement_id="life-a:0:settlement",
+        )
+
+
+def test_outcome_binds_exact_receipt_and_explicit_boundary_reset_identity() -> None:
+    ledger, state, _decision_value, _authorization, _dispatch, receipt = _dispatched()
+    with pytest.raises(ValueError, match="receipt_id|canonical"):
+        replace(receipt, receipt_id="life-a:0:other-receipt")
+
+    alternate_authorization = replace(
+        receipt.dispatch.authorization,
+        authority_id="tests.other_safety_authority.v1",
+    )
+    alternate_dispatch = replace(receipt.dispatch, authorization=alternate_authorization)
+    alternate_receipt = replace(receipt, dispatch=alternate_dispatch)
+    with pytest.raises(DecisionOwnershipError, match="receipt"):
+        ledger.record_outcome(
+            state,
+            alternate_receipt,
+            reward=1.0,
+            discount=0.9,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+
+    same_value = (0.0, 0.0, 0.0)
+    state, transaction = ledger.record_outcome(
+        state,
+        receipt,
+        reward=1.0,
+        discount=0.0,
+        terminated=True,
+        truncated=False,
+        autoreset=True,
+        bootstrap_observation_id="life-a:terminal:0",
+        bootstrap_observation=same_value,
+        next_decision_observation_id="life-a:reset:1",
+        next_decision_observation=same_value,
+    )
+    assert state.phase is TransactionPhase.OUTCOME
+    assert transaction.is_boundary and transaction.is_autoreset
+    assert transaction.bootstrap_observation == transaction.next_decision_observation
+
+
+@pytest.mark.parametrize("discount", [-0.1, 1.1, math.nan, math.inf])
+def test_outcome_rejects_invalid_discount_without_advancing(discount: float) -> None:
+    ledger, state, _decision_value, _authorization, _dispatch, receipt = _dispatched()
+    before = state
+    with pytest.raises(ValueError, match="discount"):
+        ledger.record_outcome(
+            state,
+            receipt,
+            reward=1.0,
+            discount=discount,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+    assert state == before
+
+
+def test_continuing_outcome_cannot_use_terminal_zero_discount() -> None:
+    ledger, state, _decision_value, _authorization, _dispatch, receipt = _dispatched()
+    with pytest.raises(ValueError, match="discount|terminated"):
+        ledger.record_outcome(
+            state,
+            receipt,
+            reward=1.0,
+            discount=0.0,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+
+
+def test_outcome_rejects_scalar_that_overflows_during_protocol_conversion() -> None:
+    ledger, state, _decision_value, _authorization, _dispatch, receipt = _dispatched()
+    huge = 10**400
+    with pytest.raises(ValueError, match="reward|finite|representable"):
+        ledger.record_outcome(
+            state,
+            receipt,
+            reward=huge,
+            discount=0.9,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+
+    tiny = Fraction(1, 10**400)
+    with pytest.raises(ValueError, match="reward|underflow|representable"):
+        ledger.record_outcome(
+            state,
+            receipt,
+            reward=tiny,
+            discount=0.9,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+
+
+def test_ledger_enforces_one_lifecycle_monotonic_decisions_and_exactly_once_phases() -> None:
+    ledger, armed, decision = _armed_ledger()
+    with pytest.raises(DecisionOwnershipError, match="phase|armed"):
+        ledger.arm(armed, decision)
+    with pytest.raises(DecisionOwnershipError, match="initialized|current|replay"):
+        ledger.init()
+
+    ledger, state, transaction = _outcome()
+    assert transaction.next_decision_observation_id is not None
+    assert transaction.next_decision_observation is not None
+    next_decision = _decision(
+        ledger.manifest,
+        decision_index=1,
+        observation_id=transaction.next_decision_observation_id,
+        observation=transaction.next_decision_observation.to_numpy(),
+    )
+    state, result = ledger.accept(
+        state,
+        next_decision=next_decision,
+        parameters_changed=True,
+    )
+    assert state.phase is TransactionPhase.ARMED
+    assert state.next_decision_index == 1
+    assert result.transaction_accepted and result.next_decision == next_decision
+
+    with pytest.raises(DecisionOwnershipError, match="phase|outcome"):
+        ledger.accept(state, next_decision=None, parameters_changed=False)
+    with pytest.raises(DecisionOwnershipError, match="current|replay|stale"):
+        ledger.arm(
+            replace(state, phase=TransactionPhase.READY, decision=None),
+            _decision(ledger.manifest, lifecycle_id="life-b", decision_index=1),
+        )
+
+
+def test_ledger_rejects_old_state_replay_and_phase_or_chain_forgery() -> None:
+    ledger, settled, decision, _authorization, dispatch = _settled()
+    dispatched, _receipt = ledger.record_dispatch(
+        settled,
+        dispatch,
+        receipt_id="life-a:0:receipt",
+        executor_id="tests.environment_executor.v1",
+    )
+    with pytest.raises(DecisionOwnershipError, match="current|replay|stale"):
+        ledger.record_dispatch(
+            settled,
+            dispatch,
+            receipt_id="life-a:0:second-receipt",
+            executor_id="tests.environment_executor.v1",
+        )
+    with pytest.raises(DecisionOwnershipError, match="current|replay|stale"):
+        ledger.record_outcome(
+            replace(dispatched),
+            _receipt,
+            reward=1.0,
+            discount=0.9,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            bootstrap_observation_id="life-a:observation:1",
+            bootstrap_observation=(0.1, 0.2, 0.3),
+            next_decision_observation_id="life-a:observation:1",
+            next_decision_observation=(0.1, 0.2, 0.3),
+        )
+
+    with pytest.raises(ValueError, match="phase|fields|records"):
+        replace(dispatched, phase=TransactionPhase.READY)
+
+    rolled_back = replace(
+        settled,
+        phase=TransactionPhase.READY,
+        lifecycle_id=decision.lifecycle_id,
+        decision=None,
+        authorization=None,
+        dispatch=None,
+    )
+    with pytest.raises(DecisionOwnershipError, match="current|replay|stale"):
+        ledger.arm(rolled_back, decision)
+
+    other = _manifest()
+    foreign_decision = _decision(other, lifecycle_id="life-foreign")
+    with pytest.raises(ValueError, match="manifest|lifecycle|ownership"):
+        replace(settled, decision=foreign_decision)
+
+    disarmed = _decision(
+        ledger.manifest,
+        lifecycle_id=decision.lifecycle_id,
+        decision_index=decision.decision_index,
+        armed=False,
+    )
+    with pytest.raises(ValueError, match="armed|disarmed"):
+        replace(
+            settled,
+            phase=TransactionPhase.ARMED,
+            decision=disarmed,
+            authorization=None,
+            dispatch=None,
+        )
+
+
+def test_ledger_serializes_concurrent_authorization_of_one_snapshot() -> None:
+    ledger, armed, decision = _armed_ledger(dispatch_rebinding=True)
+    barrier = threading.Barrier(2)
+
+    def authorize() -> object:
+        barrier.wait()
+        return ledger.authorize(
+            armed,
+            decision,
+            authorized_action=None,
+            authority_id="tests.safety_authority.v1",
+            policy_version="tests.safety_policy.v1",
+            authorization_id="life-a:0:authorization",
+        )
+
+    successes = 0
+    failures = 0
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(authorize) for _ in range(2)]
+        for future in futures:
+            try:
+                future.result()
+                successes += 1
+            except DecisionOwnershipError:
+                failures += 1
+
+    assert (successes, failures) == (1, 1)
+
+
+def test_live_ledger_owner_cannot_be_pickled_as_an_undeclared_resume_surface() -> None:
+    ledger, state, _decision_value = _armed_ledger()
+    with pytest.raises(TypeError, match="ledger|serialize|checkpoint|resume"):
+        pickle.dumps((ledger, state))
+
+
+def test_rejected_transaction_cannot_consume_event_or_arm_next_decision() -> None:
+    ledger, state, transaction = _outcome()
+    assert transaction.next_decision_observation_id is not None
+    assert transaction.next_decision_observation is not None
+    next_decision = _decision(
+        ledger.manifest,
+        decision_index=1,
+        observation_id=transaction.next_decision_observation_id,
+        observation=transaction.next_decision_observation.to_numpy(),
+    )
+    before_index = state.next_decision_index
+    halted, result = ledger.reject(state, reason="atomic learner update rejected")
+    assert halted.phase is TransactionPhase.HALTED
+    assert halted.next_decision_index == before_index
+    assert halted.transaction == transaction
+    assert not result.transaction_accepted
+    assert not result.parameters_changed
+    assert not result.event_consumed
+    assert result.recovery_required
+    assert result.next_decision is None
+
+    with pytest.raises(ValueError, match="rejected|next decision|next_decision"):
+        StepResult(
+            transaction=transaction,
+            next_decision=next_decision,
+            transaction_accepted=False,
+            parameters_changed=False,
+            rejection_reason="atomic learner update rejected",
+        )
+
+
+def test_step_result_rejects_disarmed_or_cross_manifest_next_decision() -> None:
+    ledger, state, transaction = _outcome()
+    assert transaction.next_decision_observation_id is not None
+    assert transaction.next_decision_observation is not None
+    disarmed = _decision(
+        ledger.manifest,
+        decision_index=1,
+        observation_id=transaction.next_decision_observation_id,
+        observation=transaction.next_decision_observation.to_numpy(),
+        armed=False,
+    )
+    with pytest.raises(ValueError, match="armed"):
+        StepResult(
+            transaction=transaction,
+            next_decision=disarmed,
+            transaction_accepted=True,
+            parameters_changed=False,
+            rejection_reason=None,
+        )
+
+    other_manifest = AgentManifest.from_config(
+        schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+        implementation_id="tests.other_reference_adapter.v1",
+        state_schema="tests.other_reference_state.v1",
+        config={},
+        observation_spec=_observation_spec(),
+        action_spec=_action_spec(),
+        capabilities=AgentCapabilities(dispatch_rebinding=False),
+    )
+    foreign = _decision(
+        other_manifest,
+        decision_index=1,
+        observation_id=transaction.next_decision_observation_id,
+        observation=transaction.next_decision_observation.to_numpy(),
+    )
+    with pytest.raises(DecisionOwnershipError, match="manifest"):
+        StepResult(
+            transaction=transaction,
+            next_decision=foreign,
+            transaction_accepted=True,
+            parameters_changed=False,
+            rejection_reason=None,
+        )
+
+
+def test_counter_is_bounded_and_final_event_is_consumed_before_disarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    with pytest.raises(ValueError, match="decision_index|uint64|maximum"):
+        _decision(manifest, decision_index=MAX_DECISION_INDEX + 1)
+
+    monkeypatch.setattr(reference_agent, "MAX_DECISION_INDEX", 0)
+    ledger, state, transaction = _outcome()
+    state, result = ledger.accept(
+        state,
+        next_decision=None,
+        parameters_changed=True,
+    )
+    assert result.transaction_accepted
+    assert result.event_consumed
+    assert result.life_exhausted
+    assert state.phase is TransactionPhase.EXHAUSTED
+    assert state.next_decision_index == 0
+
+
+def test_boundary_without_autoreset_waits_for_explicit_next_arm() -> None:
+    ledger, state, transaction = _outcome(
+        terminated=True,
+        autoreset=False,
+        bootstrap_observation=(0.0, 0.0, 0.0),
+        bootstrap_observation_id="life-a:terminal:0",
+        next_decision_observation=None,
+        next_decision_observation_id=None,
+    )
+    state, result = ledger.accept(
+        state,
+        next_decision=None,
+        parameters_changed=True,
+    )
+    assert state.phase is TransactionPhase.READY
+    assert result.next_decision is None
+
+    reset_decision = _decision(
+        ledger.manifest,
+        decision_index=1,
+        observation_id="life-a:reset:1",
+        observation=(0.0, 0.0, 0.0),
+    )
+    state = ledger.arm(state, reset_decision)
+    assert state.phase is TransactionPhase.ARMED


### PR DESCRIPTION
Focused replacement for #190.

This carries only the development-only L0 reference transaction protocol, the primitive exact-dispatch Prototype adapter, and their adversarial tests. It deliberately excludes #190’s unrelated rebrand, campaign, evidence, OCI, packaging, and overview-document changes. The protocol remains process-local and non-serializable; this is not a whole-life runner, exact resume, safety boundary, `reference-dev`, or scientific evidence.

The platform-dependent `np.longdouble` overflow/underflow test has been replaced with exact Python `int`/`Fraction` inputs, so the contract is testable on macOS arm64 where `longdouble == float64`.

Verification on current main:
- 40 reference protocol + Prototype adapter tests passed
- Ruff passed on all four files
- strict mypy passed on both source files
- `git diff --check` passed