### PR TITLE
fix(router): harden feature bank router configuration integer validation

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -79,15 +79,22 @@ class FeatureBankRouterConfig:
     active_slots: int
 
     def __post_init__(self) -> None:
+        base_dim = _require_int32("base_dim", self.base_dim, minimum=2)
+        active_slots = _require_int32(
+            "active_slots",
+            self.active_slots,
+            minimum=1,
+            maximum=_INT32_MAX - base_dim,
+        )
         object.__setattr__(
             self,
             "base_dim",
-            _require_int32("base_dim", self.base_dim, minimum=2),
+            base_dim,
         )
         object.__setattr__(
             self,
             "active_slots",
-            _require_int32("active_slots", self.active_slots, minimum=1),
+            active_slots,
         )
 
     @property

--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -27,17 +27,43 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import operator
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Int
 
 CONFIG_SCHEMA_VERSION = "alberta.feature_bank_router.config.v1"
 INACTIVE_DESCRIPTOR = (-1, -1)
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclasses.dataclass(frozen=True)
@@ -53,18 +79,16 @@ class FeatureBankRouterConfig:
     active_slots: int
 
     def __post_init__(self) -> None:
-        if (
-            isinstance(self.base_dim, bool)
-            or not isinstance(self.base_dim, int)
-            or self.base_dim < 2
-        ):
-            raise ValueError("base_dim must be an integer of at least 2")
-        if (
-            isinstance(self.active_slots, bool)
-            or not isinstance(self.active_slots, int)
-            or self.active_slots <= 0
-        ):
-            raise ValueError("active_slots must be a positive integer")
+        object.__setattr__(
+            self,
+            "base_dim",
+            _require_int32("base_dim", self.base_dim, minimum=2),
+        )
+        object.__setattr__(
+            self,
+            "active_slots",
+            _require_int32("active_slots", self.active_slots, minimum=1),
+        )
 
     @property
     def total_feature_dim(self) -> int:

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -500,3 +500,27 @@ def test_consumer_layout_and_descriptor_static_contracts_are_strict() -> None:
             _NEW.astype(jnp.float32),
             feature_axes=_feature_axes(),
         )
+
+
+@pytest.mark.unit
+def test_router_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="base_dim"):
+        FeatureBankRouterConfig(base_dim=True, active_slots=4)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="active_slots"):
+        FeatureBankRouterConfig(base_dim=4, active_slots=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="base_dim"):
+        FeatureBankRouterConfig(base_dim=4.5, active_slots=4)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="active_slots"):
+        FeatureBankRouterConfig(base_dim=4, active_slots=4.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_router_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = FeatureBankRouterConfig(
+        base_dim=np.int32(4),
+        active_slots=np.uint16(4),
+    )
+    assert type(config.base_dim) is int
+    assert type(config.active_slots) is int
+    assert config.base_dim == 4
+    assert config.active_slots == 4

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -516,11 +516,50 @@ def test_router_config_rejects_booleans_and_non_integers() -> None:
 
 @pytest.mark.unit
 def test_router_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    config = FeatureBankRouterConfig(
-        base_dim=np.int32(4),
-        active_slots=np.uint16(4),
-    )
-    assert type(config.base_dim) is int
-    assert type(config.active_slots) is int
-    assert config.base_dim == 4
-    assert config.active_slots == 4
+    integer_types = {
+        np.dtype(code).type for code in "bBhHiIlLqQpP" if np.dtype(code).kind in "iu"
+    }
+    for integer_type in integer_types:
+        config = FeatureBankRouterConfig(
+            base_dim=integer_type(4),
+            active_slots=integer_type(4),
+        )
+        assert type(config.base_dim) is int
+        assert type(config.active_slots) is int
+        assert config.base_dim == 4
+        assert config.active_slots == 4
+
+
+@pytest.mark.unit
+def test_router_config_rejects_spoofs_and_float32_sink_overflow() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:
+            raise AssertionError("invalid subclass repr must not run")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+    for value in (HostileInt(4), ClassSpoof(), np.bool_(True), np.float32(4.0)):
+        with pytest.raises(ValueError, match="base_dim"):
+            FeatureBankRouterConfig(base_dim=value, active_slots=1)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="active_slots"):
+            FeatureBankRouterConfig(base_dim=4, active_slots=value)  # type: ignore[arg-type]
+
+    maximum = 2**31 - 1
+    config = FeatureBankRouterConfig(base_dim=maximum - 1, active_slots=1)
+    assert config.total_feature_dim == maximum
+    with pytest.raises(ValueError, match="active_slots"):
+        FeatureBankRouterConfig(base_dim=maximum, active_slots=1)
+    with pytest.raises(ValueError, match="active_slots"):
+        FeatureBankRouterConfig(base_dim=maximum - 1, active_slots=2)
+
+
+@pytest.mark.unit
+def test_router_config_roundtrip_preserves_canonical_int32_dimensions() -> None:
+    config = FeatureBankRouterConfig(base_dim=np.longlong(4), active_slots=np.ulonglong(3))
+    payload = config.to_config()
+    assert type(payload["base_dim"]) is int
+    assert type(payload["active_slots"]) is int
+    assert FeatureBankRouterConfig.from_config(payload) == config


### PR DESCRIPTION
## Summary
- Hardens `FeatureBankRouterConfig` dimensions (`base_dim`, `active_slots`) to reject booleans, non-integer floats, and out-of-range dimensions while accepting and canonicalizing the full NumPy integer family.
- Enforces signed int32 bounds on dynamic tail and prefix widths.

## Verification
- `PYTHONPATH=. pytest tests/test_feature_bank_router.py`: 12 passed
- `ruff check .`: clean
- No registered evidence artifacts modified.