### PR TITLE
fix(reward-model): enforce feature vector shapes

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -137,7 +137,11 @@ class RLSRewardModel:
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: RLSRewardModelState, features: Array) -> Array:
         """Predict reward from one feature vector."""
-        x = jnp.asarray(features, dtype=jnp.float32).reshape((self._config.feature_dim,))
+        x = jnp.asarray(features, dtype=jnp.float32)
+        if x.shape != (self._config.feature_dim,):
+            raise ValueError(
+                f"features must have shape ({self._config.feature_dim},), got {x.shape}"
+            )
         return jnp.dot(state.weights, x)
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -164,7 +168,11 @@ class RLSRewardModel:
         unless the reward function is genuinely nonstationary and the
         feature stream stays exciting.
         """
-        x = jnp.asarray(features, dtype=jnp.float32).reshape((self._config.feature_dim,))
+        x = jnp.asarray(features, dtype=jnp.float32)
+        if x.shape != (self._config.feature_dim,):
+            raise ValueError(
+                f"features must have shape ({self._config.feature_dim},), got {x.shape}"
+            )
         target = jnp.asarray(reward, dtype=jnp.float32)
         prediction = jnp.dot(state.weights, x)
         error = target - prediction

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -3,11 +3,48 @@
 from __future__ import annotations
 
 import chex
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
+
+
+@pytest.mark.parametrize("operation", ["predict", "update"])
+@pytest.mark.parametrize("shape", [(), (4, 1), (1, 4), (2, 2), (3,), (5,)])
+def test_rls_reward_model_rejects_non_vector_feature_shapes(
+    operation: str,
+    shape: tuple[int, ...],
+) -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=4))
+    state = model.init()
+    features = jnp.zeros(shape, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match=r"features must have shape \(4,\)"):
+        if operation == "predict":
+            model.predict(state, features)
+        else:
+            model.update(state, features, jnp.array(0.0, dtype=jnp.float32))
+
+
+def test_rls_reward_model_feature_shape_guard_is_jit_stable() -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=4))
+    state = model.init()
+    predict = jax.jit(lambda features: model.predict(state, features))
+    update = jax.jit(
+        lambda features: model.update(
+            state,
+            features,
+            jnp.array(0.0, dtype=jnp.float32),
+        ).state.weights
+    )
+
+    chex.assert_shape(predict(jnp.ones((4,), dtype=jnp.float32)), ())
+    chex.assert_shape(update(jnp.ones((4,), dtype=jnp.float32)), (4,))
+    for call in (predict, update):
+        with pytest.raises(ValueError, match=r"features must have shape \(4,\)"):
+            call(jnp.ones((2, 2), dtype=jnp.float32))
 
 
 def test_rls_reward_model_config_roundtrip() -> None:


### PR DESCRIPTION
Supersedes closed #659 with committed regressions. Predict and update now reject scalar, matrix, equal-size reshape, and wrong-length feature inputs before JAX math, while valid feature vectors remain JIT-stable. The test panel covers both operations and compiled valid/invalid paths. Focused reward-model verification was completed on the repair branch; Ruff and diff-check are clean.