### PR TITLE
fix(actor-critic): harden configuration scalar and integer bounds across actor-critic configs

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -33,15 +33,18 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.horde import HordeLearner, HordeUpdateResult
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
@@ -56,6 +59,41 @@ from alberta_framework.core.types import AutostepParamState, DemonType, MLPParam
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
+    if type(sizes) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(
+        _require_int32(f"hidden_sizes[{index}]", size, minimum=1)
+        for index, size in enumerate(sizes)
+    )
 
 
 def _commit_scan_safe_actor_state(
@@ -152,6 +190,38 @@ class HordeActorCriticConfig:
     value_head_index: int = 0
     actor_td_error_clip: float | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "value_head_index",
+            _require_int32("value_head_index", self.value_head_index, minimum=0),
+        )
+        actor_step_size = validated_float32_scalar(
+            "actor_step_size", self.actor_step_size, positive=True
+        )
+        actor_lamda = validated_float32_scalar(
+            "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0
+        )
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        actor_td_error_clip = (
+            validated_float32_scalar(
+                "actor_td_error_clip",
+                self.actor_td_error_clip,
+                positive=True,
+            )
+            if self.actor_td_error_clip is not None
+            else None
+        )
+        object.__setattr__(self, "actor_step_size", actor_step_size)
+        object.__setattr__(self, "actor_lamda", actor_lamda)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "actor_td_error_clip", actor_td_error_clip)
+
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
         return dataclasses.asdict(self)
@@ -236,6 +306,39 @@ class QHordeActorCriticConfig:
     critic_target: str = "expected_sarsa"
     actor_update: str = "td_error"
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
+        actor_step_size = validated_float32_scalar(
+            "actor_step_size", self.actor_step_size, positive=True
+        )
+        actor_lamda = validated_float32_scalar(
+            "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0
+        )
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        actor_td_error_clip = (
+            validated_float32_scalar(
+                "actor_td_error_clip",
+                self.actor_td_error_clip,
+                positive=True,
+            )
+            if self.actor_td_error_clip is not None
+            else None
+        )
+        if self.critic_target not in {"expected_sarsa", "sampled_sarsa"}:
+            raise ValueError("critic_target must be 'expected_sarsa' or 'sampled_sarsa'")
+        if self.actor_update not in {"td_error", "expected_advantage"}:
+            raise ValueError("actor_update must be 'td_error' or 'expected_advantage'")
+        object.__setattr__(self, "gamma", gamma)
+        object.__setattr__(self, "actor_step_size", actor_step_size)
+        object.__setattr__(self, "actor_lamda", actor_lamda)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "actor_td_error_clip", actor_td_error_clip)
+
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
         return dataclasses.asdict(self)
@@ -301,13 +404,9 @@ class QHordeActorCriticAgent:
         if config.actor_td_error_clip is not None and config.actor_td_error_clip <= 0:
             raise ValueError("actor_td_error_clip must be positive when provided")
         if config.critic_target not in {"expected_sarsa", "sampled_sarsa"}:
-            raise ValueError(
-                "critic_target must be 'expected_sarsa' or 'sampled_sarsa'"
-            )
+            raise ValueError("critic_target must be 'expected_sarsa' or 'sampled_sarsa'")
         if config.actor_update not in {"td_error", "expected_advantage"}:
-            raise ValueError(
-                "actor_update must be 'td_error' or 'expected_advantage'"
-            )
+            raise ValueError("actor_update must be 'td_error' or 'expected_advantage'")
         if critic.n_demons < config.n_actions:
             raise ValueError("critic must have at least one head per action")
         for idx, demon in enumerate(critic.horde_spec.demons[: config.n_actions]):
@@ -344,9 +443,7 @@ class QHordeActorCriticAgent:
             "config": self._config.to_config(),
             "critic": self._critic.to_config(),
             "actor_bounder": (
-                self._actor_bounder.to_config()
-                if self._actor_bounder is not None
-                else None
+                self._actor_bounder.to_config() if self._actor_bounder is not None else None
             ),
         }
 
@@ -405,9 +502,7 @@ class QHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(
-            jnp.int32
-        )
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -489,9 +584,7 @@ class QHordeActorCriticAgent:
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
-        actor_trace_bias = (
-            _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
-        )
+        actor_trace_bias = _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
         actor_scale = (
             jnp.array(1.0, dtype=jnp.float32)
             if cfg.actor_update == "expected_advantage"
@@ -548,8 +641,7 @@ class QHordeActorCriticAgent:
             & (next_action < cfg.n_actions)
         )
         nested_update_applied = (
-            critic_result.update_applied
-            & critic_result.head_updates_applied[safe_last_action]
+            critic_result.update_applied & critic_result.head_updates_applied[safe_last_action]
         )
         new_state, update_applied = _commit_scan_safe_actor_state(
             state,
@@ -566,9 +658,7 @@ class QHordeActorCriticAgent:
             state=new_state,
             action=jnp.where(update_applied, next_action, jnp.asarray(0, jnp.int32)),
             policy=jnp.where(update_applied, policy, jnp.zeros_like(policy)),
-            q_values=jnp.where(
-                update_applied, q_previous, jnp.zeros_like(q_previous)
-            ),
+            q_values=jnp.where(update_applied, q_previous, jnp.zeros_like(q_previous)),
             next_q_values=jnp.where(
                 update_applied & (effective_gamma != 0.0),
                 q_next,
@@ -644,9 +734,7 @@ class HordeActorCriticAgent:
             "config": self._config.to_config(),
             "critic": self._critic.to_config(),
             "actor_bounder": (
-                self._actor_bounder.to_config()
-                if self._actor_bounder is not None
-                else None
+                self._actor_bounder.to_config() if self._actor_bounder is not None else None
             ),
         }
 
@@ -716,9 +804,7 @@ class HordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(
-            jnp.int32
-        )
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -775,15 +861,11 @@ class HordeActorCriticAgent:
         next_value = self.value(state, observation)
         value_gamma = self._critic.horde_spec.gammas[cfg.value_head_index]
         value_discount = (
-            value_gamma
-            if discount is None
-            else jnp.asarray(discount, dtype=jnp.float32)
+            value_gamma if discount is None else jnp.asarray(discount, dtype=jnp.float32)
         )
 
         if auxiliary_cumulants is None:
-            auxiliary_cumulants = jnp.zeros(
-                (self._critic.n_demons - 1,), dtype=jnp.float32
-            )
+            auxiliary_cumulants = jnp.zeros((self._critic.n_demons - 1,), dtype=jnp.float32)
         auxiliary_cumulants = jnp.asarray(auxiliary_cumulants, dtype=jnp.float32)
         cumulants_before = auxiliary_cumulants[: cfg.value_head_index]
         cumulants_after = auxiliary_cumulants[cfg.value_head_index :]
@@ -802,9 +884,7 @@ class HordeActorCriticAgent:
                 observation,
             )
         else:
