### PR TITLE
fix(recurring-ipmnist): complete derived workload contracts

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -142,6 +142,11 @@ def _positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int
     return canonical
 
 
+def _require_int32_workload(name: str, value: int) -> None:
+    if not 1 <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit in signed int32")
+
+
 def _unit_float(value: object, *, name: str, binary: bool = False) -> float:
     if type(value) is not float or not math.isfinite(value) or not 0.0 <= value <= 1.0:
         qualifier = "finite binary" if binary else "finite in [0, 1]"
@@ -360,6 +365,16 @@ class RecurringIPMNISTProtocol:
         )
         if self.relearning_window > self.phases[0].length:
             raise ValueError("relearning_window cannot exceed either equal-length A phase")
+        _require_int32_workload("trace scalar count", 2 * self.trace_length)
+        binding_counts = {
+            binding.permutation_id: binding.sentinel_case_count
+            for binding in self.sentinel_bindings
+        }
+        sentinel_evaluations = sum(
+            binding_counts[requirement.permutation_id]
+            for requirement in self.required_probe_snapshots
+        )
+        _require_int32_workload("sentinel probe evaluations", sentinel_evaluations)
 
     @property
     def trace_length(self) -> int:
@@ -440,6 +455,9 @@ class RecurringIPMNISTTrace:
             raise ValueError("the online trace must be non-empty")
         if len(self.pre_update_online_accuracy) != len(self.post_update_one_step_plasticity):
             raise ValueError("accuracy and plasticity traces must have equal length")
+        _require_int32_workload(
+            "online trace scalar count", 2 * len(self.pre_update_online_accuracy)
+        )
         for index, value in enumerate(self.pre_update_online_accuracy):
             _unit_float(value, name=f"pre_update_online_accuracy[{index}]", binary=True)
         for index, value in enumerate(self.post_update_one_step_plasticity):
@@ -504,6 +522,7 @@ class SentinelProbeSnapshot:
             raise ValueError("correctness must be a non-empty exact tuple")
         if any(type(value) is not bool for value in self.correctness):
             raise ValueError("correctness must contain only canonical booleans")
+        _require_int32_workload("sentinel correctness cases", len(self.correctness))
 
     @classmethod
     def from_requirement(

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -338,6 +338,22 @@ def test_recurring_ipmnist_dataclasses_reject_booleans_and_non_integers() -> Non
             sentinel_case_count=2.5,  # type: ignore[arg-type]
         )
 
+    class HostileInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("subclass hook must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    with pytest.raises(ValueError, match="phase_index"):
+        RecurringIPMNISTPhase(
+            phase_index=HostileInt(0),
+            start_step=0,
+            length=1,
+            permutation_id="permutation-a.v1",
+            exposure_index=0,
+        )
+
 
 def test_recurring_ipmnist_dataclasses_accept_and_canonicalize_numpy_integers() -> None:
     binding = SentinelProbeBinding(
@@ -399,3 +415,27 @@ def test_recurring_ipmnist_phase_preflights_derived_stop_step() -> None:
             permutation_id="permutation-a.v1",
             exposure_index=0,
         )
+
+
+def test_protocol_rejects_derived_trace_and_probe_workload_overflow() -> None:
+    protocol = _protocol()
+    too_many = (2**31 - 1) // 3 + 1
+    oversized_bindings = (
+        dataclasses.replace(protocol.sentinel_bindings[0], sentinel_case_count=too_many),
+        protocol.sentinel_bindings[1],
+    )
+    with pytest.raises(ValueError, match="sentinel probe evaluations"):
+        dataclasses.replace(protocol, sentinel_bindings=oversized_bindings)
+
+    phase_length = 400_000_000
+    oversized_phases = (
+        dataclasses.replace(protocol.phases[0], start_step=0, length=phase_length),
+        dataclasses.replace(
+            protocol.phases[1], start_step=phase_length, length=phase_length
+        ),
+        dataclasses.replace(
+            protocol.phases[2], start_step=2 * phase_length, length=phase_length
+        ),
+    )
+    with pytest.raises(ValueError, match="trace scalar count"):
+        dataclasses.replace(protocol, phases=oversized_phases)


### PR DESCRIPTION
Residual successor to #744 after merged #747. Preserves #744's maintainer-authored commit while resolving it onto current main.\n\n#747 already supplied exact integer/container gates, phase-end overflow rejection, and snapshot canonicalization. This residual retains the unique deeper resource checks from #744:\n- aggregate two-channel protocol trace scalar bound;\n- aggregate mandatory sentinel evaluation bound;\n- concrete trace and correctness-vector logical bounds;\n- allocation-free overflow regressions and hostile integer-hook coverage.\n\nValidation: 16 focused tests passed; scoped Ruff; strict source mypy; diff check. No benchmarks or outputs/evidence changes.