### PR TITLE
fix(streams): unify exact scalar validation

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -18,7 +18,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -47,26 +47,26 @@ def _require_positive_int(name: str, value: object) -> int:
     return value
 
 
-def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[Real, float]:
-    """Return an actual real together with its single exact binary32 rounding."""
+def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[int, int, float]:
+    """Return one trusted exact ratio together with its binary32 rounding."""
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(message)
     real = cast(Real, value)
     try:
-        narrowed = round_real_to_float32(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as exc:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
+    except Exception as exc:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed):
         raise ValueError(message)
-    return real, narrowed
+    return numerator, denominator, narrowed
 
 
 def _require_normal_float32_scale(name: str, value: object) -> float:
     """Return a positive bound with stable JAX float32 logarithm semantics."""
     message = f"{name} must be finite, positive, and representable as a normal float32 value"
-    real, narrowed = _narrow_real_to_float32(name, value, message)
-    if real <= 0 or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
+    numerator, _, narrowed = _narrow_real_to_float32(name, value, message)
+    if numerator <= 0 or narrowed < _FLOAT32_TINY or narrowed > _FLOAT32_MAX:
         raise ValueError(message)
     return narrowed
 
@@ -74,14 +74,8 @@ def _require_normal_float32_scale(name: str, value: object) -> float:
 def _require_finite_nonnegative_float32(name: str, value: object) -> float:
     """Require a finite non-negative float32 execution value."""
     message = f"{name} must be a finite non-negative float32 value"
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(message)
-    try:
-        narrowed = float(np.float32(cast(Real, value)))
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
-    if not math.isfinite(narrowed) or narrowed < 0.0:
+    numerator, _, narrowed = _narrow_real_to_float32(name, value, message)
+    if numerator < 0 or narrowed < 0.0:
         raise ValueError(message)
     return narrowed
 
@@ -92,7 +86,7 @@ def _require_finite_float32_log_scale(name: str, value: object) -> float:
         f"{name} must be finite and remain in the float32 exp-safe interval "
         f"[{_FLOAT32_EXP_SAFE_LOG_MIN}, {_FLOAT32_EXP_SAFE_LOG_MAX}]"
     )
-    _, narrowed = _narrow_real_to_float32(name, value, message)
+    _, _, narrowed = _narrow_real_to_float32(name, value, message)
     if narrowed < _FLOAT32_EXP_SAFE_LOG_MIN or narrowed > _FLOAT32_EXP_SAFE_LOG_MAX:
         raise ValueError(message)
     return narrowed

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -54,20 +54,23 @@ class TestRandomWalkStream:
             with pytest.raises(ValueError, match=name):
                 RandomWalkStream(feature_dim=4, **{name: value})
 
-    def test_rejects_class_spoofed_float_params(self):
-        """A __class__-spoofed non-float must not bypass the Real check."""
-
-        class _SpoofedFloat:
+    def test_rejects_spoofed_hostile_and_exact_negative_float_params(self):
+        class ClassSpoof:
             @property
-            def __class__(self) -> type:  # type: ignore[override]
+            def __class__(self):
                 return float
 
-            def __float__(self) -> float:
+            def __float__(self):
                 return 0.1
 
+        class HostileFloat(float):
+            def as_integer_ratio(self):
+                raise RuntimeError("untrusted ratio hook executed")
+
         for name in ("drift_rate", "noise_std", "feature_std"):
-            with pytest.raises(ValueError, match=name):
-                RandomWalkStream(feature_dim=4, **{name: _SpoofedFloat()})
+            for value in (ClassSpoof(), HostileFloat(0.1), Fraction(-1, 10**400)):
+                with pytest.raises(ValueError, match=name):
+                    RandomWalkStream(feature_dim=4, **{name: value})
 
     def test_step_produces_valid_timestep(self, rng_key):
         """Step should produce valid observation and target."""


### PR DESCRIPTION
Supersedes #649 with the deeper current-main repair.

The reported non-Real `__class__` spoof is rejected, and all synthetic scalar helpers now share one exact-ratio float32 path. Non-negativity is checked from the same numerator used for rounding, so tiny negative Rationals cannot disappear into `-0.0`; ordinary hostile `Real` conversion/ratio hooks are normalized to `ValueError`; duplicate `np.float32` double-rounding is removed.

Validation:
- `tests/test_streams.py`: 168 passed under `-W error`
- Ruff clean
- focused strict mypy clean
- diff check clean

No outputs or evidence artifacts changed.

Closes #648.

AI assistance: OpenAI GPT-5.6 Codex desktop. Attribution: self-reported.