### PR TITLE
fix(gradient-mixer): complete exact config and resource contracts

### DIFF
--- a/alberta_framework/__init__.py
+++ b/alberta_framework/__init__.py
@@ -595,6 +595,7 @@ from alberta_framework.core.representation_gradient_mixer import (
     GradientNormalization,
     RepresentationGradientMixDiagnostics,
     RepresentationGradientMixerConfig,
+    RepresentationGradientMixerResourceBudget,
     RepresentationGradientMixResult,
     mix_representation_gradients,
 )
@@ -1132,6 +1133,7 @@ __all__ = [
     "GradientNormalization",
     "RepresentationGradientMixDiagnostics",
     "RepresentationGradientMixerConfig",
+    "RepresentationGradientMixerResourceBudget",
     "RepresentationGradientMixResult",
     "mix_representation_gradients",
     # PrototypeAgent — experimental composition surface spanning Steps 1–12

--- a/alberta_framework/core/__init__.py
+++ b/alberta_framework/core/__init__.py
@@ -451,6 +451,7 @@ from alberta_framework.core.representation_gradient_mixer import (
     GradientNormalization,
     RepresentationGradientMixDiagnostics,
     RepresentationGradientMixerConfig,
+    RepresentationGradientMixerResourceBudget,
     RepresentationGradientMixResult,
     mix_representation_gradients,
 )
@@ -774,6 +775,7 @@ __all__ = [
     "GradientNormalization",
     "RepresentationGradientMixDiagnostics",
     "RepresentationGradientMixerConfig",
+    "RepresentationGradientMixerResourceBudget",
     "RepresentationGradientMixResult",
     "mix_representation_gradients",
     # Dreaming / self-simulation

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import dataclasses
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -34,6 +35,31 @@ _VALID_MODES = frozenset({"full", "behavior_only", "world_only", "discard"})
 _VALID_NORMALIZATIONS = frozenset({"none", "unit_l2"})
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _strict_float32_scalar(
@@ -83,8 +109,11 @@ class RepresentationGradientMixerConfig:
     def __post_init__(self) -> None:
         """Reject ambiguous, dynamic, or non-float32-representable rules."""
 
-        if type(self.representation_dim) is not int or self.representation_dim <= 0:
-            raise ValueError("representation_dim must be a positive strict integer")
+        object.__setattr__(
+            self,
+            "representation_dim",
+            _require_int32("representation_dim", self.representation_dim, minimum=1),
+        )
         if type(self.mode) is not str or self.mode not in _VALID_MODES:
             raise ValueError(
                 "mode must be full, behavior_only, world_only, or discard"

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -11,10 +11,8 @@ call so matched evaluator arms keep the same input and diagnostic surface.
 from __future__ import annotations
 
 import dataclasses
-import math
 import operator
 from collections.abc import Mapping
-from numbers import Real
 from typing import Any, Literal, SupportsIndex, cast
 
 import chex
@@ -22,6 +20,10 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
+
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar_with_ratio,
+)
 
 GradientMixMode = Literal["full", "behavior_only", "world_only", "discard"]
 GradientNormalization = Literal["none", "unit_l2"]
@@ -36,20 +38,14 @@ _VALID_NORMALIZATIONS = frozenset({"none", "unit_l2"})
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _INT32_MAX = 2**31 - 1
-_MAX_REPRESENTATION_DIM = _INT32_MAX // 4
+_DIAGNOSTIC_FLOAT32_SCALARS = 12
+_OUTPUT_BOOL_SCALARS = 12
+_FIXED_OUTPUT_BYTES = 4 * _DIAGNOSTIC_FLOAT32_SCALARS + _OUTPUT_BOOL_SCALARS
+_MAX_REPRESENTATION_DIM = (_INT32_MAX - _FIXED_OUTPUT_BYTES) // 4
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
+        *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
     }
 )
 
@@ -71,19 +67,21 @@ def _strict_float32_scalar(
 ) -> float:
     """Validate a finite nonnegative scalar with a stable float32 encoding."""
 
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{label} must be a real scalar")
-    normalized = float(cast(Real, value))
-    if not math.isfinite(normalized) or normalized < 0.0:
-        raise ValueError(f"{label} must be finite and non-negative")
-    if not allow_zero and normalized == 0.0:
-        raise ValueError(f"{label} must be positive")
-    if normalized > _FLOAT32_MAX:
-        raise ValueError(f"{label} exceeds the finite float32 range")
-    if normalized != 0.0 and normalized < _FLOAT32_TINY:
+    normalized, numerator, denominator = validated_float32_scalar_with_ratio(
+        label,
+        value,
+        positive=not allow_zero,
+        lower=0.0 if allow_zero else None,
+        upper=_FLOAT32_MAX,
+    )
+    tiny_numerator, tiny_denominator = _FLOAT32_TINY.as_integer_ratio()
+    exact_is_subnormal = (
+        numerator != 0
+        and numerator * tiny_denominator < tiny_numerator * denominator
+    )
+    if exact_is_subnormal or (normalized != 0.0 and normalized < _FLOAT32_TINY):
         raise ValueError(f"{label} is below the normal float32 range")
-    return normalized
+    return 0.0 if numerator == 0 else normalized
 
 
 @dataclasses.dataclass(frozen=True)
@@ -134,20 +132,32 @@ class RepresentationGradientMixerConfig:
             or self.grounded_world_normalization not in _VALID_NORMALIZATIONS
         ):
             raise ValueError("grounded_world_normalization must be none or unit_l2")
