### PR TITLE
fix(multi-head): unify exact config and allocation contracts

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import functools
 import time
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax
@@ -103,6 +103,31 @@ _NUMPY_INTEGER_SCALAR_TYPES = frozenset(
         np.ulonglong,
     )
 )
+
+_INT32_MAX: int = 2**31 - 1
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+)
+
+
+def _require_hidden_width(name: str, value: object) -> int:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or actual_type not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}]")
+    number = int(cast(int, value))
+    if not 1 <= number <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}], got {value!r}")
+    return number
 
 # =============================================================================
 # Config / state
@@ -772,6 +797,13 @@ class CBPMultiHeadMLPLearner:
                 hidden-unit utility diagnostics.
         """
         self._n_heads = n_heads
+        if type(hidden_sizes) is not tuple:
+            raise ValueError(
+                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
+            )
+        hidden_sizes = tuple(
+            _require_hidden_width(f"hidden_sizes[{i}]", v) for i, v in enumerate(hidden_sizes)
+        )
         self._hidden_sizes = hidden_sizes
         self._cbp_config = cbp_config or ContinualBackpropConfig()
         self._sparsity = sparsity
@@ -859,7 +891,16 @@ class CBPMultiHeadMLPLearner:
 
         per_head_gl = config.pop("per_head_gamma_lamda", None)
         if per_head_gl is not None:
-            per_head_gl = tuple(per_head_gl)
+            if type(per_head_gl) is not list:
+                raise ValueError(
+                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
+                )
+            per_head_gl = tuple(
+                validated_float32_scalar(
+                    f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
+                )
+                for i, v in enumerate(per_head_gl)
+            )
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
@@ -868,9 +909,16 @@ class CBPMultiHeadMLPLearner:
             else TraceMode.ACCUMULATING
         )
 
+        raw_hidden = config.pop("hidden_sizes")
+        if type(raw_hidden) is not list:
+            raise ValueError(f"hidden_sizes must be a list, got {type(raw_hidden).__name__}")
+        hidden_sizes = tuple(
+            _require_hidden_width(f"hidden_sizes[{i}]", v) for i, v in enumerate(raw_hidden)
+        )
+
         return cls(
             n_heads=config.pop("n_heads"),
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=hidden_sizes,
             cbp_config=cbp_config,
             optimizer=optimizer,
             bounder=bounder,

--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import functools
 import time
-from typing import Any, cast
+from typing import Any
 
 import chex
 import jax
@@ -103,31 +103,34 @@ _NUMPY_INTEGER_SCALAR_TYPES = frozenset(
         np.ulonglong,
     )
 )
-
-_INT32_MAX: int = 2**31 - 1
-_ACTUAL_INT_TYPES: tuple[type, ...] = (
-    int,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_CBP_CONFIG_FIELDS = frozenset(
+    {"decay_rate", "replacement_rate", "maturity_threshold", "enabled"}
 )
-
-
-def _require_hidden_width(name: str, value: object) -> int:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}]")
-    number = int(cast(int, value))
-    if not 1 <= number <= _INT32_MAX:
-        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}], got {value!r}")
-    return number
+_CBP_MULTI_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "state_schema",
+        "cbp_config",
+        "n_heads",
+        "hidden_sizes",
+        "optimizer",
+        "bounder",
+        "normalizer",
+        "head_optimizer",
+        "sparsity",
+        "leaky_relu_slope",
+        "use_layer_norm",
+        "gamma",
+        "lamda",
+        "per_head_gamma_lamda",
+        "trace_mode",
+        "utility_decay",
+    }
+)
+_CBP_SINGLE_CONFIG_FIELDS = _CBP_MULTI_CONFIG_FIELDS - {
+    "n_heads",
+    "per_head_gamma_lamda",
+}
 
 # =============================================================================
 # Config / state
@@ -202,6 +205,10 @@ class ContinualBackpropConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> ContinualBackpropConfig:
         """Reconstruct from dict."""
+        if type(config) is not dict:
+            raise ValueError("ContinualBackpropConfig payload must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CBP_CONFIG_FIELDS:
+            raise ValueError("ContinualBackpropConfig fields do not match the schema")
         return cls(**config)
 
 
@@ -796,15 +803,6 @@ class CBPMultiHeadMLPLearner:
             utility_decay: EMA decay for the underlying MLP's native
                 hidden-unit utility diagnostics.
         """
