### PR TITLE
fix(option-search): harden search control configuration integer validation

### DIFF
--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -22,12 +22,14 @@ a universal learning-value score or a learned search controller.
 from __future__ import annotations
 
 import dataclasses
+import operator
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
@@ -48,6 +50,30 @@ _CONFIG_TYPE = "OptionSearchControlConfig"
 _MAX_BACKUP_BUDGET = 4_096
 _MAX_CANDIDATE_DIAGNOSTIC_SLOTS = 262_144
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclasses.dataclass(frozen=True)
@@ -58,20 +84,26 @@ class OptionSearchControlConfig:
     min_model_completions: int = 1
 
     def __post_init__(self) -> None:
-        if (
-            type(self.backup_budget) is not int
-            or not 1 <= self.backup_budget <= _MAX_BACKUP_BUDGET
-        ):
-            raise ValueError(
-                f"backup_budget must be a strict integer in [1, {_MAX_BACKUP_BUDGET}]"
-            )
-        if (
-            type(self.min_model_completions) is not int
-            or not 1 <= self.min_model_completions <= 2_147_483_647
-        ):
-            raise ValueError(
-                "min_model_completions must be a strict positive int32-compatible integer"
-            )
+        object.__setattr__(
+            self,
+            "backup_budget",
+            _require_int32(
+                "backup_budget",
+                self.backup_budget,
+                minimum=1,
+                maximum=_MAX_BACKUP_BUDGET,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_model_completions",
+            _require_int32(
+                "min_model_completions",
+                self.min_model_completions,
+                minimum=1,
+                maximum=_INT32_MAX,
+            ),
+        )
 
     def to_config(self) -> dict[str, object]:
         """Return the exact JSON-compatible L0 configuration."""
@@ -80,9 +112,7 @@ class OptionSearchControlConfig:
             "schema": OPTION_SEARCH_CONTROL_CONFIG_SCHEMA,
             "type": _CONFIG_TYPE,
             "mechanism_status": OPTION_SEARCH_CONTROL_MECHANISM_STATUS,
-            "scientific_promotion_allowed": (
-                OPTION_SEARCH_CONTROL_SCIENTIFIC_PROMOTION_ALLOWED
-            ),
+            "scientific_promotion_allowed": (OPTION_SEARCH_CONTROL_SCIENTIFIC_PROMOTION_ALLOWED),
             "backup_budget": self.backup_budget,
             "min_model_completions": self.min_model_completions,
         }
@@ -109,19 +139,14 @@ class OptionSearchControlConfig:
             raise ValueError("unexpected option search control config schema")
         if payload.pop("type") != _CONFIG_TYPE:
             raise ValueError("unexpected option search control config type")
-        if (
-            payload.pop("mechanism_status")
-            != OPTION_SEARCH_CONTROL_MECHANISM_STATUS
-        ):
+        if payload.pop("mechanism_status") != OPTION_SEARCH_CONTROL_MECHANISM_STATUS:
             raise ValueError("option search control must remain mechanism-only")
         if payload.pop("scientific_promotion_allowed") is not False:
             raise ValueError("option search control config cannot claim promotion")
         if type(payload["backup_budget"]) is not int:
             raise ValueError("serialized backup_budget must be a JSON integer")
         if type(payload["min_model_completions"]) is not int:
-            raise ValueError(
-                "serialized min_model_completions must be a JSON integer"
-            )
+            raise ValueError("serialized min_model_completions must be a JSON integer")
         return cls(**cast(dict[str, Any], payload))
 
 
@@ -267,9 +292,7 @@ class OptionSearchControl:
     ) -> None:
         self._agent = stomp_agent
         self._config = config or OptionSearchControlConfig()
