### PR TITLE
fix(upgd): validate finite step sizes

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -45,6 +45,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.optimizers import Bounder, ObGDBounding
 from alberta_framework.core.types import MLPParams
@@ -531,9 +532,7 @@ class UPGDLearner:
         if any(size < 1 for size in hidden_sizes):
             msg = f"hidden_sizes must contain only positive sizes, got {hidden_sizes!r}"
             raise ValueError(msg)
-        if step_size < 0.0:
-            msg = f"step_size must be non-negative, got {step_size}"
-            raise ValueError(msg)
+        validated_step_size = validated_float32_scalar("step_size", step_size, lower=0.0)
         if perturbation_sigma < 0.0:
             msg = f"perturbation_sigma must be non-negative, got {perturbation_sigma}"
             raise ValueError(msg)
@@ -1033,7 +1032,7 @@ class UPGDLearner:
 
         self._n_heads = n_heads
         self._hidden_sizes = hidden_sizes
-        self._step_size = float(step_size)
+        self._step_size = validated_step_size
         self._bounder = bounder
         self._utility_decay = float(utility_decay)
         self._perturbation_sigma = float(perturbation_sigma)

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -331,6 +331,21 @@ class TestInitShapes:
 class TestValidation:
     """Invalid deployment configurations should fail before JIT compilation."""
 
+    @pytest.mark.parametrize(
+        "step_size",
+        [float("nan"), float("inf"), float("-inf"), True, 1e40],
+    )
+    def test_rejects_non_finite_or_boolean_step_size(self, step_size):
+        with pytest.raises(ValueError, match="step_size"):
+            UPGDLearner(n_heads=1, step_size=step_size)
+
+    def test_from_config_rejects_non_finite_step_size(self):
+        config = UPGDLearner(n_heads=1).to_config()
+        config["step_size"] = float("nan")
+
+        with pytest.raises(ValueError, match="step_size"):
+            UPGDLearner.from_config(config)
+
     @pytest.mark.parametrize("shape", [(1,), (), (4, 1), (5,)])
     def test_update_rejects_targets_that_are_not_one_per_head(self, shape):
         """A broadcastable target must not train every head while n_active counts 1."""


### PR DESCRIPTION
Closes #676.

## What changed

`UPGDLearner` now validates `step_size` with the repository's shared float32 scalar boundary before storing it:

- rejects NaN and both infinities;
- rejects booleans instead of silently canonicalizing `True` to `1.0`;
- rejects host-finite values such as `1e40` that narrow to float32 infinity;
- preserves the legal `step_size=0.0` endpoint, the default `0.01`, and valid finite non-negative values.

Focused regressions cover direct construction and the existing `from_config()` path, so serialized malformed values cannot bypass the constructor boundary.

## Reproduction

Before the production change, the tests-first matrix produced **4 failures / 1 pass**:

```text
NaN   -> constructs and makes trunk weights non-finite after one update
+inf  -> constructs and makes trunk weights non-finite after one update
True  -> silently stores 1.0, 100× the default step size
1e40  -> accepted despite overflowing at the float32 JAX sink
-inf  -> already rejected by the old sign check
```

## Verification

Base: `4d86eddd9e9e847c88541bbd77bc77e1c2e13599`  
Exact head: `9884918fc16a26a2b6f6c93d6e0871c3e79c4e33`

- tests-first validation matrix: **4 failed / 1 passed**;
- focused validation tests after the fix: **12 passed**;
- complete UPGD module: **88 passed**;
- full Ruff: **all checks passed**;
- full strict mypy: **no issues in 168 source files**;
- `git diff --check origin/main...HEAD`: clean;
- exact-head factory proof: recorded green for `9884918fc`.

## Ownership and scientific integrity

A complete live scan immediately before publication covered all **4 open ASI PRs / 7 changed-file rows** and **2 open issues** with zero overlap or matching claim on `alberta_framework/core/upgd.py`, `tests/test_upgd.py`, or this constructor boundary.

No `outputs/**` file, frozen protocol, benchmark threshold, seed, scientific claim, or registered evidence source changed. This patch is limited to one production file and one focused test file.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no shareable model trajectory artifact was generated; verification commands and exact-head proof are listed above

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
- Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
- Attribution status: self-reported

— [sol-upgd-step-size]
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->
