### PR TITLE
fix(router): complete derived allocation contracts

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -43,16 +43,10 @@ _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
+        *(
+            np.dtype(code).type
+            for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "p", "P")
+        ),
     }
 )
 
@@ -84,7 +78,6 @@ class FeatureBankRouterConfig:
             "active_slots",
             self.active_slots,
             minimum=1,
-            maximum=_INT32_MAX - base_dim,
         )
         object.__setattr__(
             self,
@@ -96,6 +89,13 @@ class FeatureBankRouterConfig:
             "active_slots",
             active_slots,
         )
+        if self.base_dim + self.active_slots > _INT32_MAX:
+            raise ValueError("total_feature_dim must be an integer in [3, 2147483647]")
+        router_state_scalars = 2 * self.active_slots + 2
+        if router_state_scalars > _INT32_MAX:
+            raise ValueError("router_state_scalars must not exceed 2147483647")
+        if 4 * router_state_scalars > _INT32_MAX:
+            raise ValueError("router_state_nbytes must not exceed 2147483647")
 
     @property
     def total_feature_dim(self) -> int:
@@ -128,9 +128,11 @@ class FeatureBankRouterConfig:
         }
         if set(config) != expected_keys:
             raise ValueError("feature-bank router config keys do not match the v1 schema")
-        if config.get("type") != "FeatureBankRouter":
+        config_type = config.get("type")
+        if type(config_type) is not str or config_type != "FeatureBankRouter":
             raise ValueError("feature-bank router config type is invalid")
-        if config.get("schema_version") != CONFIG_SCHEMA_VERSION:
+        schema_version = config.get("schema_version")
+        if type(schema_version) is not str or schema_version != CONFIG_SCHEMA_VERSION:
             raise ValueError("feature-bank router config schema version is unsupported")
         return cls(
             base_dim=config["base_dim"],  # type: ignore[arg-type]

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -36,6 +37,46 @@ _NEW = jnp.asarray(
     ],
     dtype=jnp.int32,
 )
