### PR TITLE
fix(ftl): complete scalar and derived-dimension contracts

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -68,6 +68,11 @@ _ACTUAL_INT_TYPES = frozenset(
 )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled error EMA replaces stale diagnostics."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
@@ -125,25 +130,36 @@ class SparseFTLWorldModelConfig:
 
     def __post_init__(self) -> None:
         """Validate all static dimensions and numerical parameters."""
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        action_dim = _require_int32("action_dim", self.action_dim, minimum=1)
+        projection_dim = _require_int32("projection_dim", self.projection_dim, minimum=1)
+        bins = _require_int32("bins", self.bins, minimum=2)
+        derived_dimensions = (
+            ("input_dim", observation_dim + action_dim),
+            ("feature_dim", projection_dim * bins),
+        )
+        for name, value in derived_dimensions:
+            if value > _INT32_MAX:
+                raise ValueError(f"derived {name} must be at most {_INT32_MAX}, got {value}")
         object.__setattr__(
             self,
             "observation_dim",
-            _require_int32("observation_dim", self.observation_dim, minimum=1),
+            observation_dim,
         )
         object.__setattr__(
             self,
             "action_dim",
-            _require_int32("action_dim", self.action_dim, minimum=1),
+            action_dim,
         )
         object.__setattr__(
             self,
             "projection_dim",
-            _require_int32("projection_dim", self.projection_dim, minimum=1),
+            projection_dim,
         )
         object.__setattr__(
             self,
             "bins",
-            _require_int32("bins", self.bins, minimum=2),
+            bins,
         )
         ridge = _finite_positive_normal_float32("ridge", self.ridge)
         statistics_decay = validated_float32_scalar(
@@ -409,7 +425,11 @@ class SparseFTLWorldModel:
         error_ema = jnp.where(
             first,
             squared_error,
-            cfg.error_decay * state.prediction_error_ema + (1.0 - cfg.error_decay) * squared_error,
+            _skip_zero_scale(
+                jnp.asarray(cfg.error_decay, dtype=jnp.float32),
+                state.prediction_error_ema,
+            )
+            + (1.0 - cfg.error_decay) * squared_error,
         )
         max_step_count = jnp.array(2_147_483_647, dtype=jnp.int32)
         next_step_count = jnp.minimum(

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -34,19 +34,47 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
 from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _FLOAT32_TINY = 2.0**-126
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _finite_positive_normal_float32(name: str, value: object) -> float:
@@ -97,25 +125,49 @@ class SparseFTLWorldModelConfig:
 
     def __post_init__(self) -> None:
         """Validate all static dimensions and numerical parameters."""
-        if self.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if self.action_dim <= 0:
-            raise ValueError("action_dim must be positive")
-        if self.projection_dim <= 0:
-            raise ValueError("projection_dim must be positive")
-        if self.bins < 2:
-            raise ValueError("bins must be at least 2")
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "action_dim",
+            _require_int32("action_dim", self.action_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "projection_dim",
+            _require_int32("projection_dim", self.projection_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "bins",
+            _require_int32("bins", self.bins, minimum=2),
+        )
         ridge = _finite_positive_normal_float32("ridge", self.ridge)
-        if not 0.0 < self.statistics_decay <= 1.0:
-            raise ValueError("statistics_decay must be in (0, 1]")
+        statistics_decay = validated_float32_scalar(
+            "statistics_decay",
+            self.statistics_decay,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=True,
+        )
         prediction_clip = _finite_positive_normal_float32(
             "prediction_clip",
             self.prediction_clip,
         )
-        if not 0.0 <= self.error_decay < 1.0:
-            raise ValueError("error_decay must be in [0, 1)")
+        error_decay = validated_float32_scalar(
+            "error_decay",
+            self.error_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
         object.__setattr__(self, "ridge", ridge)
+        object.__setattr__(self, "statistics_decay", statistics_decay)
         object.__setattr__(self, "prediction_clip", prediction_clip)
+        object.__setattr__(self, "error_decay", error_decay)
 
     @property
     def input_dim(self) -> int:

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -661,3 +661,70 @@ def test_sparse_ftl_config_accepts_and_canonicalizes_numpy_integers() -> None:
     assert config.action_dim == 2
     assert config.projection_dim == 16
     assert config.bins == 6
+
+
+def test_sparse_ftl_config_rejects_derived_dimensions_outside_int32() -> None:
+    int32_max = 2**31 - 1
+    with pytest.raises(ValueError, match="derived input_dim"):
+        SparseFTLWorldModelConfig(observation_dim=int32_max, action_dim=1)
+    with pytest.raises(ValueError, match="derived feature_dim"):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=2**30,
+            bins=2,
+        )
+    with pytest.raises(ValueError, match="derived feature_dim"):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=46_341,
+            bins=46_341,
+        )
+
+
+def test_sparse_ftl_config_accepts_derived_int32_boundary() -> None:
+    int32_max = 2**31 - 1
+    widest_input = SparseFTLWorldModelConfig(
+        observation_dim=int32_max - 1,
+        action_dim=1,
+        projection_dim=1,
+        bins=int32_max,
+    )
+    widest_active_block = SparseFTLWorldModelConfig(
+        observation_dim=1,
+        action_dim=1,
+        projection_dim=int32_max // 2,
+        bins=2,
+    )
+    assert widest_input.input_dim == int32_max
+    assert widest_input.feature_dim == int32_max
+    assert widest_input.active_feature_count == 2
+    assert widest_active_block.feature_dim == int32_max - 1
+    assert widest_active_block.active_feature_count == int32_max - 1
+
+
+def test_zero_error_decay_replaces_infinite_prior_ema_without_nan() -> None:
+    model = SparseFTLWorldModel(
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=2,
+            bins=3,
+            error_decay=0.0,
+        )
+    )
+    state = model.init(jr.key(8)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.array(1, dtype=jnp.int32),
+        prediction_error_ema=jnp.array(jnp.inf, dtype=jnp.float32),
+    )
+
+    result = model.update(
+        state,
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+    )
+
+    assert jnp.isfinite(result.squared_error)
+    assert result.state.prediction_error_ema == result.squared_error

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -617,3 +617,47 @@ def test_scan_is_jittable_and_configuration_roundtrips() -> None:
     chex.assert_shape(result.squared_errors, (4,))
     chex.assert_tree_all_finite(result)
     assert int(result.state.step_count) == 4
+
+
+def test_sparse_ftl_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        SparseFTLWorldModelConfig(observation_dim=True, action_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_dim"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="projection_dim"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, projection_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bins"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, bins=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="observation_dim"):
+        SparseFTLWorldModelConfig(observation_dim=2.5, action_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_dim"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="projection_dim"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, projection_dim=32.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bins"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, bins=7.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="statistics_decay"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, statistics_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="error_decay"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, error_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="error_decay"):
+        SparseFTLWorldModelConfig(observation_dim=1, action_dim=1, error_decay=1.0 - 1e-10)
+
+
+def test_sparse_ftl_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=np.int32(4),
+        action_dim=np.int64(2),
+        projection_dim=np.uint16(16),
+        bins=np.int8(6),
+    )
+    assert type(config.observation_dim) is int
+    assert type(config.action_dim) is int
+    assert type(config.projection_dim) is int
+    assert type(config.bins) is int
+    assert config.observation_dim == 4
+    assert config.action_dim == 2
+    assert config.projection_dim == 16
+    assert config.bins == 6


### PR DESCRIPTION
Supersedes #678 while preserving its contributor-authored commit.

The original exact built-in/NumPy integer and float32 decay validation is retained. This replacement additionally closes two downstream execution gaps found during review:

- reject derived `input_dim` and `feature_dim` values outside the signed-int32 JAX/index domain before allocation or sparse-index arithmetic;
- preserve the legal `error_decay=0` endpoint when a prior diagnostic is infinite by skipping `0 * inf`, matching the established reward-model EMA convention.

Boundary tests cover exact legal derived maxima, one-above rejection without allocation, and zero-decay recovery from an infinite prior EMA.

Verification on current main: 64 focused tests passed (`test_ftl_world_model.py` plus exact float32 helpers); Ruff passed; mypy passed; diff-check clean. No `outputs/**` files were touched. `ftl_world_model.py` is registered evidence source code, so existing artifacts remain fail-closed under source drift; this is an engineering correction, not evidence preservation or promotion.