### PR TITLE
fix(average-reward): harden actor-critic and SARSA configuration integer validation

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -25,14 +25,16 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 import time
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -45,6 +47,38 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
+    if type(hidden_sizes) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(_require_int32("hidden_sizes element", size, minimum=1) for size in hidden_sizes)
+
+
 DIFFERENTIAL_SARSA_STATE_SCHEMA = "alberta.differential-sarsa-state.v2"
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_NBYTES = 12
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_DELTA_NBYTES = 8
@@ -335,8 +369,16 @@ class AverageRewardHordeActorCriticConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if self.n_actions < 1:
-            raise ValueError("n_actions must be positive")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _validate_hidden_sizes(self.hidden_sizes),
+        )
         if self.critic_step_size < 0.0:
             raise ValueError("critic_step_size must be non-negative")
         if self.average_reward_step_size < 0.0:
@@ -672,10 +714,7 @@ class AverageRewardHordeActorCriticAgent:
         next_observation: Array,
     ) -> AverageRewardHordeActorCriticUpdateResult:
         """Apply one average-reward actor-critic update."""
-        action_valid = (
-            (state.last_action >= 0)
-            & (state.last_action < self._config.n_actions)
-        )
+        action_valid = (state.last_action >= 0) & (state.last_action < self._config.n_actions)
         safe_last_action = jnp.clip(
             state.last_action,
             0,
@@ -710,21 +749,17 @@ class AverageRewardHordeActorCriticAgent:
         )
         grad_log_policy = score[:, None] * old_features[None, :]
         bias_grad = score
-        raw_w, new_opt_w, weight_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_opt_w,
-                grad_log_policy,
-                error=actor_td_error,
-            )
+        raw_w, new_opt_w, weight_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_opt_w,
+            grad_log_policy,
+            error=actor_td_error,
         )
-        raw_b, new_opt_b, bias_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_opt_b,
-                bias_grad,
-                error=actor_td_error,
-            )
+        raw_b, new_opt_b, bias_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_opt_b,
+            bias_grad,
+            error=actor_td_error,
         )
         weight_step = jnp.clip(
             actor_td_error * raw_w,
@@ -802,12 +837,8 @@ class AverageRewardHordeActorCriticAgent:
             ),
             actor_score_scale=jnp.where(update_applied, actor_score_scale, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),
-            average_reward=jnp.where(
-                update_applied, critic_result.average_rewards[0], 0.0
-            ),
-            critic_prediction=jnp.where(
-                update_applied, critic_result.predictions[0], 0.0
-            ),
+            average_reward=jnp.where(update_applied, critic_result.average_rewards[0], 0.0),
+            critic_prediction=jnp.where(update_applied, critic_result.predictions[0], 0.0),
             update_applied=update_applied,
         )
 
@@ -922,9 +953,7 @@ class AverageRewardHordeLearner:
         cumulants = jnp.asarray(cumulants)
         expected_shape = (self._n_demons,)
         if cumulants.shape != expected_shape:
-            raise ValueError(
-                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
-            )
+            raise ValueError(f"cumulants must have shape {expected_shape}, got {cumulants.shape}")
         next_predictions = self._learner.predict(state.learner_state, next_observation)
         # NaN remains the inactive-head sentinel. Other non-finite cumulants
         # are rejected per head and reported separately from inactivity.
@@ -1343,12 +1372,10 @@ def run_differential_td_from_arrays(
             result.update_applied,
         )
 
-    final_state, (predictions, td_errors, average_rewards, metrics, updates_applied) = (
-        jax.lax.scan(
-            _scan_fn,
-            state,
-            (observations, rewards, next_observations),
-        )
+    final_state, (predictions, td_errors, average_rewards, metrics, updates_applied) = jax.lax.scan(
+        _scan_fn,
+        state,
+        (observations, rewards, next_observations),
     )
     elapsed = time.time() - start
     final_state = final_state.replace(uptime_s=final_state.uptime_s + elapsed)
@@ -1585,12 +1612,16 @@ class DifferentialSARSAConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if (
-            isinstance(self.n_actions, bool)
-            or not isinstance(self.n_actions, int)
-            or self.n_actions < 1
-        ):
-            raise ValueError("n_actions must be positive")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "epsilon_decay_steps",
+            _require_int32("epsilon_decay_steps", self.epsilon_decay_steps, minimum=0),
+        )
         if not math.isfinite(self.q_step_size) or self.q_step_size < 0.0:
             raise ValueError("q_step_size must be finite and non-negative")
         if not math.isfinite(self.average_reward_step_size) or self.average_reward_step_size < 0.0:
@@ -1601,12 +1632,6 @@ class DifferentialSARSAConfig:
             raise ValueError("epsilon_start must be finite and lie in [0, 1]")
         if not math.isfinite(self.epsilon_end) or not 0.0 <= self.epsilon_end <= 1.0:
             raise ValueError("epsilon_end must be finite and lie in [0, 1]")
