### PR TITLE
fix(continual-multiagent): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -32,10 +32,11 @@ solution.  All updates are predict-act-observe-update and use no replay.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import perf_counter, perf_counter_ns
-from typing import Literal
+from typing import Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -71,6 +72,31 @@ CONDITION_MASKS: tuple[tuple[ConditionName, tuple[bool, bool]], ...] = (
     ("learner_only", (True, False)),
     ("joint_adaptive", (True, True)),
 )
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -91,30 +117,42 @@ class ContinualMultiAgentConfig:
     bootstrap_seed: int = 2_026_073_000
 
     def __post_init__(self) -> None:
-        if self.phase_steps < 2:
-            raise ValueError("phase_steps must be at least 2")
-        if self.nuisance_dim < 0:
-            raise ValueError("nuisance_dim must be non-negative")
+        phase_steps = _require_int32("phase_steps", self.phase_steps, minimum=2)
+        nuisance_dim = _require_int32("nuisance_dim", self.nuisance_dim, minimum=0)
+        probe_horizon = _require_int32(
+            "probe_horizon", self.probe_horizon, minimum=1, maximum=phase_steps
+        )
+        probe_tail_steps = _require_int32(
+            "probe_tail_steps", self.probe_tail_steps, minimum=1, maximum=probe_horizon
+        )
+        recovery_window = _require_int32(
+            "recovery_window", self.recovery_window, minimum=1, maximum=phase_steps
+        )
+        bootstrap_resamples = _require_int32(
+            "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
+        )
+        bootstrap_seed = _require_int32(
+            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        )
+
+        object.__setattr__(self, "phase_steps", phase_steps)
+        object.__setattr__(self, "nuisance_dim", nuisance_dim)
+        object.__setattr__(self, "probe_horizon", probe_horizon)
+        object.__setattr__(self, "probe_tail_steps", probe_tail_steps)
+        object.__setattr__(self, "recovery_window", recovery_window)
+        object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
+        object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
+
         if not 0.0 < self.learning_rate <= 1.0:
             raise ValueError("learning_rate must lie in (0, 1]")
         if not 0.0 <= self.exploration_rate <= 1.0:
             raise ValueError("exploration_rate must lie in [0, 1]")
-        if not 1 <= self.probe_tail_steps <= self.probe_horizon:
-            raise ValueError("probe_tail_steps must lie in [1, probe_horizon]")
-        if self.probe_horizon > self.phase_steps:
-            raise ValueError("probe_horizon cannot cross a phase boundary")
         if not 0.0 <= self.recovery_reward_threshold <= 1.0:
             raise ValueError("recovery_reward_threshold must lie in [0, 1]")
-        if not 1 <= self.recovery_window <= self.phase_steps:
-            raise ValueError("recovery_window must lie in [1, phase_steps]")
         if not 0.0 <= self.stability_reference_reward <= 1.0:
             raise ValueError("stability_reference_reward must lie in [0, 1]")
-        if self.bootstrap_resamples < 1_000:
-            raise ValueError("bootstrap_resamples must be at least 1000")
         if not 0.0 < self.confidence_level < 1.0:
             raise ValueError("confidence_level must lie in (0, 1)")
-        if not 0 <= self.bootstrap_seed < 2**32:
-            raise ValueError("bootstrap_seed must lie in [0, 2**32)")
 
 
 @dataclass(frozen=True)
@@ -141,6 +179,18 @@ class AcceptanceThresholds:
     maximum_mean_recurrence_recovery_steps: float = 16.0
     maximum_mean_stability_gap: float = 0.20
     maximum_update_latency_ms: float = 5.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_seed_count",
