### PR TITLE
fix(world-model): enforce exact runtime shapes

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -390,9 +390,12 @@ class ActionConditionedWorldModel:
         must not form arithmetic with a non-finite public observation before
         publishing the fail-visible result.
         """
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         action_one_hot = self.encode_action(action)
         features_valid = jnp.all(jnp.isfinite(obs)) & jnp.all(
             jnp.isfinite(action_one_hot)
@@ -437,12 +440,18 @@ class ActionConditionedWorldModel:
         next_observation: Array,
     ) -> Array:
         """Build normalized ``[delta_obs, reward, discount]`` targets."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
         safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
@@ -564,18 +573,24 @@ class ActionConditionedWorldModel:
         else:
             discount = discount_or_next_observation
 
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         action_arr, action_valid = safe_discrete_action(
             action,
             self._config.n_actions,
         )
         reward_arr = jnp.asarray(reward, dtype=jnp.float32)
         discount_arr = jnp.asarray(discount, dtype=jnp.float32)
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
             & action_valid
@@ -989,25 +1004,40 @@ class OneStepWorldModel:
                 encoded,
                 jnp.full_like(encoded, jnp.nan),
             )
-        return jnp.asarray(action, dtype=jnp.float32).reshape((self._config.action_dim,))
+        action_arr = jnp.asarray(action, dtype=jnp.float32)
+        if action_arr.shape != (self._config.action_dim,):
+            raise ValueError(
+                f"action must have shape ({self._config.action_dim},) "
+                f"got {action_arr.shape}"
+            )
+        return action_arr
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def input_features(self, observation: Array, action: Array) -> Array:
         """Return ``concat(observation, encoded_action)``."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         return jnp.concatenate([obs, self.encode_action(action)], axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def targets(self, observation: Array, reward: Array, next_observation: Array) -> Array:
         """Build ``[reward, next_obs_or_delta]`` targets."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         obs_target = next_obs - obs if self._config.predict_delta else next_obs
         return jnp.concatenate(
             [jnp.reshape(jnp.asarray(reward, dtype=jnp.float32), (1,)), obs_target],
@@ -1022,9 +1052,12 @@ class OneStepWorldModel:
         action: Array,
     ) -> WorldModelPrediction:
         """Predict reward and next observation."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         raw_predictions = self._learner.predict(
             state.learner_state,
             self.input_features(obs, action),
@@ -1057,9 +1090,12 @@ class OneStepWorldModel:
                 self._config.n_actions,
             )
         else:
-            action_arr = jnp.asarray(action, dtype=jnp.float32).reshape(
-                (self._config.action_dim,)
-            )
+            action_arr = jnp.asarray(action, dtype=jnp.float32)
+            if action_arr.shape != (self._config.action_dim,):
+                raise ValueError(
+                    f"action must have shape ({self._config.action_dim},) "
+                    f"got {action_arr.shape}"
+                )
             action_valid = jnp.all(jnp.isfinite(action_arr))
             safe_action = jnp.where(
                 action_valid,
@@ -1073,9 +1109,12 @@ class OneStepWorldModel:
             self.input_features(observation, safe_action),
             targets,
         )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         reward_arr = jnp.asarray(reward, dtype=jnp.float32)
         next_observation_errors = prediction.next_observation - next_obs
         reward_error = prediction.reward - reward_arr

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -46,6 +46,14 @@ from alberta_framework.core.update_safety import (
 )
 
 
+def _float32_scalar(name: str, value: Array) -> Array:
+    """Canonicalize one scalar without flattening size-one vectors or matrices."""
+    array = jnp.asarray(value, dtype=jnp.float32)
+    if array.shape != ():
+        raise ValueError(f"{name} must be scalar; got shape {array.shape}")
+    return array
+
+
 @dataclasses.dataclass(frozen=True)
 class ActionConditionedWorldModelConfig:
     """Configuration for :class:`ActionConditionedWorldModel`.
@@ -416,6 +424,7 @@ class ActionConditionedWorldModel:
     @functools.partial(jax.jit, static_argnums=(0,))
     def encode_action(self, action: Array) -> Array:
         """Return the action code, leaving invalid discrete inputs visible."""