-            discounts = self._critic.horde_spec.gammas.at[cfg.value_head_index].set(
-                value_discount
-            )
+            discounts = self._critic.horde_spec.gammas.at[cfg.value_head_index].set(value_discount)
             critic_result = self._critic.update_with_discounts(
                 state.critic_state,
                 prev_obs,
@@ -826,9 +906,7 @@ class HordeActorCriticAgent:
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
-        actor_trace_bias = (
-            _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
-        )
+        actor_trace_bias = _skip_zero_scale(actor_decay, state.actor_trace_bias) + actor_grad_bias
         actor_steps: tuple[Array, ...] = (
             cfg.actor_step_size * actor_trace_weights,
             cfg.actor_step_size * actor_trace_bias,
@@ -878,8 +956,7 @@ class HordeActorCriticAgent:
             & (next_action < cfg.n_actions)
         )
         nested_update_applied = (
-            critic_result.update_applied
-            & critic_result.head_updates_applied[cfg.value_head_index]
+            critic_result.update_applied & critic_result.head_updates_applied[cfg.value_head_index]
         )
         new_state, update_applied = _commit_scan_safe_actor_state(
             state,
@@ -895,13 +972,9 @@ class HordeActorCriticAgent:
         return HordeActorCriticUpdateResult(  # type: ignore[call-arg]
             state=new_state,
             action=jnp.where(update_applied, next_action, jnp.asarray(0, jnp.int32)),
-            policy=jnp.where(
-                update_applied, next_policy, jnp.zeros_like(next_policy)
-            ),
+            policy=jnp.where(update_applied, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(update_applied, value, 0.0),
-            next_value=jnp.where(
-                update_applied & (value_discount != 0.0), next_value, 0.0
-            ),
+            next_value=jnp.where(update_applied & (value_discount != 0.0), next_value, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),
             bound_metric=jnp.where(update_applied, bound_metric, 0.0),
             critic_result=committed_critic_result,
@@ -983,13 +1056,16 @@ def run_horde_actor_critic_from_arrays(
             result.update_applied,
         )
 
-    final_state, (
-        out_actions,
-        policies,
-        values,
-        td_errors,
-        critic_td_errors,
-        updates_applied,
+    (
+        final_state,
+        (
+            out_actions,
+            policies,
+            values,
+            td_errors,
+            critic_td_errors,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         _scan_fn,
         state,
@@ -1019,9 +1095,7 @@ def run_horde_actor_critic_from_arrays(
 
 
 def _nlhac_log_prob(
-    actor_params: tuple[
-        tuple[Array, ...], tuple[Array, ...], Array, Array
-    ],
+    actor_params: tuple[tuple[Array, ...], tuple[Array, ...], Array, Array],
     obs: Array,
     action: Array,
     leaky_relu_slope: float,
@@ -1051,9 +1125,7 @@ _nlhac_grad = jax.grad(_nlhac_log_prob, argnums=0)
 
 
 def _nlqhac_expected_advantage_objective(
-    actor_params: tuple[
-        tuple[Array, ...], tuple[Array, ...], Array, Array
-    ],
+    actor_params: tuple[tuple[Array, ...], tuple[Array, ...], Array, Array],
     obs: Array,
     advantages: Array,
     leaky_relu_slope: float,
@@ -1075,9 +1147,7 @@ def _nlqhac_expected_advantage_objective(
     return jnp.dot(probs, advantages)
 
 
-_nlqhac_expected_advantage_grad = jax.grad(
-    _nlqhac_expected_advantage_objective, argnums=0
-)
+_nlqhac_expected_advantage_grad = jax.grad(_nlqhac_expected_advantage_objective, argnums=0)
 
 
 def _clip_nlhac_actor_grads(
@@ -1140,6 +1210,73 @@ class NonlinearHordeActorCriticConfig:
     actor_td_error_normalizer_decay: float | None = None
     actor_td_error_clip: float | None = None
     actor_gradient_clip_norm: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "value_head_index",
+            _require_int32("value_head_index", self.value_head_index, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _validate_hidden_sizes(self.hidden_sizes),
+        )
+        actor_lamda = validated_float32_scalar(
+            "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0
+        )
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        actor_sparsity = validated_float32_scalar(
+            "actor_sparsity", self.actor_sparsity, lower=0.0, upper=1.0
+        )
+        leaky_relu_slope = validated_float32_scalar(
+            "leaky_relu_slope", self.leaky_relu_slope, lower=0.0
+        )
+        actor_epsilon = validated_float32_scalar(
+            "actor_epsilon", self.actor_epsilon, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        actor_td_error_normalizer_decay = (
+            validated_float32_scalar(
+                "actor_td_error_normalizer_decay",
+                self.actor_td_error_normalizer_decay,
+                lower=0.0,
+                upper=1.0,
+                upper_inclusive=False,
+            )
+            if self.actor_td_error_normalizer_decay is not None
+            else None
+        )
+        actor_td_error_clip = (
+            validated_float32_scalar(
+                "actor_td_error_clip",
+                self.actor_td_error_clip,
+                positive=True,
+            )
+            if self.actor_td_error_clip is not None
+            else None
+        )
+        actor_gradient_clip_norm = (
+            validated_float32_scalar(
+                "actor_gradient_clip_norm",
+                self.actor_gradient_clip_norm,
+                positive=True,
+            )
+            if self.actor_gradient_clip_norm is not None
+            else None
+        )
+        object.__setattr__(self, "actor_lamda", actor_lamda)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "actor_sparsity", actor_sparsity)
+        object.__setattr__(self, "leaky_relu_slope", leaky_relu_slope)
+        object.__setattr__(self, "actor_epsilon", actor_epsilon)
+        object.__setattr__(self, "actor_td_error_normalizer_decay", actor_td_error_normalizer_decay)
+        object.__setattr__(self, "actor_td_error_clip", actor_td_error_clip)
+        object.__setattr__(self, "actor_gradient_clip_norm", actor_gradient_clip_norm)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -1260,18 +1397,11 @@ class NonlinearHordeActorCriticAgent:
             config.actor_td_error_normalizer_decay is not None
             and not 0.0 <= config.actor_td_error_normalizer_decay < 1.0
         ):
-            raise ValueError(
-                "actor_td_error_normalizer_decay must be in [0, 1)"
-            )
+            raise ValueError("actor_td_error_normalizer_decay must be in [0, 1)")
         if config.actor_td_error_clip is not None and config.actor_td_error_clip <= 0:
             raise ValueError("actor_td_error_clip must be positive when provided")
-        if (
-            config.actor_gradient_clip_norm is not None
-            and config.actor_gradient_clip_norm <= 0
-        ):
-            raise ValueError(
-                "actor_gradient_clip_norm must be positive when provided"
-            )
+        if config.actor_gradient_clip_norm is not None and config.actor_gradient_clip_norm <= 0:
+            raise ValueError("actor_gradient_clip_norm must be positive when provided")
         if not 0 <= config.value_head_index < critic.n_demons:
             raise ValueError(
                 f"value_head_index {config.value_head_index} out of range "
@@ -1315,9 +1445,7 @@ class NonlinearHordeActorCriticAgent:
             "critic": self._critic.to_config(),
             "actor_optimizer": self._actor_optimizer.to_config(),
             "actor_bounder": (
-                self._actor_bounder.to_config()
-                if self._actor_bounder is not None
-                else None
+                self._actor_bounder.to_config() if self._actor_bounder is not None else None
             ),
         }
 
@@ -1408,10 +1536,7 @@ class NonlinearHordeActorCriticAgent:
         )
         logits = state.actor_head_w @ hidden + state.actor_head_b
         probs = jax.nn.softmax(logits / cfg.temperature)
-        return (
-            (1.0 - cfg.actor_epsilon) * probs
-            + cfg.actor_epsilon / cfg.n_actions
-        )
+        return (1.0 - cfg.actor_epsilon) * probs + cfg.actor_epsilon / cfg.n_actions
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def value(
@@ -1432,9 +1557,7 @@ class NonlinearHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(
-            sample_key, jnp.log(jnp.maximum(probs, 1e-8))
-        ).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -1442,9 +1565,7 @@ class NonlinearHordeActorCriticAgent:
         self,
         state: NonlinearHordeActorCriticState,
         observation: Array,
-    ) -> tuple[
-        NonlinearHordeActorCriticState, Int[Array, ""], Float[Array, " n_actions"]
-    ]:
+    ) -> tuple[NonlinearHordeActorCriticState, Int[Array, ""], Float[Array, " n_actions"]]:
         """Select and store the first action for a stream or episode."""
         action, key, probs = self.select_action(state, observation)
         new_state = state.replace(  # type: ignore[attr-defined]
@@ -1484,15 +1605,11 @@ class NonlinearHordeActorCriticAgent:
 
         value_gamma = self._critic.horde_spec.gammas[cfg.value_head_index]
         value_discount = (
-            value_gamma
-            if discount is None
-            else jnp.asarray(discount, dtype=jnp.float32)
+            value_gamma if discount is None else jnp.asarray(discount, dtype=jnp.float32)
         )
 
         if auxiliary_cumulants is None:
-            auxiliary_cumulants = jnp.zeros(
-                (self._critic.n_demons - 1,), dtype=jnp.float32
-            )
+            auxiliary_cumulants = jnp.zeros((self._critic.n_demons - 1,), dtype=jnp.float32)
         auxiliary_cumulants = jnp.asarray(auxiliary_cumulants, dtype=jnp.float32)
         idx = cfg.value_head_index
         cumulants_before = auxiliary_cumulants[:idx]
@@ -1518,16 +1635,11 @@ class NonlinearHordeActorCriticAgent:
         )
         actor_td_error_normalizer = state.actor_td_error_normalizer
         if cfg.actor_td_error_normalizer_decay is not None:
-            decay = jnp.asarray(
-                cfg.actor_td_error_normalizer_decay, dtype=jnp.float32
-            )
-            actor_td_error_normalizer = (
-                _skip_zero_scale(decay, actor_td_error_normalizer)
-                + (1.0 - decay) * jnp.abs(actor_td_error)
-            )
-            actor_td_error = actor_td_error / jnp.maximum(
-                actor_td_error_normalizer, 1e-3
-            )
+            decay = jnp.asarray(cfg.actor_td_error_normalizer_decay, dtype=jnp.float32)
+            actor_td_error_normalizer = _skip_zero_scale(decay, actor_td_error_normalizer) + (
+                1.0 - decay
+            ) * jnp.abs(actor_td_error)
+            actor_td_error = actor_td_error / jnp.maximum(actor_td_error_normalizer, 1e-3)
 
         # Policy gradient via jax.grad through the full MLP forward pass
         actor_params = (
@@ -1546,14 +1658,12 @@ class NonlinearHordeActorCriticAgent:
             cfg.actor_epsilon,
         )
         grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = grads
-        grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = (
-            _clip_nlhac_actor_grads(
-                grad_trunk_w,
-                grad_trunk_b,
-                grad_head_w,
-                grad_head_b,
-                cfg.actor_gradient_clip_norm,
-            )
+        grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = _clip_nlhac_actor_grads(
+            grad_trunk_w,
+            grad_trunk_b,
+            grad_head_w,
+            grad_head_b,
+            cfg.actor_gradient_clip_norm,
         )
 
         actor_decay = value_discount * cfg.actor_lamda
@@ -1562,12 +1672,10 @@ class NonlinearHordeActorCriticAgent:
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):
             new_trunk_traces.append(
-                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i])
-                + grad_trunk_w[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i]) + grad_trunk_w[i]
             )
             new_trunk_traces.append(
-                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1])
-                + grad_trunk_b[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1]) + grad_trunk_b[i]
             )
 
         new_head_trace_w = _skip_zero_scale(actor_decay, state.actor_head_trace_w) + grad_head_w
@@ -1579,46 +1687,36 @@ class NonlinearHordeActorCriticAgent:
         trunk_b_steps: list[Array] = []
         optimizer_updates_applied: list[Array] = []
         for i in range(n_hidden):
-            raw_w, new_opt_w, w_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._actor_optimizer,
-                    state.actor_trunk_opt_states[2 * i],
-                    new_trunk_traces[2 * i],
-                    error=actor_td_error,
-                )
+            raw_w, new_opt_w, w_update_applied = _update_from_gradient_with_diagnostics(
+                self._actor_optimizer,
+                state.actor_trunk_opt_states[2 * i],
+                new_trunk_traces[2 * i],
+                error=actor_td_error,
             )
-            raw_b, new_opt_b, b_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._actor_optimizer,
-                    state.actor_trunk_opt_states[2 * i + 1],
-                    new_trunk_traces[2 * i + 1],
-                    error=actor_td_error,
-                )
+            raw_b, new_opt_b, b_update_applied = _update_from_gradient_with_diagnostics(
+                self._actor_optimizer,
+                state.actor_trunk_opt_states[2 * i + 1],
+                new_trunk_traces[2 * i + 1],
+                error=actor_td_error,
             )
             new_trunk_opt_states.extend([new_opt_w, new_opt_b])
             trunk_w_steps.append(raw_w)
             trunk_b_steps.append(raw_b)
             optimizer_updates_applied.extend((w_update_applied, b_update_applied))
 
-        raw_head_w, new_head_opt_w, head_w_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_head_opt_w,
-                new_head_trace_w,
-                error=actor_td_error,
-            )
+        raw_head_w, new_head_opt_w, head_w_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_head_opt_w,
+            new_head_trace_w,
+            error=actor_td_error,
         )
