### PR TITLE
fix(fusion): complete integer and allocation contracts

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -27,9 +27,10 @@ import dataclasses
 import hashlib
 import json
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -65,12 +66,32 @@ _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 
 
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
 def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
     """Return a strict positive integer within an explicit bound."""
 
-    if type(value) is not int or not 1 <= value <= maximum:
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
-    return value
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
+    return canonical
 
 
 def _strict_float32(
@@ -199,20 +220,44 @@ class PartnerPolicyFusionConfig:
     def __post_init__(self) -> None:
         """Reject dynamic dimensions, ambiguous thresholds, and unsafe bounds."""
 
-        _strict_positive_int(self.max_partners, name="max_partners", maximum=1024)
-        _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536)
-        _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536)
-        _strict_positive_int(
-            self.max_message_horizon,
-            name="max_message_horizon",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "max_partners",
+            _strict_positive_int(self.max_partners, name="max_partners", maximum=1024),
         )
-        _strict_positive_int(
-            self.min_feedback_for_learned_routing,
-            name="min_feedback_for_learned_routing",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "context_dim",
+            _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536),
         )
-        _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX)
+        object.__setattr__(
+            self,
+            "n_actions",
+            _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536),
+        )
+        object.__setattr__(
+            self,
+            "max_message_horizon",
+            _strict_positive_int(
+                self.max_message_horizon,
+                name="max_message_horizon",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_feedback_for_learned_routing",
+            _strict_positive_int(
+                self.min_feedback_for_learned_routing,
+                name="min_feedback_for_learned_routing",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "counter_cap",
+            _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX),
+        )
         if self.min_feedback_for_learned_routing > self.counter_cap:
             raise ValueError("min_feedback_for_learned_routing exceeds counter_cap")
 

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -94,6 +94,14 @@ def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX)
     return canonical
 
 
