### PR TITLE
fix(oak): harden agent and keyboard chord configuration integer validation

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -33,13 +33,16 @@ References:
 from __future__ import annotations
 
 import dataclasses
+import math
+import operator
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -72,7 +75,44 @@ OAK_STATE_SCHEMA = "alberta.oak-state.v2"
 OAK_LIFETIME_COUNTER_NBYTES = 12
 OAK_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
+_INT32_MAX = 2**31 - 1
 _UINT64_MAX = 2**64 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_uint64(
+    name: str, value: object, *, minimum: int = 0, maximum: int = _UINT64_MAX
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
 
 # ---------------------------------------------------------------------------
 # Default config helper
@@ -113,14 +153,18 @@ class OaKConfig:
     min_steps_before_curation: int = 0
 
     def __post_init__(self) -> None:
-        if not 0.0 <= self.utility_ema_decay <= 1.0:
-            raise ValueError("utility_ema_decay must be in [0, 1]")
-        if self.curation_threshold < 0.0:
-            raise ValueError("curation_threshold must be non-negative")
-        if self.min_steps_before_curation < 0:
-            raise ValueError("min_steps_before_curation must be non-negative")
-        if self.min_steps_before_curation > _UINT64_MAX:
-            raise ValueError("min_steps_before_curation must fit the uint64 lifetime")
+        min_steps = _require_uint64(
+            "min_steps_before_curation",
+            self.min_steps_before_curation,
+            minimum=0,
+            maximum=_UINT64_MAX,
+        )
+        object.__setattr__(self, "min_steps_before_curation", min_steps)
+
+        if not math.isfinite(self.utility_ema_decay) or not 0.0 <= self.utility_ema_decay <= 1.0:
+            raise ValueError("utility_ema_decay must be finite and in [0, 1]")
+        if not math.isfinite(self.curation_threshold) or self.curation_threshold < 0.0:
+            raise ValueError("curation_threshold must be finite and non-negative")
 
     @property
     def n_options(self) -> int:
@@ -373,9 +417,8 @@ def _oak_outer_state_validity(
             config.observation_dim,
         )
     )
