### PR TITLE
fix(core): reconcile Prototype and memory contracts

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -613,12 +613,6 @@ class PrototypeAgentConfig:
                     f"got {self.world_model.n_actions} and "
                     f"{self.oak.n_primitive_actions}"
                 )
-            if self.world_model.gamma <= 0.0:
-                raise ValueError(
-                    "world_model.gamma must be positive: the legacy update synthesizes "
-                    "transitions with discount=gamma and terminated=False, which the "
-                    "boundary contract rejects when gamma is zero"
-                )
         if self.world_model_ensemble is not None:
             ensemble_model = self.world_model_ensemble.model
             if ensemble_model.observation_dim != self.oak.observation_dim:
@@ -5271,7 +5265,9 @@ class PrototypeAgent:
         explicit discount.  This wrapper preserves the former behavior:
         primitive control bootstraps with one, option returns use
         ``STOMPConfig.option_gamma``, and the world model (when enabled)
-        receives its configured gamma as the target discount.
+        receives its configured gamma as the target discount. Because this
+        surface has no terminal flag, a configured zero model discount requires
+        the explicit :meth:`update_transition` API.
         """
         if self._state_builder is not None:
             raise ValueError(
@@ -5291,6 +5287,11 @@ class PrototypeAgent:
                 )
             )
         )
+        if legacy_model_discount == 0.0:
+            raise ValueError(
+                "legacy update is unavailable when the configured world-model gamma "
+                "is zero; use update_transition with an explicit terminal transition"
+            )
         current_oak_state = self._oak_component_state(state.oak_state)
         feature_consumer_binding = (
             self._feature_consumer_binding(state.oak_state)

--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -18,8 +18,6 @@ the packaged Step 2 retained-view memory
 from __future__ import annotations
 
 import functools
-import math
-from numbers import Integral, Real
 from typing import Any, cast
 
 import chex
@@ -29,7 +27,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
@@ -37,79 +35,38 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX: int = 2**31 - 1
-
-
-def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
-    """Return the original real, exact ratio, and finite binary32 rounding."""
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    real = cast(Real, value)
-    try:
-        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
-    return real, numerator, denominator, narrowed
-
-
-def canonical_float32_storage(value: Real, narrowed: float) -> float:
-    if not isinstance(value, (int, float, np.floating)):
-        return narrowed
-    try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return narrowed
-    if not math.isfinite(number):
-        raise ValueError("scalar must be finite")
-    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
-        renarrowed = np.asarray(number, dtype=np.float32)
-    if not bool(np.array_equal(narrowed, renarrowed)):
-        number = float(narrowed)
-    return number
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
-    if (
-        real < 0.0
-        or not real <= 1.0
-        or numerator < 0
-        or numerator > denominator
-        or narrowed < 0.0
-        or not narrowed <= 1.0
-    ):
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
-    if (
-        real <= 0.0
-        or not real <= 1.0
-        or numerator <= 0
-        or numerator > denominator
-        or narrowed <= 0.0
-        or not narrowed <= 1.0
-    ):
-        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(
+        name,
+        value,
+        positive=True,
+        upper=1.0,
+    )
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, lower=0.0)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, positive=True)
 
 
 def _require_int(
@@ -119,10 +76,9 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
+    number = int(cast(int, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -14,9 +14,7 @@ rather than a route-selecting portfolio.
 from __future__ import annotations
 
 import functools
-import math
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
 from typing import Any, Literal, cast
 
 import chex
@@ -27,7 +25,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.optimizers import ObGDBounding
 from alberta_framework.core.prototype_memory import (
     PrototypeMemoryConfig,
@@ -42,98 +40,52 @@ from alberta_framework.core.update_safety import (
 from alberta_framework.core.upgd import UPGDLearner, UPGDState
 
 _INT32_MAX: int = 2**31 - 1
-
-
-def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
-    """Return the original real, exact ratio, and finite binary32 rounding."""
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
-    real = cast(Real, value)
-    try:
-        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
-    if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
-    return real, numerator, denominator, narrowed
-
-
-def canonical_float32_storage(value: Real, narrowed: float) -> float:
-    if not isinstance(value, (int, float, np.floating)):
-        return narrowed
-    try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return narrowed
-    if not math.isfinite(number):
-        raise ValueError("scalar must be finite")
-    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
-        renarrowed = np.asarray(number, dtype=np.float32)
-    if not bool(np.array_equal(narrowed, renarrowed)):
-        number = float(narrowed)
-    return number
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
 
 
 def _require_real(name: str, value: object) -> float:
-    real, _, _, narrowed = finite_real_and_float32(name, value)
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
-    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
-    if (
-        real < 0.0
-        or not real <= 1.0
-        or numerator < 0
-        or numerator > denominator
-        or narrowed < 0.0
-        or not narrowed <= 1.0
-    ):
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
-    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
-    if (
-        real <= 0.0
-        or not real <= 1.0
-        or numerator <= 0
-        or numerator > denominator
-        or narrowed <= 0.0
-        or not narrowed <= 1.0
-    ):
-        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(
+        name,
+        value,
+        positive=True,
+        upper=1.0,
+    )
 
 
 def _require_half_open_zero_one_interval(name: str, value: object) -> float:
-    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
-    if (
-        real < 0.0
-        or not real < 1.0
-        or numerator < 0
-        or numerator >= denominator
-        or narrowed < 0.0
-        or not narrowed < 1.0
-    ):
-        raise ValueError(f"{name} must be in [0, 1), got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(
+        name,
+        value,
+        lower=0.0,
+        upper=1.0,
+        upper_inclusive=False,
+    )
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
-    real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, lower=0.0)
 
 
 def _require_positive_real(name: str, value: object) -> float:
-    real, numerator, _, narrowed = finite_real_and_float32(name, value)
-    if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
-    return canonical_float32_storage(real, narrowed)
+    return validated_float32_scalar(name, value, positive=True)
 
 
 def _require_int(
@@ -143,10 +95,9 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
+    number = int(cast(int, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")
@@ -433,7 +384,7 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     novelty_adaptation_rate = _require_nonnegative_real(
         "novelty_adaptation_rate", config.novelty_adaptation_rate
     )
-    target_allocation_rate = _require_half_open_zero_one_interval(
+    target_allocation_rate = _require_unit_interval(
         "target_allocation_rate", config.target_allocation_rate
     )
     min_novelty_threshold = _require_positive_real(
@@ -442,8 +393,8 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     max_novelty_threshold = _require_positive_real(
         "max_novelty_threshold", config.max_novelty_threshold
     )
-    if min_novelty_threshold >= max_novelty_threshold:
-        raise ValueError("min_novelty_threshold must be strictly less than max_novelty_threshold")
+    if min_novelty_threshold > max_novelty_threshold:
+        raise ValueError("min_novelty_threshold must be <= max_novelty_threshold")
 
     object.__setattr__(config, "feature_dim", feature_dim)
     object.__setattr__(config, "n_heads", n_heads)

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -259,10 +259,38 @@ class TestPrototypeAgentConfigValidation:
         state = agent.start(agent.init(jr.key(0)), jnp.zeros(OBS_DIM))
         assert int(agent.update(state, 0.1, jnp.ones(OBS_DIM)).state.step_count) == 1
 
-    def test_legacy_world_model_gamma_zero_is_rejected(self) -> None:
-        """gamma == 0 makes the legacy update synthesize discount=0, terminated=False forever."""
-        with pytest.raises(ValueError, match="world_model.gamma must be positive"):
-            PrototypeAgentConfig(oak=_oak_cfg(), world_model=_wm_cfg(gamma=0.0))
+    def test_world_model_gamma_zero_requires_explicit_transition_api(self) -> None:
+        """A zero model horizon is valid, but the legacy API has no terminal input."""
+        config = PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            world_model=_wm_cfg(gamma=0.0),
+        )
+        restored = PrototypeAgentConfig.from_config(config.to_config())
+        assert restored.world_model is not None
+        assert restored.world_model.gamma == 0.0
+
+        agent = PrototypeAgent(config)
+        state = agent.start(agent.init(jr.key(41)), jnp.zeros(OBS_DIM))
+        next_observation = jnp.ones(OBS_DIM, dtype=jnp.float32)
+        with pytest.raises(ValueError, match="use update_transition"):
+            agent.update(state, jnp.asarray(1.0), next_observation)
+
+        result = agent.update_transition(
+            state,
+            PrototypeTransition(
+                observation=state.current_raw_observation,
+                action=state.current_action,
+                decision_id=state.current_decision_id,
+                reward=jnp.asarray(1.0, dtype=jnp.float32),
+                discount=jnp.asarray(0.0, dtype=jnp.float32),
+                terminated=jnp.asarray(True),
+                truncated=jnp.asarray(False),
+                next_observation=next_observation,
+                next_decision_observation=next_observation,
+            ),
+        )
+        assert bool(result.transition_diagnostics.valid)
+        assert int(result.state.step_count) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -246,7 +246,7 @@ def test_prototype_memory_rejects_adversarial_ratio_floats(
         def as_integer_ratio(self) -> tuple[int, int]:
             return ratio
 
-    with pytest.raises(ValueError, match=r"update_rate must be in \(0, 1\]"):
+    with pytest.raises(ValueError, match="update_rate"):
         PrototypeMemoryConfig(
             feature_dim=4,
             n_classes=2,
@@ -264,9 +264,21 @@ def test_prototype_memory_rejects_class_property_spoofing_float() -> None:
             return (1, 2)
 
     value = ClassSpoof()
-    with pytest.raises(ValueError, match="must be a real number"):
+    with pytest.raises(ValueError, match="finite real"):
         PrototypeMemoryConfig(
             feature_dim=4,
             n_classes=2,
             update_rate=value,  # type: ignore[arg-type]
         )
+
+
+def test_prototype_memory_rejects_hostile_integral_subclasses() -> None:
+    class LieInt(int):
+        def __int__(self) -> int:
+            return 4
+
+    for field in ("feature_dim", "n_classes", "slots_per_class"):
+        with pytest.raises(ValueError, match=field):
+            PrototypeMemoryConfig(
+                **{"feature_dim": 4, "n_classes": 2, field: LieInt(-1)}
+            )

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -416,7 +416,7 @@ def test_upgd_memory_rejects_adversarial_ratio_floats(
         def as_integer_ratio(self) -> tuple[int, int]:
             return ratio
 
-    with pytest.raises(ValueError, match=r"memory_update_rate must be in \(0, 1\]"):
+    with pytest.raises(ValueError, match="memory_update_rate"):
         UPGDMemoryConfig(
             feature_dim=2,
             n_heads=2,
@@ -434,7 +434,7 @@ def test_upgd_memory_rejects_class_property_spoofing_float() -> None:
             return (1, 2)
 
     value = ClassSpoof()
-    with pytest.raises(ValueError, match="must be a real number"):
+    with pytest.raises(ValueError, match="finite real"):
         UPGDMemoryConfig(
             feature_dim=2,
             n_heads=2,
@@ -514,3 +514,38 @@ def test_upgd_memory_json_roundtrip() -> None:
     assert restored == config
     assert restored.hidden_sizes == (16, 8)
     assert restored.readout_mode == "softmax_ce"
+
+
+def test_upgd_memory_rejects_hostile_integral_subclasses() -> None:
+    class LieInt(int):
+        def __int__(self) -> int:
+            return 4
+
+    defaults: dict[str, object] = {"feature_dim": 2, "n_heads": 2}
+    for field in (
+        "feature_dim",
+        "n_heads",
+        "upgd_head_loss_pressure_warmup_steps",
+        "upgd_head_repetition_warmup_steps",
+        "slots_per_class",
+    ):
+        with pytest.raises(ValueError, match=field):
+            UPGDMemoryConfig(**{**defaults, field: LieInt(-1)})  # type: ignore[arg-type]
+
+
+def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
+    allocation_endpoint = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=2,
+        target_allocation_rate=1.0,
+    )
+    fixed_threshold = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=2,
+        min_novelty_threshold=0.5,
+        max_novelty_threshold=0.5,
+    )
+
+    assert allocation_endpoint.target_allocation_rate == 1.0
+    assert fixed_threshold.min_novelty_threshold == 0.5
+    assert fixed_threshold.max_novelty_threshold == 0.5


### PR DESCRIPTION
Corrective integration for conflicting #634, #635, and #638.

The coherent contract is:
- `gamma=0` remains a legal world-model horizon for the explicit transition API, where the caller can provide the required terminal flag. The legacy wrapper must reject that configuration at call time because it has no environmental terminal input; synthesizing `terminated=True` from a model hyperparameter would falsely reset episode state and zero Horde horizons, while globally banning zero gamma would unnecessarily break the explicit API.
- Linear UPGD memory (`hidden_sizes=()`), `target_allocation_rate=1.0`, and equal positive novelty clamp endpoints remain legal, matching the documented pre-#443 contracts and runtime algebra.
- Memory scalar validation delegates to the shared exact float32 helper and rejects hostile integer subclasses.

Verification:
- memory modules: 181 passed
- Prototype config validation: 17 passed
- Ruff clean
- strict mypy clean for four changed source files
- diff check clean