### PR TITLE
fix(gradient-mixer): harden representation gradient mixer integer validation

### DIFF
--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import dataclasses
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -34,6 +35,31 @@ _VALID_MODES = frozenset({"full", "behavior_only", "world_only", "discard"})
 _VALID_NORMALIZATIONS = frozenset({"none", "unit_l2"})
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _strict_float32_scalar(
@@ -83,8 +109,11 @@ class RepresentationGradientMixerConfig:
     def __post_init__(self) -> None:
         """Reject ambiguous, dynamic, or non-float32-representable rules."""
 
-        if type(self.representation_dim) is not int or self.representation_dim <= 0:
-            raise ValueError("representation_dim must be a positive strict integer")
+        object.__setattr__(
+            self,
+            "representation_dim",
+            _require_int32("representation_dim", self.representation_dim, minimum=1),
+        )
         if type(self.mode) is not str or self.mode not in _VALID_MODES:
             raise ValueError(
                 "mode must be full, behavior_only, world_only, or discard"

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -452,3 +452,16 @@ def test_jit_matches_eager_and_dynamic_false_predicate_rejects() -> None:
     )
     assert bool(rejected.rejected)
     assert not bool(rejected.valid)
+
+
+def test_representation_gradient_mixer_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=4.5)  # type: ignore[arg-type]
+
+
+def test_representation_gradient_mixer_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = RepresentationGradientMixerConfig(representation_dim=np.int32(8))
+    assert type(config.representation_dim) is int
+    assert config.representation_dim == 8


### PR DESCRIPTION
## Summary
- Hardens `RepresentationGradientMixerConfig.representation_dim` against booleans, non-integer floats, and out-of-range dimensions while accepting and canonicalizing the full NumPy integer family.
- Enforces signed int32 bounds on representation dimension.

## Verification
- `PYTHONPATH=. pytest tests/test_representation_gradient_mixer.py`: 32 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/representation_gradient_mixer.py`: clean
- No registered evidence artifacts modified.