### PR TITLE
fix(multi-head): complete shared validation and allocation contracts

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -83,6 +83,7 @@ from alberta_framework.core.multi_head_learner import (
     MultiHeadMLPLearner,
     MultiHeadMLPState,
     MultiHeadMLPUpdateResult,
+    _require_config_sequence,
 )
 from alberta_framework.core.normalizers import Normalizer
 from alberta_framework.core.optimizers import Bounder
@@ -771,8 +772,6 @@ class CBPMultiHeadMLPLearner:
             utility_decay: EMA decay for the underlying MLP's native
                 hidden-unit utility diagnostics.
         """
-        self._n_heads = n_heads
-        self._hidden_sizes = hidden_sizes
         self._cbp_config = cbp_config or ContinualBackpropConfig()
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope
@@ -795,6 +794,8 @@ class CBPMultiHeadMLPLearner:
             trace_mode=trace_mode,
             utility_decay=utility_decay,
         )
+        self._n_heads = self._learner.n_heads
+        self._hidden_sizes = self._learner.hidden_sizes
 
     @property
     def learner(self) -> MultiHeadMLPLearner:
@@ -838,10 +839,8 @@ class CBPMultiHeadMLPLearner:
         config = dict(config)
         config.pop("type", None)
         state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
-        if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(
-                f"Unsupported MultiHeadMLP state schema: {state_schema!r}"
-            )
+        if type(state_schema) is not str or state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
+            raise ValueError("Unsupported MultiHeadMLP state schema")
         cbp_cfg_dict = config.pop("cbp_config")
         cbp_config = ContinualBackpropConfig.from_config(cbp_cfg_dict)
 
@@ -859,7 +858,9 @@ class CBPMultiHeadMLPLearner:
 
         per_head_gl = config.pop("per_head_gamma_lamda", None)
         if per_head_gl is not None:
-            per_head_gl = tuple(per_head_gl)
+            per_head_gl = tuple(
+                _require_config_sequence("per_head_gamma_lamda", per_head_gl)
+            )
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
@@ -868,9 +869,13 @@ class CBPMultiHeadMLPLearner:
             else TraceMode.ACCUMULATING
         )
 
+        hidden_sizes = tuple(
+            _require_config_sequence("hidden_sizes", config.pop("hidden_sizes"))
+        )
+
         return cls(
             n_heads=config.pop("n_heads"),
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=hidden_sizes,  # type: ignore[arg-type]
             cbp_config=cbp_config,
             optimizer=optimizer,
             bounder=bounder,

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -18,13 +18,15 @@ Reference: Elsayed et al. 2024, "Streaming Deep Reinforcement Learning Finally W
 import dataclasses
 import functools
 import math
+import operator
 import time
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, UInt
 
@@ -63,6 +65,41 @@ MULTI_HEAD_LIFETIME_COUNTER_NBYTES = 12
 MULTI_HEAD_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
+
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if minimum is not None and number < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive")
+        if minimum == 0:
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return number
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -358,6 +395,22 @@ class MultiHeadMLPLearner:
                 gradient is nonzero, decaying the old trace elsewhere.
             utility_decay: EMA decay for hidden-unit utility diagnostics.
         """
+        n_heads = _require_int("n_heads", n_heads, minimum=1, maximum=_INT32_MAX)
+        if type(hidden_sizes) is not tuple:
+            raise ValueError(
+                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
+            )
+        hidden_sizes = tuple(
+            _require_int(f"hidden_sizes[{i}]", v, minimum=1, maximum=_INT32_MAX)
+            for i, v in enumerate(hidden_sizes)
+        )
+        for i in range(len(hidden_sizes) - 1):
+            if hidden_sizes[i] * hidden_sizes[i + 1] > _INT32_MAX:
+                raise ValueError(
+                    f"hidden_sizes[{i}] * hidden_sizes[{i+1}] must be <= {_INT32_MAX}"
+                )
+        if hidden_sizes and n_heads * hidden_sizes[-1] > _INT32_MAX:
+            raise ValueError(f"n_heads * hidden_sizes[-1] must be <= {_INT32_MAX}")
         if not 0.0 <= utility_decay < 1.0:
             raise ValueError("utility_decay must be in [0, 1)")
 
