### PR TITLE
fix(benchmarks): validate replication hyperparameter overrides

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -747,6 +747,11 @@ def resolve_hyperparameters(
         unknown = set(overrides) - set(merged)
         if unknown:
             raise ValueError(f"unknown hyperparameters for {learner}: {sorted(unknown)}")
+        for name, value in overrides.items():
+            if type(value) not in (int, float) or not math.isfinite(value):
+                raise ValueError(
+                    f"hyperparameter {name!r} must be a finite JSON number"
+                )
         merged.update({name: float(value) for name, value in overrides.items()})
     return merged
 

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -446,6 +446,11 @@ def resolve_hyperparameters(
         unknown = set(overrides) - set(merged)
         if unknown:
             raise ValueError(f"unknown hyperparameters for {learner}: {sorted(unknown)}")
+        for name, value in overrides.items():
+            if type(value) not in (int, float) or not math.isfinite(value):
+                raise ValueError(
+                    f"hyperparameter {name!r} must be a finite JSON number"
+                )
         merged.update({name: float(value) for name, value in overrides.items()})
     return merged
 

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -88,6 +88,27 @@ class TestProtocolConstants:
         with pytest.raises(ValueError, match="unknown learner"):
             resolve_hyperparameters("sgd", None)
 
+    @pytest.mark.parametrize("value", [True, float("nan"), float("inf"), "0.1"])
+    def test_resolve_hyperparameters_rejects_nonfinite_or_non_json_numbers(
+        self, value: object
+    ) -> None:
+        with pytest.raises(ValueError, match="finite JSON number"):
+            resolve_hyperparameters("upgd_w", {"step_size": value})  # type: ignore[dict-item]
+
+    def test_resolve_hyperparameters_rejects_class_spoofed_number(self) -> None:
+        class SpoofedNumber:
+            @property
+            def __class__(self) -> type[float]:
+                return float
+
+            def __float__(self) -> float:
+                return 0.1
+
+        with pytest.raises(ValueError, match="finite JSON number"):
+            resolve_hyperparameters(  # type: ignore[dict-item]
+                "upgd_w", {"step_size": SpoofedNumber()}
+            )
+
 
 class TestSchedule:
     def test_task_index_changes_exactly_at_multiples_of_task_length(self):

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -88,6 +88,27 @@ class TestConfig:
         with pytest.raises(ValueError, match="unknown learner"):
             resolve_hyperparameters("sgd")
 
+    @pytest.mark.parametrize("value", [True, float("nan"), float("inf"), "0.1"])
+    def test_resolve_hyperparameters_rejects_nonfinite_or_non_json_numbers(
+        self, value: object
+    ) -> None:
+        with pytest.raises(ValueError, match="finite JSON number"):
+            resolve_hyperparameters("upgd_w", {"step_size": value})  # type: ignore[dict-item]
+
+    def test_resolve_hyperparameters_rejects_class_spoofed_number(self) -> None:
+        class SpoofedNumber:
+            @property
+            def __class__(self) -> type[float]:
+                return float
+
+            def __float__(self) -> float:
+                return 0.1
+
+        with pytest.raises(ValueError, match="finite JSON number"):
+            resolve_hyperparameters(  # type: ignore[dict-item]
+                "upgd_w", {"step_size": SpoofedNumber()}
+            )
+
     def test_normalized_arm_hyperparameters(self):
         """EMA-norm transfer arms: published EMNIST UPGD-W values + the exact
         screening-lane normalizer settings (norm_decay=0.999, eps=1e-8)."""


### PR DESCRIPTION
Supersedes #631. Both IPMNIST replication resolvers now reject non-finite values, booleans, non-JSON numeric stand-ins, and class-spoofed values before float conversion. The boundary intentionally accepts only actual built-in int/float values because overrides originate from JSON. Added identical regression coverage for both lanes. Verification: 129 focused tests passed; Ruff passed; diff-check clean.