### PR TITLE
fix(continual-multiagent): harden benchmark configuration integer validation

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -32,10 +32,11 @@ solution.  All updates are predict-act-observe-update and use no replay.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import perf_counter, perf_counter_ns
-from typing import Literal
+from typing import Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -71,6 +72,31 @@ CONDITION_MASKS: tuple[tuple[ConditionName, tuple[bool, bool]], ...] = (
     ("learner_only", (True, False)),
     ("joint_adaptive", (True, True)),
 )
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -91,30 +117,42 @@ class ContinualMultiAgentConfig:
     bootstrap_seed: int = 2_026_073_000
 
     def __post_init__(self) -> None:
-        if self.phase_steps < 2:
-            raise ValueError("phase_steps must be at least 2")
-        if self.nuisance_dim < 0:
-            raise ValueError("nuisance_dim must be non-negative")
+        phase_steps = _require_int32("phase_steps", self.phase_steps, minimum=2)
+        nuisance_dim = _require_int32("nuisance_dim", self.nuisance_dim, minimum=0)
+        probe_horizon = _require_int32(
+            "probe_horizon", self.probe_horizon, minimum=1, maximum=phase_steps
+        )
+        probe_tail_steps = _require_int32(
+            "probe_tail_steps", self.probe_tail_steps, minimum=1, maximum=probe_horizon
+        )
+        recovery_window = _require_int32(
+            "recovery_window", self.recovery_window, minimum=1, maximum=phase_steps
+        )
+        bootstrap_resamples = _require_int32(
+            "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
+        )
+        bootstrap_seed = _require_int32(
+            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        )
+
+        object.__setattr__(self, "phase_steps", phase_steps)
+        object.__setattr__(self, "nuisance_dim", nuisance_dim)
+        object.__setattr__(self, "probe_horizon", probe_horizon)
+        object.__setattr__(self, "probe_tail_steps", probe_tail_steps)
+        object.__setattr__(self, "recovery_window", recovery_window)
+        object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
+        object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
+
         if not 0.0 < self.learning_rate <= 1.0:
             raise ValueError("learning_rate must lie in (0, 1]")
         if not 0.0 <= self.exploration_rate <= 1.0:
             raise ValueError("exploration_rate must lie in [0, 1]")
-        if not 1 <= self.probe_tail_steps <= self.probe_horizon:
-            raise ValueError("probe_tail_steps must lie in [1, probe_horizon]")
-        if self.probe_horizon > self.phase_steps:
-            raise ValueError("probe_horizon cannot cross a phase boundary")
         if not 0.0 <= self.recovery_reward_threshold <= 1.0:
             raise ValueError("recovery_reward_threshold must lie in [0, 1]")
-        if not 1 <= self.recovery_window <= self.phase_steps:
-            raise ValueError("recovery_window must lie in [1, phase_steps]")
         if not 0.0 <= self.stability_reference_reward <= 1.0:
             raise ValueError("stability_reference_reward must lie in [0, 1]")
-        if self.bootstrap_resamples < 1_000:
-            raise ValueError("bootstrap_resamples must be at least 1000")
         if not 0.0 < self.confidence_level < 1.0:
             raise ValueError("confidence_level must lie in (0, 1)")
-        if not 0 <= self.bootstrap_seed < 2**32:
-            raise ValueError("bootstrap_seed must lie in [0, 2**32)")
 
 
 @dataclass(frozen=True)
@@ -141,6 +179,18 @@ class AcceptanceThresholds:
     maximum_mean_recurrence_recovery_steps: float = 16.0
     maximum_mean_stability_gap: float = 0.20
     maximum_update_latency_ms: float = 5.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_seed_count",
+            _require_int32("minimum_seed_count", self.minimum_seed_count, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "evidence_seed_start",
+            _require_int32("evidence_seed_start", self.evidence_seed_start, minimum=0),
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -94,17 +94,13 @@ def test_three_seed_smoke_cannot_be_promoted_as_scientific_evidence(
 ) -> None:
     assert not smoke_report.acceptance.passed
     seed_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "seed_count"
+        check for check in smoke_report.acceptance.checks if check.name == "seed_count"
     )
     assert not seed_check.passed
     assert seed_check.actual == 3.0
     assert seed_check.threshold == 30.0
     schedule_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "evidence_seed_schedule"
+        check for check in smoke_report.acceptance.checks if check.name == "evidence_seed_schedule"
     )
     assert not schedule_check.passed
 
@@ -115,9 +111,7 @@ def test_seeded_learning_evidence_is_exactly_reproducible(
     evidence_seed = benchmark_report.aggregate.seeds[0]
     repeated = run_continual_multiagent_benchmark(seeds=(evidence_seed,))
     original = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
 
     assert len(original) == len(repeated.condition_results) == 3
@@ -243,16 +237,14 @@ def test_aggregate_intervals_use_matched_seed_differences(
     }
     reward_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "frozen")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "frozen")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
     )
     coadaptation_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "learner_only")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "learner_only")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
@@ -271,9 +263,7 @@ def test_public_aggregation_rejects_duplicate_seed_weighting(
 ) -> None:
     evidence_seed = benchmark_report.aggregate.seeds[0]
     one_seed = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
     with pytest.raises(ValueError, match="unique"):
         aggregate_evidence(one_seed + one_seed)