+def _require_derived_int32(name: str, value: int) -> int:
+    """Return an exact derived allocation/count that fits signed int32."""
+
+    if not 0 <= value <= _INT32_MAX:
+        raise ValueError(f"{name} must not exceed signed-int32 capacity")
+    return value
+
+
 def _strict_float32(
     value: object,
     *,
@@ -261,6 +269,38 @@ class PartnerPolicyFusionConfig:
         if self.min_feedback_for_learned_routing > self.counter_cap:
             raise ValueError("min_feedback_for_learned_routing exceeds counter_cap")
 
+        partners = self.max_partners
+        features = self.context_dim + 2
+        trainable_f32 = partners * features
+        persistent_f32 = trainable_f32 + features + 1
+        persistent_i32 = 2 * partners + 9
+        persistent_bool = 2
+        persistent_scalars = persistent_f32 + persistent_i32 + persistent_bool
+        decision_f32 = self.context_dim + 2 + 2 * partners
+        decision_i32 = 6 + 9 * partners
+        decision_bool = self.n_actions + 1 + partners
+        derived_counts = {
+            "model_feature_dim": features,
+            "reliability_weight_scalars": trainable_f32,
+            "reliability_weight_nbytes": 4 * trainable_f32,
+            "persistent_float32_scalars": persistent_f32,
+            "persistent_int32_scalars": persistent_i32,
+            "persistent_bool_scalars": persistent_bool,
+            "persistent_state_scalars": persistent_scalars,
+            "persistent_state_nbytes": 4 * (persistent_f32 + persistent_i32) + persistent_bool,
+            "partner_message_scalars": 12 * partners,
+            "partner_message_nbytes": 45 * partners,
+            "partner_pairwise_comparisons": partners * partners,
+            "context_input_nbytes": 4 * self.context_dim,
+            "action_mask_nbytes": self.n_actions,
+            "decision_input_float32_scalars": decision_f32,
+            "decision_input_int32_scalars": decision_i32,
+            "decision_input_bool_scalars": decision_bool,
+            "decision_input_nbytes": 4 * (decision_f32 + decision_i32) + decision_bool,
+        }
+        for name, value in derived_counts.items():
+            _require_derived_int32(name, value)
+
         for name in (
             "learning_rate",
             "max_abs_weight",
@@ -382,11 +422,14 @@ class PartnerPolicyFusionConfig:
         }
         if set(payload) != expected:
             raise ValueError("config fields do not match the partner-fusion v1 schema")
-        if payload.pop("schema") != PARTNER_POLICY_FUSION_CONFIG_SCHEMA:
+        schema = payload.pop("schema")
+        if type(schema) is not str or schema != PARTNER_POLICY_FUSION_CONFIG_SCHEMA:
             raise ValueError("unexpected partner-fusion config schema")
-        if payload.pop("type") != _CONFIG_TYPE:
+        config_type = payload.pop("type")
+        if type(config_type) is not str or config_type != _CONFIG_TYPE:
             raise ValueError("unexpected partner-fusion config type")
-        if payload.pop("mechanism_status") != MECHANISM_STATUS:
+        mechanism_status = payload.pop("mechanism_status")
+        if type(mechanism_status) is not str or mechanism_status != MECHANISM_STATUS:
             raise ValueError("partner fusion must remain a development L0 mechanism")
         if payload.pop("scientific_promotion_allowed") is not False:
             raise ValueError("partner fusion configuration cannot claim promotion")
@@ -696,12 +739,13 @@ class PartnerPolicyFusion:
         payload = dict(config)
         if set(payload) != {"type", "config"}:
             raise ValueError("fusion construction fields do not match the v1 schema")
-        if payload.get("type") != _FUSION_TYPE:
+        fusion_type = payload.get("type")
+        if type(fusion_type) is not str or fusion_type != _FUSION_TYPE:
             raise ValueError("unexpected partner-fusion construction type")
         nested = payload.get("config")
-        if not isinstance(nested, Mapping):
+        if not issubclass(type(nested), Mapping):
             raise ValueError("fusion construction config must be a mapping")
-        return cls(PartnerPolicyFusionConfig.from_config(nested))
+        return cls(PartnerPolicyFusionConfig.from_config(cast(Mapping[str, object], nested)))
 
     def init(self) -> PartnerPolicyFusionState:
         """Return deterministic zero state; this component owns no RNG."""

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
+import json
 from typing import Any, cast
 
 import jax
@@ -29,10 +31,44 @@ from alberta_framework.core.partner_policy_fusion import (
     PartnerPolicyFusion,
     PartnerPolicyFusionConfig,
     PartnerPolicyFusionFeedback,
+    PartnerPolicyFusionResourceBudget,
     PartnerPolicyFusionState,
 )
 
 pytestmark = pytest.mark.unit
+
+
+class _IntSubclass(int):
+    def __repr__(self) -> str:
+        raise AssertionError("repr must not run")
+
+
+class _IntSpoof:
+    @property
+    def __class__(self) -> type[int]:
+        return int
+
+    def __index__(self) -> int:
+        raise AssertionError("index must not run")
+
+    def __repr__(self) -> str:
+        raise AssertionError("repr must not run")
+
+
+class _StringSubclass(str):
+    pass
+
+
+class _StringSpoof:
+    @property
+    def __class__(self) -> type[str]:
+        return str
+
+    def __eq__(self, other: object) -> bool:
+        raise AssertionError("equality must not run")
+
+    def __repr__(self) -> str:
+        raise AssertionError("repr must not run")
 
 
 def _replace[T](value: T, **changes: object) -> T:
@@ -904,21 +940,101 @@ def test_partner_policy_fusion_config_rejects_booleans_and_non_integers() -> Non
 
 
 def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    config = PartnerPolicyFusionConfig(
-        max_partners=np.int32(2),
-        context_dim=np.int64(4),
-        n_actions=np.uint16(2),
-        max_message_horizon=np.int8(8),
-        min_feedback_for_learned_routing=np.uint32(4),
-        counter_cap=np.int32(1_000_000),
-    )
-    assert type(config.max_partners) is int
-    assert type(config.context_dim) is int
-    assert type(config.n_actions) is int
-    assert type(config.max_message_horizon) is int
-    assert type(config.min_feedback_for_learned_routing) is int
-    assert type(config.counter_cap) is int
+    integer_types = {
+        np.dtype(code).type for code in "bBhHiIlLqQpP" if np.dtype(code).kind in "iu"
+    }
+    for integer_type in integer_types:
+        config = PartnerPolicyFusionConfig(
+            max_partners=integer_type(2),
+            context_dim=integer_type(4),
+            n_actions=integer_type(2),
+            max_message_horizon=integer_type(8),
+            min_feedback_for_learned_routing=integer_type(4),
+            counter_cap=integer_type(8),
+        )
+        for field in (
+            "max_partners",
+            "context_dim",
+            "n_actions",
+            "max_message_horizon",
+            "min_feedback_for_learned_routing",
+            "counter_cap",
+        ):
+            assert type(getattr(config, field)) is int
+        json.dumps(config.to_config())
 
-    assert config.max_partners == 2
-    assert config.context_dim == 4
-    assert config.n_actions == 2
+
+@pytest.mark.parametrize(
+    "hostile",
+    [_IntSubclass(2), _IntSpoof()],
+    ids=["int-subclass", "class-spoof"],
+)
+@pytest.mark.parametrize(
+    "field",
+    [
+        "max_partners",
+        "context_dim",
+        "n_actions",
+        "max_message_horizon",
+        "min_feedback_for_learned_routing",
+        "counter_cap",
+    ],
+)
+def test_integer_fields_reject_spoofs_without_hooks(field: str, hostile: object) -> None:
+    values: dict[str, object] = {
+        "max_partners": 2,
+        "context_dim": 4,
+        "n_actions": 2,
+        "max_message_horizon": 8,
+        "min_feedback_for_learned_routing": 4,
+        "counter_cap": 8,
+    }
+    values[field] = hostile
+    with pytest.raises(ValueError, match=field):
+        PartnerPolicyFusionConfig(**values)  # type: ignore[arg-type]
+
+
+def test_dimension_endpoints_and_all_derived_resource_products_fit_int32() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=1024,
+        context_dim=65_536,
+        n_actions=65_536,
+    )
+    budget = PartnerPolicyFusion(config).resource_budget
+    assert config.model_feature_dim == 65_538
+    assert budget.trainable_float32_scalars == 1024 * 65_538
+    assert budget.persistent_state_bytes == 268_714_034
+    assert budget.partner_id_pairwise_equality_comparisons_per_decision == 1024**2
+    for value in budget.to_config().values():
+        assert 0 <= value <= 2_147_483_647
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=1025, context_dim=1, n_actions=1)
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=1, context_dim=65_537, n_actions=1)
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=1, context_dim=1, n_actions=65_537)
+
+
+def test_host_only_resource_record_remains_exact_above_int32() -> None:
+    values = {field.name: 2**40 for field in dataclasses.fields(PartnerPolicyFusionResourceBudget)}
+    record = PartnerPolicyFusionResourceBudget(**values)
+    assert all(value == 2**40 for value in record.to_config().values())
+
+
+@pytest.mark.parametrize(
+    ("field", "hostile", "message"),
+    [
+        ("schema", _StringSubclass("alberta.partner-policy-fusion.config.v1"), "schema"),
+        ("type", _StringSpoof(), "type"),
+        ("mechanism_status", _StringSpoof(), "development L0"),
+    ],
+    ids=["schema-subclass", "type-spoof", "status-spoof"],
+)
+def test_serialized_discriminators_reject_spoofs_without_hooks(
+    field: str, hostile: object, message: str
+) -> None:
+    payload = PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2).to_config()
+    payload[field] = hostile
+    with pytest.raises(ValueError, match=message):
+        PartnerPolicyFusionConfig.from_config(payload)

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -885,3 +885,40 @@ def test_state_tamper_and_static_shape_mismatch_fail_strict_validation() -> None
                 feedback_counts=jnp.zeros((2,), dtype=jnp.int32),
             )
         )