@@ -481,9 +534,7 @@ class MultiHeadMLPLearner:
         config.pop("type", None)
         state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
         if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(
-                f"Unsupported MultiHeadMLP state schema: {state_schema!r}"
-            )
+            raise ValueError("Unsupported MultiHeadMLP state schema")
 
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)
@@ -499,16 +550,31 @@ class MultiHeadMLPLearner:
 
         per_head_gl = config.pop("per_head_gamma_lamda", None)
         if per_head_gl is not None:
-            per_head_gl = tuple(per_head_gl)
+            if type(per_head_gl) is not list:
+                raise ValueError(
+                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
+                )
+            per_head_gl = tuple(
+                validated_float32_scalar(
+                    f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
+                )
+                for i, v in enumerate(per_head_gl)
+            )
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
             TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
         )
 
+        raw_hidden = config.pop("hidden_sizes")
+        if type(raw_hidden) is not list:
+            raise ValueError(
+                f"hidden_sizes must be a list, got {type(raw_hidden).__name__}"
+            )
+
         return cls(
             n_heads=config.pop("n_heads"),
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=tuple(raw_hidden),
             optimizer=optimizer,
             bounder=bounder,
             normalizer=normalizer,
@@ -529,6 +595,16 @@ class MultiHeadMLPLearner:
             Initial state with sparse trunk weights, zero biases, and
             per-head output layers
         """
+        feature_dim = _require_int(
+            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
+        )
+        if self._hidden_sizes:
+            if feature_dim * self._hidden_sizes[0] > _INT32_MAX:
+                raise ValueError(
+                    f"feature_dim * hidden_sizes[0] must be <= {_INT32_MAX}"
+                )
+        elif feature_dim * self._n_heads > _INT32_MAX:
+            raise ValueError(f"feature_dim * n_heads must be <= {_INT32_MAX}")
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -102,6 +102,45 @@ def _require_int(
     return number
 
 
+def _require_config_sequence(
+    name: str,
+    value: object,
+) -> list[object] | tuple[object, ...]:
+    """Accept only the two historical JSON/Python sequence representations."""
+    if type(value) not in (list, tuple):
+        raise ValueError(f"{name} must be an actual list or tuple")
+    return cast(list[object] | tuple[object, ...], value)
+
+
+def _require_derived_int32(name: str, value: int) -> int:
+    """Validate one exact derived JAX allocation/resource count."""
+    if not 1 <= value <= _INT32_MAX:
+        raise ValueError(f"{name} must be in [1, {_INT32_MAX}]")
+    return value
+
+
+def _validate_direct_state_resources(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> None:
+    """Preflight arrays allocated directly by :meth:`init` without allocating them."""
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_parameter_count = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_parameter_count = n_heads * (final_width + 1)
+    parameter_count = trunk_parameter_count + head_parameter_count
+    # Parameters and traces have the same shapes; utilities carry one scalar
+    # per hidden unit; the lifetime counters carry three 32-bit words.
+    state_scalars = 2 * parameter_count + sum(hidden_sizes) + 3
+    _require_derived_int32("parameter_count", parameter_count)
+    _require_derived_int32("state_scalars", state_scalars)
+    _require_derived_int32("state_bytes", 4 * state_scalars)
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -397,20 +436,15 @@ class MultiHeadMLPLearner:
         """
         n_heads = _require_int("n_heads", n_heads, minimum=1, maximum=_INT32_MAX)
         if type(hidden_sizes) is not tuple:
-            raise ValueError(
-                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
-            )
+            raise ValueError("hidden_sizes must be an actual tuple")
         hidden_sizes = tuple(
             _require_int(f"hidden_sizes[{i}]", v, minimum=1, maximum=_INT32_MAX)
             for i, v in enumerate(hidden_sizes)
         )
-        for i in range(len(hidden_sizes) - 1):
-            if hidden_sizes[i] * hidden_sizes[i + 1] > _INT32_MAX:
-                raise ValueError(
-                    f"hidden_sizes[{i}] * hidden_sizes[{i+1}] must be <= {_INT32_MAX}"
-                )
-        if hidden_sizes and n_heads * hidden_sizes[-1] > _INT32_MAX:
-            raise ValueError(f"n_heads * hidden_sizes[-1] must be <= {_INT32_MAX}")
+        # A feature width of one is the smallest legal init. This constructor
+        # preflight therefore rejects configurations whose direct state cannot
+        # fit the allocation contract for any legal input width.
+        _validate_direct_state_resources(n_heads, hidden_sizes, feature_dim=1)
         if not 0.0 <= utility_decay < 1.0:
             raise ValueError("utility_decay must be in [0, 1)")
 
@@ -454,6 +488,8 @@ class MultiHeadMLPLearner:
             )
             raise ValueError(msg)
         if per_head_gamma_lamda is not None:
+            if type(per_head_gamma_lamda) is not tuple:
+                raise ValueError("per_head_gamma_lamda must be an actual tuple")
             if len(per_head_gamma_lamda) != self._n_heads:
                 raise ValueError(
                     f"per_head_gamma_lamda must have length n_heads ({self._n_heads}), "
@@ -473,6 +509,11 @@ class MultiHeadMLPLearner:
     def n_heads(self) -> int:
         """Number of prediction heads."""
         return self._n_heads
+
+    @property
+    def hidden_sizes(self) -> tuple[int, ...]:
+        """Canonical shared-trunk widths."""
+        return self._hidden_sizes
 
     @property
     def normalizer(self) -> Normalizer[Any] | None:
@@ -533,7 +574,7 @@ class MultiHeadMLPLearner:
         config = dict(config)
         config.pop("type", None)
         state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
-        if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
+        if type(state_schema) is not str or state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
             raise ValueError("Unsupported MultiHeadMLP state schema")
 
         optimizer = optimizer_from_config(config.pop("optimizer"))
@@ -550,15 +591,14 @@ class MultiHeadMLPLearner:
 
         per_head_gl = config.pop("per_head_gamma_lamda", None)
         if per_head_gl is not None:
-            if type(per_head_gl) is not list:
-                raise ValueError(
-                    f"per_head_gamma_lamda must be a list, got {type(per_head_gl).__name__}"
-                )
+            raw_per_head_gl = _require_config_sequence(
+                "per_head_gamma_lamda", per_head_gl
+            )
             per_head_gl = tuple(
                 validated_float32_scalar(
                     f"per_head_gamma_lamda[{i}]", v, lower=0.0, upper=1.0
                 )
-                for i, v in enumerate(per_head_gl)
+                for i, v in enumerate(raw_per_head_gl)
             )
 
         trace_mode_str = config.pop("trace_mode", None)
@@ -566,11 +606,9 @@ class MultiHeadMLPLearner:
             TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
         )
 