+
+_NUMPY_INTEGER_TYPES = tuple(
+    dict.fromkeys(
+        np.dtype(code).type
+        for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "p", "P")
+    )
+)
+
+
+class _RaisingIntegerSpoof:
+    @property
+    def __class__(self) -> type[int]:
+        return int
+
+    def __index__(self) -> int:
+        raise AssertionError("__index__ must not be called")
+
+    def __repr__(self) -> str:
+        raise AssertionError("__repr__ must not be called")
+
+
+class _IntegerSubclass(int):
+    def __repr__(self) -> str:
+        raise AssertionError("__repr__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+class _RaisingStringSpoof:
+    @property
+    def __class__(self) -> type[str]:
+        return str
+
+    def __eq__(self, other: object) -> bool:
+        raise AssertionError("__eq__ must not be called")
+
+    def __repr__(self) -> str:
+        raise AssertionError("__repr__ must not be called")
 
 
 def _router() -> FeatureBankRouter:
@@ -515,51 +556,71 @@ def test_router_config_rejects_booleans_and_non_integers() -> None:
 
 
 @pytest.mark.unit
-def test_router_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    integer_types = {
-        np.dtype(code).type for code in "bBhHiIlLqQpP" if np.dtype(code).kind in "iu"
-    }
-    for integer_type in integer_types:
-        config = FeatureBankRouterConfig(
-            base_dim=integer_type(4),
-            active_slots=integer_type(4),
-        )
-        assert type(config.base_dim) is int
-        assert type(config.active_slots) is int
-        assert config.base_dim == 4
-        assert config.active_slots == 4
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_router_config_accepts_and_canonicalizes_all_numpy_integers(
+    integer_type: type[np.integer[Any]],
+) -> None:
+    config = FeatureBankRouterConfig(
+        base_dim=integer_type(4),
+        active_slots=integer_type(4),
+    )
+    assert type(config.base_dim) is int
+    assert type(config.active_slots) is int
+    assert config.base_dim == 4
+    assert config.active_slots == 4
+    assert json.loads(json.dumps(config.to_config())) == config.to_config()
 
 
 @pytest.mark.unit
-def test_router_config_rejects_spoofs_and_float32_sink_overflow() -> None:
-    class HostileInt(int):
-        def __repr__(self) -> str:
-            raise AssertionError("invalid subclass repr must not run")
+def test_router_config_rejects_derived_feature_width_outside_signed_int32() -> None:
+    with pytest.raises(ValueError, match="total_feature_dim"):
+        FeatureBankRouterConfig(base_dim=2**31 - 1, active_slots=1)
 
-    class ClassSpoof:
-        @property
-        def __class__(self) -> type[int]:
-            return int
-
-    for value in (HostileInt(4), ClassSpoof(), np.bool_(True), np.float32(4.0)):
-        with pytest.raises(ValueError, match="base_dim"):
-            FeatureBankRouterConfig(base_dim=value, active_slots=1)  # type: ignore[arg-type]
-        with pytest.raises(ValueError, match="active_slots"):
-            FeatureBankRouterConfig(base_dim=4, active_slots=value)  # type: ignore[arg-type]
-
-    maximum = 2**31 - 1
-    config = FeatureBankRouterConfig(base_dim=maximum - 1, active_slots=1)
-    assert config.total_feature_dim == maximum
-    with pytest.raises(ValueError, match="active_slots"):
-        FeatureBankRouterConfig(base_dim=maximum, active_slots=1)
-    with pytest.raises(ValueError, match="active_slots"):
-        FeatureBankRouterConfig(base_dim=maximum - 1, active_slots=2)
+    boundary = FeatureBankRouterConfig(base_dim=2**31 - 2, active_slots=1)
+    assert boundary.total_feature_dim == 2**31 - 1
 
 
 @pytest.mark.unit
-def test_router_config_roundtrip_preserves_canonical_int32_dimensions() -> None:
-    config = FeatureBankRouterConfig(base_dim=np.longlong(4), active_slots=np.ulonglong(3))
-    payload = config.to_config()
-    assert type(payload["base_dim"]) is int
-    assert type(payload["active_slots"]) is int
-    assert FeatureBankRouterConfig.from_config(payload) == config
+def test_router_config_preflights_derived_state_counts_before_allocation() -> None:
+    with pytest.raises(ValueError, match="router_state_scalars"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=1_073_741_823)
+    with pytest.raises(ValueError, match="router_state_nbytes"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=268_435_455)
+
+    boundary = FeatureBankRouterConfig(base_dim=2, active_slots=268_435_454)
+    assert 4 * (2 * boundary.active_slots + 2) == 2_147_483_640
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "hostile",
+    [_RaisingIntegerSpoof(), _IntegerSubclass(4), np.bool_(True), np.float32(4.0)],
+    ids=["class-spoof", "int-subclass", "numpy-bool", "numpy-float"],
+)
+def test_router_config_rejects_integer_spoofs_without_invoking_hooks(hostile: object) -> None:
+    with pytest.raises(ValueError, match="base_dim"):
+        FeatureBankRouterConfig(base_dim=hostile, active_slots=4)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="active_slots"):
+        FeatureBankRouterConfig(base_dim=4, active_slots=hostile)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "hostile", "message"),
+    [
+        ("type", _StringSubclass("FeatureBankRouter"), "type is invalid"),
+        ("type", _RaisingStringSpoof(), "type is invalid"),
+        ("schema_version", _StringSubclass(CONFIG_SCHEMA_VERSION), "schema version"),
+        ("schema_version", _RaisingStringSpoof(), "schema version"),
+    ],
+    ids=["type-str-subclass", "type-class-spoof", "schema-str-subclass", "schema-class-spoof"],
+)
+def test_router_config_rejects_string_spoofs_without_invoking_hooks(
+    field: str,
+    hostile: object,
+    message: str,
+) -> None:
+    serialized = FeatureBankRouterConfig(base_dim=4, active_slots=4).to_config()
+    serialized[field] = hostile
+    with pytest.raises(ValueError, match=message):
+        FeatureBankRouterConfig.from_config(serialized)


### PR DESCRIPTION
Conflict-resolved successor to #694 on top of merged #683. #683 already preserves Kayvan-Zahiri’s original exact-integer work; this retains #694’s unique deeper corrections: signed-int32 preflights for derived deployed width, router-state scalar count, and router-state bytes before allocation; exact built-in string discriminators at deserialization; dtype-derived NumPy integer coverage; and hostile integer/string spoof regressions. It also checks both base_dim and active_slots hostile paths. Host-only accounting for already-allocated consumer trees remains unbounded.\n\nVerification: 31 focused tests passed; scoped Ruff passed; strict mypy passed; diff check clean. No outputs/evidence artifacts changed.\n\nSupersedes conflicting #694.