### PR TITLE
fix(router): preflight residual state and serialization contracts

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -96,6 +96,11 @@ class FeatureBankRouterConfig:
             "active_slots",
             active_slots,
         )
+        router_state_scalars = 2 * self.active_slots + 2
+        if router_state_scalars > _INT32_MAX:
+            raise ValueError("router_state_scalars must not exceed 2147483647")
+        if 4 * router_state_scalars > _INT32_MAX:
+            raise ValueError("router_state_nbytes must not exceed 2147483647")
 
     @property
     def total_feature_dim(self) -> int:
@@ -128,9 +133,11 @@ class FeatureBankRouterConfig:
         }
         if set(config) != expected_keys:
             raise ValueError("feature-bank router config keys do not match the v1 schema")
-        if config.get("type") != "FeatureBankRouter":
+        config_type = config.get("type")
+        if type(config_type) is not str or config_type != "FeatureBankRouter":
             raise ValueError("feature-bank router config type is invalid")
-        if config.get("schema_version") != CONFIG_SCHEMA_VERSION:
+        schema_version = config.get("schema_version")
+        if type(schema_version) is not str or schema_version != CONFIG_SCHEMA_VERSION:
             raise ValueError("feature-bank router config schema version is unsupported")
         return cls(
             base_dim=config["base_dim"],  # type: ignore[arg-type]

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -38,6 +38,22 @@ _NEW = jnp.asarray(
 )
 
 
+class _StringSubclass(str):
+    pass
+
+
+class _RaisingStringSpoof:
+    @property
+    def __class__(self) -> type[str]:
+        return str
+
+    def __eq__(self, other: object) -> bool:
+        raise AssertionError("__eq__ must not be called")
+
+    def __repr__(self) -> str:
+        raise AssertionError("__repr__ must not be called")
+
+
 def _router() -> FeatureBankRouter:
     return FeatureBankRouter(
         FeatureBankRouterConfig(
@@ -563,3 +579,36 @@ def test_router_config_roundtrip_preserves_canonical_int32_dimensions() -> None:
     assert type(payload["base_dim"]) is int
     assert type(payload["active_slots"]) is int
     assert FeatureBankRouterConfig.from_config(payload) == config
+
+
+@pytest.mark.unit
+def test_router_config_preflights_derived_state_counts_before_allocation() -> None:
+    with pytest.raises(ValueError, match="router_state_scalars"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=1_073_741_823)
+    with pytest.raises(ValueError, match="router_state_nbytes"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=268_435_455)
+
+    boundary = FeatureBankRouterConfig(base_dim=2, active_slots=268_435_454)
+    assert 4 * (2 * boundary.active_slots + 2) == 2_147_483_640
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "hostile", "message"),
+    [
+        ("type", _StringSubclass("FeatureBankRouter"), "type is invalid"),
+        ("type", _RaisingStringSpoof(), "type is invalid"),
+        ("schema_version", _StringSubclass(CONFIG_SCHEMA_VERSION), "schema version"),
+        ("schema_version", _RaisingStringSpoof(), "schema version"),
+    ],
+    ids=["type-str-subclass", "type-class-spoof", "schema-str-subclass", "schema-class-spoof"],
+)
+def test_router_config_rejects_string_spoofs_without_invoking_hooks(
+    field: str,
+    hostile: object,
+    message: str,
+) -> None:
+    serialized = FeatureBankRouterConfig(base_dim=4, active_slots=4).to_config()
+    serialized[field] = hostile
+    with pytest.raises(ValueError, match=message):
+        FeatureBankRouterConfig.from_config(serialized)


### PR DESCRIPTION
Residual follow-up to merged #683, rebased onto current main. The original contributor commit is now present through #683; this branch contains only the missing corrective delta.\n\n#683 now correctly provides exact integer gates, all NumPy signed/unsigned dtype-family acceptance, built-in-int canonicalization, hostile integer rejection, and a derived total_feature_dim signed-int32 bound. This residual adds:\n- router-owned derived state scalar-count and state byte-count signed-int32 preflights before allocation;\n- exact built-in-string gates for serialized type/schema discriminators, rejecting str subclasses and __class__ spoofs without invoking equality/repr hooks;\n- exact upper-bound/no-allocation and hostile discriminator regressions.\n\nConsumer budget totals remain exact unbounded Python integers: resource_budget observes already-allocated leaves, and its host-only accounting must not silently narrow or reject them. Existing exact accounting tests cover stable-prefix, dynamic-tail, total-scalar, byte, and managed-byte products.\n\nValidation: 19 focused tests passed; scoped Ruff clean; strict mypy clean; diff check clean.