+
+
+def test_partner_policy_fusion_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=True, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=2.5, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4.5, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2.5)  # type: ignore[arg-type]
+
+
+def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=np.int32(2),
+        context_dim=np.int64(4),
+        n_actions=np.uint16(2),
+        max_message_horizon=np.int8(8),
+        min_feedback_for_learned_routing=np.uint32(4),
+        counter_cap=np.int32(1_000_000),
+    )
+    assert type(config.max_partners) is int
+    assert type(config.context_dim) is int
+    assert type(config.n_actions) is int
+    assert type(config.max_message_horizon) is int
+    assert type(config.min_feedback_for_learned_routing) is int
+    assert type(config.counter_cap) is int
+
+    assert config.max_partners == 2
+    assert config.context_dim == 4
+    assert config.n_actions == 2


### PR DESCRIPTION
Supersedes #702 while preserving its contributor commit and attribution.\n\nThe established 1,024-partner and 65,536 context/action ceilings are retained: at their joint endpoint the complete persistent state is 268,714,034 logical bytes and the quadratic partner audit is 1,048,576 booleans, both safely inside signed int32. This replacement adds exact preflights for every config-derived feature width, reliability table, persistent state scalar/byte count, partner message batch, pairwise table, context/action input, and decision input scalar/byte product.\n\nIt also covers every dtype-derived NumPy integer family, canonical JSON roundtrip, hostile integer subclasses and __class__ spoofs, exact serialized discriminator gates, last-legal/first-rejected endpoints, and explicitly preserves unbounded Python integers in independently constructed host-only resource records. Existing float domains and relationships are unchanged by this integer/allocation repair.\n\nValidation: 79 focused tests passed; scoped Ruff clean; strict mypy clean; diff check clean. No evidence artifacts changed.