### PR TITLE
fix(learning-signals): complete float32 configuration safety

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -42,15 +42,43 @@ from __future__ import annotations
 
 import dataclasses
 import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -119,24 +147,65 @@ class LearningSignalEstimatorConfig:
 
     def __post_init__(self) -> None:
         """Reject invalid static shapes, timescales, and safety bounds."""
-        _positive_integer("ensemble_size", self.ensemble_size, minimum=2)
-        _positive_integer("target_dim", self.target_dim)
-        _positive_integer("progress_warmup_steps", self.progress_warmup_steps, minimum=2)
-        _positive_integer(
+        object.__setattr__(
+            self,
+            "ensemble_size",
+            _require_int32("ensemble_size", self.ensemble_size, minimum=2),
+        )
+        object.__setattr__(
+            self,
+            "target_dim",
+            _require_int32("target_dim", self.target_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "progress_warmup_steps",
+            _require_int32(
+                "progress_warmup_steps",
+                self.progress_warmup_steps,
+                minimum=2,
+            ),
+        )
+        object.__setattr__(
+            self,
             "change_calibration_steps",
-            self.change_calibration_steps,
-            minimum=2,
+            _require_int32(
+                "change_calibration_steps",
+                self.change_calibration_steps,
+                minimum=2,
+            ),
         )
         if self.change_calibration_steps >= _INT32_MAX:
             raise ValueError("change_calibration_steps must fit in int32")
         _positive_finite("variance_floor", self.variance_floor)
-        _unit_interval("fast_loss_decay", self.fast_loss_decay)
-        _unit_interval("slow_loss_decay", self.slow_loss_decay)
-        if self.fast_loss_decay >= self.slow_loss_decay:
+        fast_loss_decay = validated_float32_scalar(
+            "fast_loss_decay",
+            self.fast_loss_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        slow_loss_decay = validated_float32_scalar(
+            "slow_loss_decay",
+            self.slow_loss_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        if fast_loss_decay >= slow_loss_decay:
             raise ValueError("fast_loss_decay must be smaller than slow_loss_decay")
+        change_decay = validated_float32_scalar(
+            "change_decay",
+            self.change_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "fast_loss_decay", fast_loss_decay)
+        object.__setattr__(self, "slow_loss_decay", slow_loss_decay)
+        object.__setattr__(self, "change_decay", change_decay)
         _positive_finite("change_z_threshold", self.change_z_threshold)
         _positive_finite("change_temperature", self.change_temperature)
-        _unit_interval("change_decay", self.change_decay)
         _positive_finite("calibration_scale_floor", self.calibration_scale_floor)
         _positive_finite("max_normalized_residual", self.max_normalized_residual)
         _positive_finite("max_input_magnitude", self.max_input_magnitude)

--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import dataclasses
 import math
 import operator
+from numbers import Real
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -52,9 +53,14 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 _INT32_MAX = 2_147_483_647
+_FLOAT32_MAX = float.fromhex("0x1.fffffep+127")
+# The largest binary32 M for which the worst-case bounded residual
+# ``(+M) - (-M)`` and its square remain finite in binary32.
+_MAX_OPERATION_SAFE_INPUT_MAGNITUDE = float.fromhex("0x1.fffffep+62")
+_MAX_OPERATION_SAFE_NONNEGATIVE_SQUARE = float.fromhex("0x1.fffffep+63")
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -81,6 +87,62 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _validated_float32_with_ratio(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> tuple[float, int, int]:
+    """Validate one exact host scalar and its binary32 sink in one hook read."""
+
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    try:
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(cast(Real, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be a finite real number") from error
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must remain finite once narrowed to float32")
+
+    def compare_to(bound: float) -> int:
+        bound_numerator, bound_denominator = bound.as_integer_ratio()
+        left = numerator * bound_denominator
+        right = bound_numerator * denominator
+        return (left > right) - (left < right)
+
+    exact_valid = not positive or numerator > 0
+    narrowed_valid = not positive or narrowed > 0.0
+    if lower is not None:
+        exact_valid = exact_valid and compare_to(lower) >= 0
+        narrowed_valid = narrowed_valid and narrowed >= lower
+    if upper is not None:
+        exact_comparison = compare_to(upper)
+        exact_valid = exact_valid and (
+            exact_comparison <= 0 if upper_inclusive else exact_comparison < 0
+        )
+        narrowed_valid = narrowed_valid and (
+            narrowed <= upper if upper_inclusive else narrowed < upper
+        )
+    if not exact_valid:
+        raise ValueError(f"{name} is outside its exact host domain")
+    if not narrowed_valid:
+        raise ValueError(f"{name} is outside its float32 execution domain")
+    stored = cast(float, value) if type(cast(Any, value)) is float else narrowed
+    return stored, numerator, denominator
+
+
+def _ratio_less(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] < right[0] * left[1]
+
+
+def _ratio_less_equal(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] <= right[0] * left[1]
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Skip ``0 * inf`` so a disabled EMA decay does not poison the next value."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -96,21 +158,6 @@ def _saturating_counter_sum(left: Array, right: Array) -> Array:
     """Add non-negative int32 counters without overflowing."""
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     return left + jnp.minimum(right, maximum - left)
-
-
-def _positive_finite(name: str, value: float) -> None:
-    if not math.isfinite(value) or value <= 0.0:
-        raise ValueError(f"{name} must be positive and finite")
-
-
-def _unit_interval(name: str, value: float) -> None:
-    if not math.isfinite(value) or not 0.0 <= value < 1.0:
-        raise ValueError(f"{name} must be finite and in [0, 1)")
-
-
-def _positive_integer(name: str, value: int, *, minimum: int = 1) -> None:
-    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
-        raise ValueError(f"{name} must be an integer >= {minimum}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -177,42 +224,93 @@ class LearningSignalEstimatorConfig:
         )
         if self.change_calibration_steps >= _INT32_MAX:
             raise ValueError("change_calibration_steps must fit in int32")
-        _positive_finite("variance_floor", self.variance_floor)
-        fast_loss_decay = validated_float32_scalar(
+        variance_floor, variance_floor_n, variance_floor_d = _validated_float32_with_ratio(
+            "variance_floor", self.variance_floor, positive=True
+        )
+        fast_loss_decay, fast_n, fast_d = _validated_float32_with_ratio(
             "fast_loss_decay",
             self.fast_loss_decay,
             lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
-        slow_loss_decay = validated_float32_scalar(
+        slow_loss_decay, slow_n, slow_d = _validated_float32_with_ratio(
             "slow_loss_decay",
             self.slow_loss_decay,
             lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
-        if fast_loss_decay >= slow_loss_decay:
+        if not _ratio_less((fast_n, fast_d), (slow_n, slow_d)) or not (
+            fast_loss_decay < slow_loss_decay
+        ):
             raise ValueError("fast_loss_decay must be smaller than slow_loss_decay")
-        change_decay = validated_float32_scalar(
+        change_decay, _, _ = _validated_float32_with_ratio(
             "change_decay",
             self.change_decay,
             lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
+        positive_values: dict[str, tuple[float, int, int]] = {
+            "change_z_threshold": _validated_float32_with_ratio(
+                "change_z_threshold", self.change_z_threshold, positive=True
+            ),
+            "change_temperature": _validated_float32_with_ratio(
+                "change_temperature", self.change_temperature, positive=True
+            ),
+            "calibration_scale_floor": _validated_float32_with_ratio(
+                "calibration_scale_floor",
+                self.calibration_scale_floor,
+                positive=True,
+                upper=_MAX_OPERATION_SAFE_NONNEGATIVE_SQUARE,
+            ),
+            "max_normalized_residual": _validated_float32_with_ratio(
+                "max_normalized_residual",
+                self.max_normalized_residual,
+                positive=True,
+                upper=_MAX_OPERATION_SAFE_NONNEGATIVE_SQUARE,
+            ),
+            "max_input_magnitude": _validated_float32_with_ratio(
+                "max_input_magnitude",
+                self.max_input_magnitude,
+                positive=True,
+                upper=_MAX_OPERATION_SAFE_INPUT_MAGNITUDE,
+            ),
+            "max_predicted_variance": _validated_float32_with_ratio(
+                "max_predicted_variance", self.max_predicted_variance, positive=True
+            ),
+            "max_observed_loss": _validated_float32_with_ratio(
+                "max_observed_loss", self.max_observed_loss, positive=True
+            ),
+        }
+        max_variance, max_variance_n, max_variance_d = positive_values["max_predicted_variance"]
+        if (
+            not _ratio_less_equal(
+                (variance_floor_n, variance_floor_d),
+                (max_variance_n, max_variance_d),
+            )
+            or variance_floor > max_variance
+        ):
+            raise ValueError("variance_floor must not exceed max_predicted_variance")
+        max_input, max_input_n, max_input_d = positive_values["max_input_magnitude"]
+        float32_max_n, float32_max_d = _FLOAT32_MAX.as_integer_ratio()
+        exact_total_left = (
+            max_input_n * max_input_n * max_variance_d + max_variance_n * max_input_d * max_input_d
+        ) * float32_max_d
+        exact_total_right = float32_max_n * max_input_d * max_input_d * max_variance_d
+        if exact_total_left > exact_total_right or (
+            max_input * max_input + max_variance > _FLOAT32_MAX
+        ):
+            raise ValueError(
+                "max_input_magnitude squared plus max_predicted_variance must fit float32"
+            )
+        object.__setattr__(self, "variance_floor", variance_floor)
         object.__setattr__(self, "fast_loss_decay", fast_loss_decay)
         object.__setattr__(self, "slow_loss_decay", slow_loss_decay)
         object.__setattr__(self, "change_decay", change_decay)
-        _positive_finite("change_z_threshold", self.change_z_threshold)
-        _positive_finite("change_temperature", self.change_temperature)
-        _positive_finite("calibration_scale_floor", self.calibration_scale_floor)
-        _positive_finite("max_normalized_residual", self.max_normalized_residual)
-        _positive_finite("max_input_magnitude", self.max_input_magnitude)
-        _positive_finite("max_predicted_variance", self.max_predicted_variance)
-        _positive_finite("max_observed_loss", self.max_observed_loss)
-        if self.variance_floor > self.max_predicted_variance:
-            raise ValueError("variance_floor must not exceed max_predicted_variance")
+        for name, (stored, _, _) in positive_values.items():
+            object.__setattr__(self, name, stored)
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-compatible configuration."""

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from fractions import Fraction
 
 import chex
 import jax
@@ -22,10 +23,7 @@ from alberta_framework.core.learning_signals import (
 
 def test_learning_signal_producer_is_publicly_exported() -> None:
     assert alberta.LearningSignalEstimator is core.LearningSignalEstimator
-    assert (
-        alberta.LearningSignalEstimatorConfig
-        is core.LearningSignalEstimatorConfig
-    )
+    assert alberta.LearningSignalEstimatorConfig is core.LearningSignalEstimatorConfig
     assert alberta.TypedLearningSignals is core.TypedLearningSignals
 
 
@@ -496,3 +494,110 @@ def test_learning_signals_config_accepts_and_canonicalizes_numpy_integers() -> N
     assert config.target_dim == 2
     assert config.progress_warmup_steps == 3
     assert config.change_calibration_steps == 8
+
+
+_POSITIVE_FLOAT32_FIELDS = (
+    "variance_floor",
+    "change_z_threshold",
+    "change_temperature",
+    "calibration_scale_floor",
+    "max_normalized_residual",
+    "max_input_magnitude",
+    "max_predicted_variance",
+    "max_observed_loss",
+)
+
+
+@pytest.mark.parametrize("field", _POSITIVE_FLOAT32_FIELDS)
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), float("nan"), float("inf"), Fraction(1, 10**400)],
+)
+def test_all_positive_config_scalars_reject_non_real_or_float32_unsafe_values(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            **{field: value},
+        )
+
+
+@pytest.mark.parametrize("field", _POSITIVE_FLOAT32_FIELDS)
+def test_all_positive_config_scalars_canonicalize_nonbuiltin_reals(field: str) -> None:
+    config = LearningSignalEstimatorConfig(
+        ensemble_size=2,
+        target_dim=1,
+        **{field: Fraction(1, 2)},
+    )
+    assert type(getattr(config, field)) is float
+    assert getattr(config, field) == 0.5
+    assert LearningSignalEstimatorConfig.from_config(config.to_config()) == config
+
+
+def test_cross_scalar_relationships_hold_in_exact_and_float32_domains() -> None:
+    below = Fraction(1, 2) - Fraction(1, 2**80)
+    above = Fraction(1, 2) + Fraction(1, 2**80)
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            fast_loss_decay=below,
+            slow_loss_decay=above,
+        )
+    with pytest.raises(ValueError, match="variance_floor"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            variance_floor=above,
+            max_predicted_variance=Fraction(1, 2),
+        )
+
+
+def test_float32_conversion_hooks_fail_closed_without_repr_or_repeat_reads() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self):
+            type(self).calls += 1
+            raise RuntimeError("hostile ratio hook")
+
+        def __repr__(self):
+            raise AssertionError("must not interpolate an untrusted repr")
+
+    with pytest.raises(ValueError, match="change_temperature"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            change_temperature=HostileFloat(0.5),
+        )
+    assert HostileFloat.calls == 1
+
+
+def test_max_input_magnitude_is_safe_at_boundary_and_rejects_adjacent_float32() -> None:
+    maximum = np.float32(float.fromhex("0x1.fffffep+62"))
+    adjacent = np.nextafter(maximum, np.float32(np.inf))
+    config = LearningSignalEstimatorConfig(
+        ensemble_size=2,
+        target_dim=1,
+        max_input_magnitude=maximum,
+    )
+    doubled = jnp.asarray(config.max_input_magnitude, dtype=jnp.float32) * 2.0
+    assert bool(jnp.isfinite(jnp.square(doubled)))
+    with pytest.raises(ValueError, match="max_input_magnitude"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            max_input_magnitude=adjacent,
+        )
+
+
+def test_input_and_variance_bounds_cannot_overflow_total_variance() -> None:
+    with pytest.raises(ValueError, match="squared plus max_predicted_variance"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            max_input_magnitude=float.fromhex("0x1.fffffep+62"),
+            max_predicted_variance=np.finfo(np.float32).max,
+        )

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -456,3 +456,43 @@ def test_zero_ema_decay_does_not_multiply_inf_trackers() -> None:
     )
     next_calibrated, _ = _observe_scalar(estimator, calibrated)
     assert bool(jnp.isfinite(next_calibrated.sustained_change_probability))
+
+
+def test_learning_signals_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LearningSignalEstimatorConfig(ensemble_size=True, target_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="target_dim"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="progress_warmup_steps"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, progress_warmup_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="change_calibration_steps"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, change_calibration_steps=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LearningSignalEstimatorConfig(ensemble_size=2.5, target_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="target_dim"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, fast_loss_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, fast_loss_decay=1.0 - 1e-10)
+    with pytest.raises(ValueError, match="change_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, change_decay=True)  # type: ignore[arg-type]
+
+
+def test_learning_signals_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = LearningSignalEstimatorConfig(
+        ensemble_size=np.int32(4),
+        target_dim=np.int64(2),
+        progress_warmup_steps=np.uint16(3),
+        change_calibration_steps=np.int8(8),
+    )
+    assert type(config.ensemble_size) is int
+    assert type(config.target_dim) is int
+    assert type(config.progress_warmup_steps) is int
+    assert type(config.change_calibration_steps) is int
+    assert config.ensemble_size == 4
+    assert config.target_dim == 2
+    assert config.progress_warmup_steps == 3
+    assert config.change_calibration_steps == 8


### PR DESCRIPTION
Supersedes #685 while preserving its contributor commit and integer hardening.

This successor validates every float32-consumed configuration scalar from one exact-ratio hook read, normalizes hostile conversion failures to ValueError, and enforces domains in both the exact host and narrowed binary32 representations. It also preserves fast-decay < slow-decay and variance-floor <= max-variance in both domains.

The numerical bounds now cover the operations, not just the inputs: max_input_magnitude is capped at the largest binary32 value whose worst-case signed difference can be squared without overflow; nonnegative calibration squares are similarly bounded; and the configured input/variance maxima cannot overflow total predictive variance.

Verification on rebased current main:
- 66 focused tests passed
- targeted Ruff passed
- strict mypy passed
- git diff --check passed

No evidence artifact or promotion claim is modified.