-        raw_head_b, new_head_opt_b, head_b_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_head_opt_b,
-                new_head_trace_b,
-                error=actor_td_error,
-            )
+        raw_head_b, new_head_opt_b, head_b_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_head_opt_b,
+            new_head_trace_b,
+            error=actor_td_error,
         )
-        optimizer_updates_applied.extend(
-            (head_w_update_applied, head_b_update_applied)
-        )
+        optimizer_updates_applied.extend((head_w_update_applied, head_b_update_applied))
         head_w_step = raw_head_w
         head_b_step = raw_head_b
 
@@ -1730,13 +1828,9 @@ class NonlinearHordeActorCriticAgent:
         return NonlinearHordeActorCriticUpdateResult(  # type: ignore[call-arg]
             state=new_state,
             action=jnp.where(update_applied, next_action, jnp.asarray(0, jnp.int32)),
-            policy=jnp.where(
-                update_applied, next_policy, jnp.zeros_like(next_policy)
-            ),
+            policy=jnp.where(update_applied, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(update_applied, value, 0.0),
-            next_value=jnp.where(
-                update_applied & (value_discount != 0.0), next_value, 0.0
-            ),
+            next_value=jnp.where(update_applied & (value_discount != 0.0), next_value, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),
             bound_metric=jnp.where(update_applied, bound_metric, 0.0),
             critic_result=committed_critic_result,
@@ -1805,13 +1899,16 @@ def run_nonlinear_horde_actor_critic_from_arrays(
             result.update_applied,
         )
 
-    final_state, (
-        out_actions,
-        policies,
-        values,
-        td_errors,
-        critic_td_errors,
-        updates_applied,
+    (
+        final_state,
+        (
+            out_actions,
+            policies,
+            values,
+            td_errors,
+            critic_td_errors,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         _scan_fn,
         state,
@@ -1844,6 +1941,58 @@ class NonlinearQHordeActorCriticConfig:
     actor_gradient_clip_norm: float | None = None
     critic_target: str = "expected_sarsa"
     actor_update: str = "td_error"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _validate_hidden_sizes(self.hidden_sizes),
+        )
+        gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
+        actor_lamda = validated_float32_scalar(
+            "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0
+        )
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        actor_sparsity = validated_float32_scalar(
+            "actor_sparsity", self.actor_sparsity, lower=0.0, upper=1.0
+        )
+        leaky_relu_slope = validated_float32_scalar(
+            "leaky_relu_slope", self.leaky_relu_slope, lower=0.0
+        )
+        actor_td_error_clip = (
+            validated_float32_scalar(
+                "actor_td_error_clip",
+                self.actor_td_error_clip,
+                positive=True,
+            )
+            if self.actor_td_error_clip is not None
+            else None
+        )
+        actor_gradient_clip_norm = (
+            validated_float32_scalar(
+                "actor_gradient_clip_norm",
+                self.actor_gradient_clip_norm,
+                positive=True,
+            )
+            if self.actor_gradient_clip_norm is not None
+            else None
+        )
+        if self.critic_target not in {"expected_sarsa", "sampled_sarsa"}:
+            raise ValueError("critic_target must be 'expected_sarsa' or 'sampled_sarsa'")
+        if self.actor_update not in {"td_error", "expected_advantage"}:
+            raise ValueError("actor_update must be 'td_error' or 'expected_advantage'")
+        object.__setattr__(self, "gamma", gamma)
+        object.__setattr__(self, "actor_lamda", actor_lamda)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "actor_sparsity", actor_sparsity)
+        object.__setattr__(self, "leaky_relu_slope", leaky_relu_slope)
+        object.__setattr__(self, "actor_td_error_clip", actor_td_error_clip)
+        object.__setattr__(self, "actor_gradient_clip_norm", actor_gradient_clip_norm)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -1893,21 +2042,12 @@ class NonlinearQHordeActorCriticAgent:
             raise ValueError("temperature must be positive")
         if config.actor_td_error_clip is not None and config.actor_td_error_clip <= 0:
             raise ValueError("actor_td_error_clip must be positive when provided")
-        if (
-            config.actor_gradient_clip_norm is not None
-            and config.actor_gradient_clip_norm <= 0
-        ):
-            raise ValueError(
-                "actor_gradient_clip_norm must be positive when provided"
-            )
+        if config.actor_gradient_clip_norm is not None and config.actor_gradient_clip_norm <= 0:
+            raise ValueError("actor_gradient_clip_norm must be positive when provided")
         if config.critic_target not in {"expected_sarsa", "sampled_sarsa"}:
-            raise ValueError(
-                "critic_target must be 'expected_sarsa' or 'sampled_sarsa'"
-            )
+            raise ValueError("critic_target must be 'expected_sarsa' or 'sampled_sarsa'")
         if config.actor_update not in {"td_error", "expected_advantage"}:
-            raise ValueError(
-                "actor_update must be 'td_error' or 'expected_advantage'"
-            )
+            raise ValueError("actor_update must be 'td_error' or 'expected_advantage'")
         if critic.n_demons < config.n_actions:
             raise ValueError("critic must have at least one head per action")
         for idx, demon in enumerate(critic.horde_spec.demons[: config.n_actions]):
@@ -1921,9 +2061,7 @@ class NonlinearQHordeActorCriticAgent:
         self._config = config
         self._critic = critic
         self._actor_optimizer = (
-            actor_optimizer
-            if actor_optimizer is not None
-            else Autostep(initial_step_size=0.01)
+            actor_optimizer if actor_optimizer is not None else Autostep(initial_step_size=0.01)
         )
         self._actor_bounder = actor_bounder
 
@@ -1955,9 +2093,7 @@ class NonlinearQHordeActorCriticAgent:
             "critic": self._critic.to_config(),
             "actor_optimizer": self._actor_optimizer.to_config(),
             "actor_bounder": (
-                self._actor_bounder.to_config()
-                if self._actor_bounder is not None
-                else None
+                self._actor_bounder.to_config() if self._actor_bounder is not None else None
             ),
         }
 
@@ -2062,9 +2198,7 @@ class NonlinearQHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(
-            sample_key, jnp.log(jnp.maximum(probs, 1e-8))
-        ).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -2072,16 +2206,18 @@ class NonlinearQHordeActorCriticAgent:
         self,
         state: NonlinearHordeActorCriticState,
         observation: Array,
-    ) -> tuple[
-        NonlinearHordeActorCriticState, Int[Array, ""], Float[Array, " n_actions"]
-    ]:
+    ) -> tuple[NonlinearHordeActorCriticState, Int[Array, ""], Float[Array, " n_actions"]]:
         """Select and store the first action for a stream or episode."""
         action, key, probs = self.select_action(state, observation)
