### PR TITLE
fix(synthetic): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -8,8 +8,9 @@ All streams use JAX-compatible pure functions that work with jax.lax.scan.
 """
 
 import math
+import operator
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -32,19 +33,29 @@ _FLOAT32_EXP_SAFE_LOG_MAX = float(
     np.nextafter(np.float32(math.log(_FLOAT32_MAX)), np.float32(-math.inf))
 )
 
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
 
 def _require_positive_int(name: str, value: object) -> int:
     """Require a positive schedule modulus representable by JAX's int32 clock."""
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, int)
-        or value < 1
-        or value > _INT32_MAX
-    ):
-        raise ValueError(
-            f"{name} must be a positive integer in [1, {_INT32_MAX}], got {value!r}"
-        )
-    return value
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a positive integer in [1, {_INT32_MAX}]")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < 1 or number > _INT32_MAX:
+        raise ValueError(f"{name} must be a positive integer in [1, {_INT32_MAX}]")
+    return number
 
 
 def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[int, int, float]:
@@ -89,6 +100,13 @@ def _require_finite_float32_log_scale(name: str, value: object) -> float:
     _, _, narrowed = _narrow_real_to_float32(name, value, message)
     if narrowed < _FLOAT32_EXP_SAFE_LOG_MIN or narrowed > _FLOAT32_EXP_SAFE_LOG_MAX:
         raise ValueError(message)
+    return narrowed
+
+
+def _require_finite_float32(name: str, value: object) -> float:
+    """Require a finite float32 execution value."""
+    message = f"{name} must be a finite float32 value"
+    _, _, narrowed = _narrow_real_to_float32(name, value, message)
     return narrowed
 
 
@@ -232,10 +250,23 @@ class HiddenStateAR2Stream:
             nonlinear_coeff: Weight on the hidden h0*h1 interaction term
             target_noise_std: Std dev of additive target noise
         """
-        if visible_dim <= 0 or visible_dim >= feature_dim:
+        feature_dim = _require_positive_int("feature_dim", feature_dim)
+        visible_dim = _require_positive_int("visible_dim", visible_dim)
+        if visible_dim >= feature_dim:
             raise ValueError("visible_dim must be in [1, feature_dim)")
         if feature_dim - visible_dim < 2:
             raise ValueError("hidden block must contain at least two channels")
+        phi1 = _require_finite_float32("phi1", phi1)
+        phi2 = _require_finite_float32("phi2", phi2)
+        innovation_std = _require_finite_nonnegative_float32(
+            "innovation_std", innovation_std
+        )
+        nonlinear_coeff = _require_finite_float32(
+            "nonlinear_coeff", nonlinear_coeff
+        )
+        target_noise_std = _require_finite_nonnegative_float32(
+            "target_noise_std", target_noise_std
+        )
         deterministic_copy = phi1 == 1.0 and phi2 == 0.0 and innovation_std == 0.0
         violates_stationarity = (
             phi1 + phi2 >= 1.0 or phi2 - phi1 >= 1.0 or abs(phi2) >= 1.0
@@ -464,11 +495,15 @@ class SuttonExperiment1Stream:
                 irrelevant-input weights (0.0 = they stay exactly zero,
                 as in the paper)
         """
-        self._num_relevant = num_relevant
-        self._num_irrelevant = num_irrelevant
+        self._num_relevant = _require_positive_int("num_relevant", num_relevant)
+        self._num_irrelevant = _require_positive_int(
+            "num_irrelevant", num_irrelevant
+        )
         self._change_interval = _require_positive_int("change_interval", change_interval)
-        self._noise_std = noise_std
-        self._bias_drift_rate = bias_drift_rate
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
+        self._bias_drift_rate = _require_finite_nonnegative_float32(
+            "bias_drift_rate", bias_drift_rate
+        )
 
     @property
     def feature_dim(self) -> int:
