### PR TITLE
fix(behavior-model): enforce exact scalar and resource contracts

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -11,17 +11,44 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -174,28 +201,45 @@ class BehaviorModelConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if (
-            isinstance(self.n_actions, bool)
-            or not isinstance(self.n_actions, int)
-            or self.n_actions <= 0
-        ):
-            raise ValueError("n_actions must be positive")
-        if not math.isfinite(self.step_size) or self.step_size < 0.0:
-            raise ValueError("step_size must be finite and non-negative")
-        if not math.isfinite(self.temperature) or self.temperature <= 0.0:
-            raise ValueError("temperature must be finite and positive")
-        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be finite and non-negative")
-        if self.max_gradient_norm is not None and (
-            not math.isfinite(self.max_gradient_norm) or self.max_gradient_norm <= 0.0
-        ):
-            raise ValueError("max_gradient_norm must be positive when provided")
-        if not math.isfinite(self.min_probability) or not 0.0 < self.min_probability < 1.0:
-            raise ValueError("min_probability must be finite and lie in (0, 1)")
-        if not math.isfinite(self.ratio_clip) or self.ratio_clip <= 0.0:
-            raise ValueError("ratio_clip must be finite and positive")
-        if not math.isfinite(self.diagnostic_decay) or not 0.0 <= self.diagnostic_decay < 1.0:
-            raise ValueError("diagnostic_decay must be finite and lie in [0, 1)")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        step_size = validated_float32_scalar("step_size", self.step_size, lower=0.0)
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        l2_penalty = validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0)
+        max_gradient_norm = (
+            validated_float32_scalar(
+                "max_gradient_norm",
+                self.max_gradient_norm,
+                positive=True,
+            )
+            if self.max_gradient_norm is not None
+            else None
+        )
+        min_probability = validated_float32_scalar(
+            "min_probability",
+            self.min_probability,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        ratio_clip = validated_float32_scalar("ratio_clip", self.ratio_clip, positive=True)
+        diagnostic_decay = validated_float32_scalar(
+            "diagnostic_decay",
+            self.diagnostic_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "l2_penalty", l2_penalty)
+        object.__setattr__(self, "max_gradient_norm", max_gradient_norm)
+        object.__setattr__(self, "min_probability", min_probability)
+        object.__setattr__(self, "ratio_clip", ratio_clip)
+        object.__setattr__(self, "diagnostic_decay", diagnostic_decay)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to a JSON-compatible dictionary."""
@@ -343,8 +387,7 @@ class BehaviorModel:
 
     def init(self, feature_dim: int, key: Array) -> BehaviorModelState:
         """Initialize parameters and diagnostics."""
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -365,8 +408,7 @@ class BehaviorModel:
         float32 arrays, keeps three float32 diagnostics and one int32 counter,
         and stores a default JAX typed key backed by two uint32 words.
         """
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trainable = self._config.n_actions * feature_dim + self._config.n_actions
         diagnostics = 3
         administrative = 1

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -51,6 +51,26 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _behavior_model_resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
+    """Preflight every fixed-width state/resource count without allocating arrays."""
+    trainable = n_actions * feature_dim + n_actions
+    diagnostics = 3
+    administrative = 1
+    rng_words = 2
+    state_scalars = trainable + diagnostics + administrative + rng_words
+    state_nbytes = 4 * state_scalars
+    touched = trainable + diagnostics
+    for name, count in (
+        ("trainable_float32_scalars", trainable),
+        ("state_scalars", state_scalars),
+        ("state_nbytes", state_nbytes),
+        ("learned_float32_scalars_touched_per_update", touched),
+    ):
+        if count > _INT32_MAX:
+            raise ValueError(f"derived {name} must be <= {_INT32_MAX}")
+    return trainable, state_nbytes
+
+
 def _saturating_int32_increment(value: Array) -> Array:
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     counter = jnp.asarray(value, dtype=jnp.int32)
@@ -201,11 +221,9 @@ class BehaviorModelConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        object.__setattr__(
-            self,
-            "n_actions",
-            _require_int32("n_actions", self.n_actions, minimum=1),
-        )
+        n_actions = _require_int32("n_actions", self.n_actions, minimum=1)
+        _behavior_model_resource_counts(n_actions, 1)
+        object.__setattr__(self, "n_actions", n_actions)
         step_size = validated_float32_scalar("step_size", self.step_size, lower=0.0)
         temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
         l2_penalty = validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0)
