### PR TITLE
fix(models): complete behavior and fusion validation contracts

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -11,17 +11,44 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from typing import Any
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -174,28 +201,45 @@ class BehaviorModelConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if (
-            isinstance(self.n_actions, bool)
-            or not isinstance(self.n_actions, int)
-            or self.n_actions <= 0
-        ):
-            raise ValueError("n_actions must be positive")
-        if not math.isfinite(self.step_size) or self.step_size < 0.0:
-            raise ValueError("step_size must be finite and non-negative")
-        if not math.isfinite(self.temperature) or self.temperature <= 0.0:
-            raise ValueError("temperature must be finite and positive")
-        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be finite and non-negative")
-        if self.max_gradient_norm is not None and (
-            not math.isfinite(self.max_gradient_norm) or self.max_gradient_norm <= 0.0
-        ):
-            raise ValueError("max_gradient_norm must be positive when provided")
-        if not math.isfinite(self.min_probability) or not 0.0 < self.min_probability < 1.0:
-            raise ValueError("min_probability must be finite and lie in (0, 1)")
-        if not math.isfinite(self.ratio_clip) or self.ratio_clip <= 0.0:
-            raise ValueError("ratio_clip must be finite and positive")
-        if not math.isfinite(self.diagnostic_decay) or not 0.0 <= self.diagnostic_decay < 1.0:
-            raise ValueError("diagnostic_decay must be finite and lie in [0, 1)")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        step_size = validated_float32_scalar("step_size", self.step_size, lower=0.0)
+        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
+        l2_penalty = validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0)
+        max_gradient_norm = (
+            validated_float32_scalar(
+                "max_gradient_norm",
+                self.max_gradient_norm,
+                positive=True,
+            )
+            if self.max_gradient_norm is not None
+            else None
+        )
+        min_probability = validated_float32_scalar(
+            "min_probability",
+            self.min_probability,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        ratio_clip = validated_float32_scalar("ratio_clip", self.ratio_clip, positive=True)
+        diagnostic_decay = validated_float32_scalar(
+            "diagnostic_decay",
+            self.diagnostic_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "l2_penalty", l2_penalty)
+        object.__setattr__(self, "max_gradient_norm", max_gradient_norm)
+        object.__setattr__(self, "min_probability", min_probability)
+        object.__setattr__(self, "ratio_clip", ratio_clip)
+        object.__setattr__(self, "diagnostic_decay", diagnostic_decay)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to a JSON-compatible dictionary."""
@@ -343,8 +387,7 @@ class BehaviorModel:
 
     def init(self, feature_dim: int, key: Array) -> BehaviorModelState:
         """Initialize parameters and diagnostics."""
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -365,8 +408,7 @@ class BehaviorModel:
         float32 arrays, keeps three float32 diagnostics and one int32 counter,
         and stores a default JAX typed key backed by two uint32 words.
         """
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trainable = self._config.n_actions * feature_dim + self._config.n_actions
         diagnostics = 3
         administrative = 1

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -237,6 +237,7 @@ class BehaviorModelConfig:
             "n_actions",
             _require_int32("n_actions", self.n_actions, minimum=1),
         )
+        _resource_counts(self.n_actions, 1)
         step_size = _validated_config_float("step_size", self.step_size, lower=0.0)
         temperature = _validated_config_float("temperature", self.temperature, positive=True)
         l2_penalty = _validated_config_float("l2_penalty", self.l2_penalty, lower=0.0)

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -40,6 +40,19 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset((float, np.float16, np.float32, np.float64, np.longdouble))
+_CONFIG_FIELDS = frozenset(
+    {
+        "n_actions",
+        "step_size",
+        "temperature",
+        "l2_penalty",
+        "max_gradient_norm",
+        "min_probability",
+        "ratio_clip",
+        "diagnostic_decay",
+    }
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -49,6 +62,24 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    """Validate only trusted concrete host scalar types at the float32 sink."""
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
+
+
+def _resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
+    """Return exact trainable scalars and bytes, rejecting unsafe derived counts."""
+    trainable = n_actions * feature_dim + n_actions
+    state_nbytes = 4 * (trainable + 3 + 1 + 2)
+    if trainable > _INT32_MAX:
+        raise ValueError(f"derived trainable scalars must be at most {_INT32_MAX}")
+    if state_nbytes > _INT32_MAX:
+        raise ValueError(f"derived state_nbytes must be at most {_INT32_MAX}")
+    return trainable, state_nbytes
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -206,11 +237,11 @@ class BehaviorModelConfig:
             "n_actions",
             _require_int32("n_actions", self.n_actions, minimum=1),
         )
