### PR TITLE
fix(config): complete option-search, average-reward, and recurring-IPMNIST contracts

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
 import operator
 import time
 from collections.abc import Mapping
@@ -38,6 +37,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
 from alberta_framework.core.multi_head_learner import MultiHeadMLPLearner, MultiHeadMLPState
 from alberta_framework.core.optimizers import Autostep, AutostepParamState, optimizer_from_config
@@ -77,6 +77,43 @@ def _validate_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
     if type(hidden_sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
     return tuple(_require_int32("hidden_sizes element", size, minimum=1) for size in hidden_sizes)
+
+
+def _decode_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
+    if type(hidden_sizes) not in (list, tuple):
+        raise ValueError("hidden_sizes must be an actual list or tuple")
+    sequence = cast(list[object] | tuple[object, ...], hidden_sizes)
+    return _validate_hidden_sizes(tuple(sequence))
+
+
+def _require_state_resources(name: str, *, scalars: int, nbytes: int) -> None:
+    if scalars > _INT32_MAX:
+        raise ValueError(f"{name} state scalars must fit signed int32")
+    if nbytes > _INT32_MAX:
+        raise ValueError(f"{name} state bytes must fit signed int32")
+
+
+def _preflight_actor_state(n_actions: int, observation_dim: int, actor_dim: int) -> None:
+    actor_parameters = n_actions * actor_dim
+    float32_scalars = 4 * actor_parameters + 6 * n_actions + observation_dim + 8
+    scalar_count = float32_scalars + 5
+    _require_state_resources(
+        "average-reward actor-critic",
+        scalars=scalar_count,
+        nbytes=4 * scalar_count,
+    )
+
+
+def _preflight_differential_sarsa_state(n_actions: int, feature_dim: int) -> None:
+    parameters = n_actions * feature_dim
+    float32_scalars = 2 * parameters + 2 * n_actions + feature_dim + 2
+    # Two int32 leaves, a two-word RNG key, and a two-word lifetime counter.
+    scalar_count = float32_scalars + 6
+    _require_state_resources(
+        "differential SARSA",
+        scalars=scalar_count,
+        nbytes=4 * scalar_count,
+    )
 
 
 DIFFERENTIAL_SARSA_STATE_SCHEMA = "alberta.differential-sarsa-state.v2"
@@ -379,18 +416,25 @@ class AverageRewardHordeActorCriticConfig:
             "hidden_sizes",
             _validate_hidden_sizes(self.hidden_sizes),
         )