@@ -388,6 +406,7 @@ class BehaviorModel:
     def init(self, feature_dim: int, key: Array) -> BehaviorModelState:
         """Initialize parameters and diagnostics."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _behavior_model_resource_counts(self._config.n_actions, feature_dim)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -409,11 +428,13 @@ class BehaviorModel:
         and stores a default JAX typed key backed by two uint32 words.
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        trainable = self._config.n_actions * feature_dim + self._config.n_actions
+        trainable, state_nbytes = _behavior_model_resource_counts(
+            self._config.n_actions,
+            feature_dim,
+        )
         diagnostics = 3
         administrative = 1
         rng_words = 2
-        state_nbytes = 4 * (trainable + diagnostics + administrative + rng_words)
         return BehaviorModelResourceBudget(
             feature_dim=feature_dim,
             n_actions=self._config.n_actions,

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -9,6 +9,7 @@ from typing import Any
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 try:
@@ -454,3 +455,28 @@ def test_importance_ratio_and_epsilon_greedy_helpers() -> None:
         jnp.array([0.1, 0.9], dtype=jnp.float32),
     )
     assert float(ratio) == 1.25
+
+
+def test_behavior_model_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        BehaviorModelConfig(n_actions=2, step_size=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="diagnostic_decay"):
+        BehaviorModelConfig(n_actions=2, diagnostic_decay=1.0 - 1e-10)
+
+
+def test_behavior_model_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = BehaviorModelConfig(n_actions=np.int32(3))
+    assert type(config.n_actions) is int
+    assert config.n_actions == 3
+
+    model = BehaviorModel(config)
+    state = model.init(feature_dim=np.int64(4), key=jax.random.key(0))
+    assert state.weights.shape == (3, 4)
+
+    budget = model.resource_budget(np.uint16(4))
+    assert budget.feature_dim == 4
+    assert type(budget.feature_dim) is int

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+
+import alberta_framework.core.behavior_model as behavior_model_module
 
 try:
     from alberta_framework.core.behavior_model import (
@@ -480,3 +484,85 @@ def test_behavior_model_config_accepts_and_canonicalizes_numpy_integers() -> Non
     budget = model.resource_budget(np.uint16(4))
     assert budget.feature_dim == 4
     assert type(budget.feature_dim) is int
+
+
+@pytest.mark.parametrize("dtype", [np.dtype(code).type for code in "bBhHiIlLqQ"])
+def test_behavior_model_accepts_every_supported_numpy_integer_dtype(dtype: type[Any]) -> None:
+    config = BehaviorModelConfig(n_actions=dtype(3))
+    model = BehaviorModel(config)
+    budget = model.resource_budget(dtype(4))
+
+    assert type(config.n_actions) is int
+    assert type(budget.feature_dim) is int
+    assert json.loads(json.dumps(config.to_config())) == config.to_config()
+    assert BehaviorModelConfig.from_config(config.to_config()) == config
+
+
+def test_behavior_model_rejects_hostile_integer_impostors() -> None:
+    class IntegerSubclass(int):
+        pass
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("validation must not inspect hostile repr")
+
+    for value in (IntegerSubclass(2), ClassSpoof()):
+        with pytest.raises(ValueError, match="n_actions"):
+            BehaviorModelConfig(n_actions=value)  # type: ignore[arg-type]
+
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2))
+    for value in (IntegerSubclass(2), ClassSpoof()):
+        with pytest.raises(ValueError, match="feature_dim"):
+            model.resource_budget(value)  # type: ignore[arg-type]
+
+
+def test_behavior_model_derived_resource_endpoints_are_allocation_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    max_actions_at_minimum_width = ((2**31 - 1) // 4 - 6) // 2
+    config = BehaviorModelConfig(n_actions=max_actions_at_minimum_width)
+    assert config.n_actions == max_actions_at_minimum_width
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        BehaviorModelConfig(n_actions=max_actions_at_minimum_width + 1)
+
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    max_feature_dim = (2**31 - 1) // 4 - 7
+    budget = model.resource_budget(max_feature_dim)
+    assert budget.state_nbytes <= 2**31 - 1
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        model.resource_budget(max_feature_dim + 1)
+
+    monkeypatch.setattr(
+        behavior_model_module.jnp,
+        "zeros",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("allocated")),
+    )
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        model.init(max_feature_dim + 1, jax.random.key(0))
+
+
+@pytest.mark.parametrize(
+    ("field", "legal", "illegal"),
+    [
+        ("step_size", Fraction(0), Fraction(-1, 10**100)),
+        ("temperature", Fraction(1, 2), Fraction(0)),
+        ("l2_penalty", Fraction(0), Fraction(-1, 10**100)),
+        ("max_gradient_norm", Fraction(1, 2), Fraction(0)),
+        ("min_probability", Fraction(1, 2), Fraction(1)),
+        ("ratio_clip", Fraction(1, 2), Fraction(0)),
+        ("diagnostic_decay", Fraction(0), Fraction(1)),
+    ],
+)
+def test_behavior_model_scalar_boundaries_use_exact_float32_contract(
+    field: str,
+    legal: Fraction,
+    illegal: Fraction,
+) -> None:
+    config = BehaviorModelConfig(**{"n_actions": 2, field: legal})
+    assert type(getattr(config, field)) is float
+    with pytest.raises(ValueError, match=field):
+        BehaviorModelConfig(**{"n_actions": 2, field: illegal})


### PR DESCRIPTION
Supersedes #701 while preserving its contributor commit.

This retains the exact Python/NumPy integer support and shared single-rounding float32 scalar validation from #701, then adds a common allocation-free preflight for trainable/state/touched counts and state bytes. Configuration, initialization, and resource reporting now share the same derived resource domain. Tests cover all supported NumPy integer dtypes, hostile subclasses and `__class__` spoofing, exact scalar endpoints, maximum legal derived dimensions, first overflow, no-allocation rejection, and JSON/config round-trips.

No registered evidence source references this module.

Verification:
- `pytest tests/test_behavior_model.py -q` (45 passed)
- scoped Ruff
- scoped strict mypy
- `git diff --check`