-        raw_hidden = config.pop("hidden_sizes")
-        if type(raw_hidden) is not list:
-            raise ValueError(
-                f"hidden_sizes must be a list, got {type(raw_hidden).__name__}"
-            )
+        raw_hidden = _require_config_sequence(
+            "hidden_sizes", config.pop("hidden_sizes")
+        )
 
         return cls(
             n_heads=config.pop("n_heads"),
@@ -598,13 +636,7 @@ class MultiHeadMLPLearner:
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
-        if self._hidden_sizes:
-            if feature_dim * self._hidden_sizes[0] > _INT32_MAX:
-                raise ValueError(
-                    f"feature_dim * hidden_sizes[0] must be <= {_INT32_MAX}"
-                )
-        elif feature_dim * self._n_heads > _INT32_MAX:
-            raise ValueError(f"feature_dim * n_heads must be <= {_INT32_MAX}")
+        _validate_direct_state_resources(self._n_heads, self._hidden_sizes, feature_dim)
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -810,3 +810,36 @@ class TestConfigRoundtrip:
         rebuilt = CBPMultiHeadMLPLearner.from_config(cfg)
         cfg2 = rebuilt.to_config()
         assert cfg2 == cfg
+
+    def test_wrapper_reuses_shared_integer_and_sequence_contracts(self) -> None:
+        learner = CBPMultiHeadMLPLearner(
+            n_heads=np.uint16(2),
+            hidden_sizes=(np.int32(4),),
+            per_head_gamma_lamda=(0.25, 0.5),
+        )
+        assert learner.n_heads == 2
+        assert learner.hidden_sizes == (4,)
+        assert type(learner.n_heads) is int
+        assert type(learner.hidden_sizes[0]) is int
+
+        payload = learner.to_config()
+        for sequence_type in (list, tuple):
+            candidate = dict(payload)
+            candidate["hidden_sizes"] = sequence_type(payload["hidden_sizes"])
+            candidate["per_head_gamma_lamda"] = sequence_type(
+                payload["per_head_gamma_lamda"]
+            )
+            assert CBPMultiHeadMLPLearner.from_config(candidate).to_config() == payload
+
+        class SequenceSpoof:
+            def __iter__(self):
+                raise AssertionError("iteration hook must not run")
+
+            def __repr__(self) -> str:
+                raise AssertionError("repr hook must not run")
+
+        for field in ("hidden_sizes", "per_head_gamma_lamda"):
+            candidate = dict(payload)
+            candidate[field] = SequenceSpoof()
+            with pytest.raises(ValueError, match=field):
+                CBPMultiHeadMLPLearner.from_config(candidate)

--- a/tests/test_multi_head_learner_validation.py
+++ b/tests/test_multi_head_learner_validation.py
@@ -1,0 +1,189 @@
+"""Committed regressions for MultiHeadMLPLearner fail-closed validation."""
+
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.multi_head_learner import MultiHeadMLPLearner
+
+_INT32_MAX = 2**31 - 1
+
+
+def test_accepts_numpy_int_types():
+    for typ in (
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ):
+        learner = MultiHeadMLPLearner(n_heads=typ(2), hidden_sizes=(typ(4),))
+        assert learner.n_heads == 2
+        state = learner.init(feature_dim=typ(3), key=jr.key(0))
+        assert state is not None
+
+
+def test_rejects_bool_and_np_bool():
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=True)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=np.bool_(True))
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(True,))
+
+
+def test_rejects_float_str_nan_inf():
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2.0)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads="2")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=float("nan"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=float("inf"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(1.5,))  # type: ignore[arg-type]
+
+
+def test_rejects_hostile_subclass():
+    class EvilInt(int):
+        def __repr__(self):
+            raise AssertionError("hostile repr must not be invoked")
+
+    with pytest.raises(ValueError) as exc:
+        MultiHeadMLPLearner(n_heads=EvilInt(2))
+    assert "EvilInt" not in str(exc.value)
+
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(EvilInt(4),))
+
+
+def test_hostile_repr_not_interpolated_for_int():
+    class Hostile:
+        def __index__(self):
+            return 2
+
+        def __repr__(self):
+            raise AssertionError("repr escape")
+
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=Hostile())  # type: ignore[arg-type]
+
+
+def test_rejects_out_of_bounds():
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=0)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=-1)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=_INT32_MAX + 1)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2**60)
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(0,))
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(2**60,))
+
+
+def test_hidden_sizes_exact_tuple_guard():
+    with pytest.raises(ValueError, match="hidden_sizes must be an actual tuple"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=[4, 4])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes must be an actual tuple"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes="4")  # type: ignore[arg-type]
+    # valid tuple passes
+    learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(4, 4))
+    assert learner._hidden_sizes == (4, 4)
+    # linear baseline empty tuple preserved
+    linear = MultiHeadMLPLearner(n_heads=2, hidden_sizes=())
+    assert linear._hidden_sizes == ()
+    state = linear.init(feature_dim=4, key=jr.key(0))
+    assert state.trunk_params.weights == ()
+
+
+def test_from_config_exact_list_guard():
+    base = {
+        "type": "MultiHeadMLPLearner",
+        "n_heads": 2,
+        "hidden_sizes": (4, 4),  # tuple not list -> should fail
+        "optimizer": {"type": "LMS", "step_size": 1.0},
+        "sparsity": 0.9,
+        "leaky_relu_slope": 0.01,
+        "use_layer_norm": True,
+        "gamma": 0.0,
+        "lamda": 0.0,
+        "trace_mode": "accumulating",
+        "utility_decay": 0.99,
+    }
+    with pytest.raises(ValueError, match="hidden_sizes must be a list"):
+        MultiHeadMLPLearner.from_config(dict(base))
+    # correct list passes
+    base["hidden_sizes"] = [4, 4]
+    learner = MultiHeadMLPLearner.from_config(dict(base))
+    assert learner._hidden_sizes == (4, 4)
+
+
+def test_derived_hidden_hidden_overflow():
+    with pytest.raises(ValueError, match=r"hidden_sizes\[0\] \* hidden_sizes\[1\]"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(50000, 50000))
+
+
+def test_derived_n_heads_hidden_overflow():
+    with pytest.raises(ValueError, match=r"n_heads \* hidden_sizes\[-1\]"):
+        MultiHeadMLPLearner(n_heads=50000, hidden_sizes=(50000,))
+
+
+def test_derived_feature_dim_hidden_overflow():
+    learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(50000,))
+    with pytest.raises(ValueError, match=r"feature_dim \* hidden_sizes\[0\]"):
+        learner.init(feature_dim=50000, key=jr.key(0))
+
+
+def test_derived_feature_dim_n_heads_overflow_linear():
+    learner = MultiHeadMLPLearner(n_heads=50000, hidden_sizes=())
+    with pytest.raises(ValueError, match=r"feature_dim \* n_heads"):
+        learner.init(feature_dim=50000, key=jr.key(0))
+
+
+def test_valid_derived_within_bounds():
+    learner = MultiHeadMLPLearner(n_heads=4, hidden_sizes=(8, 8))
+    state = learner.init(feature_dim=8, key=jr.key(1))
+    assert state is not None
+    # linear baseline within bounds
+    lin = MultiHeadMLPLearner(n_heads=4, hidden_sizes=())
+    s2 = lin.init(feature_dim=8, key=jr.key(2))
+    assert s2 is not None
+
+
+def test_per_head_decay_validated():
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(
+            n_heads=2, hidden_sizes=(), per_head_gamma_lamda=(True, 0.5)  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(
+            n_heads=2, hidden_sizes=(), per_head_gamma_lamda=(float("nan"), 0.5)
+        )
+    with pytest.raises(ValueError):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), per_head_gamma_lamda=(1.5, 0.5))
+    # from_config per_head must be list not tuple
+    base = {
+        "type": "MultiHeadMLPLearner",
+        "n_heads": 2,
+        "hidden_sizes": [],
+        "optimizer": {"type": "LMS", "step_size": 1.0},
+        "per_head_gamma_lamda": (0.5, 0.5),  # tuple not list
+        "sparsity": 0.9,
+        "leaky_relu_slope": 0.01,
+        "use_layer_norm": True,
+        "gamma": 0.0,
+        "lamda": 0.0,
+        "trace_mode": "accumulating",
+        "utility_decay": 0.99,
+    }
+    with pytest.raises(ValueError, match="per_head_gamma_lamda must be a list"):
+        MultiHeadMLPLearner.from_config(dict(base))