-        if self.critic_step_size < 0.0:
-            raise ValueError("critic_step_size must be non-negative")
-        if self.average_reward_step_size < 0.0:
-            raise ValueError("average_reward_step_size must be non-negative")
-        if self.temperature <= 0.0:
-            raise ValueError("temperature must be positive")
-        if not 0.0 <= self.epsilon <= 1.0:
-            raise ValueError("epsilon must be in [0, 1]")
-        if self.actor_update_clip <= 0.0:
-            raise ValueError("actor_update_clip must be positive")
-        if self.logit_clip <= 0.0:
-            raise ValueError("logit_clip must be positive")
+        for name in ("critic_step_size", "average_reward_step_size"):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+            )
+        for name in ("temperature", "actor_update_clip", "logit_clip"):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), positive=True),
+            )
+        object.__setattr__(
+            self,
+            "epsilon",
+            validated_float32_scalar("epsilon", self.epsilon, lower=0.0, upper=1.0),
+        )
+        if self.hidden_sizes:
+            _preflight_actor_state(self.n_actions, 1, self.hidden_sizes[-1])
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this config to a dictionary."""
@@ -414,7 +458,7 @@ class AverageRewardHordeActorCriticConfig:
         """Reconstruct a config from :meth:`to_config` output."""
         config = dict(config)
         config.pop("type", None)
-        config["hidden_sizes"] = tuple(config["hidden_sizes"])
+        config["hidden_sizes"] = _decode_hidden_sizes(config["hidden_sizes"])
         return cls(**config)
 
 
@@ -573,11 +617,11 @@ class AverageRewardHordeActorCriticAgent:
 
     def init(self, observation_dim: int, key: Array) -> AverageRewardHordeActorCriticState:
         """Initialize critic and actor state."""
-        if observation_dim < 1:
-            raise ValueError("observation_dim must be positive")
+        observation_dim = _require_int32("observation_dim", observation_dim, minimum=1)
+        actor_dim = self._config.hidden_sizes[-1] if self._config.hidden_sizes else observation_dim
+        _preflight_actor_state(self._config.n_actions, observation_dim, actor_dim)
         key, critic_key = jr.split(key)
         critic_state = self._critic.init(observation_dim, critic_key)
-        actor_dim = self._config.hidden_sizes[-1] if self._config.hidden_sizes else observation_dim
         actor_opt_w = self._actor_optimizer.init_for_shape((self._config.n_actions, actor_dim))
         actor_opt_b = self._actor_optimizer.init_for_shape((self._config.n_actions,))
         initial_policy = jnp.full(
@@ -1622,18 +1666,26 @@ class DifferentialSARSAConfig:
             "epsilon_decay_steps",
             _require_int32("epsilon_decay_steps", self.epsilon_decay_steps, minimum=0),
         )
-        if not math.isfinite(self.q_step_size) or self.q_step_size < 0.0:
-            raise ValueError("q_step_size must be finite and non-negative")
-        if not math.isfinite(self.average_reward_step_size) or self.average_reward_step_size < 0.0:
-            raise ValueError("average_reward_step_size must be finite and non-negative")
-        if not math.isfinite(self.trace_decay) or not 0.0 <= self.trace_decay <= 1.0:
-            raise ValueError("trace_decay must be finite and lie in [0, 1]")
-        if not math.isfinite(self.epsilon_start) or not 0.0 <= self.epsilon_start <= 1.0:
-            raise ValueError("epsilon_start must be finite and lie in [0, 1]")
-        if not math.isfinite(self.epsilon_end) or not 0.0 <= self.epsilon_end <= 1.0:
-            raise ValueError("epsilon_end must be finite and lie in [0, 1]")
-        if not isinstance(self.use_bias, bool):
+        for name in ("q_step_size", "average_reward_step_size"):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+            )
+        for name in ("trace_decay", "epsilon_start", "epsilon_end"):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(
+                    name,
+                    getattr(self, name),
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            )
+        if type(self.use_bias) is not bool:
             raise ValueError("use_bias must be boolean")
+        object.__setattr__(self, "use_bias", bool(self.use_bias))
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this config to a dictionary."""
@@ -1764,8 +1816,9 @@ class DifferentialSARSAAgent:
         average_reward: float = 0.0,
     ) -> DifferentialSARSAState:
         """Initialize Q weights, traces, reward-rate estimate, and RNG."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_differential_sarsa_state(self._config.n_actions, feature_dim)
+        average_reward = validated_float32_scalar("average_reward", average_reward)
         cfg = self._config
         zeros_q = jnp.zeros((cfg.n_actions, feature_dim), dtype=jnp.float32)
         zeros_bias = jnp.zeros((cfg.n_actions,), dtype=jnp.float32)

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -25,14 +25,16 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 import time
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -45,6 +47,38 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
+    if type(hidden_sizes) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(_require_int32("hidden_sizes element", size, minimum=1) for size in hidden_sizes)
+
+
 DIFFERENTIAL_SARSA_STATE_SCHEMA = "alberta.differential-sarsa-state.v2"
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_NBYTES = 12
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_DELTA_NBYTES = 8
@@ -335,8 +369,16 @@ class AverageRewardHordeActorCriticConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if self.n_actions < 1:
-            raise ValueError("n_actions must be positive")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _validate_hidden_sizes(self.hidden_sizes),
+        )
         if self.critic_step_size < 0.0:
             raise ValueError("critic_step_size must be non-negative")
         if self.average_reward_step_size < 0.0:
@@ -672,10 +714,7 @@ class AverageRewardHordeActorCriticAgent:
         next_observation: Array,
     ) -> AverageRewardHordeActorCriticUpdateResult:
         """Apply one average-reward actor-critic update."""
-        action_valid = (
-            (state.last_action >= 0)
-            & (state.last_action < self._config.n_actions)
-        )
+        action_valid = (state.last_action >= 0) & (state.last_action < self._config.n_actions)
         safe_last_action = jnp.clip(
             state.last_action,
             0,
@@ -710,21 +749,17 @@ class AverageRewardHordeActorCriticAgent:
         )
         grad_log_policy = score[:, None] * old_features[None, :]
         bias_grad = score
-        raw_w, new_opt_w, weight_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_opt_w,
-                grad_log_policy,
-                error=actor_td_error,
-            )
+        raw_w, new_opt_w, weight_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_opt_w,
+            grad_log_policy,
+            error=actor_td_error,
         )
-        raw_b, new_opt_b, bias_update_applied = (
-            _update_from_gradient_with_diagnostics(
-                self._actor_optimizer,
-                state.actor_opt_b,
-                bias_grad,
-                error=actor_td_error,
-            )
+        raw_b, new_opt_b, bias_update_applied = _update_from_gradient_with_diagnostics(
+            self._actor_optimizer,
+            state.actor_opt_b,
+            bias_grad,
+            error=actor_td_error,
         )
         weight_step = jnp.clip(
             actor_td_error * raw_w,
@@ -802,12 +837,8 @@ class AverageRewardHordeActorCriticAgent:
             ),
             actor_score_scale=jnp.where(update_applied, actor_score_scale, 0.0),
             td_error=jnp.where(update_applied, td_error, 0.0),
-            average_reward=jnp.where(
-                update_applied, critic_result.average_rewards[0], 0.0
-            ),
-            critic_prediction=jnp.where(
-                update_applied, critic_result.predictions[0], 0.0
-            ),
+            average_reward=jnp.where(update_applied, critic_result.average_rewards[0], 0.0),
+            critic_prediction=jnp.where(update_applied, critic_result.predictions[0], 0.0),
             update_applied=update_applied,
         )
 
@@ -922,9 +953,7 @@ class AverageRewardHordeLearner:
         cumulants = jnp.asarray(cumulants)
         expected_shape = (self._n_demons,)
         if cumulants.shape != expected_shape:
-            raise ValueError(
-                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
-            )
+            raise ValueError(f"cumulants must have shape {expected_shape}, got {cumulants.shape}")
         next_predictions = self._learner.predict(state.learner_state, next_observation)
         # NaN remains the inactive-head sentinel. Other non-finite cumulants
         # are rejected per head and reported separately from inactivity.
@@ -1343,12 +1372,10 @@ def run_differential_td_from_arrays(
             result.update_applied,
         )
 
-    final_state, (predictions, td_errors, average_rewards, metrics, updates_applied) = (
-        jax.lax.scan(
-            _scan_fn,
-            state,
-            (observations, rewards, next_observations),
-        )
+    final_state, (predictions, td_errors, average_rewards, metrics, updates_applied) = jax.lax.scan(
+        _scan_fn,
+        state,
+        (observations, rewards, next_observations),
     )
     elapsed = time.time() - start
     final_state = final_state.replace(uptime_s=final_state.uptime_s + elapsed)
@@ -1585,12 +1612,16 @@ class DifferentialSARSAConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if (
-            isinstance(self.n_actions, bool)
-            or not isinstance(self.n_actions, int)
-            or self.n_actions < 1
-        ):
-            raise ValueError("n_actions must be positive")
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "epsilon_decay_steps",
+            _require_int32("epsilon_decay_steps", self.epsilon_decay_steps, minimum=0),
+        )
         if not math.isfinite(self.q_step_size) or self.q_step_size < 0.0:
             raise ValueError("q_step_size must be finite and non-negative")
         if not math.isfinite(self.average_reward_step_size) or self.average_reward_step_size < 0.0:
@@ -1601,12 +1632,6 @@ class DifferentialSARSAConfig:
             raise ValueError("epsilon_start must be finite and lie in [0, 1]")
         if not math.isfinite(self.epsilon_end) or not 0.0 <= self.epsilon_end <= 1.0:
             raise ValueError("epsilon_end must be finite and lie in [0, 1]")
-        if (
-            isinstance(self.epsilon_decay_steps, bool)
-            or not isinstance(self.epsilon_decay_steps, int)
-            or self.epsilon_decay_steps < 0
-        ):
-            raise ValueError("epsilon_decay_steps must be non-negative")
         if not isinstance(self.use_bias, bool):
             raise ValueError("use_bias must be boolean")
 
@@ -1766,8 +1791,7 @@ class DifferentialSARSAAgent:
         q_weights = jnp.asarray(state.q_weights)
         if q_weights.ndim != 2 or q_weights.shape[0] != self._config.n_actions:
             raise ValueError(
-                "differential SARSA q_weights must have shape "
-                "(n_actions, feature_dim)"
+                "differential SARSA q_weights must have shape (n_actions, feature_dim)"
             )
         feature_dim = q_weights.shape[1]
         if feature_dim < 1:
@@ -1835,11 +1859,7 @@ class DifferentialSARSAAgent:
             value = jnp.asarray(leaf)
             if jnp.issubdtype(value.dtype, jnp.inexact):
                 checks.append(jnp.all(jnp.isfinite(value)))
-        return (
-            jnp.all(jnp.stack(checks))
-            if checks
-            else jnp.asarray(True, dtype=jnp.bool_)
-        )
+        return jnp.all(jnp.stack(checks)) if checks else jnp.asarray(True, dtype=jnp.bool_)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def q_values(
@@ -1953,8 +1973,7 @@ class DifferentialSARSAAgent:
         raw_next_observation = jnp.asarray(next_observation)
         if raw_next_observation.shape != (feature_dim,):
             raise ValueError(
-                "differential SARSA next_observation must have shape "
-                f"({feature_dim},)"
+                f"differential SARSA next_observation must have shape ({feature_dim},)"
             )
         if not (
             jnp.issubdtype(raw_next_observation.dtype, jnp.floating)
@@ -1980,8 +1999,8 @@ class DifferentialSARSAAgent:
         ):
             raise TypeError("differential SARSA discount must be real numeric")
         discount_s = raw_discount.astype(jnp.float32)
-        proposed_step_words, lifetime_capacity_available = (
-            _checked_lifetime_words_increment(state.step_words)
+        proposed_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+            state.step_words
         )
         lifetime_counter_valid = _lifetime_counter_valid(
             state.step_words,
@@ -2060,10 +2079,7 @@ class DifferentialSARSAAgent:
         )
         candidate_state_finite = self._candidate_finite(proposed_state)
         update_available = (
-            state_valid
-            & input_valid
-            & lifetime_capacity_available
-            & candidate_state_finite
+            state_valid & input_valid & lifetime_capacity_available & candidate_state_finite
         )
         new_state = jax.lax.cond(
             update_available,
@@ -2135,12 +2151,15 @@ def run_differential_sarsa_from_arrays(
             result.update_applied,
         )
 
-    final_state, (
-        q_values,
-        td_errors,
-        average_rewards,
-        actions,
-        updates_applied,
+    (
+        final_state,
+        (
+            q_values,
+            td_errors,
+            average_rewards,
+            actions,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         _scan_fn,
         state,

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -80,9 +80,9 @@ def _validate_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
 
 
 def _decode_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
-    if type(hidden_sizes) not in (list, tuple):
-        raise ValueError("hidden_sizes must be an actual list or tuple")
-    sequence = cast(list[object] | tuple[object, ...], hidden_sizes)
+    if type(hidden_sizes) is not list:
+        raise ValueError("serialized hidden_sizes must be an actual list")
+    sequence = cast(list[object], hidden_sizes)
     return _validate_hidden_sizes(tuple(sequence))
 
 
@@ -456,10 +456,16 @@ class AverageRewardHordeActorCriticConfig:
         config: dict[str, Any],
     ) -> AverageRewardHordeActorCriticConfig:
         """Reconstruct a config from :meth:`to_config` output."""
-        config = dict(config)
-        config.pop("type", None)
-        config["hidden_sizes"] = _decode_hidden_sizes(config["hidden_sizes"])
-        return cls(**config)
+        if type(config) is not dict:
+            raise ValueError("actor-critic config must be an actual dict")
+        payload = dict(config)
+        expected = {field.name for field in dataclasses.fields(cls)} | {"type"}
+        if set(payload) != expected:
+            raise ValueError("actor-critic config fields do not match its schema")
+        if payload.pop("type") != "AverageRewardHordeActorCriticConfig":
+            raise ValueError("actor-critic config type is invalid")
+        payload["hidden_sizes"] = _decode_hidden_sizes(payload["hidden_sizes"])
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -607,12 +613,18 @@ class AverageRewardHordeActorCriticAgent:
         config: dict[str, Any],
     ) -> AverageRewardHordeActorCriticAgent:
         """Reconstruct an agent from :meth:`to_config` output."""
-        config = dict(config)
-        config.pop("type", None)
-        cfg = AverageRewardHordeActorCriticConfig.from_config(config["config"])
-        actor_opt: Autostep | None = None
-        if config.get("actor_optimizer"):
-            actor_opt = cast(Autostep, optimizer_from_config(config["actor_optimizer"]))
+        if type(config) is not dict:
+            raise ValueError("actor-critic agent config must be an actual dict")
+        if set(config) != {"type", "config", "actor_optimizer"}:
+            raise ValueError("actor-critic agent config fields do not match its schema")
+        if config["type"] != "AverageRewardHordeActorCriticAgent":
+            raise ValueError("actor-critic agent config type is invalid")
+        nested = config["config"]
+        optimizer_config = config["actor_optimizer"]
+        if type(nested) is not dict or type(optimizer_config) is not dict:
+            raise ValueError("actor-critic nested configs must be actual dicts")
+        cfg = AverageRewardHordeActorCriticConfig.from_config(nested)
+        actor_opt = cast(Autostep, optimizer_from_config(optimizer_config))
         return cls(cfg, actor_optimizer=actor_opt)
 
     def init(self, observation_dim: int, key: Array) -> AverageRewardHordeActorCriticState:
@@ -1704,10 +1716,19 @@ class DifferentialSARSAConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> DifferentialSARSAConfig:
         """Reconstruct a config from :meth:`to_config` output."""
-        config = dict(config)
-        config.pop("type", None)
-        config.setdefault("use_bias", True)
-        return cls(**config)
+        if type(config) is not dict:
+            raise ValueError("differential SARSA config must be an actual dict")
+        payload = dict(config)
+        expected = {field.name for field in dataclasses.fields(cls)} | {"type"}
+        # Historical configs predate the use_bias field and retain the documented
+        # compatibility default. No other schema omission is accepted.
+        if set(payload) == expected - {"use_bias"}:
+            payload["use_bias"] = True
+        elif set(payload) != expected:
+            raise ValueError("differential SARSA config fields do not match its schema")
+        if payload.pop("type") != "DifferentialSARSAConfig":
+            raise ValueError("differential SARSA config type is invalid")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -1793,6 +1814,8 @@ class DifferentialSARSAAgent:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> DifferentialSARSAAgent:
         """Reconstruct an agent from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("differential SARSA agent config must be an actual dict")
         payload = dict(config)
         if set(payload) != {"type", "state_schema", "config"}:
             raise ValueError(
@@ -1804,9 +1827,9 @@ class DifferentialSARSAAgent:
         if payload["state_schema"] != DIFFERENTIAL_SARSA_STATE_SCHEMA:
             raise ValueError("differential SARSA state schema is unsupported")
         nested = payload["config"]
-        if not isinstance(nested, Mapping):
-            raise ValueError("differential SARSA nested config must be a mapping")
-        return cls(DifferentialSARSAConfig.from_config(dict(nested)))
+        if type(nested) is not dict:
+            raise ValueError("differential SARSA nested config must be an actual dict")
+        return cls(DifferentialSARSAConfig.from_config(nested))
 
     def init(
         self,

--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -22,12 +22,14 @@ a universal learning-value score or a learned search controller.
 from __future__ import annotations
 
 import dataclasses
+import operator
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
@@ -48,6 +50,30 @@ _CONFIG_TYPE = "OptionSearchControlConfig"
 _MAX_BACKUP_BUDGET = 4_096
 _MAX_CANDIDATE_DIAGNOSTIC_SLOTS = 262_144
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclasses.dataclass(frozen=True)
@@ -58,20 +84,26 @@ class OptionSearchControlConfig:
     min_model_completions: int = 1
 
     def __post_init__(self) -> None:
-        if (
-            type(self.backup_budget) is not int
-            or not 1 <= self.backup_budget <= _MAX_BACKUP_BUDGET
-        ):
-            raise ValueError(
-                f"backup_budget must be a strict integer in [1, {_MAX_BACKUP_BUDGET}]"
-            )
-        if (
-            type(self.min_model_completions) is not int
-            or not 1 <= self.min_model_completions <= 2_147_483_647
-        ):
-            raise ValueError(
-                "min_model_completions must be a strict positive int32-compatible integer"
-            )
+        object.__setattr__(
+            self,
+            "backup_budget",
+            _require_int32(
+                "backup_budget",
+                self.backup_budget,
+                minimum=1,
+                maximum=_MAX_BACKUP_BUDGET,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "min_model_completions",
+            _require_int32(
+                "min_model_completions",
+                self.min_model_completions,
+                minimum=1,
+                maximum=_INT32_MAX,
+            ),
+        )
 
     def to_config(self) -> dict[str, object]:
         """Return the exact JSON-compatible L0 configuration."""
@@ -80,9 +112,7 @@ class OptionSearchControlConfig:
             "schema": OPTION_SEARCH_CONTROL_CONFIG_SCHEMA,
             "type": _CONFIG_TYPE,
             "mechanism_status": OPTION_SEARCH_CONTROL_MECHANISM_STATUS,
-            "scientific_promotion_allowed": (
-                OPTION_SEARCH_CONTROL_SCIENTIFIC_PROMOTION_ALLOWED
-            ),
+            "scientific_promotion_allowed": (OPTION_SEARCH_CONTROL_SCIENTIFIC_PROMOTION_ALLOWED),
             "backup_budget": self.backup_budget,
             "min_model_completions": self.min_model_completions,
         }
@@ -109,19 +139,14 @@ class OptionSearchControlConfig:
             raise ValueError("unexpected option search control config schema")
         if payload.pop("type") != _CONFIG_TYPE:
             raise ValueError("unexpected option search control config type")
-        if (
-            payload.pop("mechanism_status")
-            != OPTION_SEARCH_CONTROL_MECHANISM_STATUS
-        ):
+        if payload.pop("mechanism_status") != OPTION_SEARCH_CONTROL_MECHANISM_STATUS:
             raise ValueError("option search control must remain mechanism-only")
         if payload.pop("scientific_promotion_allowed") is not False:
             raise ValueError("option search control config cannot claim promotion")
         if type(payload["backup_budget"]) is not int:
             raise ValueError("serialized backup_budget must be a JSON integer")
         if type(payload["min_model_completions"]) is not int:
-            raise ValueError(
-                "serialized min_model_completions must be a JSON integer"
-            )
+            raise ValueError("serialized min_model_completions must be a JSON integer")
         return cls(**cast(dict[str, Any], payload))
 
 
@@ -267,9 +292,7 @@ class OptionSearchControl:
     ) -> None:
         self._agent = stomp_agent
         self._config = config or OptionSearchControlConfig()
-        candidate_slots = (
-            self._agent.config.n_options * self._config.backup_budget
-        )
+        candidate_slots = self._agent.config.n_options * self._config.backup_budget
         if candidate_slots > _MAX_CANDIDATE_DIAGNOSTIC_SLOTS:
             raise ValueError(
                 "backup_budget * n_options exceeds the option-search "
@@ -324,10 +347,7 @@ class OptionSearchControl:
     def _lms_state_static_contract_valid(state: Any) -> bool:
         """Return whether one STOMP optimizer leaf is scalar float32 LMS."""
 
-        return (
-            isinstance(state, LMSState)
-            and _array_has_contract(state.step_size, (), jnp.float32)
-        )
+        return isinstance(state, LMSState) and _array_has_contract(state.step_size, (), jnp.float32)
 
     def _base_state_static_contract_valid(self, state: STOMPState) -> bool:
         """Validate every base-learner collection before prediction/update."""
@@ -490,18 +510,15 @@ class OptionSearchControl:
                 dtype=jnp.float32,
             )
         )
