### PR TITLE
fix(ftl): close residual config and resource contracts

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -90,7 +90,7 @@ def _finite_positive_normal_float32(name: str, value: object) -> float:
         raise ValueError(message)
     try:
         narrowed = round_real_to_float32(value)
-    except (TypeError, ValueError, OverflowError) as exc:
+    except Exception as exc:
         raise ValueError(message) from exc
     if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY:
         raise ValueError(message)
@@ -99,6 +99,24 @@ def _finite_positive_normal_float32(name: str, value: object) -> float:
         if round_real_to_float32(cast(Real, concrete)) == narrowed:
             return concrete
     return narrowed
+
+
+def _configured_state_nbytes(
+    *,
+    observation_dim: int,
+    input_dim: int,
+    projection_dim: int,
+    feature_dim: int,
+) -> int:
+    """Return the exact persistent-array size without allocating it."""
+    float_count = (
+        projection_dim * input_dim
+        + feature_dim * feature_dim
+        + 2 * feature_dim * observation_dim
+        + 1
+    )
+    # Every configured array is float32 except one int32 step counter.
+    return 4 * (float_count + 1)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -134,9 +152,18 @@ class SparseFTLWorldModelConfig:
         action_dim = _require_int32("action_dim", self.action_dim, minimum=1)
         projection_dim = _require_int32("projection_dim", self.projection_dim, minimum=1)
         bins = _require_int32("bins", self.bins, minimum=2)
+        input_dim = observation_dim + action_dim
+        feature_dim = projection_dim * bins
+        state_nbytes = _configured_state_nbytes(
+            observation_dim=observation_dim,
+            input_dim=input_dim,
+            projection_dim=projection_dim,
+            feature_dim=feature_dim,
+        )
         derived_dimensions = (
-            ("input_dim", observation_dim + action_dim),
-            ("feature_dim", projection_dim * bins),
+            ("input_dim", input_dim),
+            ("feature_dim", feature_dim),
+            ("state_nbytes", state_nbytes),
         )
         for name, value in derived_dimensions:
             if value > _INT32_MAX:
@@ -281,14 +308,12 @@ class SparseFTLWorldModel:
     def state_nbytes(self) -> int:
         """Configured serialized array size, independent of lifetime."""
         cfg = self._config
-        float_count = (
-            cfg.projection_dim * cfg.input_dim
-            + cfg.feature_dim * cfg.feature_dim
-            + 2 * cfg.feature_dim * cfg.observation_dim
-            + 1
+        return _configured_state_nbytes(
+            observation_dim=cfg.observation_dim,
+            input_dim=cfg.input_dim,
+            projection_dim=cfg.projection_dim,
+            feature_dim=cfg.feature_dim,
         )
-        # All configured arrays are float32; step_count is int32.
-        return 4 * (float_count + 1)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize model type and static configuration."""

--- a/tests/test_ftl_world_model.py
+++ b/tests/test_ftl_world_model.py
@@ -681,27 +681,44 @@ def test_sparse_ftl_config_rejects_derived_dimensions_outside_int32() -> None:
             projection_dim=46_341,
             bins=46_341,
         )
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=11_585,
+            bins=2,
+        )
 
 
-def test_sparse_ftl_config_accepts_derived_int32_boundary() -> None:
-    int32_max = 2**31 - 1
-    widest_input = SparseFTLWorldModelConfig(
-        observation_dim=int32_max - 1,
-        action_dim=1,
-        projection_dim=1,
-        bins=int32_max,
-    )
-    widest_active_block = SparseFTLWorldModelConfig(
+def test_sparse_ftl_config_accepts_largest_state_below_int32_boundary() -> None:
+    config = SparseFTLWorldModelConfig(
         observation_dim=1,
         action_dim=1,
-        projection_dim=int32_max // 2,
+        projection_dim=11_584,
         bins=2,
     )
-    assert widest_input.input_dim == int32_max
-    assert widest_input.feature_dim == int32_max
-    assert widest_input.active_feature_count == 2
-    assert widest_active_block.feature_dim == int32_max - 1
-    assert widest_active_block.active_feature_count == int32_max - 1
+    model = SparseFTLWorldModel(config)
+    assert config.input_dim == 2
+    assert config.feature_dim == 23_168
+    assert config.active_feature_count == 23_168
+    assert model.state_nbytes == 2_147_302_920
+
+
+@pytest.mark.parametrize("field", ["ridge", "prediction_clip"])
+def test_sparse_ftl_config_normalizes_hostile_ratio_hook_errors(field: str) -> None:
+    class RatioBomb(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("hostile ratio hook")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    with pytest.raises(ValueError, match=field):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            **{field: RatioBomb(0.5)},
+        )
 
 
 def test_zero_error_decay_replaces_infinite_prior_ema_without_nan() -> None:


### PR DESCRIPTION
Completes the narrow residual repair after merged #693, which superseded #678 and preserved its contributor-authored validation commit.

The merged repair bounded derived shape axes and fixed the legal zero-error-decay path. This follow-up only:

- preflights the exact persistent `state_nbytes` formula in Python arithmetic before any JAX allocation, using the established signed-int32 allocation/resource boundary;
- normalizes arbitrary ordinary `Exception` failures from hostile exact-ratio hooks for `ridge` and `prediction_clip` to their documented `ValueError` boundary without invoking hostile `repr`;
- tests the last legal resource point, the first overflowing point, and hostile ratio/repr behavior.

Permissive historical `from_config` behavior is unchanged; this PR adds no exact-dict, exact-field-set, or type-discriminator requirement.

Verification at `98f20c81e01a1937a3b81ddb76574d1fd6f37559` on main `4d1c7867320ac41494760e9edb775efa7ac7f612`:

- `pytest tests/test_ftl_world_model.py tests/test_float32.py -q -o addopts=''`: 66 passed in 15.58s
- `ruff check .`: clean
- strict `mypy`: clean (168 source files)
- `git diff --check`: clean

No `outputs/**` files are changed. `alberta_framework/core/ftl_world_model.py` is a registered source for the historical FTL claim, so existing evidence remains fail-closed under source drift; this engineering correction does not preserve or promote evidence.