--- a/tests/test_multi_head_learner_validation.py
+++ b/tests/test_multi_head_learner_validation.py
@@ -1,5 +1,7 @@
 """Committed regressions for MultiHeadMLPLearner fail-closed validation."""
 
+import jax
+import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import pytest
@@ -10,20 +12,18 @@ _INT32_MAX = 2**31 - 1
 
 
 def test_accepts_numpy_int_types():
-    for typ in (
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    ):
+    integer_types = tuple(
+        dict.fromkeys(
+            np.dtype(code).type
+            for code in ("b", "h", "i", "l", "q", "B", "H", "I", "L", "Q", "p", "P")
+        )
+    )
+    for typ in integer_types:
         learner = MultiHeadMLPLearner(n_heads=typ(2), hidden_sizes=(typ(4),))
         assert learner.n_heads == 2
+        assert learner.hidden_sizes == (4,)
+        assert type(learner.n_heads) is int
+        assert type(learner.hidden_sizes[0]) is int
         state = learner.init(feature_dim=typ(3), key=jr.key(0))
         assert state is not None
 
@@ -105,11 +105,11 @@ def test_hidden_sizes_exact_tuple_guard():
     assert state.trunk_params.weights == ()
 
 
-def test_from_config_exact_list_guard():
+def test_from_config_accepts_exact_list_or_tuple_without_arbitrary_coercion():
     base = {
         "type": "MultiHeadMLPLearner",
         "n_heads": 2,
-        "hidden_sizes": (4, 4),  # tuple not list -> should fail
+        "hidden_sizes": [4, 4],
         "optimizer": {"type": "LMS", "step_size": 1.0},
         "sparsity": 0.9,
         "leaky_relu_slope": 0.01,
@@ -119,34 +119,52 @@ def test_from_config_exact_list_guard():
         "trace_mode": "accumulating",
         "utility_decay": 0.99,
     }