-        _strict_float32_scalar(
-            self.behavior_weight,
+        object.__setattr__(
+            self,
             "behavior_weight",
-            allow_zero=True,
+            _strict_float32_scalar(
+                self.behavior_weight,
+                "behavior_weight",
+                allow_zero=True,
+            ),
         )
-        _strict_float32_scalar(
-            self.grounded_world_weight,
+        object.__setattr__(
+            self,
             "grounded_world_weight",
-            allow_zero=True,
+            _strict_float32_scalar(
+                self.grounded_world_weight,
+                "grounded_world_weight",
+                allow_zero=True,
+            ),
         )
-        _strict_float32_scalar(
-            self.normalization_epsilon,
+        object.__setattr__(
+            self,
             "normalization_epsilon",
-            allow_zero=False,
+            _strict_float32_scalar(
+                self.normalization_epsilon,
+                "normalization_epsilon",
+                allow_zero=False,
+            ),
         )
         for label, value in (
             ("behavior_clip_norm", self.behavior_clip_norm),
@@ -155,7 +165,11 @@ class RepresentationGradientMixerConfig:
             ("final_clip_norm", self.final_clip_norm),
         ):
             if value is not None:
-                _strict_float32_scalar(value, label, allow_zero=False)
+                object.__setattr__(
+                    self,
+                    label,
+                    _strict_float32_scalar(value, label, allow_zero=False),
+                )
 
     def to_config(self) -> dict[str, object]:
         """Return the complete JSON-compatible mixing rule."""
@@ -192,7 +206,12 @@ class RepresentationGradientMixerConfig:
     ) -> RepresentationGradientMixerConfig:
         """Strictly reconstruct only an exact :meth:`to_config` payload."""
 
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config mapping could not be read") from error
         expected = {
             "schema",
             "type",
@@ -209,9 +228,14 @@ class RepresentationGradientMixerConfig:
         }
         if set(payload) != expected:
             raise ValueError("config fields do not match the serialized schema")
-        if payload.pop("schema") != REPRESENTATION_GRADIENT_MIXER_CONFIG_SCHEMA:
+        schema = payload.pop("schema")
+        if (
+            type(schema) is not str
+            or schema != REPRESENTATION_GRADIENT_MIXER_CONFIG_SCHEMA
+        ):
             raise ValueError("config schema differs")
-        if payload.pop("type") != _CONFIG_TYPE:
+        config_type = payload.pop("type")
+        if type(config_type) is not str or config_type != _CONFIG_TYPE:
             raise ValueError("config type differs")
         return cls(**cast(dict[str, Any], payload))
 
@@ -223,19 +247,37 @@ class RepresentationGradientMixerConfig:
             representation_dim=self.representation_dim,
             persistent_state_scalars=0,
             persistent_state_bytes=0,
-            output_float32_scalars=self.representation_dim,
-            output_nbytes=4 * self.representation_dim,
+            output_float32_scalars=(
+                self.representation_dim + _DIAGNOSTIC_FLOAT32_SCALARS
+            ),
+            output_bool_scalars=_OUTPUT_BOOL_SCALARS,
+            output_scalars=(
+                self.representation_dim
+                + _DIAGNOSTIC_FLOAT32_SCALARS
+                + _OUTPUT_BOOL_SCALARS
+            ),
+            output_nbytes=(
+                4 * (self.representation_dim + _DIAGNOSTIC_FLOAT32_SCALARS)
+                + _OUTPUT_BOOL_SCALARS
+            ),
         )
 
 
 @dataclasses.dataclass(frozen=True)
 class RepresentationGradientMixerResourceBudget:
-    """Exact persistent-state and fixed-width output allocation accounting."""
+    """Exact persistent state and logical public-result payload accounting.
+
+    Output counts include the mixed gradient, diagnostics, and repeated
+    top-level decision fields. They intentionally exclude compiler-dependent
+    temporaries and do not assume that repeated result leaves alias buffers.
+    """
 
     representation_dim: int
     persistent_state_scalars: int
     persistent_state_bytes: int
     output_float32_scalars: int
+    output_bool_scalars: int
+    output_scalars: int
     output_nbytes: int
 
     def to_dict(self) -> dict[str, int]:

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -36,6 +36,7 @@ _VALID_NORMALIZATIONS = frozenset({"none", "unit_l2"})
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _INT32_MAX = 2**31 - 1
+_MAX_REPRESENTATION_DIM = _INT32_MAX // 4
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -112,7 +113,12 @@ class RepresentationGradientMixerConfig:
         object.__setattr__(
             self,
             "representation_dim",
-            _require_int32("representation_dim", self.representation_dim, minimum=1),
+            _require_int32(
+                "representation_dim",
+                self.representation_dim,
+                minimum=1,
+                maximum=_MAX_REPRESENTATION_DIM,
+            ),
         )
         if type(self.mode) is not str or self.mode not in _VALID_MODES:
             raise ValueError(
@@ -208,6 +214,34 @@ class RepresentationGradientMixerConfig:
         if payload.pop("type") != _CONFIG_TYPE:
             raise ValueError("config type differs")
         return cls(**cast(dict[str, Any], payload))
+
+    @property
+    def resource_budget(self) -> RepresentationGradientMixerResourceBudget:
+        """Return the allocation contract for this stateless mixer."""
+
+        return RepresentationGradientMixerResourceBudget(
+            representation_dim=self.representation_dim,
+            persistent_state_scalars=0,
+            persistent_state_bytes=0,
+            output_float32_scalars=self.representation_dim,
+            output_nbytes=4 * self.representation_dim,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class RepresentationGradientMixerResourceBudget:
+    """Exact persistent-state and fixed-width output allocation accounting."""
+
+    representation_dim: int
+    persistent_state_scalars: int
+    persistent_state_bytes: int
+    output_float32_scalars: int
+    output_nbytes: int
+
+    def to_dict(self) -> dict[str, int]:
+        """Return a JSON-compatible resource record."""
+
+        return dataclasses.asdict(self)
 
 
 @chex.dataclass(frozen=True)
@@ -597,5 +631,6 @@ __all__ = [
     "RepresentationGradientMixDiagnostics",
     "RepresentationGradientMixResult",
     "RepresentationGradientMixerConfig",
+    "RepresentationGradientMixerResourceBudget",
     "mix_representation_gradients",
 ]

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -48,6 +48,9 @@ _ACTUAL_INT_TYPES = frozenset(
         *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -66,6 +69,9 @@ def _strict_float32_scalar(
     allow_zero: bool,
 ) -> float:
     """Validate a finite nonnegative scalar with a stable float32 encoding."""
+
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{label} must be a finite real scalar")
 
     normalized, numerator, denominator = validated_float32_scalar_with_ratio(
         label,
@@ -206,12 +212,9 @@ class RepresentationGradientMixerConfig:
     ) -> RepresentationGradientMixerConfig:
         """Strictly reconstruct only an exact :meth:`to_config` payload."""
 
-        if not issubclass(type(config), Mapping):
-            raise ValueError("config must be a mapping")
-        try:
-            payload = dict(config)
-        except Exception as error:
-            raise ValueError("config mapping could not be read") from error
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        payload = dict(config)
         expected = {
             "schema",
             "type",
@@ -226,7 +229,7 @@ class RepresentationGradientMixerConfig:
             "grounded_world_clip_norm",
             "final_clip_norm",
         }
-        if set(payload) != expected:
+        if any(type(key) is not str for key in payload) or set(payload) != expected:
             raise ValueError("config fields do not match the serialized schema")
         schema = payload.pop("schema")
         if (

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -465,3 +465,56 @@ def test_representation_gradient_mixer_config_accepts_and_canonicalizes_numpy_in
     config = RepresentationGradientMixerConfig(representation_dim=np.int32(8))
     assert type(config.representation_dim) is int
     assert config.representation_dim == 8
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    tuple(
+        dict.fromkeys(
+            np.dtype(code).type
+            for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+        )
+    ),
+)
+def test_gradient_mixer_canonicalizes_every_numpy_integer_type(
+    integer_type: type,
+) -> None:
+    config = RepresentationGradientMixerConfig(representation_dim=integer_type(3))
+    assert type(config.representation_dim) is int
+    assert config.representation_dim == 3
+    assert RepresentationGradientMixerConfig.from_config(config.to_config()) == config
+
+
+def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
+    class IntSubclass(int):
+        pass
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:  # type: ignore[override]
+            return int
+
+        def __repr__(self) -> str:
+            raise RuntimeError("repr must not run")
+
+    for value in (True, np.bool_(True), 0, -1, 1.0, IntSubclass(3), ClassSpoof()):
+        with pytest.raises(ValueError, match="representation_dim"):
+            RepresentationGradientMixerConfig(
+                representation_dim=value  # type: ignore[arg-type]
+            )
+
+
+def test_gradient_mixer_allocation_contract_endpoints_are_allocation_free() -> None:
+    last_legal = (2**31 - 1) // 4
+    config = RepresentationGradientMixerConfig(representation_dim=last_legal)
+    budget = config.resource_budget
+
+    assert budget.representation_dim == last_legal
+    assert budget.persistent_state_scalars == 0
+    assert budget.persistent_state_bytes == 0
+    assert budget.output_float32_scalars == last_legal
+    assert budget.output_nbytes == 4 * last_legal
+    json.dumps(budget.to_dict(), allow_nan=False)
+
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=last_legal + 1)

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -452,3 +452,16 @@ def test_jit_matches_eager_and_dynamic_false_predicate_rejects() -> None:
     )
     assert bool(rejected.rejected)
     assert not bool(rejected.valid)
+
+
+def test_representation_gradient_mixer_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=4.5)  # type: ignore[arg-type]
+
+
+def test_representation_gradient_mixer_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    config = RepresentationGradientMixerConfig(representation_dim=np.int32(8))
+    assert type(config.representation_dim) is int
+    assert config.representation_dim == 8

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from collections import UserDict
+from fractions import Fraction
+from types import MappingProxyType
 from typing import cast
 
 import jax
@@ -487,7 +490,18 @@ def test_gradient_mixer_canonicalizes_every_numpy_integer_type(
 
 def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
     class IntSubclass(int):
-        pass
+        def __index__(self) -> int:
+            raise AssertionError("subclass index must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("subclass repr must not run")
+
+    class NumpyIntSubclass(np.int64):
+        def __index__(self) -> int:
+            raise AssertionError("NumPy subclass index must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("NumPy subclass repr must not run")
 
     class ClassSpoof:
         @property
@@ -497,7 +511,16 @@ def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
         def __repr__(self) -> str:
             raise RuntimeError("repr must not run")
 
-    for value in (True, np.bool_(True), 0, -1, 1.0, IntSubclass(3), ClassSpoof()):
+    for value in (
+        True,
+        np.bool_(True),
+        0,
+        -1,
+        1.0,
+        IntSubclass(3),
+        NumpyIntSubclass(3),
+        ClassSpoof(),
+    ):
         with pytest.raises(ValueError, match="representation_dim"):
             RepresentationGradientMixerConfig(
                 representation_dim=value  # type: ignore[arg-type]
@@ -505,16 +528,187 @@ def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
 
 
 def test_gradient_mixer_allocation_contract_endpoints_are_allocation_free() -> None:
-    last_legal = (2**31 - 1) // 4
+    fixed_output_bytes = 12 * 4 + 12
+    last_legal = ((2**31 - 1) - fixed_output_bytes) // 4
     config = RepresentationGradientMixerConfig(representation_dim=last_legal)
     budget = config.resource_budget
 
     assert budget.representation_dim == last_legal
     assert budget.persistent_state_scalars == 0
     assert budget.persistent_state_bytes == 0
-    assert budget.output_float32_scalars == last_legal
-    assert budget.output_nbytes == 4 * last_legal
+    assert budget.output_float32_scalars == last_legal + 12
+    assert budget.output_bool_scalars == 12
+    assert budget.output_scalars == last_legal + 24
+    assert budget.output_nbytes == 4 * (last_legal + 12) + 12
+    assert budget.output_nbytes <= 2**31 - 1
+    assert 4 * (last_legal + 1 + 12) + 12 > 2**31 - 1
     json.dumps(budget.to_dict(), allow_nan=False)
 
     with pytest.raises(ValueError, match="representation_dim"):
         RepresentationGradientMixerConfig(representation_dim=last_legal + 1)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["full", "behavior_only", "world_only", "discard"],
+)
+def test_gradient_mixer_accepts_every_exact_mode(mode: GradientMixMode) -> None:
+    assert RepresentationGradientMixerConfig(representation_dim=1, mode=mode).mode == mode
+
+
+@pytest.mark.parametrize("normalization", ["none", "unit_l2"])
+@pytest.mark.parametrize(
+    "field", ["behavior_normalization", "grounded_world_normalization"]
+)
+def test_gradient_mixer_accepts_every_exact_normalization(
+    field: str, normalization: str
+) -> None:
+    config = RepresentationGradientMixerConfig(
+        representation_dim=1,
+        **{field: normalization},  # type: ignore[arg-type]
+    )
+    assert getattr(config, field) == normalization
+
+
+def test_gradient_mixer_rejects_string_subclasses_for_all_static_tokens() -> None:
+    class StringSubclass(str):
+        pass
+
+    for field, value in (
+        ("mode", StringSubclass("full")),
+        ("behavior_normalization", StringSubclass("none")),
+        ("grounded_world_normalization", StringSubclass("unit_l2")),
+    ):
+        with pytest.raises(ValueError, match=field):
+            RepresentationGradientMixerConfig(
+                representation_dim=1,
+                **{field: value},  # type: ignore[arg-type]
+            )
+
+
+@pytest.mark.parametrize(
+    ("field", "allow_zero"),
+    [
+        ("behavior_weight", True),
+        ("grounded_world_weight", True),
+        ("normalization_epsilon", False),
+        ("behavior_clip_norm", False),
+        ("grounded_world_clip_norm", False),
+        ("final_clip_norm", False),
+    ],
+)
+def test_gradient_mixer_float32_scalar_endpoints_and_canonicalization(
+    field: str, allow_zero: bool
+) -> None:
+    tiny = float(np.finfo(np.float32).tiny)
+    maximum = float(np.finfo(np.float32).max)
+    valid_values = [
+        tiny,
+        maximum,
+        *(np.dtype(code).type(0.5) for code in ("e", "f", "d", "g")),
+        Fraction(1, 4),
+    ]
+    if allow_zero:
+        valid_values.extend((0, -0.0))
+    for value in valid_values:
+        config = RepresentationGradientMixerConfig(
+            representation_dim=1,
+            **{field: value},  # type: ignore[arg-type]
+        )
+        stored = getattr(config, field)
+        assert type(stored) is float
+        if value == 0:
+            assert not np.signbit(stored)
+        assert RepresentationGradientMixerConfig.from_config(config.to_config()) == config
+
+    invalid_values: list[object] = [
+        True,
+        np.bool_(True),
+        -1,
+        float("nan"),
+        float("inf"),
+        Fraction(*tiny.as_integer_ratio()) / 2,
+        Fraction(int(maximum) + 1, 1),
+    ]
+    if not allow_zero:
+        invalid_values.append(0)
+    for value in invalid_values:
+        with pytest.raises(ValueError, match=field):
+            RepresentationGradientMixerConfig(
+                representation_dim=1,
+                **{field: value},  # type: ignore[arg-type]
+            )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "behavior_weight",
+        "grounded_world_weight",
+        "normalization_epsilon",
+        "behavior_clip_norm",
+        "grounded_world_clip_norm",
+        "final_clip_norm",
+    ],
+)
+def test_gradient_mixer_rejects_hostile_real_subclasses_as_value_errors(
+    field: str,
+) -> None:
+    class HostileFraction(Fraction):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise AssertionError("hostile ratio must be contained")
+
+        def __repr__(self) -> str:
+            raise AssertionError("hostile repr must not run")
+
+    with pytest.raises(ValueError, match=field):
+        RepresentationGradientMixerConfig(
+            representation_dim=1,
+            **{field: HostileFraction(1, 2)},  # type: ignore[arg-type]
+        )
+
+
+def test_gradient_mixer_from_config_accepts_mappings_and_rejects_token_subclasses() -> None:
+    config = RepresentationGradientMixerConfig(representation_dim=3)
+    payload = config.to_config()
+    for mapping in (MappingProxyType(payload), UserDict(payload)):
+        assert RepresentationGradientMixerConfig.from_config(mapping) == config
+
+    with pytest.raises(ValueError, match="mapping"):
+        RepresentationGradientMixerConfig.from_config(  # type: ignore[arg-type]
+            list(payload.items())
+        )
+
+    class MappingSpoof:
+        @property
+        def __class__(self) -> type[dict[object, object]]:  # type: ignore[override]
+            return dict
+
+        def __repr__(self) -> str:
+            raise AssertionError("mapping repr must not run")
+
+    with pytest.raises(ValueError, match="mapping"):
+        RepresentationGradientMixerConfig.from_config(  # type: ignore[arg-type]
+            MappingSpoof()
+        )
+
+    class StringSubclass(str):
+        pass
+
+    for field, value in (
+        ("schema", StringSubclass(cast(str, payload["schema"]))),
+        ("type", StringSubclass(cast(str, payload["type"]))),
+    ):
+        with pytest.raises(ValueError, match=field):
+            RepresentationGradientMixerConfig.from_config({**payload, field: value})
+
+
+def test_gradient_mixer_resource_budget_is_exported_from_public_packages() -> None:
+    from alberta_framework import RepresentationGradientMixerResourceBudget as RootBudget
+    from alberta_framework.core import (
+        RepresentationGradientMixerResourceBudget as CoreBudget,
+    )
+
+    budget = RepresentationGradientMixerConfig(representation_dim=3).resource_budget
+    assert isinstance(budget, RootBudget)
+    assert RootBudget is CoreBudget

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -606,7 +606,6 @@ def test_gradient_mixer_float32_scalar_endpoints_and_canonicalization(
         tiny,
         maximum,
         *(np.dtype(code).type(0.5) for code in ("e", "f", "d", "g")),
-        Fraction(1, 4),
     ]
     if allow_zero:
         valid_values.extend((0, -0.0))
@@ -651,7 +650,7 @@ def test_gradient_mixer_float32_scalar_endpoints_and_canonicalization(
         "final_clip_norm",
     ],
 )
-def test_gradient_mixer_rejects_hostile_real_subclasses_as_value_errors(
+def test_gradient_mixer_rejects_hostile_real_subclasses_without_running_hooks(
     field: str,
 ) -> None:
     class HostileFraction(Fraction):
@@ -661,20 +660,37 @@ def test_gradient_mixer_rejects_hostile_real_subclasses_as_value_errors(
         def __repr__(self) -> str:
             raise AssertionError("hostile repr must not run")
 
-    with pytest.raises(ValueError, match=field):
-        RepresentationGradientMixerConfig(
-            representation_dim=1,
-            **{field: HostileFraction(1, 2)},  # type: ignore[arg-type]
-        )
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise AssertionError("hostile ratio must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("hostile repr must not run")
+
+    for value in (HostileFraction(1, 2), HostileFloat(0.5)):
+        with pytest.raises(ValueError, match=field):
+            RepresentationGradientMixerConfig(
+                representation_dim=1,
+                **{field: value},  # type: ignore[arg-type]
+            )
 
 
-def test_gradient_mixer_from_config_accepts_mappings_and_rejects_token_subclasses() -> None:
+def test_gradient_mixer_from_config_requires_exact_dict_and_tokens() -> None:
     config = RepresentationGradientMixerConfig(representation_dim=3)
     payload = config.to_config()
-    for mapping in (MappingProxyType(payload), UserDict(payload)):
-        assert RepresentationGradientMixerConfig.from_config(mapping) == config
 
-    with pytest.raises(ValueError, match="mapping"):
+    class HostileDict(dict[str, object]):
+        def __iter__(self):
+            raise AssertionError("hostile dict iteration must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("hostile dict repr must not run")
+
+    for mapping in (MappingProxyType(payload), UserDict(payload), HostileDict(payload)):
+        with pytest.raises(ValueError, match="exact built-in dict"):
+            RepresentationGradientMixerConfig.from_config(mapping)
+
+    with pytest.raises(ValueError, match="exact built-in dict"):
         RepresentationGradientMixerConfig.from_config(  # type: ignore[arg-type]
             list(payload.items())
         )
@@ -687,7 +703,7 @@ def test_gradient_mixer_from_config_accepts_mappings_and_rejects_token_subclasse
         def __repr__(self) -> str:
             raise AssertionError("mapping repr must not run")
 
-    with pytest.raises(ValueError, match="mapping"):
+    with pytest.raises(ValueError, match="exact built-in dict"):
         RepresentationGradientMixerConfig.from_config(  # type: ignore[arg-type]
             MappingSpoof()
         )


### PR DESCRIPTION
Supersedes #703 and #717 while preserving all three contributor and repair commits. This keeps the exact NumPy integer validation, fixes the complete returned-result budget (gradient plus 12 float32 diagnostics and 12 boolean outputs), exports that budget consistently, canonicalizes all scalar fields, and narrows the remaining host boundaries to exact built-in/NumPy scalar types and an exact built-in serialized dict so hostile subclasses and mappings cannot execute hooks.\n\nVerification: 67 focused tests passed; scoped Ruff passed; strict mypy passed; diff check passed. No outputs or evidence artifacts changed.