### PR TITLE
fix(fusion): enforce exact integer and derived resource contracts

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -27,9 +27,10 @@ import dataclasses
 import hashlib
 import json
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -65,12 +66,32 @@ _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 
 
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
 def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
     """Return a strict positive integer within an explicit bound."""
 
-    if type(value) is not int or not 1 <= value <= maximum:
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
-    return value
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a strict integer in [1, {maximum}]")
+    return canonical
 
 
 def _strict_float32(
@@ -199,20 +220,44 @@ class PartnerPolicyFusionConfig:
     def __post_init__(self) -> None:
         """Reject dynamic dimensions, ambiguous thresholds, and unsafe bounds."""
 
-        _strict_positive_int(self.max_partners, name="max_partners", maximum=1024)
-        _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536)
-        _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536)
-        _strict_positive_int(
-            self.max_message_horizon,
-            name="max_message_horizon",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "max_partners",
+            _strict_positive_int(self.max_partners, name="max_partners", maximum=1024),
         )
-        _strict_positive_int(
-            self.min_feedback_for_learned_routing,
-            name="min_feedback_for_learned_routing",
-            maximum=_INT32_MAX,
+        object.__setattr__(
+            self,
+            "context_dim",
+            _strict_positive_int(self.context_dim, name="context_dim", maximum=65_536),
         )
-        _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX)
+        object.__setattr__(
+            self,
+            "n_actions",
+            _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536),
+        )
+        object.__setattr__(
+            self,
+            "max_message_horizon",
+            _strict_positive_int(
+                self.max_message_horizon,
+                name="max_message_horizon",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_feedback_for_learned_routing",
+            _strict_positive_int(
+                self.min_feedback_for_learned_routing,
+                name="min_feedback_for_learned_routing",
+                maximum=_INT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "counter_cap",
+            _strict_positive_int(self.counter_cap, name="counter_cap", maximum=_INT32_MAX),
+        )
         if self.min_feedback_for_learned_routing > self.counter_cap:
             raise ValueError("min_feedback_for_learned_routing exceeds counter_cap")
 

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -94,6 +94,40 @@ def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX)
     return canonical
 
 
+def _partner_fusion_resource_counts(
+    max_partners: int,
+    context_dim: int,
+    n_actions: int,
+) -> dict[str, int]:
+    """Compute and preflight all dimension-derived logical resource counts."""
+
+    features = context_dim + 2
+    counts = {
+        "model_feature_dim": features,
+        "trainable_float32_scalars": max_partners * features,
+        "persistent_float32_scalars": max_partners * features + features + 1,
+        "persistent_int32_scalars": 2 * max_partners + 9,
+        "persistent_bool_scalars": 2,
+        "partner_id_pairwise_equality_comparisons_per_decision": max_partners
+        * max_partners,
+        "decision_input_float32_scalars": context_dim + 2 + 2 * max_partners,
+        "decision_input_int32_scalars": 6 + 9 * max_partners,
+        "decision_input_bool_scalars": n_actions + 1 + max_partners,
+    }
+    counts["persistent_state_scalars"] = (
+        counts["persistent_float32_scalars"]
+        + counts["persistent_int32_scalars"]
+        + counts["persistent_bool_scalars"]
+    )
+    counts["persistent_state_bytes"] = 4 * (
+        counts["persistent_float32_scalars"] + counts["persistent_int32_scalars"]
+    ) + counts["persistent_bool_scalars"]
+    for name, count in counts.items():
+        if count > _INT32_MAX:
+            raise ValueError(f"derived {name} must be <= {_INT32_MAX}")
+    return counts
+
+
 def _strict_float32(
     value: object,
     *,
@@ -235,6 +269,7 @@ class PartnerPolicyFusionConfig:
             "n_actions",
             _strict_positive_int(self.n_actions, name="n_actions", maximum=65_536),
         )
+        _partner_fusion_resource_counts(self.max_partners, self.context_dim, self.n_actions)
         object.__setattr__(
             self,
             "max_message_horizon",
@@ -652,29 +687,28 @@ class PartnerPolicyFusion:
 
         cfg = self._config
         partners = cfg.max_partners
-        features = cfg.model_feature_dim
-        persistent_f32 = partners * features + features + 1
-        persistent_i32 = 2 * partners + 9
-        persistent_bool = 2
-        persistent_scalars = persistent_f32 + persistent_i32 + persistent_bool
+        counts = _partner_fusion_resource_counts(partners, cfg.context_dim, cfg.n_actions)
+        features = counts["model_feature_dim"]
         return PartnerPolicyFusionResourceBudget(
             max_partners=partners,
             context_dim=cfg.context_dim,
             n_actions=cfg.n_actions,
             model_feature_dim=features,
-            trainable_float32_scalars=partners * features,
-            persistent_float32_scalars=persistent_f32,
-            persistent_int32_scalars=persistent_i32,
-            persistent_bool_scalars=persistent_bool,
-            persistent_state_scalars=persistent_scalars,
-            persistent_state_bytes=4 * (persistent_f32 + persistent_i32) + persistent_bool,
+            trainable_float32_scalars=counts["trainable_float32_scalars"],
+            persistent_float32_scalars=counts["persistent_float32_scalars"],
+            persistent_int32_scalars=counts["persistent_int32_scalars"],
+            persistent_bool_scalars=counts["persistent_bool_scalars"],
+            persistent_state_scalars=counts["persistent_state_scalars"],
+            persistent_state_bytes=counts["persistent_state_bytes"],
             max_messages_per_decision=partners,
             max_model_scores_per_decision=partners,
-            partner_id_pairwise_equality_comparisons_per_decision=partners * partners,
+            partner_id_pairwise_equality_comparisons_per_decision=counts[
+                "partner_id_pairwise_equality_comparisons_per_decision"
+            ],
             max_trainable_scalars_touched_per_feedback=features,
-            decision_input_float32_scalars=cfg.context_dim + 2 + 2 * partners,
-            decision_input_int32_scalars=6 + 9 * partners,
-            decision_input_bool_scalars=cfg.n_actions + 1 + partners,
+            decision_input_float32_scalars=counts["decision_input_float32_scalars"],
+            decision_input_int32_scalars=counts["decision_input_int32_scalars"],
+            decision_input_bool_scalars=counts["decision_input_bool_scalars"],
             feedback_input_float32_scalars=1,
             feedback_input_int32_scalars=4,
             feedback_input_bool_scalars=4,

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from typing import Any, cast
 
 import jax
@@ -922,3 +923,104 @@ def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers()
     assert config.max_partners == 2
     assert config.context_dim == 4
     assert config.n_actions == 2
+
+
+@pytest.mark.parametrize("dtype", [np.dtype(code).type for code in "bBhHiIlLqQ"])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "max_partners",
+        "context_dim",
+        "n_actions",
+        "max_message_horizon",
+        "min_feedback_for_learned_routing",
+        "counter_cap",
+    ],
+)
+def test_partner_policy_fusion_accepts_full_numpy_integer_matrix(
+    dtype: type[Any],
+    field: str,
+) -> None:
+    kwargs: dict[str, Any] = {
+        "max_partners": 2,
+        "context_dim": 4,
+        "n_actions": 2,
+        "min_feedback_for_learned_routing": 1,
+    }
+    kwargs[field] = dtype(2)
+    config = PartnerPolicyFusionConfig(**kwargs)
+
+    assert type(getattr(config, field)) is int
+    serialized = config.to_config()
+    assert json.loads(json.dumps(serialized)) == serialized
+    assert PartnerPolicyFusionConfig.from_config(serialized) == config
+
+
+def test_partner_policy_fusion_rejects_hostile_integer_impostors() -> None:
+    class IntegerSubclass(int):
+        pass
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("validation must not inspect hostile repr")
+
+    for field in (
+        "max_partners",
+        "context_dim",
+        "n_actions",
+        "max_message_horizon",
+        "min_feedback_for_learned_routing",
+        "counter_cap",
+    ):
+        for value in (IntegerSubclass(2), ClassSpoof()):
+            kwargs: dict[str, Any] = {
+                "max_partners": 2,
+                "context_dim": 4,
+                "n_actions": 2,
+                field: value,
+            }
+            with pytest.raises(ValueError, match=field):
+                PartnerPolicyFusionConfig(**kwargs)
+
+
+def test_partner_policy_fusion_maximum_declared_resources_are_int32_safe() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=1024,
+        context_dim=65_536,
+        n_actions=65_536,
+        max_message_horizon=2**31 - 1,
+        min_feedback_for_learned_routing=2**31 - 1,
+        counter_cap=2**31 - 1,
+    )
+    budget = PartnerPolicyFusion(config).resource_budget
+
+    for value in budget.to_config().values():
+        assert type(value) is int
+        assert 0 <= value <= 2**31 - 1
+    assert budget.model_feature_dim == 65_538
+    assert budget.partner_id_pairwise_equality_comparisons_per_decision == 1024**2
+    assert json.loads(json.dumps(budget.to_config())) == budget.to_config()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("max_partners", 1025), ("context_dim", 65_537), ("n_actions", 65_537)],
+)
+def test_partner_policy_fusion_rejects_first_declared_dimension_overflow(
+    field: str,
+    value: int,
+) -> None:
+    kwargs = {"max_partners": 2, "context_dim": 4, "n_actions": 2, field: value}
+    with pytest.raises(ValueError, match=field):
+        PartnerPolicyFusionConfig(**kwargs)
+
+
+def test_partner_policy_fusion_serialized_integer_contract_is_json_exact() -> None:
+    payload = PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2).to_config()
+    payload["max_partners"] = np.int32(2)
+    with pytest.raises(ValueError, match="serialized max_partners"):
+        PartnerPolicyFusionConfig.from_config(payload)

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -885,3 +885,40 @@ def test_state_tamper_and_static_shape_mismatch_fail_strict_validation() -> None
                 feedback_counts=jnp.zeros((2,), dtype=jnp.int32),
             )
         )