+        action = _float32_scalar("action", action)
         safe_action, action_valid = safe_discrete_action(
             action,
             self._config.n_actions,
@@ -460,10 +469,9 @@ class ActionConditionedWorldModel:
             next_obs / safe_scale,
         )
         reward_target = jnp.reshape(
-            jnp.asarray(reward, dtype=jnp.float32) / self._config.reward_scale,
-            (1,),
+            _float32_scalar("reward", reward) / self._config.reward_scale, (1,)
         )
-        discount_target = jnp.reshape(jnp.asarray(discount, dtype=jnp.float32), (1,))
+        discount_target = jnp.reshape(_float32_scalar("discount", discount), (1,))
         return jnp.concatenate([normalized_delta, reward_target, discount_target], axis=0)
 
     def _prediction_and_raw_diagnostics(
@@ -580,11 +588,11 @@ class ActionConditionedWorldModel:
                 f"got {obs.shape}"
             )
         action_arr, action_valid = safe_discrete_action(
-            action,
+            _float32_scalar("action", action),
             self._config.n_actions,
         )
-        reward_arr = jnp.asarray(reward, dtype=jnp.float32)
-        discount_arr = jnp.asarray(discount, dtype=jnp.float32)
+        reward_arr = _float32_scalar("reward", reward)
+        discount_arr = _float32_scalar("discount", discount)
         next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
         if next_obs.shape != (self._config.observation_dim,):
             raise ValueError(
@@ -991,7 +999,7 @@ class OneStepWorldModel:
         """Encode a discrete or vector action."""
         if self._config.n_actions is not None:
             safe_action, action_valid = safe_discrete_action(
-                action,
+                _float32_scalar("action", action),
                 self._config.n_actions,
             )
             encoded = jax.nn.one_hot(
@@ -1040,7 +1048,7 @@ class OneStepWorldModel:
             )
         obs_target = next_obs - obs if self._config.predict_delta else next_obs
         return jnp.concatenate(
-            [jnp.reshape(jnp.asarray(reward, dtype=jnp.float32), (1,)), obs_target],
+            [jnp.reshape(_float32_scalar("reward", reward), (1,)), obs_target],
             axis=0,
         )
 
@@ -1086,7 +1094,7 @@ class OneStepWorldModel:
         """Update from one real transition."""
         if self._config.n_actions is not None:
             safe_action, action_valid = safe_discrete_action(
-                action,
+                _float32_scalar("action", action),
                 self._config.n_actions,
             )
         else:
@@ -1115,7 +1123,7 @@ class OneStepWorldModel:
                 f"next_observation must have shape ({self._config.observation_dim},) "
                 f"got {next_obs.shape}"
             )
-        reward_arr = jnp.asarray(reward, dtype=jnp.float32)
+        reward_arr = _float32_scalar("reward", reward)
         next_observation_errors = prediction.next_observation - next_obs
         reward_error = prediction.reward - reward_arr
         observation_mse = jnp.nanmean(next_observation_errors**2)

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -33,6 +33,142 @@ from alberta_framework.core.world_model import (
 )
 
 
