### PR TITLE
fix(normalizers): enforce exact feature dimensions

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -24,11 +24,12 @@ import math
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -53,6 +54,39 @@ NORMALIZER_LIFETIME_COUNTER_DELTA_NBYTES = 8
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 _FLOAT32_CONSECUTIVE_INTEGER_LIMIT = 2**24
+
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = int(cast(int, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
 
 
 def _stored_float32_equals_one(value: float) -> bool:
@@ -475,6 +509,9 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
             Initial normalizer state whose zero mean and unit variance form
             the estimator's one explicit prior pseudo-sample.
         """
+        feature_dim = _require_int(
+            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+        )
         return EMANormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -620,6 +657,9 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
         Returns:
             Initial normalizer state with zero mean and unit variance
         """
+        feature_dim = _require_int(
+            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+        )
         return WelfordNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -757,6 +797,9 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
 
     def init(self, feature_dim: int) -> StreamingBatchNormalizerState:
         """Initialize running moments."""
+        feature_dim = _require_int(
+            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+        )
         return StreamingBatchNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),

--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -21,10 +21,11 @@ Three normalizer variants are provided:
 
 import dataclasses
 import math
+import operator
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -57,14 +58,7 @@ _FLOAT32_CONSECUTIVE_INTEGER_LIMIT = 2**24
 
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
 )
 
 
@@ -77,7 +71,7 @@ def _require_int(
 ) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(int, value))
+    number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -2,6 +2,7 @@
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -691,3 +692,59 @@ class TestNormalizerScalarSpoofRejection:
         """A real (non-spoofed) int must remain accepted and coerced to float."""
         normalizer = StreamingBatchNormalizer(momentum=1)
         assert normalizer._momentum == 1.0
+
+
+class TestNormalizerFeatureDimValidation:
+    @pytest.mark.parametrize(
+        "normalizer",
+        [EMANormalizer(), WelfordNormalizer(), StreamingBatchNormalizer()],
+        ids=["ema", "welford", "streaming-batch"],
+    )
+    @pytest.mark.parametrize(
+        "feature_dim",
+        [
+            pytest.param(True, id="bool"),
+            pytest.param(np.bool_(True), id="numpy-bool"),
+            pytest.param(1.5, id="float"),
+            pytest.param(np.float32(4), id="numpy-float"),
+            pytest.param(0, id="zero"),
+            pytest.param(-1, id="negative"),
+            pytest.param(2**31, id="int32-overflow"),
+            pytest.param("4", id="string"),
+            pytest.param([4], id="list"),
+        ],
+    )
+    def test_init_rejects_invalid_feature_dim(self, normalizer, feature_dim: object) -> None:
+        with pytest.raises(ValueError, match="feature_dim"):
+            normalizer.init(feature_dim)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "integer_type",
+        [int, np.int32, np.longlong, np.ulonglong],
+        ids=["builtin", "numpy-int32", "numpy-longlong", "numpy-ulonglong"],
+    )
+    def test_init_accepts_and_canonicalizes_supported_integer_families(
+        self,
+        integer_type: type,
+    ) -> None:
+        for normalizer in (
+            EMANormalizer(),
+            WelfordNormalizer(),
+            StreamingBatchNormalizer(),
+        ):
+            state = normalizer.init(integer_type(4))
+            chex.assert_shape(state.mean, (4,))
+            chex.assert_shape(state.var, (4,))
+
+    def test_init_rejects_hostile_integer_subclasses(self) -> None:
+        class LyingInt(int):
+            def __index__(self) -> int:
+                return 4
+
+        for normalizer in (
+            EMANormalizer(),
+            WelfordNormalizer(),
+            StreamingBatchNormalizer(),
+        ):
+            with pytest.raises(ValueError, match="feature_dim"):
+                normalizer.init(LyingInt(-1))


### PR DESCRIPTION
Replacement for #668, preserving its contributor-authored implementation commit on current main.

The original correctly identified missing `init(feature_dim)` validation but had no committed tests and omitted distinct NumPy `longlong`/`ulonglong` scalar families. This integration:
- validates all three normalizer initializers before JAX allocation;
- accepts only exact built-in and dtype-derived standard NumPy integer types;
- canonicalizes through `operator.index`;
- requires `1 <= feature_dim <= INT32_MAX`;
- rejects booleans, float aliases, hostile integer subclasses, coercible containers, and overflow;
- adds committed regression coverage across EMA, Welford, and streaming-batch normalizers.

Validation:
- `pytest tests/test_normalizers.py -q -o addopts=` — 103 passed
- scoped Ruff — passed
- strict mypy for `normalizers.py` — passed
- `git diff --check` — clean

No outputs or registered evidence artifacts changed.