### PR TITLE
fix(core): restore empty UPGD memory trunk support

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -288,14 +288,10 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
         raise TypeError(
             f"hidden_sizes must be an actual tuple, got {type(config.hidden_sizes).__name__}"
         )
-    if not config.hidden_sizes:
-        raise ValueError("hidden_sizes must contain only positive widths")
     canonical_hidden = tuple(
         _require_int("hidden_sizes element", size, minimum=1, maximum=_INT32_MAX)
         for size in config.hidden_sizes
     )
-    if not canonical_hidden:
-        raise ValueError("hidden_sizes must contain only positive widths")
     readout_mode = config.readout_mode
     if type(readout_mode) is not str:
         raise TypeError(

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -17,8 +17,11 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.dreaming import DreamingConfig
+from alberta_framework.core.dual_replay import DualReplayConfig
 from alberta_framework.core.experiential_memory import ExperientialMemoryConfig
 from alberta_framework.core.intelligence_amplification import IAConfig
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.model_replay_rehearsal import ModelReplayRehearsalConfig
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
@@ -37,6 +40,7 @@ from alberta_framework.core.prototype_agent import (
 )
 from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import WorldModelEnsembleConfig
 
 pytestmark = pytest.mark.slow
 
@@ -101,6 +105,17 @@ def _wm_cfg(
         hidden_sizes=(),  # linear for speed
         step_size=0.1,
         error_decay=0.99,
+    )
+
+
+def _ensemble_cfg(*, gamma: float) -> WorldModelEnsembleConfig:
+    return WorldModelEnsembleConfig(
+        model=_wm_cfg(gamma=gamma),
+        signal_estimator=LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=OBS_DIM + 2,
+        ),
+        ensemble_size=2,
     )
 
 
@@ -274,7 +289,6 @@ class TestPrototypeAgentConfigValidation:
         next_observation = jnp.ones(OBS_DIM, dtype=jnp.float32)
         with pytest.raises(ValueError, match="use update_transition"):
             agent.update(state, jnp.asarray(1.0), next_observation)
-
         result = agent.update_transition(
             state,
             PrototypeTransition(
@@ -291,6 +305,56 @@ class TestPrototypeAgentConfigValidation:
         )
         assert bool(result.transition_diagnostics.valid)
         assert int(result.state.step_count) == 1
+
+    @pytest.mark.parametrize("lane", ["ensemble", "replay"])
+    def test_legacy_gamma_zero_requires_explicit_boundary(self, lane: str) -> None:
+        kwargs: dict[str, object]
+        if lane == "ensemble":
+            kwargs = {"world_model_ensemble": _ensemble_cfg(gamma=0.0)}
+        else:
+            kwargs = {
+                "model_replay_rehearsal": ModelReplayRehearsalConfig(
+                    ensemble=_ensemble_cfg(gamma=0.0),
+                    replay=DualReplayConfig(
+                        total_capacity=4,
+                        short_term_capacity=2,
+                        observation_dim=OBS_DIM,
+                        action_dim=N_PRIM,
+                        short_term_sample_size=1,
+                        long_term_sample_size=1,
+                    ),
+                )
+            }
+        config = PrototypeAgentConfig(oak=_oak_cfg(), **kwargs)  # type: ignore[arg-type]
+        if lane == "replay":
+            # The replay constructor's independent resource-accounting gate is
+            # outside this wrapper contract. The guard executes before state
+            # access, so a shell instance isolates the dispatch regression.
+            agent = object.__new__(PrototypeAgent)
+            agent._config = config
+            agent._state_builder = None
+            state = object()
+        else:
+            agent = PrototypeAgent(config)
+            state = agent.start(agent.init(jr.key(42)), jnp.zeros(OBS_DIM))
+        with pytest.raises(ValueError, match="use update_transition"):
+            agent.update(
+                state,  # type: ignore[arg-type]
+                jnp.asarray(1.0, dtype=jnp.float32),
+                jnp.ones(OBS_DIM, dtype=jnp.float32),
+            )
+
+    def test_scan_rejects_legacy_gamma_zero_without_explicit_boundaries(self) -> None:
+        agent = PrototypeAgent(
+            PrototypeAgentConfig(oak=_oak_cfg(), world_model=_wm_cfg(gamma=0.0))
+        )
+        state = agent.start(agent.init(jr.key(43)), jnp.zeros(OBS_DIM))
+        with pytest.raises(ValueError, match="use update_transition"):
+            agent.scan(
+                state,
+                jnp.ones((1,), dtype=jnp.float32),
+                jnp.ones((1, OBS_DIM), dtype=jnp.float32),
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -290,7 +290,6 @@ _INVALID_UPGD_MEMORY_CONFIGS: tuple[dict[str, object], ...] = (
     {"feature_dim": 2, "n_heads": -1},
     {"feature_dim": 2, "n_heads": 2**31},
     {"feature_dim": 2, "n_heads": True},
-    {"feature_dim": 2, "n_heads": 2, "hidden_sizes": ()},
     {"feature_dim": 2, "n_heads": 2, "hidden_sizes": (0,)},
     {"feature_dim": 2, "n_heads": 2, "hidden_sizes": (2**31,)},
     {"feature_dim": 2, "n_heads": 2, "hidden_sizes": (True,)},
@@ -398,6 +397,22 @@ _INVALID_UPGD_MEMORY_CONFIGS: tuple[dict[str, object], ...] = (
 def test_upgd_memory_config_rejects_invalid_inputs(kwargs: dict[str, object]) -> None:
     with pytest.raises(ValueError):
         UPGDMemoryConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"hidden_sizes": ()},
+        {"target_allocation_rate": 1.0},
+        {"min_novelty_threshold": 0.25, "max_novelty_threshold": 0.25},
+    ],
+)
+def test_upgd_memory_preserves_legal_boundary_configs(
+    overrides: dict[str, object],
+) -> None:
+    config = UPGDMemoryConfig(feature_dim=2, n_heads=2, **overrides)
+    assert config.target_allocation_rate <= 1.0
+    assert config.min_novelty_threshold <= config.max_novelty_threshold
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replacement for #634 after #644 merged the shared scalar, integer, gamma, and closed-endpoint repairs.

This contains the remaining supported boundary that #644 did not restore: `UPGDMemoryConfig.hidden_sizes=()`. The underlying UPGD learner explicitly supports an empty hidden tuple as a direct input-to-head projection, so the facade must not reject it.

It also extends the legacy gamma regression across ensemble and model-replay lanes and verifies that legacy `scan` fails loudly, while the explicit terminal `update_transition` path remains legal. No synthetic environment termination is introduced.

Verification:
- pytest tests/test_prototype_agent.py::TestPrototypeAgentConfigValidation tests/test_upgd_memory.py -q -o addopts='' (153 passed)
- ruff check on changed source/tests
- mypy alberta_framework/core/upgd_memory.py alberta_framework/core/prototype_agent.py
- git diff --check