+def _shape_contract_model() -> tuple[
+    ActionConditionedWorldModel, ActionConditionedWorldModelState
+]:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+            use_layer_norm=False,
+        )
+    )
+    return model, model.init(jr.key(91))
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("input_features", "observation"),
+        ("targets", "observation"),
+        ("targets", "next_observation"),
+        ("predict", "observation"),
+        ("update", "observation"),
+        ("update", "next_observation"),
+    ],
+)
+def test_action_world_model_rejects_wrong_vector_shapes_on_every_public_path(
+    operation: str, field: str
+) -> None:
+    model, state = _shape_contract_model()
+    values = {
+        "observation": jnp.zeros((2,), dtype=jnp.float32),
+        "action": jnp.asarray(0, dtype=jnp.int32),
+        "reward": jnp.asarray(0.5, dtype=jnp.float32),
+        "discount": jnp.asarray(0.9, dtype=jnp.float32),
+        "next_observation": jnp.ones((2,), dtype=jnp.float32),
+    }
+    values[field] = jnp.zeros((1, 2), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "input_features":
+            return model.input_features(values["observation"], values["action"])
+        if operation == "targets":
+            return model.targets(
+                values["observation"],
+                values["reward"],
+                values["discount"],
+                values["next_observation"],
+            )
+        if operation == "predict":
+            return model.predict(state, values["observation"], values["action"])
+        return model.update(
+            state,
+            values["observation"],
+            values["action"],
+            values["reward"],
+            values["discount"],
+            values["next_observation"],
+        )
+
+    with pytest.raises(ValueError, match=field):
+        call()
+    with pytest.raises(ValueError, match=field):
+        jax.jit(call)()
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("encode_action", "action"),
+        ("input_features", "action"),
+        ("targets", "reward"),
+        ("targets", "discount"),
+        ("predict", "action"),
+        ("update", "action"),
+        ("update", "reward"),
+        ("update", "discount"),
+    ],
+)
+def test_action_world_model_rejects_size_one_scalar_aliases(
+    operation: str, field: str
+) -> None:
+    model, state = _shape_contract_model()
+    values = {
+        "observation": jnp.zeros((2,), dtype=jnp.float32),
+        "action": jnp.asarray(0, dtype=jnp.int32),
+        "reward": jnp.asarray(0.5, dtype=jnp.float32),
+        "discount": jnp.asarray(0.9, dtype=jnp.float32),
+        "next_observation": jnp.ones((2,), dtype=jnp.float32),
+    }
+    values[field] = jnp.ones((1,), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "encode_action":
+            return model.encode_action(values["action"])
+        if operation == "input_features":
+            return model.input_features(values["observation"], values["action"])
+        if operation == "targets":
+            return model.targets(
+                values["observation"],
+                values["reward"],
+                values["discount"],
+                values["next_observation"],
+            )
+        if operation == "predict":
+            return model.predict(state, values["observation"], values["action"])
+        return model.update(
+            state,
+            values["observation"],
+            values["action"],
+            values["reward"],
+            values["discount"],
+            values["next_observation"],
+        )
+
+    with pytest.raises(ValueError, match=field):
+        call()
+    with pytest.raises(ValueError, match=field):
+        jax.jit(call)()
+
+
+def test_action_world_model_preserves_numeric_dtype_canonicalization() -> None:
+    model, _ = _shape_contract_model()
+    features = model.input_features(
+        jnp.asarray([1, 2], dtype=jnp.int32), jnp.asarray(1, dtype=jnp.int16)
+    )
+    targets = model.targets(
+        jnp.asarray([1, 2], dtype=jnp.int32),
+        jnp.asarray(1, dtype=jnp.int16),
+        jnp.asarray(1, dtype=jnp.int16),
+        jnp.asarray([2, 3], dtype=jnp.int16),
+    )
+    assert features.dtype == jnp.float32
+    assert targets.dtype == jnp.float32
+
+
 def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     config = ActionConditionedWorldModelConfig(
         observation_dim=2,

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -6,12 +6,164 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelConfig,
+    WorldModelState,
     run_world_model_learning_loop,
 )
+
+
+def _one_step_shape_model(
+    *, continuous: bool = False
+) -> tuple[OneStepWorldModel, WorldModelState]:
+    model = OneStepWorldModel(
+        WorldModelConfig(
+            observation_dim=2,
+            n_actions=None if continuous else 2,
+            action_dim=2 if continuous else 1,
+            hidden_sizes=(),
+            sparsity=0.0,
+            use_layer_norm=False,
+        )
+    )
+    return model, model.init(jr.key(92))
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("input_features", "observation"),
+        ("targets", "observation"),
+        ("targets", "next_observation"),
+        ("predict", "observation"),
+        ("update", "observation"),
+        ("update", "next_observation"),
+    ],
+)
+def test_one_step_world_model_rejects_wrong_observation_shapes(
+    operation: str, field: str
+) -> None:
+    model, state = _one_step_shape_model()
+    values = {
+        "observation": jnp.zeros((2,), dtype=jnp.float32),
+        "action": jnp.asarray(0, dtype=jnp.int32),
+        "reward": jnp.asarray(0.5, dtype=jnp.float32),
+        "next_observation": jnp.ones((2,), dtype=jnp.float32),
+    }
+    values[field] = jnp.zeros((2, 1), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "input_features":
+            return model.input_features(values["observation"], values["action"])
+        if operation == "targets":
+            return model.targets(
+                values["observation"], values["reward"], values["next_observation"]
+            )
+        if operation == "predict":
+            return model.predict(state, values["observation"], values["action"])
+        return model.update(
+            state,
+            values["observation"],
+            values["action"],
+            values["reward"],
+            values["next_observation"],
+        )
+
+    with pytest.raises(ValueError, match=field):
+        call()
+    with pytest.raises(ValueError, match=field):
+        jax.jit(call)()
+
+
+@pytest.mark.parametrize("operation", ["encode_action", "input_features", "predict", "update"])
+def test_one_step_world_model_rejects_wrong_continuous_action_shapes(
+    operation: str,
+) -> None:
+    model, state = _one_step_shape_model(continuous=True)
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    action = jnp.zeros((1, 2), dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    next_observation = jnp.ones((2,), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "encode_action":
+            return model.encode_action(action)
+        if operation == "input_features":
+            return model.input_features(observation, action)
+        if operation == "predict":
+            return model.predict(state, observation, action)
+        return model.update(state, observation, action, reward, next_observation)
+
+    with pytest.raises(ValueError, match="action"):
+        call()
+    with pytest.raises(ValueError, match="action"):
+        jax.jit(call)()
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("encode_action", "action"),
+        ("input_features", "action"),
+        ("targets", "reward"),
+        ("predict", "action"),
+        ("update", "action"),
+        ("update", "reward"),
+    ],
+)
+def test_one_step_world_model_rejects_size_one_scalar_aliases(
+    operation: str, field: str
+) -> None:
+    model, state = _one_step_shape_model()
+    values = {
+        "observation": jnp.zeros((2,), dtype=jnp.float32),
+        "action": jnp.asarray(0, dtype=jnp.int32),
+        "reward": jnp.asarray(0.5, dtype=jnp.float32),
+        "next_observation": jnp.ones((2,), dtype=jnp.float32),
+    }
+    values[field] = jnp.ones((1,), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "encode_action":
+            return model.encode_action(values["action"])
+        if operation == "input_features":
+            return model.input_features(values["observation"], values["action"])
+        if operation == "targets":
+            return model.targets(
+                values["observation"], values["reward"], values["next_observation"]
+            )
+        if operation == "predict":
+            return model.predict(state, values["observation"], values["action"])
+        return model.update(
+            state,
+            values["observation"],
+            values["action"],
+            values["reward"],
+            values["next_observation"],
+        )
+
+    with pytest.raises(ValueError, match=field):
+        call()
+    with pytest.raises(ValueError, match=field):
+        jax.jit(call)()
+
+
+def test_one_step_world_model_preserves_numeric_dtype_canonicalization() -> None:
+    model, _ = _one_step_shape_model(continuous=True)
+    features = model.input_features(
+        jnp.asarray([1, 2], dtype=jnp.int32),
+        jnp.asarray([3, 4], dtype=jnp.int16),
+    )
+    targets = model.targets(
+        jnp.asarray([1, 2], dtype=jnp.int32),
+        jnp.asarray(1, dtype=jnp.int16),
+        jnp.asarray([2, 3], dtype=jnp.int16),
+    )
+    assert features.dtype == jnp.float32
+    assert targets.dtype == jnp.float32
 
 
 def test_world_model_update_is_finite_and_shape_stable() -> None:


### PR DESCRIPTION
## Summary

- preserve the original vector-shape hardening commit from #679 with byt61 authorship
- reject size-one vector/matrix aliases for discrete actions, rewards, and discounts before JAX computation
- cover every public ActionConditionedWorldModel and OneStepWorldModel path in eager and outer-jitted use
- preserve intentional numeric-to-float32 canonicalization

## Why this replaces #679

The original change fixes a real silent-flattening bug for observation and continuous-action vectors, but it leaves the same shape-poisoning class open for scalar fields. In particular, a `(1,)` discrete action is silently accepted, ActionConditioned reward/discount aliases reach opaque downstream scalar errors, and OneStep reward aliases are accepted and committed. This branch includes the original contributor commit unchanged in history and adds the missing scalar boundary plus committed mutation-resistant tests.

## Validation

- `pytest tests/test_action_conditioned_world_model.py tests/test_world_model.py -q` — 72 passed
- `ruff check .` — passed
- `mypy` — 168 source files passed
- `git diff --check origin/main...HEAD` — passed

No registered evidence source is changed.