### PR TITLE
fix(behavior-model): harden configuration scalar and integer validation

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -11,17 +11,44 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -174,28 +201,45 @@ class BehaviorModelConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if (
-            isinstance(self.n_actions, bool)
-            or not isinstance(self.n_actions, int)
-            or self.n_actions <= 0
-        ):
-            raise ValueError("n_actions must be positive")
-        if not math.isfinite(self.step_size) or self.step_size < 0.0:
-            raise ValueError("step_size must be finite and non-negative")
-        if not math.isfinite(self.temperature) or self.temperature <= 0.0:
-            raise ValueError("temperature must be finite and positive")
-        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be finite and non-negative")
-        if self.max_gradient_norm is not None and (
-            not math.isfinite(self.max_gradient_norm) or self.max_gradient_norm <= 0.0
-        ):
-            raise ValueError("max_gradient_norm must be positive when provided")
-        if not math.isfinite(self.min_probability) or not 0.0 < self.min_probability < 1.0:
-            raise ValueError("min_probability must be finite and lie in (0, 1)")
-        if not math.isfinite(self.ratio_clip) or self.ratio_clip <= 0.0:
-            raise ValueError("ratio_clip must be finite and positive")
-        if not math.isfinite(self.diagnostic_decay) or not 0.0 <= self.diagnostic_decay < 1.0:
-            raise ValueError("diagnostic_decay must be finite and lie in [0, 1)")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        step_size = validated_float32_scalar("step_size", self.step_size, lower=0.0)
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        l2_penalty = validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0)
+        max_gradient_norm = (
+            validated_float32_scalar(
+                "max_gradient_norm",
+                self.max_gradient_norm,
+                positive=True,
+            )
+            if self.max_gradient_norm is not None
+            else None
+        )
+        min_probability = validated_float32_scalar(
+            "min_probability",
+            self.min_probability,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        ratio_clip = validated_float32_scalar("ratio_clip", self.ratio_clip, positive=True)
+        diagnostic_decay = validated_float32_scalar(
+            "diagnostic_decay",
+            self.diagnostic_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "l2_penalty", l2_penalty)
+        object.__setattr__(self, "max_gradient_norm", max_gradient_norm)
+        object.__setattr__(self, "min_probability", min_probability)
+        object.__setattr__(self, "ratio_clip", ratio_clip)
+        object.__setattr__(self, "diagnostic_decay", diagnostic_decay)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to a JSON-compatible dictionary."""
@@ -343,8 +387,7 @@ class BehaviorModel:
 
     def init(self, feature_dim: int, key: Array) -> BehaviorModelState:
         """Initialize parameters and diagnostics."""
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -365,8 +408,7 @@ class BehaviorModel:
         float32 arrays, keeps three float32 diagnostics and one int32 counter,
         and stores a default JAX typed key backed by two uint32 words.
         """
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trainable = self._config.n_actions * feature_dim + self._config.n_actions
         diagnostics = 3
         administrative = 1

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -9,6 +9,7 @@ from typing import Any
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 try:
@@ -454,3 +455,28 @@ def test_importance_ratio_and_epsilon_greedy_helpers() -> None:
         jnp.array([0.1, 0.9], dtype=jnp.float32),
     )
     assert float(ratio) == 1.25
+
+
+def test_behavior_model_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        BehaviorModelConfig(n_actions=2, step_size=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="diagnostic_decay"):
+        BehaviorModelConfig(n_actions=2, diagnostic_decay=1.0 - 1e-10)
+
+
+def test_behavior_model_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = BehaviorModelConfig(n_actions=np.int32(3))
+    assert type(config.n_actions) is int
+    assert config.n_actions == 3
+
+    model = BehaviorModel(config)
+    state = model.init(feature_dim=np.int64(4), key=jax.random.key(0))
+    assert state.weights.shape == (3, 4)
+
+    budget = model.resource_budget(np.uint16(4))
+    assert budget.feature_dim == 4
+    assert type(budget.feature_dim) is int


### PR DESCRIPTION
## Summary
- Hardens `BehaviorModelConfig.n_actions` and `BehaviorModel` method dimensions (`feature_dim`) against booleans, non-integer floats, and out-of-range values while accepting and canonicalizing the full NumPy integer family.
- Replaces raw `math.isfinite` checks on float scalars (`step_size`, `temperature`, `l2_penalty`, `max_gradient_norm`, `min_probability`, `ratio_clip`, `diagnostic_decay`) with `validated_float32_scalar` to enforce float32 bounds and reject booleans, non-finite values, and binary32 boundary overflow.

## Verification
- `PYTHONPATH=. pytest tests/test_behavior_model.py`: 26 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/behavior_model.py`: clean
- No registered evidence artifacts modified.