### PR TITLE
test(streams): stabilize hostile reward parameter ids

### DIFF
--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -339,6 +339,16 @@ class TestRiverSwim:
             1.0e100,
             -1.0e100,
         ],
+        ids=(
+            "bool",
+            "numpy-bool",
+            "string",
+            "object",
+            "class-spoof",
+            "exploding-ratio",
+            "positive-overflow",
+            "negative-overflow",
+        ),
     )
     def test_rewards_reject_untrusted_or_non_float32_values(
         self,


### PR DESCRIPTION
## Summary

Assign stable explicit pytest IDs to the hostile RiverSwim reward values. The default ID for `_SpoofedReward()` included a process-specific memory address, causing pytest-xdist workers to collect different node IDs. This independently failed both Python 3.12 and 3.13 shard 6 in PR #671.

## Verification

- `pytest tests/test_closed_loop_env.py -q -o addopts='' -n 2`: 82 passed
- scoped Ruff: clean
- diff check: clean

Test-only; no runtime or evidence artifacts changed.