### PR TITLE
fix(learning-signals): complete scalar and integer contracts

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -41,7 +41,6 @@ calibration on an external environment or a scientific-result claim.
 from __future__ import annotations
 
 import dataclasses
-import math
 import operator
 from typing import Any, SupportsIndex, cast
 
@@ -96,21 +95,6 @@ def _saturating_counter_sum(left: Array, right: Array) -> Array:
     """Add non-negative int32 counters without overflowing."""
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     return left + jnp.minimum(right, maximum - left)
-
-
-def _positive_finite(name: str, value: float) -> None:
-    if not math.isfinite(value) or value <= 0.0:
-        raise ValueError(f"{name} must be positive and finite")
-
-
-def _unit_interval(name: str, value: float) -> None:
-    if not math.isfinite(value) or not 0.0 <= value < 1.0:
-        raise ValueError(f"{name} must be finite and in [0, 1)")
-
-
-def _positive_integer(name: str, value: int, *, minimum: int = 1) -> None:
-    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
-        raise ValueError(f"{name} must be an integer >= {minimum}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -173,11 +157,29 @@ class LearningSignalEstimatorConfig:
                 "change_calibration_steps",
                 self.change_calibration_steps,
                 minimum=2,
+                maximum=_INT32_MAX - 1,
             ),
         )
-        if self.change_calibration_steps >= _INT32_MAX:
-            raise ValueError("change_calibration_steps must fit in int32")
-        _positive_finite("variance_floor", self.variance_floor)
+        positive_fields = (
+            "variance_floor",
+            "change_z_threshold",
+            "change_temperature",
+            "calibration_scale_floor",
+            "max_normalized_residual",
+            "max_input_magnitude",
+            "max_predicted_variance",
+            "max_observed_loss",
+        )
+        for field_name in positive_fields:
+            object.__setattr__(
+                self,
+                field_name,
+                validated_float32_scalar(
+                    field_name,
+                    getattr(self, field_name),
+                    positive=True,
+                ),
+            )
         fast_loss_decay = validated_float32_scalar(
             "fast_loss_decay",
             self.fast_loss_decay,
@@ -204,13 +206,6 @@ class LearningSignalEstimatorConfig:
         object.__setattr__(self, "fast_loss_decay", fast_loss_decay)
         object.__setattr__(self, "slow_loss_decay", slow_loss_decay)
         object.__setattr__(self, "change_decay", change_decay)
-        _positive_finite("change_z_threshold", self.change_z_threshold)
-        _positive_finite("change_temperature", self.change_temperature)
-        _positive_finite("calibration_scale_floor", self.calibration_scale_floor)
-        _positive_finite("max_normalized_residual", self.max_normalized_residual)
-        _positive_finite("max_input_magnitude", self.max_input_magnitude)
-        _positive_finite("max_predicted_variance", self.max_predicted_variance)
-        _positive_finite("max_observed_loss", self.max_observed_loss)
         if self.variance_floor > self.max_predicted_variance:
             raise ValueError("variance_floor must not exceed max_predicted_variance")
 
@@ -228,9 +223,11 @@ class LearningSignalEstimatorConfig:
         config: dict[str, Any],
     ) -> LearningSignalEstimatorConfig:
         """Reconstruct a configuration and reject a mismatched type marker."""
+        if type(config) is not dict:
+            raise ValueError("config must be an actual dict")
         payload = dict(config)
         type_name = payload.pop("type", "LearningSignalEstimatorConfig")
-        if type_name != "LearningSignalEstimatorConfig":
+        if type(type_name) is not str or type_name != "LearningSignalEstimatorConfig":
             raise ValueError("type must be LearningSignalEstimatorConfig")
         development_only = payload.pop("development_only", True)
         if development_only is not True:

--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -42,15 +42,43 @@ from __future__ import annotations
 
 import dataclasses
 import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -119,24 +147,65 @@ class LearningSignalEstimatorConfig:
 
     def __post_init__(self) -> None:
         """Reject invalid static shapes, timescales, and safety bounds."""
