### PR TITLE
fix(step9): preserve uint32 seeds and reject spoofed hidden-size containers

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -35,6 +35,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAState,
@@ -259,7 +260,7 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
             f"control.n_actions ({config.control.n_actions}) must equal "
             f"n_actions ({n_actions})"
         )
-    if not isinstance(config.model_hidden_sizes, tuple):
+    if type(config.model_hidden_sizes) is not tuple:
         raise ValueError(
             f"model_hidden_sizes must be a tuple of integers, got "
             f"{config.model_hidden_sizes!r}"
@@ -818,7 +819,7 @@ def run_step9_smoke(
 ) -> Step9SmokeResult:
     """Run a tiny deterministic Step 9 dreaming integration probe."""
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
-    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    seed = require_jax_seed(seed, name="seed")
 
     cfg = config or Step9DreamingConfig()
     agent, model, buffer = make_step9_components(cfg)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -853,13 +853,27 @@ def test_step9_smoke_rejects_class_spoofed_integer_steps() -> None:
     [
         ({"steps": 2**31}, "steps"),
         ({"seed": -1}, "seed"),
-        ({"seed": 2**31}, "seed"),
+        ({"seed": 2**32}, "seed"),
         ({"seed": True}, "seed"),
     ],
 )
 def test_step9_smoke_enforces_int32_inputs(kwargs: dict[str, object], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         run_step9_smoke(**kwargs)  # type: ignore[arg-type]
+
+
+def test_step9_smoke_accepts_full_uint32_seed_range() -> None:
+    assert run_step9_smoke(steps=1, seed=2**32 - 1).seed == 2**32 - 1
+
+
+def test_step9_config_requires_actual_hidden_size_tuple() -> None:
+    class SpoofedTuple(list[int]):
+        @property
+        def __class__(self) -> type[tuple]:
+            return tuple
+
+    with pytest.raises(ValueError, match="model_hidden_sizes"):
+        Step9DreamingConfig(model_hidden_sizes=SpoofedTuple([4]))  # type: ignore[arg-type]
 
 
 def test_step9_smoke_linear_model() -> None:


### PR DESCRIPTION
Residual repair for closed #389 after #630 landed its int32 facade/count bounds.

This uses the shared `require_jax_seed` contract so the full JAX uint32 seed domain remains legal (`2**32 - 1`), while rejecting negative, bool, and overflow seeds. It also requires an actual tuple for `model_hidden_sizes`, closing the dynamic-`__class__` container spoof path without disturbing the current exact-ratio scalar helpers.

Verification:
- 242 Step 9 + dreaming tests passed
- Ruff, strict mypy, and `git diff --check` passed