### PR TITLE
fix(core): complete working-memory boundary validation

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -11,7 +11,6 @@ updates.
 from __future__ import annotations
 
 import functools
-import math
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from typing import Any, cast
@@ -19,9 +18,11 @@ from typing import Any, cast
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
@@ -184,44 +185,63 @@ class WorkingMemoryArrayResult:
         yield self.features
 
 
-def _validate_decay_rates(name: str, rates: tuple[float, ...]) -> None:
-    if not isinstance(rates, tuple):
-        raise ValueError(f"{name} must be a tuple")
-    for v in rates:
-        if isinstance(v, bool) or not isinstance(v, int | float):
-            raise ValueError(f"{name} must contain finite values in [0, 1); got {rates!r}")
-        if not math.isfinite(float(v)) or v < 0.0 or v >= 1.0:
-            raise ValueError(f"{name} must contain finite values in [0, 1); got {rates!r}")
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = int(cast(int, value))
+    if number < minimum or number > _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
+    return number
+
+
+def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
+    if type(rates) is not tuple:
+        raise ValueError(f"{name} must be an actual tuple")
+    return tuple(
+        validated_float32_scalar(
+            f"{name}[{index}]",
+            value,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        for index, value in enumerate(rates)
+    )
 
 
 def _validate_config(config: WorkingMemoryConfig) -> None:
-    if isinstance(config.observation_dim, bool) or not isinstance(config.observation_dim, int):
-        raise ValueError("observation_dim must be an int")
-    if config.observation_dim < 1:
-        raise ValueError("observation_dim must be positive")
-    if isinstance(config.action_dim, bool) or not isinstance(config.action_dim, int):
-        raise ValueError("action_dim must be an int")
-    if config.action_dim < 0:
-        raise ValueError("action_dim must be non-negative")
-    if isinstance(config.reward_dim, bool) or not isinstance(config.reward_dim, int):
-        raise ValueError("reward_dim must be an int")
-    if config.reward_dim < 0:
-        raise ValueError("reward_dim must be non-negative")
-    _validate_decay_rates("observation_decay_rates", config.observation_decay_rates)
-    _validate_decay_rates("action_decay_rates", config.action_decay_rates)
-    _validate_decay_rates("reward_decay_rates", config.reward_decay_rates)
-    if isinstance(config.gate_threshold, bool) or not isinstance(
-        config.gate_threshold, int | float
-    ):
-        raise ValueError("gate_threshold must be finite")
-    if not math.isfinite(float(config.gate_threshold)) or config.gate_threshold < 0.0:
-        raise ValueError("gate_threshold must be finite and non-negative")
-    if isinstance(config.gate_temperature, bool) or not isinstance(
-        config.gate_temperature, int | float
-    ):
-        raise ValueError("gate_temperature must be finite")
-    if not math.isfinite(float(config.gate_temperature)) or config.gate_temperature <= 0.0:
-        raise ValueError("gate_temperature must be finite and positive")
+    observation_dim = _require_int32("observation_dim", config.observation_dim, minimum=1)
+    action_dim = _require_int32("action_dim", config.action_dim, minimum=0)
+    reward_dim = _require_int32("reward_dim", config.reward_dim, minimum=0)
+    observation_decay_rates = _validate_decay_rates(
+        "observation_decay_rates", config.observation_decay_rates
+    )
+    action_decay_rates = _validate_decay_rates(
+        "action_decay_rates", config.action_decay_rates
+    )
+    reward_decay_rates = _validate_decay_rates(
+        "reward_decay_rates", config.reward_decay_rates
+    )
+    gate_threshold = validated_float32_scalar(
+        "gate_threshold", config.gate_threshold, lower=0.0
+    )
+    gate_temperature = validated_float32_scalar(
+        "gate_temperature", config.gate_temperature, positive=True
+    )
     for name in (
         "include_current_observation",
         "include_current_action",
@@ -230,10 +250,23 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         "include_innovations",
         "gated_update",
     ):
-        if not isinstance(getattr(config, name), bool):
-            raise ValueError(f"{name} must be a bool")
-    if config.feature_dim() < 1:
-        raise ValueError("configuration must produce at least one feature")
+        if type(getattr(config, name)) is not bool:
+            raise ValueError(f"{name} must be an actual bool")
+
+    object.__setattr__(config, "observation_dim", observation_dim)
+    object.__setattr__(config, "action_dim", action_dim)
+    object.__setattr__(config, "reward_dim", reward_dim)
+    object.__setattr__(config, "observation_decay_rates", observation_decay_rates)
+    object.__setattr__(config, "action_decay_rates", action_decay_rates)
+    object.__setattr__(config, "reward_decay_rates", reward_decay_rates)
+    object.__setattr__(config, "gate_threshold", gate_threshold)
+    object.__setattr__(config, "gate_temperature", gate_temperature)
+
+    feature_dim = config.feature_dim()
+    if feature_dim < 1 or feature_dim > _INT32_MAX:
+        raise ValueError(
+            f"configuration feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
+        )
 
 
 def _empty_or_vector(value: Array, dim: int) -> Array:

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.working_memory import (
@@ -391,6 +394,221 @@ def _minimal_config(**overrides: object) -> WorkingMemoryConfig:
     }
     payload.update(overrides)
     return WorkingMemoryConfig(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("observation_dim", True),
+        ("observation_dim", 1.5),
+        ("observation_dim", 0),
+        ("observation_dim", 2**31),
+        ("action_dim", True),
+        ("action_dim", -1),
+        ("action_dim", 2**31),
+        ("reward_dim", True),
+        ("reward_dim", -1),
+        ("reward_dim", 2**31),
+    ],
+)
+def test_config_rejects_invalid_int32_dimensions(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        _minimal_config(**{field: value})
+
+
+def test_config_rejects_hostile_integral_subclasses() -> None:
+    class LieInt(int):
+        def __int__(self) -> int:
+            return 2
+
+    for field in ("observation_dim", "action_dim", "reward_dim"):
+        with pytest.raises(ValueError, match=field):
+            _minimal_config(**{field: LieInt(1)})
+
+
+def test_config_canonicalizes_supported_numpy_dimensions() -> None:
+    config = _minimal_config(
+        observation_dim=np.int64(2),
+        action_dim=np.uint16(1),
+        reward_dim=np.int32(0),
+    )
+    assert type(config.observation_dim) is int
+    assert type(config.action_dim) is int
+    assert type(config.reward_dim) is int
+
+
+@pytest.mark.parametrize(
+    "rates",
+    [[0.5], 0.5, (False,), (1.0,), (-0.1,), (1e100,)],
+)
+def test_config_rejects_invalid_decay_containers_and_float32_values(
+    rates: object,
+) -> None:
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        _minimal_config(observation_decay_rates=rates)
+
+
+def test_config_rejects_tuple_and_bool_class_spoofs() -> None:
+    class TupleSubclass(tuple):
+        pass
+
+    class BoolSpoof:
+        @property
+        def __class__(self) -> type[bool]:
+            return bool
+
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        _minimal_config(observation_decay_rates=TupleSubclass((0.5,)))
+    for field in (
+        "include_current_observation",
+        "include_current_action",
+        "include_current_reward",
+        "include_traces",
+        "include_innovations",
+        "gated_update",
+    ):
+        with pytest.raises(ValueError, match=field):
+            _minimal_config(**{field: BoolSpoof()})
+
+
+@pytest.mark.parametrize(
+    ("field", "ratio"),
+    [
+        ("observation_decay_rates", (-1, 2**200)),
+        ("observation_decay_rates", (2**200 - 1, 2**200)),
+        ("gate_threshold", (-1, 2**200)),
+        ("gate_temperature", (-1, 2**200)),
+    ],
+)
+def test_config_rejects_hostile_exact_float_ratios(
+    field: str,
+    ratio: tuple[int, int],
+) -> None:
+    class HiddenBoundaryFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            return ratio
+
+    value: object = HiddenBoundaryFloat(0.5)
+    if field.endswith("decay_rates"):
+        value = (value,)
+    with pytest.raises(ValueError, match=field):
+        _minimal_config(**{field: value})
+
+
+def test_config_canonicalizes_float32_scalars_and_round_trips() -> None:
+    config = _minimal_config(
+        observation_decay_rates=(
+            Fraction(1, 10),
+            np.float64(0.25),
+            Fraction(1, 10**400),
+        ),
+        gate_threshold=Fraction(1, 10),
+        gate_temperature=np.float64(0.5),
+    )
+    assert config.observation_decay_rates == (float(np.float32(0.1)), 0.25, 0.0)
+    assert type(config.gate_threshold) is float
+    assert config.gate_threshold == float(np.float32(0.1))
+    assert type(config.gate_temperature) is float
+    assert WorkingMemoryConfig.from_config(config.to_config()) == config
+
+
+def test_config_rejects_derived_feature_dimension_above_int32() -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        WorkingMemoryConfig(observation_dim=2**31 - 1)
+
+
+@pytest.mark.parametrize("method", ["features", "update_checked", "step"])
+@pytest.mark.parametrize(
+    ("field", "shape"),
+    [
+        ("observation", (2, 1)),
+        ("observation", (1, 2)),
+        ("observation", ()),
+        ("action", (1, 1)),
+        ("action", ()),
+        ("reward", (1, 1)),
+        ("reward", ()),
+    ],
+)
+def test_vector_entry_points_reject_same_size_wrong_shapes(
+    method: str,
+    field: str,
+    shape: tuple[int, ...],
+) -> None:
+    memory = WorkingMemoryFeaturizer(
+        _minimal_config(action_dim=1, reward_dim=1, include_current_action=True)
+    )
+    values = {
+        "observation": jnp.ones((2,), dtype=jnp.float32),
+        "action": jnp.ones((1,), dtype=jnp.float32),
+        "reward": jnp.ones((1,), dtype=jnp.float32),
+    }
+    values[field] = jnp.ones(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="vector must have shape"):
+        getattr(memory, method)(
+            memory.init(),
+            values["observation"],
+            values["action"],
+            values["reward"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "shape"),
+    [
+        ("observations", (3,)),
+        ("observations", (3, 1)),
+        ("actions", (3,)),
+        ("actions", (3, 2)),
+        ("rewards", (3,)),
+        ("rewards", (3, 2)),
+        ("actions", (2, 1)),
+        ("rewards", (4, 1)),
+        ("external_gates", (3, 1)),
+        ("external_gates", (2,)),
+    ],
+)
+def test_batch_transform_rejects_wrong_shapes(
+    field: str,
+    shape: tuple[int, ...],
+) -> None:
+    memory = WorkingMemoryFeaturizer(
+        _minimal_config(action_dim=1, reward_dim=1, include_current_action=True)
+    )
+    values: dict[str, object] = {
+        "observations": jnp.ones((3, 2), dtype=jnp.float32),
+        "actions": jnp.ones((3, 1), dtype=jnp.float32),
+        "rewards": jnp.ones((3, 1), dtype=jnp.float32),
+        "external_gates": jnp.ones((3,), dtype=jnp.float32),
+    }
+    values[field] = jnp.ones(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match=field if field != "external_gates" else "external_gates"):
+        transform_working_memory_arrays(
+            memory,
+            values["observations"],  # type: ignore[arg-type]
+            values["actions"],  # type: ignore[arg-type]
+            values["rewards"],  # type: ignore[arg-type]
+            external_gates=values["external_gates"],  # type: ignore[arg-type]
+        )
+
+
+def test_zero_width_vectors_and_batches_preserve_exact_shapes() -> None:
+    memory = WorkingMemoryFeaturizer(_minimal_config())
+    state = memory.init()
+    features = memory.features(
+        state,
+        jnp.ones((2,), dtype=jnp.float32),
+        jnp.empty((0,), dtype=jnp.float32),
+        jnp.empty((0,), dtype=jnp.float32),
+    )
+    result = transform_working_memory_arrays(
+        memory,
+        jnp.ones((3, 2), dtype=jnp.float32),
+        jnp.empty((3, 0), dtype=jnp.float32),
+        jnp.empty((3, 0), dtype=jnp.float32),
+    )
+    chex.assert_shape(features, (memory.feature_dim(),))
+    chex.assert_shape(result.features, (3, memory.feature_dim()))
 
 
 @pytest.mark.parametrize("field", [


### PR DESCRIPTION
Corrective follow-up to #650.

The original shape preflights are retained. This completes the configuration boundary contract by:

- requiring exact tuple and bool containers/discriminators;
- accepting only supported built-in/NumPy integer scalar types, canonicalizing them to built-in int, and enforcing signed-int32 dimensions plus the derived feature-size bound;
- validating every decay/gate scalar in both its exact host domain and its float32 execution domain through the shared single-rounding helper;
- canonicalizing non-built-in real scalars and preserving exact config round-trips;
- rejecting class spoofs, hostile Integral/Real subclasses, exact negative underflow, float32 overflow, and half-open endpoint rounding;
- adding committed vector, zero-width, batch-rank, trailing-dimension, leading-dimension, and external-gate shape regressions.

Verification:
- pytest tests/test_working_memory.py -q -o addopts='' (98 passed)
- ruff check alberta_framework/core/working_memory.py tests/test_working_memory.py
- mypy alberta_framework/core/working_memory.py
- git diff --check