### PR TITLE
fix(core): complete state-builder and IA config validation

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -81,8 +81,7 @@ RECOMMENDATION_PROTOCOL_STATE_SCHEMA = "alberta.recommendation-protocol-state.v2
 EXO_CEREBELLUM_LIFETIME_COUNTER_NBYTES = 12
 EXO_CEREBELLUM_LIFETIME_COUNTER_DELTA_NBYTES = 8
 IA_LIFETIME_COUNTER_NBYTES = (
-    2 * EXO_CEREBELLUM_LIFETIME_COUNTER_NBYTES
-    + 3 * OAK_LIFETIME_COUNTER_NBYTES
+    2 * EXO_CEREBELLUM_LIFETIME_COUNTER_NBYTES + 3 * OAK_LIFETIME_COUNTER_NBYTES
 )
 IA_LIFETIME_COUNTER_DELTA_NBYTES = 2 * EXO_CEREBELLUM_LIFETIME_COUNTER_DELTA_NBYTES
 RECOMMENDATION_PROTOCOL_LIFETIME_COUNTER_NBYTES = 36
@@ -141,6 +140,7 @@ def _positive_float32_scalar(name: str, value: object) -> float:
         return float(value)
     return narrowed
 
+
 # ---------------------------------------------------------------------------
 # Exo-cerebellum
 # ---------------------------------------------------------------------------
@@ -167,12 +167,12 @@ class ExoCerebellumConfig:
         object.__setattr__(
             self,
             "n_demons",
-            _require_int32("n_demons", self.n_demons, minimum=1, maximum=65_536),
+            _require_int32("n_demons", self.n_demons, minimum=1),
         )
         object.__setattr__(
             self,
             "obs_dim",
-            _require_int32("obs_dim", self.obs_dim, minimum=1, maximum=65_536),
+            _require_int32("obs_dim", self.obs_dim, minimum=1),
         )
         step_size = _positive_float32_scalar("step_size", self.step_size)
         object.__setattr__(self, "step_size", step_size)
@@ -315,8 +315,8 @@ class ExoCerebellumAgent:
         input_valid = jnp.all(jnp.isfinite(obs)) & jnp.all(jnp.isfinite(next_obs))
         safe_obs = jnp.where(jnp.isfinite(obs), obs, jnp.float32(0.0))
         safe_next_obs = jnp.where(jnp.isfinite(next_obs), next_obs, jnp.float32(0.0))
-        proposed_step_words, lifetime_capacity_available = (
-            _checked_lifetime_words_increment(state.step_words)
+        proposed_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+            state.step_words
         )
         alpha = jnp.asarray(self._config.step_size, dtype=jnp.float32)
         predictions = state.weights @ safe_obs
