### PR TITLE
fix(step2): accept complete NumPy integer family

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -107,14 +107,7 @@ _STEP2_MEMORY_CONFIG_KEYS = frozenset(
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
 )
 
 

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -1079,6 +1079,24 @@ def test_step2_configs_reject_hostile_integral_subclasses() -> None:
             config_type(**{field: LieInt(-1)})
 
 
+def test_step2_kernel_accepts_all_standard_numpy_integer_families() -> None:
+    config = Step2KernelConfig(
+        feature_dim=np.longlong(4),
+        n_heads=np.ulonglong(3),
+        hidden_sizes=(np.longlong(8),),
+        context_length=np.ulonglong(64),
+    )
+
+    assert config.feature_dim == 4
+    assert config.n_heads == 3
+    assert config.hidden_sizes == (8,)
+    assert config.context_length == 64
+    assert type(config.feature_dim) is int
+    assert type(config.n_heads) is int
+    assert type(config.hidden_sizes[0]) is int
+    assert type(config.context_length) is int
+
+
 def test_step2_configs_require_actual_tuple_containers() -> None:
     class TupleSpoof(list[int]):
         @property


### PR DESCRIPTION
Corrective follow-up to #636.

The exact-type hardening was correct, but its hand-written NumPy list omitted genuine `np.longlong` and `np.ulonglong` scalar types on platforms where those are distinct from the fixed-width aliases. Derive the trusted exact family from NumPy dtype codes, matching Step 1 and retaining rejection of booleans and hostile subclasses.

Validation:
- `pytest tests/test_production_steps.py -q -o addopts=` — 384 passed
- scoped ruff — passed
- strict mypy for `step2.py` — passed
- `git diff --check` — clean

No outputs or evidence artifacts changed.