@@ -299,10 +289,7 @@ def test_artifact_has_deterministic_scientific_content_and_digest(
     operational = changed_diagnostics["operational_diagnostics"]
     assert isinstance(operational, dict)
     operational["maximum_update_latency_ms"] = 123_456.0
-    assert (
-        changed_diagnostics["content_digest"]["sha256"]
-        == first["content_digest"]["sha256"]
-    )
+    assert changed_diagnostics["content_digest"]["sha256"] == first["content_digest"]["sha256"]
     validation = validate_evidence_artifact(changed_diagnostics)
     assert not validation.valid
     assert not validation.accepted
@@ -326,24 +313,15 @@ def test_artifact_is_strict_json_with_narrow_claim_and_seed_evidence(
     content = loaded["content"]
     assert content["protocol"]["protocol_version"] == PROTOCOL_VERSION
     assert len(content["seed_summaries"]) == 30
-    assert (
-        "coadaptation_uplift_over_learner_only"
-        in content["aggregate"]
-    )
+    assert "coadaptation_uplift_over_learner_only" in content["aggregate"]
     excluded = content["protocol"]["excluded_claims"]
     assert "general feature discovery" in excluded
     assert "intelligence amplification or recommendation intervention" in excluded
-    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(
-        range(30, 60)
-    )
-    recovery_interval = content["aggregate"][
-        "recurrence_recovery_fraction_interval"
-    ]
+    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(range(30, 60))
+    recovery_interval = content["aggregate"]["recurrence_recovery_fraction_interval"]
     assert recovery_interval["method"] == "wilson-score"
     assert recovery_interval["sample_size"] == 30
-    assert recovery_interval["lower"] < content["aggregate"][
-        "recurrence_recovery_fraction"
-    ]
+    assert recovery_interval["lower"] < content["aggregate"]["recurrence_recovery_fraction"]
 
 
 def test_artifact_loader_rejects_duplicate_object_keys(tmp_path) -> None:
@@ -430,12 +408,9 @@ def test_rehashed_incomplete_seed_payload_still_fails_closed(
     assert not validation.valid
     assert not validation.accepted
     assert any(
-        "must contain exactly unique held-out seeds 30-59" in error
-        for error in validation.errors
+        "must contain exactly unique held-out seeds 30-59" in error for error in validation.errors
     )
-    assert any(
-        "aggregate.seeds must match" in error for error in validation.errors
-    )
+    assert any("aggregate.seeds must match" in error for error in validation.errors)
 
 
 def test_rehashed_interval_with_wrong_sample_size_fails_closed(
@@ -511,9 +486,7 @@ def test_cli_fails_for_underpowered_smoke_without_rerun(
     content = artifact["content"]
     assert content["acceptance"]["passed"] is False
     seed_check = next(
-        check
-        for check in content["acceptance"]["checks"]
-        if check["name"] == "seed_count"
+        check for check in content["acceptance"]["checks"] if check["name"] == "seed_count"
     )
     assert seed_check["actual"] == 3.0
     assert seed_check["passed"] is False
@@ -543,11 +516,7 @@ def test_cli_rechecks_impossible_thresholds_without_rerun(
     assert validation.valid
     assert not validation.accepted
     content = artifact["content"]
-    failed = {
-        check["name"]
-        for check in content["acceptance"]["checks"]
-        if not check["passed"]
-    }
+    failed = {check["name"] for check in content["acceptance"]["checks"] if not check["passed"]}
     assert "reward_uplift_over_frozen" in failed
 
 
@@ -572,3 +541,46 @@ def test_cli_rejects_weaker_than_canonical_thresholds_without_rerun(
     assert emitted["accepted"] is False
     assert emitted["valid"] is False
     assert not path.exists()
+
+
+def test_continual_multiagent_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=64.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nuisance_dim"):
+        ContinualMultiAgentConfig(nuisance_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
+        ContinualMultiAgentConfig(bootstrap_resamples=1000.5)  # type: ignore[arg-type]
+
+
+def test_continual_multiagent_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = ContinualMultiAgentConfig(
+        phase_steps=np.int32(64),
+        nuisance_dim=np.int64(4),
+        probe_horizon=np.uint16(12),
+        probe_tail_steps=np.uint8(4),
+        recovery_window=np.int32(4),
+        bootstrap_resamples=np.int64(10_000),
+        bootstrap_seed=np.uint32(2_026_073_000),
+    )
+    assert type(cfg.phase_steps) is int
+    assert type(cfg.nuisance_dim) is int
+    assert type(cfg.probe_horizon) is int
+    assert type(cfg.probe_tail_steps) is int
+    assert type(cfg.recovery_window) is int
+    assert type(cfg.bootstrap_resamples) is int
+    assert type(cfg.bootstrap_seed) is int
+    assert cfg.phase_steps == 64
+    assert cfg.nuisance_dim == 4
+
+
+def test_acceptance_thresholds_accepts_and_canonicalizes_numpy_integers() -> None:
+    thresholds = AcceptanceThresholds(
+        minimum_seed_count=np.int32(30),
+        evidence_seed_start=np.int64(30),
+    )
+    assert type(thresholds.minimum_seed_count) is int
+    assert type(thresholds.evidence_seed_start) is int
+    assert thresholds.minimum_seed_count == 30
+    assert thresholds.evidence_seed_start == 30


### PR DESCRIPTION
## Summary
- Hardens `ContinualMultiAgentConfig` integer dimensions (`phase_steps`, `nuisance_dim`, `probe_horizon`, `probe_tail_steps`, `recovery_window`, `bootstrap_resamples`, `bootstrap_seed`) and `AcceptanceThresholds` integer fields (`minimum_seed_count`, `evidence_seed_start`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Canonicalizes all integer attributes to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_continual_multiagent_benchmark.py tests/test_recurring_multiagent_stream.py`: 54 passed
- `ruff check .`: clean
- `mypy alberta_framework/evaluation/continual_multiagent.py`: clean
- No registered evidence artifacts modified.