-        values_finite = (
-            jnp.asarray(static_valid, dtype=jnp.bool_)
-            & jnp.all(jnp.isfinite(observation))
+        values_finite = jnp.asarray(static_valid, dtype=jnp.bool_) & jnp.all(
+            jnp.isfinite(observation)
         )
         budget = self._config.backup_budget
         n_options = self._agent.config.n_options
         matrix_shape = (budget, n_options)
         return OptionSearchControlDiagnostics(
             decision_observation=jnp.where(values_finite, observation, 0.0),
-            decision_observation_static_contract_valid=jnp.asarray(
-                static_valid, dtype=jnp.bool_
-            ),
+            decision_observation_static_contract_valid=jnp.asarray(static_valid, dtype=jnp.bool_),
             decision_observation_values_finite=values_finite,
             option_model_static_contract_valid=jnp.asarray(
                 option_model_static_contract_valid, dtype=jnp.bool_
@@ -511,31 +528,21 @@ class OptionSearchControl:
             ),
             base_state_values_finite=jnp.asarray(False, dtype=jnp.bool_),
             option_model_values_finite=jnp.asarray(False, dtype=jnp.bool_),
-            state_counters_valid=jnp.asarray(
-                state_counters_valid, dtype=jnp.bool_
-            ),
+            state_counters_valid=jnp.asarray(state_counters_valid, dtype=jnp.bool_),
             base_update_capacity_available=jnp.asarray(
                 base_update_capacity_available, dtype=jnp.bool_
             ),
             stomp_state_static_contract_valid=jnp.asarray(
                 stomp_state_static_contract_valid, dtype=jnp.bool_
             ),
-            stomp_state_values_finite=jnp.asarray(
-                stomp_state_values_finite, dtype=jnp.bool_
-            ),
-            stomp_rng_key_valid=jnp.asarray(
-                stomp_rng_key_valid, dtype=jnp.bool_
-            ),
-            stomp_action_ownership_valid=jnp.asarray(
-                stomp_action_ownership_valid, dtype=jnp.bool_
-            ),
+            stomp_state_values_finite=jnp.asarray(stomp_state_values_finite, dtype=jnp.bool_),
+            stomp_rng_key_valid=jnp.asarray(stomp_rng_key_valid, dtype=jnp.bool_),
+            stomp_action_ownership_valid=jnp.asarray(stomp_action_ownership_valid, dtype=jnp.bool_),
             stomp_state_valid=jnp.asarray(stomp_state_valid, dtype=jnp.bool_),
             decision_observation_matches_state=jnp.asarray(
                 decision_observation_matches_state, dtype=jnp.bool_
             ),
-            cached_decision_action_refreshed=jnp.asarray(
-                False, dtype=jnp.bool_
-            ),
+            cached_decision_action_refreshed=jnp.asarray(False, dtype=jnp.bool_),
             value_effect_deferred_to_next_extended_action_selection=(
                 jnp.asarray(False, dtype=jnp.bool_)
             ),
@@ -546,23 +553,15 @@ class OptionSearchControl:
             candidate_semantics_valid=jnp.zeros(matrix_shape, dtype=jnp.bool_),
             candidate_predictions_finite=jnp.zeros(matrix_shape, dtype=jnp.bool_),
             candidate_targets=jnp.zeros(matrix_shape, dtype=jnp.float32),
-            candidate_bellman_residuals=jnp.zeros(
-                matrix_shape, dtype=jnp.float32
-            ),
+            candidate_bellman_residuals=jnp.zeros(matrix_shape, dtype=jnp.float32),
             candidate_priorities=jnp.zeros(matrix_shape, dtype=jnp.float32),
             candidate_valid=jnp.zeros(matrix_shape, dtype=jnp.bool_),
-            selected_option_indices=jnp.full(
-                (budget,), -1, dtype=jnp.int32
-            ),
-            selected_extended_action_indices=jnp.full(
-                (budget,), -1, dtype=jnp.int32
-            ),
+            selected_option_indices=jnp.full((budget,), -1, dtype=jnp.int32),
+            selected_extended_action_indices=jnp.full((budget,), -1, dtype=jnp.int32),
             selected_priorities=jnp.zeros((budget,), dtype=jnp.float32),
             td_errors=jnp.zeros((budget,), dtype=jnp.float32),
             candidate_update_finite=jnp.zeros((budget,), dtype=jnp.bool_),
-            trace_isolation_preserved=jnp.zeros(
-                (budget,), dtype=jnp.bool_
-            ),
+            trace_isolation_preserved=jnp.zeros((budget,), dtype=jnp.bool_),
             applied=jnp.zeros((budget,), dtype=jnp.bool_),
             applied_count=jnp.asarray(0, dtype=jnp.int32),
         )
@@ -582,15 +581,10 @@ class OptionSearchControl:
             learner_state,
             observation,
         )
