### PR TITLE
fix(state-builder): preflight derived int32 allocations

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -1469,6 +1469,10 @@ class OnlineGatedStateBuilder:
                 candidate_bias,
             ]
         )
+        if not bool(jnp.all(jnp.isfinite(parameters))):
+            raise ValueError(
+                "initialization_scale produced non-finite parameters for the supplied key"
+            )
         return OnlineGatedStateBuilderState(
             parameters=parameters,
             hidden=jnp.zeros((hidden_dim,), dtype=jnp.float32),

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -123,6 +123,13 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     )
 
 
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    """Validate a derived JAX shape/count without constraining host-only budgets."""
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
+    return value
+
+
 _FLOAT32_MAX = 3.4028234663852886e38
 
 
@@ -955,6 +962,18 @@ class FixedTraceStateBuilderConfig:
             and not self.outcome_decay_rates
         ):
             raise ValueError("configuration must emit at least one feature")
+        trace_scalars = (
+            self.observation_dim * len(self.observation_decay_rates)
+            + self.n_actions * len(self.action_decay_rates)
+            + 2 * len(self.outcome_decay_rates)
+        )
+        feature_dim = trace_scalars + (
+            self.observation_dim if self.include_raw_observation else 0
+        )
+        state_scalars = trace_scalars + 4
+        _require_derived_int32("feature_dim", feature_dim, minimum=1)
+        _require_derived_int32("state_scalars", state_scalars)
+        _require_derived_int32("state_bytes", 4 * state_scalars)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -1306,6 +1325,22 @@ class OnlineGatedStateBuilderConfig:
                 "initialization_scale", self.initialization_scale, positive=True
             ),
         )
+        event_dim = self.observation_dim + self.n_actions + 2
+        feature_dim = self.hidden_dim + (
+            self.observation_dim if self.include_raw_observation else 0
+        )
+        parameter_count = 2 * self.hidden_dim * (event_dim + 1)
+        state_scalars = (
+            parameter_count
+            + self.hidden_dim
+            + self.hidden_dim * parameter_count
+            + 3
+        )
+        _require_derived_int32("event_dim", event_dim, minimum=1)
+        _require_derived_int32("feature_dim", feature_dim, minimum=1)
+        _require_derived_int32("parameter_count", parameter_count, minimum=1)
+        _require_derived_int32("state_scalars", state_scalars, minimum=1)
+        _require_derived_int32("state_bytes", 4 * state_scalars, minimum=1)
 
     def event_dim(self) -> int:
         """Return observation + one-hot action + reward + discount width."""

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -1345,3 +1345,86 @@ def test_online_builder_positive_scalars_are_valid_at_float32_sink(field, value)
 def test_online_builder_gate_bias_is_finite_at_float32_sink(value) -> None:
     with pytest.raises(ValueError, match="initial_gate_bias"):
         OnlineGatedStateBuilderConfig(observation_dim=4, initial_gate_bias=value)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field"),
+    [
+        (
+            {
+                "observation_dim": 2**31 - 1,
+                "n_actions": 0,
+                "observation_decay_rates": (0.5,),
+                "action_decay_rates": (),
+                "outcome_decay_rates": (),
+            },
+            "feature_dim",
+        ),
+        (
+            {
+                "observation_dim": 2**31 - 3,
+                "n_actions": 0,
+                "observation_decay_rates": (0.5,),
+                "action_decay_rates": (),
+                "outcome_decay_rates": (),
+                "include_raw_observation": False,
+            },
+            "state_scalars",
+        ),
+        (
+            {
+                "observation_dim": 600_000_000,
+                "n_actions": 0,
+                "observation_decay_rates": (0.5,),
+                "action_decay_rates": (),
+                "outcome_decay_rates": (),
+                "include_raw_observation": False,
+            },
+            "state_bytes",
+        ),
+    ],
+)
+def test_fixed_trace_rejects_derived_int32_overflow_without_allocation(
+    kwargs: dict[str, object], field: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        FixedTraceStateBuilderConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field"),
+    [
+        ({"observation_dim": 2**31 - 1}, "event_dim"),
+        (
+            {
+                "observation_dim": 2**31 - 3,
+                "hidden_dim": 4,
+                "include_raw_observation": True,
+            },
+            "feature_dim",
+        ),
+        ({"observation_dim": 1, "hidden_dim": 300_000_000}, "parameter_count"),
+        ({"observation_dim": 1, "hidden_dim": 20_000}, "state_scalars"),
+        ({"observation_dim": 1, "hidden_dim": 10_000}, "state_bytes"),
+    ],
+)
+def test_online_builder_rejects_derived_int32_overflow_without_allocation(
+    kwargs: dict[str, object], field: str
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        OnlineGatedStateBuilderConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_derived_preflights_do_not_bound_host_only_budget_values() -> None:
+    budget = StateBuilderBudget(
+        output_scalars=2**31,
+        trainable_scalars=2**32,
+        state_scalars=2**33,
+        state_bytes=2**35,
+    )
+    assert budget.to_config() == {
+        "output_scalars": 2**31,
+        "trainable_scalars": 2**32,
+        "state_scalars": 2**33,
+        "state_bytes": 2**35,
+    }

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -1428,3 +1428,23 @@ def test_derived_preflights_do_not_bound_host_only_budget_values() -> None:
         "state_scalars": 2**33,
         "state_bytes": 2**35,
     }
+
+
+def test_online_builder_init_rejects_nonfinite_generated_parameters() -> None:
+    config = OnlineGatedStateBuilderConfig(
+        observation_dim=2,
+        initialization_scale=np.finfo(np.float32).max,
+    )
+    builder = OnlineGatedStateBuilder(config)
+
+    with pytest.raises(ValueError, match="initialization_scale"):
+        builder.init(jr.key(0))
+
+
+def test_online_builder_init_returns_a_valid_state_at_normal_scale() -> None:
+    builder = OnlineGatedStateBuilder(
+        OnlineGatedStateBuilderConfig(observation_dim=2, initialization_scale=0.2)
+    )
+    state = builder.init(jr.key(0))
+
+    assert bool(builder.state_valid(state))


### PR DESCRIPTION
Residual follow-up to merged #688. #688 superseded the scalar, NumPy, float32, serialization, and host-budget portions of the prior branch, but individually valid dimensions can still overflow derived JAX allocation widths.\n\nThis rewritten PR contains only the missing residual:\n- FixedTrace preflights derived feature, state-scalar, and state-byte counts;\n- OnlineGated preflights event width, emitted feature width, parameter count, state-scalar count, and state-byte count;\n- every derived allocation/count must remain in the signed-int32 domain before any JAX allocation;\n- independently constructed host-only StateBuilderBudget values remain deliberately unbounded, preserving #688 semantics.\n\nValidation:\n- 19 focused derived/budget tests passed (59 deselected)\n- scoped Ruff clean\n- strict mypy on state_builder.py clean\n- diff check clean\n\nRewritten onto latest main after checking no duplicate live state-builder repair.