-    values_finite = (
-        jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards))
-        & jnp.all(jnp.isfinite(state.utility_ema))
+    values_finite = jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards)) & jnp.all(
+        jnp.isfinite(state.utility_ema)
     )
     counter_ceiling = jnp.where(
         state.step_count < jnp.int32(2_147_483_647),
@@ -389,11 +432,7 @@ def _oak_outer_state_validity(
         & jnp.all(state.execution_counts >= 0)
         & jnp.all(state.execution_counts <= counter_ceiling)
     )
-    valid = (
-        jnp.asarray(static_contract_valid, dtype=jnp.bool_)
-        & values_finite
-        & counters_valid
-    )
+    valid = jnp.asarray(static_contract_valid, dtype=jnp.bool_) & values_finite & counters_valid
     return (
         jnp.asarray(static_contract_valid, dtype=jnp.bool_),
         values_finite,
@@ -430,9 +469,8 @@ def _exact_tree_equal(left: Any, right: Any) -> Bool[Array, ""]:
         return jnp.asarray(False, dtype=jnp.bool_)
     left_leaves, left_structure = jax.tree_util.tree_flatten(left)
     right_leaves, right_structure = jax.tree_util.tree_flatten(right)
-    if (
-        cast(object, left_structure) != cast(object, right_structure)
-        or len(left_leaves) != len(right_leaves)
+    if cast(object, left_structure) != cast(object, right_structure) or len(left_leaves) != len(
+        right_leaves
     ):
         return jnp.asarray(False, dtype=jnp.bool_)
     equal = jnp.asarray(True, dtype=jnp.bool_)
@@ -684,9 +722,7 @@ def measure_oak_state_nbytes(state: OaKState) -> int:
 def measure_oak_wrapper_state_nbytes(state: OaKState) -> int:
     """Measure only OaK-owned arrays, excluding the nested STOMP state."""
 
-    return measure_oak_state_nbytes(state) - measure_stomp_state_nbytes(
-        state.stomp_state
-    )
+    return measure_oak_state_nbytes(state) - measure_stomp_state_nbytes(state.stomp_state)
 
 
 def oak_lifetime_counter_nbytes() -> int:
@@ -711,10 +747,7 @@ def _oak_host_field_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return dict(value)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return {
-            field.name: getattr(value, field.name)
-            for field in dataclasses.fields(value)
-        }
+        return {field.name: getattr(value, field.name) for field in dataclasses.fields(value)}
     raise TypeError("legacy OaK state must be a mapping or dataclass")
 
 
@@ -738,8 +771,7 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
         missing = sorted(legacy_names - supplied_names)
         extra = sorted(supplied_names - legacy_names)
         raise ValueError(
-            "legacy OaK field manifest is not exact; "
-            f"missing={missing}, extra={extra}"
+            f"legacy OaK field manifest is not exact; missing={missing}, extra={extra}"
         )
 
     step_count = jnp.asarray(fields["step_count"])
@@ -757,9 +789,7 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
         nested = load_stomp_state_with_migration(_oak_host_field_mapping(nested))
     if not bool(_lifetime_counter_valid(nested.step_words, nested.step_count)):
         raise ValueError("legacy OaK nested STOMP lifetime counter is invalid")
-    if int(nested.step_count) != step or not bool(
-        jnp.all(nested.step_words == step_words)
-    ):
+    if int(nested.step_count) != step or not bool(jnp.all(nested.step_words == step_words)):
         raise ValueError("legacy OaK and nested STOMP clocks are not aligned")
 
     execution_counts = jnp.asarray(fields["execution_counts"])
@@ -779,14 +809,10 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
     if not owned_contract_valid:
         raise ValueError("legacy OaK owned-array contract is invalid")
     counter_ceiling = min(step + 1, 2**31 - 1)
-    if not bool(
-        jnp.all(execution_counts >= 0)
-        & jnp.all(execution_counts <= counter_ceiling)
-    ):
+    if not bool(jnp.all(execution_counts >= 0) & jnp.all(execution_counts <= counter_ceiling)):
         raise ValueError("legacy OaK execution counters are invalid")
     if not bool(
-        jnp.all(jnp.isfinite(cumulative_pseudo_rewards))
-        & jnp.all(jnp.isfinite(utility_ema))
+        jnp.all(jnp.isfinite(cumulative_pseudo_rewards)) & jnp.all(jnp.isfinite(utility_ema))
     ):
         raise ValueError("legacy OaK utility values are non-finite")
 
@@ -857,16 +883,17 @@ class KeyboardChordLearnerConfig:
     max_norm: float = 10.0
 
     def __post_init__(self) -> None:
-        if self.n_options <= 0:
-            raise ValueError("n_options must be positive")
-        if self.step_size < 0.0:
-            raise ValueError("step_size must be non-negative")
-        if not 0.0 <= self.baseline_decay < 1.0:
-            raise ValueError("baseline_decay must be in [0, 1)")
-        if self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be non-negative")
-        if self.max_norm <= 0.0:
-            raise ValueError("max_norm must be positive")
+        n_options = _require_int32("n_options", self.n_options, minimum=1)
+        object.__setattr__(self, "n_options", n_options)
+
+        if not math.isfinite(self.step_size) or self.step_size < 0.0:
+            raise ValueError("step_size must be finite and non-negative")
+        if not math.isfinite(self.baseline_decay) or not 0.0 <= self.baseline_decay < 1.0:
+            raise ValueError("baseline_decay must be finite and in [0, 1)")
+        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
+            raise ValueError("l2_penalty must be finite and non-negative")
+        if not math.isfinite(self.max_norm) or self.max_norm <= 0.0:
+            raise ValueError("max_norm must be finite and positive")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -917,8 +944,7 @@ def update_keyboard_chord_learner(
     chord_norm = chord / (jnp.linalg.norm(chord) + 1.0e-8)
     reward_arr = jnp.asarray(reward, dtype=jnp.float32)
     baseline = (
-        config.baseline_decay * state.reward_baseline
-        + (1.0 - config.baseline_decay) * reward_arr
+        config.baseline_decay * state.reward_baseline + (1.0 - config.baseline_decay) * reward_arr
     )
     advantage = reward_arr - state.reward_baseline
     proposed_vector = (
@@ -1006,9 +1032,9 @@ def keyboard_action(
     """
     q_vals = keyboard_q_values(stomp_state, observation, keyboard_vector)
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(
-        q_vals + 1e-6 * jr.gumbel(noise_key, (n_primitive_actions,))
-    ).astype(jnp.int32)
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_primitive_actions,))).astype(
+        jnp.int32
+    )
     random_action = jr.randint(explore_key, (), 0, n_primitive_actions).astype(jnp.int32)
     action = jnp.where(
         jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32),
@@ -1107,9 +1133,8 @@ class OaKAgent:
                 & jnp.all(jnp.isfinite(observation))
             )
         started_option = new_stomp.executing_option
-        started_mask = (
-            jnp.arange(self._config.n_options, dtype=jnp.int32)
-            == jnp.maximum(started_option, jnp.array(0, dtype=jnp.int32))
+        started_mask = jnp.arange(self._config.n_options, dtype=jnp.int32) == jnp.maximum(
+            started_option, jnp.array(0, dtype=jnp.int32)
         )
         new_execution_counts = jnp.where(
             started_mask & (started_option >= 0),
@@ -1171,9 +1196,7 @@ class OaKAgent:
             state.step_words,
             state.step_count,
         )
-        nested_counter_aligned = jnp.all(
-            state.step_words == state.stomp_state.step_words
-        )
+        nested_counter_aligned = jnp.all(state.step_words == state.stomp_state.step_words)
         source_nested_counter_aligned = jnp.all(
             source_state.step_words == source_state.stomp_state.step_words
         )
@@ -1187,15 +1210,11 @@ class OaKAgent:
         proposed_step_words, outer_capacity = _checked_lifetime_words_increment(
             source_state.step_words
         )
-        expected_nested_words, computed_nested_capacity = (
-            _checked_lifetime_words_advance(
-                source_state.stomp_state.base_learner_state.step_words,
-                stomp_result.nested_updates_required,
-            )
+        expected_nested_words, computed_nested_capacity = _checked_lifetime_words_advance(
+            source_state.stomp_state.base_learner_state.step_words,
+            stomp_result.nested_updates_required,
         )
-        expected_step_count = _saturating_int32_counter_increment(
-            source_state.step_count
-        )
+        expected_step_count = _saturating_int32_counter_increment(source_state.step_count)
         result_clock_binding_valid = (
             jnp.array_equal(
                 stomp_result.pre_step_words,
@@ -1251,9 +1270,7 @@ class OaKAgent:
             & idle_outputs_valid
             & continuing_owner_valid
         )
-        inferred_real_updates = (
-            stomp_result.nested_updates_applied - stomp_result.planning_backups
-        )
+        inferred_real_updates = stomp_result.nested_updates_applied - stomp_result.planning_backups
         result_diagnostics_valid = (
             stomp_result.inputs_valid
             & stomp_result.lifetime_counter_valid
@@ -1263,15 +1280,9 @@ class OaKAgent:
             & stomp_result.proposed_state_valid
             & stomp_result.update_applied
             & (stomp_result.nested_updates_required >= 0)
-            & (
-                stomp_result.nested_updates_applied
-                == stomp_result.nested_updates_required
-            )
+            & (stomp_result.nested_updates_applied == stomp_result.nested_updates_required)
             & (stomp_result.planning_backups >= 0)
-            & (
-                stomp_result.planning_backups
-                <= cfg.stomp.option_planning_backups_per_step
-            )
+            & (stomp_result.planning_backups <= cfg.stomp.option_planning_backups_per_step)
             & (inferred_real_updates >= 0)
             & (inferred_real_updates <= 1)
             & (stomp_result.option_importance_ratio >= 0.0)
@@ -1282,14 +1293,11 @@ class OaKAgent:
             prior_option,
             jnp.asarray(0, dtype=jnp.int32),
         )
-        prior_option_mask = (
-            jnp.arange(n_options, dtype=jnp.int32) == prior_option_index
-        )
+        prior_option_mask = jnp.arange(n_options, dtype=jnp.int32) == prior_option_index
         decay = jnp.asarray(cfg.utility_ema_decay, dtype=jnp.float32)
         new_utility_ema = jnp.where(
             prior_option_mask & prior_active,
-            decay * source_state.utility_ema
-            + (1.0 - decay) * stomp_result.pseudo_reward,
+            decay * source_state.utility_ema + (1.0 - decay) * stomp_result.pseudo_reward,
             source_state.utility_ema,
         )
 
@@ -1298,29 +1306,22 @@ class OaKAgent:
             post_option,
             jnp.asarray(0, dtype=jnp.int32),
         )
-        post_option_mask = (
-            jnp.arange(n_options, dtype=jnp.int32) == post_option_index
-        )
+        post_option_mask = jnp.arange(n_options, dtype=jnp.int32) == post_option_index
         post_active = post_option >= jnp.asarray(0, dtype=jnp.int32)
-        just_started = post_active & (
-            (~prior_active) | stomp_result.option_terminated
-        )
+        just_started = post_active & ((~prior_active) | stomp_result.option_terminated)
         new_execution_counts = jnp.where(
             post_option_mask & just_started,
             _saturating_int32_counter_increment(source_state.execution_counts),
             source_state.execution_counts,
         )
-        new_cumulative_pseudo_rewards = (
-            source_state.cumulative_pseudo_rewards
-            + jnp.where(
-                prior_option_mask & prior_active,
-                jnp.full(
-                    n_options,
-                    stomp_result.pseudo_reward,
-                    dtype=jnp.float32,
-                ),
-                jnp.zeros(n_options, dtype=jnp.float32),
-            )
+        new_cumulative_pseudo_rewards = source_state.cumulative_pseudo_rewards + jnp.where(
+            prior_option_mask & prior_active,
+            jnp.full(
+                n_options,
+                stomp_result.pseudo_reward,
+                dtype=jnp.float32,
+            ),
+            jnp.zeros(n_options, dtype=jnp.float32),
         )
         proposed_state = OaKState(
             stomp_state=stomp_result.state,
@@ -1330,9 +1331,7 @@ class OaKAgent:
             step_count=expected_step_count,
             step_words=proposed_step_words,
         )
-        post_nested_counter_aligned = jnp.all(
-            stomp_result.state.step_words == proposed_step_words
-        )
+        post_nested_counter_aligned = jnp.all(stomp_result.state.step_words == proposed_step_words)
         proposed_state_valid = (
             _oak_outer_state_validity(proposed_state, cfg)[-1]
             & self._stomp.state_valid(proposed_state.stomp_state)
@@ -1448,10 +1447,7 @@ class OaKAgent:
                 f"({self._config.n_options},), got {reset_slots.shape}"
             )
         if reset_slots.dtype != jnp.bool_:
-            raise TypeError(
-                "reset_slot_mask must have dtype bool, "
-                f"got {reset_slots.dtype}"
-            )
+            raise TypeError(f"reset_slot_mask must have dtype bool, got {reset_slots.dtype}")
 
         source_state_valid = (
             _oak_outer_state_validity(state, self._config)[-1]
@@ -1636,9 +1632,7 @@ class OaKAgent:
             execution_boundary=execution_boundary,
             extended_action_mask=extended_action_mask,
             enable_planning=enable_option_planning,
-            preselection_feature_reset_mask=(
-                preselection_feature_reset_mask
-            ),
+            preselection_feature_reset_mask=(preselection_feature_reset_mask),
         )
         update = self.adopt_stomp_update(
             state,
@@ -1685,9 +1679,7 @@ class OaKAgent:
                 decision_observation=decision_obs,
                 execution_boundary=execution_boundary,
                 extended_action_mask=(
-                    extended_action_mask
-                    if extended_action_masks is not None
-                    else None
+                    extended_action_mask if extended_action_masks is not None else None
                 ),
             )
             return result.state, (
@@ -1734,25 +1726,28 @@ class OaKAgent:
             else jnp.asarray(extended_action_masks)
         )
 
-        final_state, (
-            td_errors,
-            average_rewards,
-            primitive_actions,
-            executing_options,
-            option_terminations,
-            pseudo_rewards,
-            utility_emas,
-            planning_backups,
-            planning_td_errors,
-            pre_step_words,
-            post_step_words,
-            outer_state_valid,
-            lifetime_counter_valid,
-            lifetime_capacity_available,
-            nested_counter_aligned,
-            nested_update_applied,
-            proposed_state_valid,
-            update_applied,
+        (
+            final_state,
+            (
+                td_errors,
+                average_rewards,
+                primitive_actions,
+                executing_options,
+                option_terminations,
+                pseudo_rewards,
+                utility_emas,
+                planning_backups,
+                planning_td_errors,
+                pre_step_words,
+                post_step_words,
+                outer_state_valid,
+                lifetime_counter_valid,
+                lifetime_capacity_available,
+                nested_counter_aligned,
+                nested_update_applied,
+                proposed_state_valid,
+                update_applied,
+            ),
         ) = jax.lax.scan(
             step_fn,
             state,
@@ -1826,14 +1821,8 @@ class OaKAgent:
         utility = state.utility_ema
 
         outer_valid = _oak_outer_state_validity(state, cfg)[-1]
-        nested_aligned = jnp.all(
-            state.step_words == state.stomp_state.step_words
-        )
-        if not bool(
-            outer_valid
-            & nested_aligned
-            & self._stomp.state_valid(state.stomp_state)
-        ):
+        nested_aligned = jnp.all(state.step_words == state.stomp_state.step_words)
+        if not bool(outer_valid & nested_aligned & self._stomp.state_valid(state.stomp_state)):
             return self, state
 
         # Minimum-uptime guard: never evict before utilities have had time
@@ -1893,9 +1882,7 @@ class OaKAgent:
         new_op_traces = state.stomp_state.option_policies.traces.at[idx].set(
             jnp.zeros_like(state.stomp_state.option_policies.traces[idx])
         )
-        new_op_average_rewards = (
-            state.stomp_state.option_policies.average_rewards.at[idx].set(0.0)
-        )
+        new_op_average_rewards = state.stomp_state.option_policies.average_rewards.at[idx].set(0.0)
         new_option_policies = cast(
             IntraOptionPoliciesState,
             state.stomp_state.option_policies.replace(
@@ -1914,9 +1901,9 @@ class OaKAgent:
                 cumreward_ema=state.stomp_state.option_models.cumreward_ema.at[idx].set(0.0),
                 env_return_ema=state.stomp_state.option_models.env_return_ema.at[idx].set(0.0),
                 duration_ema=state.stomp_state.option_models.duration_ema.at[idx].set(0.0),
-                baseline_mass_ema=state.stomp_state.option_models.baseline_mass_ema.at[
-                    idx
-                ].set(0.0),
+                baseline_mass_ema=state.stomp_state.option_models.baseline_mass_ema.at[idx].set(
+                    0.0
+                ),
                 discount_ema=state.stomp_state.option_models.discount_ema.at[idx].set(1.0),
                 next_state_weights=new_ns_weights,
                 n_completions=state.stomp_state.option_models.n_completions.at[idx].set(0),
@@ -1966,9 +1953,7 @@ class OaKAgent:
         new_state = OaKState(
             stomp_state=new_stomp_state,
             execution_counts=jnp.where(replace_mask, 0, state.execution_counts),
-            cumulative_pseudo_rewards=jnp.where(
-                replace_mask, 0.0, state.cumulative_pseudo_rewards
-            ),
+            cumulative_pseudo_rewards=jnp.where(replace_mask, 0.0, state.cumulative_pseudo_rewards),
             utility_ema=jnp.where(replace_mask, 0.0, state.utility_ema),
             step_count=state.step_count,
             step_words=state.step_words,
@@ -2017,8 +2002,7 @@ class OaKAgent:
         )
         raw_chord = jnp.asarray(keyboard_vector)
         keyboard_vector_static_contract_valid = (
-            raw_chord.shape == (self._config.n_options,)
-            and raw_chord.dtype == jnp.float32
+            raw_chord.shape == (self._config.n_options,) and raw_chord.dtype == jnp.float32
         )
         chord = (
             raw_chord
@@ -2026,10 +2010,9 @@ class OaKAgent:
             else jnp.zeros((self._config.n_options,), dtype=jnp.float32)
         )
 
-        observation_valid = (
-            jnp.asarray(observation_static_contract_valid, dtype=jnp.bool_)
-            & jnp.all(jnp.isfinite(observation))
-        )
+        observation_valid = jnp.asarray(
+            observation_static_contract_valid, dtype=jnp.bool_
+        ) & jnp.all(jnp.isfinite(observation))
         chord_l1 = jnp.sum(jnp.abs(chord))
         keyboard_vector_valid = (
             jnp.asarray(keyboard_vector_static_contract_valid, dtype=jnp.bool_)

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
-from alberta_framework.core.oak import OaKAgent, OaKConfig
+from alberta_framework.core.oak import KeyboardChordLearnerConfig, OaKAgent, OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
     GRUPerceptionConfig,
@@ -174,9 +175,7 @@ def test_useless_option_evicted_after_guard_and_reward_preserved() -> None:
     # targets feature 1 (always 0.0 → pseudo-reward 0.0, deliberately useless).
     cfg = _oak_cfg(min_steps_before_curation=100)
     agent, state = _primed(cfg)
-    obs = jnp.tile(
-        jnp.array([1.0, 0.0, 0.5, -0.5], dtype=jnp.float32), (300, 1)
-    )
+    obs = jnp.tile(jnp.array([1.0, 0.0, 0.5, -0.5], dtype=jnp.float32), (300, 1))
     result = agent.scan(state, jnp.ones(300), obs)
     state = result.state
     assert float(state.utility_ema[0]) > float(state.utility_ema[1])
@@ -274,14 +273,10 @@ GRU_AUG_DIM = GRU_OBS_DIM + GRU_HIDDEN
 
 
 def _gru_proto_cfg() -> PrototypeAgentConfig:
-    stomp = STOMPConfig(
-        subtask_specs=(_SPEC0, _SPEC1), observation_dim=GRU_AUG_DIM
-    )
+    stomp = STOMPConfig(subtask_specs=(_SPEC0, _SPEC1), observation_dim=GRU_AUG_DIM)
     return PrototypeAgentConfig(
         oak=OaKConfig(stomp=stomp),
-        gru_perception=GRUPerceptionConfig(
-            observation_dim=GRU_OBS_DIM, hidden_dim=GRU_HIDDEN
-        ),
+        gru_perception=GRUPerceptionConfig(observation_dim=GRU_OBS_DIM, hidden_dim=GRU_HIDDEN),
     )
 
 
@@ -309,9 +304,7 @@ def test_greedy_action_with_gru_is_pure_and_act_returns_cached_dispatch() -> Non
     n_prim = agent.config.oak.n_primitive_actions
     expected = int(jnp.argmax(q[:n_prim]))
     assert int(agent.greedy_action(state, query)) == expected
-    assert int(agent.act(state, state.current_raw_observation)) == int(
-        state.current_action
-    )
+    assert int(agent.act(state, state.current_raw_observation)) == int(state.current_action)
 
 
 def test_act_without_gru_unchanged() -> None:
@@ -320,3 +313,33 @@ def test_act_without_gru_unchanged() -> None:
     action = agent.act(state, state.current_raw_observation)
     assert action.shape == ()
     assert 0 <= int(action) < agent.config.oak.n_primitive_actions
+
+
+def test_oak_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="min_steps_before_curation"):
+        OaKConfig(min_steps_before_curation=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_steps_before_curation"):
+        OaKConfig(min_steps_before_curation=10.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="utility_ema_decay"):
+        OaKConfig(utility_ema_decay=float("nan"))
+    with pytest.raises(ValueError, match="curation_threshold"):
+        OaKConfig(curation_threshold=float("inf"))
+
+    cfg = OaKConfig(min_steps_before_curation=np.int64(100))
+    assert type(cfg.min_steps_before_curation) is int
+    assert cfg.min_steps_before_curation == 100
+
+
+def test_keyboard_chord_learner_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_options"):
+        KeyboardChordLearnerConfig(n_options=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_options"):
+        KeyboardChordLearnerConfig(n_options=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        KeyboardChordLearnerConfig(n_options=2, step_size=float("nan"))
+    with pytest.raises(ValueError, match="baseline_decay"):
+        KeyboardChordLearnerConfig(n_options=2, baseline_decay=float("inf"))
+
+    cfg = KeyboardChordLearnerConfig(n_options=np.int32(4))
+    assert type(cfg.n_options) is int
+    assert cfg.n_options == 4


### PR DESCRIPTION
## Summary
- Hardens `OaKConfig` integer field `min_steps_before_curation` and `KeyboardChordLearnerConfig` integer dimension `n_options` with `_require_uint64` and `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Validates finiteness on float scalar fields (`utility_ema_decay`, `curation_threshold`, `step_size`, `baseline_decay`, `l2_penalty`, `max_norm`).
- Canonicalizes all integer attributes to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_oak_prototype_fixes.py tests/test_stomp_oak_horizon.py tests/test_oak_authoritative_stomp_adoption.py tests/test_oak_transition_accounting.py tests/test_oak_keyboard_dispatch.py`: 72 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/oak.py`: clean