### PR TITLE
fix(history-features): enforce exact sink contracts

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -30,14 +30,17 @@ nexting work.
 from __future__ import annotations
 
 import functools
-import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 # =============================================================================
 # Types
@@ -59,6 +62,64 @@ class HistoryFeatureState:
 # =============================================================================
 # Extractor
 # =============================================================================
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_decay_rates(value: object) -> tuple[float, ...]:
+    if type(value) is not tuple:
+        raise ValueError("decay_rates must be an actual tuple")
+    rates = cast(tuple[object, ...], value)
+    return tuple(
+        validated_float32_scalar(
+            f"decay_rates[{index}]",
+            rate,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        for index, rate in enumerate(rates)
+    )
+
+
+def _require_channels(value: object, raw_dim: int) -> tuple[int, ...] | None:
+    if value is None:
+        return None
+    if type(value) is not tuple:
+        raise ValueError("channels must be an actual tuple or None")
+    return tuple(
+        _require_int32(
+            f"channels[{index}]",
+            channel,
+            minimum=0,
+            maximum=raw_dim - 1,
+        )
+        for index, channel in enumerate(cast(tuple[object, ...], value))
+    )
 
 
 class HistoryFeatureExtractor:
@@ -116,20 +177,28 @@ class HistoryFeatureExtractor:
             include_raw: If True (default), the raw observation is
                 concatenated to the front of the augmented observation.
         """
-        if any(not math.isfinite(b) or (b < 0.0) or (b >= 1.0) for b in decay_rates):
+        raw_dim = _require_int32(
+            "raw_dim", raw_dim, minimum=1, maximum=_INT32_MAX
+        )
+        decay_rates = _require_decay_rates(decay_rates)
+        canonical_channels = _require_channels(channels, raw_dim)
+        if type(include_raw) is not bool:
+            raise ValueError("include_raw must be an actual bool")
+
+        channel_count = raw_dim if canonical_channels is None else len(canonical_channels)
+        feature_dim = channel_count * len(decay_rates)
+        if include_raw:
+            feature_dim += raw_dim
+        if feature_dim < 1 or feature_dim > _INT32_MAX:
             raise ValueError(
-                f"decay_rates must be finite and lie in [0, 1); got {decay_rates}"
+                f"feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
             )
-        if channels is None:
-            channels = tuple(range(raw_dim))
-        if any(c < 0 or c >= raw_dim for c in channels):
-            raise ValueError(
-                f"channels {channels} contains an index outside [0, {raw_dim})"
-            )
+        if canonical_channels is None:
+            canonical_channels = tuple(range(raw_dim))
 
         self._raw_dim = raw_dim
         self._decay_rates = decay_rates
-        self._channels = channels
+        self._channels = canonical_channels
         self._include_raw = include_raw
 
     @property
@@ -233,9 +302,15 @@ class HistoryFeatureExtractor:
         """Reconstruct from config dict."""
         config = dict(config)
         config.pop("type", None)
+        raw_rates = config["decay_rates"]
+        if type(raw_rates) is list:
+            raw_rates = tuple(raw_rates)
+        raw_channels = config["channels"]
+        if type(raw_channels) is list:
+            raw_channels = tuple(raw_channels)
         return cls(
-            raw_dim=int(config["raw_dim"]),
-            decay_rates=tuple(config["decay_rates"]),
-            channels=tuple(config["channels"]) if config["channels"] is not None else None,
-            include_raw=bool(config["include_raw"]),
+            raw_dim=config["raw_dim"],
+            decay_rates=raw_rates,
+            channels=raw_channels,
+            include_raw=config["include_raw"],
         )

--- a/tests/test_history_features.py
+++ b/tests/test_history_features.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import cast
 
 import chex
@@ -59,6 +60,90 @@ class TestValidation:
     def test_invalid_channel_index(self) -> None:
         with pytest.raises(ValueError, match="channels"):
             HistoryFeatureExtractor(raw_dim=4, channels=(0, 5))
+
+    @pytest.mark.parametrize("value", [True, 1.5, 0, 2**31, "4"])
+    def test_raw_dim_requires_supported_signed_int32(self, value: object) -> None:
+        with pytest.raises(ValueError, match="raw_dim"):
+            HistoryFeatureExtractor(raw_dim=value)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "rates",
+        [
+            [0.5],
+            (True,),
+            (float("inf"),),
+            (1.0 - 1e-10,),
+            (1e100,),
+            (Fraction(-1, 10**50),),
+        ],
+    )
+    def test_decay_rates_require_exact_tuple_and_float32_domain(
+        self, rates: object
+    ) -> None:
+        with pytest.raises(ValueError, match="decay_rates"):
+            HistoryFeatureExtractor(raw_dim=2, decay_rates=rates)  # type: ignore[arg-type]
+
+    def test_scalar_class_spoofs_are_rejected_without_conversion(self) -> None:
+        class Spoof:
+            @property
+            def __class__(self) -> type[float]:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                raise RuntimeError("must not convert")
+
+        with pytest.raises(ValueError, match="raw_dim"):
+            HistoryFeatureExtractor(raw_dim=Spoof())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="decay_rates"):
+            HistoryFeatureExtractor(raw_dim=2, decay_rates=(Spoof(),))  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "channels",
+        [[0], (True,), (1.5,), ("0",), (2,)],
+    )
+    def test_channels_require_exact_tuple_of_in_range_integers(
+        self, channels: object
+    ) -> None:
+        with pytest.raises(ValueError, match="channels"):
+            HistoryFeatureExtractor(raw_dim=2, channels=channels)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("value", [1, 0, np.bool_(True), "true"])
+    def test_include_raw_requires_actual_bool(self, value: object) -> None:
+        with pytest.raises(ValueError, match="include_raw"):
+            HistoryFeatureExtractor(raw_dim=2, include_raw=value)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("integer_type", [np.longlong, np.ulonglong])
+    def test_numpy_integer_scalars_are_canonicalized(
+        self, integer_type: type[np.integer[object]]
+    ) -> None:
+        extractor = HistoryFeatureExtractor(
+            raw_dim=integer_type(3),
+            channels=(integer_type(0), integer_type(2)),
+        )
+        assert type(extractor.raw_dim) is int
+        assert all(type(channel) is int for channel in extractor.channels)
+
+    def test_nonbuiltin_real_rates_are_canonicalized_for_json(self) -> None:
+        extractor = HistoryFeatureExtractor(
+            raw_dim=2,
+            decay_rates=(np.float32(0.5), Fraction(3, 4)),
+        )
+        assert all(type(rate) is float for rate in extractor.decay_rates)
+        assert extractor.to_config()["decay_rates"] == [0.5, 0.75]
+
+    def test_derived_feature_dim_requires_signed_int32(self) -> None:
+        with pytest.raises(ValueError, match="feature_dim"):
+            HistoryFeatureExtractor(
+                raw_dim=2**31 - 1,
+                decay_rates=(0.5,),
+                channels=(0,),
+            )
+        boundary = HistoryFeatureExtractor(
+            raw_dim=2**31 - 2,
+            decay_rates=(0.5,),
+            channels=(0,),
+        )
+        assert boundary.feature_dim() == 2**31 - 1
 
 
 class TestStep:


### PR DESCRIPTION
Supersedes #657 with a current-main repair.\n\nThe original patch reproduced the coercion bug but retained spoofable `isinstance` gates, host-only float validation, inconsistent NumPy handling, noncanonical storage, and unbounded JAX dimensions. This replacement:\n- accepts only actual supported built-in/NumPy integer scalar types, canonicalizes them, and enforces signed-int32 bounds;\n- requires actual tuple/bool containers and canonicalizes channel indices;\n- validates decay rates in both their exact host and float32 execution domains through the shared scalar helper;\n- enforces the derived feature width in the signed-int32 domain;\n- preserves exact JSON list-to-tuple round-trips without truthiness or numeric coercion.\n\nValidation:\n- `pytest tests/test_history_features.py -q -o addopts=''`: 49 passed\n- Ruff on changed source/tests: clean\n- strict mypy on `history_features.py`: clean\n- diff check: clean\n\nNo outputs or registered evidence sources changed.