### PR TITLE
fix: close benchmark and CBP scalar boundary gaps

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -114,6 +114,7 @@ from alberta_framework._seed_validation import (
     require_jax_seed,
     require_unique_jax_seeds,
 )
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.baseline_optimizers import Adam
 from alberta_framework.core.canonical_upgd import CanonicalUPGD, CanonicalUPGDConfig
 from alberta_framework.core.update_safety import (
@@ -709,6 +710,20 @@ _LEARNER_DEFAULT_HYPERPARAMETERS: dict[str, dict[str, float]] = {
 }
 
 
+def _validated_hyperparameter(name: str, value: object) -> float:
+    """Validate one JSON override in its exact host and float32 execution domains."""
+    if type(value) not in (int, float):
+        raise ValueError(f"hyperparameter {name!r} must be a finite JSON number")
+    label = f"hyperparameter {name!r}"
+    if name in {"step_size", "eps"}:
+        return validated_float32_scalar(label, value, positive=True)
+    if name in {"utility_decay", "beta1", "beta2"}:
+        return validated_float32_scalar(
+            label, value, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+    return validated_float32_scalar(label, value, lower=0.0)
+
+
 @dataclass(frozen=True)
 class IPMNISTRunResult:
     """Host-side result of one learner's multi-seed run.
@@ -747,12 +762,10 @@ def resolve_hyperparameters(
         unknown = set(overrides) - set(merged)
         if unknown:
             raise ValueError(f"unknown hyperparameters for {learner}: {sorted(unknown)}")
+        validated: dict[str, float] = {}
         for name, value in overrides.items():
-            if type(value) not in (int, float) or not math.isfinite(value):
-                raise ValueError(
-                    f"hyperparameter {name!r} must be a finite JSON number"
-                )
-        merged.update({name: float(value) for name, value in overrides.items()})
+            validated[name] = _validated_hyperparameter(name, value)
+        merged.update(validated)
     return merged
 
 

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -123,6 +123,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     task_index_for_step,
     validated_ipmnist_data,
 )
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +229,20 @@ _LEARNER_DEFAULT_HYPERPARAMETERS: dict[str, dict[str, float]] = {
     "upgd_ema_norm_sigma0": UPGD_EMA_NORM_SIGMA0_HYPERPARAMETERS,
     "sgd_ema_norm": SGD_EMA_NORM_HYPERPARAMETERS,
 }
+
+
+def _validated_hyperparameter(name: str, value: object) -> float:
+    """Validate one JSON override in its exact host and float32 execution domains."""
+    if type(value) not in (int, float):
+        raise ValueError(f"hyperparameter {name!r} must be a finite JSON number")
+    label = f"hyperparameter {name!r}"
+    if name in {"step_size", "eps", "norm_epsilon"}:
+        return validated_float32_scalar(label, value, positive=True)
+    if name in {"utility_decay", "beta1", "beta2", "norm_decay"}:
+        return validated_float32_scalar(
+            label, value, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+    return validated_float32_scalar(label, value, lower=0.0)
 
 
 def _wrapped_v1_factory(
@@ -446,12 +461,10 @@ def resolve_hyperparameters(
         unknown = set(overrides) - set(merged)
         if unknown:
             raise ValueError(f"unknown hyperparameters for {learner}: {sorted(unknown)}")
+        validated: dict[str, float] = {}
         for name, value in overrides.items():
-            if type(value) not in (int, float) or not math.isfinite(value):
-                raise ValueError(
-                    f"hyperparameter {name!r} must be a finite JSON number"
-                )
-        merged.update({name: float(value) for name, value in overrides.items()})
+            validated[name] = _validated_hyperparameter(name, value)
+        merged.update(validated)
     return merged
 
 

--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -88,6 +88,11 @@ from alberta_framework.core.normalizers import Normalizer
 from alberta_framework.core.optimizers import Bounder
 from alberta_framework.core.types import TraceMode
 
+_NUMPY_FLOAT_SCALAR_TYPES = frozenset((np.float16, np.float32, np.float64, np.longdouble))
+_NUMPY_INTEGER_SCALAR_TYPES = frozenset(
+    (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64)
+)
+
 # =============================================================================
 # Config / state
 # =============================================================================
@@ -136,7 +141,7 @@ class ContinualBackpropConfig:
         maturity_type = type(self.maturity_threshold)
         if maturity_type is int:
             maturity_threshold = self.maturity_threshold
-        elif issubclass(maturity_type, np.integer):
+        elif maturity_type in _NUMPY_INTEGER_SCALAR_TYPES:
             maturity_threshold = int(self.maturity_threshold)
         else:
             raise ValueError("maturity_threshold must be an integer in the int32 domain")
@@ -174,8 +179,8 @@ def _validated_config_float(
 ) -> float:
     """Validate trusted built-in/NumPy numerics in both host and float32 domains."""
     actual_type = type(value)
-    if actual_type not in (int, float) and not issubclass(
-        actual_type, (np.integer, np.floating)
+    if actual_type not in (int, float) and actual_type not in (
+        _NUMPY_INTEGER_SCALAR_TYPES | _NUMPY_FLOAT_SCALAR_TYPES
     ):
         raise ValueError(f"{name} must be a finite real number")
     return validated_float32_scalar(

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -744,6 +744,42 @@ class TestContinualBackpropConfigValidation:
         assert type(config.enabled) is bool
         assert ContinualBackpropConfig.from_config(config.to_config()) == config
 
+    @pytest.mark.parametrize("base", [np.float32, np.float64])
+    def test_rejects_hostile_numpy_float_subclasses(self, base: type[np.floating]) -> None:
+        class LyingFloat(base):  # type: ignore[misc, valid-type]
+            def as_integer_ratio(self) -> tuple[int, int]:
+                return (1, 2)
+
+        class RaisingFloat(base):  # type: ignore[misc, valid-type]
+            def as_integer_ratio(self) -> tuple[int, int]:
+                raise RuntimeError("must not run")
+
+        for value in (LyingFloat(float("nan")), RaisingFloat(0.5)):
+            with pytest.raises(ValueError, match="decay_rate"):
+                ContinualBackpropConfig(decay_rate=value)  # type: ignore[arg-type]
+
+    def test_rejects_hostile_numpy_integer_subclasses(self) -> None:
+        class LyingInt(np.int64):
+            def __int__(self) -> int:
+                return 7
+
+        class RaisingInt(np.int64):
+            def __int__(self) -> int:
+                raise RuntimeError("must not run")
+
+        for value in (LyingInt(-1), RaisingInt(7)):
+            with pytest.raises(ValueError, match="maturity_threshold"):
+                ContinualBackpropConfig(maturity_threshold=value)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "value",
+        [np.int8(7), np.int16(7), np.int32(7), np.int64(7), np.uint64(7)],
+    )
+    def test_canonicalizes_supported_numpy_integer_widths(self, value: np.integer) -> None:
+        config = ContinualBackpropConfig(maturity_threshold=value)  # type: ignore[arg-type]
+        assert config.maturity_threshold == 7
+        assert type(config.maturity_threshold) is int
+
 
 class TestConfigRoundtrip:
     """to_config/from_config preserves CBP config + learner hyperparameters."""

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -92,7 +92,7 @@ class TestProtocolConstants:
     def test_resolve_hyperparameters_rejects_nonfinite_or_non_json_numbers(
         self, value: object
     ) -> None:
-        with pytest.raises(ValueError, match="finite JSON number"):
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
             resolve_hyperparameters("upgd_w", {"step_size": value})  # type: ignore[dict-item]
 
     def test_resolve_hyperparameters_rejects_class_spoofed_number(self) -> None:
@@ -104,10 +104,59 @@ class TestProtocolConstants:
             def __float__(self) -> float:
                 return 0.1
 
-        with pytest.raises(ValueError, match="finite JSON number"):
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
             resolve_hyperparameters(  # type: ignore[dict-item]
                 "upgd_w", {"step_size": SpoofedNumber()}
             )
+
+    @pytest.mark.parametrize("value", [1e100, 10**400, 1e-50])
+    def test_resolve_hyperparameters_rejects_float32_unsafe_values(
+        self, value: int | float
+    ) -> None:
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
+            resolve_hyperparameters("upgd_w", {"step_size": value})
+
+    def test_resolve_hyperparameters_rejects_hostile_numeric_subclass(self) -> None:
+        class HostileFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
+            resolve_hyperparameters(  # type: ignore[dict-item]
+                "upgd_w", {"step_size": HostileFloat(0.1)}
+            )
+
+    @pytest.mark.parametrize(
+        ("learner", "name", "value"),
+        [
+            ("upgd_w", "step_size", 0.0),
+            ("upgd_w", "utility_decay", -0.1),
+            ("upgd_w", "utility_decay", 1.0),
+            ("upgd_w", "noise_std", -0.1),
+            ("upgd_w", "weight_decay", -0.1),
+            ("adamw", "step_size", 0.0),
+            ("adamw", "beta1", -0.1),
+            ("adamw", "beta1", 1.0),
+            ("adamw", "beta2", 1.0),
+            ("adamw", "eps", 0.0),
+            ("adamw", "weight_decay", -0.1),
+        ],
+    )
+    def test_resolve_hyperparameters_enforces_field_domains(
+        self, learner: str, name: str, value: float
+    ) -> None:
+        with pytest.raises(ValueError, match=f"hyperparameter {name!r}"):
+            resolve_hyperparameters(learner, {name: value})
+
+    def test_resolve_hyperparameters_accepts_endpoints_and_canonicalizes_ints(self) -> None:
+        resolved = resolve_hyperparameters(
+            "upgd_w",
+            {"utility_decay": 0, "noise_std": 0, "weight_decay": 1},
+        )
+        assert resolved["utility_decay"] == 0.0
+        assert resolved["noise_std"] == 0.0
+        assert resolved["weight_decay"] == 1.0
+        assert all(type(resolved[name]) is float for name in resolved)
 
 
 class TestSchedule:

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -92,7 +92,7 @@ class TestConfig:
     def test_resolve_hyperparameters_rejects_nonfinite_or_non_json_numbers(
         self, value: object
     ) -> None:
-        with pytest.raises(ValueError, match="finite JSON number"):
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
             resolve_hyperparameters("upgd_w", {"step_size": value})  # type: ignore[dict-item]
 
     def test_resolve_hyperparameters_rejects_class_spoofed_number(self) -> None:
@@ -104,10 +104,64 @@ class TestConfig:
             def __float__(self) -> float:
                 return 0.1
 
-        with pytest.raises(ValueError, match="finite JSON number"):
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
             resolve_hyperparameters(  # type: ignore[dict-item]
                 "upgd_w", {"step_size": SpoofedNumber()}
             )
+
+    @pytest.mark.parametrize("value", [1e100, 10**400, 1e-50])
+    def test_resolve_hyperparameters_rejects_float32_unsafe_values(
+        self, value: int | float
+    ) -> None:
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
+            resolve_hyperparameters("upgd_w", {"step_size": value})
+
+    def test_resolve_hyperparameters_rejects_hostile_numeric_subclass(self) -> None:
+        class HostileFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match="hyperparameter 'step_size'"):
+            resolve_hyperparameters(  # type: ignore[dict-item]
+                "upgd_w", {"step_size": HostileFloat(0.1)}
+            )
+
+    @pytest.mark.parametrize(
+        ("learner", "name", "value"),
+        [
+            ("upgd_w", "step_size", 0.0),
+            ("upgd_w", "utility_decay", 1.0),
+            ("upgd_w", "noise_std", -0.1),
+            ("adamw", "beta1", -0.1),
+            ("adamw", "beta2", 1.0),
+            ("adamw", "eps", 0.0),
+            ("adamw", "weight_decay", -0.1),
+            ("upgd_ema_norm", "norm_decay", 1.0),
+            ("upgd_ema_norm", "norm_epsilon", 0.0),
+            ("sgd_ema_norm", "step_size", 0.0),
+            ("sgd_ema_norm", "weight_decay", -0.1),
+        ],
+    )
+    def test_resolve_hyperparameters_enforces_field_domains(
+        self, learner: str, name: str, value: float
+    ) -> None:
+        with pytest.raises(ValueError, match=f"hyperparameter {name!r}"):
+            resolve_hyperparameters(learner, {name: value})
+
+    def test_resolve_hyperparameters_accepts_endpoints_and_canonicalizes_ints(self) -> None:
+        resolved = resolve_hyperparameters(
+            "upgd_ema_norm",
+            {
+                "utility_decay": 0,
+                "noise_std": 0,
+                "weight_decay": 1,
+                "norm_decay": 0,
+            },
+        )
+        assert all(type(resolved[name]) is float for name in resolved)
+        assert resolved["utility_decay"] == 0.0
+        assert resolved["norm_decay"] == 0.0
+        assert resolved["weight_decay"] == 1.0
 
     def test_normalized_arm_hyperparameters(self):
         """EMA-norm transfer arms: published EMNIST UPGD-W values + the exact


### PR DESCRIPTION
## Summary

Completes the post-review corrections left after #647 and #633:

- validate replication overrides in both the exact host and float32 execution domains
- enforce optimizer-specific parameter domains (positive rates/epsilons, half-open EMA/beta intervals, nonnegative noise/decay)
- preserve the exact JSON-number intake boundary and canonicalize accepted integer overrides to floats
- replace NumPy-family `issubclass` intake in Continual Backprop with exact supported scalar-type identities
- reject lying and raising NumPy scalar subclasses before invoking conversion hooks

#631 was already closed as superseded by #647 while this combined correction was being prepared. This PR retains only the missing sink/domain and CBP residuals on current main.

## Verification

- `pytest tests/test_upgd_ipmnist.py tests/test_upgd_label_emnist.py tests/test_continual_backprop.py -q -o addopts=""`: 211 passed
- focused post-rebase validation: 69 passed
- `ruff check .`: passed
- `mypy`: 168 source files passed
- root `alberta_framework` / Continual Backprop import: passed
- no registered evidence artifact is modified; active development outputs are untouched