-        option_values = base_values[
-            self._agent.config.n_primitive_actions :
-        ]
-        completion_supported = (
-            models.n_completions
-            >= jnp.asarray(
-                self._config.min_model_completions,
-                dtype=jnp.int32,
-            )
+        option_values = base_values[self._agent.config.n_primitive_actions :]
+        completion_supported = models.n_completions >= jnp.asarray(
+            self._config.min_model_completions,
+            dtype=jnp.int32,
         )
         candidate_semantics_valid = (
             (models.n_completions >= 0)
@@ -638,11 +632,7 @@ class OptionSearchControl:
                 & jnp.isfinite(target)
                 & jnp.isfinite(residual)
             )
-            valid = (
-                planner_inputs_valid
-                & safe_model
-                & prediction_finite
-            )
+            valid = planner_inputs_valid & safe_model & prediction_finite
             return (
                 jnp.where(valid, target, jnp.float32(0.0)),
                 jnp.where(valid, residual, jnp.float32(0.0)),
@@ -650,9 +640,7 @@ class OptionSearchControl:
                 valid,
             )
 
-        targets, residuals, predictions_finite, candidate_valid = jax.vmap(
-            evaluate_one
-        )(indices)
+        targets, residuals, predictions_finite, candidate_valid = jax.vmap(evaluate_one)(indices)
         priorities = jnp.where(candidate_valid, jnp.abs(residuals), 0.0)
         return (
             completion_supported,
@@ -687,11 +675,7 @@ class OptionSearchControl:
         )
         model_static_valid = self._option_model_static_contract_valid(state)
         base_static_valid = self._base_state_static_contract_valid(state)
-        if (
-            not observation_static_valid
-            or not model_static_valid
-            or not base_static_valid
-        ):
+        if not observation_static_valid or not model_static_valid or not base_static_valid:
             return OptionSearchControlResult(
                 state=state,
                 diagnostics=self.unavailable_diagnostics(
@@ -722,15 +706,10 @@ class OptionSearchControl:
                 ),
             )
         observation_values_finite = jnp.all(jnp.isfinite(observation))
-        base_state_values_finite = _floating_tree_is_finite(
+        base_state_values_finite = _floating_tree_is_finite(state.base_learner_state)
+        option_model_values_finite = _floating_tree_is_finite(state.option_models)
+        state_counters_valid = stomp_audit.state_counters_valid & _all_integer_leaves_nonnegative(
             state.base_learner_state
-        )
-        option_model_values_finite = _floating_tree_is_finite(
-            state.option_models
-        )
-        state_counters_valid = (
-            stomp_audit.state_counters_valid
-            & _all_integer_leaves_nonnegative(state.base_learner_state)
         )
         max_step_count_before_call = jnp.asarray(
             _INT32_MAX - self._config.backup_budget,
@@ -767,9 +746,7 @@ class OptionSearchControl:
         priorities_log = jnp.zeros(matrix_shape, dtype=jnp.float32)
         candidate_valid_log = jnp.zeros(matrix_shape, dtype=jnp.bool_)
         selected_options = jnp.full((budget,), -1, dtype=jnp.int32)
-        selected_extended_actions = jnp.full(
-            (budget,), -1, dtype=jnp.int32
-        )
+        selected_extended_actions = jnp.full((budget,), -1, dtype=jnp.int32)
         selected_priorities = jnp.zeros((budget,), dtype=jnp.float32)
         td_errors = jnp.zeros((budget,), dtype=jnp.float32)
         update_finite_log = jnp.zeros((budget,), dtype=jnp.bool_)
@@ -839,12 +816,9 @@ class OptionSearchControl:
                 jnp.int32(-1),
             )
             safe_option = jnp.maximum(selected_option, jnp.int32(0))
-            selected_extended = (
-                safe_option
-                + jnp.asarray(
-                    self._agent.config.n_primitive_actions,
-                    dtype=jnp.int32,
-                )
+            selected_extended = safe_option + jnp.asarray(
+                self._agent.config.n_primitive_actions,
+                dtype=jnp.int32,
             )
             selected_target = candidate_targets[safe_option]
             selected_priority = candidate_priorities[safe_option]
@@ -857,8 +831,7 @@ class OptionSearchControl:
                 MultiHeadMLPState,
                 learner_state.replace(
                     trunk_traces=tuple(
-                        jnp.zeros_like(trace)
-                        for trace in learner_state.trunk_traces
+                        jnp.zeros_like(trace) for trace in learner_state.trunk_traces
                     ),
                     head_traces=tuple(
                         (
@@ -869,11 +842,15 @@ class OptionSearchControl:
                     ),
                 ),
             )
-            targets = jnp.full(
-                (self._agent.config.n_total_actions,),
-                jnp.nan,
-                dtype=jnp.float32,
-            ).at[selected_extended].set(selected_target)
+            targets = (
+                jnp.full(
+                    (self._agent.config.n_total_actions,),
+                    jnp.nan,
+                    dtype=jnp.float32,
+                )
+                .at[selected_extended]
+                .set(selected_target)
+            )
 
             def propose_update(_: None) -> tuple[MultiHeadMLPState, Array]:
                 update = self._agent.base_learner.update(
@@ -980,32 +957,20 @@ class OptionSearchControl:
                 observation_static_valid, dtype=jnp.bool_
             ),
             decision_observation_values_finite=observation_values_finite,
-            option_model_static_contract_valid=jnp.asarray(
-                model_static_valid, dtype=jnp.bool_
-            ),
-            base_state_static_contract_valid=jnp.asarray(
-                base_static_valid, dtype=jnp.bool_
-            ),
+            option_model_static_contract_valid=jnp.asarray(model_static_valid, dtype=jnp.bool_),
+            base_state_static_contract_valid=jnp.asarray(base_static_valid, dtype=jnp.bool_),
             base_state_values_finite=base_state_values_finite,
             option_model_values_finite=option_model_values_finite,
             state_counters_valid=state_counters_valid,
             base_update_capacity_available=base_update_capacity_available,
-            stomp_state_static_contract_valid=(
-                stomp_audit.state_static_contract_valid
-            ),
+            stomp_state_static_contract_valid=(stomp_audit.state_static_contract_valid),
             stomp_state_values_finite=stomp_audit.state_values_finite,
             stomp_rng_key_valid=stomp_audit.rng_key_valid,
             stomp_action_ownership_valid=stomp_audit.ownership_valid,
             stomp_state_valid=stomp_audit.state_valid,
-            decision_observation_matches_state=(
-                stomp_audit.observation_matches
-            ),
-            cached_decision_action_refreshed=jnp.asarray(
-                False, dtype=jnp.bool_
-            ),
-            value_effect_deferred_to_next_extended_action_selection=(
-                jnp.any(applied_log)
-            ),
+            decision_observation_matches_state=(stomp_audit.observation_matches),
+            cached_decision_action_refreshed=jnp.asarray(False, dtype=jnp.bool_),
+            value_effect_deferred_to_next_extended_action_selection=(jnp.any(applied_log)),
             average_reward_valid=average_reward_valid,
             planner_inputs_valid=planner_inputs_valid,
             completion_counts=jnp.where(

--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -124,6 +124,8 @@ class OptionSearchControlConfig:
     ) -> OptionSearchControlConfig:
         """Strictly reconstruct only the exact v1 configuration schema."""
 
+        if type(config) is not dict:
+            raise ValueError("option search control config must be an actual dict")
         payload = dict(config)
         expected = {
             "schema",

--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -28,8 +28,12 @@ import dataclasses
 import hashlib
 import json
 import math
+import operator
 import re
 from collections.abc import Mapping, Sequence
+from typing import SupportsIndex, cast
+
+import numpy as np
 
 RECURRING_IPMNIST_PROTOCOL_SCHEMA = "alberta.recurring-ipmnist-retention.protocol.v1"
 RECURRING_IPMNIST_TRACE_SCHEMA = "alberta.recurring-ipmnist-retention.trace.v1"
@@ -61,9 +65,7 @@ METRIC_DEFINITIONS: Mapping[str, str] = {
     "peak_to_revisit_forgetting": (
         "non-negative peak sentinel accuracy before revisit minus the pre-revisit score"
     ),
-    "revisit_recovery": (
-        "revisit-end sentinel accuracy minus pre-revisit sentinel accuracy"
-    ),
+    "revisit_recovery": ("revisit-end sentinel accuracy minus pre-revisit sentinel accuracy"),
     "relearning_savings_mistakes": (
         "first-exposure leading-window mistakes minus revisit leading-window mistakes"
     ),
@@ -104,17 +106,40 @@ def _sha256(value: object, *, name: str) -> str:
     return value
 
 
-def _nonnegative_int(value: object, *, name: str) -> int:
-    if type(value) is not int or value < 0:
-        raise ValueError(f"{name} must be a non-negative integer")
-    return value
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
 
 
-def _positive_int(value: object, *, name: str) -> int:
-    result = _nonnegative_int(value, name=name)
-    if result == 0:
-        raise ValueError(f"{name} must be positive")
-    return result
+def _nonnegative_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a non-negative integer in [0, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 0 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a non-negative integer in [0, {maximum}]")
+    return canonical
+
+
+def _positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a positive integer in [1, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= maximum:
+        raise ValueError(f"{name} must be a positive integer in [1, {maximum}]")
+    return canonical
 
 
 def _unit_float(value: object, *, name: str, binary: bool = False) -> float:
@@ -161,7 +186,11 @@ class SentinelProbeBinding:
         _sha256(self.permutation_sha256, name="permutation_sha256")
         _identifier(self.sentinel_set_id, name="sentinel_set_id", versioned=True)
         _sha256(self.sentinel_set_sha256, name="sentinel_set_sha256")
-        _positive_int(self.sentinel_case_count, name="sentinel_case_count")
+        object.__setattr__(
+            self,
+            "sentinel_case_count",
+            _positive_int(self.sentinel_case_count, name="sentinel_case_count"),
+        )
 
     def to_config(self) -> dict[str, object]:
         return {
@@ -184,11 +213,27 @@ class RecurringIPMNISTPhase:
     exposure_index: int
 
     def __post_init__(self) -> None:
-        _nonnegative_int(self.phase_index, name="phase_index")
-        _nonnegative_int(self.start_step, name="start_step")
-        _positive_int(self.length, name="length")
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        object.__setattr__(
+            self,
+            "start_step",
+            _nonnegative_int(self.start_step, name="start_step"),
+        )
+        object.__setattr__(
+            self,
+            "length",
+            _positive_int(self.length, name="length"),
+        )
         _identifier(self.permutation_id, name="permutation_id", versioned=True)
-        _nonnegative_int(self.exposure_index, name="exposure_index")
+        object.__setattr__(
+            self,
+            "exposure_index",
+            _nonnegative_int(self.exposure_index, name="exposure_index"),
+        )
 
     @property
     def stop_step(self) -> int:
@@ -306,7 +351,11 @@ class RecurringIPMNISTProtocol:
         if len(set(sentinel_ids)) != len(sentinel_ids):
             raise ValueError("A and B must bind distinct sentinel set identities")
 
-        _positive_int(self.relearning_window, name="relearning_window")
+        object.__setattr__(
+            self,
+            "relearning_window",
+            _positive_int(self.relearning_window, name="relearning_window"),
+        )
         if self.relearning_window > self.phases[0].length:
             raise ValueError("relearning_window cannot exceed either equal-length A phase")
 
@@ -359,9 +408,7 @@ class RecurringIPMNISTProtocol:
             "evaluator_only_fields": list(EVALUATOR_ONLY_FIELDS),
             "protocol_id": self.protocol_id,
             "phases": [phase.to_config() for phase in self.phases],
-            "sentinel_bindings": [
-                binding.to_config() for binding in self.sentinel_bindings
-            ],
+            "sentinel_bindings": [binding.to_config() for binding in self.sentinel_bindings],
             "required_probe_snapshots": [
                 requirement.to_config() for requirement in self.required_probe_snapshots
             ],
@@ -389,9 +436,7 @@ class RecurringIPMNISTTrace:
             raise TypeError("post_update_one_step_plasticity must be an exact tuple")
         if not self.pre_update_online_accuracy:
             raise ValueError("the online trace must be non-empty")
-        if len(self.pre_update_online_accuracy) != len(
-            self.post_update_one_step_plasticity
-        ):
+        if len(self.pre_update_online_accuracy) != len(self.post_update_one_step_plasticity):
             raise ValueError("accuracy and plasticity traces must have equal length")
         for index, value in enumerate(self.pre_update_online_accuracy):
             _unit_float(value, name=f"pre_update_online_accuracy[{index}]", binary=True)
@@ -404,9 +449,7 @@ class RecurringIPMNISTTrace:
             "ordering": "predict-before-update",
             "learner_visible_fields": list(LEARNER_VISIBLE_TRACE_FIELDS),
             "pre_update_online_accuracy": list(self.pre_update_online_accuracy),
-            "post_update_one_step_plasticity": list(
-                self.post_update_one_step_plasticity
-            ),
+            "post_update_one_step_plasticity": list(self.post_update_one_step_plasticity),
         }
 
 
@@ -617,26 +660,20 @@ def _validate_sentinel_snapshots(
     resolved = tuple(snapshots)
     expected = protocol.required_probe_snapshots
     if len(resolved) != len(expected):
-        raise ValueError(
-            "sentinel snapshots must appear once each in the exact required order"
-        )
+        raise ValueError("sentinel snapshots must appear once each in the exact required order")
     checkpoint_states: dict[int, str] = {}
     for index, (snapshot, requirement) in enumerate(zip(resolved, expected, strict=True)):
         if type(snapshot) is not SentinelProbeSnapshot:
             raise TypeError(f"sentinel_snapshots[{index}] must be SentinelProbeSnapshot")
         if snapshot.ordering_key != requirement.ordering_key:
-            raise ValueError(
-                "sentinel snapshots must appear once each in the exact required order"
-            )
+            raise ValueError("sentinel snapshots must appear once each in the exact required order")
         if snapshot.frozen_binding != requirement.frozen_binding:
             if len(snapshot.correctness) != requirement.sentinel_case_count:
                 raise ValueError(
                     f"sentinel snapshot {index} correctness case count does not match "
                     "its frozen requirement"
                 )
-            raise ValueError(
-                f"sentinel snapshot {index} does not match its frozen requirement"
-            )
+            raise ValueError(f"sentinel snapshot {index} does not match its frozen requirement")
         prior_state = checkpoint_states.setdefault(
             snapshot.checkpoint_step,
             snapshot.learner_state_sha256_before,
@@ -662,9 +699,7 @@ def _phase_summaries(
     summaries: list[PhaseOnlineSummary] = []
     for phase in protocol.phases:
         accuracies = trace.pre_update_online_accuracy[phase.start_step : phase.stop_step]
-        plasticities = trace.post_update_one_step_plasticity[
-            phase.start_step : phase.stop_step
-        ]
+        plasticities = trace.post_update_one_step_plasticity[phase.start_step : phase.stop_step]
         summaries.append(
             PhaseOnlineSummary(
                 phase_index=phase.phase_index,
@@ -778,9 +813,7 @@ def build_recurring_ipmnist_retention_report(
         protocol=protocol,
         protocol_sha256=_digest(protocol.to_config()),
         trace_sha256=_digest(trace.to_config()),
-        sentinel_snapshots_sha256=_digest(
-            [snapshot.to_config() for snapshot in snapshots]
-        ),
+        sentinel_snapshots_sha256=_digest([snapshot.to_config() for snapshot in snapshots]),
         phase_summaries=_phase_summaries(protocol, trace),
         sentinel_scores=_sentinel_scores(snapshots),
         recurrence=_recurrence_metrics(protocol, trace, snapshots),

--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -228,6 +228,8 @@ class RecurringIPMNISTPhase:
             "length",
             _positive_int(self.length, name="length"),
         )
+        if self.start_step > _INT32_MAX - self.length:
+            raise ValueError("stop_step must fit signed int32")
         _identifier(self.permutation_id, name="permutation_id", versioned=True)
         object.__setattr__(
             self,
@@ -469,11 +471,23 @@ class SentinelProbeSnapshot:
     correctness: tuple[bool, ...]
 
     def __post_init__(self) -> None:
-        _nonnegative_int(self.phase_index, name="phase_index")
-        _positive_int(self.checkpoint_step, name="checkpoint_step")
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        object.__setattr__(
+            self,
+            "checkpoint_step",
+            _positive_int(self.checkpoint_step, name="checkpoint_step"),
+        )
         _identifier(self.permutation_id, name="permutation_id", versioned=True)
         _sha256(self.permutation_sha256, name="permutation_sha256")
-        _nonnegative_int(self.exposure_index, name="exposure_index")
+        object.__setattr__(
+            self,
+            "exposure_index",
+            _nonnegative_int(self.exposure_index, name="exposure_index"),
+        )
         _identifier(self.sentinel_set_id, name="sentinel_set_id", versioned=True)
         _sha256(self.sentinel_set_sha256, name="sentinel_set_sha256")
         before = _sha256(

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -4,6 +4,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -34,9 +35,7 @@ def test_differential_td_config_and_top_level_exports() -> None:
         average_reward_step_size=0.02,
         trace_decay=0.5,
     )
-    learner = DifferentialTDLearner.from_config(
-        DifferentialTDLearner(config).to_config()
-    )
+    learner = DifferentialTDLearner.from_config(DifferentialTDLearner(config).to_config())
 
     assert learner.config == config
     assert CoreDifferentialTDLearner is DifferentialTDLearner
@@ -109,9 +108,7 @@ def test_differential_td_infinite_reward_does_not_poison_weights() -> None:
     assert float(poisoned.td_error) == 0.0
     chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt)
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.average_reward)
     assert int(recovered.state.step_count) == int(state.step_count) + 1
@@ -136,9 +133,7 @@ def test_differential_gtd_infinite_reward_does_not_poison_weights() -> None:
     assert float(poisoned.td_error) == 0.0
     chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, rho
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array(1.0, dtype=jnp.float32), nxt, rho)
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.secondary_weights)
     assert bool(recovered.update_applied)
@@ -162,12 +157,8 @@ def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
     obs = jnp.ones(3, dtype=jnp.float32)
     nxt = jnp.ones(3, dtype=jnp.float32)
 
-    poisoned = learner.update(
-        state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), nxt
-    )
-    chex.assert_trees_all_close(
-        poisoned.average_rewards[0], state.average_rewards[0]
-    )
+    poisoned = learner.update(state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), nxt)
+    chex.assert_trees_all_close(poisoned.average_rewards[0], state.average_rewards[0])
     assert bool(jnp.isfinite(poisoned.average_rewards[1]))
     assert int(poisoned.state.step_count) == 1
     assert bool(poisoned.update_applied)
@@ -177,9 +168,7 @@ def test_average_reward_horde_infinite_cumulant_does_not_poison_rbar() -> None:
     )
     assert float(poisoned.td_errors[0]) == 0.0
 
-    recovered = learner.update(
-        poisoned.state, obs, jnp.array([0.5, 1.0], dtype=jnp.float32), nxt
-    )
+    recovered = learner.update(poisoned.state, obs, jnp.array([0.5, 1.0], dtype=jnp.float32), nxt)
     chex.assert_tree_all_finite(recovered.average_rewards)
     assert int(recovered.state.step_count) == 2
     assert bool(recovered.update_applied)
@@ -244,9 +233,7 @@ def test_differential_gtd_config_roundtrip_and_ratio_clipping() -> None:
         trace_decay=0.3,
         ratio_clip=1.5,
     )
-    learner = DifferentialGTDLearner.from_config(
-        DifferentialGTDLearner(config).to_config()
-    )
+    learner = DifferentialGTDLearner.from_config(DifferentialGTDLearner(config).to_config())
     state = learner.init(1)
 
     result = learner.update(
@@ -435,9 +422,7 @@ def test_average_reward_horde_actor_critic_rejects_nonfinite_reward() -> None:
     )
 
     assert not bool(result.update_applied)
-    chex.assert_trees_all_equal(
-        jr.key_data(result.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(result.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         result.state.replace(rng_key=jr.key_data(result.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -499,9 +484,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         temperature=0.7,
     )
     agent = AverageRewardHordeActorCriticAgent(config)
-    initial = agent.init(2, jr.key(4)).replace(
-        actor_bias=jnp.array([1.0, -1.0], dtype=jnp.float32)
-    )
+    initial = agent.init(2, jr.key(4)).replace(actor_bias=jnp.array([1.0, -1.0], dtype=jnp.float32))
     observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
     state, _ = agent.start(initial, observation)
     stored = state.last_policy_sample
@@ -511,11 +494,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         jnp.array(1.0, dtype=jnp.float32),
         jnp.array([-0.25, 0.75], dtype=jnp.float32),
     )
-    expected_scale = (
-        (1.0 - epsilon)
-        * stored.target_probability
-        / stored.behavior_probability
-    )
+    expected_scale = (1.0 - epsilon) * stored.target_probability / stored.behavior_probability
     chex.assert_trees_all_close(result.actor_score_scale, expected_scale)
 
     # Finite-difference d log(mu_a) / d target-logit_a agrees with the
@@ -530,9 +509,7 @@ def test_average_reward_actor_critic_score_matches_mixture_derivative(
         return jnp.log(behavior[action])
 
     finite_difference = jax.grad(selected_log_behavior)(bias[action])
-    expected_component = expected_scale * (
-        1.0 - stored.target_policy[action]
-    ) / config.temperature
+    expected_component = expected_scale * (1.0 - stored.target_policy[action]) / config.temperature
     chex.assert_trees_all_close(
         finite_difference,
         expected_component,
@@ -760,9 +737,7 @@ def test_differential_sarsa_update_and_scan_are_finite() -> None:
     chex.assert_shape(result.average_rewards, (4,))
     chex.assert_shape(result.actions, (4,))
     assert int(result.state.step_count) == 4
-    chex.assert_tree_all_finite(
-        (result.q_values, result.td_errors, result.average_rewards)
-    )
+    chex.assert_tree_all_finite((result.q_values, result.td_errors, result.average_rewards))
     assert bool(jnp.all(result.actions >= 0))
     assert bool(jnp.all(result.actions < 3))
 
@@ -791,3 +766,40 @@ def test_differential_sarsa_learns_better_action_on_continuing_bandit() -> None:
     q_values = agent.q_values(state, obs)
     assert float(q_values[1]) > float(q_values[0]) + 0.25
     assert float(state.average_reward) > 0.75
+
+
+def test_average_reward_horde_actor_critic_config_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        AverageRewardHordeActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        AverageRewardHordeActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        AverageRewardHordeActorCriticConfig(n_actions=2, hidden_sizes=(True,))  # type: ignore[arg-type]
+
+    cfg = AverageRewardHordeActorCriticConfig(
+        n_actions=np.int32(4),
+        hidden_sizes=(np.int32(32), np.int64(16)),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.hidden_sizes[0]) is int
+    assert type(cfg.hidden_sizes[1]) is int
+    assert cfg.n_actions == 4
+    assert cfg.hidden_sizes == (32, 16)
+
+
+def test_differential_sarsa_config_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        DifferentialSARSAConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        DifferentialSARSAConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="epsilon_decay_steps"):
+        DifferentialSARSAConfig(n_actions=2, epsilon_decay_steps=True)  # type: ignore[arg-type]
+
+    cfg = DifferentialSARSAConfig(
+        n_actions=np.int32(3),
+        epsilon_decay_steps=np.int64(100),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.epsilon_decay_steps) is int
+    assert cfg.n_actions == 3
+    assert cfg.epsilon_decay_steps == 100

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -803,3 +803,104 @@ def test_differential_sarsa_config_scalar_validation() -> None:
     assert type(cfg.epsilon_decay_steps) is int
     assert cfg.n_actions == 3
     assert cfg.epsilon_decay_steps == 100
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_average_reward_configs_canonicalize_all_numpy_integer_families(
+    integer_type: type[np.integer],
+) -> None:
+    actor = AverageRewardHordeActorCriticConfig(
+        n_actions=integer_type(2),
+        hidden_sizes=(integer_type(3),),
+    )
+    sarsa = DifferentialSARSAConfig(
+        n_actions=integer_type(2),
+        epsilon_decay_steps=integer_type(3),
+    )
+
+    assert type(actor.n_actions) is int
+    assert type(actor.hidden_sizes[0]) is int
+    assert type(sarsa.n_actions) is int
+    assert type(sarsa.epsilon_decay_steps) is int
+
+
+def test_average_reward_configs_reject_hostile_integer_and_container_types() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    class TupleSubclass(tuple):
+        pass
+
+    with pytest.raises(ValueError, match="n_actions"):
+        AverageRewardHordeActorCriticConfig(n_actions=HostileInt(2))
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        AverageRewardHordeActorCriticConfig(n_actions=2, hidden_sizes=TupleSubclass((3,)))
+    payload = AverageRewardHordeActorCriticConfig(n_actions=2).to_config()
+    payload["hidden_sizes"] = "16"
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        AverageRewardHordeActorCriticConfig.from_config(payload)
+
+
+@pytest.mark.parametrize(
+    ("config_type", "field", "value"),
+    (
+        (AverageRewardHordeActorCriticConfig, "temperature", 0.0),
+        (AverageRewardHordeActorCriticConfig, "epsilon", 1.0 + 1.0e-10),
+        (AverageRewardHordeActorCriticConfig, "critic_step_size", 1.0e100),
+        (DifferentialSARSAConfig, "q_step_size", -1.0),
+        (DifferentialSARSAConfig, "trace_decay", 1.0 + 1.0e-10),
+        (DifferentialSARSAConfig, "epsilon_start", 1.0e100),
+        (DifferentialSARSAConfig, "use_bias", np.bool_(True)),
+    ),
+)
+def test_average_reward_configs_reject_invalid_float32_sink_values(
+    config_type: type,
+    field: str,
+    value: object,
+) -> None:
+    kwargs = {"n_actions": 2, field: value}
+    with pytest.raises(ValueError, match=field):
+        config_type(**kwargs)
+
+
+def test_average_reward_configs_canonicalize_float32_sink_values() -> None:
+    actor = AverageRewardHordeActorCriticConfig(
+        n_actions=2,
+        critic_step_size=np.float64(0.2),
+    )
+    sarsa = DifferentialSARSAConfig(
+        n_actions=2,
+        epsilon_start=np.float64(0.2),
+    )
+
+    assert type(actor.critic_step_size) is float
+    assert actor.critic_step_size == float(np.float32(0.2))
+    assert type(sarsa.epsilon_start) is float
+    assert sarsa.epsilon_start == float(np.float32(0.2))
+
+
+def test_average_reward_actor_preflights_state_before_allocation() -> None:
+    last_legal_n_actions = (2**29 - 1 - 14) // 10
+    AverageRewardHordeActorCriticConfig(
+        n_actions=last_legal_n_actions,
+        hidden_sizes=(1,),
+    )
+    with pytest.raises(ValueError, match="state bytes"):
+        AverageRewardHordeActorCriticConfig(
+            n_actions=last_legal_n_actions + 1,
+            hidden_sizes=(1,),
+        )
+
+
+def test_differential_sarsa_preflights_state_before_allocation() -> None:
+    agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=1))
+    last_legal_feature_dim = (2**29 - 1 - 10) // 3
+
+    with pytest.raises(ValueError, match="state bytes"):
+        agent.init(last_legal_feature_dim + 1, jr.key(0))
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(True, jr.key(0))  # type: ignore[arg-type]

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -845,6 +845,49 @@ def test_average_reward_configs_reject_hostile_integer_and_container_types() -> 
         AverageRewardHordeActorCriticConfig.from_config(payload)
 
 
+def test_average_reward_decoders_reject_schema_and_container_ambiguity() -> None:
+    class DictSubclass(dict[str, object]):
+        pass
+
+    actor_config = AverageRewardHordeActorCriticConfig(n_actions=2).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        AverageRewardHordeActorCriticConfig.from_config(DictSubclass(actor_config))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fields"):
+        AverageRewardHordeActorCriticConfig.from_config({**actor_config, "extra": 1})
+    with pytest.raises(ValueError, match="type"):
+        AverageRewardHordeActorCriticConfig.from_config({**actor_config, "type": "wrong"})
+    with pytest.raises(ValueError, match="serialized hidden_sizes"):
+        AverageRewardHordeActorCriticConfig.from_config(
+            {**actor_config, "hidden_sizes": tuple(actor_config["hidden_sizes"])}
+        )
+
+    actor_agent = AverageRewardHordeActorCriticAgent(
+        AverageRewardHordeActorCriticConfig(n_actions=2)
+    ).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        AverageRewardHordeActorCriticAgent.from_config(DictSubclass(actor_agent))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nested configs"):
+        AverageRewardHordeActorCriticAgent.from_config(
+            {**actor_agent, "config": DictSubclass(actor_agent["config"])}  # type: ignore[arg-type]
+        )
+
+    sarsa_config = DifferentialSARSAConfig(n_actions=2).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        DifferentialSARSAConfig.from_config(DictSubclass(sarsa_config))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fields"):
+        DifferentialSARSAConfig.from_config({**sarsa_config, "extra": 1})
+    with pytest.raises(ValueError, match="type"):
+        DifferentialSARSAConfig.from_config({**sarsa_config, "type": "wrong"})
+
+    sarsa_agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=2)).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        DifferentialSARSAAgent.from_config(DictSubclass(sarsa_agent))
+    with pytest.raises(ValueError, match="nested config"):
+        DifferentialSARSAAgent.from_config(
+            {**sarsa_agent, "config": DictSubclass(sarsa_agent["config"])}  # type: ignore[arg-type]
+        )
+
+
 @pytest.mark.parametrize(
     ("config_type", "field", "value"),
     (

--- a/tests/test_option_search_control.py
+++ b/tests/test_option_search_control.py
@@ -78,12 +78,10 @@ def _supported_state(
     learner = state.base_learner_state.replace(
         head_params=state.base_learner_state.head_params.replace(
             weights=tuple(
-                jnp.zeros_like(weight)
-                for weight in state.base_learner_state.head_params.weights
+                jnp.zeros_like(weight) for weight in state.base_learner_state.head_params.weights
             ),
             biases=tuple(
-                jnp.zeros_like(bias)
-                for bias in state.base_learner_state.head_params.biases
+                jnp.zeros_like(bias) for bias in state.base_learner_state.head_params.biases
             ),
         )
     )
@@ -93,9 +91,7 @@ def _supported_state(
         duration_ema=jnp.ones((n_options,), dtype=jnp.float32),
         baseline_mass_ema=jnp.ones((n_options,), dtype=jnp.float32),
         discount_ema=jnp.zeros((n_options,), dtype=jnp.float32),
-        next_state_weights=jnp.zeros(
-            (n_options, 2, 2), dtype=jnp.float32
-        ),
+        next_state_weights=jnp.zeros((n_options, 2, 2), dtype=jnp.float32),
         n_completions=jnp.ones((n_options,), dtype=jnp.int32),
     )
     return cast(
@@ -190,10 +186,7 @@ def test_zero_discount_does_not_multiply_overflowed_next_values() -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent, targets=(1.0, 4.0))
     huge = jnp.finfo(jnp.float32).max
-    ones = tuple(
-        jnp.ones_like(weight)
-        for weight in state.base_learner_state.head_params.weights
-    )
+    ones = tuple(jnp.ones_like(weight) for weight in state.base_learner_state.head_params.weights)
     learner = state.base_learner_state.replace(
         head_params=state.base_learner_state.head_params.replace(weights=ones)
     )
@@ -239,10 +232,14 @@ def test_partial_completion_support_excludes_the_unsupported_candidate() -> None
             n_completions=jnp.array([2, 1], dtype=jnp.int32),
         )
     )
-    diagnostics = OptionSearchControl(
-        agent,
-        OptionSearchControlConfig(min_model_completions=2),
-    ).apply(state, ANCHOR).diagnostics
+    diagnostics = (
+        OptionSearchControl(
+            agent,
+            OptionSearchControlConfig(min_model_completions=2),
+        )
+        .apply(state, ANCHOR)
+        .diagnostics
+    )
 
     np.testing.assert_array_equal(
         np.asarray(diagnostics.completion_supported[0]),
@@ -307,9 +304,8 @@ def test_residuals_are_recomputed_after_each_backup() -> None:
         np.array([0, 1], dtype=np.int32),
     )
     assert bool(jnp.all(result.diagnostics.applied))
-    assert (
-        float(result.diagnostics.candidate_priorities[1, 0])
-        < float(result.diagnostics.candidate_priorities[0, 0])
+    assert float(result.diagnostics.candidate_priorities[1, 0]) < float(
+        result.diagnostics.candidate_priorities[0, 0]
     )
 
 
@@ -328,9 +324,7 @@ def test_unsupported_or_invalid_models_are_exact_planner_noops(
 ) -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent)
-    state = state.replace(
-        option_models=state.option_models.replace(**{field: replacement})
-    )
+    state = state.replace(option_models=state.option_models.replace(**{field: replacement}))
     result = OptionSearchControl(
         agent,
         OptionSearchControlConfig(backup_budget=2),
@@ -356,12 +350,8 @@ def test_malformed_base_state_contracts_fail_closed_without_indexing() -> None:
         )
     )
     malformed_states = (
-        state.replace(
-            base_average_reward=jnp.zeros((1,), dtype=jnp.float32)
-        ),
-        state.replace(
-            base_average_reward=jnp.asarray(0, dtype=jnp.int32)
-        ),
+        state.replace(base_average_reward=jnp.zeros((1,), dtype=jnp.float32)),
+        state.replace(base_average_reward=jnp.asarray(0, dtype=jnp.int32)),
         state.replace(base_average_reward=0.0),
         state.replace(step_count=0),
         state.replace(base_learner_state=shortened_heads),
@@ -380,11 +370,7 @@ def test_malformed_nested_model_and_outer_leaves_fail_closed() -> None:
     agent = STOMPAgent(_stomp_config())
     state = _supported_state(agent)
     malformed_states = (
-        state.replace(
-            option_models=state.option_models.replace(
-                cumreward_ema=[100.0, 101.0]
-            )
-        ),
+        state.replace(option_models=state.option_models.replace(cumreward_ema=[100.0, 101.0])),
         state.replace(base_last_obs=[1.0, 0.0]),
         state.replace(base_last_action=0),
         state.replace(
@@ -496,8 +482,7 @@ def test_planning_preserves_real_traces_normalizer_caches_rng_and_option_state()
     state = _supported_state(agent)
     learner = state.base_learner_state.replace(
         trunk_traces=tuple(
-            jnp.full_like(trace, 0.25)
-            for trace in state.base_learner_state.trunk_traces
+            jnp.full_like(trace, 0.25) for trace in state.base_learner_state.trunk_traces
         ),
         head_traces=tuple(
             (jnp.full_like(weight_trace, 0.5), jnp.full_like(bias_trace, -0.5))
@@ -626,9 +611,7 @@ def test_prototype_applies_search_at_next_decision_observation() -> None:
         option_search_control=option_search,
     )
     search_agent = PrototypeAgent(config)
-    baseline_agent = PrototypeAgent(
-        PrototypeAgentConfig(oak=config.oak)
-    )
+    baseline_agent = PrototypeAgent(PrototypeAgentConfig(oak=config.oak))
     state = search_agent.start(search_agent.init(jr.key(21)), ANCHOR)
     supported_stomp = _supported_state(search_agent.oak_agent.stomp_agent)
     state = state.replace(
@@ -663,9 +646,7 @@ def test_prototype_applies_search_at_next_decision_observation() -> None:
     )
     assert int(diagnostics.applied_count) == 1
     assert not bool(diagnostics.cached_decision_action_refreshed)
-    assert bool(
-        diagnostics.value_effect_deferred_to_next_extended_action_selection
-    )
+    assert bool(diagnostics.value_effect_deferred_to_next_extended_action_selection)
     searched_q = search_agent.oak_agent.base_q_values(
         searched.state.oak_state,
         next_decision,
@@ -722,3 +703,25 @@ def test_rejected_prototype_transition_returns_fixed_neutral_search_diagnostics(
     assert not bool(jnp.any(diagnostics.applied))
     assert int(diagnostics.applied_count) == 0
     chex.assert_trees_all_equal(rejected.state, state)
+
+
+def test_option_search_control_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="backup_budget"):
+        OptionSearchControlConfig(backup_budget=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="backup_budget"):
+        OptionSearchControlConfig(backup_budget=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_model_completions"):
+        OptionSearchControlConfig(min_model_completions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_model_completions"):
+        OptionSearchControlConfig(min_model_completions=1.5)  # type: ignore[arg-type]
+
+
+def test_option_search_control_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = OptionSearchControlConfig(
+        backup_budget=np.int32(4),
+        min_model_completions=np.int64(2),
+    )
+    assert type(cfg.backup_budget) is int
+    assert type(cfg.min_model_completions) is int
+    assert cfg.backup_budget == 4
+    assert cfg.min_model_completions == 2

--- a/tests/test_option_search_control.py
+++ b/tests/test_option_search_control.py
@@ -725,3 +725,12 @@ def test_option_search_control_config_accepts_and_canonicalizes_numpy_integers()
     assert type(cfg.min_model_completions) is int
     assert cfg.backup_budget == 4
     assert cfg.min_model_completions == 2
+
+
+def test_option_search_control_config_rejects_noncanonical_serialized_containers() -> None:
+    class DictSubclass(dict[str, object]):
+        pass
+
+    payload = OptionSearchControlConfig().to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        OptionSearchControlConfig.from_config(DictSubclass(payload))

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 
+import numpy as np
 import pytest
 
 from alberta_framework.evaluation.recurring_ipmnist_retention import (
@@ -114,8 +115,7 @@ def _snapshots(
             requirement,
             learner_state_sha256_before=state_hash,
             learner_state_sha256_after=state_hash,
-            correctness=(True,) * count
-            + (False,) * (requirement.sentinel_case_count - count),
+            correctness=(True,) * count + (False,) * (requirement.sentinel_case_count - count),
         )
         for requirement, count, state_hash in zip(
             protocol.required_probe_snapshots,
@@ -167,9 +167,7 @@ def test_protocol_binds_aba_identity_exposures_and_keeps_trace_task_id_free() ->
         "pre_update_online_accuracy",
         "post_update_one_step_plasticity",
     )
-    assert tuple(
-        (phase.permutation_id, phase.exposure_index) for phase in protocol.phases
-    ) == (
+    assert tuple((phase.permutation_id, phase.exposure_index) for phase in protocol.phases) == (
         ("permutation-a.v1", 0),
         ("permutation-b.v1", 0),
         ("permutation-a.v1", 1),
@@ -320,3 +318,47 @@ def test_trace_requires_binary_pre_update_outcomes(bad_accuracy: float) -> None:
             pre_update_online_accuracy=(bad_accuracy,),
             post_update_one_step_plasticity=(0.2,),
         )
+
+
+def test_recurring_ipmnist_dataclasses_reject_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="phase_index"):
+        RecurringIPMNISTPhase(
+            phase_index=True,  # type: ignore[arg-type]
+            start_step=0,
+            length=4,
+            permutation_id="permutation-a.v1",
+            exposure_index=0,
+        )
+    with pytest.raises(ValueError, match="sentinel_case_count"):
+        SentinelProbeBinding(
+            permutation_id="permutation-a.v1",
+            permutation_sha256=_sha("a"),
+            sentinel_set_id="sentinel-a.v1",
+            sentinel_set_sha256=_sha("2"),
+            sentinel_case_count=2.5,  # type: ignore[arg-type]
+        )
+
+
+def test_recurring_ipmnist_dataclasses_accept_and_canonicalize_numpy_integers() -> None:
+    binding = SentinelProbeBinding(
+        permutation_id="permutation-a.v1",
+        permutation_sha256=_sha("a"),
+        sentinel_set_id="sentinel-a.v1",
+        sentinel_set_sha256=_sha("2"),
+        sentinel_case_count=np.int32(4),
+    )
+    assert type(binding.sentinel_case_count) is int
+    assert binding.sentinel_case_count == 4
+
+    phase = RecurringIPMNISTPhase(
+        phase_index=np.int32(0),
+        start_step=np.int64(0),
+        length=np.uint16(4),
+        permutation_id="permutation-a.v1",
+        exposure_index=np.uint8(0),
+    )
+    assert type(phase.phase_index) is int
+    assert type(phase.start_step) is int
+    assert type(phase.length) is int
+    assert type(phase.exposure_index) is int
+    assert phase.length == 4

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -362,3 +362,40 @@ def test_recurring_ipmnist_dataclasses_accept_and_canonicalize_numpy_integers() 
     assert type(phase.length) is int
     assert type(phase.exposure_index) is int
     assert phase.length == 4
+
+    snapshot = SentinelProbeSnapshot(
+        phase_index=np.int8(0),
+        checkpoint_step=np.uint16(4),
+        permutation_id="permutation-a.v1",
+        permutation_sha256=_sha("a"),
+        exposure_index=np.int64(0),
+        sentinel_set_id="sentinel-a.v1",
+        sentinel_set_sha256=_sha("2"),
+        learner_state_sha256_before=_sha("3"),
+        learner_state_sha256_after=_sha("3"),
+        correctness=(True,),
+    )
+    assert type(snapshot.phase_index) is int
+    assert type(snapshot.checkpoint_step) is int
+    assert type(snapshot.exposure_index) is int
+    assert type(snapshot.to_config()["checkpoint_step"]) is int
+
+
+def test_recurring_ipmnist_phase_preflights_derived_stop_step() -> None:
+    legal = RecurringIPMNISTPhase(
+        phase_index=0,
+        start_step=2**31 - 2,
+        length=1,
+        permutation_id="permutation-a.v1",
+        exposure_index=0,
+    )
+    assert legal.stop_step == 2**31 - 1
+
+    with pytest.raises(ValueError, match="stop_step"):
+        RecurringIPMNISTPhase(
+            phase_index=0,
+            start_step=2**31 - 1,
+            length=1,
+            permutation_id="permutation-a.v1",
+            exposure_index=0,
+        )


### PR DESCRIPTION
Consolidated successor to #721, #724/#734, and #726. Preserves the contributor commits and the existing maintainer repair commit.\n\nDeep audit additions:\n- reject non-canonical mapping implementations at exact serialized config boundaries while preserving Differential SARSA's documented legacy use_bias omission;\n- require exact schema fields/types and exact JSON list encoding for actor hidden sizes;\n- retain verified signed-int32 scalar/byte allocation preflights for actor-critic and Differential SARSA state;\n- reject recurring-IPMNIST phase schedules whose derived exclusive stop exceeds signed int32;\n- actually canonicalize SentinelProbeSnapshot NumPy integers before serialization (the original patch only validated them);\n- retain exact tuple/scalar gates and the option-search diagnostic-slot ceiling.\n\nValidation on current main, without benchmark or output/evidence changes:\n- 97 focused tests passed\n- scoped Ruff passed\n- strict mypy passed for all three source modules\n- git diff --check passed\n\nCloses #721\nCloses #724\nCloses #726