### PR TITLE
fix(cbp): complete NumPy integer scalar support

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -90,7 +90,18 @@ from alberta_framework.core.types import TraceMode
 
 _NUMPY_FLOAT_SCALAR_TYPES = frozenset((np.float16, np.float32, np.float64, np.longdouble))
 _NUMPY_INTEGER_SCALAR_TYPES = frozenset(
-    (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64)
+    (
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.longlong,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.ulonglong,
+    )
 )
 
 # =============================================================================

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -773,7 +773,15 @@ class TestContinualBackpropConfigValidation:
 
     @pytest.mark.parametrize(
         "value",
-        [np.int8(7), np.int16(7), np.int32(7), np.int64(7), np.uint64(7)],
+        [
+            np.int8(7),
+            np.int16(7),
+            np.int32(7),
+            np.int64(7),
+            np.longlong(7),
+            np.uint64(7),
+            np.ulonglong(7),
+        ],
     )
     def test_canonicalizes_supported_numpy_integer_widths(self, value: np.integer) -> None:
         config = ContinualBackpropConfig(maturity_threshold=value)  # type: ignore[arg-type]


### PR DESCRIPTION
Narrow follow-up to #663. Continual Backprop now recognizes the platform-distinct standard NumPy longlong and ulonglong scalar types alongside the other supported widths, while continuing to reject subclasses by exact type identity. Focused canonicalization coverage is included. Verification: 52 tests passed; Ruff passed; strict source mypy passed; diff-check clean.