-        return state.replace(  # type: ignore[attr-defined]
-            last_observation=observation,
-            last_action=action,
-            rng_key=key,
-        ), action, probs
+        return (
+            state.replace(  # type: ignore[attr-defined]
+                last_observation=observation,
+                last_action=action,
+                rng_key=key,
+            ),
+            action,
+            probs,
+        )
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def update(
@@ -2162,14 +2298,12 @@ class NonlinearQHordeActorCriticAgent:
             )
             actor_signal = actor_td_error
         grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = grads
-        grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = (
-            _clip_nlhac_actor_grads(
-                grad_trunk_w,
-                grad_trunk_b,
-                grad_head_w,
-                grad_head_b,
-                cfg.actor_gradient_clip_norm,
-            )
+        grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = _clip_nlhac_actor_grads(
+            grad_trunk_w,
+            grad_trunk_b,
+            grad_head_w,
+            grad_head_b,
+            cfg.actor_gradient_clip_norm,
         )
 
         actor_decay = effective_gamma * cfg.actor_lamda
@@ -2177,12 +2311,10 @@ class NonlinearQHordeActorCriticAgent:
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):
             new_trunk_traces.append(
-                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i])
-                + grad_trunk_w[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i]) + grad_trunk_w[i]
             )
             new_trunk_traces.append(
-                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1])
-                + grad_trunk_b[i]
+                _skip_zero_scale(actor_decay, state.actor_trunk_traces[2 * i + 1]) + grad_trunk_b[i]
             )
         new_head_trace_w = _skip_zero_scale(actor_decay, state.actor_head_trace_w) + grad_head_w
         new_head_trace_b = _skip_zero_scale(actor_decay, state.actor_head_trace_b) + grad_head_b