+
+
+def test_partner_policy_fusion_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=True, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionConfig(max_partners=2.5, context_dim=4, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="context_dim"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4.5, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        PartnerPolicyFusionConfig(max_partners=2, context_dim=4, n_actions=2.5)  # type: ignore[arg-type]
+
+
+def test_partner_policy_fusion_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = PartnerPolicyFusionConfig(
+        max_partners=np.int32(2),
+        context_dim=np.int64(4),
+        n_actions=np.uint16(2),
+        max_message_horizon=np.int8(8),
+        min_feedback_for_learned_routing=np.uint32(4),
+        counter_cap=np.int32(1_000_000),
+    )
+    assert type(config.max_partners) is int
+    assert type(config.context_dim) is int
+    assert type(config.n_actions) is int
+    assert type(config.max_message_horizon) is int
+    assert type(config.min_feedback_for_learned_routing) is int
+    assert type(config.counter_cap) is int
+
+    assert config.max_partners == 2
+    assert config.context_dim == 4
+    assert config.n_actions == 2


### PR DESCRIPTION
Supersedes #702 while preserving its contributor commit.

The existing public caps (1024 partners, 65,536 context/actions) are retained because their complete derived resource panel remains int32-safe. A shared allocation-free resource computation now proves and enforces that domain in both construction and `resource_budget`. The tests cover all six integer fields across every supported NumPy integer dtype, hostile subclasses and `__class__` spoofing, canonical JSON/from_config boundaries, maximum legal resource formulas, and first declared overflows.

No registered evidence source references this module.

Verification:
- `pytest tests/test_partner_policy_fusion.py -q` (128 passed)
- scoped Ruff
- scoped strict mypy
- `git diff --check`