### PR TITLE
fix(normalizers): enforce exact feature dimensions

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -21,14 +21,16 @@ Three normalizer variants are provided:
 
 import dataclasses
 import math
+import operator
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -53,6 +55,31 @@ NORMALIZER_LIFETIME_COUNTER_DELTA_NBYTES = 8
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 _FLOAT32_CONSECUTIVE_INTEGER_LIMIT = 2**24
+_ACTUAL_INT_TYPES = frozenset(
+    (
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.longlong,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.ulonglong,
+    )
+)
+
+
+def _require_feature_dim(value: object) -> int:
+    """Return a canonical positive signed-int32 feature dimension."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError("feature_dim must be an integer in [1, 2147483647]")
+    feature_dim = operator.index(cast(SupportsIndex, value))
+    if not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("feature_dim must be an integer in [1, 2147483647]")
+    return feature_dim
 
 
 def _stored_float32_equals_one(value: float) -> bool:
@@ -475,6 +502,7 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
             Initial normalizer state whose zero mean and unit variance form
             the estimator's one explicit prior pseudo-sample.
         """
+        feature_dim = _require_feature_dim(feature_dim)
         return EMANormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -620,6 +648,7 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
         Returns:
             Initial normalizer state with zero mean and unit variance
         """
+        feature_dim = _require_feature_dim(feature_dim)
         return WelfordNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -757,6 +786,7 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
 
     def init(self, feature_dim: int) -> StreamingBatchNormalizerState:
         """Initialize running moments."""
+        feature_dim = _require_feature_dim(feature_dim)
         return StreamingBatchNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -2,6 +2,7 @@
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -14,6 +15,53 @@ from alberta_framework import (
     WelfordNormalizerState,
     normalizer_from_config,
 )
+
+_NORMALIZERS = (EMANormalizer, WelfordNormalizer, StreamingBatchNormalizer)
+
+
+@pytest.mark.parametrize("normalizer_type", _NORMALIZERS)
+@pytest.mark.parametrize(
+    "feature_dim",
+    [
+        4,
+        np.int8(4),
+        np.int32(4),
+        np.int64(4),
+        np.longlong(4),
+        np.uint64(4),
+        np.ulonglong(4),
+    ],
+)
+def test_normalizer_init_accepts_supported_exact_integer_types(
+    normalizer_type,
+    feature_dim,
+) -> None:
+    state = normalizer_type().init(feature_dim)
+    chex.assert_shape(state.mean, (4,))
+    chex.assert_shape(state.var, (4,))
+
+
+@pytest.mark.parametrize("normalizer_type", _NORMALIZERS)
+@pytest.mark.parametrize(
+    "feature_dim",
+    [True, np.bool_(True), 1.5, np.float32(4), 0, -1, 2**31, "4", [4]],
+)
+def test_normalizer_init_rejects_invalid_feature_dimensions(
+    normalizer_type,
+    feature_dim,
+) -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        normalizer_type().init(feature_dim)
+
+
+@pytest.mark.parametrize("normalizer_type", _NORMALIZERS)
+def test_normalizer_init_rejects_integer_subclasses(normalizer_type) -> None:
+    class LyingInt(int):
+        def __int__(self) -> int:
+            return 4
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        normalizer_type().init(LyingInt(-1))
 
 
 class TestEMANormalizer:


### PR DESCRIPTION
Supersedes #668 with committed regression coverage. All three normalizer init paths accept only actual supported built-in and NumPy integer scalar types, including platform-distinct longlong/ulonglong, canonicalize through the index protocol, and enforce the positive signed-int32 domain before allocation. Tests cover accepted widths, bool/float/NumPy-float/string/list/zero/negative/overflow rejection, and hostile integer subclasses. Verification: 122 tests passed; Ruff passed; strict source mypy passed; diff-check clean.