### PR TITLE
fix(core): retain world-model shape and prototype integer guards

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -45,6 +45,8 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.uint16,
     np.uint32,
     np.uint64,
+    np.longlong,
+    np.ulonglong,
 )
 
 

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -390,9 +390,12 @@ class ActionConditionedWorldModel:
         must not form arithmetic with a non-finite public observation before
         publishing the fail-visible result.
         """
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         action_one_hot = self.encode_action(action)
         features_valid = jnp.all(jnp.isfinite(obs)) & jnp.all(
             jnp.isfinite(action_one_hot)
@@ -437,12 +440,18 @@ class ActionConditionedWorldModel:
         next_observation: Array,
     ) -> Array:
         """Build normalized ``[delta_obs, reward, discount]`` targets."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
         safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
@@ -564,18 +573,24 @@ class ActionConditionedWorldModel:
         else:
             discount = discount_or_next_observation
 
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         action_arr, action_valid = safe_discrete_action(
             action,
             self._config.n_actions,
         )
         reward_arr = jnp.asarray(reward, dtype=jnp.float32)
         discount_arr = jnp.asarray(discount, dtype=jnp.float32)
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
             & action_valid
@@ -989,25 +1004,40 @@ class OneStepWorldModel:
                 encoded,
                 jnp.full_like(encoded, jnp.nan),
             )
