### PR TITLE
fix(streams): reject class-spoofed non-real synthetic-stream scalars

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -68,10 +68,11 @@ def _require_normal_float32_scale(name: str, value: object) -> float:
 def _require_finite_nonnegative_float32(name: str, value: object) -> float:
     """Require a finite non-negative float32 execution value."""
     message = f"{name} must be a finite non-negative float32 value"
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(message)
     try:
-        narrowed = float(np.float32(value))
+        narrowed = float(np.float32(cast(Real, value)))
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed) or narrowed < 0.0:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -54,6 +54,21 @@ class TestRandomWalkStream:
             with pytest.raises(ValueError, match=name):
                 RandomWalkStream(feature_dim=4, **{name: value})
 
+    def test_rejects_class_spoofed_float_params(self):
+        """A __class__-spoofed non-float must not bypass the Real check."""
+
+        class _SpoofedFloat:
+            @property
+            def __class__(self) -> type:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                return 0.1
+
+        for name in ("drift_rate", "noise_std", "feature_std"):
+            with pytest.raises(ValueError, match=name):
+                RandomWalkStream(feature_dim=4, **{name: _SpoofedFloat()})
+
     def test_step_produces_valid_timestep(self, rng_key):
         """Step should produce valid observation and target."""
         stream = RandomWalkStream(feature_dim=10)


### PR DESCRIPTION
Closes #648.

## What changed

Same isinstance-spoofing class already fixed across `step*.py`, `forager_results.py` (#424), and `representation_gradient_mixer.py`/`partner_policy_fusion.py`/`types.py` (#569/#571/#574): `_require_finite_nonnegative_float32` in `synthetic.py` used `isinstance(value, bool) or not isinstance(value, Real)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passes `isinstance(value, Real)` even though `type(value) is not float`.

`RandomWalkStream.__init__`, `AbruptChangeStream.__init__`, and `CyclicStream.__init__` all route `drift_rate`/`noise_std`/`feature_std` through this helper.

## Reachability

All three stream classes are exported from `alberta_framework.streams.__all__`, and each constructor runs the vulnerable check on every instantiation - publicly reachable with ordinary concrete inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED drift_rate ACCEPTED: 0.10000000149011612 <class 'float'>
```

- new test `test_rejects_class_spoofed_float_params` in `TestRandomWalkStream`, covering all 3 fields, added next to the existing `test_rejects_non_finite_or_negative_float_params`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `165 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