-        self._n_heads = n_heads
-        if type(hidden_sizes) is not tuple:
-            raise ValueError(
-                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
-            )
-        hidden_sizes = tuple(
-            _require_hidden_width(f"hidden_sizes[{i}]", v) for i, v in enumerate(hidden_sizes)
-        )
-        self._hidden_sizes = hidden_sizes
         self._cbp_config = cbp_config or ContinualBackpropConfig()
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope
@@ -827,6 +825,8 @@ class CBPMultiHeadMLPLearner:
             trace_mode=trace_mode,
             utility_decay=utility_decay,
         )
+        self._n_heads = self._learner.n_heads
+        self._hidden_sizes = self._learner.hidden_sizes
 
     @property
     def learner(self) -> MultiHeadMLPLearner:
@@ -867,13 +867,27 @@ class CBPMultiHeadMLPLearner:
             optimizer_from_config,
         )
 
-        config = dict(config)
-        config.pop("type", None)
-        state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
-        if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(
-                f"Unsupported MultiHeadMLP state schema: {state_schema!r}"
-            )
+        if type(config) is not dict:
+            raise ValueError("CBPMultiHeadMLPLearner config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CBP_MULTI_CONFIG_FIELDS:
+            raise ValueError("CBPMultiHeadMLPLearner config fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "CBPMultiHeadMLPLearner":
+            raise ValueError("unexpected CBPMultiHeadMLPLearner config type")
+        if (
+            type(config["state_schema"]) is not str
+            or config["state_schema"] != MULTI_HEAD_MLP_STATE_SCHEMA
+        ):
+            raise ValueError("unsupported MultiHeadMLP state schema")
+        if type(config["hidden_sizes"]) is not list:
+            raise ValueError("hidden_sizes must be a list")
+        if (
+            config["per_head_gamma_lamda"] is not None
+            and type(config["per_head_gamma_lamda"]) is not list
+        ):
+            raise ValueError("per_head_gamma_lamda must be a list")
+        config = config.copy()
+        config.pop("type")
+        config.pop("state_schema")
         cbp_cfg_dict = config.pop("cbp_config")
         cbp_config = ContinualBackpropConfig.from_config(cbp_cfg_dict)
 
@@ -889,36 +903,19 @@ class CBPMultiHeadMLPLearner:
             optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
         )
 
-        per_head_gl = config.pop("per_head_gamma_lamda", None)
+        per_head_gl = config.pop("per_head_gamma_lamda")
         if per_head_gl is not None:
-            if type(per_head_gl) is not list:
-                raise ValueError(
-                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
-                )
-            per_head_gl = tuple(
-                validated_float32_scalar(
-                    f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
-                )
-                for i, v in enumerate(per_head_gl)
-            )
+            per_head_gl = tuple(per_head_gl)
 
-        trace_mode_str = config.pop("trace_mode", None)
-        trace_mode = (
-            TraceMode(trace_mode_str)
-            if trace_mode_str is not None
-            else TraceMode.ACCUMULATING
-        )
+        trace_mode_str = config.pop("trace_mode")
+        if type(trace_mode_str) is not str:
+            raise ValueError("trace_mode must be a string")
+        trace_mode = TraceMode(trace_mode_str)
 
         raw_hidden = config.pop("hidden_sizes")
-        if type(raw_hidden) is not list:
-            raise ValueError(f"hidden_sizes must be a list, got {type(raw_hidden).__name__}")
-        hidden_sizes = tuple(
-            _require_hidden_width(f"hidden_sizes[{i}]", v) for i, v in enumerate(raw_hidden)
-        )
-
         return cls(
             n_heads=config.pop("n_heads"),
-            hidden_sizes=hidden_sizes,
+            hidden_sizes=tuple(raw_hidden),
             cbp_config=cbp_config,
             optimizer=optimizer,
             bounder=bounder,
@@ -1156,9 +1153,16 @@ class CBPMLPLearner:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> CBPMLPLearner:
         """Reconstruct from a config dict produced by :meth:`to_config`."""
-        config = dict(config)
+        if type(config) is not dict:
+            raise ValueError("CBPMLPLearner config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CBP_SINGLE_CONFIG_FIELDS:
+            raise ValueError("CBPMLPLearner config fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "CBPMLPLearner":
+            raise ValueError("unexpected CBPMLPLearner config type")
+        config = config.copy()
         config["type"] = "CBPMultiHeadMLPLearner"
         config["n_heads"] = 1
+        config["per_head_gamma_lamda"] = None
         rebuilt = CBPMultiHeadMLPLearner.from_config(config)
         instance = cls.__new__(cls)
         instance._learner = rebuilt

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -18,13 +18,15 @@ Reference: Elsayed et al. 2024, "Streaming Deep Reinforcement Learning Finally W
 import dataclasses
 import functools
 import math
+import operator
 import time
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, UInt
 
@@ -63,6 +65,41 @@ MULTI_HEAD_LIFETIME_COUNTER_NBYTES = 12
 MULTI_HEAD_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
+
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    number = operator.index(cast(SupportsIndex, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return number
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -358,6 +395,15 @@ class MultiHeadMLPLearner:
                 gradient is nonzero, decaying the old trace elsewhere.
             utility_decay: EMA decay for hidden-unit utility diagnostics.
         """
+        n_heads = _require_int("n_heads", n_heads, minimum=1, maximum=_INT32_MAX)
+        if type(hidden_sizes) is not tuple:
+            raise ValueError(
+                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
+            )
+        hidden_sizes = tuple(
+            _require_int(f"hidden_sizes[{i}]", v, minimum=1, maximum=_INT32_MAX)
+            for i, v in enumerate(hidden_sizes)
+        )
         if not 0.0 <= utility_decay < 1.0:
             raise ValueError("utility_decay must be in [0, 1)")
 
@@ -499,16 +545,31 @@ class MultiHeadMLPLearner:
 
         per_head_gl = config.pop("per_head_gamma_lamda", None)
         if per_head_gl is not None:
-            per_head_gl = tuple(per_head_gl)
+            if type(per_head_gl) is not list:
+                raise ValueError(
+                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
+                )
+            per_head_gl = tuple(
+                validated_float32_scalar(
+                    f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
+                )
+                for i, v in enumerate(per_head_gl)
+            )
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
             TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
         )
 
+        raw_hidden = config.pop("hidden_sizes")
+        if type(raw_hidden) is not list:
+            raise ValueError(
+                f"hidden_sizes must be a list, got {type(raw_hidden).__name__}"
+            )
+
         return cls(
             n_heads=config.pop("n_heads"),
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=tuple(raw_hidden),
             optimizer=optimizer,
             bounder=bounder,
             normalizer=normalizer,
@@ -529,6 +590,9 @@ class MultiHeadMLPLearner:
             Initial state with sparse trunk weights, zero biases, and
             per-head output layers
         """
+        feature_dim = _require_int(
+            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+        )
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -65,6 +65,26 @@ MULTI_HEAD_LIFETIME_COUNTER_NBYTES = 12
 MULTI_HEAD_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
+_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "state_schema",
+        "n_heads",
+        "hidden_sizes",
+        "optimizer",
+        "bounder",
+        "normalizer",
+        "head_optimizer",
+        "sparsity",
+        "leaky_relu_slope",
+        "use_layer_norm",
+        "gamma",
+        "lamda",
+        "per_head_gamma_lamda",
+        "trace_mode",
+        "utility_decay",
+    }
+)
 
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -89,17 +109,24 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer, got {value!r}")
+        raise ValueError(f"{name} must be an integer")
     number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive, got {number}")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative, got {number}")
+        raise ValueError(f"{name} must be >= {minimum}, got {number}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}, got {number}")
     return number
+
+
+def _require_int32_product(name: str, left: int, right: int) -> int:
+    """Return a derived allocation count or reject it before array construction."""
+    if left > _INT32_MAX // right:
+        raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
+    return left * right
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -404,6 +431,21 @@ class MultiHeadMLPLearner:
             _require_int(f"hidden_sizes[{i}]", v, minimum=1, maximum=_INT32_MAX)
             for i, v in enumerate(hidden_sizes)
         )
+        for layer_index, (fan_in, fan_out) in enumerate(
+            zip(hidden_sizes, hidden_sizes[1:], strict=False)
+        ):
+            _require_int32_product(
+                f"hidden_layer[{layer_index}]_scalars",
+                fan_in,
+                fan_out,
+            )
+        _require_int32_product("per_head_metrics_scalars", n_heads, 3)
+        if hidden_sizes:
+            _require_int32_product("head_weight_scalars", n_heads, hidden_sizes[-1])
+        if per_head_gamma_lamda is not None and type(per_head_gamma_lamda) is not tuple:
+            raise ValueError(
+                "per_head_gamma_lamda must be an actual tuple when constructed directly"
+            )
         if not 0.0 <= utility_decay < 1.0:
             raise ValueError("utility_decay must be in [0, 1)")
 
@@ -468,6 +510,11 @@ class MultiHeadMLPLearner:
         return self._n_heads
 
     @property
+    def hidden_sizes(self) -> tuple[int, ...]:
+        """Canonical hidden-layer widths."""
+        return self._hidden_sizes
+
+    @property
     def normalizer(self) -> Normalizer[Any] | None:
         """The feature normalizer, or None if normalization is disabled."""
         return self._normalizer
@@ -523,13 +570,27 @@ class MultiHeadMLPLearner:
             optimizer_from_config,
         )
 
-        config = dict(config)
-        config.pop("type", None)
-        state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
-        if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(
-                f"Unsupported MultiHeadMLP state schema: {state_schema!r}"
-            )
+        if type(config) is not dict:
+            raise ValueError("MultiHeadMLPLearner config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CONFIG_FIELDS:
+            raise ValueError("MultiHeadMLPLearner config fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "MultiHeadMLPLearner":
+            raise ValueError("unexpected MultiHeadMLPLearner config type")
+        if (
+            type(config["state_schema"]) is not str
+            or config["state_schema"] != MULTI_HEAD_MLP_STATE_SCHEMA
+        ):
+            raise ValueError("unsupported MultiHeadMLP state schema")
+        if type(config["hidden_sizes"]) is not list:
+            raise ValueError("hidden_sizes must be a list")
+        if (
+            config["per_head_gamma_lamda"] is not None
+            and type(config["per_head_gamma_lamda"]) is not list
+        ):
+            raise ValueError("per_head_gamma_lamda must be a list")
+        config = config.copy()
+        config.pop("type")
+        config.pop("state_schema")
 
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)
@@ -543,29 +604,16 @@ class MultiHeadMLPLearner:
             optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
         )
 
-        per_head_gl = config.pop("per_head_gamma_lamda", None)
+        per_head_gl = config.pop("per_head_gamma_lamda")
         if per_head_gl is not None:
-            if type(per_head_gl) is not list:
-                raise ValueError(
-                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
-                )
-            per_head_gl = tuple(
-                validated_float32_scalar(
-                    f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
-                )
-                for i, v in enumerate(per_head_gl)
-            )
+            per_head_gl = tuple(per_head_gl)
 
-        trace_mode_str = config.pop("trace_mode", None)
-        trace_mode = (
-            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
-        )
+        trace_mode_str = config.pop("trace_mode")
+        if type(trace_mode_str) is not str:
+            raise ValueError("trace_mode must be a string")
+        trace_mode = TraceMode(trace_mode_str)
 
         raw_hidden = config.pop("hidden_sizes")
-        if type(raw_hidden) is not list:
-            raise ValueError(
-                f"hidden_sizes must be a list, got {type(raw_hidden).__name__}"
-            )
 
         return cls(
             n_heads=config.pop("n_heads"),
@@ -593,6 +641,12 @@ class MultiHeadMLPLearner:
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        if self._hidden_sizes:
+            _require_int32_product(
+                "input_layer_scalars", feature_dim, self._hidden_sizes[0]
+            )
+        else:
+            _require_int32_product("linear_head_weight_scalars", self._n_heads, feature_dim)
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -88,6 +88,66 @@ class TestInitCbpStateShapes:
         with pytest.raises(ValueError, match=r"^hidden_sizes\[0\]=1 does not match"):
             init_cbp_state(mlp_state, (1, 4), key=jr.key(1))
 
+    def test_wrapper_reuses_canonical_multi_head_dimensions(self):
+        learner = CBPMultiHeadMLPLearner(
+            n_heads=np.int32(2),  # type: ignore[arg-type]
+            hidden_sizes=(np.uint16(3),),  # type: ignore[arg-type]
+        )
+        assert type(learner.n_heads) is int
+        assert learner.n_heads == 2
+        assert learner.hidden_sizes == (3,)
+        assert type(learner.hidden_sizes[0]) is int
+
+    def test_wrapper_delegates_direct_tuple_and_feature_dimension_validation(self):
+        with pytest.raises(ValueError, match="hidden_sizes.*tuple"):
+            CBPMultiHeadMLPLearner(n_heads=1, hidden_sizes=[2])  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="per_head_gamma_lamda.*tuple"):
+            CBPMultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                per_head_gamma_lamda=[0.5],  # type: ignore[arg-type]
+            )
+
+        learner = CBPMultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+        with pytest.raises(ValueError, match="feature_dim"):
+            learner.init(True, jr.key(0))  # type: ignore[arg-type]
+
+    def test_wrapper_from_config_requires_json_lists(self):
+        learner = CBPMultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(),
+            per_head_gamma_lamda=(0.5,),
+        )
+        hidden_tuple = learner.to_config()
+        hidden_tuple["hidden_sizes"] = ()
+        with pytest.raises(ValueError, match="hidden_sizes.*list"):
+            CBPMultiHeadMLPLearner.from_config(hidden_tuple)
+
+        per_head_tuple = learner.to_config()
+        per_head_tuple["per_head_gamma_lamda"] = (0.5,)
+        with pytest.raises(ValueError, match="per_head_gamma_lamda.*list"):
+            CBPMultiHeadMLPLearner.from_config(per_head_tuple)
+
+    def test_wrapper_from_config_requires_exact_outer_schema(self):
+        config = CBPMultiHeadMLPLearner(n_heads=1, hidden_sizes=()).to_config()
+        for field, value in (
+            ("type", "WrongLearner"),
+            ("state_schema", "wrong-schema"),
+        ):
+            invalid = dict(config)
+            invalid[field] = value
+            with pytest.raises(ValueError):
+                CBPMultiHeadMLPLearner.from_config(invalid)
+
+        missing = dict(config)
+        missing.pop("optimizer")
+        with pytest.raises(ValueError, match="fields"):
+            CBPMultiHeadMLPLearner.from_config(missing)
+        unknown = dict(config)
+        unknown["unknown"] = 1
+        with pytest.raises(ValueError, match="fields"):
+            CBPMultiHeadMLPLearner.from_config(unknown)
+
 
 # =============================================================================
 # Utility update behaviour

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -29,6 +29,21 @@ from alberta_framework import (
     run_multi_head_learning_loop_batched,
 )
 