-    with pytest.raises(ValueError, match="hidden_sizes must be a list"):
-        MultiHeadMLPLearner.from_config(dict(base))
-    # correct list passes
-    base["hidden_sizes"] = [4, 4]
-    learner = MultiHeadMLPLearner.from_config(dict(base))
-    assert learner._hidden_sizes == (4, 4)
+    for sequence_type in (list, tuple):
+        base["hidden_sizes"] = sequence_type((4, 4))
+        learner = MultiHeadMLPLearner.from_config(dict(base))
+        assert learner.hidden_sizes == (4, 4)
+
+    class SequenceSpoof:
+        def __iter__(self):
+            raise AssertionError("iteration hook must not run")
+
+        def __repr__(self):
+            raise AssertionError("repr hook must not run")
+
+    for invalid in ("44", SequenceSpoof()):
+        base["hidden_sizes"] = invalid
+        with pytest.raises(ValueError, match="hidden_sizes"):
+            MultiHeadMLPLearner.from_config(dict(base))
 
 
 def test_derived_hidden_hidden_overflow():
-    with pytest.raises(ValueError, match=r"hidden_sizes\[0\] \* hidden_sizes\[1\]"):
+    with pytest.raises(ValueError, match="parameter_count"):
         MultiHeadMLPLearner(n_heads=2, hidden_sizes=(50000, 50000))
 
 
 def test_derived_n_heads_hidden_overflow():
-    with pytest.raises(ValueError, match=r"n_heads \* hidden_sizes\[-1\]"):
+    with pytest.raises(ValueError, match="parameter_count"):
         MultiHeadMLPLearner(n_heads=50000, hidden_sizes=(50000,))
 
 
 def test_derived_feature_dim_hidden_overflow():
     learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(50000,))
-    with pytest.raises(ValueError, match=r"feature_dim \* hidden_sizes\[0\]"):
+    with pytest.raises(ValueError, match="parameter_count"):
         learner.init(feature_dim=50000, key=jr.key(0))
 
 
 def test_derived_feature_dim_n_heads_overflow_linear():
     learner = MultiHeadMLPLearner(n_heads=50000, hidden_sizes=())
-    with pytest.raises(ValueError, match=r"feature_dim \* n_heads"):
+    with pytest.raises(ValueError, match="parameter_count"):
         learner.init(feature_dim=50000, key=jr.key(0))
+
+
+def test_derived_resource_bytes_overflow_before_allocation():
+    with pytest.raises(ValueError, match="state_bytes"):
+        MultiHeadMLPLearner(n_heads=134_217_728, hidden_sizes=())
+    learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+    with pytest.raises(ValueError, match="state_bytes"):
+        learner.init(feature_dim=300_000_000, key=jr.key(0))
 
 
 def test_valid_derived_within_bounds():
@@ -157,6 +175,9 @@ def test_valid_derived_within_bounds():
     lin = MultiHeadMLPLearner(n_heads=4, hidden_sizes=())
     s2 = lin.init(feature_dim=8, key=jr.key(2))
     assert s2 is not None
+    prediction = jax.jit(lin.predict)(s2, jnp.ones((8,), dtype=jnp.float32))
+    assert prediction.shape == (4,)
+    assert bool(jnp.all(jnp.isfinite(prediction)))
 
 
 def test_per_head_decay_validated():
@@ -170,13 +191,13 @@ def test_per_head_decay_validated():
         )
     with pytest.raises(ValueError):
         MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), per_head_gamma_lamda=(1.5, 0.5))