@@ -912,6 +947,7 @@ def make_scale_range(
     stream = ScaledStreamWrapper(RandomWalkStream(10), scales)
     ```
     """
+    feature_dim = _require_positive_int("feature_dim", feature_dim)
     if log_spaced:
         min_bound = _require_normal_float32_scale("min_scale", min_scale)
         max_bound = _require_normal_float32_scale("max_scale", max_scale)
@@ -944,7 +980,9 @@ def make_scale_range(
                 )
         return jnp.asarray(values, dtype=jnp.float32)
     else:
-        return jnp.linspace(min_scale, max_scale, feature_dim, dtype=jnp.float32)
+        min_bound = _require_finite_nonnegative_float32("min_scale", min_scale)
+        max_bound = _require_finite_nonnegative_float32("max_scale", max_scale)
+        return jnp.linspace(min_bound, max_bound, feature_dim, dtype=jnp.float32)
 
 
 @chex.dataclass(frozen=True)
@@ -1003,7 +1041,7 @@ class DynamicScaleShiftStream:
             max_scale: Maximum scale factor (log-uniform sampling)
             noise_std: Std dev of target noise
         """
-        self._feature_dim = feature_dim
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
         self._scale_change_interval = _require_positive_int(
             "scale_change_interval", scale_change_interval
         )
@@ -1014,7 +1052,7 @@ class DynamicScaleShiftStream:
         self._max_scale = _require_normal_float32_scale("max_scale", max_scale)
         if self._min_scale > self._max_scale:
             raise ValueError("min_scale must be <= max_scale")
-        self._noise_std = noise_std
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
 
     @property
     def feature_dim(self) -> int:
@@ -1154,14 +1192,18 @@ class ScaleDriftStream:
             max_log_scale: Maximum log-scale (clips drift)
             noise_std: Std dev of target noise
         """
-        self._feature_dim = feature_dim
-        self._weight_drift_rate = weight_drift_rate
-        self._scale_drift_rate = scale_drift_rate
+        self._feature_dim = _require_positive_int("feature_dim", feature_dim)
+        self._weight_drift_rate = _require_finite_nonnegative_float32(
+            "weight_drift_rate", weight_drift_rate
+        )
+        self._scale_drift_rate = _require_finite_nonnegative_float32(
+            "scale_drift_rate", scale_drift_rate
+        )
         self._min_log_scale = _require_finite_float32_log_scale("min_log_scale", min_log_scale)
         self._max_log_scale = _require_finite_float32_log_scale("max_log_scale", max_log_scale)
         if self._min_log_scale > self._max_log_scale:
             raise ValueError("min_log_scale must be <= max_log_scale")
-        self._noise_std = noise_std
+        self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
 
     @property
     def feature_dim(self) -> int:

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -58,6 +58,19 @@ def _require_positive_int(name: str, value: object) -> int:
     return number
 
 
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[int, int, float]:
     """Return one trusted exact ratio together with its binary32 rounding."""
     actual_type = type(value)
@@ -256,6 +269,11 @@ class HiddenStateAR2Stream:
             raise ValueError("visible_dim must be in [1, feature_dim)")
         if feature_dim - visible_dim < 2:
             raise ValueError("hidden block must contain at least two channels")
+        _require_float32_resource(
+            "HiddenStateAR2Stream state",
+            vector_scalars=2 * feature_dim,
+            fixed_scalars=2,
+        )
         phi1 = _require_finite_float32("phi1", phi1)
         phi2 = _require_finite_float32("phi2", phi2)
         innovation_std = _require_finite_nonnegative_float32(
@@ -498,6 +516,14 @@ class SuttonExperiment1Stream:
         self._num_relevant = _require_positive_int("num_relevant", num_relevant)
         self._num_irrelevant = _require_positive_int(
             "num_irrelevant", num_irrelevant
+        )
+        feature_dim = self._num_relevant + self._num_irrelevant
+        if feature_dim > _INT32_MAX:
+            raise ValueError("SuttonExperiment1Stream feature_dim must fit signed int32")
+        _require_float32_resource(
+            "SuttonExperiment1Stream state",
+            vector_scalars=feature_dim,
+            fixed_scalars=3,
         )
         self._change_interval = _require_positive_int("change_interval", change_interval)
         self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
@@ -948,6 +974,7 @@ def make_scale_range(
     ```
     """
     feature_dim = _require_positive_int("feature_dim", feature_dim)
+    _require_float32_resource("scale range", vector_scalars=feature_dim)
     if log_spaced:
         min_bound = _require_normal_float32_scale("min_scale", min_scale)
         max_bound = _require_normal_float32_scale("max_scale", max_scale)
@@ -1042,6 +1069,11 @@ class DynamicScaleShiftStream:
             noise_std: Std dev of target noise
         """
         self._feature_dim = _require_positive_int("feature_dim", feature_dim)
+        _require_float32_resource(
+            "DynamicScaleShiftStream state",
+            vector_scalars=2 * self._feature_dim,
+            fixed_scalars=3,
+        )
         self._scale_change_interval = _require_positive_int(
             "scale_change_interval", scale_change_interval
         )
@@ -1193,6 +1225,11 @@ class ScaleDriftStream:
             noise_std: Std dev of target noise
         """
         self._feature_dim = _require_positive_int("feature_dim", feature_dim)
+        _require_float32_resource(
+            "ScaleDriftStream state",
+            vector_scalars=2 * self._feature_dim,
+            fixed_scalars=3,
+        )
         self._weight_drift_rate = _require_finite_nonnegative_float32(
             "weight_drift_rate", weight_drift_rate
         )

--- a/tests/test_synthetic_stream_validation.py
+++ b/tests/test_synthetic_stream_validation.py
@@ -165,3 +165,38 @@ def test_dynamic_scale_shift_float_validators_reject_nonfinite() -> None:
 def test_make_scale_range_rejects_invalid_feature_dim_hostile() -> None:
     with pytest.raises(ValueError, match="feature_dim"):
         make_scale_range(feature_dim=_RaisingIntSubclass(5))  # type: ignore[arg-type]
+
+
+def test_hidden_and_scale_streams_preflight_state_bytes_without_allocation() -> None:
+    last_legal = (2**29 - 1 - 3) // 2
+
+    DynamicScaleShiftStream(feature_dim=last_legal)
+    ScaleDriftStream(feature_dim=last_legal)
+    with pytest.raises(ValueError, match="byte count"):
+        DynamicScaleShiftStream(feature_dim=last_legal + 1)
+    with pytest.raises(ValueError, match="byte count"):
+        ScaleDriftStream(feature_dim=last_legal + 1)
+
+    hidden_last_legal = (2**29 - 1 - 2) // 2
+    HiddenStateAR2Stream(feature_dim=hidden_last_legal, visible_dim=2)
+    with pytest.raises(ValueError, match="byte count"):
+        HiddenStateAR2Stream(feature_dim=hidden_last_legal + 1, visible_dim=2)
+
+
+def test_sutton_stream_preflights_derived_feature_and_state_bytes() -> None:
+    last_legal_total = 2**29 - 1 - 3
+
+    SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total - 1)
+    with pytest.raises(ValueError, match="byte count"):
+        SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total)
+    with pytest.raises(ValueError, match="feature_dim"):
+        SuttonExperiment1Stream(num_relevant=2**30, num_irrelevant=2**30)
+
+
+def test_make_scale_range_rejects_oversize_before_numpy_allocation(monkeypatch) -> None:
+    def allocation_must_not_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("allocation ran before resource validation")
+
+    monkeypatch.setattr(np, "geomspace", allocation_must_not_run)
+    with pytest.raises(ValueError, match="byte count"):
+        make_scale_range(feature_dim=2**29)

--- a/tests/test_synthetic_stream_validation.py
+++ b/tests/test_synthetic_stream_validation.py
@@ -1,0 +1,167 @@
+"""Validation hardening for synthetic streams (issue synthetic int/float bounds)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.synthetic import (
+    DynamicScaleShiftStream,
+    HiddenStateAR2Stream,
+    ScaleDriftStream,
+    SuttonExperiment1Stream,
+    make_scale_range,
+)
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: HiddenStateAR2Stream(feature_dim=v, visible_dim=2),
+        lambda v: HiddenStateAR2Stream(feature_dim=8, visible_dim=v),
+        lambda v: SuttonExperiment1Stream(num_relevant=v),
+        lambda v: SuttonExperiment1Stream(num_irrelevant=v),
+        lambda v: SuttonExperiment1Stream(change_interval=v),
+        lambda v: DynamicScaleShiftStream(feature_dim=v),
+        lambda v: ScaleDriftStream(feature_dim=v),
+        lambda v: make_scale_range(feature_dim=v),
+    ],
+)
+def test_synthetic_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: HiddenStateAR2Stream(feature_dim=v, visible_dim=2),
+        lambda v: SuttonExperiment1Stream(num_relevant=v),
+    ],
+)
+def test_synthetic_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_synthetic_int_validators_canonicalize_numpy_scalars(np_type: type) -> None:
+    s = HiddenStateAR2Stream(feature_dim=np_type(8), visible_dim=np_type(2))
+    assert s.feature_dim == 8
+    assert type(s.feature_dim) is int
+    t = SuttonExperiment1Stream(num_relevant=np_type(3), num_irrelevant=np_type(4))
+    assert t.feature_dim == 7
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: HiddenStateAR2Stream(feature_dim=v, visible_dim=2),
+        lambda v: SuttonExperiment1Stream(num_relevant=v),
+        lambda v: DynamicScaleShiftStream(feature_dim=v),
+        lambda v: make_scale_range(feature_dim=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value", [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1, 10**100]
+)
+def test_synthetic_int_validators_reject_non_integer_and_out_of_range(ctor, value: object) -> None:
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+def test_hidden_ar2_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("phi1", float("nan")),
+        ("phi1", float("inf")),
+        ("phi2", HostileFloat(0.5)),
+        ("innovation_std", -0.1),
+        ("innovation_std", float("nan")),
+        ("nonlinear_coeff", ClassSpoof()),  # type: ignore[arg-type]
+        ("target_noise_std", -1.0),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            HiddenStateAR2Stream(feature_dim=8, visible_dim=2, **{field: bad})  # type: ignore[arg-type]
+
+
+def test_sutton_float_validators_reject_nonfinite() -> None:
+    for field, bad in [
+        ("noise_std", float("nan")),
+        ("noise_std", float("inf")),
+        ("bias_drift_rate", -0.1),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            SuttonExperiment1Stream(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_scale_drift_float_validators_reject_nonfinite() -> None:
+    for field, bad in [
+        ("weight_drift_rate", float("nan")),
+        ("scale_drift_rate", float("inf")),
+        ("noise_std", -0.5),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            ScaleDriftStream(feature_dim=4, **{field: bad})  # type: ignore[arg-type]
+
+
+def test_dynamic_scale_shift_float_validators_reject_nonfinite() -> None:
+    with pytest.raises(ValueError, match="noise_std"):
+        DynamicScaleShiftStream(feature_dim=4, noise_std=float("nan"))
+
+
+def test_make_scale_range_rejects_invalid_feature_dim_hostile() -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        make_scale_range(feature_dim=_RaisingIntSubclass(5))  # type: ignore[arg-type]


### PR DESCRIPTION
Supersedes #728 while preserving its contributor commit. The original hostile-safe integer and float32 validation is sound, but individually legal dimensions could still overflow derived feature widths or request multi-gigabyte JAX/NumPy arrays. This successor adds exact signed-int32 scalar/byte preflights for HiddenStateAR2, Sutton Experiment 1, DynamicScaleShift, ScaleDrift, and make_scale_range before allocation, including the derived relevant+irrelevant feature width. Coverage includes all original hostile and NumPy-family cases plus allocation-free adjacent resource endpoints. Verification: 236 synthetic/streams tests passed; scoped Ruff clean; strict targeted mypy clean; diff-check clean. No registered evidence source or outputs are changed.