### PR TITLE
fix(fusion): harden partner policy fusion configuration integer validation

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -27,9 +27,10 @@ import dataclasses
 import hashlib
 import json
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -65,12 +66,32 @@ _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 
 
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
 def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
     """Return a strict positive integer within an explicit bound."""
 
-    if type(value) is not int or not 1 <= value <= maximum:
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
-    return value
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
+    return canonical
 
 
 def _strict_float32(
@@ -199,20 +220,44 @@ class PartnerPolicyFusionConfig:
     def __post_init__(self) -> None:
         """Reject dynamic dimensions, ambiguous thresholds, and unsafe bounds."""
 
-        _strict_positive_int(self.max_partners, name="max_partners", maximum=1024)
-        _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536)
-        _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536)
-        _strict_positive_int(
-            self.max_message_horizon,
-            name="max_message_horizon",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "max_partners",
+            _strict_positive_int(self.max_partners, name="max_partners", maximum=1024),
         )
-        _strict_positive_int(
-            self.min_feedback_for_learned_routing,
-            name="min_feedback_for_learned_routing",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "context_dim",
+            _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536),
         )
-        _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX)
+        object.__setattr__(
+            self,
+            "n_actions",
+            _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536),
+        )
+        object.__setattr__(
+            self,
+            "max_message_horizon",
+            _strict_positive_int(
+                self.max_message_horizon,
+                name="max_message_horizon",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_feedback_for_learned_routing",
+            _strict_positive_int(
+                self.min_feedback_for_learned_routing,
+                name="min_feedback_for_learned_routing",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "counter_cap",
+            _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX),
+        )
         if self.min_feedback_for_learned_routing > self.counter_cap:
             raise ValueError("min_feedback_for_learned_routing exceeds counter_cap")
 

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -885,3 +885,40 @@ def test_state_tamper_and_static_shape_mismatch_fail_strict_validation() -> None
                 feedback_counts=jnp.zeros((2,), dtype=jnp.int32),
             )
         )
+
+
+def test_partner_policy_fusion_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=True, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=2.5, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4.5, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2.5)  # type: ignore[arg-type]
+
+
+def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=np.int32(2),
+        context_dim=np.int64(4),
+        n_actions=np.uint16(2),
+        max_message_horizon=np.int8(8),
+        min_feedback_for_learned_routing=np.uint32(4),
+        counter_cap=np.int32(1_000_000),
+    )
+    assert type(config.max_partners) is int
+    assert type(config.context_dim) is int
+    assert type(config.n_actions) is int
+    assert type(config.max_message_horizon) is int
+    assert type(config.min_feedback_for_learned_routing) is int
+    assert type(config.counter_cap) is int
+
+    assert config.max_partners == 2
+    assert config.context_dim == 4
+    assert config.n_actions == 2


### PR DESCRIPTION
## Summary
- Hardens `PartnerPolicyFusionConfig` integer dimensions (`max_partners`, `context_dim`, `n_actions`, `max_message_horizon`, `min_feedback_for_learned_routing`, `counter_cap`) to reject booleans, non-integer floats, and out-of-bound values while accepting and canonicalizing the full NumPy integer family.
- Enforces strict upper bounds and canonicalizes attributes to Python `int`.

## Verification
- `PYTHONPATH=. pytest tests/test_partner_policy_fusion.py`: 62 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/partner_policy_fusion.py`: clean
- No registered evidence artifacts modified.