@@ -329,10 +329,7 @@ class ExoCerebellumAgent:
         )
         candidate_state_valid = self.state_is_valid(candidate_state)
         update_applied = (
-            source_state_valid
-            & input_valid
-            & lifetime_capacity_available
-            & candidate_state_valid
+            source_state_valid & input_valid & lifetime_capacity_available & candidate_state_valid
         )
         new_state = jax.tree.map(
             lambda candidate, source: jnp.where(update_applied, candidate, source),
@@ -408,9 +405,7 @@ def _checked_partner_action(
     executed = jnp.asarray(raw, dtype=jnp.int32)
     valid = (executed >= 0) & (executed < n_primitive_actions)
     if not isinstance(valid, jax.core.Tracer) and not bool(valid):
-        raise ValueError(
-            f"partner_action must be in [0, {n_primitive_actions})"
-        )
+        raise ValueError(f"partner_action must be in [0, {n_primitive_actions})")
     return (
         jnp.where(valid, executed, jnp.array(0, dtype=jnp.int32)),
         valid,
@@ -458,9 +453,7 @@ class ExoCortexAgent:
         outer_valid = _oak_outer_state_validity(state, self.config)[-1]
         nested_valid = self._oak.stomp_agent.state_valid(state.stomp_state)
         return (
-            outer_valid
-            & nested_valid
-            & jnp.all(state.step_words == state.stomp_state.step_words)
+            outer_valid & nested_valid & jnp.all(state.step_words == state.stomp_state.step_words)
         )
 
     def _prepare_update_source(
@@ -539,11 +532,7 @@ class ExoCortexAgent:
             partner_action,
             discount,
         )
-        decision_obs = (
-            partner_next_obs
-            if decision_observation is None
-            else decision_observation
-        )
+        decision_obs = partner_next_obs if decision_observation is None else decision_observation
         result = self._oak.update(
             state,
             partner_reward,
@@ -940,17 +929,15 @@ def update_recommendation_protocol(
         state.accepted_words,
         state.rejected_words,
     )
-    exact_partition_valid = source_sum_available & jnp.all(
-        source_total_words == state.step_words
+    exact_partition_valid = source_sum_available & jnp.all(source_total_words == state.step_words)
+    next_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+        state.step_words
     )
-    next_step_words, lifetime_capacity_available = (
-        _checked_lifetime_words_increment(state.step_words)
+    next_accepted_words, accepted_capacity_available = _checked_lifetime_words_increment(
+        state.accepted_words
     )
-    next_accepted_words, accepted_capacity_available = (
-        _checked_lifetime_words_increment(state.accepted_words)
-    )
-    next_rejected_words, rejected_capacity_available = (
-        _checked_lifetime_words_increment(state.rejected_words)
+    next_rejected_words, rejected_capacity_available = _checked_lifetime_words_increment(
+        state.rejected_words
     )
     selected_counter_capacity_available = jnp.where(
         accepted,
@@ -1065,9 +1052,7 @@ class IAAgent:
         return (
             jnp.all(state.step_words == state.cerebellum_state.step_words)
             & jnp.all(state.step_words == state.cortex_state.step_words)
-            & jnp.all(
-                state.step_words == state.cortex_state.stomp_state.step_words
-            )
+            & jnp.all(state.step_words == state.cortex_state.stomp_state.step_words)
         )
 
     def state_is_valid(self, state: IAState) -> Bool[Array, ""]:
@@ -1110,9 +1095,7 @@ class IAAgent:
         start_applied = source_state_valid & input_valid & candidate_valid
         return jax.tree_util.tree_map(
             lambda proposed, source: (
-                jnp.where(start_applied, proposed, source)
-                if isinstance(source, Array)
-                else source
+                jnp.where(start_applied, proposed, source) if isinstance(source, Array) else source
             ),
             candidate,
             state,
@@ -1155,13 +1138,10 @@ class IAAgent:
         reward = jnp.asarray(partner_reward, dtype=jnp.float32)
         expected_obs_shape = (self._config.cortex.observation_dim,)
         if obs.shape != expected_obs_shape:
-            raise ValueError(
-                f"partner_obs must have shape {expected_obs_shape}, got {obs.shape}"
-            )
+            raise ValueError(f"partner_obs must have shape {expected_obs_shape}, got {obs.shape}")
         if next_obs.shape != expected_obs_shape:
             raise ValueError(
-                "partner_next_obs must have shape "
-                f"{expected_obs_shape}, got {next_obs.shape}"
+                f"partner_next_obs must have shape {expected_obs_shape}, got {next_obs.shape}"
             )
         if reward.shape != ():
             raise ValueError("partner_reward must be scalar")
@@ -1194,12 +1174,10 @@ class IAAgent:
                 partner_action,
                 n_primitive_actions=self._config.cortex.n_primitive_actions,
             )
-        prepared_cortex_state, _, prepared_action_valid = (
-            self._cortex._prepare_update_source(
-                state.cortex_state,
-                partner_action,
-                discount,
-            )
+        prepared_cortex_state, _, prepared_action_valid = self._cortex._prepare_update_source(
+            state.cortex_state,
+            partner_action,
+            discount,
         )
         action_valid = action_valid & prepared_action_valid
         input_valid = (
@@ -1217,14 +1195,12 @@ class IAAgent:
             & self._cortex.state_is_valid(prepared_cortex_state)
             & child_clocks_aligned
         )
-        proposed_step_words, lifetime_capacity_available = (
-            _checked_lifetime_words_increment(state.step_words)
+        proposed_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+            state.step_words
         )
 
         # Cerebellum: predict from obs, update from (obs, next_obs)
-        cerebellum_result = self._cerebellum.update_result(
-            state.cerebellum_state, obs, next_obs
-        )
+        cerebellum_result = self._cerebellum.update_result(state.cerebellum_state, obs, next_obs)
 
         # Cortex: update Q from (reward, next_obs) crediting the partner's
         # executed action when known, get recommendation
@@ -1352,9 +1328,7 @@ class IAAgent:
                 next_ob,
                 partner_action=action if use_actions else None,
                 discount=transition_discount if use_discounts else None,
-                decision_observation=(
-                    decision_ob if use_decision_observations else None
-                ),
+                decision_observation=(decision_ob if use_decision_observations else None),
                 execution_boundary=execution_boundary,
             )
             return result.state, (
@@ -1458,10 +1432,7 @@ def _host_field_mapping(value: Any, *, name: str) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return dict(value)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return {
-            field.name: getattr(value, field.name)
-            for field in dataclasses.fields(value)
-        }
+        return {field.name: getattr(value, field.name) for field in dataclasses.fields(value)}
     raise TypeError(f"legacy {name} state must be a mapping or dataclass")
 
 
@@ -1491,8 +1462,7 @@ def migrate_legacy_exo_cerebellum_state(
         missing = sorted({"weights", "step_count"} - set(fields))
         extra = sorted(set(fields) - {"weights", "step_count"})
         raise ValueError(
-            "legacy exo-cerebellum field manifest is not exact; "
-            f"missing={missing}, extra={extra}"
+            f"legacy exo-cerebellum field manifest is not exact; missing={missing}, extra={extra}"
         )
     step = _strict_legacy_counter(fields["step_count"], name="exo-cerebellum step_count")
     state = ExoCerebellumState(
@@ -1519,10 +1489,7 @@ def migrate_legacy_ia_state(
     if set(fields) != expected:
         missing = sorted(expected - set(fields))
         extra = sorted(set(fields) - expected)
-        raise ValueError(
-            "legacy IA field manifest is not exact; "
-            f"missing={missing}, extra={extra}"
-        )
+        raise ValueError(f"legacy IA field manifest is not exact; missing={missing}, extra={extra}")
     step = _strict_legacy_counter(fields["step_count"], name="IA step_count")
     cerebellum = migrate_legacy_exo_cerebellum_state(
         fields["cerebellum_state"],
@@ -1530,9 +1497,7 @@ def migrate_legacy_ia_state(
     )
     cortex_raw = fields["cortex_state"]
     cortex = (
-        cortex_raw
-        if isinstance(cortex_raw, OaKState)
-        else migrate_legacy_oak_state(cortex_raw)
+        cortex_raw if isinstance(cortex_raw, OaKState) else migrate_legacy_oak_state(cortex_raw)
     )
     state = IAState(
         cerebellum_state=cerebellum,
@@ -1613,9 +1578,7 @@ def measure_ia_state_nbytes(state: IAState) -> int:
 def measure_ia_wrapper_state_nbytes(state: IAState) -> int:
     """Measure IA-owned outer/cerebellum arrays, excluding nested OaK."""
 
-    return measure_ia_state_nbytes(state) - measure_oak_state_nbytes(
-        state.cortex_state
-    )
+    return measure_ia_state_nbytes(state) - measure_oak_state_nbytes(state.cortex_state)
 
 
 def measure_recommendation_protocol_state_nbytes(
@@ -1639,10 +1602,7 @@ def exo_cerebellum_lifetime_counter_nbytes() -> int:
 def ia_lifetime_counter_nbytes() -> int:
     """Return bytes for IA, cerebellum, and all nested OaK clocks."""
 
-    return (
-        2 * EXO_CEREBELLUM_LIFETIME_COUNTER_NBYTES
-        + oak_total_lifetime_counter_nbytes()
-    )
+    return 2 * EXO_CEREBELLUM_LIFETIME_COUNTER_NBYTES + oak_total_lifetime_counter_nbytes()
 
 
 def recommendation_protocol_lifetime_counter_nbytes() -> int:

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -38,17 +38,20 @@ from __future__ import annotations
 
 import dataclasses
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
 from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.normalizers import (
     _checked_lifetime_words_increment,
     _lifetime_counter_valid,
@@ -86,6 +89,30 @@ RECOMMENDATION_PROTOCOL_LIFETIME_COUNTER_NBYTES = 36
 RECOMMENDATION_PROTOCOL_LIFETIME_COUNTER_DELTA_NBYTES = 24
 
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _positive_float32_scalar(name: str, value: object) -> float:
@@ -137,10 +164,16 @@ class ExoCerebellumConfig:
     step_size: float = 0.05
 
     def __post_init__(self) -> None:
-        if self.n_demons <= 0:
-            raise ValueError("n_demons must be positive")
-        if self.obs_dim <= 0:
-            raise ValueError("obs_dim must be positive")
+        object.__setattr__(
+            self,
+            "n_demons",
+            _require_int32("n_demons", self.n_demons, minimum=1, maximum=65_536),
+        )
+        object.__setattr__(
+            self,
+            "obs_dim",
+            _require_int32("obs_dim", self.obs_dim, minimum=1, maximum=65_536),
+        )
         step_size = _positive_float32_scalar("step_size", self.step_size)
         object.__setattr__(self, "step_size", step_size)
 
@@ -705,8 +738,17 @@ class RecommendationProtocolConfig:
     acceptance_ema_decay: float = 0.95
 
     def __post_init__(self) -> None:
-        if not 0.0 <= self.acceptance_ema_decay < 1.0:
-            raise ValueError("acceptance_ema_decay must be in [0, 1)")
+        object.__setattr__(
+            self,
+            "acceptance_ema_decay",
+            validated_float32_scalar(
+                "acceptance_ema_decay",
+                self.acceptance_ema_decay,
+                lower=0.0,
+                upper=1.0,
+                upper_inclusive=False,
+            ),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -87,13 +87,24 @@ _ACTUAL_INT_TYPES = frozenset(
 )
 
 
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+def _require_integer(
+    name: str,
+    value: object,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+        raise ValueError(f"{name} must be an integer")
     canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    if canonical < minimum or (maximum is not None and canonical > maximum):
+        domain = f"[{minimum}, {maximum}]" if maximum is not None else f">= {minimum}"
+        raise ValueError(f"{name} must be an integer in {domain}")
     return canonical
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    return _require_integer(name, value, minimum=minimum, maximum=_INT32_MAX)
 
 
 def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
@@ -110,6 +121,8 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
         )
         for index, rate in enumerate(rates)
     )
+
+
 _FLOAT32_MAX = 3.4028234663852886e38
 
 
@@ -117,6 +130,7 @@ def _saturating_int32_increment(value: Array) -> Array:
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     counter = jnp.asarray(value, dtype=jnp.int32)
     return jnp.minimum(jnp.maximum(counter, 0), maximum - 1) + 1
+
 
 StateT = TypeVar("StateT")
 
@@ -142,22 +156,22 @@ class StateBuilderBudget:
         object.__setattr__(
             self,
             "output_scalars",
-            _require_int32("output_scalars", self.output_scalars, minimum=0),
+            _require_integer("output_scalars", self.output_scalars, minimum=0),
         )
         object.__setattr__(
             self,
             "trainable_scalars",
-            _require_int32("trainable_scalars", self.trainable_scalars, minimum=0),
+            _require_integer("trainable_scalars", self.trainable_scalars, minimum=0),
         )
         object.__setattr__(
             self,
             "state_scalars",
-            _require_int32("state_scalars", self.state_scalars, minimum=0),
+            _require_integer("state_scalars", self.state_scalars, minimum=0),
         )
         object.__setattr__(
             self,
             "state_bytes",
-            _require_int32("state_bytes", self.state_bytes, minimum=0),
+            _require_integer("state_bytes", self.state_bytes, minimum=0),
         )
 
     def to_config(self) -> dict[str, int]:
@@ -338,9 +352,7 @@ def _zero_learning_diagnostics(
     zero = jnp.asarray(0.0, dtype=jnp.float32)
     valid_array = jnp.asarray(valid, dtype=jnp.bool_)
     proposal_valid_array = (
-        valid_array
-        if proposal_valid is None
-        else jnp.asarray(proposal_valid, dtype=jnp.bool_)
+        valid_array if proposal_valid is None else jnp.asarray(proposal_valid, dtype=jnp.bool_)
     )
     return StateBuilderLearningDiagnostics(
         gradient_norm=zero,
@@ -542,8 +554,7 @@ def replace_state_builder_learning_proposal_update(
     source_shape = tuple(proposal.source_parameters.shape)
     if len(source_shape) != 1:
         raise ValueError(
-            "proposal.source_parameters must be a rank-one parameter vector; "
-            f"got {source_shape}"
+            f"proposal.source_parameters must be a rank-one parameter vector; got {source_shape}"
         )
     parameter_count = source_shape[0]
     _validate_learning_proposal_static_contract(proposal, parameter_count)
@@ -587,11 +598,6 @@ def replace_state_builder_learning_proposal_update(
             rejected=~valid,
         ),
     )
-
-
-def _validate_observation_dim(observation_dim: int) -> None:
-    if observation_dim < 1:
-        raise ValueError("observation_dim must be positive")
 
 
 def _action_features(action: Array | int, n_actions: int) -> Array:
@@ -968,12 +974,12 @@ class FixedTraceStateBuilderConfig:
         data = dict(payload)
         data.pop("type", None)
         return cls(
-            observation_dim=int(data["observation_dim"]),
-            n_actions=int(data.get("n_actions", 0)),
+            observation_dim=data["observation_dim"],
+            n_actions=data.get("n_actions", 0),
             observation_decay_rates=tuple(data.get("observation_decay_rates", ())),
             action_decay_rates=tuple(data.get("action_decay_rates", ())),
             outcome_decay_rates=tuple(data.get("outcome_decay_rates", ())),
-            include_raw_observation=bool(data.get("include_raw_observation", True)),
+            include_raw_observation=data.get("include_raw_observation", True),
         )
 
 
@@ -1543,9 +1549,7 @@ class OnlineGatedStateBuilder:
             last_gradient_norm=state.last_gradient_norm,
         )
         update_applied = (
-            event_valid
-            & self._state_is_valid(state)
-            & self._state_is_valid(candidate_state)
+            event_valid & self._state_is_valid(state) & self._state_is_valid(candidate_state)
         )
         next_state = select_transaction(update_applied, candidate_state, state)
         representation = self.encode(next_state, raw_observation)
@@ -1700,21 +1704,15 @@ class OnlineGatedStateBuilder:
             safe_gradient_norm,
             jnp.asarray(_FLOAT32_MAX, dtype=jnp.float32),
         )
-        clipped_parameter_gradient_valid = jnp.all(
-            jnp.isfinite(clipped_parameter_gradient)
-        )
+        clipped_parameter_gradient_valid = jnp.all(jnp.isfinite(clipped_parameter_gradient))
         candidate_parameter_update = (
-            -jnp.asarray(self._config.step_size, dtype=jnp.float32)
-            * clipped_parameter_gradient
+            -jnp.asarray(self._config.step_size, dtype=jnp.float32) * clipped_parameter_gradient
         )
-        candidate_parameter_update_valid = jnp.all(
-            jnp.isfinite(candidate_parameter_update)
-        )
+        candidate_parameter_update_valid = jnp.all(jnp.isfinite(candidate_parameter_update))
         candidate_parameters = source_state.parameters + candidate_parameter_update
         candidate_parameters_valid = jnp.all(jnp.isfinite(candidate_parameters))
-        capacity_available = (
-            (source_state.update_count >= 0)
-            & (source_state.update_count < _INT32_MAX)
+        capacity_available = (source_state.update_count >= 0) & (
+            source_state.update_count < _INT32_MAX
         )
         valid = (
             source_state_valid
@@ -1784,13 +1782,10 @@ class OnlineGatedStateBuilder:
             )
         )
         update_valid = jnp.all(jnp.isfinite(proposal.candidate_parameter_update))
-        candidate_parameters = (
-            proposal.source_parameters + proposal.candidate_parameter_update
-        )
+        candidate_parameters = proposal.source_parameters + proposal.candidate_parameter_update
         candidate_parameters_valid = jnp.all(jnp.isfinite(candidate_parameters))
-        capacity_available = (
-            (proposal.source_update_count >= 0)
-            & (proposal.source_update_count < _INT32_MAX)
+        capacity_available = (proposal.source_update_count >= 0) & (
+            proposal.source_update_count < _INT32_MAX
         )
         expected_valid = (
             proposal.source_state_valid
@@ -1871,9 +1866,7 @@ class OnlineGatedStateBuilder:
             & (destination_state.update_count < _INT32_MAX)
             & proposal.capacity_available
         )
-        candidate_parameters = (
-            destination_state.parameters + proposal.candidate_parameter_update
-        )
+        candidate_parameters = destination_state.parameters + proposal.candidate_parameter_update
         candidate_parameters_valid = jnp.all(jnp.isfinite(candidate_parameters))
         proposal_valid = proposal_integrity & proposal.valid
         applied = (
@@ -1944,9 +1937,7 @@ class OnlineGatedStateBuilder:
 
 
 StateBuilderConfig = (
-    IdentityStateBuilderConfig
-    | FixedTraceStateBuilderConfig
-    | OnlineGatedStateBuilderConfig
+    IdentityStateBuilderConfig | FixedTraceStateBuilderConfig | OnlineGatedStateBuilderConfig
 )
 
 

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -43,18 +43,20 @@ from __future__ import annotations
 import functools
 import hashlib
 import json
-import math
+import operator
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import Any, Protocol, TypeVar, cast, runtime_checkable
+from typing import Any, Protocol, SupportsIndex, TypeVar, cast, runtime_checkable
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -68,6 +70,46 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be an actual tuple")
+    rates = cast(tuple[object, ...], value)
+    return tuple(
+        validated_float32_scalar(
+            f"{name}[{index}]",
+            rate,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        for index, rate in enumerate(rates)
+    )
 _FLOAT32_MAX = 3.4028234663852886e38
 
 
@@ -95,6 +137,28 @@ class StateBuilderBudget:
     trainable_scalars: int
     state_scalars: int
     state_bytes: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "output_scalars",
+            _require_int32("output_scalars", self.output_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int32("trainable_scalars", self.trainable_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "state_scalars",
+            _require_int32("state_scalars", self.state_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "state_bytes",
+            _require_int32("state_bytes", self.state_bytes, minimum=0),
+        )
 
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible budget description."""
@@ -630,7 +694,11 @@ class IdentityStateBuilderConfig:
     observation_dim: int
 
     def __post_init__(self) -> None:
-        _validate_observation_dim(self.observation_dim)
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -644,7 +712,7 @@ class IdentityStateBuilderConfig:
         """Reconstruct from :meth:`to_config` output."""
         data = dict(payload)
         data.pop("type", None)
-        return cls(observation_dim=int(data["observation_dim"]))
+        return cls(observation_dim=data["observation_dim"])
 
 
 @chex.dataclass(frozen=True)
@@ -847,16 +915,33 @@ class FixedTraceStateBuilderConfig:
     include_raw_observation: bool = True
 
     def __post_init__(self) -> None:
-        _validate_observation_dim(self.observation_dim)
-        if self.n_actions < 0:
-            raise ValueError("n_actions must be non-negative")
-        for name, rates in (
-            ("observation_decay_rates", self.observation_decay_rates),
-            ("action_decay_rates", self.action_decay_rates),
-            ("outcome_decay_rates", self.outcome_decay_rates),
-        ):
-            if any(not math.isfinite(rate) or rate < 0.0 or rate >= 1.0 for rate in rates):
-                raise ValueError(f"{name} must contain finite values in [0, 1)")
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=0),
+        )
+        if type(self.include_raw_observation) is not bool:
+            raise ValueError("include_raw_observation must be a bool")
+        object.__setattr__(
+            self,
+            "observation_decay_rates",
+            _require_decay_rates("observation_decay_rates", self.observation_decay_rates),
+        )
+        object.__setattr__(
+            self,
+            "action_decay_rates",
+            _require_decay_rates("action_decay_rates", self.action_decay_rates),
+        )
+        object.__setattr__(
+            self,
+            "outcome_decay_rates",
+            _require_decay_rates("outcome_decay_rates", self.outcome_decay_rates),
+        )
         if (
             not self.include_raw_observation
             and not self.observation_decay_rates
@@ -1176,19 +1261,45 @@ class OnlineGatedStateBuilderConfig:
     include_raw_observation: bool = True
 
     def __post_init__(self) -> None:
-        _validate_observation_dim(self.observation_dim)
-        if self.n_actions < 0:
-            raise ValueError("n_actions must be non-negative")
-        if self.hidden_dim < 1:
-            raise ValueError("hidden_dim must be positive")
-        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
-            raise ValueError("step_size must be finite and positive")
-        if not math.isfinite(self.gradient_clip) or self.gradient_clip <= 0.0:
-            raise ValueError("gradient_clip must be finite and positive")
-        if not math.isfinite(self.initial_gate_bias):
-            raise ValueError("initial_gate_bias must be finite")
-        if not math.isfinite(self.initialization_scale) or self.initialization_scale <= 0.0:
-            raise ValueError("initialization_scale must be finite and positive")
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "hidden_dim",
+            _require_int32("hidden_dim", self.hidden_dim, minimum=1),
+        )
+        if type(self.include_raw_observation) is not bool:
+            raise ValueError("include_raw_observation must be a bool")
+        object.__setattr__(
+            self,
+            "step_size",
+            validated_float32_scalar("step_size", self.step_size, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "gradient_clip",
+            validated_float32_scalar("gradient_clip", self.gradient_clip, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "initial_gate_bias",
+            validated_float32_scalar("initial_gate_bias", self.initial_gate_bias),
+        )
+        object.__setattr__(
+            self,
+            "initialization_scale",
+            validated_float32_scalar(
+                "initialization_scale", self.initialization_scale, positive=True
+            ),
+        )
 
     def event_dim(self) -> int:
         """Return observation + one-hot action + reward + discount width."""

--- a/tests/test_ia_amplification.py
+++ b/tests/test_ia_amplification.py
@@ -468,3 +468,30 @@ def test_ia_configs_accept_and_canonicalize_numpy_integers() -> None:
     assert type(cfg.obs_dim) is int
     assert cfg.n_demons == 8
     assert cfg.obs_dim == 16
+
+    protocol = RecommendationProtocolConfig(acceptance_ema_decay=np.float32(0.5))
+    assert type(protocol.acceptance_ema_decay) is float
+
+
+@pytest.mark.parametrize("field", ["n_demons", "obs_dim"])
+@pytest.mark.parametrize("value", [0, -1, 2**31, np.uint64(2**63)])
+def test_exo_cerebellum_dimensions_use_signed_int32_domain(field, value) -> None:
+    with pytest.raises(ValueError, match=field):
+        ExoCerebellumConfig(**{field: value})
+
+
+def test_ia_configs_reject_class_spoofed_scalars() -> None:
+    class Spoof:
+        @property
+        def __class__(self):
+            return int
+
+        def __index__(self):
+            return 4
+
+    with pytest.raises(ValueError, match="n_demons"):
+        ExoCerebellumConfig(n_demons=Spoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="acceptance_ema_decay"):
+        RecommendationProtocolConfig(  # type: ignore[arg-type]
+            acceptance_ema_decay=Spoof()
+        )

--- a/tests/test_ia_amplification.py
+++ b/tests/test_ia_amplification.py
@@ -83,6 +83,7 @@ import functools
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 from jax import Array
 
@@ -441,3 +442,29 @@ def test_recommendation_protocol_accounting() -> None:
     for proto in data["protocols"][0.0]:
         assert int(proto.accepted_count) == 0
         assert int(proto.rejected_count) == _NUM_STEPS
+
+
+def test_ia_configs_reject_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        ExoCerebellumConfig(n_demons=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="obs_dim"):
+        ExoCerebellumConfig(obs_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_demons"):
+        ExoCerebellumConfig(n_demons=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="obs_dim"):
+        ExoCerebellumConfig(obs_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="acceptance_ema_decay"):
+        RecommendationProtocolConfig(acceptance_ema_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="acceptance_ema_decay"):
+        RecommendationProtocolConfig(acceptance_ema_decay=1.0 - 1e-10)
+
+
+def test_ia_configs_accept_and_canonicalize_numpy_integers() -> None:
+    cfg = ExoCerebellumConfig(
+        n_demons=np.int32(8),
+        obs_dim=np.uint16(16),
+    )
+    assert type(cfg.n_demons) is int
+    assert type(cfg.obs_dim) is int
+    assert cfg.n_demons == 8
+    assert cfg.obs_dim == 16

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -436,9 +436,7 @@ def test_online_learn_equals_propose_then_same_state_commit() -> None:
 
 def test_online_proposal_capacity_max_minus_one_and_exhaustion_are_fail_closed() -> None:
     builder, source, gradient = _online_learning_source()
-    almost_exhausted = source.replace(
-        update_count=jnp.asarray(2**31 - 2, dtype=jnp.int32)
-    )
+    almost_exhausted = source.replace(update_count=jnp.asarray(2**31 - 2, dtype=jnp.int32))
     proposal = builder.propose_learning_update(almost_exhausted, gradient)
     final_state, final_diagnostics = builder.commit_learning_update(
         almost_exhausted,
@@ -501,9 +499,7 @@ def test_online_commit_rejects_corrupt_proposal_and_static_contract_errors() -> 
     "builder",
     [
         IdentityStateBuilder(IdentityStateBuilderConfig(observation_dim=2)),
-        FixedTraceStateBuilder(
-            FixedTraceStateBuilderConfig(observation_dim=2, n_actions=2)
-        ),
+        FixedTraceStateBuilder(FixedTraceStateBuilderConfig(observation_dim=2, n_actions=2)),
     ],
     ids=("identity", "fixed-trace"),
 )
@@ -1268,6 +1264,15 @@ def test_state_builder_budget_validation() -> None:
     assert type(budget.state_scalars) is int
     assert type(budget.state_bytes) is int
 
+    large_host_budget = StateBuilderBudget(
+        output_scalars=1,
+        trainable_scalars=0,
+        state_scalars=2**31,
+        state_bytes=2**33,
+    )
+    assert large_host_budget.state_scalars == 2**31
+    assert large_host_budget.state_bytes == 2**33
+
     with pytest.raises(ValueError, match="output_scalars"):
         StateBuilderBudget(
             output_scalars=-1,
@@ -1282,3 +1287,61 @@ def test_state_builder_budget_validation() -> None:
             state_scalars=0,
             state_bytes=True,  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda value: IdentityStateBuilderConfig(observation_dim=value),
+        lambda value: FixedTraceStateBuilderConfig(observation_dim=value),
+        lambda value: OnlineGatedStateBuilderConfig(observation_dim=value),
+    ],
+)
+@pytest.mark.parametrize("value", [2**31, np.uint64(2**63), -1])
+def test_builder_dimensions_reject_values_outside_signed_int32(factory, value) -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        factory(value)
+
+
+def test_fixed_trace_from_config_does_not_coerce_invalid_scalars() -> None:
+    base = FixedTraceStateBuilderConfig(observation_dim=4).to_config()
+    for field, value in (
+        ("observation_dim", True),
+        ("n_actions", False),
+        ("include_raw_observation", 1),
+        ("include_raw_observation", "false"),
+    ):
+        payload = {**base, field: value}
+        with pytest.raises(ValueError, match=field):
+            FixedTraceStateBuilderConfig.from_config(payload)
+
+
+def test_builder_configs_reject_class_spoofed_scalars() -> None:
+    class Spoof:
+        @property
+        def __class__(self):
+            return int
+
+        def __index__(self):
+            return 4
+
+    with pytest.raises(ValueError, match="observation_dim"):
+        IdentityStateBuilderConfig(observation_dim=Spoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        OnlineGatedStateBuilderConfig(  # type: ignore[arg-type]
+            observation_dim=4,
+            step_size=Spoof(),
+        )
+
+
+@pytest.mark.parametrize("field", ["step_size", "gradient_clip", "initialization_scale"])
+@pytest.mark.parametrize("value", [True, 1e100, 1e-100])
+def test_online_builder_positive_scalars_are_valid_at_float32_sink(field, value) -> None:
+    with pytest.raises(ValueError, match=field):
+        OnlineGatedStateBuilderConfig(observation_dim=4, **{field: value})
+
+
+@pytest.mark.parametrize("value", [True, 1e100])
+def test_online_builder_gate_bias_is_finite_at_float32_sink(value) -> None:
+    with pytest.raises(ValueError, match="initial_gate_bias"):
+        OnlineGatedStateBuilderConfig(observation_dim=4, initial_gate_bias=value)

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -28,6 +28,7 @@ from alberta_framework.core.state_builder import (
     OnlineGatedStateBuilder,
     OnlineGatedStateBuilderConfig,
     StateBuilder,
+    StateBuilderBudget,
     StateBuilderConfig,
     StateBuilderLearningProposal,
     load_state_builder_checkpoint,
@@ -1194,3 +1195,90 @@ def test_nonfinite_builder_hyperparameters_are_rejected(invalid: float) -> None:
         OnlineGatedStateBuilderConfig(observation_dim=1, initial_gate_bias=invalid)
     with pytest.raises(ValueError, match="initialization_scale"):
         OnlineGatedStateBuilderConfig(observation_dim=1, initialization_scale=invalid)
+
+
+def test_builder_configs_reject_booleans_and_non_integers() -> None:
+    # Booleans
+    with pytest.raises(ValueError, match="observation_dim"):
+        IdentityStateBuilderConfig(observation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observation_dim"):
+        FixedTraceStateBuilderConfig(observation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        FixedTraceStateBuilderConfig(observation_dim=4, n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="include_raw_observation"):
+        FixedTraceStateBuilderConfig(observation_dim=4, include_raw_observation=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_dim"):
+        OnlineGatedStateBuilderConfig(observation_dim=4, hidden_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="include_raw_observation"):
+        OnlineGatedStateBuilderConfig(observation_dim=4, include_raw_observation=0)  # type: ignore[arg-type]
+
+    # Non-integer floats
+    with pytest.raises(ValueError, match="observation_dim"):
+        IdentityStateBuilderConfig(observation_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        FixedTraceStateBuilderConfig(observation_dim=4, n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_dim"):
+        OnlineGatedStateBuilderConfig(observation_dim=4, hidden_dim=8.5)  # type: ignore[arg-type]
+
+    # Non-tuple decay rates
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        FixedTraceStateBuilderConfig(observation_dim=4, observation_decay_rates=[0.5, 0.9])  # type: ignore[arg-type]
+
+    # Float32 boundary decay rate (1.0 - 1e-10 rounds to 1.0 in float32)
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        FixedTraceStateBuilderConfig(observation_dim=4, observation_decay_rates=(1.0 - 1e-10,))
+
+
+def test_builder_configs_accept_and_canonicalize_numpy_integers() -> None:
+    cfg_id = IdentityStateBuilderConfig(observation_dim=np.int32(4))
+    assert type(cfg_id.observation_dim) is int
+    assert cfg_id.observation_dim == 4
+
+    cfg_ft = FixedTraceStateBuilderConfig(
+        observation_dim=np.int64(4),
+        n_actions=np.uint16(2),
+    )
+    assert type(cfg_ft.observation_dim) is int
+    assert type(cfg_ft.n_actions) is int
+    assert cfg_ft.observation_dim == 4
+    assert cfg_ft.n_actions == 2
+
+    cfg_og = OnlineGatedStateBuilderConfig(
+        observation_dim=np.int32(4),
+        n_actions=np.int16(2),
+        hidden_dim=np.uint8(8),
+    )
+    assert type(cfg_og.observation_dim) is int
+    assert type(cfg_og.n_actions) is int
+    assert type(cfg_og.hidden_dim) is int
+    assert cfg_og.observation_dim == 4
+    assert cfg_og.n_actions == 2
+    assert cfg_og.hidden_dim == 8
+
+
+def test_state_builder_budget_validation() -> None:
+    budget = StateBuilderBudget(
+        output_scalars=np.int32(10),
+        trainable_scalars=np.int64(20),
+        state_scalars=np.uint16(30),
+        state_bytes=np.int32(120),
+    )
+    assert type(budget.output_scalars) is int
+    assert type(budget.trainable_scalars) is int
+    assert type(budget.state_scalars) is int
+    assert type(budget.state_bytes) is int
+
+    with pytest.raises(ValueError, match="output_scalars"):
+        StateBuilderBudget(
+            output_scalars=-1,
+            trainable_scalars=0,
+            state_scalars=0,
+            state_bytes=0,
+        )
+    with pytest.raises(ValueError, match="state_bytes"):
+        StateBuilderBudget(
+            output_scalars=1,
+            trainable_scalars=0,
+            state_scalars=0,
+            state_bytes=True,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Supersedes #672 and #675 while retaining both original commits and author attribution.\n\nDeep review fixes added here:\n- FixedTrace deserialization no longer converts bool/string aliases before strict validation;\n- host-only StateBuilderBudget counts remain capable of accurately reporting values above signed int32;\n- ExoCerebellum dimensions use the repository signed-int32 contract instead of an unexplained 65,536 cap;\n- retained out-of-range, float32 sink, deserialization, and class-spoof regressions.\n\nValidation: 74 combined tests plus 27 focused boundary tests; Ruff; strict mypy; diff check.