-        candidate_slots = (
-            self._agent.config.n_options * self._config.backup_budget
-        )
+        candidate_slots = self._agent.config.n_options * self._config.backup_budget
         if candidate_slots > _MAX_CANDIDATE_DIAGNOSTIC_SLOTS:
             raise ValueError(
                 "backup_budget * n_options exceeds the option-search "
@@ -324,10 +347,7 @@ class OptionSearchControl:
     def _lms_state_static_contract_valid(state: Any) -> bool:
         """Return whether one STOMP optimizer leaf is scalar float32 LMS."""
 
-        return (
-            isinstance(state, LMSState)
-            and _array_has_contract(state.step_size, (), jnp.float32)
-        )
+        return isinstance(state, LMSState) and _array_has_contract(state.step_size, (), jnp.float32)
 
     def _base_state_static_contract_valid(self, state: STOMPState) -> bool:
         """Validate every base-learner collection before prediction/update."""
@@ -490,18 +510,15 @@ class OptionSearchControl:
                 dtype=jnp.float32,
             )
         )
-        values_finite = (
-            jnp.asarray(static_valid, dtype=jnp.bool_)
-            & jnp.all(jnp.isfinite(observation))
+        values_finite = jnp.asarray(static_valid, dtype=jnp.bool_) & jnp.all(
+            jnp.isfinite(observation)
         )
         budget = self._config.backup_budget
         n_options = self._agent.config.n_options
         matrix_shape = (budget, n_options)
         return OptionSearchControlDiagnostics(
             decision_observation=jnp.where(values_finite, observation, 0.0),
-            decision_observation_static_contract_valid=jnp.asarray(
-                static_valid, dtype=jnp.bool_
-            ),
+            decision_observation_static_contract_valid=jnp.asarray(static_valid, dtype=jnp.bool_),
             decision_observation_values_finite=values_finite,
             option_model_static_contract_valid=jnp.asarray(
                 option_model_static_contract_valid, dtype=jnp.bool_
@@ -511,31 +528,21 @@ class OptionSearchControl:
             ),
             base_state_values_finite=jnp.asarray(False, dtype=jnp.bool_),
             option_model_values_finite=jnp.asarray(False, dtype=jnp.bool_),
-            state_counters_valid=jnp.asarray(
-                state_counters_valid, dtype=jnp.bool_
-            ),
+            state_counters_valid=jnp.asarray(state_counters_valid, dtype=jnp.bool_),
             base_update_capacity_available=jnp.asarray(
                 base_update_capacity_available, dtype=jnp.bool_
             ),
             stomp_state_static_contract_valid=jnp.asarray(
                 stomp_state_static_contract_valid, dtype=jnp.bool_
             ),
-            stomp_state_values_finite=jnp.asarray(
-                stomp_state_values_finite, dtype=jnp.bool_
-            ),
-            stomp_rng_key_valid=jnp.asarray(
-                stomp_rng_key_valid, dtype=jnp.bool_
-            ),
-            stomp_action_ownership_valid=jnp.asarray(
-                stomp_action_ownership_valid, dtype=jnp.bool_
-            ),
+            stomp_state_values_finite=jnp.asarray(stomp_state_values_finite, dtype=jnp.bool_),
+            stomp_rng_key_valid=jnp.asarray(stomp_rng_key_valid, dtype=jnp.bool_),
+            stomp_action_ownership_valid=jnp.asarray(stomp_action_ownership_valid, dtype=jnp.bool_),
             stomp_state_valid=jnp.asarray(stomp_state_valid, dtype=jnp.bool_),
             decision_observation_matches_state=jnp.asarray(
                 decision_observation_matches_state, dtype=jnp.bool_
             ),
-            cached_decision_action_refreshed=jnp.asarray(
-                False, dtype=jnp.bool_
-            ),
+            cached_decision_action_refreshed=jnp.asarray(False, dtype=jnp.bool_),
             value_effect_deferred_to_next_extended_action_selection=(
                 jnp.asarray(False, dtype=jnp.bool_)
             ),
@@ -546,23 +553,15 @@ class OptionSearchControl:
             candidate_semantics_valid=jnp.zeros(matrix_shape, dtype=jnp.bool_),
             candidate_predictions_finite=jnp.zeros(matrix_shape, dtype=jnp.bool_),
             candidate_targets=jnp.zeros(matrix_shape, dtype=jnp.float32),
-            candidate_bellman_residuals=jnp.zeros(
-                matrix_shape, dtype=jnp.float32
-            ),
+            candidate_bellman_residuals=jnp.zeros(matrix_shape, dtype=jnp.float32),
             candidate_priorities=jnp.zeros(matrix_shape, dtype=jnp.float32),
             candidate_valid=jnp.zeros(matrix_shape, dtype=jnp.bool_),
-            selected_option_indices=jnp.full(
-                (budget,), -1, dtype=jnp.int32
-            ),
-            selected_extended_action_indices=jnp.full(
-                (budget,), -1, dtype=jnp.int32
-            ),
+            selected_option_indices=jnp.full((budget,), -1, dtype=jnp.int32),
+            selected_extended_action_indices=jnp.full((budget,), -1, dtype=jnp.int32),
             selected_priorities=jnp.zeros((budget,), dtype=jnp.float32),
             td_errors=jnp.zeros((budget,), dtype=jnp.float32),
             candidate_update_finite=jnp.zeros((budget,), dtype=jnp.bool_),
-            trace_isolation_preserved=jnp.zeros(
-                (budget,), dtype=jnp.bool_
-            ),
+            trace_isolation_preserved=jnp.zeros((budget,), dtype=jnp.bool_),
             applied=jnp.zeros((budget,), dtype=jnp.bool_),
             applied_count=jnp.asarray(0, dtype=jnp.int32),
         )
@@ -582,15 +581,10 @@ class OptionSearchControl:
             learner_state,
             observation,
         )
