### PR TITLE
fix(step11): use canonical JAX uint32 smoke seed domain

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -37,6 +37,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.oak import (
     KeyboardChordLearnerConfig,
     KeyboardChordLearnerState,
@@ -471,7 +472,7 @@ def run_step11_smoke(
         :class:`Step11SmokeResult` with shape/fineness summary.
     """
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
-    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    seed = require_jax_seed(seed, name="seed")
 
     cfg = config
     if cfg is None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1074,6 +1074,19 @@ def test_run_step11_smoke_rejects_class_spoofed_integer_steps() -> None:
         run_step11_smoke(steps=_SpoofedInt())  # type: ignore[arg-type]
 
 
+def test_step11_checks_host_ratio_and_float32_domains() -> None:
+    class ContradictoryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return (1, 2)
+
+    with pytest.raises(ValueError, match="option_gamma"):
+        Step11OaKConfig(option_gamma=ContradictoryFloat(-0.5))
+
+
+def test_step11_smoke_uses_full_jax_uint32_seed_contract() -> None:
+    assert run_step11_smoke(steps=1, seed=2**32 - 1).seed == 2**32 - 1
+
+
 # ---------------------------------------------------------------------------
 # Long-horizon fineness
 # ---------------------------------------------------------------------------
@@ -1159,7 +1172,7 @@ def test_step11_oak_rejects_integer_subclass_conversion_hooks() -> None:
         ({"steps": True}, "steps"),
         ({"steps": "64"}, "steps"),
         ({"seed": -1}, "seed"),
-        ({"seed": 2**31}, "seed"),
+        ({"seed": 2**32}, "seed"),
         ({"seed": True}, "seed"),
     ],
 )


### PR DESCRIPTION
Narrow residual repair after #640.

The earlier version duplicated #640 and would have weakened its strict integer-family checks. This update merges current main and keeps only the remaining valid delta: `run_step11_smoke` now uses the shared `require_jax_seed` contract, accepting the complete uint32 JAX scalar-key domain while rejecting booleans, aliases, negatives, and values above `2**32 - 1`.

Validation:
- `pytest tests/test_step11_production.py -q -o addopts=` — 207 passed
- scoped ruff — passed
- strict mypy for `step11.py` — passed
- `git diff --check` — clean

No outputs or evidence artifacts changed.