### PR TITLE
fix(learning-signals): bind limits to actual operations

### DIFF
--- a/alberta_framework/core/_float32_scalars.py
+++ b/alberta_framework/core/_float32_scalars.py
@@ -35,6 +35,27 @@ def validated_float32_scalar(
             to a finite binary32, or leaves the declared domain either as the
             exact host value or once narrowed to binary32.
     """
+    stored, _, _ = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        positive=positive,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
+    return stored
+
+
+def validated_float32_scalar_with_ratio(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> tuple[float, int, int]:
+    """Validate once and also return the exact host numerator and denominator."""
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise ValueError(f"{name} must be a finite real number")
@@ -79,7 +100,8 @@ def validated_float32_scalar(
         raise ValueError(f"{name} must be {domain}")
     if not narrowed_in_domain(narrowed):
         raise ValueError(f"{name} must remain {domain} once narrowed to float32")
-    return real if type(real) is float else narrowed
+    stored = real if type(real) is float else narrowed
+    return stored, numerator, denominator
 
 
 def _describe_domain(
@@ -96,4 +118,4 @@ def _describe_domain(
     return "finite"
 
 
-__all__ = ["validated_float32_scalar"]
+__all__ = ["validated_float32_scalar", "validated_float32_scalar_with_ratio"]

--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -51,9 +51,13 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 
 _INT32_MAX = 2_147_483_647
+_FLOAT32_MAX = float.fromhex("0x1.fffffep+127")
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -78,6 +82,20 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _ratio_less(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] < right[0] * left[1]
+
+
+def _ratio_less_equal(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] <= right[0] * left[1]
+
+
+def _stable_mean(values: Array, *, axis: int | None = None) -> Array:
+    """Average bounded float32 values without overflowing the reduction sum."""
+    count = values.size if axis is None else values.shape[axis]
+    return jnp.sum(values / jnp.asarray(count, dtype=jnp.float32), axis=axis)
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -160,41 +178,38 @@ class LearningSignalEstimatorConfig:
                 maximum=_INT32_MAX - 1,
             ),
         )
-        positive_fields = (
-            "variance_floor",
-            "change_z_threshold",
-            "change_temperature",
-            "calibration_scale_floor",
-            "max_normalized_residual",
-            "max_input_magnitude",
-            "max_predicted_variance",
-            "max_observed_loss",
-        )
-        for field_name in positive_fields:
-            object.__setattr__(
-                self,
-                field_name,
-                validated_float32_scalar(
-                    field_name,
-                    getattr(self, field_name),
-                    positive=True,
-                ),
+        positive_values = {
+            field_name: validated_float32_scalar_with_ratio(
+                field_name, getattr(self, field_name), positive=True
             )
-        fast_loss_decay = validated_float32_scalar(
+            for field_name in (
+                "variance_floor",
+                "change_z_threshold",
+                "change_temperature",
+                "calibration_scale_floor",
+                "max_normalized_residual",
+                "max_input_magnitude",
+                "max_predicted_variance",
+                "max_observed_loss",
+            )
+        }
+        fast_loss_decay, fast_n, fast_d = validated_float32_scalar_with_ratio(
             "fast_loss_decay",
             self.fast_loss_decay,
             lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
-        slow_loss_decay = validated_float32_scalar(
+        slow_loss_decay, slow_n, slow_d = validated_float32_scalar_with_ratio(
             "slow_loss_decay",
             self.slow_loss_decay,
             lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
-        if fast_loss_decay >= slow_loss_decay:
+        if not _ratio_less((fast_n, fast_d), (slow_n, slow_d)) or not (
+            fast_loss_decay < slow_loss_decay
+        ):
             raise ValueError("fast_loss_decay must be smaller than slow_loss_decay")
         change_decay = validated_float32_scalar(
             "change_decay",
@@ -206,8 +221,45 @@ class LearningSignalEstimatorConfig:
         object.__setattr__(self, "fast_loss_decay", fast_loss_decay)
         object.__setattr__(self, "slow_loss_decay", slow_loss_decay)
         object.__setattr__(self, "change_decay", change_decay)
-        if self.variance_floor > self.max_predicted_variance:
+        for field_name, (stored, _, _) in positive_values.items():
+            object.__setattr__(self, field_name, stored)
+        _, variance_floor_n, variance_floor_d = positive_values["variance_floor"]
+        _, max_variance_n, max_variance_d = positive_values["max_predicted_variance"]
+        if not _ratio_less_equal(
+            (variance_floor_n, variance_floor_d),
+            (max_variance_n, max_variance_d),
+        ) or self.variance_floor > self.max_predicted_variance:
             raise ValueError("variance_floor must not exceed max_predicted_variance")
+        max_input, max_input_n, max_input_d = positive_values["max_input_magnitude"]
+        float32_max_n, float32_max_d = _FLOAT32_MAX.as_integer_ratio()
+        total_variance_left = (
+            4 * max_input_n * max_input_n * max_variance_d
+            + max_variance_n * max_input_d * max_input_d
+        ) * float32_max_d
+        total_variance_right = (
+            float32_max_n * max_input_d * max_input_d * max_variance_d
+        )
+        if total_variance_left > total_variance_right or (
+            4.0 * max_input * max_input + self.max_predicted_variance > _FLOAT32_MAX
+        ):
+            raise ValueError(
+                "four times max_input_magnitude squared plus "
+                "max_predicted_variance must fit float32"
+            )
+        max_residual, max_residual_n, max_residual_d = positive_values[
+            "max_normalized_residual"
+        ]
+        calibration_left = (
+            _INT32_MAX * max_residual_n * max_residual_n * float32_max_d
+        )
+        calibration_right = float32_max_n * max_residual_d * max_residual_d
+        if calibration_left > calibration_right or (
+            _INT32_MAX * max_residual * max_residual > _FLOAT32_MAX
+        ):
+            raise ValueError(
+                "max_normalized_residual squared times the counter lifetime "
+                "must fit float32"
+            )
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-compatible configuration."""
@@ -529,14 +581,14 @@ class LearningSignalEstimator:
         )
         safe_loss = jnp.clip(safe_loss, 0.0, self._config.max_observed_loss)
 
