### PR TITLE
fix(router): preserve mapping config compatibility

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import jax
@@ -140,13 +141,16 @@ class FeatureBankRouterConfig:
     @classmethod
     def from_config(
         cls,
-        config: dict[str, object],
+        config: Mapping[str, object],
     ) -> FeatureBankRouterConfig:
         """Reconstruct only the exact versioned configuration schema."""
 
-        if type(config) is not dict:
-            raise TypeError("feature-bank router config must be an exact dict")
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("feature-bank router config must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception:
+            raise ValueError("feature-bank router config could not be read") from None
         expected_keys = {
             "type",
             "schema_version",
@@ -421,7 +425,7 @@ class FeatureBankRouter:
     @classmethod
     def from_config(
         cls,
-        config: dict[str, object],
+        config: Mapping[str, object],
     ) -> FeatureBankRouter:
         """Construct a router from the strict versioned configuration."""
 

--- a/tests/test_feature_bank_router.py
+++ b/tests/test_feature_bank_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, cast
 
 import jax
@@ -630,19 +631,26 @@ def test_router_config_rejects_string_spoofs_without_invoking_hooks(
 
 
 @pytest.mark.unit
-def test_router_from_config_requires_an_exact_dict_and_exact_schema() -> None:
+def test_router_from_config_accepts_mappings_and_normalizes_hostile_hooks() -> None:
     payload = FeatureBankRouterConfig(base_dim=4, active_slots=3).to_config()
 
-    class HostileDict(dict[str, object]):
+    class HostileMapping(Mapping[str, object]):
         def __iter__(self) -> Any:
-            raise AssertionError("mapping hooks must not run")
+            raise RuntimeError("mapping hooks must be normalized")
+
+        def __len__(self) -> int:
+            return len(payload)
+
+        def __getitem__(self, key: str) -> object:
+            return payload[key]
 
         def __repr__(self) -> str:
             raise AssertionError("repr hook must not run")
 
     for loader in (FeatureBankRouterConfig.from_config, FeatureBankRouter.from_config):
-        with pytest.raises(TypeError, match="exact dict"):
-            loader(HostileDict(payload))  # type: ignore[arg-type]
+        assert loader(MappingProxyType(payload)).to_config() == payload
+        with pytest.raises(ValueError, match="could not be read"):
+            loader(HostileMapping())
         with pytest.raises(ValueError, match="keys"):
             loader({key: value for key, value in payload.items() if key != "active_slots"})
         with pytest.raises(ValueError, match="keys"):


### PR DESCRIPTION
Follow-up to #704. Restores the documented `Mapping[str, object]` deserialization contract instead of requiring an exact built-in dict, while retaining #704’s strict flat schema, exact string discriminators, resource formulas, and hostile-input safety. Mapping contents are copied once under ordinary-Exception normalization; valid immutable/custom mappings remain supported and hostile hooks cannot escape as arbitrary exceptions or execute repr.

Validation:
- `tests/test_feature_bank_router.py`: 42 passed
- scoped Ruff: clean
- strict source mypy: clean
- diff check: clean

No evidence source or artifact changes.