### PR TITLE
fix(recurring-ipmnist): bound aggregate evaluation workloads

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -142,6 +142,11 @@ def _positive_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int
     return canonical
 
 
+def _require_int32_workload(name: str, value: int) -> None:
+    if not 1 <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit in signed int32")
+
+
 def _unit_float(value: object, *, name: str, binary: bool = False) -> float:
     if type(value) is not float or not math.isfinite(value) or not 0.0 <= value <= 1.0:
         qualifier = "finite binary" if binary else "finite in [0, 1]"
@@ -360,6 +365,16 @@ class RecurringIPMNISTProtocol:
         )
         if self.relearning_window > self.phases[0].length:
             raise ValueError("relearning_window cannot exceed either equal-length A phase")
+        _require_int32_workload("trace scalar count", 2 * self.trace_length)
+        binding_counts = {
+            binding.permutation_id: binding.sentinel_case_count
+            for binding in self.sentinel_bindings
+        }
+        sentinel_evaluations = sum(
+            binding_counts[requirement.permutation_id]
+            for requirement in self.required_probe_snapshots
+        )
+        _require_int32_workload("sentinel probe evaluations", sentinel_evaluations)
 
     @property
     def trace_length(self) -> int:
@@ -440,6 +455,9 @@ class RecurringIPMNISTTrace:
             raise ValueError("the online trace must be non-empty")
         if len(self.pre_update_online_accuracy) != len(self.post_update_one_step_plasticity):
             raise ValueError("accuracy and plasticity traces must have equal length")
+        _require_int32_workload(
+            "online trace scalar count", 2 * len(self.pre_update_online_accuracy)
+        )
         for index, value in enumerate(self.pre_update_online_accuracy):
             _unit_float(value, name=f"pre_update_online_accuracy[{index}]", binary=True)
         for index, value in enumerate(self.post_update_one_step_plasticity):
@@ -504,6 +522,7 @@ class SentinelProbeSnapshot:
             raise ValueError("correctness must be a non-empty exact tuple")
         if any(type(value) is not bool for value in self.correctness):
             raise ValueError("correctness must contain only canonical booleans")
+        _require_int32_workload("sentinel correctness cases", len(self.correctness))
 
     @classmethod
     def from_requirement(

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -69,6 +69,32 @@ def _protocol() -> RecurringIPMNISTProtocol:
     )
 
 
+def test_protocol_rejects_aggregate_trace_and_probe_workload_overflow() -> None:
+    protocol = _protocol()
+    too_many = (2**31 - 1) // 3 + 1
+    oversized_bindings = (
+        dataclasses.replace(protocol.sentinel_bindings[0], sentinel_case_count=too_many),
+        protocol.sentinel_bindings[1],
+    )
+    with pytest.raises(ValueError, match="sentinel probe evaluations"):
+        dataclasses.replace(protocol, sentinel_bindings=oversized_bindings)
+
+    long_phase = 400_000_000
+    with pytest.raises(ValueError, match="trace scalar count"):
+        dataclasses.replace(
+            protocol,
+            phases=(
+                dataclasses.replace(protocol.phases[0], length=long_phase),
+                dataclasses.replace(
+                    protocol.phases[1], start_step=long_phase, length=long_phase
+                ),
+                dataclasses.replace(
+                    protocol.phases[2], start_step=2 * long_phase, length=long_phase
+                ),
+            ),
+        )
+
+
 def _trace(*, retaining: bool) -> RecurringIPMNISTTrace:
     revisit = (1.0, 1.0, 1.0, 1.0) if retaining else (0.0, 0.0, 1.0, 1.0)
     return RecurringIPMNISTTrace(


### PR DESCRIPTION
Follow-up residual after merged #747 (and closed #744). #747 completed exact integer/schema gates, phase stop bounds, and snapshot canonicalization. This focused diff adds the remaining aggregate logical workload limits: two-channel protocol/trace scalar counts, the total sentinel cases evaluated across all five required probes, and each correctness vector must fit signed int32. Tests use allocation-free oversized metadata.\n\nVerification on #747 main: 16/16 focused tests, Ruff, strict source mypy, diff-check passed. This source remains unregistered development-only evaluation machinery; no outputs/evidence artifacts changed.