### PR TITLE
fix(ftl-decision-fidelity): complete exact resource contracts

### DIFF
--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -30,6 +30,7 @@ completion of the Alberta Plan.
 
 from __future__ import annotations
 
+import math
 import operator
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -42,6 +43,10 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.ftl_world_model import (
     SparseFTLWorldModel,
     SparseFTLWorldModelConfig,
@@ -66,6 +71,9 @@ CONDITION_NAMES = (
 DEVELOPMENT_SEEDS = tuple(range(30))
 EVIDENCE_SEEDS = tuple(range(30, 60))
 _INT32_MAX = 2**31 - 1
+_UINT32_MAX = 2**32 - 1
+_BOOTSTRAP_MAX_SEED_OFFSET = 103
+_FLOAT32_REWARD_TERM_LIMIT = math.sqrt(float(np.finfo(np.float32).max) / 2.0)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -90,6 +98,29 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_uint32(name: str, value: object) -> int:
+    return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
+
+
+def _require_derived_int32(name: str, value: int) -> int:
+    if value > _INT32_MAX:
+        raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
+    return value
+
+
+def _validate_bootstrap_capacity(config: DecisionFidelityConfig, sample_count: int) -> None:
+    """Reject the exact bootstrap working set before NumPy allocates it."""
+
+    draws = _require_derived_int32(
+        "bootstrap draw count", config.bootstrap_resamples * sample_count
+    )
+    # NumPy holds the int64 index matrix and indexed float64 samples together,
+    # then materializes one float64 mean per row.
+    _require_derived_int32(
+        "bootstrap working bytes", 16 * draws + 8 * config.bootstrap_resamples
+    )
 
 
 @dataclass(frozen=True)
@@ -145,9 +176,7 @@ class DecisionFidelityConfig:
         bootstrap_resamples = _require_int32(
             "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
         )
-        bootstrap_seed = _require_int32(
-            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
-        )
+        bootstrap_seed = _require_uint32("bootstrap_seed", self.bootstrap_seed)
 
         object.__setattr__(self, "phase_steps", phase_steps)
         object.__setattr__(self, "horizon", horizon)
@@ -157,22 +186,85 @@ class DecisionFidelityConfig:
         object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
         object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
 
+        if type(self.menu_amplitudes) is not tuple:
+            raise ValueError("menu_amplitudes must be an exact tuple")
         if len(self.menu_amplitudes) < 3:
             raise ValueError("menu_amplitudes must contain at least three choices")
-        if len(set(self.menu_amplitudes)) != len(self.menu_amplitudes):
+        menu_values: list[float] = []
+        menu_ratios: list[tuple[int, int]] = []
+        for index, value in enumerate(self.menu_amplitudes):
+            stored, numerator, denominator = validated_float32_scalar_with_ratio(
+                f"menu_amplitudes[{index}]", value
+            )
+            menu_values.append(stored)
+            menu_ratios.append((numerator, denominator))
+        if len(set(menu_ratios)) != len(menu_ratios) or len(set(menu_values)) != len(menu_values):
             raise ValueError("menu_amplitudes must be unique")
-        if not all(np.isfinite(self.menu_amplitudes)):
-            raise ValueError("menu_amplitudes must be finite")
-        if self.ridge <= 0.0:
-            raise ValueError("ridge must be positive")
-        if self.prediction_clip <= 0.0:
-            raise ValueError("prediction_clip must be positive")
-        if self.state_bound <= 0.0:
-            raise ValueError("state_bound must be positive")
-        if self.action_cost < 0.0:
-            raise ValueError("action_cost must be non-negative")
-        if not 0.0 < self.confidence_level < 1.0:
-            raise ValueError("confidence_level must lie in (0, 1)")
+        menu_amplitudes = tuple(menu_values)
+        ridge = validated_float32_scalar("ridge", self.ridge, positive=True)
+        prediction_clip = validated_float32_scalar(
+            "prediction_clip", self.prediction_clip, positive=True
+        )
+        state_bound = validated_float32_scalar("state_bound", self.state_bound, positive=True)
+        action_cost = validated_float32_scalar("action_cost", self.action_cost, lower=0.0)
+        confidence_level = validated_float32_scalar(
+            "confidence_level",
+            self.confidence_level,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "menu_amplitudes", menu_amplitudes)
+        object.__setattr__(self, "ridge", ridge)
+        object.__setattr__(self, "prediction_clip", prediction_clip)
+        object.__setattr__(self, "state_bound", state_bound)
+        object.__setattr__(self, "action_cost", action_cost)
+        object.__setattr__(self, "confidence_level", confidence_level)
+
+        menu_count = len(menu_amplitudes)
+        probe_count = _require_derived_int32("probe count", 2 * probes_per_domain)
+        _require_derived_int32("phase schedule length", 3 * phase_steps)
+        _require_derived_int32("phase array bytes", 12 * phase_steps)
+        _require_derived_int32("action menu scalars", menu_count * horizon)
+        rollout_scalars = _require_derived_int32(
+            "probe rollout work", probe_count * menu_count * horizon
+        )
+        _require_derived_int32(
+            "probe and rollout array bytes",
+            16 * rollout_scalars
+            + 8 * probe_count * menu_count
+            + 8 * menu_count * horizon
+            + 16 * probe_count,
+        )
+        sparse_config = SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=projection_dim,
+            bins=bins,
+            ridge=ridge,
+            statistics_decay=1.0,
+            prediction_clip=prediction_clip,
+        )
+        _require_derived_int32("SparseFTL feature dimension", sparse_config.feature_dim)
+        _require_derived_int32(
+            "SparseFTL persistent state bytes", SparseFTLWorldModel(sparse_config).state_nbytes
+        )
+        maximum_predicted_distance = 1.89 * state_bound + horizon * prediction_clip
+        if (
+            not math.isfinite(maximum_predicted_distance)
+            or maximum_predicted_distance > _FLOAT32_REWARD_TERM_LIMIT
+        ):
+            raise ValueError("state_bound and prediction_clip exceed the float32 reward domain")
+        maximum_amplitude = max(abs(value) for value in menu_amplitudes)
+        if action_cost > 0.0 and maximum_amplitude > _FLOAT32_REWARD_TERM_LIMIT / math.sqrt(
+            action_cost
+        ):
+            raise ValueError("menu_amplitudes and action_cost exceed the float32 reward domain")
+        if bootstrap_seed + _BOOTSTRAP_MAX_SEED_OFFSET > _UINT32_MAX:
+            raise ValueError(
+                "bootstrap_seed plus the frozen maximum offset must lie in [0, 2**32)"
+            )
+        _validate_bootstrap_capacity(self, len(EVIDENCE_SEEDS))
 
 
 @dataclass(frozen=True)
@@ -391,8 +483,7 @@ def precompute_decision_probes(
 ) -> DecisionProbeSet:
     """Precompute true outcomes without consulting a learned model."""
 
-    if not 0 <= seed < 2**31:
-        raise ValueError("seed must lie in [0, 2**31)")
+    seed = _require_int32("seed", seed, minimum=0)
     initial, goals, domains, action_sequences = _probe_inputs(config, seed)
     probe_count = initial.shape[0]
     menu_size = action_sequences.shape[0]
@@ -693,11 +784,13 @@ def _bootstrap_mean(
 ) -> BootstrapEstimate:
     if values.ndim != 1 or values.size == 0:
         raise ValueError("bootstrap values must be a non-empty vector")
+    _validate_bootstrap_capacity(config, int(values.size))
     generator = np.random.default_rng(config.bootstrap_seed + seed_offset)
     indices = generator.integers(
         0,
         values.size,
         size=(config.bootstrap_resamples, values.size),
+        dtype=np.int64,
     )
     resampled_means = values[indices].mean(axis=1)
     tail = (1.0 - config.confidence_level) / 2.0
@@ -832,13 +925,29 @@ def run_ftl_decision_fidelity_evaluation(
     """
 
     resolved = DecisionFidelityConfig() if config is None else config
-    seed_tuple = tuple(int(seed) for seed in seeds)
+    try:
+        raw_seeds = tuple(seeds)
+    except Exception as error:
+        raise ValueError("seeds must be a finite sequence of exact integers") from error
+    seed_tuple = tuple(
+        _require_int32(f"seeds[{index}]", seed, minimum=0)
+        for index, seed in enumerate(raw_seeds)
+    )
     if not seed_tuple:
         raise ValueError("seeds must be non-empty")
     if len(set(seed_tuple)) != len(seed_tuple):
         raise ValueError("seeds must be unique for paired evidence")
-    if not all(0 <= seed < 2**31 for seed in seed_tuple):
-        raise ValueError("seeds must lie in [0, 2**31)")
+    seed_count = len(seed_tuple)
+    probe_count = 2 * resolved.probes_per_domain
+    menu_count = len(resolved.menu_amplitudes)
+    _require_derived_int32(
+        "evaluation phase transitions", seed_count * 3 * resolved.phase_steps
+    )
+    _require_derived_int32(
+        "evaluation rollout work",
+        seed_count * probe_count * menu_count * resolved.horizon * len(CONDITION_NAMES),
+    )
+    _validate_bootstrap_capacity(resolved, seed_count)
 
     sparse_model = SparseFTLWorldModel(
         SparseFTLWorldModelConfig(

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -30,9 +30,10 @@ completion of the Alberta Plan.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import NamedTuple, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -64,6 +65,31 @@ CONDITION_NAMES = (
 # their outcomes.
 DEVELOPMENT_SEEDS = tuple(range(30))
 EVIDENCE_SEEDS = tuple(range(30, 60))
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -111,22 +137,32 @@ class DecisionFidelityConfig:
     bootstrap_seed: int = 2_026_073_001
 
     def __post_init__(self) -> None:
-        if self.phase_steps < 16:
-            raise ValueError("phase_steps must be at least 16")
-        if self.horizon < 3:
-            raise ValueError("horizon must be at least 3")
-        if self.probes_per_domain < 2:
-            raise ValueError("probes_per_domain must be at least 2")
+        phase_steps = _require_int32("phase_steps", self.phase_steps, minimum=16)
+        horizon = _require_int32("horizon", self.horizon, minimum=3)
+        probes_per_domain = _require_int32("probes_per_domain", self.probes_per_domain, minimum=2)
+        projection_dim = _require_int32("projection_dim", self.projection_dim, minimum=1)
+        bins = _require_int32("bins", self.bins, minimum=2)
+        bootstrap_resamples = _require_int32(
+            "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
+        )
+        bootstrap_seed = _require_int32(
+            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        )
+
+        object.__setattr__(self, "phase_steps", phase_steps)
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "probes_per_domain", probes_per_domain)
+        object.__setattr__(self, "projection_dim", projection_dim)
+        object.__setattr__(self, "bins", bins)
+        object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
+        object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
+
         if len(self.menu_amplitudes) < 3:
             raise ValueError("menu_amplitudes must contain at least three choices")
         if len(set(self.menu_amplitudes)) != len(self.menu_amplitudes):
             raise ValueError("menu_amplitudes must be unique")
         if not all(np.isfinite(self.menu_amplitudes)):
             raise ValueError("menu_amplitudes must be finite")
-        if self.projection_dim <= 0:
-            raise ValueError("projection_dim must be positive")
-        if self.bins < 2:
-            raise ValueError("bins must be at least 2")
         if self.ridge <= 0.0:
             raise ValueError("ridge must be positive")
         if self.prediction_clip <= 0.0:
@@ -135,12 +171,8 @@ class DecisionFidelityConfig:
             raise ValueError("state_bound must be positive")
         if self.action_cost < 0.0:
             raise ValueError("action_cost must be non-negative")
-        if self.bootstrap_resamples < 1_000:
-            raise ValueError("bootstrap_resamples must be at least 1000")
         if not 0.0 < self.confidence_level < 1.0:
             raise ValueError("confidence_level must lie in (0, 1)")
-        if not 0 <= self.bootstrap_seed < 2**32:
-            raise ValueError("bootstrap_seed must lie in [0, 2**32)")
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -190,8 +190,23 @@ class DecisionFidelityConfig:
 
         if type(self.menu_amplitudes) is not tuple:
             raise ValueError("menu_amplitudes must be an exact tuple")
-        if len(self.menu_amplitudes) < 3:
+        menu_count = len(self.menu_amplitudes)
+        if menu_count < 3:
             raise ValueError("menu_amplitudes must contain at least three choices")
+        probe_count = _require_derived_int32("probe count", 2 * probes_per_domain)
+        _require_derived_int32("phase schedule length", 3 * phase_steps)
+        _require_derived_int32("phase array bytes", 12 * phase_steps)
+        _require_derived_int32("action menu scalars", menu_count * horizon)
+        rollout_scalars = _require_derived_int32(
+            "probe rollout work", probe_count * menu_count * horizon
+        )
+        _require_derived_int32(
+            "probe and rollout array bytes",
+            16 * rollout_scalars
+            + 8 * probe_count * menu_count
+            + 8 * menu_count * horizon
+            + 16 * probe_count,
+        )
         menu_values: list[float] = []
         menu_ratios: list[tuple[int, int]] = []
         for index, value in enumerate(self.menu_amplitudes):
@@ -223,21 +238,6 @@ class DecisionFidelityConfig:
         object.__setattr__(self, "action_cost", action_cost)
         object.__setattr__(self, "confidence_level", confidence_level)
 
-        menu_count = len(menu_amplitudes)
-        probe_count = _require_derived_int32("probe count", 2 * probes_per_domain)
-        _require_derived_int32("phase schedule length", 3 * phase_steps)
-        _require_derived_int32("phase array bytes", 12 * phase_steps)
-        _require_derived_int32("action menu scalars", menu_count * horizon)
-        rollout_scalars = _require_derived_int32(
-            "probe rollout work", probe_count * menu_count * horizon
-        )
-        _require_derived_int32(
-            "probe and rollout array bytes",
-            16 * rollout_scalars
-            + 8 * probe_count * menu_count
-            + 8 * menu_count * horizon
-            + 16 * probe_count,
-        )
         sparse_config = SparseFTLWorldModelConfig(
             observation_dim=1,
             action_dim=1,

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -73,7 +73,9 @@ EVIDENCE_SEEDS = tuple(range(30, 60))
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 _BOOTSTRAP_MAX_SEED_OFFSET = 103
-_FLOAT32_REWARD_TERM_LIMIT = math.sqrt(float(np.finfo(np.float32).max) / 2.0)
+_FLOAT32_MAX_BELOW_OVERFLOW = float(
+    np.nextafter(np.float32(np.finfo(np.float32).max), np.float32(0.0))
+)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -249,17 +251,23 @@ class DecisionFidelityConfig:
         _require_derived_int32(
             "SparseFTL persistent state bytes", SparseFTLWorldModel(sparse_config).state_nbytes
         )
-        maximum_predicted_distance = 1.89 * state_bound + horizon * prediction_clip
+        reward_term_limit = math.sqrt(
+            _FLOAT32_MAX_BELOW_OVERFLOW / (2.0 * horizon)
+        )
+        # Probe initial states are bounded by 1.30 independently of state_bound;
+        # goals are clipped to 0.89 * state_bound. Slightly wider decimal
+        # coefficients conservatively cover float32 narrowing at both sinks.
+        maximum_predicted_distance = 1.31 + 0.90 * state_bound + horizon * prediction_clip
         if (
             not math.isfinite(maximum_predicted_distance)
-            or maximum_predicted_distance > _FLOAT32_REWARD_TERM_LIMIT
+            or maximum_predicted_distance > reward_term_limit
         ):
-            raise ValueError("state_bound and prediction_clip exceed the float32 reward domain")
+            raise ValueError(
+                "state_bound and prediction_clip exceed the float32 return domain"
+            )
         maximum_amplitude = max(abs(value) for value in menu_amplitudes)
-        if action_cost > 0.0 and maximum_amplitude > _FLOAT32_REWARD_TERM_LIMIT / math.sqrt(
-            action_cost
-        ):
-            raise ValueError("menu_amplitudes and action_cost exceed the float32 reward domain")
+        if action_cost > 0.0 and maximum_amplitude > reward_term_limit / math.sqrt(action_cost):
+            raise ValueError("menu_amplitudes and action_cost exceed the float32 return domain")
         if bootstrap_seed + _BOOTSTRAP_MAX_SEED_OFFSET > _UINT32_MAX:
             raise ValueError(
                 "bootstrap_seed plus the frozen maximum offset must lie in [0, 2**32)"
@@ -925,19 +933,11 @@ def run_ftl_decision_fidelity_evaluation(
     """
 
     resolved = DecisionFidelityConfig() if config is None else config
-    try:
-        raw_seeds = tuple(seeds)
-    except Exception as error:
-        raise ValueError("seeds must be a finite sequence of exact integers") from error
-    seed_tuple = tuple(
-        _require_int32(f"seeds[{index}]", seed, minimum=0)
-        for index, seed in enumerate(raw_seeds)
-    )
-    if not seed_tuple:
+    if type(seeds) not in (tuple, list):
+        raise ValueError("seeds must be an actual tuple or list of exact integers")
+    seed_count = len(seeds)
+    if seed_count == 0:
         raise ValueError("seeds must be non-empty")
-    if len(set(seed_tuple)) != len(seed_tuple):
-        raise ValueError("seeds must be unique for paired evidence")
-    seed_count = len(seed_tuple)
     probe_count = 2 * resolved.probes_per_domain
     menu_count = len(resolved.menu_amplitudes)
     _require_derived_int32(
@@ -948,6 +948,13 @@ def run_ftl_decision_fidelity_evaluation(
         seed_count * probe_count * menu_count * resolved.horizon * len(CONDITION_NAMES),
     )
     _validate_bootstrap_capacity(resolved, seed_count)
+    raw_seeds = tuple(seeds)
+    seed_tuple = tuple(
+        _require_int32(f"seeds[{index}]", seed, minimum=0)
+        for index, seed in enumerate(raw_seeds)
+    )
+    if len(set(seed_tuple)) != len(seed_tuple):
+        raise ValueError("seeds must be unique for paired evidence")
 
     sparse_model = SparseFTLWorldModel(
         SparseFTLWorldModelConfig(

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
 from numbers import Real
 
 import jax
@@ -408,3 +409,28 @@ def test_default_config_json_and_numpy_canonicalization_preserve_frozen_payload(
         "bootstrap_seed": 2_026_073_001,
     }
     assert json.loads(json.dumps(dataclasses.asdict(DecisionFidelityConfig()))) == expected
+
+
+def test_return_accumulation_domain_is_preflighted_not_only_each_reward() -> None:
+    horizon = 6
+    individually_safe_clip = (
+        math.sqrt(float(np.finfo(np.float32).max) / 2.0) / horizon * 0.9
+    )
+    with pytest.raises(ValueError, match="return domain"):
+        DecisionFidelityConfig(
+            horizon=horizon,
+            state_bound=np.finfo(np.float32).tiny,
+            prediction_clip=individually_safe_clip,
+        )
+
+
+def test_custom_seed_container_rejects_hostile_iterables_without_iteration() -> None:
+    class HostileIterable:
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("iteration hook must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    with pytest.raises(ValueError, match="actual tuple or list"):
+        run_ftl_decision_fidelity_evaluation(seeds=HostileIterable())  # type: ignore[arg-type]

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -434,3 +434,20 @@ def test_custom_seed_container_rejects_hostile_iterables_without_iteration() -> 
 
     with pytest.raises(ValueError, match="actual tuple or list"):
         run_ftl_decision_fidelity_evaluation(seeds=HostileIterable())  # type: ignore[arg-type]
+
+
+def test_menu_resource_preflight_runs_before_element_hooks() -> None:
+    class HostileMenuValue:
+        @property
+        def __class__(self) -> type[float]:  # pragma: no cover - must not run
+            raise AssertionError("menu element hook ran before resource preflight")
+
+        def __repr__(self) -> str:  # pragma: no cover - must not run
+            raise AssertionError("menu repr ran before resource preflight")
+
+    hostile = HostileMenuValue()
+    with pytest.raises(ValueError, match="action menu scalars"):
+        DecisionFidelityConfig(
+            horizon=2**31 - 1,
+            menu_amplitudes=(hostile, hostile, hostile),  # type: ignore[arg-type]
+        )

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -219,3 +219,35 @@ def test_invalid_decision_configuration_is_rejected(
 def test_invalid_seed_schedules_are_rejected(seeds: tuple[int, ...]) -> None:
     with pytest.raises(ValueError):
         run_ftl_decision_fidelity_evaluation(seeds=seeds)
+
+
+def test_decision_fidelity_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="phase_steps"):
+        DecisionFidelityConfig(phase_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase_steps"):
+        DecisionFidelityConfig(phase_steps=180.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="horizon"):
+        DecisionFidelityConfig(horizon=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="projection_dim"):
+        DecisionFidelityConfig(projection_dim=12.5)  # type: ignore[arg-type]
+
+
+def test_decision_fidelity_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = DecisionFidelityConfig(
+        phase_steps=np.int32(180),
+        horizon=np.int64(6),
+        probes_per_domain=np.uint16(12),
+        projection_dim=np.int32(12),
+        bins=np.uint8(7),
+        bootstrap_resamples=np.int64(5_000),
+        bootstrap_seed=np.uint32(2_026_073_001),
+    )
+    assert type(cfg.phase_steps) is int
+    assert type(cfg.horizon) is int
+    assert type(cfg.probes_per_domain) is int
+    assert type(cfg.projection_dim) is int
+    assert type(cfg.bins) is int
+    assert type(cfg.bootstrap_resamples) is int
+    assert type(cfg.bootstrap_seed) is int
+    assert cfg.phase_steps == 180
+    assert cfg.horizon == 6

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import dataclasses
+import json
+from numbers import Real
 
 import jax
 import numpy as np
@@ -251,3 +253,158 @@ def test_decision_fidelity_config_accepts_and_canonicalizes_numpy_integers() -> 
     assert type(cfg.bootstrap_seed) is int
     assert cfg.phase_steps == 180
     assert cfg.horizon == 6
+
+
+_INTEGER_FIELDS_AND_VALUES = (
+    ("phase_steps", 180),
+    ("horizon", 6),
+    ("probes_per_domain", 12),
+    ("projection_dim", 12),
+    ("bins", 7),
+    ("bootstrap_resamples", 5_000),
+    ("bootstrap_seed", 2_026_073_001),
+)
+_NUMPY_INTEGER_TYPES = tuple(
+    dict.fromkeys(
+        (
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.longlong,
+            np.ulonglong,
+        )
+    )
+)
+
+
+@pytest.mark.parametrize(("field", "value"), _INTEGER_FIELDS_AND_VALUES)
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_every_integer_field_accepts_every_representable_numpy_family(
+    field: str, value: int, integer_type: type[np.integer],
+) -> None:
+    try:
+        typed_value = integer_type(value)
+    except OverflowError:
+        pytest.skip("value is not representable by this NumPy integer type")
+    config = DecisionFidelityConfig(**{field: typed_value})
+    assert type(getattr(config, field)) is int
+    assert getattr(config, field) == value
+
+
+class _IntSubclass(int):
+    pass
+
+
+class _IndexStandIn:
+    def __index__(self) -> int:
+        raise AssertionError("an unapproved __index__ hook must not run")
+
+
+class _ClassSpoof:
+    @property
+    def __class__(self) -> type[int]:
+        return int
+
+    def __repr__(self) -> str:
+        raise AssertionError("error reporting must not call repr")
+
+
+class _HostileReal(float, Real):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile ratio")
+
+    def __repr__(self) -> str:
+        raise AssertionError("error reporting must not call repr")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, _IntSubclass(180), _IndexStandIn(), _ClassSpoof()],
+    ids=("bool", "int-subclass", "index-stand-in", "class-spoof"),
+)
+def test_integer_gate_rejects_subclasses_spoofs_and_hooks_without_invoking_repr(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="phase_steps"):
+        DecisionFidelityConfig(phase_steps=value)  # type: ignore[arg-type]
+
+
+def test_float_and_menu_gates_are_exact_canonical_and_hook_safe() -> None:
+    config = DecisionFidelityConfig(
+        menu_amplitudes=(np.float32(-0.5), np.float64(0.0), np.float32(0.5)),
+        ridge=np.float64(0.01),
+        prediction_clip=np.float32(3.0),
+        state_bound=np.float64(1.75),
+        action_cost=np.float32(0.025),
+        confidence_level=np.float64(0.95),
+    )
+    assert type(config.menu_amplitudes) is tuple
+    assert all(type(value) is float for value in config.menu_amplitudes)
+    assert all(
+        type(getattr(config, field)) is float
+        for field in ("ridge", "prediction_clip", "state_bound", "action_cost", "confidence_level")
+    )
+    for field in ("ridge", "prediction_clip", "state_bound", "action_cost", "confidence_level"):
+        with pytest.raises(ValueError, match=field):
+            DecisionFidelityConfig(**{field: _HostileReal(0.5)})
+
+
+def test_menu_rejects_container_subclasses_and_float32_collisions() -> None:
+    class TupleSubclass(tuple):
+        pass
+
+    with pytest.raises(ValueError, match="exact tuple"):
+        DecisionFidelityConfig(menu_amplitudes=TupleSubclass((-0.5, 0.0, 0.5)))
+    with pytest.raises(ValueError, match="unique"):
+        DecisionFidelityConfig(
+            menu_amplitudes=(1.0, np.nextafter(1.0, 2.0), 2.0)
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"phase_steps": 2**31 // 3 + 1},
+        {"projection_dim": 100_000, "bins": 2},
+        {"bootstrap_resamples": 2**31 - 1},
+        {"bootstrap_seed": 2**32 - 1},
+        {"prediction_clip": np.finfo(np.float32).max},
+        {
+            "menu_amplitudes": (-np.finfo(np.float32).max, 0.0, np.finfo(np.float32).max),
+            "action_cost": 1.0,
+        },
+    ],
+)
+def test_derived_resource_and_operation_overflow_is_rejected_before_allocation(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, object]
+) -> None:
+    def forbidden(*args: object, **kwds: object) -> None:
+        raise AssertionError("allocation occurred before validation")
+
+    monkeypatch.setattr(np, "empty", forbidden)
+    with pytest.raises(ValueError):
+        DecisionFidelityConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_default_config_json_and_numpy_canonicalization_preserve_frozen_payload() -> None:
+    expected = {
+        "phase_steps": 180,
+        "horizon": 6,
+        "probes_per_domain": 12,
+        "menu_amplitudes": [-0.85, -0.45, 0.0, 0.45, 0.85],
+        "projection_dim": 12,
+        "bins": 7,
+        "ridge": 0.01,
+        "prediction_clip": 3.0,
+        "state_bound": 1.75,
+        "action_cost": 0.025,
+        "bootstrap_resamples": 5_000,
+        "confidence_level": 0.95,
+        "bootstrap_seed": 2_026_073_001,
+    }
+    assert json.loads(json.dumps(dataclasses.asdict(DecisionFidelityConfig()))) == expected


### PR DESCRIPTION
Supersedes #733 while preserving kzahiri1's original commit and attribution.

Closes the remaining fail-closed configuration contract: exact/canonical integer and float32 sinks, exact tuple menu validation, uint32 bootstrap seeds, derived phase/rollout/SparseFTL/bootstrap allocation preflights, operation-safe reward bounds, and exact custom seed validation. Tests cover all NumPy integer families, hostile hooks/spoofs/subclasses, adjacent resource failures before allocation, canonical frozen defaults, artifact reconstruction, and the existing evaluation semantics.

Evidence impact: this intentionally changes a registered source. No pinned artifact, hash, or outputs were edited. The historical FTL evidence remains fail-closed invalid until the exact frozen protocol is rerun and its strict validator accepts a new artifact.

Validation: 124 passed, 7 skipped across FTL fidelity/artifact/CLI tests; Ruff and strict mypy pass; diff check clean.