### PR TITLE
fix(core): complete working-memory integer family

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -196,6 +196,8 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.uint16,
     np.uint32,
     np.uint64,
+    np.longlong,
+    np.ulonglong,
 )
 
 

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -428,8 +428,8 @@ def test_config_rejects_hostile_integral_subclasses() -> None:
 
 def test_config_canonicalizes_supported_numpy_dimensions() -> None:
     config = _minimal_config(
-        observation_dim=np.int64(2),
-        action_dim=np.uint16(1),
+        observation_dim=np.longlong(2),
+        action_dim=np.ulonglong(1),
         reward_dim=np.int32(0),
     )
     assert type(config.observation_dim) is int
@@ -515,6 +515,22 @@ def test_config_canonicalizes_float32_scalars_and_round_trips() -> None:
 def test_config_rejects_derived_feature_dimension_above_int32() -> None:
     with pytest.raises(ValueError, match="feature_dim"):
         WorkingMemoryConfig(observation_dim=2**31 - 1)
+
+
+def test_config_accepts_exact_int32_max_derived_feature_dimension() -> None:
+    config = WorkingMemoryConfig(
+        observation_dim=2**31 - 1,
+        action_dim=0,
+        reward_dim=0,
+        observation_decay_rates=(),
+        action_decay_rates=(),
+        reward_decay_rates=(),
+        include_current_action=False,
+        include_current_reward=False,
+        include_traces=False,
+    )
+
+    assert config.feature_dim() == 2**31 - 1
 
 
 @pytest.mark.parametrize("method", ["features", "update_checked", "step"])


### PR DESCRIPTION
## Summary
- preserve the full standard NumPy integer scalar contract for working-memory dimensions, including the platform-distinct `longlong` and `ulonglong` types
- add canonicalization coverage for both families
- pin the exact accepted derived `feature_dim == INT32_MAX` boundary alongside the existing overflow rejection

## Validation
- `python -m pytest tests/test_working_memory.py -q` (99 passed)
- Ruff on touched files
- strict mypy on `working_memory.py`
- `git diff --check`

This is the narrow residual repair after #658; it does not touch registered evidence sources or artifacts.