### PR TITLE
fix(working-memory): enforce JSON list config boundary

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -114,7 +114,10 @@ class WorkingMemoryConfig:
             "reward_decay_rates",
         ):
             if key in payload:
-                payload[key] = tuple(payload[key])
+                value = payload[key]
+                if type(value) is not list:
+                    raise ValueError(f"{key} must be a list")
+                payload[key] = tuple(value)
         return cls(**payload)
 
 

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from fractions import Fraction
 
 import chex
@@ -39,6 +40,36 @@ def test_working_memory_config_roundtrip_and_shapes() -> None:
     chex.assert_shape(state.action_traces, (1, 2))
     chex.assert_shape(state.reward_traces, (2, 1))
     chex.assert_shape(state.last_gate, (3,))
+
+
+def test_working_memory_config_from_config_requires_actual_json_lists() -> None:
+    class HostileList(list[float]):
+        def __iter__(self) -> Iterator[float]:
+            raise AssertionError("invalid list subclass must not be iterated")
+
+    base = WorkingMemoryConfig(observation_dim=2, action_dim=1).to_config()
+    keys = (
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    )
+    invalid_values: tuple[object, ...] = (
+        (0.5,),
+        "0.5",
+        np.asarray([0.5]),
+        HostileList([0.5]),
+        0.5,
+    )
+    for key in keys:
+        for value in invalid_values:
+            payload = {**base, key: value}
+            with pytest.raises(ValueError, match=key):
+                WorkingMemoryConfig.from_config(payload)  # type: ignore[arg-type]
+
+    restored = WorkingMemoryConfig.from_config(base)
+    assert type(restored.observation_decay_rates) is tuple
+    assert type(restored.action_decay_rates) is tuple
+    assert type(restored.reward_decay_rates) is tuple
 
 
 def test_working_memory_trace_decay_and_feature_causality() -> None:


### PR DESCRIPTION
Replacement for #682, preserving byt61 as the source-fix author. The original validation is correct but had no committed regressions. This branch retains the exact-list boundary and adds regressions for all three decay fields covering tuple, string, ndarray, scalar, and hostile list-subclass inputs without invoking their iteration hooks; exact built-in lists still round-trip to canonical tuples.\n\nRebuilt on current main after detecting and removing stale branch ancestry. Final verification: 100 focused tests passed; scoped Ruff passed; strict mypy on the source passed; diff check clean. No output or evidence artifacts changed.\n\nSupersedes #682.