-        _positive_integer("ensemble_size", self.ensemble_size, minimum=2)
-        _positive_integer("target_dim", self.target_dim)
-        _positive_integer("progress_warmup_steps", self.progress_warmup_steps, minimum=2)
-        _positive_integer(
+        object.__setattr__(
+            self,
+            "ensemble_size",
+            _require_int32("ensemble_size", self.ensemble_size, minimum=2),
+        )
+        object.__setattr__(
+            self,
+            "target_dim",
+            _require_int32("target_dim", self.target_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "progress_warmup_steps",
+            _require_int32(
+                "progress_warmup_steps",
+                self.progress_warmup_steps,
+                minimum=2,
+            ),
+        )
+        object.__setattr__(
+            self,
             "change_calibration_steps",
-            self.change_calibration_steps,
-            minimum=2,
+            _require_int32(
+                "change_calibration_steps",
+                self.change_calibration_steps,
+                minimum=2,
+            ),
         )
         if self.change_calibration_steps >= _INT32_MAX:
             raise ValueError("change_calibration_steps must fit in int32")
         _positive_finite("variance_floor", self.variance_floor)
-        _unit_interval("fast_loss_decay", self.fast_loss_decay)
-        _unit_interval("slow_loss_decay", self.slow_loss_decay)
-        if self.fast_loss_decay >= self.slow_loss_decay:
+        fast_loss_decay = validated_float32_scalar(
+            "fast_loss_decay",
+            self.fast_loss_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        slow_loss_decay = validated_float32_scalar(
+            "slow_loss_decay",
+            self.slow_loss_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        if fast_loss_decay >= slow_loss_decay:
             raise ValueError("fast_loss_decay must be smaller than slow_loss_decay")
+        change_decay = validated_float32_scalar(
+            "change_decay",
+            self.change_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "fast_loss_decay", fast_loss_decay)
+        object.__setattr__(self, "slow_loss_decay", slow_loss_decay)
+        object.__setattr__(self, "change_decay", change_decay)
         _positive_finite("change_z_threshold", self.change_z_threshold)
         _positive_finite("change_temperature", self.change_temperature)
-        _unit_interval("change_decay", self.change_decay)
         _positive_finite("calibration_scale_floor", self.calibration_scale_floor)
         _positive_finite("max_normalized_residual", self.max_normalized_residual)
         _positive_finite("max_input_magnitude", self.max_input_magnitude)

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -103,7 +103,7 @@ def test_config_roundtrip_validation_and_exact_resource_budget() -> None:
             target_dim=1,
             change_calibration_steps=1,
         )
-    with pytest.raises(ValueError, match="fit in int32"):
+    with pytest.raises(ValueError, match="change_calibration_steps"):
         LearningSignalEstimatorConfig(
             ensemble_size=2,
             target_dim=1,
@@ -496,3 +496,63 @@ def test_learning_signals_config_accepts_and_canonicalizes_numpy_integers() -> N
     assert config.target_dim == 2
     assert config.progress_warmup_steps == 3
     assert config.change_calibration_steps == 8
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    (
+        "variance_floor",
+        "change_z_threshold",
+        "change_temperature",
+        "calibration_scale_floor",
+        "max_normalized_residual",
+        "max_input_magnitude",
+        "max_predicted_variance",
+        "max_observed_loss",
+    ),
+)
+@pytest.mark.parametrize("invalid", (True, float("inf"), 1.0e40, 0.0))
+def test_learning_signals_positive_float32_fields_fail_closed(
+    field_name: str, invalid: object
+) -> None:
+    with pytest.raises(ValueError, match=field_name):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            **{field_name: invalid},
+        )
+
+
+def test_learning_signals_config_rejects_spoofed_scalar_and_schema_types() -> None:
+    class HostileInt(int):
+        @property
+        def __class__(self) -> type:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    class SpoofedStr(str):
+        @property
+        def __class__(self) -> type:
+            return str
+
+
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LearningSignalEstimatorConfig(ensemble_size=HostileInt(2), target_dim=1)
+    with pytest.raises(ValueError, match="type"):
+        LearningSignalEstimatorConfig.from_config(
+            {
+                "type": SpoofedStr("LearningSignalEstimatorConfig"),
+                "ensemble_size": 2,
+                "target_dim": 1,
+            }
+        )
+    with pytest.raises(ValueError, match="actual dict"):
+        LearningSignalEstimatorConfig.from_config(  # type: ignore[arg-type]
+            _DictSubclass(ensemble_size=2, target_dim=1)
+        )
+
+
+class _DictSubclass(dict[str, object]):
+    """A mapping subtype that must not reach deserialization hooks."""

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -456,3 +456,43 @@ def test_zero_ema_decay_does_not_multiply_inf_trackers() -> None:
     )
     next_calibrated, _ = _observe_scalar(estimator, calibrated)
     assert bool(jnp.isfinite(next_calibrated.sustained_change_probability))
+
+
+def test_learning_signals_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LearningSignalEstimatorConfig(ensemble_size=True, target_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="target_dim"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="progress_warmup_steps"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, progress_warmup_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="change_calibration_steps"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, change_calibration_steps=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LearningSignalEstimatorConfig(ensemble_size=2.5, target_dim=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="target_dim"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, fast_loss_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, fast_loss_decay=1.0 - 1e-10)
+    with pytest.raises(ValueError, match="change_decay"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1, change_decay=True)  # type: ignore[arg-type]
+
+
+def test_learning_signals_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = LearningSignalEstimatorConfig(
+        ensemble_size=np.int32(4),
+        target_dim=np.int64(2),
+        progress_warmup_steps=np.uint16(3),
+        change_calibration_steps=np.int8(8),
+    )
+    assert type(config.ensemble_size) is int
+    assert type(config.target_dim) is int
+    assert type(config.progress_warmup_steps) is int
+    assert type(config.change_calibration_steps) is int
+    assert config.ensemble_size == 4
+    assert config.target_dim == 2
+    assert config.progress_warmup_steps == 3
+    assert config.change_calibration_steps == 8


### PR DESCRIPTION
Supersedes #685 while preserving its contributor commit and authorship.

The original direction was sound but left eight float32-consumed positive fields on a bool-permissive, host-only validator. This replacement validates and canonicalizes every float32 sink, enforces the pre-increment calibration counter bound, rejects spoofed integer/schema/container types before hooks, and retains exact NumPy integer support.

Verification:
- `pytest tests/test_learning_signals.py -q` (47 passed)
- `ruff check alberta_framework/core/learning_signals.py tests/test_learning_signals.py`
- strict mypy on source
- `git diff --check`

No outputs or evidence artifacts changed.

Co-authored-by: Kayvan Zahiri <kzahiri@dons.usfca.edu>