### PR TITLE
fix(world-model): complete latent configuration contracts

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -113,6 +113,18 @@ def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
     )
 
 
+def _require_int32_product(name: str, left: int, right: int) -> int:
+    if left > _INT32_MAX // right:
+        raise ValueError(f"derived {name} must fit in signed int32")
+    return left * right
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a bool")
+    return value
+
+
 @dataclasses.dataclass(frozen=True)
 class LatentWorldModelConfig:
     """Configuration for :class:`LatentWorldModel`.
@@ -153,7 +165,7 @@ class LatentWorldModelConfig:
     encoder_collapse_gate_threshold: float = 0.0
 
     def __post_init__(self) -> None:
-        """Validate structural dimensions and canonicalize integer types."""
+        """Validate and canonicalize the complete static construction."""
         object.__setattr__(
             self,
             "observation_dim",
@@ -174,6 +186,77 @@ class LatentWorldModelConfig:
             "hidden_sizes",
             _validate_hidden_sizes(self.hidden_sizes),
         )
+        for name in (
+            "predict_delta",
+            "use_layer_norm",
+            "include_action_interactions",
+            "encoder_learning",
+        ):
+            object.__setattr__(self, name, _require_bool(name, getattr(self, name)))
+        if type(self.trace_mode) is not TraceMode:
+            raise ValueError("trace_mode must be a TraceMode")
+
+        observation_scale = self.observation_scale
+        if observation_scale is not None:
+            if type(observation_scale) is not tuple:
+                raise ValueError("observation_scale must be an actual tuple or None")
+            if len(observation_scale) != self.observation_dim:
+                raise ValueError("observation_scale length must equal observation_dim")
+            observation_scale = tuple(
+                validated_float32_scalar(
+                    f"observation_scale[{index}]", scale, positive=True
+                )
+                for index, scale in enumerate(observation_scale)
+            )
+            object.__setattr__(self, "observation_scale", observation_scale)
+
+        scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
+            ("gamma", {"lower": 0.0, "upper": 1.0}),
+            ("reward_scale", {"positive": True}),
+            ("encoder_scale", {"positive": True}),
+            ("encoder_bias_scale", {"lower": 0.0}),
+            ("step_size", {"positive": True}),
+            ("sparsity", {"lower": 0.0, "upper": 1.0}),
+            ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
+            ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+            ("surprise_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+            ("collapse_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+            ("min_latent_std", {"lower": 0.0}),
+            ("max_latent_delta", {"positive": True}),
+            ("encoder_step_size", {"positive": True}),
+            ("max_encoder_update", {"positive": True}),
+            ("encoder_collapse_gate_threshold", {"lower": 0.0, "upper": 1.0}),
+        )
+        for name, bounds in scalar_specs:
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), **bounds),
+            )
+
+        _require_int32_product(
+            "encoder_matrix_scalars", self.observation_dim, self.latent_dim
+        )
+        if self.latent_dim > _INT32_MAX - 2:
+            raise ValueError("derived n_heads must fit in signed int32")
+        n_heads = self.latent_dim + 2
+        if self.latent_dim > _INT32_MAX - self.n_actions:
+            raise ValueError("derived input_dim must fit in signed int32")
+        input_dim = self.latent_dim + self.n_actions
+        if self.include_action_interactions:
+            interactions = _require_int32_product(
+                "action_interaction_scalars", self.latent_dim, self.n_actions
+            )
+            if input_dim > _INT32_MAX - interactions:
+                raise ValueError("derived input_dim must fit in signed int32")
+            input_dim += interactions
+        layer_sizes = (input_dim, *self.hidden_sizes)
+        for index, (fan_in, fan_out) in enumerate(
+            zip(layer_sizes, layer_sizes[1:], strict=False)
+        ):
+            _require_int32_product(f"hidden_layer[{index}]_scalars", fan_in, fan_out)
+        head_input = self.hidden_sizes[-1] if self.hidden_sizes else input_dim
+        _require_int32_product("head_weight_scalars", n_heads, head_input)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -188,13 +271,26 @@ class LatentWorldModelConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> LatentWorldModelConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("config must be an actual dict")
         payload = dict(config)
-        payload.pop("type", None)
+        config_type = payload.pop("type", None)
+        if config_type is not None and config_type != "LatentWorldModelConfig":
+            raise ValueError("unexpected latent world model config type")
+        expected_fields = {field.name for field in dataclasses.fields(cls)}
+        if not set(payload) <= expected_fields:
+            raise ValueError("config contains unknown fields")
         if "hidden_sizes" in payload:
+            if type(payload["hidden_sizes"]) is not list:
+                raise ValueError("hidden_sizes must be a list in serialized config")
             payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
         if "observation_scale" in payload and payload["observation_scale"] is not None:
+            if type(payload["observation_scale"]) is not list:
+                raise ValueError("observation_scale must be a list in serialized config")
             payload["observation_scale"] = tuple(payload["observation_scale"])
         if "trace_mode" in payload:
+            if type(payload["trace_mode"]) is not str:
+                raise ValueError("trace_mode must be a string in serialized config")
             payload["trace_mode"] = TraceMode(payload["trace_mode"])
         return cls(**payload)
 
@@ -389,8 +485,16 @@ class LatentWorldModel:
             optimizer_from_config,
         )
 
+        if type(config) is not dict:
+            raise ValueError("model config must be an actual dict")
+        if set(config) != {"type", "config", "learner"}:
+            raise ValueError("model config fields do not match the serialized schema")
+        if config.get("type") != "LatentWorldModel":
+            raise ValueError("unexpected latent world model type")
         payload = dict(config)
-        payload.pop("type", None)
+        payload.pop("type")
+        if type(payload["config"]) is not dict or type(payload["learner"]) is not dict:
+            raise ValueError("nested model configs must be actual dicts")
         model_config = LatentWorldModelConfig.from_config(payload["config"])
         learner_cfg = dict(payload["learner"])
         optimizer = optimizer_from_config(learner_cfg["optimizer"])
@@ -426,6 +530,11 @@ class LatentWorldModel:
             if self._config.encoder_bias_scale > 0.0
             else jnp.zeros((latent_dim,), dtype=jnp.float32)
         )
+        if not bool(
+            jnp.all(jnp.isfinite(encoder_matrix))
+            & jnp.all(jnp.isfinite(encoder_bias))
+        ):
+            raise ValueError("encoder initialization produced non-finite parameters")
         return LatentWorldModelState(
             encoder_matrix=encoder_matrix,
             encoder_bias=encoder_bias,
@@ -846,60 +955,10 @@ class LatentWorldModel:
         )
 
     def _validate_config(self, config: LatentWorldModelConfig) -> LatentWorldModelConfig:
-        """Fail closed on malformed configuration and return its canonical float32 form."""
-        _require_int32("observation_dim", config.observation_dim, minimum=1)
-        _require_int32("n_actions", config.n_actions, minimum=1)
-        _require_int32("latent_dim", config.latent_dim, minimum=1)
-        _validate_hidden_sizes(config.hidden_sizes)
-        observation_scale = config.observation_scale
-        if observation_scale is not None:
-            if len(observation_scale) != config.observation_dim:
-                raise ValueError("observation_scale length must equal observation_dim")
-            observation_scale = tuple(
-                validated_float32_scalar("observation_scale values", scale, positive=True)
-                for scale in observation_scale
-            )
-        return dataclasses.replace(
-            config,
-            gamma=validated_float32_scalar("gamma", config.gamma, lower=0.0, upper=1.0),
-            observation_scale=observation_scale,
-            reward_scale=validated_float32_scalar(
-                "reward_scale", config.reward_scale, positive=True
-            ),
-            encoder_scale=validated_float32_scalar(
-                "encoder_scale", config.encoder_scale, positive=True
-            ),
-            encoder_bias_scale=validated_float32_scalar(
-                "encoder_bias_scale", config.encoder_bias_scale, lower=0.0
-            ),
-            min_latent_std=validated_float32_scalar(
-                "min_latent_std", config.min_latent_std, lower=0.0
-            ),
-            max_latent_delta=validated_float32_scalar(
-                "max_latent_delta", config.max_latent_delta, positive=True
-            ),
-            encoder_step_size=validated_float32_scalar(
-                "encoder_step_size", config.encoder_step_size, positive=True
-            ),
-            max_encoder_update=validated_float32_scalar(
-                "max_encoder_update", config.max_encoder_update, positive=True
-            ),
-            encoder_collapse_gate_threshold=validated_float32_scalar(
-                "encoder_collapse_gate_threshold",
-                config.encoder_collapse_gate_threshold,
-                lower=0.0,
-                upper=1.0,
-            ),
-            utility_decay=validated_float32_scalar(
-                "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
-            ),
-            surprise_decay=validated_float32_scalar(
-                "surprise_decay", config.surprise_decay, lower=0.0, upper=1.0, upper_inclusive=False
-            ),
-            collapse_decay=validated_float32_scalar(
-                "collapse_decay", config.collapse_decay, lower=0.0, upper=1.0, upper_inclusive=False
-            ),
-        )
+        """Return the fail-closed canonical dataclass construction."""
+        if type(config) is not LatentWorldModelConfig:
+            raise ValueError("config must be a LatentWorldModelConfig")
+        return config
 
 
 def run_latent_world_model_learning_loop(

--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -48,12 +48,14 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -75,6 +77,40 @@ from alberta_framework.core.update_safety import (
 
 EVIDENCE_LEVEL = "L0"
 SCIENTIFIC_PROMOTION_ALLOWED = False
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
+    if type(sizes) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(
+        _require_int32(f"hidden_sizes[{index}]", size, minimum=1)
+        for index, size in enumerate(sizes)
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -115,6 +151,29 @@ class LatentWorldModelConfig:
     encoder_step_size: float = 0.01
     max_encoder_update: float = 0.1
     encoder_collapse_gate_threshold: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate structural dimensions and canonicalize integer types."""
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "latent_dim",
+            _require_int32("latent_dim", self.latent_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _validate_hidden_sizes(self.hidden_sizes),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -386,9 +445,7 @@ class LatentWorldModel:
         observation: Array,
     ) -> Float[Array, " latent_dim"]:
         """Encode one observation with explicit (differentiable) encoder params."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
         scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
@@ -555,9 +612,7 @@ class LatentWorldModel:
             encoder_bias: Array,
         ) -> Array:
             latent = self._encode_with(encoder_matrix, encoder_bias, observation)
-            target_next_latent = self._encode_with(
-                encoder_matrix, encoder_bias, next_observation
-            )
+            target_next_latent = self._encode_with(encoder_matrix, encoder_bias, next_observation)
             raw_predictions = self._learner.predict(
                 state.learner_state,
                 self.input_features_from_latent(latent, action),
@@ -586,9 +641,7 @@ class LatentWorldModel:
         )
         step_size = jnp.asarray(config.encoder_step_size, dtype=jnp.float32)
         bound = jnp.asarray(config.max_encoder_update, dtype=jnp.float32)
-        candidate_matrix = state.encoder_matrix + jnp.clip(
-            -step_size * grad_matrix, -bound, bound
-        )
+        candidate_matrix = state.encoder_matrix + jnp.clip(-step_size * grad_matrix, -bound, bound)
         candidate_bias = state.encoder_bias + jnp.clip(-step_size * grad_bias, -bound, bound)
         gate_blocked = collapse_score > jnp.asarray(
             config.encoder_collapse_gate_threshold, dtype=jnp.float32
@@ -630,9 +683,9 @@ class LatentWorldModel:
         )
         reward_arr = jnp.asarray(reward, dtype=jnp.float32)
         discount_arr = jnp.asarray(discount, dtype=jnp.float32)
-        next_observation_arr = jnp.asarray(
-            next_observation, dtype=jnp.float32
-        ).reshape((self._config.observation_dim,))
+        next_observation_arr = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
+            (self._config.observation_dim,)
+        )
         inputs_valid = (
             jnp.all(jnp.isfinite(observation_arr))
             & action_valid
@@ -642,14 +695,10 @@ class LatentWorldModel:
             & jnp.all(discount_arr <= 1.0)
             & jnp.all(jnp.isfinite(next_observation_arr))
         )
-        safe_observation = jnp.where(
-            inputs_valid, observation_arr, jnp.zeros_like(observation_arr)
-        )
+        safe_observation = jnp.where(inputs_valid, observation_arr, jnp.zeros_like(observation_arr))
         safe_action = jnp.where(inputs_valid, action_arr, jnp.zeros_like(action_arr))
         safe_reward = jnp.where(inputs_valid, reward_arr, jnp.zeros_like(reward_arr))
-        safe_discount = jnp.where(
-            inputs_valid, discount_arr, jnp.zeros_like(discount_arr)
-        )
+        safe_discount = jnp.where(inputs_valid, discount_arr, jnp.zeros_like(discount_arr))
         safe_next_observation = jnp.where(
             inputs_valid,
             next_observation_arr,
@@ -681,8 +730,7 @@ class LatentWorldModel:
         next_mean = jnp.where(
             first,
             target_next_latent,
-            collapse_decay * state.latent_mean_ema
-            + (1.0 - collapse_decay) * target_next_latent,
+            collapse_decay * state.latent_mean_ema + (1.0 - collapse_decay) * target_next_latent,
         )
         centered = target_next_latent - next_mean
         next_var = jnp.where(
@@ -705,8 +753,7 @@ class LatentWorldModel:
         next_prediction_error_ema = jnp.where(
             first,
             prediction_error,
-            surprise_decay * state.prediction_error_ema
-            + (1.0 - surprise_decay) * prediction_error,
+            surprise_decay * state.prediction_error_ema + (1.0 - surprise_decay) * prediction_error,
         )
         next_collapse_score_ema = jnp.where(
             first,
@@ -776,9 +823,7 @@ class LatentWorldModel:
             next_latent=neutralize_array(update_applied, prediction.next_latent),
             reward=neutralize_array(update_applied, prediction.reward),
             discount=neutralize_array(update_applied, prediction.discount),
-            raw_predictions=neutralize_array(
-                update_applied, prediction.raw_predictions
-            ),
+            raw_predictions=neutralize_array(update_applied, prediction.raw_predictions),
         )
         return LatentWorldModelUpdateResult(
             state=committed_state,
@@ -796,22 +841,16 @@ class LatentWorldModel:
             learner_result=reported_learner_result,
             encoder_update_applied=encoder_update_applied & update_applied,
             encoder_collapse_gated=encoder_collapse_gated & update_applied,
-            encoder_gradient_norm=neutralize_array(
-                update_applied, encoder_gradient_norm
-            ),
+            encoder_gradient_norm=neutralize_array(update_applied, encoder_gradient_norm),
             update_applied=update_applied,
         )
 
     def _validate_config(self, config: LatentWorldModelConfig) -> LatentWorldModelConfig:
         """Fail closed on malformed configuration and return its canonical float32 form."""
-        if config.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if config.n_actions <= 0:
-            raise ValueError("n_actions must be positive")
-        if config.latent_dim <= 0:
-            raise ValueError("latent_dim must be positive")
-        if any(size <= 0 for size in config.hidden_sizes):
-            raise ValueError("hidden_sizes must contain only positive widths")
+        _require_int32("observation_dim", config.observation_dim, minimum=1)
+        _require_int32("n_actions", config.n_actions, minimum=1)
+        _require_int32("latent_dim", config.latent_dim, minimum=1)
+        _validate_hidden_sizes(config.hidden_sizes)
         observation_scale = config.observation_scale
         if observation_scale is not None:
             if len(observation_scale) != config.observation_dim:
@@ -905,23 +944,26 @@ def run_latent_world_model_learning_loop(
             result.update_applied,
         )
 
-    final_state, (
-        latent_predictions,
-        next_latent_predictions,
-        reward_predictions,
-        discount_predictions,
-        target_next_latents,
-        surprises,
-        prediction_errors,
-        reward_errors,
-        discount_errors,
-        latent_std_means,
-        collapse_scores,
-        per_head_metrics,
-        encoder_updates_applied,
-        encoder_collapse_gates,
-        encoder_gradient_norms,
-        updates_applied,
+    (
+        final_state,
+        (
+            latent_predictions,
+            next_latent_predictions,
+            reward_predictions,
+            discount_predictions,
+            target_next_latents,
+            surprises,
+            prediction_errors,
+            reward_errors,
+            discount_errors,
+            latent_std_means,
+            collapse_scores,
+            per_head_metrics,
+            encoder_updates_applied,
+            encoder_collapse_gates,
+            encoder_gradient_norms,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         _scan_fn,
         state,

--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -103,6 +103,15 @@ def _positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int
     return canonical
 
 
+def _nonnegative_int(value: object, *, name: str, maximum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in 0..{maximum}")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 0 <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in 0..{maximum}")
+    return canonical
+
+
 def _finite_float32(
     value: object,
     *,
@@ -313,17 +322,14 @@ class RecurrentLatentWorldModelEnsembleConfig:
             "max_updates",
             _positive_int(self.max_updates, name="max_updates"),
         )
-        if (
-            type(self.uncertainty_warmup_steps) not in _ACTUAL_INT_TYPES
-            or not 0
-            <= operator.index(cast(SupportsIndex, self.uncertainty_warmup_steps))
-            <= self.max_updates
-        ):
-            raise ValueError("uncertainty_warmup_steps must be in 0..max_updates")
         object.__setattr__(
             self,
             "uncertainty_warmup_steps",
-            operator.index(cast(SupportsIndex, self.uncertainty_warmup_steps)),
+            _nonnegative_int(
+                self.uncertainty_warmup_steps,
+                name="uncertainty_warmup_steps",
+                maximum=self.max_updates,
+            ),
         )
 
         positive_fields = (
@@ -432,13 +438,15 @@ class RecurrentLatentWorldModelEnsembleConfig:
         config: Mapping[str, object],
     ) -> RecurrentLatentWorldModelEnsembleConfig:
         """Strictly reconstruct :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("config must be an actual dict")
         expected = {field.name for field in dataclasses.fields(cls)} | {"type"}
         if set(config) != expected:
             raise ValueError("config fields do not match the serialized schema")
         if config.get("type") != cls.__name__:
             raise ValueError("unexpected recurrent latent ensemble config type")
         kwargs = {field.name: config[field.name] for field in dataclasses.fields(cls)}
