### PR TITLE
fix(working-memory): preserve tuple config compatibility

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -115,9 +115,10 @@ class WorkingMemoryConfig:
         ):
             if key in payload:
                 value = payload[key]
-                if type(value) is not list:
-                    raise ValueError(f"{key} must be a list")
-                payload[key] = tuple(value)
+                if type(value) is list:
+                    payload[key] = tuple(value)
+                elif type(value) is not tuple:
+                    raise ValueError(f"{key} must be an actual list or tuple")
         return cls(**payload)
 
 

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -42,10 +42,13 @@ def test_working_memory_config_roundtrip_and_shapes() -> None:
     chex.assert_shape(state.last_gate, (3,))
 
 
-def test_working_memory_config_from_config_requires_actual_json_lists() -> None:
+def test_working_memory_config_from_config_accepts_exact_lists_or_tuples() -> None:
     class HostileList(list[float]):
         def __iter__(self) -> Iterator[float]:
             raise AssertionError("invalid list subclass must not be iterated")
+
+    class HostileTuple(tuple):
+        pass
 
     base = WorkingMemoryConfig(observation_dim=2, action_dim=1).to_config()
     keys = (
@@ -54,10 +57,10 @@ def test_working_memory_config_from_config_requires_actual_json_lists() -> None:
         "reward_decay_rates",
     )
     invalid_values: tuple[object, ...] = (
-        (0.5,),
         "0.5",
         np.asarray([0.5]),
         HostileList([0.5]),
+        HostileTuple((0.5,)),
         0.5,
     )
     for key in keys:
@@ -70,6 +73,16 @@ def test_working_memory_config_from_config_requires_actual_json_lists() -> None:
     assert type(restored.observation_decay_rates) is tuple
     assert type(restored.action_decay_rates) is tuple
     assert type(restored.reward_decay_rates) is tuple
+
+    tuple_payload = {
+        **base,
+        "observation_decay_rates": tuple(base["observation_decay_rates"]),
+        "action_decay_rates": tuple(base["action_decay_rates"]),
+        "reward_decay_rates": tuple(base["reward_decay_rates"]),
+    }
+    assert WorkingMemoryConfig.from_config(tuple_payload) == WorkingMemoryConfig.from_config(
+        base
+    )
 
 
 def test_working_memory_trace_decay_and_feature_causality() -> None:


### PR DESCRIPTION
Restores the exact-tuple input accepted by `WorkingMemoryConfig.from_config` before #692, while retaining #692’s fail-closed rejection of tuple/list subclasses, strings, arrays, scalars, and hostile iterables. Exact JSON lists still normalize once to canonical tuples; programmatic callers and legacy serialized dictionaries using exact tuples remain compatible without reopening arbitrary iterable coercion.

Validation:
- `tests/test_working_memory.py`: 100 passed
- scoped Ruff: clean
- strict source mypy: clean
- diff check: clean

No evidence source or artifact changes.