-        if (
-            isinstance(self.epsilon_decay_steps, bool)
-            or not isinstance(self.epsilon_decay_steps, int)
-            or self.epsilon_decay_steps < 0
-        ):
-            raise ValueError("epsilon_decay_steps must be non-negative")
         if not isinstance(self.use_bias, bool):
             raise ValueError("use_bias must be boolean")
 
@@ -1766,8 +1791,7 @@ class DifferentialSARSAAgent:
         q_weights = jnp.asarray(state.q_weights)
         if q_weights.ndim != 2 or q_weights.shape[0] != self._config.n_actions:
             raise ValueError(
-                "differential SARSA q_weights must have shape "
-                "(n_actions, feature_dim)"
+                "differential SARSA q_weights must have shape (n_actions, feature_dim)"
             )
         feature_dim = q_weights.shape[1]
         if feature_dim < 1:
@@ -1835,11 +1859,7 @@ class DifferentialSARSAAgent:
             value = jnp.asarray(leaf)
             if jnp.issubdtype(value.dtype, jnp.inexact):
                 checks.append(jnp.all(jnp.isfinite(value)))
-        return (
-            jnp.all(jnp.stack(checks))
-            if checks
-            else jnp.asarray(True, dtype=jnp.bool_)
-        )
+        return jnp.all(jnp.stack(checks)) if checks else jnp.asarray(True, dtype=jnp.bool_)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def q_values(
@@ -1953,8 +1973,7 @@ class DifferentialSARSAAgent:
         raw_next_observation = jnp.asarray(next_observation)
         if raw_next_observation.shape != (feature_dim,):
             raise ValueError(
-                "differential SARSA next_observation must have shape "
-                f"({feature_dim},)"
+                f"differential SARSA next_observation must have shape ({feature_dim},)"
             )
         if not (
             jnp.issubdtype(raw_next_observation.dtype, jnp.floating)
@@ -1980,8 +1999,8 @@ class DifferentialSARSAAgent:
         ):
             raise TypeError("differential SARSA discount must be real numeric")
         discount_s = raw_discount.astype(jnp.float32)
-        proposed_step_words, lifetime_capacity_available = (
-            _checked_lifetime_words_increment(state.step_words)
+        proposed_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+            state.step_words
         )
         lifetime_counter_valid = _lifetime_counter_valid(
             state.step_words,
@@ -2060,10 +2079,7 @@ class DifferentialSARSAAgent:
         )
         candidate_state_finite = self._candidate_finite(proposed_state)
         update_available = (
-            state_valid
-            & input_valid
-            & lifetime_capacity_available
-            & candidate_state_finite
+            state_valid & input_valid & lifetime_capacity_available & candidate_state_finite
         )
         new_state = jax.lax.cond(
             update_available,
@@ -2135,12 +2151,15 @@ def run_differential_sarsa_from_arrays(
             result.update_applied,
         )
 
-    final_state, (
-        q_values,
-        td_errors,
-        average_rewards,
-        actions,
-        updates_applied,
+    (
+        final_state,
+        (
+            q_values,
+            td_errors,
+            average_rewards,
+            actions,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         _scan_fn,
         state,

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -4,6 +4,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -34,9 +35,7 @@ def test_differential_td_config_and_top_level_exports() -> None:
         average_reward_step_size=0.02,
         trace_decay=0.5,
     )
-    learner = DifferentialTDLearner.from_config(
-        DifferentialTDLearner(config).to_config()
-    )
+    learner = DifferentialTDLearner.from_config(DifferentialTDLearner(config).to_config())
 
     assert learner.config == config
     assert CoreDifferentialTDLearner is DifferentialTDLearner
@@ -109,9 +108,7 @@ def test_differential_td_infinite_reward_does_not_poison_weights() -> None:
     assert float(poisoned.td_error) == 0.0
     chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt)
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.average_reward)
     assert int(recovered.state.step_count) == int(state.step_count) + 1
@@ -136,9 +133,7 @@ def test_differential_gtd_infinite_reward_does_not_poison_weights() -> None:
     assert float(poisoned.td_error) == 0.0
     chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, rho
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, rho)
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.secondary_weights)
     assert bool(recovered.update_applied)
@@ -162,12 +157,8 @@ def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
     obs = jnp.ones(3, dtype=jnp.float32)
     nxt = jnp.ones(3, dtype=jnp.float32)
 
-    poisoned = learner.update(
-        state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), nxt
-    )
-    chex.assert_trees_all_close(
-        poisoned.average_rewards[0], state.average_rewards[0]
-    )
+    poisoned = learner.update(state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), nxt)
+    chex.assert_trees_all_close(poisoned.average_rewards[0], state.average_rewards[0])
     assert bool(jnp.isfinite(poisoned.average_rewards[1]))
     assert int(poisoned.state.step_count) == 1
     assert bool(poisoned.update_applied)
