### PR TITLE
fix(prototype-memory): close residual integer boundary gaps

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -18,7 +18,8 @@ the packaged Step 2 retained-view memory
 from __future__ import annotations
 
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -79,16 +80,16 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(int, value))
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -321,3 +321,42 @@ def test_prototype_memory_rejects_hostile_integral_subclasses() -> None:
             PrototypeMemoryConfig(
                 **{"feature_dim": 4, "n_classes": 2, field: LieInt(-1)}
             )
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    tuple(
+        dict.fromkeys(
+            np.dtype(code).type
+            for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+        )
+    ),
+)
+def test_prototype_memory_canonicalizes_every_numpy_integer_type(
+    integer_type: type,
+) -> None:
+    config = PrototypeMemoryConfig(
+        feature_dim=integer_type(4),
+        n_classes=integer_type(4),
+        slots_per_class=integer_type(4),
+    )
+
+    assert type(config.feature_dim) is int
+    assert type(config.n_classes) is int
+    assert type(config.slots_per_class) is int
+
+
+def test_prototype_memory_integer_errors_do_not_interpolate_hostile_repr() -> None:
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:  # type: ignore[override]
+            return int
+
+        def __repr__(self) -> str:
+            raise RuntimeError("repr must not run")
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        PrototypeMemoryConfig(
+            feature_dim=ClassSpoof(),  # type: ignore[arg-type]
+            n_classes=2,
+        )


### PR DESCRIPTION
Narrow residual after merged #700. The original longlong/ulonglong source fix and basic tests are already upstream; this rebased PR now contains only the remaining boundary corrections: use `operator.index` after exact-type admission, never interpolate hostile rejected values through `__repr__`, and cover every dtype-derived NumPy integer type plus class-spoof rejection across the config boundary.

Validation on current main:
- `tests/test_prototype_memory.py`: 76 passed
- scoped Ruff: clean
- strict source mypy was clean before the no-conflict rebase
- diff check: clean

No registered evidence source or artifact changes.