+
+class _HostileRepr:
+    def __repr__(self) -> str:
+        raise AssertionError("repr hook must not run")
+
+
+class _HostileTuple(tuple[object, ...]):
+    def __len__(self) -> int:
+        raise AssertionError("tuple subclass hook must not run")
+
+
+class _HostileDict(dict[str, object]):
+    def __iter__(self):
+        raise AssertionError("dict subclass hook must not run")
+
 # =============================================================================
 # Init tests
 # =============================================================================
@@ -43,6 +58,163 @@ class TestMultiHeadInit:
 
         with pytest.raises(ValueError, match="head_optimizer.*MLP"):
             MultiHeadMLPLearner(n_heads=2, head_optimizer=AutostepGTDLambda())
+
+    @pytest.mark.parametrize(
+        "value",
+        [True, np.bool_(True), 1.5, "2", 0, -1, 2**31],
+    )
+    def test_rejects_invalid_head_count_before_allocation(self, value: object):
+        with pytest.raises(ValueError, match="n_heads"):
+            MultiHeadMLPLearner(n_heads=value)  # type: ignore[arg-type]
+
+    def test_rejected_integer_spoof_does_not_run_repr(self):
+        with pytest.raises(ValueError, match="n_heads"):
+            MultiHeadMLPLearner(n_heads=_HostileRepr())  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "value",
+        [True, np.bool_(True), 1.5, "2", 0, -1, 2**31],
+    )
+    def test_rejects_invalid_hidden_width_before_allocation(self, value: object):
+        with pytest.raises(ValueError, match=r"hidden_sizes\[0\]"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(value,))  # type: ignore[arg-type]
+
+    def test_direct_sequence_boundaries_require_actual_tuples(self):
+        with pytest.raises(ValueError, match="hidden_sizes.*tuple"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=[2])  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="per_head_gamma_lamda.*tuple"):
+            MultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                per_head_gamma_lamda=[0.5],  # type: ignore[arg-type]
+            )
+        with pytest.raises(ValueError, match="per_head_gamma_lamda.*tuple"):
+            MultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                per_head_gamma_lamda=_HostileTuple((0.5,)),  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize(
+        "scalar_type",
+        [
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.longlong,
+            np.ulonglong,
+        ],
+    )
+    def test_numpy_integer_family_is_canonicalized(self, scalar_type: type):
+        learner = MultiHeadMLPLearner(
+            n_heads=scalar_type(2),  # type: ignore[call-arg,arg-type]
+            hidden_sizes=(scalar_type(3),),  # type: ignore[call-arg,arg-type]
+        )
+        config = learner.to_config()
+        assert type(learner.n_heads) is int
+        assert type(learner.hidden_sizes[0]) is int
+        assert type(config["n_heads"]) is int
+        assert type(config["hidden_sizes"][0]) is int
+
+    @pytest.mark.parametrize("feature_dim", [True, np.bool_(True), 1.5, "2", 0, -1, 2**31])
+    def test_init_rejects_invalid_feature_dimension_before_allocation(
+        self, feature_dim: object
+    ):
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+        with pytest.raises(ValueError, match="feature_dim"):
+            learner.init(feature_dim, jr.key(0))  # type: ignore[arg-type]
+
+    def test_from_config_requires_json_lists_and_delegates_element_validation(self):
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(),
+            per_head_gamma_lamda=(0.0, 0.5),
+        )
+        hidden_tuple = learner.to_config()
+        hidden_tuple["hidden_sizes"] = ()
+        with pytest.raises(ValueError, match="hidden_sizes.*list"):
+            MultiHeadMLPLearner.from_config(hidden_tuple)
+
+        per_head_tuple = learner.to_config()
+        per_head_tuple["per_head_gamma_lamda"] = (0.0, 0.5)
+        with pytest.raises(ValueError, match="per_head_gamma_lamda.*list"):
+            MultiHeadMLPLearner.from_config(per_head_tuple)
+
+        invalid_element = learner.to_config()
+        invalid_element["per_head_gamma_lamda"] = [0.0, True]
+        with pytest.raises(ValueError, match=r"per_head_gamma_lamda\[1\]"):
+            MultiHeadMLPLearner.from_config(invalid_element)
+
+    def test_from_config_requires_exact_outer_schema_before_dispatch(self):
+        config = MultiHeadMLPLearner(n_heads=1, hidden_sizes=()).to_config()
+        with pytest.raises(ValueError, match="actual dict"):
+            MultiHeadMLPLearner.from_config(_HostileDict(config))  # type: ignore[arg-type]
+
+        for field, value in (
+            ("type", "WrongLearner"),
+            ("type", _HostileRepr()),
+            ("state_schema", "wrong-schema"),
+            ("state_schema", _HostileRepr()),
+        ):
+            invalid = dict(config)
+            invalid[field] = value
+            with pytest.raises(ValueError):
+                MultiHeadMLPLearner.from_config(invalid)
+
+        missing = dict(config)
+        missing.pop("optimizer")
+        with pytest.raises(ValueError, match="fields"):
+            MultiHeadMLPLearner.from_config(missing)
+        unknown = dict(config)
+        unknown["unknown"] = 1
+        with pytest.raises(ValueError, match="fields"):
+            MultiHeadMLPLearner.from_config(unknown)
+
+    def test_constructor_rejects_derived_allocation_counts(self):
+        with pytest.raises(ValueError, match="hidden_layer"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(46_341, 46_341))
+        with pytest.raises(ValueError, match="head_weight"):
+            MultiHeadMLPLearner(n_heads=46_341, hidden_sizes=(46_341,))
+        with pytest.raises(ValueError, match="per_head_metrics"):
+            MultiHeadMLPLearner(n_heads=(2**31 - 1) // 3 + 1, hidden_sizes=())
+
+        boundary = MultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(1, 2**31 - 1),
+        )
+        assert boundary.hidden_sizes == (1, 2**31 - 1)
+
+    def test_init_preflights_derived_allocations_before_sparse_init(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        calls = 0
+
+        def forbidden_allocator(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise AssertionError("allocator reached")
+
+        monkeypatch.setattr(
+            "alberta_framework.core.multi_head_learner.sparse_init",
+            forbidden_allocator,
+        )
+        trunk = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(2,))
+        with pytest.raises(ValueError, match="input_layer"):
+            trunk.init(2**30, jr.key(0))
+        linear = MultiHeadMLPLearner(n_heads=2, hidden_sizes=())
+        with pytest.raises(ValueError, match="linear_head"):
+            linear.init(2**30, jr.key(0))
+        assert calls == 0
+
+        boundary = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(1,))
+        with pytest.raises(AssertionError, match="allocator reached"):
+            boundary.init(2**31 - 1, jr.key(0))
+        assert calls == 1
 
     def test_trunk_shapes_single_hidden(self):
         """Trunk with one hidden layer has correct shapes."""


### PR DESCRIPTION
Supersedes #691 and #695 (which replaced closed #684) while retaining both original byt61 commits and authorship.

This integrated repair centralizes dimension and per-head scalar validation in `MultiHeadMLPLearner`; the CBP wrapper consumes canonical shared dimensions and owns only its outer schema/container boundary. It adds:

- exact built-in/full NumPy integer admission without invoking hostile `__repr__` or index hooks;
- exact tuple boundaries for direct construction and exact JSON-list boundaries for deserialization;
- exact complete outer dict/type/schema validation before nested optimizer dispatch;
- pre-allocation signed-int32 checks for adjacent hidden matrices, aggregate head weights, per-head metrics, first-layer weights, and linear-head weights;
- CBP multi-head and single-head schema parity and canonical dimension storage;
- committed regressions for hostile subclasses/hooks, missing/unknown/wrong schema fields, NumPy canonicalization, empty linear trunks, derived pass/fail boundaries, and allocator-before-validation ordering.

Verification on the integrated branch: 221 focused tests passed (`multi_head_learner`, `continual_backprop`, `config_serialization`, `horde`); scoped Ruff passed; strict mypy passed; diff-check clean. No `outputs/**` files or registered evidence sources are changed.