+            _require_int32("minimum_seed_count", self.minimum_seed_count, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "evidence_seed_start",
+            _require_int32("evidence_seed_start", self.evidence_seed_start, minimum=0),
+        )
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -45,6 +45,8 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
+from alberta_framework._seed_validation import JAX_KEY_SEED_MAX, require_jax_seed
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.streams.recurring_multiagent import (
     AVOID_CONTEXT,
     AVOID_CONTEXT_INDEX,
@@ -99,6 +101,18 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_uint32_seed(name: str, value: object) -> int:
+    canonical = _require_int32(name, value, minimum=0, maximum=JAX_KEY_SEED_MAX)
+    return require_jax_seed(canonical, name=name)
+
+
+def _require_int32_resource(name: str, *, scalars: int, nbytes: int) -> None:
+    if scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalars must fit signed int32")
+    if nbytes > _INT32_MAX:
+        raise ValueError(f"{name} bytes must fit signed int32")
+
+
 @dataclass(frozen=True)
 class ContinualMultiAgentConfig:
     """Scientific and resource configuration for one A-B-A life."""
@@ -131,8 +145,21 @@ class ContinualMultiAgentConfig:
         bootstrap_resamples = _require_int32(
             "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
         )
-        bootstrap_seed = _require_int32(
-            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        bootstrap_seed = _require_uint32_seed("bootstrap_seed", self.bootstrap_seed)
+
+        total_steps = 3 * phase_steps
+        if total_steps > _INT32_MAX:
+            raise ValueError("3 * phase_steps must fit signed int32")
+        _require_int32_resource(
+            "condition result buffers",
+            scalars=2 * total_steps,
+            nbytes=16 * total_steps,
+        )
+        world_state_scalars = 2 * nuisance_dim + 9
+        _require_int32_resource(
+            "recurring two-agent world state",
+            scalars=world_state_scalars,
+            nbytes=4 * world_state_scalars,
         )
 
         object.__setattr__(self, "phase_steps", phase_steps)
@@ -143,16 +170,36 @@ class ContinualMultiAgentConfig:
         object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
         object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
 
-        if not 0.0 < self.learning_rate <= 1.0:
-            raise ValueError("learning_rate must lie in (0, 1]")
-        if not 0.0 <= self.exploration_rate <= 1.0:
-            raise ValueError("exploration_rate must lie in [0, 1]")
-        if not 0.0 <= self.recovery_reward_threshold <= 1.0:
-            raise ValueError("recovery_reward_threshold must lie in [0, 1]")
-        if not 0.0 <= self.stability_reference_reward <= 1.0:
-            raise ValueError("stability_reference_reward must lie in [0, 1]")
-        if not 0.0 < self.confidence_level < 1.0:
-            raise ValueError("confidence_level must lie in (0, 1)")
+        object.__setattr__(
+            self,
+            "learning_rate",
+            validated_float32_scalar(
+                "learning_rate", self.learning_rate, positive=True, upper=1.0
+            ),
+        )
+        for name in (
+            "exploration_rate",
+            "recovery_reward_threshold",
+            "stability_reference_reward",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(
+                    name, getattr(self, name), lower=0.0, upper=1.0
+                ),
+            )
+        object.__setattr__(
+            self,
+            "confidence_level",
+            validated_float32_scalar(
+                "confidence_level",
+                self.confidence_level,
+                positive=True,
+                upper=1.0,
+                upper_inclusive=False,
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -189,8 +236,10 @@ class AcceptanceThresholds:
         object.__setattr__(
             self,
             "evidence_seed_start",
-            _require_int32("evidence_seed_start", self.evidence_seed_start, minimum=0),
+            _require_uint32_seed("evidence_seed_start", self.evidence_seed_start),
         )
+        if self.evidence_seed_start + self.minimum_seed_count - 1 > JAX_KEY_SEED_MAX:
+            raise ValueError("evidence seed schedule must remain in the JAX uint32 domain")
 
 
 @dataclass(frozen=True)
@@ -569,10 +618,14 @@ def paired_bootstrap_mean_interval(
         raise ValueError("paired_differences must contain only finite values")
     if not 0.0 < confidence_level < 1.0:
         raise ValueError("confidence_level must lie in (0, 1)")
-    if resamples < 1:
-        raise ValueError("resamples must be positive")
-    if not 0 <= seed < 2**32:
-        raise ValueError("seed must lie in [0, 2**32)")
+    resamples = _require_int32("resamples", resamples, minimum=1)
+    seed = _require_uint32_seed("seed", seed)
+    index_scalars = resamples * int(values.size)
+    _require_int32_resource(
+        "paired bootstrap workspace",
+        scalars=2 * index_scalars + resamples + int(values.size),
+        nbytes=16 * index_scalars + 8 * resamples + 8 * int(values.size),
+    )
 
     generator = np.random.default_rng(seed)
     indices = generator.integers(

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -584,3 +584,106 @@ def test_acceptance_thresholds_accepts_and_canonicalizes_numpy_integers() -> Non
     assert type(thresholds.evidence_seed_start) is int
     assert thresholds.minimum_seed_count == 30
     assert thresholds.evidence_seed_start == 30
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+@pytest.mark.parametrize(
+    "field",
+    (
+        "phase_steps",
+        "nuisance_dim",
+        "probe_horizon",
+        "probe_tail_steps",
+        "recovery_window",
+        "bootstrap_resamples",
+        "bootstrap_seed",
+    ),
+)
+def test_continual_multiagent_config_canonicalizes_every_numpy_integer_family(
+    integer_type: type,
+    field: str,
+) -> None:
+    values = {
+        "phase_steps": 64,
+        "nuisance_dim": 4,
+        "probe_horizon": 12,
+        "probe_tail_steps": 4,
+        "recovery_window": 4,
+        "bootstrap_resamples": 1_000,
+        "bootstrap_seed": 7,
+    }
+    if field == "bootstrap_resamples" and np.iinfo(integer_type).max < 1_000:
+        pytest.skip("this integer dtype has no value in the documented resample domain")
+    values[field] = integer_type(values[field])
+    config = ContinualMultiAgentConfig(**values)
+
+    assert type(getattr(config, field)) is int
+
+
+def test_continual_multiagent_integer_boundaries_are_hostile_safe() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    for value in (HostileInt(64), ClassSpoof()):
+        with pytest.raises(ValueError, match="phase_steps"):
+            ContinualMultiAgentConfig(phase_steps=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="minimum_seed_count"):
+        AcceptanceThresholds(minimum_seed_count=True)  # type: ignore[arg-type]
+
+
+def test_continual_multiagent_preflights_derived_life_and_world_resources() -> None:
+    last_phase_steps = (2**31 - 1) // 48
+    ContinualMultiAgentConfig(phase_steps=last_phase_steps)
+    with pytest.raises(ValueError, match="condition result buffers bytes"):
+        ContinualMultiAgentConfig(phase_steps=last_phase_steps + 1)
+
+    last_nuisance_dim = ((2**31 - 1) // 4 - 9) // 2
+    ContinualMultiAgentConfig(nuisance_dim=last_nuisance_dim)
+    with pytest.raises(ValueError, match="world state bytes"):
+        ContinualMultiAgentConfig(nuisance_dim=last_nuisance_dim + 1)
+
+
+def test_multiagent_seed_schedules_remain_in_uint32_domain() -> None:
+    thresholds = AcceptanceThresholds(
+        minimum_seed_count=1,
+        evidence_seed_start=2**32 - 1,
+    )
+    assert thresholds.evidence_seed_start == 2**32 - 1
+    with pytest.raises(ValueError, match="seed schedule"):
+        AcceptanceThresholds(
+            minimum_seed_count=2,
+            evidence_seed_start=2**32 - 1,
+        )
+
+
+def test_paired_bootstrap_preflights_exact_workspace_before_allocation() -> None:
+    last_resamples = (2**31 - 1 - 16) // 40
+    with pytest.raises(ValueError, match="workspace bytes"):
+        paired_bootstrap_mean_interval(
+            np.asarray((0.1, 0.2)),
+            confidence_level=0.95,
+            resamples=last_resamples + 1,
+            seed=0,
+        )
+
+
+def test_multiagent_float32_configuration_is_canonical_and_sink_safe() -> None:
+    config = ContinualMultiAgentConfig(learning_rate=np.float64(0.2))
+    assert type(config.learning_rate) is float
+    assert config.learning_rate == float(np.float32(0.2))
+    with pytest.raises(ValueError, match="learning_rate"):
+        ContinualMultiAgentConfig(learning_rate=1.0e100)
+    with pytest.raises(ValueError, match="confidence_level"):
+        ContinualMultiAgentConfig(confidence_level=1.0 - 1.0e-10)

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -94,17 +94,13 @@ def test_three_seed_smoke_cannot_be_promoted_as_scientific_evidence(
 ) -> None:
     assert not smoke_report.acceptance.passed
     seed_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "seed_count"
+        check for check in smoke_report.acceptance.checks if check.name == "seed_count"
     )
     assert not seed_check.passed
     assert seed_check.actual == 3.0
     assert seed_check.threshold == 30.0
     schedule_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "evidence_seed_schedule"
+        check for check in smoke_report.acceptance.checks if check.name == "evidence_seed_schedule"
     )
     assert not schedule_check.passed
 
@@ -115,9 +111,7 @@ def test_seeded_learning_evidence_is_exactly_reproducible(
     evidence_seed = benchmark_report.aggregate.seeds[0]
     repeated = run_continual_multiagent_benchmark(seeds=(evidence_seed,))
     original = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
 
     assert len(original) == len(repeated.condition_results) == 3
@@ -243,16 +237,14 @@ def test_aggregate_intervals_use_matched_seed_differences(
     }
     reward_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "frozen")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "frozen")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
     )
     coadaptation_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "learner_only")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "learner_only")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
@@ -271,9 +263,7 @@ def test_public_aggregation_rejects_duplicate_seed_weighting(
 ) -> None:
     evidence_seed = benchmark_report.aggregate.seeds[0]
     one_seed = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
     with pytest.raises(ValueError, match="unique"):
         aggregate_evidence(one_seed + one_seed)
@@ -299,10 +289,7 @@ def test_artifact_has_deterministic_scientific_content_and_digest(
     operational = changed_diagnostics["operational_diagnostics"]
     assert isinstance(operational, dict)
     operational["maximum_update_latency_ms"] = 123_456.0
-    assert (
-        changed_diagnostics["content_digest"]["sha256"]
-        == first["content_digest"]["sha256"]
-    )
+    assert changed_diagnostics["content_digest"]["sha256"] == first["content_digest"]["sha256"]
     validation = validate_evidence_artifact(changed_diagnostics)
     assert not validation.valid
     assert not validation.accepted
@@ -326,24 +313,15 @@ def test_artifact_is_strict_json_with_narrow_claim_and_seed_evidence(
     content = loaded["content"]
     assert content["protocol"]["protocol_version"] == PROTOCOL_VERSION
     assert len(content["seed_summaries"]) == 30
-    assert (
-        "coadaptation_uplift_over_learner_only"
-        in content["aggregate"]
-    )
+    assert "coadaptation_uplift_over_learner_only" in content["aggregate"]
     excluded = content["protocol"]["excluded_claims"]
     assert "general feature discovery" in excluded
     assert "intelligence amplification or recommendation intervention" in excluded
-    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(
-        range(30, 60)
-    )
-    recovery_interval = content["aggregate"][
-        "recurrence_recovery_fraction_interval"
-    ]
+    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(range(30, 60))
+    recovery_interval = content["aggregate"]["recurrence_recovery_fraction_interval"]
     assert recovery_interval["method"] == "wilson-score"
     assert recovery_interval["sample_size"] == 30
-    assert recovery_interval["lower"] < content["aggregate"][
-        "recurrence_recovery_fraction"
-    ]
+    assert recovery_interval["lower"] < content["aggregate"]["recurrence_recovery_fraction"]
 
 
 def test_artifact_loader_rejects_duplicate_object_keys(tmp_path) -> None:
@@ -430,12 +408,9 @@ def test_rehashed_incomplete_seed_payload_still_fails_closed(
     assert not validation.valid
     assert not validation.accepted
     assert any(
-        "must contain exactly unique held-out seeds 30-59" in error
-        for error in validation.errors
+        "must contain exactly unique held-out seeds 30-59" in error for error in validation.errors
     )
-    assert any(
-        "aggregate.seeds must match" in error for error in validation.errors
-    )
+    assert any("aggregate.seeds must match" in error for error in validation.errors)
 
 
 def test_rehashed_interval_with_wrong_sample_size_fails_closed(
@@ -511,9 +486,7 @@ def test_cli_fails_for_underpowered_smoke_without_rerun(
     content = artifact["content"]
     assert content["acceptance"]["passed"] is False
     seed_check = next(
-        check
-        for check in content["acceptance"]["checks"]
-        if check["name"] == "seed_count"
+        check for check in content["acceptance"]["checks"] if check["name"] == "seed_count"
     )
     assert seed_check["actual"] == 3.0
     assert seed_check["passed"] is False
@@ -543,11 +516,7 @@ def test_cli_rechecks_impossible_thresholds_without_rerun(
     assert validation.valid
     assert not validation.accepted
     content = artifact["content"]
-    failed = {
-        check["name"]
-        for check in content["acceptance"]["checks"]
-        if not check["passed"]
-    }
+    failed = {check["name"] for check in content["acceptance"]["checks"] if not check["passed"]}
     assert "reward_uplift_over_frozen" in failed
 
 
@@ -572,3 +541,46 @@ def test_cli_rejects_weaker_than_canonical_thresholds_without_rerun(
     assert emitted["accepted"] is False
     assert emitted["valid"] is False
     assert not path.exists()
+
+
+def test_continual_multiagent_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=64.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nuisance_dim"):
+        ContinualMultiAgentConfig(nuisance_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
+        ContinualMultiAgentConfig(bootstrap_resamples=1000.5)  # type: ignore[arg-type]
+
+
+def test_continual_multiagent_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = ContinualMultiAgentConfig(
+        phase_steps=np.int32(64),
+        nuisance_dim=np.int64(4),
+        probe_horizon=np.uint16(12),
+        probe_tail_steps=np.uint8(4),
+        recovery_window=np.int32(4),
+        bootstrap_resamples=np.int64(10_000),
+        bootstrap_seed=np.uint32(2_026_073_000),
+    )
+    assert type(cfg.phase_steps) is int
+    assert type(cfg.nuisance_dim) is int
+    assert type(cfg.probe_horizon) is int
+    assert type(cfg.probe_tail_steps) is int
+    assert type(cfg.recovery_window) is int
+    assert type(cfg.bootstrap_resamples) is int
+    assert type(cfg.bootstrap_seed) is int
+    assert cfg.phase_steps == 64
+    assert cfg.nuisance_dim == 4
+
+
+def test_acceptance_thresholds_accepts_and_canonicalizes_numpy_integers() -> None:
+    thresholds = AcceptanceThresholds(
+        minimum_seed_count=np.int32(30),
+        evidence_seed_start=np.int64(30),
+    )
+    assert type(thresholds.minimum_seed_count) is int
+    assert type(thresholds.evidence_seed_start) is int
+    assert thresholds.minimum_seed_count == 30
+    assert thresholds.evidence_seed_start == 30


### PR DESCRIPTION
Supersedes #731 while preserving its contributor commit. The original exact integer admission is useful but did not guard the derived A-B-A horizon, result buffers, recurring-world state, bootstrap workspace, or held-out seed schedule; its float32-consumed configuration values also remained spoofable/noncanonical. This successor preserves the frozen default protocol bytes while adding full Python/NumPy integer canonicalization, uint32 seed validation, exact host+float32 scalar domains, signed-int32 scalar/byte formulas before allocation, and exact seed-schedule endpoints. Bootstrap accounting includes the int64 index matrix, indexed float64 temporary, means, and input vector. Verification: 97 focused tests passed (2 dtype-domain skips where 8-bit types cannot represent the documented minimum of 1000), plus the corrected adjacent workspace test; Ruff, strict targeted mypy, and diff-check are clean. This edits the registered recurring_multiagent_coadaptation source, so the pinned accepted artifact must remain untouched and is expected to fail closed on source-hash drift until a separately authorized frozen rerun; no outputs are modified or promoted.