@@ -2192,46 +2324,36 @@ class NonlinearQHordeActorCriticAgent:
         trunk_b_steps: list[Array] = []
         optimizer_updates_applied: list[Array] = []
         for i in range(n_hidden):
-            raw_w, new_opt_w, w_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._actor_optimizer,
-                    state.actor_trunk_opt_states[2 * i],
-                    new_trunk_traces[2 * i],
-                    error=actor_signal,
-                )
+            raw_w, new_opt_w, w_update_applied = _update_from_gradient_with_diagnostics(
+                self._actor_optimizer,
+                state.actor_trunk_opt_states[2 * i],
+                new_trunk_traces[2 * i],
+                error=actor_signal,
             )
-            raw_b, new_opt_b, b_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._actor_optimizer,
-                    state.actor_trunk_opt_states[2 * i + 1],
-                    new_trunk_traces[2 * i + 1],
-                    error=actor_signal,
-                )
+            raw_b, new_opt_b, b_update_applied = _update_from_gradient_with_diagnostics(
+                self._actor_optimizer,
+                state.actor_trunk_opt_states[2 * i + 1],
+                new_trunk_traces[2 * i + 1],
+                error=actor_signal,
             )
             new_trunk_opt_states.extend([new_opt_w, new_opt_b])
             trunk_w_steps.append(raw_w)
             trunk_b_steps.append(raw_b)
             optimizer_updates_applied.extend((w_update_applied, b_update_applied))
 
