### PR TITLE
fix(upgd-ipmnist): bound configuration-derived allocations

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -94,6 +94,7 @@ import hashlib
 import json
 import logging
 import math
+import operator
 import os
 import platform
 import tempfile
@@ -101,7 +102,7 @@ import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
@@ -271,30 +272,32 @@ REPRODUCTION_GAP_THRESHOLD = 0.02
 _PLASTICITY_LOSS_FLOOR = 1e-8
 
 _INT32_MAX: int = 2**31 - 1
-_ACTUAL_INT_TYPES: tuple[type, ...] = (
-    int,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.longlong,
-    np.ulonglong,
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        *(np.dtype(code).type
+          for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
+    }
 )
 
 
 def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer, got {value!r}")
-    from typing import cast
-
-    number = int(cast(int, value))
+        raise ValueError(f"{name} must be an integer")
+    try:
+        number = operator.index(cast(SupportsIndex, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be an integer") from error
     if number < minimum or number > _INT32_MAX:
-        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}], got {value!r}")
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
     return number
+
+
+def _require_int32_product(name: str, *factors: int) -> int:
+    product = math.prod(factors)
+    if product > _INT32_MAX:
+        raise ValueError(f"derived {name} must fit in signed int32")
+    return product
 
 
 @dataclass(frozen=True)
@@ -324,6 +327,18 @@ class IPMNISTConfig:
         for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes"):
             value = _require_int32(name, getattr(self, name), minimum=1)
             object.__setattr__(self, name, value)
+        _require_int32_product("run horizon", self.n_tasks, self.task_length)
+        _require_int32_product("permutation schedule", self.n_tasks, self.input_dim)
+        parameter_scalars = (
+            _require_int32_product("w1 allocation", self.input_dim, self.hidden1)
+            + _require_int32_product("w2 allocation", self.hidden1, self.hidden2)
+            + _require_int32_product("w3 allocation", self.hidden2, self.n_classes)
+            + self.hidden1
+            + self.hidden2
+            + self.n_classes
+        )
+        if parameter_scalars > _INT32_MAX:
+            raise ValueError("derived total parameter allocation must fit in signed int32")
 
     @property
     def n_steps(self) -> int:
@@ -1013,7 +1028,7 @@ def load_mnist_train(data_home: Path | None = None) -> tuple[np.ndarray, np.ndar
     matches ``ToTensor`` + ``Normalize((0.5,), (0.5,))``.
     """
     try:
-        from sklearn.datasets import fetch_openml
+        from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
     except ModuleNotFoundError as exc:  # pragma: no cover - environment dependent
         raise RuntimeError("scikit-learn is required to load OpenML MNIST") from exc
 

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -270,6 +270,32 @@ REPRODUCTION_GAP_THRESHOLD = 0.02
 
 _PLASTICITY_LOSS_FLOOR = 1e-8
 
+_INT32_MAX: int = 2**31 - 1
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    from typing import cast
+
+    number = int(cast(int, value))
+    if number < minimum or number > _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}], got {value!r}")
+    return number
+
 
 @dataclass(frozen=True)
 class IPMNISTConfig:
@@ -296,9 +322,8 @@ class IPMNISTConfig:
 
     def __post_init__(self) -> None:
         for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes"):
-            value = getattr(self, name)
-            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+            value = _require_int32(name, getattr(self, name), minimum=1)
+            object.__setattr__(self, name, value)
 
     @property
     def n_steps(self) -> int:
@@ -988,7 +1013,7 @@ def load_mnist_train(data_home: Path | None = None) -> tuple[np.ndarray, np.ndar
     matches ``ToTensor`` + ``Normalize((0.5,), (0.5,))``.
     """
     try:
-        from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
+        from sklearn.datasets import fetch_openml
     except ModuleNotFoundError as exc:  # pragma: no cover - environment dependent
         raise RuntimeError("scikit-learn is required to load OpenML MNIST") from exc
 

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -93,26 +93,49 @@ class TestProtocolConstants:
         with pytest.raises(ValueError, match="n_tasks"):
             IPMNISTConfig(n_tasks=value)
 
-    def test_config_rejects_hostile_integer_subclasses_without_calling_hooks(self):
-        class HostileInt(int):
+    def test_config_rejects_spoofs_and_subclasses_without_calling_hooks(self):
+        class HostileIndex:
             def __index__(self):
                 raise AssertionError("must not call hostile __index__")
 
             def __repr__(self):
                 raise AssertionError("must not call hostile __repr__")
 
-        with pytest.raises(ValueError, match="n_tasks"):
-            IPMNISTConfig(n_tasks=HostileInt(2))
+        class HostileInt(int):
+            def __index__(self):
+                raise AssertionError("must not call subclass __index__")
+
+            def __repr__(self):
+                raise AssertionError("must not call subclass __repr__")
+
+        class HostileNumpyInt(np.int64):
+            def __index__(self):
+                raise AssertionError("must not call NumPy subclass __index__")
+
+            def __repr__(self):
+                raise AssertionError("must not call NumPy subclass __repr__")
+
+        for value in (HostileIndex(), HostileInt(2), HostileNumpyInt(2)):
+            with pytest.raises(ValueError, match="n_tasks"):
+                IPMNISTConfig(n_tasks=value)
 
     def test_config_rejects_derived_horizon_and_schedule_overflow(self):
         with pytest.raises(ValueError, match="run horizon"):
             IPMNISTConfig(n_tasks=46_341, task_length=46_341)
+        with pytest.raises(ValueError, match="run horizon"):
+            IPMNISTConfig(n_tasks=2, task_length=2**30, input_dim=1)
         with pytest.raises(ValueError, match="permutation schedule"):
             IPMNISTConfig(n_tasks=3_000_000, task_length=1)
+        with pytest.raises(ValueError, match="permutation schedule"):
+            IPMNISTConfig(n_tasks=2, task_length=1, input_dim=2**30)
 
     def test_config_rejects_derived_parameter_allocations(self):
         with pytest.raises(ValueError, match="w1 allocation"):
             IPMNISTConfig(input_dim=50_000, hidden1=50_000)
+        with pytest.raises(ValueError, match="w2 allocation"):
+            IPMNISTConfig(input_dim=1, hidden1=46_341, hidden2=46_341, n_classes=1)
+        with pytest.raises(ValueError, match="w3 allocation"):
+            IPMNISTConfig(input_dim=1, hidden1=1, hidden2=46_341, n_classes=46_341)
         with pytest.raises(ValueError, match="total parameter allocation"):
             IPMNISTConfig(
                 input_dim=32_768,
@@ -126,6 +149,46 @@ class TestProtocolConstants:
         assert horizon.n_steps == 2**31 - 1
         schedule = IPMNISTConfig(n_tasks=2**31 - 1, task_length=1, input_dim=1)
         assert schedule.n_tasks * schedule.input_dim == 2**31 - 1
+
+    def test_config_total_parameter_boundary_and_adjacent_overflow_are_allocation_free(self):
+        boundary = IPMNISTConfig(
+            n_tasks=1,
+            task_length=1,
+            input_dim=(2**31 - 1) - 5,
+            hidden1=1,
+            hidden2=1,
+            n_classes=1,
+        )
+        assert (
+            boundary.input_dim * boundary.hidden1
+            + boundary.hidden1 * boundary.hidden2
+            + boundary.hidden2 * boundary.n_classes
+            + boundary.hidden1
+            + boundary.hidden2
+            + boundary.n_classes
+            == 2**31 - 1
+        )
+        with pytest.raises(ValueError, match="total parameter allocation"):
+            IPMNISTConfig(
+                n_tasks=1,
+                task_length=1,
+                input_dim=(2**31 - 1) - 4,
+                hidden1=1,
+                hidden2=1,
+                n_classes=1,
+            )
+
+    def test_config_roundtrip_canonicalizes_numpy_integer_scalars(self):
+        config = IPMNISTConfig(
+            n_tasks=np.int16(2),
+            task_length=np.uint16(3),
+            input_dim=np.int32(4),
+            hidden1=np.uint32(5),
+            hidden2=np.int64(6),
+            n_classes=np.uint64(2),
+        )
+        assert IPMNISTConfig(**config.to_config()) == config
+        assert all(type(value) is int for value in config.to_config().values())
 
     def test_published_hyperparameters(self):
         assert UPGD_W_PROTOCOL_HYPERPARAMETERS == {

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -67,6 +67,66 @@ class TestProtocolConstants:
     def test_shrunk_config_does_not_match_selected_publication_shape(self):
         assert not TINY.matches_selected_publication_configuration
 
+    @pytest.mark.parametrize(
+        "integer_type",
+        sorted(
+            {
+                np.dtype(code).type
+                for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+            },
+            key=lambda value: value.__name__,
+        ),
+    )
+    def test_config_accepts_every_numpy_integer_scalar_type(self, integer_type):
+        config = IPMNISTConfig(
+            n_tasks=integer_type(2),
+            task_length=integer_type(3),
+            input_dim=integer_type(4),
+            hidden1=integer_type(5),
+            hidden2=integer_type(6),
+            n_classes=integer_type(2),
+        )
+        assert all(type(value) is int for value in config.to_config().values())
+
+    @pytest.mark.parametrize("value", [True, np.bool_(True), 1.0, "1", 0, -1, 2**31])
+    def test_config_rejects_non_integer_and_out_of_range_dimensions(self, value):
+        with pytest.raises(ValueError, match="n_tasks"):
+            IPMNISTConfig(n_tasks=value)
+
+    def test_config_rejects_hostile_integer_subclasses_without_calling_hooks(self):
+        class HostileInt(int):
+            def __index__(self):
+                raise AssertionError("must not call hostile __index__")
+
+            def __repr__(self):
+                raise AssertionError("must not call hostile __repr__")
+
+        with pytest.raises(ValueError, match="n_tasks"):
+            IPMNISTConfig(n_tasks=HostileInt(2))
+
+    def test_config_rejects_derived_horizon_and_schedule_overflow(self):
+        with pytest.raises(ValueError, match="run horizon"):
+            IPMNISTConfig(n_tasks=46_341, task_length=46_341)
+        with pytest.raises(ValueError, match="permutation schedule"):
+            IPMNISTConfig(n_tasks=3_000_000, task_length=1)
+
+    def test_config_rejects_derived_parameter_allocations(self):
+        with pytest.raises(ValueError, match="w1 allocation"):
+            IPMNISTConfig(input_dim=50_000, hidden1=50_000)
+        with pytest.raises(ValueError, match="total parameter allocation"):
+            IPMNISTConfig(
+                input_dim=32_768,
+                hidden1=32_768,
+                hidden2=32_768,
+                n_classes=1,
+            )
+
+    def test_config_accepts_exact_derived_int32_boundaries(self):
+        horizon = IPMNISTConfig(n_tasks=1, task_length=2**31 - 1, input_dim=1)
+        assert horizon.n_steps == 2**31 - 1
+        schedule = IPMNISTConfig(n_tasks=2**31 - 1, task_length=1, input_dim=1)
+        assert schedule.n_tasks * schedule.input_dim == 2**31 - 1
+
     def test_published_hyperparameters(self):
         assert UPGD_W_PROTOCOL_HYPERPARAMETERS == {
             "step_size": 0.01,


### PR DESCRIPTION
Supersedes #686 while preserving its contributor commit and exact NumPy integer support.

This successor uses operator.index only after exact runtime-type admission, emits fixed rejection messages that never evaluate an untrusted repr, and rejects hostile integer subclasses. It adds signed-int32 preflight bounds for the total run horizon, permutation schedule, each weight-matrix allocation, and the combined flattened parameter allocation used by optimizer/noise state.

The unrelated sklearn type-ignore deletion from #686 is restored.

Campaign provenance: this file is an active, permanently nonpromoting IPMNIST development-runner source. The change intentionally alters current source identity but does not rewrite any checked-in output. Existing shards retain their recorded historical provenance and must not be represented as generated by this revision. Remeasure the selected control under the new source before any new A/B comparison.

Verification on rebased current main:
- 103 focused tests passed
- targeted Ruff passed
- strict mypy passed
- git diff --check passed