-        ensemble_mean = jnp.mean(safe_means, axis=0)
-        per_dimension_epistemic = jnp.mean(
+        ensemble_mean = _stable_mean(safe_means, axis=0)
+        per_dimension_epistemic = _stable_mean(
             jnp.square(safe_means - ensemble_mean[None, :]),
             axis=0,
         )
-        per_dimension_aleatoric = jnp.mean(safe_variances, axis=0)
-        epistemic_disagreement = jnp.mean(per_dimension_epistemic)
-        epistemic_surprise = jnp.mean(
+        per_dimension_aleatoric = _stable_mean(safe_variances, axis=0)
+        epistemic_disagreement = _stable_mean(per_dimension_epistemic)
+        epistemic_surprise = _stable_mean(
             per_dimension_epistemic
             / jnp.maximum(per_dimension_aleatoric, self._config.variance_floor)
         )
@@ -544,12 +596,14 @@ class LearningSignalEstimator:
             epistemic_surprise,
             self._config.max_normalized_residual,
         )
-        aleatoric_uncertainty = jnp.mean(per_dimension_aleatoric)
+        aleatoric_uncertainty = _stable_mean(per_dimension_aleatoric)
         total_variance = jnp.maximum(
             per_dimension_epistemic + per_dimension_aleatoric,
             self._config.variance_floor,
         )
-        normalized_residual = jnp.mean(jnp.square(safe_target - ensemble_mean) / total_variance)
+        normalized_residual = _stable_mean(
+            jnp.square(safe_target - ensemble_mean) / total_variance
+        )
         normalized_residual = jnp.minimum(
             normalized_residual,
             self._config.max_normalized_residual,

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from fractions import Fraction
 
 import chex
 import jax
@@ -556,3 +557,59 @@ def test_learning_signals_config_rejects_spoofed_scalar_and_schema_types() -> No
 
 class _DictSubclass(dict[str, object]):
     """A mapping subtype that must not reach deserialization hooks."""
+
+
+def test_learning_signal_cross_scalar_order_holds_before_and_after_narrowing() -> None:
+    below = Fraction(1, 2) - Fraction(1, 2**80)
+    above = Fraction(1, 2) + Fraction(1, 2**80)
+    with pytest.raises(ValueError, match="fast_loss_decay"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            fast_loss_decay=below,
+            slow_loss_decay=above,
+        )
+    with pytest.raises(ValueError, match="variance_floor"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            variance_floor=above,
+            max_predicted_variance=Fraction(1, 2),
+        )
+
+
+def test_learning_signal_bounds_cover_actual_worst_case_operations() -> None:
+    with pytest.raises(ValueError, match="four times max_input_magnitude"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            max_input_magnitude=float.fromhex("0x1.fffffep+62"),
+            max_predicted_variance=np.finfo(np.float32).max,
+        )
+    with pytest.raises(ValueError, match="counter lifetime"):
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            max_normalized_residual=1.0e20,
+        )
+
+
+def test_learning_signal_stable_reductions_remain_finite_at_legal_large_bounds() -> None:
+    estimator = LearningSignalEstimator(
+        LearningSignalEstimatorConfig(
+            ensemble_size=2,
+            target_dim=1,
+            max_input_magnitude=1.0e18,
+            max_predicted_variance=1.0,
+        )
+    )
+    state = estimator.init()
+    next_state, signals = estimator.observe(
+        state,
+        jnp.asarray([[-1.0e18], [1.0e18]], dtype=jnp.float32),
+        jnp.ones((2, 1), dtype=jnp.float32),
+        jnp.asarray([-1.0e18], dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert bool(jnp.isfinite(signals.epistemic_disagreement))
+    assert bool(jnp.isfinite(next_state.calibration_m2))


### PR DESCRIPTION
Supersedes conflicting #705 after a deeper review of its numerical formulas.

#705 correctly identified that cross-field relations must hold in both the exact host domain and float32 execution domain, but its proposed `M² + variance` bound did not cover the actual `(2M)² + variance` worst case and its residual cap did not cover int32-lifetime Welford M2 growth. This replacement:

- exposes a one-read shared float32 validator returning the exact ratio;
- enforces cross-field order in exact and narrowed domains;
- bounds `4*M² + max_variance` and `INT32_MAX*max_residual²`;
- uses divide-before-sum means so legal bounded arrays cannot overflow reduction sums;
- retains the full exact scalar/schema work already merged in #709.

Verification: 65 learning-signal/float32 tests, scoped Ruff, strict mypy on both sources, and diff check all pass. No outputs or evidence artifacts changed.