### PR TITLE
fix(router): validate residual resource and schema contracts

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
-from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import jax
@@ -57,6 +56,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
+    return value
+
+
+def _require_host_count(name: str, value: object, *, minimum: int = 0) -> int:
+    """Canonicalize one exact host-only accounting integer without narrowing it."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if canonical < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
     return canonical
 
 
@@ -89,13 +104,22 @@ class FeatureBankRouterConfig:
             "active_slots",
             active_slots,
         )
-        if self.base_dim + self.active_slots > _INT32_MAX:
-            raise ValueError("total_feature_dim must be an integer in [3, 2147483647]")
-        router_state_scalars = 2 * self.active_slots + 2
-        if router_state_scalars > _INT32_MAX:
-            raise ValueError("router_state_scalars must not exceed 2147483647")
-        if 4 * router_state_scalars > _INT32_MAX:
-            raise ValueError("router_state_nbytes must not exceed 2147483647")
+        _require_derived_int32("total_feature_dim", self.total_feature_dim, minimum=3)
+        descriptor_scalars = _require_derived_int32(
+            "descriptor_int32_scalars",
+            2 * self.active_slots,
+            minimum=2,
+        )
+        router_state_scalars = _require_derived_int32(
+            "router_state_scalars",
+            descriptor_scalars + 2,
+            minimum=4,
+        )
+        _require_derived_int32(
+            "router_state_nbytes",
+            4 * router_state_scalars,
+            minimum=16,
+        )
 
     @property
     def total_feature_dim(self) -> int:
@@ -116,27 +140,30 @@ class FeatureBankRouterConfig:
     @classmethod
     def from_config(
         cls,
-        config: Mapping[str, object],
+        config: dict[str, object],
     ) -> FeatureBankRouterConfig:
         """Reconstruct only the exact versioned configuration schema."""
 
+        if type(config) is not dict:
+            raise TypeError("feature-bank router config must be an exact dict")
+        payload = dict(config)
         expected_keys = {
             "type",
             "schema_version",
             "base_dim",
             "active_slots",
         }
-        if set(config) != expected_keys:
+        if set(payload) != expected_keys:
             raise ValueError("feature-bank router config keys do not match the v1 schema")
-        config_type = config.get("type")
+        config_type = payload["type"]
         if type(config_type) is not str or config_type != "FeatureBankRouter":
             raise ValueError("feature-bank router config type is invalid")
-        schema_version = config.get("schema_version")
+        schema_version = payload["schema_version"]
         if type(schema_version) is not str or schema_version != CONFIG_SCHEMA_VERSION:
             raise ValueError("feature-bank router config schema version is unsupported")
         return cls(
-            base_dim=config["base_dim"],  # type: ignore[arg-type]
-            active_slots=config["active_slots"],  # type: ignore[arg-type]
+            base_dim=payload["base_dim"],  # type: ignore[arg-type]
+            active_slots=payload["active_slots"],  # type: ignore[arg-type]
         )
 
 
@@ -268,6 +295,58 @@ class FeatureBankRouterResourceBudget:
     consumer_state_nbytes: int
     total_managed_nbytes: int
 
+    def __post_init__(self) -> None:
+        """Validate exact formulas while leaving host-only consumer totals unbounded."""
+        int32_fields = {
+            "base_feature_slots": 2,
+            "dynamic_feature_slots": 1,
+            "total_feature_slots": 3,
+            "descriptor_int32_scalars": 2,
+            "counter_int32_scalars": 2,
+            "router_state_scalars": 4,
+            "router_state_nbytes": 16,
+        }
+        for name, minimum in int32_fields.items():
+            object.__setattr__(
+                self,
+                name,
+                _require_int32(name, getattr(self, name), minimum=minimum),
+            )
+        host_fields = {
+            "consumer_leaf_count": 1,
+            "consumer_feature_groups": 0,
+            "consumer_stable_prefix_scalars": 0,
+            "consumer_dynamic_tail_scalars": 0,
+            "consumer_total_scalars": 0,
+            "consumer_state_nbytes": 0,
+            "total_managed_nbytes": 0,
+        }
+        for name, minimum in host_fields.items():
+            object.__setattr__(
+                self,
+                name,
+                _require_host_count(name, getattr(self, name), minimum=minimum),
+            )
+
+        expected = {
+            "total_feature_slots": self.base_feature_slots + self.dynamic_feature_slots,
+            "descriptor_int32_scalars": 2 * self.dynamic_feature_slots,
+            "counter_int32_scalars": 2,
+            "router_state_scalars": self.descriptor_int32_scalars
+            + self.counter_int32_scalars,
+            "router_state_nbytes": 4 * self.router_state_scalars,
+            "consumer_stable_prefix_scalars": self.consumer_feature_groups
+            * self.base_feature_slots,
+            "consumer_dynamic_tail_scalars": self.consumer_feature_groups
+            * self.dynamic_feature_slots,
+            "consumer_total_scalars": self.consumer_stable_prefix_scalars
+            + self.consumer_dynamic_tail_scalars,
+            "total_managed_nbytes": self.router_state_nbytes + self.consumer_state_nbytes,
+        }
+        for name, required in expected.items():
+            if getattr(self, name) != required:
+                raise ValueError(f"{name} does not match the derived resource contract")
+
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible exact accounting record."""
 