-        option_values = base_values[
-            self._agent.config.n_primitive_actions :
-        ]
-        completion_supported = (
-            models.n_completions
-            >= jnp.asarray(
-                self._config.min_model_completions,
-                dtype=jnp.int32,
-            )
+        option_values = base_values[self._agent.config.n_primitive_actions :]
+        completion_supported = models.n_completions >= jnp.asarray(
+            self._config.min_model_completions,
+            dtype=jnp.int32,
         )
         candidate_semantics_valid = (
             (models.n_completions >= 0)
@@ -638,11 +632,7 @@ class OptionSearchControl:
                 & jnp.isfinite(target)
                 & jnp.isfinite(residual)
             )
-            valid = (
-                planner_inputs_valid
-                & safe_model
-                & prediction_finite
-            )
+            valid = planner_inputs_valid & safe_model & prediction_finite
             return (
                 jnp.where(valid, target, jnp.float32(0.0)),
                 jnp.where(valid, residual, jnp.float32(0.0)),
@@ -650,9 +640,7 @@ class OptionSearchControl:
                 valid,
             )
 
-        targets, residuals, predictions_finite, candidate_valid = jax.vmap(
-            evaluate_one
-        )(indices)
+        targets, residuals, predictions_finite, candidate_valid = jax.vmap(evaluate_one)(indices)
         priorities = jnp.where(candidate_valid, jnp.abs(residuals), 0.0)
         return (
             completion_supported,
@@ -687,11 +675,7 @@ class OptionSearchControl:
         )
         model_static_valid = self._option_model_static_contract_valid(state)
         base_static_valid = self._base_state_static_contract_valid(state)
-        if (
-            not observation_static_valid
-            or not model_static_valid
-            or not base_static_valid
-        ):
+        if not observation_static_valid or not model_static_valid or not base_static_valid:
             return OptionSearchControlResult(
                 state=state,
                 diagnostics=self.unavailable_diagnostics(
@@ -722,15 +706,10 @@ class OptionSearchControl:
                 ),
             )
         observation_values_finite = jnp.all(jnp.isfinite(observation))
-        base_state_values_finite = _floating_tree_is_finite(
+        base_state_values_finite = _floating_tree_is_finite(state.base_learner_state)
+        option_model_values_finite = _floating_tree_is_finite(state.option_models)
+        state_counters_valid = stomp_audit.state_counters_valid & _all_integer_leaves_nonnegative(
             state.base_learner_state
-        )
-        option_model_values_finite = _floating_tree_is_finite(
-            state.option_models
-        )
-        state_counters_valid = (
-            stomp_audit.state_counters_valid
-            & _all_integer_leaves_nonnegative(state.base_learner_state)
         )
         max_step_count_before_call = jnp.asarray(
             _INT32_MAX - self._config.backup_budget,
@@ -767,9 +746,7 @@ class OptionSearchControl:
         priorities_log = jnp.zeros(matrix_shape, dtype=jnp.float32)
         candidate_valid_log = jnp.zeros(matrix_shape, dtype=jnp.bool_)
         selected_options = jnp.full((budget,), -1, dtype=jnp.int32)
-        selected_extended_actions = jnp.full(
-            (budget,), -1, dtype=jnp.int32
-        )
+        selected_extended_actions = jnp.full((budget,), -1, dtype=jnp.int32)
         selected_priorities = jnp.zeros((budget,), dtype=jnp.float32)
         td_errors = jnp.zeros((budget,), dtype=jnp.float32)
         update_finite_log = jnp.zeros((budget,), dtype=jnp.bool_)
@@ -839,12 +816,9 @@ class OptionSearchControl:
                 jnp.int32(-1),
             )
             safe_option = jnp.maximum(selected_option, jnp.int32(0))
-            selected_extended = (
-                safe_option
-                + jnp.asarray(
-                    self._agent.config.n_primitive_actions,
-                    dtype=jnp.int32,
-                )
+            selected_extended = safe_option + jnp.asarray(
+                self._agent.config.n_primitive_actions,
+                dtype=jnp.int32,
             )
             selected_target = candidate_targets[safe_option]
             selected_priority = candidate_priorities[safe_option]
@@ -857,8 +831,7 @@ class OptionSearchControl:
                 MultiHeadMLPState,
                 learner_state.replace(
                     trunk_traces=tuple(
-                        jnp.zeros_like(trace)
-                        for trace in learner_state.trunk_traces
+                        jnp.zeros_like(trace) for trace in learner_state.trunk_traces
                     ),
                     head_traces=tuple(
                         (
@@ -869,11 +842,15 @@ class OptionSearchControl:
                     ),
                 ),
             )
-            targets = jnp.full(
-                (self._agent.config.n_total_actions,),
-                jnp.nan,
-                dtype=jnp.float32,
-            ).at[selected_extended].set(selected_target)
+            targets = (
+                jnp.full(
+                    (self._agent.config.n_total_actions,),
+                    jnp.nan,
+                    dtype=jnp.float32,
+                )
+                .at[selected_extended]
+                .set(selected_target)
+            )
 
             def propose_update(_: None) -> tuple[MultiHeadMLPState, Array]:
                 update = self._agent.base_learner.update(
@@ -980,32 +957,20 @@ class OptionSearchControl:
                 observation_static_valid, dtype=jnp.bool_
             ),
             decision_observation_values_finite=observation_values_finite,
-            option_model_static_contract_valid=jnp.asarray(
-                model_static_valid, dtype=jnp.bool_
-            ),
-            base_state_static_contract_valid=jnp.asarray(
-                base_static_valid, dtype=jnp.bool_
-            ),
+            option_model_static_contract_valid=jnp.asarray(model_static_valid, dtype=jnp.bool_),
+            base_state_static_contract_valid=jnp.asarray(base_static_valid, dtype=jnp.bool_),
             base_state_values_finite=base_state_values_finite,
             option_model_values_finite=option_model_values_finite,
             state_counters_valid=state_counters_valid,
             base_update_capacity_available=base_update_capacity_available,
-            stomp_state_static_contract_valid=(
-                stomp_audit.state_static_contract_valid
-            ),
+            stomp_state_static_contract_valid=(stomp_audit.state_static_contract_valid),
             stomp_state_values_finite=stomp_audit.state_values_finite,
             stomp_rng_key_valid=stomp_audit.rng_key_valid,
             stomp_action_ownership_valid=stomp_audit.ownership_valid,
             stomp_state_valid=stomp_audit.state_valid,
-            decision_observation_matches_state=(
-                stomp_audit.observation_matches
-            ),
-            cached_decision_action_refreshed=jnp.asarray(
-                False, dtype=jnp.bool_
-            ),
-            value_effect_deferred_to_next_extended_action_selection=(
-                jnp.any(applied_log)
-            ),
+            decision_observation_matches_state=(stomp_audit.observation_matches),
+            cached_decision_action_refreshed=jnp.asarray(False, dtype=jnp.bool_),
+            value_effect_deferred_to_next_extended_action_selection=(jnp.any(applied_log)),
             average_reward_valid=average_reward_valid,
             planner_inputs_valid=planner_inputs_valid,
             completion_counts=jnp.where(

--- a/tests/test_option_search_control.py
+++ b/tests/test_option_search_control.py
@@ -78,12 +78,10 @@ def _supported_state(
     learner = state.base_learner_state.replace(
         head_params=state.base_learner_state.head_params.replace(
             weights=tuple(
-                jnp.zeros_like(weight)
-                for weight in state.base_learner_state.head_params.weights
+                jnp.zeros_like(weight) for weight in state.base_learner_state.head_params.weights
             ),
             biases=tuple(
-                jnp.zeros_like(bias)
-                for bias in state.base_learner_state.head_params.biases
+                jnp.zeros_like(bias) for bias in state.base_learner_state.head_params.biases
             ),
         )
     )
@@ -93,9 +91,7 @@ def _supported_state(
         duration_ema=jnp.ones((n_options,), dtype=jnp.float32),
         baseline_mass_ema=jnp.ones((n_options,), dtype=jnp.float32),
         discount_ema=jnp.zeros((n_options,), dtype=jnp.float32),
-        next_state_weights=jnp.zeros(
-            (n_options, 2, 2), dtype=jnp.float32
-        ),
+        next_state_weights=jnp.zeros((n_options, 2, 2), dtype=jnp.float32),
         n_completions=jnp.ones((n_options,), dtype=jnp.int32),
     )
     return cast(
@@ -190,10 +186,7 @@ def test_zero_discount_does_not_multiply_overflowed_next_values() -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent, targets=(1.0, 4.0))
     huge = jnp.finfo(jnp.float32).max
-    ones = tuple(
-        jnp.ones_like(weight)
-        for weight in state.base_learner_state.head_params.weights
-    )
+    ones = tuple(jnp.ones_like(weight) for weight in state.base_learner_state.head_params.weights)
     learner = state.base_learner_state.replace(
         head_params=state.base_learner_state.head_params.replace(weights=ones)
     )
@@ -239,10 +232,14 @@ def test_partial_completion_support_excludes_the_unsupported_candidate() -> None
             n_completions=jnp.array([2, 1], dtype=jnp.int32),
         )
     )
-    diagnostics = OptionSearchControl(
-        agent,
-        OptionSearchControlConfig(min_model_completions=2),
-    ).apply(state, ANCHOR).diagnostics
+    diagnostics = (
+        OptionSearchControl(
+            agent,
+            OptionSearchControlConfig(min_model_completions=2),
+        )
+        .apply(state, ANCHOR)
+        .diagnostics
+    )
 
     np.testing.assert_array_equal(
         np.asarray(diagnostics.completion_supported[0]),
@@ -307,9 +304,8 @@ def test_residuals_are_recomputed_after_each_backup() -> None:
         np.array([0, 1], dtype=np.int32),
     )
     assert bool(jnp.all(result.diagnostics.applied))
-    assert (
-        float(result.diagnostics.candidate_priorities[1, 0])
-        < float(result.diagnostics.candidate_priorities[0, 0])
+    assert float(result.diagnostics.candidate_priorities[1, 0]) < float(
+        result.diagnostics.candidate_priorities[0, 0]
     )
 
 
@@ -328,9 +324,7 @@ def test_unsupported_or_invalid_models_are_exact_planner_noops(
 ) -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent)
-    state = state.replace(
-        option_models=state.option_models.replace(**{field: replacement})
-    )
+    state = state.replace(option_models=state.option_models.replace(**{field: replacement}))
     result = OptionSearchControl(
         agent,
         OptionSearchControlConfig(backup_budget=2),
@@ -356,12 +350,8 @@ def test_malformed_base_state_contracts_fail_closed_without_indexing() -> None:
         )
     )
     malformed_states = (
-        state.replace(
-            base_average_reward=jnp.zeros((1,), dtype=jnp.float32)
-        ),
-        state.replace(
-            base_average_reward=jnp.asarray(0, dtype=jnp.int32)
-        ),
+        state.replace(base_average_reward=jnp.zeros((1,), dtype=jnp.float32)),
+        state.replace(base_average_reward=jnp.asarray(0, dtype=jnp.int32)),
         state.replace(base_average_reward=0.0),
         state.replace(step_count=0),
         state.replace(base_learner_state=shortened_heads),
@@ -380,11 +370,7 @@ def test_malformed_nested_model_and_outer_leaves_fail_closed() -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent)
     malformed_states = (
-        state.replace(
-            option_models=state.option_models.replace(
-                cumreward_ema=[100.0, 101.0]
-            )
-        ),
+        state.replace(option_models=state.option_models.replace(cumreward_ema=[100.0, 101.0])),
         state.replace(base_last_obs=[1.0, 0.0]),
         state.replace(base_last_action=0),
         state.replace(
@@ -496,8 +482,7 @@ def test_planning_preserves_real_traces_normalizer_caches_rng_and_option_state()
     state = _supported_state(agent)
     learner = state.base_learner_state.replace(
         trunk_traces=tuple(
-            jnp.full_like(trace, 0.25)
-            for trace in state.base_learner_state.trunk_traces
+            jnp.full_like(trace, 0.25) for trace in state.base_learner_state.trunk_traces
         ),
         head_traces=tuple(
             (jnp.full_like(weight_trace, 0.5), jnp.full_like(bias_trace, -0.5))
@@ -626,9 +611,7 @@ def test_prototype_applies_search_at_next_decision_observation() -> None:
         option_search_control=option_search,
     )
     search_agent = PrototypeAgent(config)
-    baseline_agent = PrototypeAgent(
-        PrototypeAgentConfig(oak=config.oak)
-    )
+    baseline_agent = PrototypeAgent(PrototypeAgentConfig(oak=config.oak))
     state = search_agent.start(search_agent.init(jr.key(21)), ANCHOR)
     supported_stomp = _supported_state(search_agent.oak_agent.stomp_agent)
     state = state.replace(
@@ -663,9 +646,7 @@ def test_prototype_applies_search_at_next_decision_observation() -> None:
     )
     assert int(diagnostics.applied_count) == 1
     assert not bool(diagnostics.cached_decision_action_refreshed)
-    assert bool(
-        diagnostics.value_effect_deferred_to_next_extended_action_selection
-    )
+    assert bool(diagnostics.value_effect_deferred_to_next_extended_action_selection)
     searched_q = search_agent.oak_agent.base_q_values(
         searched.state.oak_state,
         next_decision,
@@ -722,3 +703,25 @@ def test_rejected_prototype_transition_returns_fixed_neutral_search_diagnostics(
     assert not bool(jnp.any(diagnostics.applied))
     assert int(diagnostics.applied_count) == 0
     chex.assert_trees_all_equal(rejected.state, state)
+
+
+def test_option_search_control_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="backup_budget"):
+        OptionSearchControlConfig(backup_budget=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="backup_budget"):
+        OptionSearchControlConfig(backup_budget=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_model_completions"):
+        OptionSearchControlConfig(min_model_completions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_model_completions"):
+        OptionSearchControlConfig(min_model_completions=1.5)  # type: ignore[arg-type]
+
+
+def test_option_search_control_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = OptionSearchControlConfig(
+        backup_budget=np.int32(4),
+        min_model_completions=np.int64(2),
+    )
+    assert type(cfg.backup_budget) is int
+    assert type(cfg.min_model_completions) is int
+    assert cfg.backup_budget == 4
+    assert cfg.min_model_completions == 2


### PR DESCRIPTION
## Summary
- Hardens `OptionSearchControlConfig` integer dimensions (`backup_budget` and `min_model_completions`) using `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Canonicalizes `backup_budget` and `min_model_completions` to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_option_search_control.py`: 27 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/option_search_control.py`: clean
- No registered evidence artifacts modified.