-        restored = cls(**cast(dict[str, Any], kwargs))
+        restored = cls(**kwargs)
         if not _strict_json_equal(dict(config), restored.to_config()):
             raise ValueError("config is not the canonical serialized construction")
         return restored
@@ -696,6 +704,8 @@ class RecurrentLatentWorldModelEnsemble:
         config: Mapping[str, object],
     ) -> RecurrentLatentWorldModelEnsemble:
         """Strictly reconstruct :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("model config must be an actual dict")
         if set(config) != {"type", "config"}:
             raise ValueError("model config fields do not match the serialized schema")
         if config.get("type") != cls.__name__:

--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -46,10 +46,11 @@ import functools
 import hashlib
 import json
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -71,17 +72,35 @@ RECURRENT_LATENT_WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA = (
     "alberta.recurrent_latent_world_model_ensemble.v1"
 )
 
-_INT32_MAX = 2**31 - 1
 _MAX_STATE_NBYTES = 256 * 1024 * 1024
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _LOG_TWO_PI = float(math.log(2.0 * math.pi))
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
 
 
 def _positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
-    if type(value) is not int or not 1 <= value <= maximum:
+    if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer in 1..{maximum}")
-    return value
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in 1..{maximum}")
+    return canonical
 
 
 def _finite_float32(
@@ -201,9 +220,7 @@ def _saturating_increment(value: Array, maximum: int) -> Array:
 
 def _static_signature(tree: Any) -> tuple[Any, tuple[tuple[tuple[int, ...], Any], ...]]:
     leaves, structure = jax.tree_util.tree_flatten(tree)
-    return structure, tuple(
-        (jnp.asarray(leaf).shape, jnp.asarray(leaf).dtype) for leaf in leaves
-    )
+    return structure, tuple((jnp.asarray(leaf).shape, jnp.asarray(leaf).dtype) for leaf in leaves)
 
 
 def _validate_static_signature(
@@ -269,18 +286,45 @@ class RecurrentLatentWorldModelEnsembleConfig:
     max_updates: int = _INT32_MAX
 
     def __post_init__(self) -> None:
-        _positive_int(self.observation_dim, name="observation_dim")
-        _positive_int(self.n_actions, name="n_actions")
-        _positive_int(self.latent_dim, name="latent_dim")
-        _positive_int(self.ensemble_size, name="ensemble_size")
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _positive_int(self.observation_dim, name="observation_dim"),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _positive_int(self.n_actions, name="n_actions"),
+        )
+        object.__setattr__(
+            self,
+            "latent_dim",
+            _positive_int(self.latent_dim, name="latent_dim"),
+        )
+        object.__setattr__(
+            self,
+            "ensemble_size",
+            _positive_int(self.ensemble_size, name="ensemble_size"),
+        )
         if self.ensemble_size < 2:
             raise ValueError("ensemble_size must be at least 2 for epistemic disagreement")
-        _positive_int(self.max_updates, name="max_updates")
+        object.__setattr__(
+            self,
+            "max_updates",
+            _positive_int(self.max_updates, name="max_updates"),
+        )
         if (
-            type(self.uncertainty_warmup_steps) is not int
-            or not 0 <= self.uncertainty_warmup_steps <= self.max_updates
+            type(self.uncertainty_warmup_steps) not in _ACTUAL_INT_TYPES
+            or not 0
+            <= operator.index(cast(SupportsIndex, self.uncertainty_warmup_steps))
+            <= self.max_updates
         ):
             raise ValueError("uncertainty_warmup_steps must be in 0..max_updates")
+        object.__setattr__(
+            self,
+            "uncertainty_warmup_steps",
+            operator.index(cast(SupportsIndex, self.uncertainty_warmup_steps)),
+        )
 
         positive_fields = (
             "learning_rate",
@@ -370,9 +414,7 @@ class RecurrentLatentWorldModelEnsembleConfig:
     @property
     def state_nbytes(self) -> int:
         """Exact persistent logical array bytes for this configuration."""
-        float32_scalars = self.ensemble_size * (
-            self.trainable_scalars_per_member + self.latent_dim
-        )
+        float32_scalars = self.ensemble_size * (self.trainable_scalars_per_member + self.latent_dim)
         int32_scalars = self.ensemble_size + 3
         uint32_scalars = 2
         bool_scalars = self.ensemble_size
@@ -556,12 +598,7 @@ class _LogicalAccounting:
 
     @property
     def logical_scalars(self) -> int:
-        return (
-            self.float32_scalars
-            + self.int32_scalars
-            + self.uint32_scalars
-            + self.bool_scalars
-        )
+        return self.float32_scalars + self.int32_scalars + self.uint32_scalars + self.bool_scalars
 
     @property
     def logical_bytes(self) -> int:
@@ -969,9 +1006,7 @@ class RecurrentLatentWorldModelEnsemble:
             member_mean_predictions=means,
             mean_prediction=jnp.mean(means, axis=0),
             member_next_observations=means[:, : self._config.observation_dim],
-            mean_next_observation=jnp.mean(
-                means[:, : self._config.observation_dim], axis=0
-            ),
+            mean_next_observation=jnp.mean(means[:, : self._config.observation_dim], axis=0),
             member_rewards=means[:, -2],
             mean_reward=jnp.mean(means[:, -2]),
             member_continuations=means[:, -1],
@@ -1011,9 +1046,7 @@ class RecurrentLatentWorldModelEnsemble:
             (act >= 0)
             & (act < self._config.n_actions)
             & jnp.all(jnp.isfinite(start_cache.observation))
-            & jnp.all(
-                jnp.abs(start_cache.observation) <= self._config.max_input_magnitude
-            )
+            & jnp.all(jnp.abs(start_cache.observation) <= self._config.max_input_magnitude)
         )
         can_predict = self._state_valid(state) & ownership & input_valid
 
@@ -1089,12 +1122,8 @@ class RecurrentLatentWorldModelEnsemble:
             predictions_valid=false,
             losses_valid=false,
             representation_gradient_valid=false,
-            member_gradients_valid=jnp.zeros(
-                (self._config.ensemble_size,), dtype=jnp.bool_
-            ),
-            candidate_parameters_valid=jnp.zeros(
-                (self._config.ensemble_size,), dtype=jnp.bool_
-            ),
+            member_gradients_valid=jnp.zeros((self._config.ensemble_size,), dtype=jnp.bool_),
+            candidate_parameters_valid=jnp.zeros((self._config.ensemble_size,), dtype=jnp.bool_),
             candidate_state_valid=false,
             recurrent_advanced_once=false,
             recurrent_reset=false,
@@ -1161,14 +1190,10 @@ class RecurrentLatentWorldModelEnsemble:
             ),
             mean_negative_log_likelihood=jnp.asarray(0.0, dtype=jnp.float32),
             representation_objective=jnp.asarray(0.0, dtype=jnp.float32),
-            representation_gradient=jnp.zeros(
-                (self._config.observation_dim,), dtype=jnp.float32
-            ),
+            representation_gradient=jnp.zeros((self._config.observation_dim,), dtype=jnp.float32),
             representation_gradient_available=jnp.asarray(False, dtype=jnp.bool_),
             bootstrap_mask=jnp.zeros((self._config.ensemble_size,), dtype=jnp.bool_),
-            member_updates_applied=jnp.zeros(
-                (self._config.ensemble_size,), dtype=jnp.bool_
-            ),
+            member_updates_applied=jnp.zeros((self._config.ensemble_size,), dtype=jnp.bool_),
             next_start_cache=recoverable_cache,
             diagnostics=diagnostics,
         )
@@ -1291,9 +1316,7 @@ class RecurrentLatentWorldModelEnsemble:
         )
 
         def accepted_branch(_: None) -> RecurrentLatentWorldModelUpdateResult:
-            targets = jnp.concatenate(
-                (bootstrap_observation, reward[None], discount[None]), axis=0
-            )
+            targets = jnp.concatenate((bootstrap_observation, reward[None], discount[None]), axis=0)
             stopped_targets = jax.lax.stop_gradient(targets)
             prediction = self._predict_unchecked(state, observation, action)
             cached_prediction_exact = _tree_equal(prediction, decision_cache.prediction)
@@ -1371,8 +1394,10 @@ class RecurrentLatentWorldModelEnsemble:
                     cfg.gradient_clip_norm / jnp.maximum(gradient_norm_array[index], 1.0e-12),
                 )
                 updated = jax.tree_util.tree_map(
-                    lambda parameter, gradient: parameter
-                    - jnp.asarray(cfg.learning_rate, dtype=jnp.float32) * scale * gradient,
+                    lambda parameter, gradient: (
+                        parameter
+                        - jnp.asarray(cfg.learning_rate, dtype=jnp.float32) * scale * gradient
+                    ),
                     parameters,
                     member_gradients[index],
                 )
@@ -1532,9 +1557,7 @@ class RecurrentLatentWorldModelEnsemble:
             latent_dim=self._config.latent_dim,
             target_dim=self._config.target_dim,
             trainable_scalars_per_member=trainable.float32_scalars,
-            total_trainable_scalars=(
-                self._config.ensemble_size * trainable.float32_scalars
-            ),
+            total_trainable_scalars=(self._config.ensemble_size * trainable.float32_scalars),
             persistent_float32_scalars=persistent.float32_scalars,
             persistent_int32_scalars=persistent.int32_scalars,
             persistent_uint32_scalars=persistent.uint32_scalars,

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -170,13 +170,16 @@ class _FloatSpoof:
 def test_latent_config_rejects_scalars_that_leave_the_float32_domain(
     overrides: dict[str, object], message: str
 ) -> None:
-    config = LatentWorldModelConfig(
-        observation_dim=2, n_actions=2, latent_dim=4, hidden_sizes=(8,), **overrides  # type: ignore[arg-type]
-    )
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         with pytest.raises(ValueError, match=message):
-            LatentWorldModel(config)
+            LatentWorldModelConfig(
+                observation_dim=2,
+                n_actions=2,
+                latent_dim=4,
+                hidden_sizes=(8,),
+                **overrides,  # type: ignore[arg-type]
+            )
 
 
 def test_latent_config_canonicalizes_real_scalars() -> None:
@@ -547,14 +550,13 @@ def test_trainable_encoder_serialization_roundtrip() -> None:
 def test_trainable_encoder_config_validation_fails_closed(
     overrides: dict[str, float],
 ) -> None:
-    config = LatentWorldModelConfig(
-        observation_dim=2,
-        n_actions=2,
-        encoder_learning=True,
-        **overrides,  # type: ignore[arg-type]
-    )
     with pytest.raises(ValueError):
-        LatentWorldModel(config)
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            encoder_learning=True,
+            **overrides,  # type: ignore[arg-type]
+        )
 
 
 def test_latent_world_model_config_rejects_booleans_and_non_integers() -> None:
@@ -584,3 +586,108 @@ def test_latent_world_model_config_accepts_and_canonicalizes_numpy_integers() ->
     assert cfg.n_actions == 2
     assert cfg.latent_dim == 8
     assert cfg.hidden_sizes == (32, 16)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("predict_delta", "use_layer_norm", "include_action_interactions", "encoder_learning"),
+)
+def test_latent_world_model_config_requires_exact_booleans(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            **{field: 1},  # type: ignore[arg-type]
+        )
+
+
+def test_latent_world_model_config_requires_exact_containers_and_schema() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=[8],  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            observation_scale=[1.0, 1.0],  # type: ignore[arg-type]
+        )
+
+    payload = LatentWorldModelConfig(observation_dim=2, n_actions=2).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        LatentWorldModelConfig.from_config(type("ConfigDict", (dict,), {})(payload))
+    malformed = dict(payload)
+    malformed["hidden_sizes"] = (64,)
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        LatentWorldModelConfig.from_config(malformed)
+    malformed = dict(payload)
+    malformed["task_id"] = 3
+    with pytest.raises(ValueError, match="unknown fields"):
+        LatentWorldModelConfig.from_config(malformed)
+
+    model_payload = LatentWorldModel(
+        LatentWorldModelConfig(observation_dim=2, n_actions=2, hidden_sizes=())
+    ).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        LatentWorldModel.from_config(type("ModelDict", (dict,), {})(model_payload))
+    malformed_model = dict(model_payload)
+    malformed_model["task_id"] = 3
+    with pytest.raises(ValueError, match="fields"):
+        LatentWorldModel.from_config(malformed_model)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"observation_dim": 50_000, "latent_dim": 50_000}, "encoder_matrix"),
+        ({"observation_dim": 1, "latent_dim": 2**31 - 2}, "n_heads"),
+        (
+            {"observation_dim": 1, "latent_dim": 2**31 - 3, "n_actions": 3},
+            "input_dim",
+        ),
+        (
+            {
+                "observation_dim": 1,
+                "latent_dim": 50_000,
+                "n_actions": 50_000,
+                "include_action_interactions": True,
+            },
+            "action_interaction",
+        ),
+        ({"observation_dim": 1, "n_actions": 1, "hidden_sizes": (2**31 - 1,)}, "hidden_layer"),
+        ({"observation_dim": 1, "n_actions": 1, "hidden_sizes": (50_000, 50_000)}, "hidden_layer"),
+        (
+            {
+                "observation_dim": 1,
+                "n_actions": 1,
+                "latent_dim": 50_000,
+                "hidden_sizes": (1, 50_000),
+            },
+            "head_weight",
+        ),
+    ],
+)
+def test_latent_world_model_config_rejects_derived_allocation_overflow(
+    overrides: dict[str, object], message: str
+) -> None:
+    base: dict[str, object] = {"observation_dim": 2, "n_actions": 2}
+    base.update(overrides)
+    with pytest.raises(ValueError, match=message):
+        LatentWorldModelConfig(**base)  # type: ignore[arg-type]
+
+
+def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            latent_dim=2,
+            hidden_sizes=(),
+            encoder_scale=np.finfo(np.float32).max,
+        )
+    )
+
+    with pytest.raises(ValueError, match="encoder initialization"):
+        model.init(jr.key(0))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -555,3 +555,32 @@ def test_trainable_encoder_config_validation_fails_closed(
     )
     with pytest.raises(ValueError):
         LatentWorldModel(config)
+
+
+def test_latent_world_model_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        LatentWorldModelConfig(observation_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        LatentWorldModelConfig(observation_dim=2, n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="latent_dim"):
+        LatentWorldModelConfig(observation_dim=2, n_actions=2, latent_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        LatentWorldModelConfig(observation_dim=2, n_actions=2, hidden_sizes=(True,))  # type: ignore[arg-type]
+
+
+def test_latent_world_model_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = LatentWorldModelConfig(
+        observation_dim=np.int32(4),
+        n_actions=np.int64(2),
+        latent_dim=np.uint16(8),
+        hidden_sizes=(np.int32(32), np.int64(16)),
+    )
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.n_actions) is int
+    assert type(cfg.latent_dim) is int
+    assert type(cfg.hidden_sizes[0]) is int
+    assert type(cfg.hidden_sizes[1]) is int
+    assert cfg.observation_dim == 4
+    assert cfg.n_actions == 2
+    assert cfg.latent_dim == 8
+    assert cfg.hidden_sizes == (32, 16)

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -987,3 +987,76 @@ def test_recurrent_ensemble_config_accepts_numpy_integers() -> None:
     assert cfg.latent_dim == 8
     assert cfg.ensemble_size == 3
     assert cfg.uncertainty_warmup_steps == 2
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    (
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ),
+)
+def test_recurrent_ensemble_config_canonicalizes_every_integer_field(
+    integer_type,
+) -> None:
+    cfg = RecurrentLatentWorldModelEnsembleConfig(
+        observation_dim=integer_type(4),
+        n_actions=integer_type(2),
+        latent_dim=integer_type(8),
+        ensemble_size=integer_type(3),
+        max_updates=integer_type(4),
+        uncertainty_warmup_steps=integer_type(2),
+    )
+
+    assert all(
+        type(getattr(cfg, field)) is int
+        for field in (
+            "observation_dim",
+            "n_actions",
+            "latent_dim",
+            "ensemble_size",
+            "max_updates",
+            "uncertainty_warmup_steps",
+        )
+    )
+    assert RecurrentLatentWorldModelEnsembleConfig.from_config(cfg.to_config()) == cfg
+
+
+@pytest.mark.parametrize("value", [True, np.bool_(True), 1.0, "1", 0, -1, 2**31])
+def test_recurrent_ensemble_config_rejects_invalid_integer_domains(value: object) -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        _config(observation_dim=value)
+
+
+@pytest.mark.parametrize("value", [True, np.bool_(True), 1.0, "1", -1, 5, 2**31])
+def test_recurrent_ensemble_config_rejects_invalid_warmup_domains(value: object) -> None:
+    with pytest.raises(ValueError, match="uncertainty_warmup_steps"):
+        _config(max_updates=4, uncertainty_warmup_steps=value)
+
+
+def test_recurrent_ensemble_config_rejects_non_dict_schema_containers() -> None:
+    config = _config()
+    payload = config.to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        RecurrentLatentWorldModelEnsembleConfig.from_config(
+            type("ConfigDict", (dict,), {})(payload)
+        )
+
+    model_payload = RecurrentLatentWorldModelEnsemble(config).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        RecurrentLatentWorldModelEnsemble.from_config(
+            type("ModelDict", (dict,), {})(model_payload)
+        )
+
+
+def test_recurrent_ensemble_config_rejects_derived_resource_overflow() -> None:
+    with pytest.raises(ValueError, match="persistent state"):
+        _config(observation_dim=3_000_000)

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -433,9 +433,7 @@ def test_member_gradient_validity_is_finiteness_only_not_a_raw_norm_ceiling() ->
     state = model.init(jr.key(20))
     decision = _decision(model, state)
     far_bootstrap = jnp.asarray((900.0, -900.0), dtype=jnp.float32)
-    stopped_targets = jnp.concatenate(
-        (far_bootstrap, jnp.asarray((0.5, 0.9), dtype=jnp.float32))
-    )
+    stopped_targets = jnp.concatenate((far_bootstrap, jnp.asarray((0.5, 0.9), dtype=jnp.float32)))
     member_norms = []
     for index in range(model.config.ensemble_size):
         _, gradient = jax.value_and_grad(model._member_nll)(  # noqa: SLF001
@@ -622,9 +620,7 @@ def test_state_invalid_rejection_still_returns_a_non_recoverable_cache() -> None
     model = RecurrentLatentWorldModelEnsemble(_config())
     valid_state = model.init(jr.key(26))
     valid_decision = _decision(model, valid_state)
-    corrupt_state = cast(Any, valid_state).replace(
-        event_count=jnp.asarray(1, dtype=jnp.int32)
-    )
+    corrupt_state = cast(Any, valid_state).replace(event_count=jnp.asarray(1, dtype=jnp.int32))
     assert not bool(model.state_valid(corrupt_state))
 
     result = model.update(corrupt_state, valid_decision, _transition())
@@ -718,9 +714,7 @@ def test_dynamically_corrupt_state_is_an_atomic_noop_including_rng() -> None:
     valid_state = model.init(jr.key(61))
     valid_decision = _decision(model, valid_state)
 
-    counter_corrupt = cast(Any, valid_state).replace(
-        event_count=jnp.asarray(1, dtype=jnp.int32)
-    )
+    counter_corrupt = cast(Any, valid_state).replace(event_count=jnp.asarray(1, dtype=jnp.int32))
     nan_parameters = cast(Any, valid_state.member_parameters[0]).replace(
         mean_bias=valid_state.member_parameters[0].mean_bias.at[0].set(jnp.nan)
     )
@@ -728,9 +722,9 @@ def test_dynamically_corrupt_state_is_an_atomic_noop_including_rng() -> None:
         member_parameters=(nan_parameters, *valid_state.member_parameters[1:])
     )
     overbound_parameters = cast(Any, valid_state.member_parameters[0]).replace(
-        mean_bias=valid_state.member_parameters[0].mean_bias.at[0].set(
-            model.config.max_parameter_magnitude + 1.0
-        )
+        mean_bias=valid_state.member_parameters[0]
+        .mean_bias.at[0]
+        .set(model.config.max_parameter_magnitude + 1.0)
     )
     overbound_corrupt = cast(Any, valid_state).replace(
         member_parameters=(overbound_parameters, *valid_state.member_parameters[1:])
@@ -781,9 +775,7 @@ def test_jit_and_scan_match_sequential_cache_state_and_outputs() -> None:
     initial = model.init(jr.key(8))
     initial_cache = model.start(initial, OBSERVATION)
     rewards = jnp.asarray((0.1, -0.2, 0.3), dtype=jnp.float32)
-    next_observations = jnp.asarray(
-        ((0.1, 0.2), (0.3, -0.4), (0.5, 0.6)), dtype=jnp.float32
-    )
+    next_observations = jnp.asarray(((0.1, 0.2), (0.3, -0.4), (0.5, 0.6)), dtype=jnp.float32)
 
     def one_step(
         carry: tuple[RecurrentLatentWorldModelEnsembleState, Any],
@@ -951,8 +943,7 @@ def test_static_shape_and_dtype_contracts_fail_before_compiled_execution() -> No
 
 def test_transition_schema_contains_no_task_or_regime_channel() -> None:
     fields = {
-        field.name
-        for field in dataclasses.fields(cast(Any, RecurrentLatentTransitionRecord))
+        field.name for field in dataclasses.fields(cast(Any, RecurrentLatentTransitionRecord))
     }
     assert fields == {
         "observation",
@@ -965,3 +956,34 @@ def test_transition_schema_contains_no_task_or_regime_channel() -> None:
         "next_decision_observation",
     }
     assert not ({"task_id", "regime_id"} & fields)
+
+
+def test_recurrent_ensemble_config_rejects_booleans() -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        RecurrentLatentWorldModelEnsembleConfig(observation_dim=True, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        RecurrentLatentWorldModelEnsembleConfig(observation_dim=2, n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="latent_dim"):
+        RecurrentLatentWorldModelEnsembleConfig(observation_dim=2, n_actions=2, latent_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="ensemble_size"):
+        RecurrentLatentWorldModelEnsembleConfig(observation_dim=2, n_actions=2, ensemble_size=2.0)  # type: ignore[arg-type]
+
+
+def test_recurrent_ensemble_config_accepts_numpy_integers() -> None:
+    cfg = RecurrentLatentWorldModelEnsembleConfig(
+        observation_dim=np.int32(4),
+        n_actions=np.int64(2),
+        latent_dim=np.uint16(8),
+        ensemble_size=np.int32(3),
+        uncertainty_warmup_steps=np.uint8(2),
+    )
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.n_actions) is int
+    assert type(cfg.latent_dim) is int
+    assert type(cfg.ensemble_size) is int
+    assert type(cfg.uncertainty_warmup_steps) is int
+    assert cfg.observation_dim == 4
+    assert cfg.n_actions == 2
+    assert cfg.latent_dim == 8
+    assert cfg.ensemble_size == 3
+    assert cfg.uncertainty_warmup_steps == 2


### PR DESCRIPTION
Supersedes #711 and #712 while preserving both kzahiri1 contributor commits and authorship.

The submitted integer canonicalization is retained. Deep review adds the missing surrounding contracts:
- LatentWorldModelConfig now validates/canonicalizes every scalar at construction, requires exact boolean/tuple/enum containers, preflights encoder, interaction, hidden-layer, input, and head allocations, and rejects nonfinite generated encoder parameters.
- latent config/model deserialization rejects non-dict containers, unknown/wrong schema fields, and noncanonical serialized list/string containers while retaining the documented legacy defaults for omitted trainable-encoder fields.
- recurrent ensemble warmup validation shares the exact bounded-integer gate, config/model deserialization requires actual dicts, and tests prove its existing 256 MiB derived persistent-state cap rejects oversized configurations before allocation.
- retained tests cover all concrete NumPy integer families, hostile/spoof values, exact booleans and containers, float32 sink behavior, schema round-trips, derived bounds, and initialization.

Validation on current main (including merged multi-head aggregate preflight #727):
- 134 focused latent/recurrent/checkpoint tests passed
- scoped Ruff passed
- strict mypy passed for both changed source modules
- diff check passed

No output or evidence artifacts changed.