-        return jnp.asarray(action, dtype=jnp.float32).reshape((self._config.action_dim,))
+        action_arr = jnp.asarray(action, dtype=jnp.float32)
+        if action_arr.shape != (self._config.action_dim,):
+            raise ValueError(
+                f"action must have shape ({self._config.action_dim},) "
+                f"got {action_arr.shape}"
+            )
+        return action_arr
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def input_features(self, observation: Array, action: Array) -> Array:
         """Return ``concat(observation, encoded_action)``."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         return jnp.concatenate([obs, self.encode_action(action)], axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def targets(self, observation: Array, reward: Array, next_observation: Array) -> Array:
         """Build ``[reward, next_obs_or_delta]`` targets."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         obs_target = next_obs - obs if self._config.predict_delta else next_obs
         return jnp.concatenate(
             [jnp.reshape(jnp.asarray(reward, dtype=jnp.float32), (1,)), obs_target],
@@ -1022,9 +1052,12 @@ class OneStepWorldModel:
         action: Array,
     ) -> WorldModelPrediction:
         """Predict reward and next observation."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32)
+        if obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"observation must have shape ({self._config.observation_dim},) "
+                f"got {obs.shape}"
+            )
         raw_predictions = self._learner.predict(
             state.learner_state,
             self.input_features(obs, action),
@@ -1057,9 +1090,12 @@ class OneStepWorldModel:
                 self._config.n_actions,
             )
         else:
-            action_arr = jnp.asarray(action, dtype=jnp.float32).reshape(
-                (self._config.action_dim,)
-            )
+            action_arr = jnp.asarray(action, dtype=jnp.float32)
+            if action_arr.shape != (self._config.action_dim,):
+                raise ValueError(
+                    f"action must have shape ({self._config.action_dim},) "
+                    f"got {action_arr.shape}"
+                )
             action_valid = jnp.all(jnp.isfinite(action_arr))
             safe_action = jnp.where(
                 action_valid,
@@ -1073,9 +1109,12 @@ class OneStepWorldModel:
             self.input_features(observation, safe_action),
             targets,
         )
-        next_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        next_obs = jnp.asarray(next_observation, dtype=jnp.float32)
+        if next_obs.shape != (self._config.observation_dim,):
+            raise ValueError(
+                f"next_observation must have shape ({self._config.observation_dim},) "
+                f"got {next_obs.shape}"
+            )
         reward_arr = jnp.asarray(reward, dtype=jnp.float32)
         next_observation_errors = prediction.next_observation - next_obs
         reward_error = prediction.reward - reward_arr

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -33,6 +33,57 @@ from alberta_framework.core.world_model import (
 )
 
 
+@pytest.mark.parametrize(
+    "malformed_observation",
+    [
+        pytest.param(jnp.zeros((2, 1), dtype=jnp.float32), id="column"),
+        pytest.param(jnp.zeros((1, 2), dtype=jnp.float32), id="row"),
+        pytest.param(jnp.zeros((1,), dtype=jnp.float32), id="short"),
+    ],
+)
+def test_action_conditioned_world_model_rejects_malformed_observation_vectors(
+    malformed_observation: jax.Array,
+) -> None:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+    )
+    state = model.init(jr.key(10))
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+    reward = jnp.array(0.0, dtype=jnp.float32)
+    discount = jnp.array(0.9, dtype=jnp.float32)
+
+    calls = (
+        lambda: model.input_features(malformed_observation, action),
+        lambda: model.targets(malformed_observation, reward, discount, observation),
+        lambda: model.targets(observation, reward, discount, malformed_observation),
+        lambda: model.predict(state, malformed_observation, action),
+        lambda: model.update(
+            state,
+            malformed_observation,
+            action,
+            reward,
+            discount,
+            observation,
+        ),
+        lambda: model.update(
+            state,
+            observation,
+            action,
+            reward,
+            discount,
+            malformed_observation,
+        ),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            call()
+
+
 def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     config = ActionConditionedWorldModelConfig(
         observation_dim=2,

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -4,6 +4,7 @@
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.prototype_memory import (
@@ -228,6 +229,44 @@ _INVALID_PROTOTYPE_CONFIGS: tuple[dict[str, object], ...] = (
 def test_prototype_memory_config_rejects_invalid_inputs(kwargs: dict[str, object]) -> None:
     with pytest.raises(ValueError):
         PrototypeMemoryConfig(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("numpy_type", [np.longlong, np.ulonglong])
+@pytest.mark.parametrize("field", ["feature_dim", "n_classes", "slots_per_class"])
+def test_prototype_memory_config_accepts_extended_numpy_integers(
+    field: str,
+    numpy_type: type[np.generic],
+) -> None:
+    kwargs: dict[str, object] = {"feature_dim": 4, "n_classes": 2}
+    kwargs[field] = numpy_type(4)
+
+    config = PrototypeMemoryConfig(**kwargs)
+
+    assert getattr(config, field) == 4
+    assert type(getattr(config, field)) is int
+    assert PrototypeMemoryConfig.from_config(config.to_config()) == config
+
+
+@pytest.mark.parametrize("numpy_type", [np.longlong, np.ulonglong])
+@pytest.mark.parametrize("field", ["feature_dim", "n_classes", "slots_per_class"])
+def test_prototype_memory_config_bounds_extended_numpy_integers(
+    field: str,
+    numpy_type: type[np.generic],
+) -> None:
+    kwargs: dict[str, object] = {"feature_dim": 4, "n_classes": 2}
+    kwargs[field] = numpy_type(2**31)
+
+    with pytest.raises(ValueError, match=field):
+        PrototypeMemoryConfig(**kwargs)
+
+
+@pytest.mark.parametrize("field", ["feature_dim", "n_classes", "slots_per_class"])
+def test_prototype_memory_config_rejects_negative_numpy_longlong(field: str) -> None:
+    kwargs: dict[str, object] = {"feature_dim": 4, "n_classes": 2}
+    kwargs[field] = np.longlong(-1)
+
+    with pytest.raises(ValueError, match=field):
+        PrototypeMemoryConfig(**kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -6,12 +6,76 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelConfig,
     run_world_model_learning_loop,
 )
+
+
+@pytest.mark.parametrize(
+    "malformed_observation",
+    [
+        pytest.param(jnp.zeros((2, 1), dtype=jnp.float32), id="column"),
+        pytest.param(jnp.zeros((1, 2), dtype=jnp.float32), id="row"),
+        pytest.param(jnp.zeros((1,), dtype=jnp.float32), id="short"),
+    ],
+)
+def test_world_model_rejects_malformed_observation_vectors(
+    malformed_observation: jax.Array,
+) -> None:
+    """Wrong-rank vectors must not be silently flattened through jitted APIs."""
+    model = OneStepWorldModel(
+        WorldModelConfig(observation_dim=2, n_actions=2, hidden_sizes=())
+    )
+    state = model.init(jr.key(10))
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    action = jnp.array(0, dtype=jnp.int32)
+    reward = jnp.array(0.0, dtype=jnp.float32)
+
+    calls = (
+        lambda: model.input_features(malformed_observation, action),
+        lambda: model.targets(malformed_observation, reward, observation),
+        lambda: model.targets(observation, reward, malformed_observation),
+        lambda: model.predict(state, malformed_observation, action),
+        lambda: model.update(state, malformed_observation, action, reward, observation),
+        lambda: model.update(state, observation, action, reward, malformed_observation),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            call()
+
+
+def test_world_model_rejects_malformed_continuous_actions() -> None:
+    model = OneStepWorldModel(
+        WorldModelConfig(
+            observation_dim=2,
+            n_actions=None,
+            action_dim=2,
+            hidden_sizes=(),
+        )
+    )
+    state = model.init(jr.key(11))
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    malformed_action = jnp.zeros((1, 2), dtype=jnp.float32)
+
+    calls = (
+        lambda: model.encode_action(malformed_action),
+        lambda: model.input_features(observation, malformed_action),
+        lambda: model.predict(state, observation, malformed_action),
+        lambda: model.update(
+            state,
+            observation,
+            malformed_action,
+            jnp.array(0.0, dtype=jnp.float32),
+            observation,
+        ),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match=r"action must have shape \(2,\)"):
+            call()
 
 
 def test_world_model_update_is_finite_and_shape_stable() -> None:


### PR DESCRIPTION
Supersedes #679 and #680 while preserving both original commits and byt61 authorship.

The source fixes are correct: world-model public vector operands now reject wrong-rank/same-size arrays instead of flattening them, and PrototypeMemoryConfig accepts NumPy longlong/ulonglong while preserving its strict integer and int32 bounds. This repair adds committed regressions covering all public observation-bearing methods on both world-model classes, every continuous-action public path, JIT-traced calls, and all three prototype-memory integer fields for acceptance, built-in-int canonicalization, serialization, upper bounds, and signed lower bounds.

Validation on current main:
- 112 focused tests passed
- 286-test broader world-model/ensemble suite passed
- scoped Ruff passed
- strict mypy passed for both changed source modules
- diff check passed

No evidence or output artifacts changed.