-        raw_head_w, new_head_opt_w, head_w_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_head_opt_w,
-                new_head_trace_w,
-                error=actor_signal,
-            )
+        raw_head_w, new_head_opt_w, head_w_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_head_opt_w,
+            new_head_trace_w,
+            error=actor_signal,
         )
-        raw_head_b, new_head_opt_b, head_b_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_head_opt_b,
-                new_head_trace_b,
-                error=actor_signal,
-            )
+        raw_head_b, new_head_opt_b, head_b_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_head_opt_b,
+            new_head_trace_b,
+            error=actor_signal,
         )
-        optimizer_updates_applied.extend(
-            (head_w_update_applied, head_b_update_applied)
-        )
+        optimizer_updates_applied.extend((head_w_update_applied, head_b_update_applied))
         head_w_step = raw_head_w
         head_b_step = raw_head_b
 
@@ -2261,20 +2383,17 @@ class NonlinearQHordeActorCriticAgent:
             actor_trunk=MLPParams(  # type: ignore[call-arg]
                 {
                     "weights": tuple(
-                        w + step
-                        for w, step in zip(state.actor_trunk.weights, trunk_w_steps)
+                        w + step for w, step in zip(state.actor_trunk.weights, trunk_w_steps)
                     ),
                     "biases": tuple(
-                        b + step
-                        for b, step in zip(state.actor_trunk.biases, trunk_b_steps)
+                        b + step for b, step in zip(state.actor_trunk.biases, trunk_b_steps)
                     ),
                 }
             ),
             actor_head_w=state.actor_head_w + head_w_step,
             actor_head_b=state.actor_head_b + head_b_step,
             actor_trunk_traces=tuple(
-                jnp.where(carry_traces, trace, jnp.zeros_like(trace))
-                for trace in new_trunk_traces
+                jnp.where(carry_traces, trace, jnp.zeros_like(trace)) for trace in new_trunk_traces
             ),
             actor_head_trace_w=jnp.where(
                 carry_traces, new_head_trace_w, jnp.zeros_like(new_head_trace_w)
@@ -2332,9 +2451,7 @@ class NonlinearQHordeActorCriticAgent:
             state=new_state,
             action=jnp.where(update_applied, next_action, jnp.asarray(0, jnp.int32)),
             policy=jnp.where(update_applied, policy, jnp.zeros_like(policy)),
-            q_values=jnp.where(
-                update_applied, q_previous, jnp.zeros_like(q_previous)
-            ),
+            q_values=jnp.where(update_applied, q_previous, jnp.zeros_like(q_previous)),
             next_q_values=jnp.where(
                 update_applied & (effective_gamma != 0.0),
                 q_next,

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -4,6 +4,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import HordeActorCriticAgent as TopLevelHordeActorCriticAgent
@@ -213,12 +214,8 @@ def test_horde_actor_critic_update_is_jittable() -> None:
 def test_run_horde_actor_critic_from_arrays_scan() -> None:
     agent = _make_agent(n_demons=2)
     state = agent.init(feature_dim=2, key=jr.key(3))
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     aux = jnp.array([[0.5], [1.0], [-0.5]], dtype=jnp.float32)
     actions = jnp.array([0, 1, 0], dtype=jnp.int32)
@@ -422,9 +419,7 @@ def test_qhorde_terminal_does_not_multiply_inf_next_value() -> None:
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
     chex.assert_trees_all_equal(result.next_q_values, jnp.zeros((2,), jnp.float32))
-    chex.assert_tree_all_finite(
-        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
-    )
+    chex.assert_tree_all_finite(result.state.replace(rng_key=jr.key_data(result.state.rng_key)))
     chex.assert_tree_all_finite(
         (result.policy, result.q_values, result.next_q_values, result.td_error)
     )
@@ -453,12 +448,8 @@ def test_horde_zero_discount_neutralizes_inf_next_value_diagnostic() -> None:
 
     assert bool(result.update_applied)
     chex.assert_trees_all_equal(result.next_value, jnp.array(0.0, jnp.float32))
-    chex.assert_tree_all_finite(
-        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
-    )
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite(result.state.replace(rng_key=jr.key_data(result.state.rng_key)))
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 def test_qhorde_actor_critic_auxiliary_prediction_and_terminal_trace_reset() -> None:
@@ -730,21 +721,22 @@ def test_nonlinear_horde_zero_discount_neutralizes_inf_next_value() -> None:
 
     assert bool(result.update_applied)
     chex.assert_trees_all_equal(result.next_value, jnp.array(0.0, jnp.float32))
-    chex.assert_tree_all_finite(
-        result.state.replace(rng_key=jr.key_data(result.state.rng_key))
-    )
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite(result.state.replace(rng_key=jr.key_data(result.state.rng_key)))
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 class TestNonlinearHordeActorCriticConfig:
     def _simple_critic(self) -> HordeLearner:
         spec = create_horde_spec(
-            [GVFSpec(  # type: ignore[call-arg]
-                name="v", demon_type=DemonType.PREDICTION,
-                gamma=0.9, lamda=0.0, cumulant_index=0,
-            )]
+            [
+                GVFSpec(  # type: ignore[call-arg]
+                    name="v",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=0.9,
+                    lamda=0.0,
+                    cumulant_index=0,
+                )
+            ]
         )
         return HordeLearner(spec, hidden_sizes=(16,))
 
@@ -761,17 +753,20 @@ class TestNonlinearHordeActorCriticConfig:
             critic = self._simple_critic()
             critic = HordeLearner(
                 create_horde_spec(
-                    [GVFSpec(  # type: ignore[call-arg]
-                        name="v", demon_type=DemonType.PREDICTION,
-                        gamma=0.9, lamda=0.0, cumulant_index=0,
-                    )]
+                    [
+                        GVFSpec(  # type: ignore[call-arg]
+                            name="v",
+                            demon_type=DemonType.PREDICTION,
+                            gamma=0.9,
+                            lamda=0.0,
+                            cumulant_index=0,
+                        )
+                    ]
                 ),
                 hidden_sizes=(16,),
             )
             NonlinearHordeActorCriticAgent(
-                NonlinearHordeActorCriticConfig(
-                    n_actions=2, hidden_sizes=(16,), temperature=0.0
-                ),
+                NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=(16,), temperature=0.0),
                 critic,
             )
 
@@ -843,9 +838,7 @@ class TestNonlinearHordeActorCriticInit:
     def test_traces_zero_at_init(self) -> None:
         agent = _make_nlhac_agent(hidden_sizes=(32,))
         state = agent.init(OBS_DIM, jr.key(0))
-        chex.assert_trees_all_close(
-            state.actor_head_trace_w, jnp.zeros((N_ACTIONS, 32))
-        )
+        chex.assert_trees_all_close(state.actor_head_trace_w, jnp.zeros((N_ACTIONS, 32)))
 
     def test_linear_actor_no_trunk(self) -> None:
         agent = _make_nlhac_agent(hidden_sizes=())
@@ -877,13 +870,15 @@ class TestNonlinearHordeActorCriticUpdate:
         """Inf TD error zeros the ObGD step, then td_error*step is 0*inf=NaN."""
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v",
-                    demon_type=DemonType.PREDICTION,
-                    gamma=0.0,
-                    lamda=0.0,
-                    cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.0,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(),
             step_size=0.03,
@@ -912,19 +907,22 @@ class TestNonlinearHordeActorCriticUpdate:
         chex.assert_tree_all_finite(poisoned.policy)
         chex.assert_tree_all_finite(poisoned.critic_result.predictions)
 
-        recovered = agent.update(
-            poisoned.state, jnp.array(1.0, dtype=jnp.float32), observation
-        )
+        recovered = agent.update(poisoned.state, jnp.array(1.0, dtype=jnp.float32), observation)
         assert bool(jnp.all(jnp.isfinite(recovered.state.actor_head_w)))
         assert bool(recovered.update_applied)
 
     def test_actor_td_error_normalizer_updates(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v", demon_type=DemonType.PREDICTION,
-                    gamma=0.99, lamda=0.0, cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(32,),
             step_size=0.03,
@@ -945,10 +943,15 @@ class TestNonlinearHordeActorCriticUpdate:
         """decay=0 times leftover inf actor TD-error EMA is NaN."""
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v", demon_type=DemonType.PREDICTION,
-                    gamma=0.99, lamda=0.0, cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(8,),
             step_size=0.03,
@@ -976,17 +979,20 @@ class TestNonlinearHordeActorCriticUpdate:
         agent = _make_nlhac_agent()
         state = _init_nlhac(agent)
         result = agent.update(state, jnp.array(0.0), jnp.zeros(OBS_DIM))
-        chex.assert_trees_all_close(
-            jnp.sum(result.policy), jnp.array(1.0), atol=1e-5
-        )
+        chex.assert_trees_all_close(jnp.sum(result.policy), jnp.array(1.0), atol=1e-5)
 
     def test_actor_weights_update(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v", demon_type=DemonType.PREDICTION,
-                    gamma=0.99, lamda=0.0, cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(32,),
             step_size=0.03,
@@ -1006,10 +1012,15 @@ class TestNonlinearHordeActorCriticUpdate:
     def test_actor_gradient_clip_limits_new_trace_norm(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v", demon_type=DemonType.PREDICTION,
-                    gamma=0.99, lamda=0.0, cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(32,),
             step_size=0.03,
@@ -1029,10 +1040,7 @@ class TestNonlinearHordeActorCriticUpdate:
         trace_norm = jnp.sqrt(
             jnp.sum(jnp.square(result.state.actor_head_trace_w))
             + jnp.sum(jnp.square(result.state.actor_head_trace_b))
-            + sum(
-                jnp.sum(jnp.square(trace))
-                for trace in result.state.actor_trunk_traces
-            )
+            + sum(jnp.sum(jnp.square(trace)) for trace in result.state.actor_trunk_traces)
         )
         assert float(trace_norm) <= 0.0501
 
@@ -1040,13 +1048,15 @@ class TestNonlinearHordeActorCriticUpdate:
         """Large TD errors must enter the ObGD denominator exactly once."""
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v",
-                    demon_type=DemonType.PREDICTION,
-                    gamma=0.0,
-                    lamda=0.0,
-                    cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.0,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(),
             step_size=0.03,
@@ -1114,10 +1124,15 @@ class TestNonlinearHordeActorCriticUpdate:
     def test_trunk_weights_update(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v", demon_type=DemonType.PREDICTION,
-                    gamma=0.99, lamda=0.0, cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(32,),
             step_size=0.03,
@@ -1149,9 +1164,7 @@ class TestNonlinearHordeActorCriticScan:
         n_steps = 15
         obs = jnp.zeros((n_steps, OBS_DIM))
         rews = jnp.ones(n_steps)
-        result = run_nonlinear_horde_actor_critic_from_arrays(
-            agent, state, obs, rews, obs
-        )
+        result = run_nonlinear_horde_actor_critic_from_arrays(agent, state, obs, rews, obs)
         chex.assert_shape(result.actions, (n_steps,))
         chex.assert_shape(result.values, (n_steps,))
         chex.assert_shape(result.td_errors, (n_steps,))
@@ -1163,9 +1176,7 @@ class TestNonlinearHordeActorCriticScan:
         n_steps = 20
         obs = jr.normal(jr.key(5), (n_steps, OBS_DIM))
         rews = jr.normal(jr.key(6), (n_steps,))
-        result = run_nonlinear_horde_actor_critic_from_arrays(
-            agent, state, obs, rews, obs
-        )
+        result = run_nonlinear_horde_actor_critic_from_arrays(agent, state, obs, rews, obs)
         chex.assert_tree_all_finite(result.td_errors)
 
     def test_scan_step_count_final(self) -> None:
@@ -1184,9 +1195,7 @@ class TestNonlinearHordeActorCriticScan:
         n_steps = 200
         obs = jr.normal(jr.key(99), (n_steps, OBS_DIM))
         rews = jr.normal(jr.key(100), (n_steps,))
-        result = run_nonlinear_horde_actor_critic_from_arrays(
-            agent, state, obs, rews, obs
-        )
+        result = run_nonlinear_horde_actor_critic_from_arrays(agent, state, obs, rews, obs)
         chex.assert_tree_all_finite(result.td_errors)
         assert int(result.state.step_count) == n_steps
 
@@ -1289,9 +1298,7 @@ class TestNonlinearQHordeActorCritic:
         state = agent.init(2, jr.key(21))
         state, _, _ = agent.start(state, jnp.array([0.0, 1.0], jnp.float32))
         poisoned_w = jnp.asarray([[huge, 0.0]], dtype=jnp.float32)
-        head_params = state.critic_state.head_params.replace(
-            weights=(poisoned_w, poisoned_w)
-        )
+        head_params = state.critic_state.head_params.replace(weights=(poisoned_w, poisoned_w))
         state = state.replace(  # type: ignore[attr-defined]
             critic_state=state.critic_state.replace(head_params=head_params)
         )
@@ -1304,12 +1311,8 @@ class TestNonlinearQHordeActorCritic:
         )
 
         assert bool(result.update_applied)
-        chex.assert_trees_all_equal(
-            result.next_q_values, jnp.zeros((2,), jnp.float32)
-        )
-        chex.assert_tree_all_finite(
-            result.state.replace(rng_key=jr.key_data(result.state.rng_key))
-        )
+        chex.assert_trees_all_equal(result.next_q_values, jnp.zeros((2,), jnp.float32))
+        chex.assert_tree_all_finite(result.state.replace(rng_key=jr.key_data(result.state.rng_key)))
         chex.assert_tree_all_finite(
             (result.policy, result.q_values, result.next_q_values, result.td_error)
         )
@@ -1372,13 +1375,15 @@ class TestNonlinearQHordeActorCritic:
     def test_requires_control_heads(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="v",
-                    demon_type=DemonType.PREDICTION,
-                    gamma=0.9,
-                    lamda=0.0,
-                    cumulant_index=0,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.9,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
             ),
             hidden_sizes=(16,),
         )
@@ -1391,13 +1396,15 @@ class TestNonlinearQHordeActorCritic:
     def test_requires_zero_gamma_for_prebootstrapped_action_heads(self) -> None:
         critic = HordeLearner(
             create_horde_spec(
-                [GVFSpec(  # type: ignore[call-arg]
-                    name="q",
-                    demon_type=DemonType.CONTROL,
-                    gamma=0.9,
-                    lamda=0.0,
-                    cumulant_index=-1,
-                )]
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="q",
+                        demon_type=DemonType.CONTROL,
+                        gamma=0.9,
+                        lamda=0.0,
+                        cumulant_index=-1,
+                    )
+                ]
             ),
             hidden_sizes=(16,),
         )
@@ -1476,3 +1483,68 @@ class TestNonlinearQHordeActorCritic:
 
         assert after[1] > before[1]
         assert after[0] < before[0]
+
+
+def test_horde_actor_critic_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        HordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        HordeActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="value_head_index"):
+        HordeActorCriticConfig(n_actions=2, value_head_index=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="actor_step_size"):
+        HordeActorCriticConfig(n_actions=2, actor_step_size=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="n_actions"):
+        QHordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gamma"):
+        QHordeActorCriticConfig(n_actions=2, gamma=True)  # type: ignore[arg-type]
+
+
+def test_horde_actor_critic_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = HordeActorCriticConfig(n_actions=np.int32(3), value_head_index=np.uint16(0))
+    assert type(cfg.n_actions) is int
+    assert type(cfg.value_head_index) is int
+    assert cfg.n_actions == 3
+    assert cfg.value_head_index == 0
+
+    q_cfg = QHordeActorCriticConfig(n_actions=np.int64(4))
+    assert type(q_cfg.n_actions) is int
+    assert q_cfg.n_actions == 4
+
+
+def test_nonlinear_horde_actor_critic_configs_reject_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        NonlinearHordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=[32])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=(True,))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="actor_lamda"):
+        NonlinearHordeActorCriticConfig(n_actions=2, actor_lamda=1.0 + 1e-6)
+
+    with pytest.raises(ValueError, match="n_actions"):
+        NonlinearQHordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        NonlinearQHordeActorCriticConfig(n_actions=2, hidden_sizes=(np.int32(0),))
+
+
+def test_nonlinear_horde_actor_critic_configs_accept_and_canonicalizes_numpy_integers() -> None:
+    cfg = NonlinearHordeActorCriticConfig(
+        n_actions=np.int32(2),
+        value_head_index=np.uint16(0),
+        hidden_sizes=(np.int32(32), np.int64(16)),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.value_head_index) is int
+    assert type(cfg.hidden_sizes[0]) is int
+    assert type(cfg.hidden_sizes[1]) is int
+    assert cfg.hidden_sizes == (32, 16)
+
+    q_cfg = NonlinearQHordeActorCriticConfig(
+        n_actions=np.int32(3),
+        hidden_sizes=(np.int64(64),),
+    )
+    assert type(q_cfg.n_actions) is int
+    assert type(q_cfg.hidden_sizes[0]) is int
+    assert q_cfg.hidden_sizes == (64,)


### PR DESCRIPTION
## Summary
- Hardens `HordeActorCriticConfig`, `QHordeActorCriticConfig`, `NonlinearHordeActorCriticConfig`, and `NonlinearQHordeActorCriticConfig` integer fields (`n_actions`, `value_head_index`, `hidden_sizes`) against booleans, non-integer floats, and out-of-bound dimensions while accepting and canonicalizing the full NumPy integer family.
- Replaces unvalidated or raw float inequality checks on learning and trace parameters (`gamma`, `actor_step_size`, `actor_lamda`, `temperature`, `actor_sparsity`, `leaky_relu_slope`, `actor_epsilon`, `actor_td_error_normalizer_decay`, `actor_td_error_clip`, `actor_gradient_clip_norm`) with `validated_float32_scalar` to enforce float32 bounds and eliminate binary32 boundary overflow.

## Verification
- `PYTHONPATH=. pytest tests/test_horde_actor_critic.py`: 59 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/horde_actor_critic.py`: clean
- No registered evidence artifacts modified.