### PR TITLE
fix(normalizers): align formula and dimension contracts

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -70,16 +70,16 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer, got {value!r}")
+        raise ValueError(f"{name} must be an integer")
     number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
@@ -899,8 +899,9 @@ def normalizer_state_nbytes_formula(
 ) -> int:
     """Return exact persistent JAX-array bytes for a normalizer state."""
 
-    if type(feature_dim) is not int or feature_dim < 0:
-        raise ValueError("feature_dim must be a non-negative exact integer")
+    feature_dim = _require_int(
+        "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+    )
     if normalizer_type in {"EMANormalizer", "StreamingBatchNormalizer"}:
         return 8 * feature_dim + 16
     if normalizer_type == "WelfordNormalizer":

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -14,6 +14,7 @@ from alberta_framework import (
     WelfordNormalizer,
     WelfordNormalizerState,
     normalizer_from_config,
+    normalizer_state_nbytes_formula,
 )
 
 
@@ -748,3 +749,93 @@ class TestNormalizerFeatureDimValidation:
         ):
             with pytest.raises(ValueError, match="feature_dim"):
                 normalizer.init(LyingInt(-1))
+
+    @pytest.mark.parametrize(
+        "integer_type",
+        tuple(
+            dict.fromkeys(
+                np.dtype(code).type
+                for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+            )
+        ),
+    )
+    def test_init_accepts_every_dtype_derived_numpy_integer_type(
+        self, integer_type: type
+    ) -> None:
+        for normalizer in (
+            EMANormalizer(),
+            WelfordNormalizer(),
+            StreamingBatchNormalizer(),
+        ):
+            state = normalizer.init(integer_type(4))
+            chex.assert_shape(state.mean, (4,))
+
+    def test_invalid_feature_dim_never_interpolates_hostile_repr(self) -> None:
+        class ClassSpoof:
+            @property
+            def __class__(self) -> type[int]:  # type: ignore[override]
+                return int
+
+            def __repr__(self) -> str:
+                raise RuntimeError("repr must not run")
+
+        value = ClassSpoof()
+        for normalizer in (
+            EMANormalizer(),
+            WelfordNormalizer(),
+            StreamingBatchNormalizer(),
+        ):
+            with pytest.raises(ValueError, match="feature_dim"):
+                normalizer.init(value)  # type: ignore[arg-type]
+
+
+class TestNormalizerStateNbytesFormulaValidation:
+    @pytest.mark.parametrize(
+        "feature_dim",
+        [True, np.bool_(True), 0, -1, 1.5, np.float32(4), 2**31, "4", [4]],
+    )
+    def test_formula_matches_initializer_feature_dim_rejections(
+        self, feature_dim: object
+    ) -> None:
+        with pytest.raises(ValueError, match="feature_dim"):
+            normalizer_state_nbytes_formula(
+                "EMANormalizer", feature_dim  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize(
+        "integer_type",
+        tuple(
+            dict.fromkeys(
+                [
+                    int,
+                    *(
+                        np.dtype(code).type
+                        for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+                    ),
+                ]
+            )
+        ),
+    )
+    def test_formula_accepts_all_supported_integer_types(self, integer_type: type) -> None:
+        assert normalizer_state_nbytes_formula("EMANormalizer", integer_type(4)) == 48
+
+    def test_formula_accepts_int32_max_without_allocating(self) -> None:
+        maximum = 2**31 - 1
+        assert normalizer_state_nbytes_formula("EMANormalizer", maximum) == 8 * maximum + 16
+        assert normalizer_state_nbytes_formula("WelfordNormalizer", maximum) == (
+            12 * maximum + 12
+        )
+
+    def test_formula_rejects_class_spoof_without_calling_repr(self) -> None:
+        class ClassSpoof:
+            @property
+            def __class__(self) -> type[int]:  # type: ignore[override]
+                return int
+
+            def __repr__(self) -> str:
+                raise RuntimeError("repr must not run")
+
+        with pytest.raises(ValueError, match="feature_dim"):
+            normalizer_state_nbytes_formula(
+                "EMANormalizer", ClassSpoof()  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
Residual follow-up to merged #669.\n\nThis removes hostile `repr` interpolation from the shared integer validator and routes `normalizer_state_nbytes_formula` through the same exact supported-integer, `[1, INT32_MAX]`, canonicalizing contract as all three normalizer initializers. Tests cover every dtype-derived NumPy integer runtime type, a raising-`__repr__` `__class__` spoof, formula zero/negative/overflow/type parity, and formula evaluation at `INT32_MAX` without allocation.\n\nValidation:\n- `pytest tests/test_normalizers.py -q -o addopts=''`: 136 passed\n- scoped Ruff: clean\n- strict mypy on `normalizers.py`: clean\n- `git diff --check`: clean\n\nLive overlap check immediately before publication found current main still at merged #669 and no open normalizer PRs. No outputs or registered evidence artifacts changed.