### PR TITLE
fix(horde): validate average-reward scan array contracts

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -1427,6 +1427,28 @@ def run_average_reward_horde_from_arrays(
     next_observations: Float[Array, "num_steps feature_dim"],
 ) -> AverageRewardHordeLearningResult:
     """Run a shared-trunk average-reward Horde over transition arrays."""
+    observations = jnp.asarray(observations)
+    cumulants = jnp.asarray(cumulants)
+    next_observations = jnp.asarray(next_observations)
+    if observations.ndim != 2:
+        raise ValueError(
+            f"observations must have shape (num_steps, feature_dim), got {observations.shape}"
+        )
+    if next_observations.ndim != 2:
+        raise ValueError(
+            "next_observations must have shape (num_steps, feature_dim), "
+            f"got {next_observations.shape}"
+        )
+    if observations.shape != next_observations.shape:
+        raise ValueError(
+            "observations and next_observations must have matching shapes, got "
+            f"{observations.shape} and {next_observations.shape}"
+        )
+    expected_cumulant_shape = (observations.shape[0], learner.n_demons)
+    if cumulants.shape != expected_cumulant_shape:
+        raise ValueError(
+            f"cumulants must have shape {expected_cumulant_shape}, got {cumulants.shape}"
+        )
     start = time.time()
 
     def _scan_fn(

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -348,6 +348,36 @@ def test_average_reward_horde_shared_trunk_scan_learns_reward_rates() -> None:
     chex.assert_tree_all_finite(result)
 
 
+@pytest.mark.parametrize(
+    ("observations_shape", "cumulants_shape", "next_observations_shape", "match"),
+    [
+        ((5, 3), (), (5, 3), "cumulants"),
+        ((5, 3), (5,), (5, 3), "cumulants"),
+        ((5, 3), (5, 1), (5, 3), "cumulants"),
+        ((5, 3), (4, 2), (5, 3), "cumulants"),
+        ((5,), (5, 2), (5, 3), "observations"),
+        ((5, 3), (5, 2), (5,), "next_observations"),
+        ((5, 3), (5, 2), (5, 4), "matching shapes"),
+    ],
+)
+def test_average_reward_horde_scan_rejects_misaligned_arrays(
+    observations_shape,
+    cumulants_shape,
+    next_observations_shape,
+    match,
+) -> None:
+    learner = AverageRewardHordeLearner(n_demons=2, hidden_sizes=())
+    state = learner.init(3, jr.key(2))
+    with pytest.raises(ValueError, match=match):
+        run_average_reward_horde_from_arrays(
+            learner,
+            state,
+            jnp.zeros(observations_shape, dtype=jnp.float32),
+            jnp.zeros(cumulants_shape, dtype=jnp.float32),
+            jnp.zeros(next_observations_shape, dtype=jnp.float32),
+        )
+
+
 def test_average_reward_horde_actor_critic_single_update_is_finite() -> None:
     agent = AverageRewardHordeActorCriticAgent(
         AverageRewardHordeActorCriticConfig(


### PR DESCRIPTION
Supersedes conflicting #641 while preserving its contribution. The per-update cumulant shape check is already merged via #548. This replacement retains the missing aggregate-runner validation and deepens it to reject rank errors and mismatched observation feature shapes before `lax.scan`.\n\nValidation: 30 average-reward tests; Ruff; strict mypy.