### PR TITLE
fix(stacked-horde): harden configuration integer validation and canonicalization

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -37,10 +37,11 @@ the NaN-masking convention of the loop-based hordes.
 """
 
 import math
+import operator
 from dataclasses import dataclass
 from fractions import Fraction
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -90,11 +91,7 @@ def _snapshot_exact_fraction(value: Fraction) -> Fraction:
         denominator = value.denominator
     except AttributeError:
         raise ValueError(_STEP_SIZE_ERROR) from None
-    if (
-        type(numerator) is not int
-        or type(denominator) is not int
-        or denominator <= 0
-    ):
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         raise ValueError(_STEP_SIZE_ERROR)
     return Fraction(numerator, denominator)
 
@@ -132,6 +129,33 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
     return cast(float, value) if preserve_builtin_float else narrowed
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @dataclass(frozen=True)
 class StackedHordeConfig:
     """Static configuration for :class:`StackedLinearHorde`.
@@ -157,25 +181,29 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        if self.n_demons < 1:
-            raise ValueError("n_demons must be positive")
-        if self.feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+
         for name, seq in (
             ("gammas", self.gammas),
             ("lamdas", self.lamdas),
             ("cumulant_indices", self.cumulant_indices),
         ):
-            if len(seq) != self.n_demons:
-                raise ValueError(f"{name} must have length n_demons={self.n_demons}")
+            if len(seq) != n_demons:
+                raise ValueError(f"{name} must have length n_demons={n_demons}")
         if any(not 0.0 <= g <= 1.0 for g in self.gammas):
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
-        # Identity-only check: bools and numpy integers are refused so a JAX
-        # gather can never wrap (negative) or reinterpret the channel.
-        if any(type(idx) is not int or idx < 0 for idx in self.cumulant_indices):
-            raise ValueError("cumulant_indices entries must be nonnegative builtin ints")
+
+        cumulant_indices = tuple(
+            _require_int32(f"cumulant_indices[{i}]", idx, minimum=0)
+            for i, idx in enumerate(self.cumulant_indices)
+        )
+
+        object.__setattr__(self, "n_demons", n_demons)
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "cumulant_indices", cumulant_indices)
         object.__setattr__(
             self,
             "step_size",
@@ -346,9 +374,7 @@ class StackedLinearHorde:
         # so a short source would silently train demons on the wrong channel.
         # Shapes are static, so these checks also fire at jit/scan trace time.
         if len(source_shape) != 1:
-            raise ValueError(
-                f"cumulant_source must be rank-one, got shape {source_shape}"
-            )
+            raise ValueError(f"cumulant_source must be rank-one, got shape {source_shape}")
         if source_shape[0] <= self._max_cumulant_index:
             raise ValueError(
                 f"cumulant_source has {source_shape[0]} channels but "
@@ -365,12 +391,8 @@ class StackedLinearHorde:
         # gamma=0 must not multiply an inf bootstrap (0*inf).
         bootstrap = jnp.where(self._gammas == 0.0, 0.0, self._gammas * v_next)
         raw_td_errors = cumulants + bootstrap - v
-        prediction_valid = jnp.isfinite(v) & (
-            (self._gammas == 0.0) | jnp.isfinite(v_next)
-        )
-        channel_valid = (
-            active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
-        )
+        prediction_valid = jnp.isfinite(v) & ((self._gammas == 0.0) | jnp.isfinite(v_next))
+        channel_valid = active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
         safe_cumulants = jnp.where(channel_valid, cumulants, 0.0)
         td_errors = safe_cumulants + bootstrap - v
 
@@ -382,15 +404,10 @@ class StackedLinearHorde:
         # Inactive demons: trace decays but the current gradient is withheld.
         decayed_only = carried
         safe_rho = jnp.where(rho_valid, rho_vec, 0.0)
-        proposed_traces = safe_rho[:, None] * jnp.where(
-            active[:, None], accumulated, decayed_only
-        )
+        proposed_traces = safe_rho[:, None] * jnp.where(active[:, None], accumulated, decayed_only)
 
         masked_delta = jnp.where(channel_valid, td_errors, 0.0)
-        proposed_weights = (
-            state.weights
-            + cfg.step_size * masked_delta[:, None] * proposed_traces
-        )
+        proposed_weights = state.weights + cfg.step_size * masked_delta[:, None] * proposed_traces
         source_weights_finite = jnp.all(jnp.isfinite(state.weights))
         traces_needed = decay[:, 0] != 0.0
         traces_usable = (~traces_needed) | jnp.all(jnp.isfinite(state.traces), axis=1)
@@ -414,12 +431,8 @@ class StackedLinearHorde:
             & traces_usable
         )
         accepted_channels = head_updates_applied | inactive_trace_applied
-        new_weights = jnp.where(
-            head_updates_applied[:, None], proposed_weights, state.weights
-        )
-        new_traces = jnp.where(
-            accepted_channels[:, None], proposed_traces, state.traces
-        )
+        new_weights = jnp.where(head_updates_applied[:, None], proposed_weights, state.weights)
+        new_traces = jnp.where(accepted_channels[:, None], proposed_traces, state.traces)
         update_applied = jnp.any(accepted_channels)
         proposed_state = StackedHordeState(
             weights=new_weights,
@@ -484,9 +497,7 @@ def run_stacked_horde_scan(
     """
     sources_shape = jnp.shape(cumulant_sources)
     if len(sources_shape) != 2:
-        raise ValueError(
-            f"cumulant_sources must be rank-two, got shape {sources_shape}"
-        )
+        raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
     max_index = max(horde.config.cumulant_indices)
     if sources_shape[-1] <= max_index:
         raise ValueError(

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -75,9 +75,7 @@ class TestConfig:
             Fraction(1, 2),
         ],
     )
-    def test_step_size_supported_reals_canonicalize_for_json(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_supported_reals_canonicalize_for_json(self, step_size: object) -> None:
         cfg = _simple_config(step_size=step_size)
         payload = cfg.to_config()
 
@@ -92,9 +90,7 @@ class TestConfig:
         assert cfg.step_size == 0.1
 
     def test_fraction_step_size_rounds_directly_to_float32(self) -> None:
-        above_half_midpoint = (
-            Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
-        )
+        above_half_midpoint = Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
         expected = float(np.nextafter(np.float32(0.5), np.float32(1.0)))
 
         cfg = _simple_config(step_size=above_half_midpoint)
@@ -124,9 +120,7 @@ class TestConfig:
             float(np.nextafter(np.finfo(np.float32).tiny, np.float32(0.0))),
         ],
     )
-    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(self, step_size: object) -> None:
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=step_size)
 
@@ -255,9 +249,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_sizes[attack]
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_sizes[attack])
 
@@ -278,9 +270,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -313,18 +303,14 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
         assert calls == []
 
     @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
-    def test_step_size_rejects_exact_fraction_with_zero_denominator(
-        self, serialized: bool
-    ) -> None:
+    def test_step_size_rejects_exact_fraction_with_zero_denominator(self, serialized: bool) -> None:
         property_calls: list[str] = []
 
         class Carrier(Fraction):
@@ -347,9 +333,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -366,9 +350,7 @@ class TestConfig:
         payload["step_size"] = step_size
 
         with pytest.raises(ValueError, match="step_size"):
-            StackedLinearHorde.from_config(
-                {"type": "StackedLinearHorde", "config": payload}
-            )
+            StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
 
     def test_minimum_normal_step_size_survives_jit_execution(self) -> None:
         minimum = float(np.finfo(np.float32).tiny)
@@ -419,8 +401,8 @@ class TestCumulantSourceDomain:
 
     @pytest.mark.parametrize(
         "bad_index",
-        [-1, True, False, np.int32(1), 1.0, "1"],
-        ids=("negative", "true", "false", "numpy-int", "float", "str"),
+        [-1, True, False, 1.5, 1.0, "1"],
+        ids=("negative", "true", "false", "float-fraction", "float-int", "str"),
     )
     def test_config_rejects_non_builtin_or_negative_indices(self, bad_index: object) -> None:
         with pytest.raises(ValueError, match="cumulant_indices"):
@@ -523,9 +505,7 @@ class TestExactSemantics:
         # w += 0.1*2.18*[0.45,1] = [0.2981, 0.218].
         r2 = horde.update(r1.state, x1, x0, c)
         np.testing.assert_allclose(np.asarray(r2.td_errors), [2.18], rtol=1e-6)
-        np.testing.assert_allclose(
-            np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5
-        )
+        np.testing.assert_allclose(np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5)
 
     def test_nan_cumulant_freezes_weights_decays_trace(self):
         cfg = _simple_config()
@@ -550,9 +530,7 @@ class TestExactSemantics:
             rtol=1e-6,
         )
         # Demon 1 weights moved.
-        assert not np.array_equal(
-            np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1])
-        )
+        assert not np.array_equal(np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1]))
 
     def test_rho_composes_into_trace(self):
         """z = rho * (decay * z + x): rho=0 zeroes the trace and the update."""
@@ -738,17 +716,13 @@ class TestDemonAxisScaling:
         sources = jr.normal(rng[1], (num_steps, feature_dim), dtype=jnp.float32)
 
         t0 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         first_call = time.time() - t0
         assert first_call < 30.0, f"compile+run took {first_call:.1f}s"
 
         t1 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         steady = time.time() - t1
         assert steady < 5.0, f"steady-state run took {steady:.1f}s"
@@ -783,3 +757,47 @@ class TestDemonAxisScaling:
         assert bool(jnp.all(late < early))
         # And the late TD error is near zero for all timescales.
         assert float(jnp.max(late)) < 0.01
+
+
+def test_stacked_horde_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=True,  # type: ignore[arg-type]
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="feature_dim"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4.5,  # type: ignore[arg-type]
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="cumulant_indices"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(True,),  # type: ignore[arg-type]
+        )
+
+
+def test_stacked_horde_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = StackedHordeConfig(
+        n_demons=np.int32(2),
+        feature_dim=np.int64(4),
+        gammas=(0.9, 0.5),
+        lamdas=(0.8, 0.7),
+        cumulant_indices=(np.int32(0), np.int64(1)),
+    )
+    assert type(cfg.n_demons) is int
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.cumulant_indices[0]) is int
+    assert type(cfg.cumulant_indices[1]) is int
+    assert cfg.n_demons == 2
+    assert cfg.feature_dim == 4
+    assert cfg.cumulant_indices == (0, 1)


### PR DESCRIPTION
## Summary
- Hardens `StackedHordeConfig` integer fields `n_demons`, `feature_dim`, and `cumulant_indices` entries with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Canonicalizes all integer attributes to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_stacked_horde.py`: 76 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/stacked_horde.py`: clean