### PR TITLE
test(core): complete history-feature boundary regressions

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -30,14 +30,40 @@ nexting work.
 from __future__ import annotations
 
 import functools
-import math
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = int(cast(int, value))
+    if number < minimum or number > _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
+    return number
 
 # =============================================================================
 # Types
@@ -116,21 +142,43 @@ class HistoryFeatureExtractor:
             include_raw: If True (default), the raw observation is
                 concatenated to the front of the augmented observation.
         """
-        if any(not math.isfinite(b) or (b < 0.0) or (b >= 1.0) for b in decay_rates):
-            raise ValueError(
-                f"decay_rates must be finite and lie in [0, 1); got {decay_rates}"
+        raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
+        if type(decay_rates) is not tuple:
+            raise ValueError("decay_rates must be an actual tuple")
+        canonical_decays = tuple(
+            validated_float32_scalar(
+                f"decay_rates[{index}]",
+                value,
+                lower=0.0,
+                upper=1.0,
+                upper_inclusive=False,
             )
+            for index, value in enumerate(decay_rates)
+        )
+        if type(include_raw) is not bool:
+            raise ValueError("include_raw must be an actual bool")
         if channels is None:
             channels = tuple(range(raw_dim))
-        if any(c < 0 or c >= raw_dim for c in channels):
+        elif type(channels) is not tuple:
+            raise ValueError("channels must be an actual tuple or None")
+        canonical_channels = tuple(
+            _require_int32(f"channels[{index}]", channel, minimum=0)
+            for index, channel in enumerate(channels)
+        )
+        if any(channel >= raw_dim for channel in canonical_channels):
             raise ValueError(
-                f"channels {channels} contains an index outside [0, {raw_dim})"
+                f"channels {canonical_channels} contains an index outside [0, {raw_dim})"
             )
 
         self._raw_dim = raw_dim
-        self._decay_rates = decay_rates
-        self._channels = channels
+        self._decay_rates = canonical_decays
+        self._channels = canonical_channels
         self._include_raw = include_raw
+        feature_dim = self.feature_dim()
+        if feature_dim < 1 or feature_dim > _INT32_MAX:
+            raise ValueError(
+                f"feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
+            )
 
     @property
     def raw_dim(self) -> int:
@@ -231,11 +279,17 @@ class HistoryFeatureExtractor:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> HistoryFeatureExtractor:
         """Reconstruct from config dict."""
-        config = dict(config)
-        config.pop("type", None)
+        payload = dict(config)
+        payload.pop("type", None)
+        decay_rates = payload["decay_rates"]
+        if type(decay_rates) is list:
+            decay_rates = tuple(decay_rates)
+        channels = payload["channels"]
+        if type(channels) is list:
+            channels = tuple(channels)
         return cls(
-            raw_dim=int(config["raw_dim"]),
-            decay_rates=tuple(config["decay_rates"]),
-            channels=tuple(config["channels"]) if config["channels"] is not None else None,
-            include_raw=bool(config["include_raw"]),
+            raw_dim=payload["raw_dim"],
+            decay_rates=decay_rates,
+            channels=channels,
+            include_raw=payload["include_raw"],
         )

--- a/tests/test_history_features.py
+++ b/tests/test_history_features.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import cast
 
 import chex
@@ -59,6 +60,129 @@ class TestValidation:
     def test_invalid_channel_index(self) -> None:
         with pytest.raises(ValueError, match="channels"):
             HistoryFeatureExtractor(raw_dim=4, channels=(0, 5))
+
+    @pytest.mark.parametrize("value", [True, 1.5, 0, -1, 2**31])
+    def test_raw_dim_requires_supported_positive_int32(self, value: object) -> None:
+        with pytest.raises(ValueError, match="raw_dim"):
+            HistoryFeatureExtractor(raw_dim=value)  # type: ignore[arg-type]
+
+    def test_rejects_hostile_integral_subclasses(self) -> None:
+        class LieInt(int):
+            def __int__(self) -> int:
+                return 1
+
+        with pytest.raises(ValueError, match="raw_dim"):
+            HistoryFeatureExtractor(raw_dim=LieInt(4))
+        with pytest.raises(ValueError, match=r"channels\[0\]"):
+            HistoryFeatureExtractor(raw_dim=4, channels=(LieInt(0),))
+
+    def test_canonicalizes_supported_numpy_integer_families(self) -> None:
+        assert np.longlong is not np.int64
+        assert np.ulonglong is not np.uint64
+        extractor = HistoryFeatureExtractor(
+            raw_dim=np.longlong(4),
+            channels=(np.ulonglong(0), np.int32(2)),
+        )
+        assert extractor.raw_dim == 4 and type(extractor.raw_dim) is int
+        assert extractor.channels == (0, 2)
+        assert all(type(channel) is int for channel in extractor.channels)
+
+    @pytest.mark.parametrize(
+        "decay_rates",
+        [
+            [0.5],
+            (False,),
+            (1.0,),
+            (-0.1,),
+            (1e100,),
+            (1.0 - 1e-10,),
+        ],
+    )
+    def test_decay_rates_require_exact_tuple_and_float32_domain(
+        self,
+        decay_rates: object,
+    ) -> None:
+        with pytest.raises(ValueError, match="decay_rates"):
+            HistoryFeatureExtractor(raw_dim=4, decay_rates=decay_rates)  # type: ignore[arg-type]
+
+    def test_rejects_tuple_bool_and_class_spoofs(self) -> None:
+        class TupleSubclass(tuple):
+            pass
+
+        class BoolSpoof:
+            @property
+            def __class__(self) -> type[bool]:
+                return bool
+
+        with pytest.raises(ValueError, match="decay_rates"):
+            HistoryFeatureExtractor(
+                raw_dim=4,
+                decay_rates=TupleSubclass((0.5,)),
+            )
+        with pytest.raises(ValueError, match="channels"):
+            HistoryFeatureExtractor(raw_dim=4, channels=TupleSubclass((0,)))
+        with pytest.raises(ValueError, match="include_raw"):
+            HistoryFeatureExtractor(raw_dim=4, include_raw=BoolSpoof())  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "ratio",
+        [
+            pytest.param((-1, 2**200), id="negative-rounds-to-zero"),
+            pytest.param((2**200 - 1, 2**200), id="below-one-rounds-to-one"),
+        ],
+    )
+    def test_rejects_hostile_exact_decay_ratios(
+        self,
+        ratio: tuple[int, int],
+    ) -> None:
+        class HiddenBoundaryFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return ratio
+
+        with pytest.raises(ValueError, match=r"decay_rates\[0\]"):
+            HistoryFeatureExtractor(
+                raw_dim=4,
+                decay_rates=(HiddenBoundaryFloat(0.5),),
+            )
+
+    def test_canonicalizes_decay_scalars_and_json_round_trip(self) -> None:
+        extractor = HistoryFeatureExtractor(
+            raw_dim=np.int32(4),
+            decay_rates=(
+                Fraction(1, 10),
+                np.float64(0.25),
+                Fraction(1, 10**400),
+            ),
+            channels=(np.int16(0), np.uint8(2)),
+            include_raw=False,
+        )
+        assert extractor.decay_rates == (float(np.float32(0.1)), 0.25, 0.0)
+        assert all(type(rate) is float for rate in extractor.decay_rates)
+        restored = HistoryFeatureExtractor.from_config(extractor.to_config())
+        assert restored.to_config() == extractor.to_config()
+        assert restored.feature_dim() == extractor.feature_dim()
+
+    def test_from_config_does_not_coerce_invalid_scalar_types(self) -> None:
+        payload = HistoryFeatureExtractor(raw_dim=2).to_config()
+        with pytest.raises(ValueError, match="raw_dim"):
+            HistoryFeatureExtractor.from_config({**payload, "raw_dim": 2.5})
+        with pytest.raises(ValueError, match="include_raw"):
+            HistoryFeatureExtractor.from_config({**payload, "include_raw": 1})
+
+    def test_derived_feature_dimension_is_positive_int32(self) -> None:
+        with pytest.raises(ValueError, match="feature_dim"):
+            HistoryFeatureExtractor(
+                raw_dim=2**31 - 1,
+                decay_rates=(0.5,),
+                channels=(0,),
+            )
+        with pytest.raises(ValueError, match="feature_dim"):
+            HistoryFeatureExtractor(
+                raw_dim=1,
+                decay_rates=(),
+                channels=(),
+                include_raw=False,
+            )
 
 
 class TestStep:


### PR DESCRIPTION
Focused follow-up to merged #661, which superseded the source portion of #657 with the strict HistoryFeature implementation.

This adds the residual adversarial coverage not present in #661:

- hostile actual Integral subclasses at raw/channel boundaries;
- tuple subclasses at decay/channel container boundaries;
- actual Real subclasses whose exact ratios cross the nonnegative or half-open float32 decay bounds;
- canonical Fraction/NumPy scalar JSON round-trip, including exact positive underflow to zero;
- proof that from_config does not coerce invalid scalar types;
- the zero-derived-feature endpoint.

Existing observation vector-shape regressions remain on main.

Verification:
- pytest tests/test_history_features.py -q -o addopts='' (56 passed)
- ruff check tests/test_history_features.py
- mypy alberta_framework/core/history_features.py
- git diff --check