@@ -342,7 +421,7 @@ class FeatureBankRouter:
     @classmethod
     def from_config(
         cls,
-        config: Mapping[str, object],
+        config: dict[str, object],
     ) -> FeatureBankRouter:
         """Construct a router from the strict versioned configuration."""
 

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -16,6 +16,7 @@ from alberta_framework.core.feature_bank_router import (
     CONFIG_SCHEMA_VERSION,
     FeatureBankRouter,
     FeatureBankRouterConfig,
+    FeatureBankRouterResourceBudget,
     FeatureBankRouterState,
 )
 
@@ -582,6 +583,8 @@ def test_router_config_rejects_derived_feature_width_outside_signed_int32() -> N
 
 @pytest.mark.unit
 def test_router_config_preflights_derived_state_counts_before_allocation() -> None:
+    with pytest.raises(ValueError, match="descriptor_int32_scalars"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=1_073_741_824)
     with pytest.raises(ValueError, match="router_state_scalars"):
         FeatureBankRouterConfig(base_dim=2, active_slots=1_073_741_823)
     with pytest.raises(ValueError, match="router_state_nbytes"):
@@ -624,3 +627,78 @@ def test_router_config_rejects_string_spoofs_without_invoking_hooks(
     serialized[field] = hostile
     with pytest.raises(ValueError, match=message):
         FeatureBankRouterConfig.from_config(serialized)
+
+
+@pytest.mark.unit
+def test_router_from_config_requires_an_exact_dict_and_exact_schema() -> None:
+    payload = FeatureBankRouterConfig(base_dim=4, active_slots=3).to_config()
+
+    class HostileDict(dict[str, object]):
+        def __iter__(self) -> Any:
+            raise AssertionError("mapping hooks must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    for loader in (FeatureBankRouterConfig.from_config, FeatureBankRouter.from_config):
+        with pytest.raises(TypeError, match="exact dict"):
+            loader(HostileDict(payload))  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="keys"):
+            loader({key: value for key, value in payload.items() if key != "active_slots"})
+        with pytest.raises(ValueError, match="keys"):
+            loader({**payload, "unexpected": 1})
+        with pytest.raises(ValueError, match="base_dim"):
+            loader({**payload, "base_dim": 4.5})
+        with pytest.raises(ValueError, match="active_slots"):
+            loader({**payload, "active_slots": True})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field",
+    [
+        "total_feature_slots",
+        "descriptor_int32_scalars",
+        "counter_int32_scalars",
+        "router_state_scalars",
+        "router_state_nbytes",
+        "consumer_stable_prefix_scalars",
+        "consumer_dynamic_tail_scalars",
+        "consumer_total_scalars",
+        "total_managed_nbytes",
+    ],
+)
+def test_router_resource_budget_rejects_each_inconsistent_derived_count(field: str) -> None:
+    router = _router()
+    budget = router.resource_budget(
+        router.init(_OLD),
+        _consumers(),
+        feature_axes=_feature_axes(),
+    )
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(budget, **{field: getattr(budget, field) + 1})
+
+
+@pytest.mark.unit
+def test_router_resource_budget_keeps_host_only_consumer_counts_unbounded() -> None:
+    groups = 10**30
+    consumer_nbytes = 10**40
+    budget = FeatureBankRouterResourceBudget(
+        base_feature_slots=np.int32(2),
+        dynamic_feature_slots=np.uint8(1),
+        total_feature_slots=np.int64(3),
+        descriptor_int32_scalars=np.int16(2),
+        counter_int32_scalars=np.uint16(2),
+        router_state_scalars=np.int32(4),
+        router_state_nbytes=np.int64(16),
+        consumer_leaf_count=np.uint8(1),
+        consumer_feature_groups=groups,
+        consumer_stable_prefix_scalars=2 * groups,
+        consumer_dynamic_tail_scalars=groups,
+        consumer_total_scalars=3 * groups,
+        consumer_state_nbytes=consumer_nbytes,
+        total_managed_nbytes=consumer_nbytes + 16,
+    )
+    assert budget.consumer_total_scalars > 2**31
+    assert budget.consumer_state_nbytes > 2**31
+    assert all(type(value) is int for value in budget.to_dict().values())


### PR DESCRIPTION
Completes the router hardening begun in #683 and #699 while preserving the contributor-authored integer validation now present on main.

The merged repairs cover exact supported integer families, hostile integer/string discriminators, `total_feature_dim`, and coarse router-state bounds. This follow-up closes the remaining contracts:

- explicitly preflights `total_feature_dim`, descriptor scalar count, router scalar count, and router byte count in their signed-int32 allocation/accounting domains, with their true minimums and adjacent boundary tests;
- requires an exact built-in dictionary before inspecting the flat versioned schema, preventing mapping-subclass hooks at both config and router loaders;
- validates every derived resource-budget identity: feature totals, descriptor/counter/state counts, stable-prefix and dynamic-tail products, consumer totals, and total managed bytes;
- canonicalizes every public budget integer and rejects booleans, subclasses, negatives, or inconsistent formulas;
- deliberately leaves measured consumer group/scalar/byte totals as unbounded exact Python integers because they are host-only accounting over already-allocated mixed-dtype arrays, and tests this distinction above the int32 range;
- retains the full dtype-derived NumPy family, hostile integer/string, serialization, and exact-max coverage from the merged repairs.

Verification at `369b1f0b1bdc6654ac653099aee39618a2c291ef` on main `197e447caba63ab2ac6a8481ff528ea083425276`:

- `pytest tests/test_feature_bank_router.py -q -o addopts=''`: 42 passed in 9.41s
- `ruff check .`: clean
- strict `mypy`: clean (168 source files)
- `git diff --check origin/main...HEAD`: clean

No `outputs/**` or registered evidence source files are changed.
