### PR TITLE
fix(step7): prevent full replay-memory counter overflow

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -219,7 +219,8 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_memory_size",
         config.planning_memory_size,
         minimum=1,
-        maximum=_INT32_MAX,
+        # ``memory_count + 1`` is computed in int32 before saturation.
+        maximum=_INT32_MAX - 1,
     )
     importance_clip = _require_positive_real(
         "planning_importance_ratio_clip",

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -655,7 +655,7 @@ def test_step7_dyna_preserves_float32_boundaries() -> None:
         planning_steps=2**31 - 1,
         planning_rollout_depth=2**31 - 1,
         planning_warmup_steps=2**31 - 1,
-        planning_memory_size=2**31 - 1,
+        planning_memory_size=2**31 - 2,
         planning_importance_ratio_clip=f32_max,
         planning_priority_propagation=f32_max,
         planning_utility_step_size=1.0,
@@ -663,10 +663,13 @@ def test_step7_dyna_preserves_float32_boundaries() -> None:
     assert config.planning_steps == 2**31 - 1
     assert config.planning_rollout_depth == 2**31 - 1
     assert config.planning_warmup_steps == 2**31 - 1
-    assert config.planning_memory_size == 2**31 - 1
+    assert config.planning_memory_size == 2**31 - 2
     assert config.planning_importance_ratio_clip == f32_max
     assert config.planning_priority_propagation == f32_max
     assert config.planning_utility_step_size == 1.0
+
+    with pytest.raises(ValueError, match="planning_memory_size"):
+        Step7DynaConfig(planning_memory_size=2**31 - 1)
 
 
 def test_step7_dyna_exact_fraction_rounding() -> None:


### PR DESCRIPTION
Follow-up to merged #352.

`planning_memory_size=INT32_MAX` is not a safe endpoint: once the int32 `memory_count` is full, `memory_count + 1` overflows before the existing saturation. Cap the ring-buffer capacity at `INT32_MAX - 1` and pin both the accepted and rejected endpoints. Other Step 7 dimensions retain their INT32_MAX endpoint.

Verification:
- 119 Step 7 production tests passed
- Ruff, strict mypy, and `git diff --check` passed