### PR TITLE
fix(core): complete working-memory and stream boundary hardening

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -11,17 +11,19 @@ updates.
 from __future__ import annotations
 
 import functools
-import math
+import operator
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
@@ -184,44 +186,66 @@ class WorkingMemoryArrayResult:
         yield self.features
 
 
-def _validate_decay_rates(name: str, rates: tuple[float, ...]) -> None:
-    if not isinstance(rates, tuple):
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
+
+
+def _validate_decay_rates(name: str, rates: tuple[float, ...]) -> tuple[float, ...]:
+    if type(rates) is not tuple:
         raise ValueError(f"{name} must be a tuple")
-    for v in rates:
-        if isinstance(v, bool) or not isinstance(v, int | float):
-            raise ValueError(f"{name} must contain finite values in [0, 1); got {rates!r}")
-        if not math.isfinite(float(v)) or v < 0.0 or v >= 1.0:
-            raise ValueError(f"{name} must contain finite values in [0, 1); got {rates!r}")
+    return tuple(
+        validated_float32_scalar(name, value, lower=0.0, upper=1.0, upper_inclusive=False)
+        for value in rates
+    )
 
 
 def _validate_config(config: WorkingMemoryConfig) -> None:
-    if isinstance(config.observation_dim, bool) or not isinstance(config.observation_dim, int):
-        raise ValueError("observation_dim must be an int")
-    if config.observation_dim < 1:
-        raise ValueError("observation_dim must be positive")
-    if isinstance(config.action_dim, bool) or not isinstance(config.action_dim, int):
-        raise ValueError("action_dim must be an int")
-    if config.action_dim < 0:
-        raise ValueError("action_dim must be non-negative")
-    if isinstance(config.reward_dim, bool) or not isinstance(config.reward_dim, int):
-        raise ValueError("reward_dim must be an int")
-    if config.reward_dim < 0:
-        raise ValueError("reward_dim must be non-negative")
-    _validate_decay_rates("observation_decay_rates", config.observation_decay_rates)
-    _validate_decay_rates("action_decay_rates", config.action_decay_rates)
-    _validate_decay_rates("reward_decay_rates", config.reward_decay_rates)
-    if isinstance(config.gate_threshold, bool) or not isinstance(
-        config.gate_threshold, int | float
+    object.__setattr__(
+        config,
+        "observation_dim",
+        _require_int32("observation_dim", config.observation_dim, minimum=1),
+    )
+    for name in ("action_dim", "reward_dim"):
+        object.__setattr__(config, name, _require_int32(name, getattr(config, name), minimum=0))
+    for name in (
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
     ):
-        raise ValueError("gate_threshold must be finite")
-    if not math.isfinite(float(config.gate_threshold)) or config.gate_threshold < 0.0:
-        raise ValueError("gate_threshold must be finite and non-negative")
-    if isinstance(config.gate_temperature, bool) or not isinstance(
-        config.gate_temperature, int | float
-    ):
-        raise ValueError("gate_temperature must be finite")
-    if not math.isfinite(float(config.gate_temperature)) or config.gate_temperature <= 0.0:
-        raise ValueError("gate_temperature must be finite and positive")
+        object.__setattr__(config, name, _validate_decay_rates(name, getattr(config, name)))
+    object.__setattr__(
+        config,
+        "gate_threshold",
+        validated_float32_scalar("gate_threshold", config.gate_threshold, lower=0.0),
+    )
+    object.__setattr__(
+        config,
+        "gate_temperature",
+        validated_float32_scalar("gate_temperature", config.gate_temperature, positive=True),
+    )
     for name in (
         "include_current_observation",
         "include_current_action",
@@ -230,7 +254,7 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         "include_innovations",
         "gated_update",
     ):
-        if not isinstance(getattr(config, name), bool):
+        if type(getattr(config, name)) is not bool:
             raise ValueError(f"{name} must be a bool")
     if config.feature_dim() < 1:
         raise ValueError("configuration must produce at least one feature")

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -19,6 +19,7 @@ from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
 from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -73,17 +74,7 @@ def _require_normal_float32_scale(name: str, value: object) -> float:
 
 def _require_finite_nonnegative_float32(name: str, value: object) -> float:
     """Require a finite non-negative float32 execution value."""
-    message = f"{name} must be a finite non-negative float32 value"
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(message)
-    try:
-        narrowed = float(np.float32(cast(Real, value)))
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
-    if not math.isfinite(narrowed) or narrowed < 0.0:
-        raise ValueError(message)
-    return narrowed
+    return validated_float32_scalar(name, value, lower=0.0)
 
 
 def _require_finite_float32_log_scale(name: str, value: object) -> float:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -54,20 +54,23 @@ class TestRandomWalkStream:
             with pytest.raises(ValueError, match=name):
                 RandomWalkStream(feature_dim=4, **{name: value})
 
-    def test_rejects_class_spoofed_float_params(self):
-        """A __class__-spoofed non-float must not bypass the Real check."""
-
-        class _SpoofedFloat:
+    def test_rejects_class_spoofed_and_exact_negative_float_params(self):
+        class Spoof:
             @property
-            def __class__(self) -> type:  # type: ignore[override]
+            def __class__(self) -> type[float]:  # type: ignore[override]
                 return float
 
             def __float__(self) -> float:
-                return 0.1
+                raise RuntimeError("must not convert")
 
         for name in ("drift_rate", "noise_std", "feature_std"):
             with pytest.raises(ValueError, match=name):
-                RandomWalkStream(feature_dim=4, **{name: _SpoofedFloat()})
+                RandomWalkStream(feature_dim=4, **{name: Spoof()})
+            with pytest.raises(ValueError, match=name):
+                RandomWalkStream(
+                    feature_dim=4,
+                    **{name: Fraction(-1, 10**50)},
+                )
 
     def test_step_produces_valid_timestep(self, rng_key):
         """Step should produce valid observation and target."""

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.working_memory import (
@@ -391,6 +394,84 @@ def _minimal_config(**overrides: object) -> WorkingMemoryConfig:
     }
     payload.update(overrides)
     return WorkingMemoryConfig(**payload)  # type: ignore[arg-type]
+
+
+class _ScalarSpoof:
+    @property
+    def __class__(self) -> type[float]:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        raise RuntimeError("must not convert")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"observation_dim": True},
+        {"observation_dim": 1.5},
+        {"observation_dim": 2**31},
+        {"observation_decay_rates": [0.5]},
+        {"observation_decay_rates": (_ScalarSpoof(),)},
+        {"observation_decay_rates": (1.0 - 1e-10,)},
+        {"gate_threshold": _ScalarSpoof()},
+        {"gate_threshold": 1e100},
+        {"gate_temperature": Fraction(1, 10**50)},
+        {"include_traces": np.bool_(True)},
+    ],
+)
+def test_working_memory_rejects_untrusted_or_sink_invalid_config(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _minimal_config(**overrides)
+
+
+def test_working_memory_canonicalizes_numpy_config_scalars() -> None:
+    config = _minimal_config(
+        observation_dim=np.longlong(2),
+        action_dim=np.int32(0),
+        observation_decay_rates=(np.float32(0.5),),
+        gate_threshold=np.float64(0.25),
+        gate_temperature=Fraction(1, 2),
+    )
+
+    assert type(config.observation_dim) is int
+    assert type(config.action_dim) is int
+    assert type(config.observation_decay_rates[0]) is float
+    assert type(config.gate_threshold) is float
+    assert type(config.gate_temperature) is float
+
+
+@pytest.mark.parametrize("shape", [(), (2, 1), (1, 2), (1,)])
+def test_working_memory_rejects_wrong_vector_shapes(shape: tuple[int, ...]) -> None:
+    memory = WorkingMemoryFeaturizer(_minimal_config())
+    with pytest.raises(ValueError, match=r"shape \(2,\)"):
+        memory.features(
+            memory.init(),
+            jnp.ones(shape, dtype=jnp.float32),
+            memory.zero_action(),
+            memory.zero_reward(),
+        )
+
+
+def test_working_memory_array_transform_rejects_misaligned_shapes() -> None:
+    memory = WorkingMemoryFeaturizer(_minimal_config())
+    observations = jnp.ones((3, 2), dtype=jnp.float32)
+    actions = jnp.empty((3, 0), dtype=jnp.float32)
+    rewards = jnp.empty((3, 0), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observations"):
+        transform_working_memory_arrays(memory, jnp.ones((3, 1)), actions, rewards)
+    with pytest.raises(ValueError, match="leading dims"):
+        transform_working_memory_arrays(memory, observations, actions[:2], rewards)
+    with pytest.raises(ValueError, match="external_gates"):
+        transform_working_memory_arrays(
+            memory,
+            observations,
+            actions,
+            rewards,
+            external_gates=jnp.ones((3, 1)),
+        )
 
 
 @pytest.mark.parametrize("field", [


### PR DESCRIPTION
Corrective follow-up to #649/#650. Preserves the useful exact vector and batch-shape preflights, while replacing spoofable host-only config gates with exact supported integer families, signed-int32 bounds, exact booleans, shared host+float32 sink validation, and canonical JSON-safe storage. Synthetic nonnegative stream scalars now use the same shared validator, rejecting exact negatives that merely narrow to -0.0 as well as hostile class spoofs.

Validation: 225 working-memory/stream tests passed; Ruff clean; strict mypy clean; diff check clean.

Closes #648.