@@ -177,9 +168,7 @@ def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
     )
     assert float(poisoned.td_errors[0]) == 0.0
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array([0.5, 1.0], dtype=jnp.float32), nxt
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array([0.5, 1.0], dtype=jnp.float32), nxt)
     chex.assert_tree_all_finite(recovered.average_rewards)
     assert int(recovered.state.step_count) == 2
     assert bool(recovered.update_applied)
@@ -244,9 +233,7 @@ def test_differential_gtd_config_roundtrip_and_ratio_clipping() -> None:
         trace_decay=0.3,
         ratio_clip=1.5,
     )
-    learner = DifferentialGTDLearner.from_config(
-        DifferentialGTDLearner(config).to_config()
-    )
+    learner = DifferentialGTDLearner.from_config(DifferentialGTDLearner(config).to_config())
     state = learner.init(1)
 
     result = learner.update(
@@ -435,9 +422,7 @@ def test_average_reward_horde_actor_critic_rejects_nonfinite_reward() -> None:
     )
 
     assert not bool(result.update_applied)
-    chex.assert_trees_all_equal(
-        jr.key_data(result.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(result.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         result.state.replace(rng_key=jr.key_data(result.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -499,9 +484,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         temperature=0.7,
     )
     agent = AverageRewardHordeActorCriticAgent(config)
-    initial = agent.init(2, jr.key(4)).replace(
-        actor_bias=jnp.array([1.0, -1.0], dtype=jnp.float32)
-    )
+    initial = agent.init(2, jr.key(4)).replace(actor_bias=jnp.array([1.0, -1.0], dtype=jnp.float32))
     observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
     state, _ = agent.start(initial, observation)
     stored = state.last_policy_sample
@@ -511,11 +494,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         jnp.array(1.0, dtype=jnp.float32),
         jnp.array([-0.25, 0.75], dtype=jnp.float32),
     )
-    expected_scale = (
-        (1.0 - epsilon)
-        * stored.target_probability
-        / stored.behavior_probability
-    )
+    expected_scale = (1.0 - epsilon) * stored.target_probability / stored.behavior_probability
     chex.assert_trees_all_close(result.actor_score_scale, expected_scale)
 
     # Finite-difference d log(mu_a) / d target-logit_a agrees with the
@@ -530,9 +509,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         return jnp.log(behavior[action])
 
     finite_difference = jax.grad(selected_log_behavior)(bias[action])
-    expected_component = expected_scale * (
-        1.0 - stored.target_policy[action]
-    ) / config.temperature
+    expected_component = expected_scale * (1.0 - stored.target_policy[action]) / config.temperature
     chex.assert_trees_all_close(
         finite_difference,
         expected_component,
@@ -760,9 +737,7 @@ def test_differential_sarsa_update_and_scan_are_finite() -> None:
     chex.assert_shape(result.average_rewards, (4,))
     chex.assert_shape(result.actions, (4,))
     assert int(result.state.step_count) == 4
-    chex.assert_tree_all_finite(
-        (result.q_values, result.td_errors, result.average_rewards)
-    )
+    chex.assert_tree_all_finite((result.q_values, result.td_errors, result.average_rewards))
     assert bool(jnp.all(result.actions >= 0))
     assert bool(jnp.all(result.actions < 3))
 
@@ -791,3 +766,40 @@ def test_differential_sarsa_learns_better_action_on_continuing_bandit() -> None:
     q_values = agent.q_values(state, obs)
     assert float(q_values[1]) > float(q_values[0]) + 0.25
     assert float(state.average_reward) > 0.75
+
+
+def test_average_reward_horde_actor_critic_config_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        AverageRewardHordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        AverageRewardHordeActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        AverageRewardHordeActorCriticConfig(n_actions=2, hidden_sizes=(True,))  # type: ignore[arg-type]
+
+    cfg = AverageRewardHordeActorCriticConfig(
+        n_actions=np.int32(4),
+        hidden_sizes=(np.int32(32), np.int64(16)),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.hidden_sizes[0]) is int
+    assert type(cfg.hidden_sizes[1]) is int
+    assert cfg.n_actions == 4
+    assert cfg.hidden_sizes == (32, 16)
+
+
+def test_differential_sarsa_config_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        DifferentialSARSAConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        DifferentialSARSAConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="epsilon_decay_steps"):
+        DifferentialSARSAConfig(n_actions=2, epsilon_decay_steps=True)  # type: ignore[arg-type]
+
+    cfg = DifferentialSARSAConfig(
+        n_actions=np.int32(3),
+        epsilon_decay_steps=np.int64(100),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.epsilon_decay_steps) is int
+    assert cfg.n_actions == 3
+    assert cfg.epsilon_decay_steps == 100


### PR DESCRIPTION
## Summary
- Hardens `AverageRewardHordeActorCriticConfig` integer dimensions (`n_actions`, `hidden_sizes`) and `DifferentialSARSAConfig` integer fields (`n_actions`, `epsilon_decay_steps`) using `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Canonicalizes `n_actions`, `hidden_sizes`, and `epsilon_decay_steps` to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_average_reward.py`: 32 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/average_reward.py`: clean
- No registered evidence artifacts modified.