-        step_size = validated_float32_scalar("step_size", self.step_size, lower=0.0)
-        temperature = validated_float32_scalar("temperature", self.temperature, positive=True)
-        l2_penalty = validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0)
+        step_size = _validated_config_float("step_size", self.step_size, lower=0.0)
+        temperature = _validated_config_float("temperature", self.temperature, positive=True)
+        l2_penalty = _validated_config_float("l2_penalty", self.l2_penalty, lower=0.0)
         max_gradient_norm = (
-            validated_float32_scalar(
+            _validated_config_float(
                 "max_gradient_norm",
                 self.max_gradient_norm,
                 positive=True,
@@ -218,15 +249,15 @@ class BehaviorModelConfig:
             if self.max_gradient_norm is not None
             else None
         )
-        min_probability = validated_float32_scalar(
+        min_probability = _validated_config_float(
             "min_probability",
             self.min_probability,
             positive=True,
             upper=1.0,
             upper_inclusive=False,
         )
-        ratio_clip = validated_float32_scalar("ratio_clip", self.ratio_clip, positive=True)
-        diagnostic_decay = validated_float32_scalar(
+        ratio_clip = _validated_config_float("ratio_clip", self.ratio_clip, positive=True)
+        diagnostic_decay = _validated_config_float(
             "diagnostic_decay",
             self.diagnostic_decay,
             lower=0.0,
@@ -248,6 +279,10 @@ class BehaviorModelConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> BehaviorModelConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("BehaviorModelConfig payload must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CONFIG_FIELDS:
+            raise ValueError("BehaviorModelConfig fields do not match the schema")
         return cls(**config)
 
 
@@ -381,13 +416,21 @@ class BehaviorModel:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> BehaviorModel:
         """Reconstruct a behavior model from :meth:`to_config` output."""
-        config = dict(config)
-        config.pop("type", None)
-        return cls(BehaviorModelConfig.from_config(config["config"]))
+        if type(config) is not dict:
+            raise ValueError("BehaviorModel construction must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != {"type", "config"}:
+            raise ValueError("BehaviorModel construction fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "BehaviorModel":
+            raise ValueError("unexpected BehaviorModel construction type")
+        nested = config["config"]
+        if type(nested) is not dict:
+            raise ValueError("BehaviorModel nested config must be an actual dict")
+        return cls(BehaviorModelConfig.from_config(nested))
 
     def init(self, feature_dim: int, key: Array) -> BehaviorModelState:
         """Initialize parameters and diagnostics."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _resource_counts(self._config.n_actions, feature_dim)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -409,11 +452,10 @@ class BehaviorModel:
         and stores a default JAX typed key backed by two uint32 words.
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        trainable = self._config.n_actions * feature_dim + self._config.n_actions
+        trainable, state_nbytes = _resource_counts(self._config.n_actions, feature_dim)
         diagnostics = 3
         administrative = 1
         rng_words = 2
-        state_nbytes = 4 * (trainable + diagnostics + administrative + rng_words)
         return BehaviorModelResourceBudget(
             feature_dim=feature_dim,
             n_actions=self._config.n_actions,

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -27,9 +27,10 @@ import dataclasses
 import hashlib
 import json
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -65,12 +66,32 @@ _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 
 
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
 def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
     """Return a strict positive integer within an explicit bound."""
 
-    if type(value) is not int or not 1 <= value <= maximum:
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
-    return value
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
+    return canonical
 
 
 def _strict_float32(
@@ -199,20 +220,44 @@ class PartnerPolicyFusionConfig:
     def __post_init__(self) -> None:
         """Reject dynamic dimensions, ambiguous thresholds, and unsafe bounds."""
 
-        _strict_positive_int(self.max_partners, name="max_partners", maximum=1024)
-        _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536)
-        _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536)
-        _strict_positive_int(
-            self.max_message_horizon,
-            name="max_message_horizon",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "max_partners",
+            _strict_positive_int(self.max_partners, name="max_partners", maximum=1024),
         )
-        _strict_positive_int(
-            self.min_feedback_for_learned_routing,
-            name="min_feedback_for_learned_routing",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "context_dim",
+            _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536),
         )
-        _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX)
+        object.__setattr__(
+            self,
+            "n_actions",
+            _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536),
+        )
+        object.__setattr__(
+            self,
+            "max_message_horizon",
+            _strict_positive_int(
+                self.max_message_horizon,
+                name="max_message_horizon",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_feedback_for_learned_routing",
+            _strict_positive_int(
+                self.min_feedback_for_learned_routing,
+                name="min_feedback_for_learned_routing",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "counter_cap",
+            _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX),
+        )
         if self.min_feedback_for_learned_routing > self.counter_cap:
             raise ValueError("min_feedback_for_learned_routing exceeds counter_cap")
 

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -81,6 +81,7 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset((float, np.float16, np.float32, np.float64, np.longdouble))
 
 
 def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
@@ -106,7 +107,7 @@ def _strict_float32(
     """Return a finite normal float32-compatible configuration scalar."""
 
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    if actual_type not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a real scalar, not boolean")
     normalized = float(cast(Real, value))
     if not math.isfinite(normalized) or abs(normalized) > _FLOAT32_MAX:
@@ -269,11 +270,15 @@ class PartnerPolicyFusionConfig:
             "assistance_value_bound",
             "max_abs_declared_score",
         ):
-            _strict_float32(
-                getattr(self, name),
-                name=name,
-                positive=True,
-                allow_zero=False,
+            object.__setattr__(
+                self,
+                name,
+                _strict_float32(
+                    getattr(self, name),
+                    name=name,
+                    positive=True,
+                    allow_zero=False,
+                ),
             )
         for name in (
             "communication_cost_weight",
@@ -281,42 +286,56 @@ class PartnerPolicyFusionConfig:
             "option_blend_weight",
             "partner_blend_weight",
         ):
-            _strict_float32(
-                getattr(self, name),
-                name=name,
-                positive=True,
-                allow_zero=True,
+            object.__setattr__(
+                self,
+                name,
+                _strict_float32(
+                    getattr(self, name),
+                    name=name,
+                    positive=True,
+                    allow_zero=True,
+                ),
             )
-        _strict_float32(
-            self.safety_target_weight,
-            name="safety_target_weight",
-            lower=0.0,
-            upper=1.0,
-        )
-        _strict_float32(
-            self.clarification_confidence_threshold,
-            name="clarification_confidence_threshold",
-            lower=0.0,
-            upper=1.0,
-        )
-        _strict_float32(
-            self.max_query_cost,
-            name="max_query_cost",
-            lower=0.0,
-            upper=float(self.max_communication_cost),
-        )
-        _strict_float32(
-            self.blend_net_value_threshold,
-            name="blend_net_value_threshold",
-        )
-        _strict_float32(
-            self.accept_net_value_threshold,
-            name="accept_net_value_threshold",
-        )
+        for name, lower, upper in (
+            ("safety_target_weight", 0.0, 1.0),
+            ("clarification_confidence_threshold", 0.0, 1.0),
+            ("max_query_cost", 0.0, float(self.max_communication_cost)),
+            ("blend_net_value_threshold", None, None),
+            ("accept_net_value_threshold", None, None),
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _strict_float32(getattr(self, name), name=name, lower=lower, upper=upper),
+            )
         if self.blend_net_value_threshold >= self.accept_net_value_threshold:
             raise ValueError("blend_net_value_threshold must be below accept threshold")
 
         feature_width = self.model_feature_dim
+        derived_resources = {
+            "reliability_weight_scalars": self.max_partners * feature_width,
+            "persistent_state_scalars": (
+                self.max_partners * feature_width
+                + feature_width
+                + 1
+                + 2 * self.max_partners
+                + 9
+                + 2
+            ),
+            "persistent_state_bytes": 4
+            * (
+                self.max_partners * feature_width
+                + feature_width
+                + 1
+                + 2 * self.max_partners
+                + 9
+            )
+            + 2,
+            "pairwise_comparisons": self.max_partners * self.max_partners,
+        }
+        for name, value in derived_resources.items():
+            if value > _INT32_MAX:
+                raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
         maximum_update = (
             float(self.learning_rate)
             * math.sqrt(float(feature_width))
@@ -372,7 +391,11 @@ class PartnerPolicyFusionConfig:
     def from_config(cls, config: Mapping[str, object]) -> PartnerPolicyFusionConfig:
         """Strictly reconstruct only an exact :meth:`to_config` record."""
 
-        payload = dict(config)
+        if type(config) is not dict:
+            raise ValueError("partner-fusion config must be an actual dict")
+        if not all(type(key) is str for key in config):
+            raise ValueError("partner-fusion config keys must be strings")
+        payload = config.copy()
         field_names = {field.name for field in dataclasses.fields(cls)}
         expected = field_names | {
             "schema",
@@ -382,11 +405,14 @@ class PartnerPolicyFusionConfig:
         }
         if set(payload) != expected:
             raise ValueError("config fields do not match the partner-fusion v1 schema")
-        if payload.pop("schema") != PARTNER_POLICY_FUSION_CONFIG_SCHEMA:
+        schema = payload.pop("schema")
+        if type(schema) is not str or schema != PARTNER_POLICY_FUSION_CONFIG_SCHEMA:
             raise ValueError("unexpected partner-fusion config schema")
-        if payload.pop("type") != _CONFIG_TYPE:
+        config_type = payload.pop("type")
+        if type(config_type) is not str or config_type != _CONFIG_TYPE:
             raise ValueError("unexpected partner-fusion config type")
-        if payload.pop("mechanism_status") != MECHANISM_STATUS:
+        mechanism_status = payload.pop("mechanism_status")
+        if type(mechanism_status) is not str or mechanism_status != MECHANISM_STATUS:
             raise ValueError("partner fusion must remain a development L0 mechanism")
         if payload.pop("scientific_promotion_allowed") is not False:
             raise ValueError("partner fusion configuration cannot claim promotion")
@@ -693,14 +719,19 @@ class PartnerPolicyFusion:
     def from_config(cls, config: Mapping[str, object]) -> PartnerPolicyFusion:
         """Strictly restore :class:`PartnerPolicyFusion` construction."""
 
-        payload = dict(config)
+        if type(config) is not dict:
+            raise ValueError("fusion construction must be an actual dict")
+        if not all(type(key) is str for key in config):
+            raise ValueError("fusion construction keys must be strings")
+        payload = config.copy()
         if set(payload) != {"type", "config"}:
             raise ValueError("fusion construction fields do not match the v1 schema")
-        if payload.get("type") != _FUSION_TYPE:
+        config_type = payload.get("type")
+        if type(config_type) is not str or config_type != _FUSION_TYPE:
             raise ValueError("unexpected partner-fusion construction type")
         nested = payload.get("config")
-        if not isinstance(nested, Mapping):
-            raise ValueError("fusion construction config must be a mapping")
+        if type(nested) is not dict:
+            raise ValueError("fusion construction config must be an actual dict")
         return cls(PartnerPolicyFusionConfig.from_config(nested))
 
     def init(self) -> PartnerPolicyFusionState:

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -312,26 +312,27 @@ class PartnerPolicyFusionConfig:
             raise ValueError("blend_net_value_threshold must be below accept threshold")
 
         feature_width = self.model_feature_dim
+        partners = self.max_partners
+        persistent_f32 = partners * feature_width + feature_width + 1
+        persistent_i32 = 2 * partners + 9
+        decision_f32 = self.context_dim + 2 + 2 * partners
+        decision_i32 = 6 + 9 * partners
+        decision_bool = self.n_actions + 1 + partners
         derived_resources = {
-            "reliability_weight_scalars": self.max_partners * feature_width,
-            "persistent_state_scalars": (
-                self.max_partners * feature_width
-                + feature_width
-                + 1
-                + 2 * self.max_partners
-                + 9
-                + 2
-            ),
-            "persistent_state_bytes": 4
-            * (
-                self.max_partners * feature_width
-                + feature_width
-                + 1
-                + 2 * self.max_partners
-                + 9
-            )
-            + 2,
-            "pairwise_comparisons": self.max_partners * self.max_partners,
+            "model_feature_dim": feature_width,
+            "reliability_weight_scalars": partners * feature_width,
+            "reliability_weight_nbytes": 4 * partners * feature_width,
+            "persistent_state_scalars": persistent_f32 + persistent_i32 + 2,
+            "persistent_state_nbytes": 4 * (persistent_f32 + persistent_i32) + 2,
+            "partner_message_scalars": 12 * partners,
+            "partner_message_nbytes": 45 * partners,
+            "pairwise_comparisons": partners * partners,
+            "context_input_nbytes": 4 * self.context_dim,
+            "action_mask_nbytes": self.n_actions,
+            "decision_input_float32_scalars": decision_f32,
+            "decision_input_int32_scalars": decision_i32,
+            "decision_input_bool_scalars": decision_bool,
+            "decision_input_nbytes": 4 * (decision_f32 + decision_i32) + decision_bool,
         }
         for name, value in derived_resources.items():
             if value > _INT32_MAX:

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -9,6 +9,7 @@ from typing import Any
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 try:
@@ -454,3 +455,28 @@ def test_importance_ratio_and_epsilon_greedy_helpers() -> None:
         jnp.array([0.1, 0.9], dtype=jnp.float32),
     )
     assert float(ratio) == 1.25
+
+
+def test_behavior_model_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        BehaviorModelConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        BehaviorModelConfig(n_actions=2, step_size=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="diagnostic_decay"):
+        BehaviorModelConfig(n_actions=2, diagnostic_decay=1.0 - 1e-10)
+
+
+def test_behavior_model_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = BehaviorModelConfig(n_actions=np.int32(3))
+    assert type(config.n_actions) is int
+    assert config.n_actions == 3
+
+    model = BehaviorModel(config)
+    state = model.init(feature_dim=np.int64(4), key=jax.random.key(0))
+    assert state.weights.shape == (3, 4)
+
+    budget = model.resource_budget(np.uint16(4))
+    assert budget.feature_dim == 4
+    assert type(budget.feature_dim) is int

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -12,6 +12,16 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise AssertionError("scalar hook must not run")
+
+
+class _HostileDict(dict[str, Any]):
+    def __iter__(self):
+        raise AssertionError("mapping hook must not run")
+
 try:
     from alberta_framework.core.behavior_model import (
         BehaviorModel,
@@ -480,3 +490,77 @@ def test_behavior_model_config_accepts_and_canonicalizes_numpy_integers() -> Non
     budget = model.resource_budget(np.uint16(4))
     assert budget.feature_dim == 4
     assert type(budget.feature_dim) is int
+
+
+@pytest.mark.parametrize(
+    "scalar_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ],
+)
+def test_behavior_model_accepts_full_numpy_integer_family(scalar_type: type) -> None:
+    config = BehaviorModelConfig(n_actions=scalar_type(2))  # type: ignore[call-arg,arg-type]
+    assert type(config.n_actions) is int
+    assert config.n_actions == 2
+
+
+def test_behavior_model_rejects_hostile_scalar_without_running_hooks() -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        BehaviorModelConfig(n_actions=2, step_size=_HostileFloat(0.1))
+
+
+def test_behavior_model_deserialization_requires_exact_complete_dicts() -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2))
+    construction = model.to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        BehaviorModel.from_config(_HostileDict(construction))
+
+    wrong_type = model.to_config()
+    wrong_type["type"] = _HostileFloat(0.0)
+    with pytest.raises(ValueError, match="type"):
+        BehaviorModel.from_config(wrong_type)
+    missing = model.to_config()
+    missing.pop("type")
+    with pytest.raises(ValueError, match="fields"):
+        BehaviorModel.from_config(missing)
+    nested_subclass = model.to_config()
+    nested = nested_subclass["config"]
+    assert isinstance(nested, dict)
+    nested_subclass["config"] = _HostileDict(nested)
+    with pytest.raises(ValueError, match="nested config"):
+        BehaviorModel.from_config(nested_subclass)
+
+
+def test_behavior_model_preflights_resource_bytes_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2))
+    max_feature_dim = ((2**31 - 1) - 32) // 8
+    budget = model.resource_budget(max_feature_dim)
+    assert budget.state_nbytes <= 2**31 - 1
+    with pytest.raises(ValueError, match="state_nbytes"):
+        model.resource_budget(max_feature_dim + 1)
+
+    calls = 0
+
+    def forbidden_zeros(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("allocator reached")
+
+    monkeypatch.setattr("alberta_framework.core.behavior_model.jnp.zeros", forbidden_zeros)
+    with pytest.raises(ValueError, match="state_nbytes"):
+        model.init(max_feature_dim + 1, jax.random.key(0))
+    assert calls == 0
+    with pytest.raises(AssertionError, match="allocator reached"):
+        model.init(max_feature_dim, jax.random.key(0))
+    assert calls == 1

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -885,3 +885,40 @@ def test_state_tamper_and_static_shape_mismatch_fail_strict_validation() -> None
                 feedback_counts=jnp.zeros((2,), dtype=jnp.int32),
             )
         )
+
+
+def test_partner_policy_fusion_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=True, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=2.5, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4.5, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2.5)  # type: ignore[arg-type]
+
+
+def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=np.int32(2),
+        context_dim=np.int64(4),
+        n_actions=np.uint16(2),
+        max_message_horizon=np.int8(8),
+        min_feedback_for_learned_routing=np.uint32(4),
+        counter_cap=np.int32(1_000_000),
+    )
+    assert type(config.max_partners) is int
+    assert type(config.context_dim) is int
+    assert type(config.n_actions) is int
+    assert type(config.max_message_horizon) is int
+    assert type(config.min_feedback_for_learned_routing) is int
+    assert type(config.counter_cap) is int
+
+    assert config.max_partners == 2
+    assert config.context_dim == 4
+    assert config.n_actions == 2

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -35,6 +35,16 @@ from alberta_framework.core.partner_policy_fusion import (
 pytestmark = pytest.mark.unit
 
 
+class _HostileFloat(float):
+    def __float__(self) -> float:
+        raise AssertionError("float hook must not run")
+
+
+class _HostileDict(dict[str, Any]):
+    def __iter__(self):
+        raise AssertionError("mapping hook must not run")
+
+
 def _replace[T](value: T, **changes: object) -> T:
     """Use chex's immutable replacement method while retaining the type."""
 
@@ -922,3 +932,46 @@ def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers()
     assert config.max_partners == 2
     assert config.context_dim == 4
     assert config.n_actions == 2
+
+
+def test_partner_policy_fusion_rejects_float_subclass_without_hooks() -> None:
+    with pytest.raises(ValueError, match="learning_rate"):
+        PartnerPolicyFusionConfig(
+            max_partners=2,
+            context_dim=2,
+            n_actions=3,
+            learning_rate=_HostileFloat(0.5),
+        )
+
+
+def test_partner_policy_fusion_requires_exact_outer_dicts_and_markers() -> None:
+    fusion = _fusion()
+    with pytest.raises(ValueError, match="actual dict"):
+        PartnerPolicyFusion.from_config(_HostileDict(fusion.to_config()))
+
+    nested_subclass = fusion.to_config()
+    nested = nested_subclass["config"]
+    assert isinstance(nested, dict)
+    nested_subclass["config"] = _HostileDict(nested)
+    with pytest.raises(ValueError, match="actual dict"):
+        PartnerPolicyFusion.from_config(nested_subclass)
+
+    wrong_marker = fusion.to_config()
+    nested_wrong = wrong_marker["config"]
+    assert isinstance(nested_wrong, dict)
+    nested_wrong["schema"] = _HostileFloat(0.0)
+    with pytest.raises(ValueError, match="schema"):
+        PartnerPolicyFusion.from_config(wrong_marker)
+
+
+def test_maximum_fusion_config_keeps_derived_resources_in_int32_domain() -> None:
+    budget = PartnerPolicyFusion(
+        PartnerPolicyFusionConfig(
+            max_partners=1024,
+            context_dim=65_536,
+            n_actions=65_536,
+        )
+    ).resource_budget
+    for value in budget.to_config().values():
+        if type(value) is int:
+            assert 0 <= value <= 2**31 - 1


### PR DESCRIPTION
Supersedes #701 and #702 while retaining both Kayvan-Zahiri contributor commits/authorship.

The original exact integer and float32 hardening is retained and completed with:

- trusted concrete built-in/NumPy scalar admission and canonical storage without hostile scalar hooks;
- exact complete outer/nested dict and marker validation before reconstruction dispatch;
- behavior-model trainable-state and state-byte preflights before allocation/resource publication;
- explicit partner-fusion derived persistent-state, byte, weight, and pairwise bounds;
- full NumPy integer family, hostile subclass/mapping, exact schema, maximum-resource, and allocation-order regressions.

Verification on current main: 104 focused tests passed; scoped Ruff passed; strict mypy passed; diff-check clean. No `outputs/**` or registered evidence sources changed.