-    # from_config per_head must be list not tuple
+    # Historical JSON lists and in-process tuples are both accepted.
     base = {
         "type": "MultiHeadMLPLearner",
         "n_heads": 2,
         "hidden_sizes": [],
         "optimizer": {"type": "LMS", "step_size": 1.0},
-        "per_head_gamma_lamda": (0.5, 0.5),  # tuple not list
+        "per_head_gamma_lamda": [0.5, 0.5],
         "sparsity": 0.9,
         "leaky_relu_slope": 0.01,
         "use_layer_norm": True,
@@ -185,5 +206,41 @@ def test_per_head_decay_validated():
         "trace_mode": "accumulating",
         "utility_decay": 0.99,
     }
-    with pytest.raises(ValueError, match="per_head_gamma_lamda must be a list"):
+    for sequence_type in (list, tuple):
+        base["per_head_gamma_lamda"] = sequence_type((0.5, 0.5))
+        restored = MultiHeadMLPLearner.from_config(dict(base))
+        assert restored.to_config()["per_head_gamma_lamda"] == [0.5, 0.5]
+
+    class SequenceSpoof:
+        def __iter__(self):
+            raise AssertionError("iteration hook must not run")
+
+        def __repr__(self):
+            raise AssertionError("repr hook must not run")
+
+    base["per_head_gamma_lamda"] = SequenceSpoof()
+    with pytest.raises(ValueError, match="per_head_gamma_lamda"):
         MultiHeadMLPLearner.from_config(dict(base))
+
+
+def test_from_config_preserves_permissive_outer_schema_compatibility():
+    payload = MultiHeadMLPLearner(n_heads=2, hidden_sizes=()).to_config()
+
+    class DictSubclass(dict[str, object]):
+        pass
+
+    payload["type"] = object()
+    restored = MultiHeadMLPLearner.from_config(DictSubclass(payload))
+    assert restored.n_heads == 2
+    assert restored.hidden_sizes == ()
+
+    class SchemaSpoof:
+        def __eq__(self, other: object) -> bool:
+            raise AssertionError("equality hook must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    payload["state_schema"] = SchemaSpoof()
+    with pytest.raises(ValueError, match="state schema"):
+        MultiHeadMLPLearner.from_config(payload)


### PR DESCRIPTION
Supersedes #691 and #695 while preserving the latest contributor-authored #691 commit as the first commit in this branch.

The shared `MultiHeadMLPLearner` is the canonical validation boundary. This replacement:

- accepts and canonicalizes built-in integers plus every NumPy signed/unsigned integer dtype family for `n_heads`, every hidden width, and `init(feature_dim)` while rejecting booleans, subclasses, and class/index/repr spoofs without invoking hostile hooks;
- preserves the supported `hidden_sizes=()` linear baseline and verifies its initialized prediction path under JIT;
- preflights exact parameter, directly allocated state-scalar, and state-byte counts in Python before any JAX allocation, both at construction and once `feature_dim` is known;
- retains exact host plus float32-sink validation for every per-head decay and requires actual tuples at constructors;
- preserves historical deserialization compatibility: exact JSON lists and exact in-process tuples are accepted for `hidden_sizes` and `per_head_gamma_lamda`, while strings, generators, subclasses, and spoofed iterables are rejected without iteration;
- deliberately keeps the permissive outer mapping/type-marker behavior; it does not add an unrelated exact-dict/full-field schema requirement;
- makes `CBPMultiHeadMLPLearner` reuse the shared canonical values and sequence guard, eliminating the need for #695's duplicate wrapper validation.

Verification on final head `58527c5`:

- focused MultiHead + CBP suites: 144 passed in 86.82s
- validation-only regressions: 16 passed
- adjacent config/Horde/SARSA/forward-view suites: 131 passed
- `ruff check .`: clean
- strict `mypy`: clean (168 source files)
- `git diff --check`: clean

Neither changed source file is registered in the five-claim evidence manifest, and no `outputs/**` artifacts are modified. Historical development snapshots that inventory these files remain historical; this engineering change creates no evidence or promotion.
