### PR TITLE
fix(continual-multiagent): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -45,6 +45,7 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.streams.recurring_multiagent import (
     AVOID_CONTEXT,
     AVOID_CONTEXT_INDEX,
@@ -202,16 +203,39 @@ class ContinualMultiAgentConfig:
         object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
         object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
 
-        if not 0.0 < self.learning_rate <= 1.0:
-            raise ValueError("learning_rate must lie in (0, 1]")
-        if not 0.0 <= self.exploration_rate <= 1.0:
-            raise ValueError("exploration_rate must lie in [0, 1]")
-        if not 0.0 <= self.recovery_reward_threshold <= 1.0:
-            raise ValueError("recovery_reward_threshold must lie in [0, 1]")
-        if not 0.0 <= self.stability_reference_reward <= 1.0:
-            raise ValueError("stability_reference_reward must lie in [0, 1]")
-        if not 0.0 < self.confidence_level < 1.0:
-            raise ValueError("confidence_level must lie in (0, 1)")
+        object.__setattr__(
+            self,
+            "learning_rate",
+            validated_float32_scalar(
+                "learning_rate", self.learning_rate, positive=True, upper=1.0
+            ),
+        )
+        for name in (
+            "exploration_rate",
+            "recovery_reward_threshold",
+            "stability_reference_reward",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(
+                    name,
+                    getattr(self, name),
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "confidence_level",
+            validated_float32_scalar(
+                "confidence_level",
+                self.confidence_level,
+                positive=True,
+                upper=1.0,
+                upper_inclusive=False,
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -260,6 +284,22 @@ class AcceptanceThresholds:
             "evidence_seed_start",
             evidence_seed_start,
         )
+        for name in (
+            "minimum_reward_uplift_over_frozen",
+            "minimum_partner_uplift",
+            "minimum_recurrent_a_probe_reward",
+            "maximum_mean_forgetting",
+            "maximum_interference_forgetting",
+            "minimum_recurrence_recovery_fraction",
+            "maximum_mean_recurrence_recovery_steps",
+            "maximum_mean_stability_gap",
+            "maximum_update_latency_ms",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name)),
+            )
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -73,6 +73,8 @@ CONDITION_MASKS: tuple[tuple[ConditionName, tuple[bool, bool]], ...] = (
     ("joint_adaptive", (True, True)),
 )
 _INT32_MAX = 2**31 - 1
+_UINT32_MAX = 2**32 - 1
+_MAX_CONFIGURED_ARRAY_NBYTES = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -97,6 +99,54 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_uint32(name: str, value: object) -> int:
+    return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
+
+
+def _require_seed(value: object) -> int:
+    try:
+        return _require_int32("seed", value, minimum=0)
+    except ValueError as error:
+        raise ValueError("seeds must lie in [0, 2**31)") from error
+
+
+def _condition_working_nbytes(phase_steps: int) -> int:
+    """Exact bytes in the two phase-length float64 work vectors."""
+    return 2 * (3 * phase_steps) * np.dtype(np.float64).itemsize
+
+
+def _condition_result_array_nbytes(phase_steps: int) -> int:
+    """Exact retained NumPy payload for one completed condition."""
+    float64_nbytes = np.dtype(np.float64).itemsize
+    int64_nbytes = np.dtype(np.int64).itemsize
+    return (
+        3 * phase_steps * float64_nbytes
+        + 3 * float64_nbytes
+        + 3 * 2 * float64_nbytes
+        + 2 * int64_nbytes
+    )
+
+
+def _world_array_nbytes(nuisance_dim: int) -> tuple[int, int]:
+    """Exact persistent-state and one-observation array bytes for the world."""
+    state_nbytes = 36 + 2 * nuisance_dim * np.dtype(np.float32).itemsize
+    observation_nbytes = 2 * (6 + nuisance_dim) * np.dtype(np.float32).itemsize
+    return state_nbytes, observation_nbytes
+
+
+def _bootstrap_working_nbytes(resamples: int, sample_size: int) -> int:
+    """Peak owned NumPy payload for indices, sampled values, and means."""
+    itemsize = np.dtype(np.float64).itemsize
+    return 2 * resamples * sample_size * itemsize + resamples * itemsize
+
+
+def _require_resource_limit(name: str, nbytes: int) -> None:
+    if nbytes > _MAX_CONFIGURED_ARRAY_NBYTES:
+        raise ValueError(
+            f"{name} requires {nbytes} bytes; limit is {_MAX_CONFIGURED_ARRAY_NBYTES}"
+        )
 
 
 @dataclass(frozen=True)
@@ -129,11 +179,20 @@ class ContinualMultiAgentConfig:
             "recovery_window", self.recovery_window, minimum=1, maximum=phase_steps
         )
         bootstrap_resamples = _require_int32(
-            "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
+            "bootstrap_resamples",
+            self.bootstrap_resamples,
+            minimum=1000,
+            maximum=_MAX_CONFIGURED_ARRAY_NBYTES // (3 * np.dtype(np.float64).itemsize),
         )
-        bootstrap_seed = _require_int32(
-            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        bootstrap_seed = _require_uint32("bootstrap_seed", self.bootstrap_seed)
+
+        _require_resource_limit(
+            "per-condition phase work arrays",
+            _condition_working_nbytes(phase_steps),
         )
+        world_state_nbytes, observation_nbytes = _world_array_nbytes(nuisance_dim)
+        _require_resource_limit("recurring world state", world_state_nbytes)
+        _require_resource_limit("recurring world observation", observation_nbytes)
 
         object.__setattr__(self, "phase_steps", phase_steps)
         object.__setattr__(self, "nuisance_dim", nuisance_dim)
@@ -181,15 +240,25 @@ class AcceptanceThresholds:
     maximum_update_latency_ms: float = 5.0
 
     def __post_init__(self) -> None:
+        minimum_seed_count = _require_int32(
+            "minimum_seed_count", self.minimum_seed_count, minimum=1
+        )
+        evidence_seed_start = _require_int32(
+            "evidence_seed_start", self.evidence_seed_start, minimum=0
+        )
+        if evidence_seed_start + minimum_seed_count > _INT32_MAX + 1:
+            raise ValueError(
+                "evidence_seed_start + minimum_seed_count must not exceed 2147483648"
+            )
         object.__setattr__(
             self,
             "minimum_seed_count",
-            _require_int32("minimum_seed_count", self.minimum_seed_count, minimum=1),
+            minimum_seed_count,
         )
         object.__setattr__(
             self,
             "evidence_seed_start",
-            _require_int32("evidence_seed_start", self.evidence_seed_start, minimum=0),
+            evidence_seed_start,
         )
 
 
@@ -569,10 +638,17 @@ def paired_bootstrap_mean_interval(
         raise ValueError("paired_differences must contain only finite values")
     if not 0.0 < confidence_level < 1.0:
         raise ValueError("confidence_level must lie in (0, 1)")
-    if resamples < 1:
-        raise ValueError("resamples must be positive")
-    if not 0 <= seed < 2**32:
-        raise ValueError("seed must lie in [0, 2**32)")
+    resamples = _require_int32(
+        "resamples",
+        resamples,
+        minimum=1,
+        maximum=_MAX_CONFIGURED_ARRAY_NBYTES // (3 * np.dtype(np.float64).itemsize),
+    )
+    seed = _require_uint32("seed", seed)
+    _require_resource_limit(
+        "paired bootstrap working arrays",
+        _bootstrap_working_nbytes(resamples, int(values.size)),
+    )
 
     generator = np.random.default_rng(seed)
     indices = generator.integers(
@@ -769,11 +845,9 @@ def evaluate_acceptance(
     """
 
     limits = AcceptanceThresholds() if thresholds is None else thresholds
-    expected_evidence_seeds = tuple(
-        range(
-            limits.evidence_seed_start,
-            limits.evidence_seed_start + limits.minimum_seed_count,
-        )
+    seed_schedule_matches = len(aggregate.seeds) == limits.minimum_seed_count and all(
+        seed == limits.evidence_seed_start + offset
+        for offset, seed in enumerate(aggregate.seeds)
     )
     checks = (
         _minimum_check(
@@ -784,7 +858,7 @@ def evaluate_acceptance(
         ),
         _minimum_check(
             "evidence_seed_schedule",
-            float(aggregate.seeds == expected_evidence_seeds),
+            float(seed_schedule_matches),
             1.0,
             "Promoted evidence must use the frozen held-out consecutive seed schedule.",
         ),
@@ -873,13 +947,20 @@ def run_continual_multiagent_benchmark(
 
     benchmark_config = ContinualMultiAgentConfig() if config is None else config
     acceptance_thresholds = AcceptanceThresholds() if thresholds is None else thresholds
-    seed_tuple = tuple(int(seed) for seed in seeds)
-    if not seed_tuple:
+    if type(seeds) not in (list, tuple, range):
+        raise ValueError("seeds must be an actual list, tuple, or range")
+    seed_count = len(seeds)
+    if seed_count == 0:
         raise ValueError("seeds must be non-empty")
+    _require_resource_limit(
+        "retained condition-result arrays",
+        seed_count
+        * len(CONDITION_MASKS)
+        * _condition_result_array_nbytes(benchmark_config.phase_steps),
+    )
+    seed_tuple = tuple(_require_seed(seed) for seed in seeds)
     if len(set(seed_tuple)) != len(seed_tuple):
         raise ValueError("seeds must be unique")
-    if any(seed < 0 or seed >= 2**31 for seed in seed_tuple):
-        raise ValueError("seeds must lie in [0, 2**31)")
 
     # Immediate dynamics make the causal effect of each bounded action visible
     # while preserving an uninterrupted physical state across phase switches.

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -32,10 +32,11 @@ solution.  All updates are predict-act-observe-update and use no replay.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import perf_counter, perf_counter_ns
-from typing import Literal
+from typing import Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -71,6 +72,31 @@ CONDITION_MASKS: tuple[tuple[ConditionName, tuple[bool, bool]], ...] = (
     ("learner_only", (True, False)),
     ("joint_adaptive", (True, True)),
 )
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -91,30 +117,42 @@ class ContinualMultiAgentConfig:
     bootstrap_seed: int = 2_026_073_000
 
     def __post_init__(self) -> None:
-        if self.phase_steps < 2:
-            raise ValueError("phase_steps must be at least 2")
-        if self.nuisance_dim < 0:
-            raise ValueError("nuisance_dim must be non-negative")
+        phase_steps = _require_int32("phase_steps", self.phase_steps, minimum=2)
+        nuisance_dim = _require_int32("nuisance_dim", self.nuisance_dim, minimum=0)
+        probe_horizon = _require_int32(
+            "probe_horizon", self.probe_horizon, minimum=1, maximum=phase_steps
+        )
+        probe_tail_steps = _require_int32(
+            "probe_tail_steps", self.probe_tail_steps, minimum=1, maximum=probe_horizon
+        )
+        recovery_window = _require_int32(
+            "recovery_window", self.recovery_window, minimum=1, maximum=phase_steps
+        )
+        bootstrap_resamples = _require_int32(
+            "bootstrap_resamples", self.bootstrap_resamples, minimum=1000
+        )
+        bootstrap_seed = _require_int32(
+            "bootstrap_seed", self.bootstrap_seed, minimum=0, maximum=2**32 - 1
+        )
+
+        object.__setattr__(self, "phase_steps", phase_steps)
+        object.__setattr__(self, "nuisance_dim", nuisance_dim)
+        object.__setattr__(self, "probe_horizon", probe_horizon)
+        object.__setattr__(self, "probe_tail_steps", probe_tail_steps)
+        object.__setattr__(self, "recovery_window", recovery_window)
+        object.__setattr__(self, "bootstrap_resamples", bootstrap_resamples)
+        object.__setattr__(self, "bootstrap_seed", bootstrap_seed)
+
         if not 0.0 < self.learning_rate <= 1.0:
             raise ValueError("learning_rate must lie in (0, 1]")
         if not 0.0 <= self.exploration_rate <= 1.0:
             raise ValueError("exploration_rate must lie in [0, 1]")
-        if not 1 <= self.probe_tail_steps <= self.probe_horizon:
-            raise ValueError("probe_tail_steps must lie in [1, probe_horizon]")
-        if self.probe_horizon > self.phase_steps:
-            raise ValueError("probe_horizon cannot cross a phase boundary")
         if not 0.0 <= self.recovery_reward_threshold <= 1.0:
             raise ValueError("recovery_reward_threshold must lie in [0, 1]")
-        if not 1 <= self.recovery_window <= self.phase_steps:
-            raise ValueError("recovery_window must lie in [1, phase_steps]")
         if not 0.0 <= self.stability_reference_reward <= 1.0:
             raise ValueError("stability_reference_reward must lie in [0, 1]")
-        if self.bootstrap_resamples < 1_000:
-            raise ValueError("bootstrap_resamples must be at least 1000")
         if not 0.0 < self.confidence_level < 1.0:
             raise ValueError("confidence_level must lie in (0, 1)")
-        if not 0 <= self.bootstrap_seed < 2**32:
-            raise ValueError("bootstrap_seed must lie in [0, 2**32)")
 
 
 @dataclass(frozen=True)
@@ -141,6 +179,18 @@ class AcceptanceThresholds:
     maximum_mean_recurrence_recovery_steps: float = 16.0
     maximum_mean_stability_gap: float = 0.20
     maximum_update_latency_ms: float = 5.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_seed_count",
+            _require_int32("minimum_seed_count", self.minimum_seed_count, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "evidence_seed_start",
+            _require_int32("evidence_seed_start", self.evidence_seed_start, minimum=0),
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -94,13 +94,17 @@ def test_three_seed_smoke_cannot_be_promoted_as_scientific_evidence(
 ) -> None:
     assert not smoke_report.acceptance.passed
     seed_check = next(
-        check for check in smoke_report.acceptance.checks if check.name == "seed_count"
+        check
+        for check in smoke_report.acceptance.checks
+        if check.name == "seed_count"
     )
     assert not seed_check.passed
     assert seed_check.actual == 3.0
     assert seed_check.threshold == 30.0
     schedule_check = next(
-        check for check in smoke_report.acceptance.checks if check.name == "evidence_seed_schedule"
+        check
+        for check in smoke_report.acceptance.checks
+        if check.name == "evidence_seed_schedule"
     )
     assert not schedule_check.passed
 
@@ -111,7 +115,9 @@ def test_seeded_learning_evidence_is_exactly_reproducible(
     evidence_seed = benchmark_report.aggregate.seeds[0]
     repeated = run_continual_multiagent_benchmark(seeds=(evidence_seed,))
     original = tuple(
-        result for result in benchmark_report.condition_results if result.seed == evidence_seed
+        result
+        for result in benchmark_report.condition_results
+        if result.seed == evidence_seed
     )
 
     assert len(original) == len(repeated.condition_results) == 3
@@ -237,14 +243,16 @@ def test_aggregate_intervals_use_matched_seed_differences(
     }
     reward_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")] - prequential[(seed, "frozen")]
+            prequential[(seed, "joint_adaptive")]
+            - prequential[(seed, "frozen")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
     )
     coadaptation_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")] - prequential[(seed, "learner_only")]
+            prequential[(seed, "joint_adaptive")]
+            - prequential[(seed, "learner_only")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
@@ -263,7 +271,9 @@ def test_public_aggregation_rejects_duplicate_seed_weighting(
 ) -> None:
     evidence_seed = benchmark_report.aggregate.seeds[0]
     one_seed = tuple(
-        result for result in benchmark_report.condition_results if result.seed == evidence_seed
+        result
+        for result in benchmark_report.condition_results
+        if result.seed == evidence_seed
     )
     with pytest.raises(ValueError, match="unique"):
         aggregate_evidence(one_seed + one_seed)
@@ -289,7 +299,10 @@ def test_artifact_has_deterministic_scientific_content_and_digest(
     operational = changed_diagnostics["operational_diagnostics"]
     assert isinstance(operational, dict)
     operational["maximum_update_latency_ms"] = 123_456.0
-    assert changed_diagnostics["content_digest"]["sha256"] == first["content_digest"]["sha256"]
+    assert (
+        changed_diagnostics["content_digest"]["sha256"]
+        == first["content_digest"]["sha256"]
+    )
     validation = validate_evidence_artifact(changed_diagnostics)
     assert not validation.valid
     assert not validation.accepted
@@ -313,15 +326,24 @@ def test_artifact_is_strict_json_with_narrow_claim_and_seed_evidence(
     content = loaded["content"]
     assert content["protocol"]["protocol_version"] == PROTOCOL_VERSION
     assert len(content["seed_summaries"]) == 30
-    assert "coadaptation_uplift_over_learner_only" in content["aggregate"]
+    assert (
+        "coadaptation_uplift_over_learner_only"
+        in content["aggregate"]
+    )
     excluded = content["protocol"]["excluded_claims"]
     assert "general feature discovery" in excluded
     assert "intelligence amplification or recommendation intervention" in excluded
-    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(range(30, 60))
-    recovery_interval = content["aggregate"]["recurrence_recovery_fraction_interval"]
+    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(
+        range(30, 60)
+    )
+    recovery_interval = content["aggregate"][
+        "recurrence_recovery_fraction_interval"
+    ]
     assert recovery_interval["method"] == "wilson-score"
     assert recovery_interval["sample_size"] == 30
-    assert recovery_interval["lower"] < content["aggregate"]["recurrence_recovery_fraction"]
+    assert recovery_interval["lower"] < content["aggregate"][
+        "recurrence_recovery_fraction"
+    ]
 
 
 def test_artifact_loader_rejects_duplicate_object_keys(tmp_path) -> None:
@@ -408,9 +430,12 @@ def test_rehashed_incomplete_seed_payload_still_fails_closed(
     assert not validation.valid
     assert not validation.accepted
     assert any(
-        "must contain exactly unique held-out seeds 30-59" in error for error in validation.errors
+        "must contain exactly unique held-out seeds 30-59" in error
+        for error in validation.errors
     )
-    assert any("aggregate.seeds must match" in error for error in validation.errors)
+    assert any(
+        "aggregate.seeds must match" in error for error in validation.errors
+    )
 
 
 def test_rehashed_interval_with_wrong_sample_size_fails_closed(
@@ -486,7 +511,9 @@ def test_cli_fails_for_underpowered_smoke_without_rerun(
     content = artifact["content"]
     assert content["acceptance"]["passed"] is False
     seed_check = next(
-        check for check in content["acceptance"]["checks"] if check["name"] == "seed_count"
+        check
+        for check in content["acceptance"]["checks"]
+        if check["name"] == "seed_count"
     )
     assert seed_check["actual"] == 3.0
     assert seed_check["passed"] is False
@@ -516,7 +543,11 @@ def test_cli_rechecks_impossible_thresholds_without_rerun(
     assert validation.valid
     assert not validation.accepted
     content = artifact["content"]
-    failed = {check["name"] for check in content["acceptance"]["checks"] if not check["passed"]}
+    failed = {
+        check["name"]
+        for check in content["acceptance"]["checks"]
+        if not check["passed"]
+    }
     assert "reward_uplift_over_frozen" in failed
 
 
@@ -541,46 +572,3 @@ def test_cli_rejects_weaker_than_canonical_thresholds_without_rerun(
     assert emitted["accepted"] is False
     assert emitted["valid"] is False
     assert not path.exists()
-
-
-def test_continual_multiagent_config_rejects_booleans_and_non_integers() -> None:
-    with pytest.raises(ValueError, match="phase_steps"):
-        ContinualMultiAgentConfig(phase_steps=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="phase_steps"):
-        ContinualMultiAgentConfig(phase_steps=64.5)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="nuisance_dim"):
-        ContinualMultiAgentConfig(nuisance_dim=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="bootstrap_resamples"):
-        ContinualMultiAgentConfig(bootstrap_resamples=1000.5)  # type: ignore[arg-type]
-
-
-def test_continual_multiagent_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    cfg = ContinualMultiAgentConfig(
-        phase_steps=np.int32(64),
-        nuisance_dim=np.int64(4),
-        probe_horizon=np.uint16(12),
-        probe_tail_steps=np.uint8(4),
-        recovery_window=np.int32(4),
-        bootstrap_resamples=np.int64(10_000),
-        bootstrap_seed=np.uint32(2_026_073_000),
-    )
-    assert type(cfg.phase_steps) is int
-    assert type(cfg.nuisance_dim) is int
-    assert type(cfg.probe_horizon) is int
-    assert type(cfg.probe_tail_steps) is int
-    assert type(cfg.recovery_window) is int
-    assert type(cfg.bootstrap_resamples) is int
-    assert type(cfg.bootstrap_seed) is int
-    assert cfg.phase_steps == 64
-    assert cfg.nuisance_dim == 4
-
-
-def test_acceptance_thresholds_accepts_and_canonicalizes_numpy_integers() -> None:
-    thresholds = AcceptanceThresholds(
-        minimum_seed_count=np.int32(30),
-        evidence_seed_start=np.int64(30),
-    )
-    assert type(thresholds.minimum_seed_count) is int
-    assert type(thresholds.evidence_seed_start) is int
-    assert thresholds.minimum_seed_count == 30
-    assert thresholds.evidence_seed_start == 30

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -94,17 +94,13 @@ def test_three_seed_smoke_cannot_be_promoted_as_scientific_evidence(
 ) -> None:
     assert not smoke_report.acceptance.passed
     seed_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "seed_count"
+        check for check in smoke_report.acceptance.checks if check.name == "seed_count"
     )
     assert not seed_check.passed
     assert seed_check.actual == 3.0
     assert seed_check.threshold == 30.0
     schedule_check = next(
-        check
-        for check in smoke_report.acceptance.checks
-        if check.name == "evidence_seed_schedule"
+        check for check in smoke_report.acceptance.checks if check.name == "evidence_seed_schedule"
     )
     assert not schedule_check.passed
 
@@ -115,9 +111,7 @@ def test_seeded_learning_evidence_is_exactly_reproducible(
     evidence_seed = benchmark_report.aggregate.seeds[0]
     repeated = run_continual_multiagent_benchmark(seeds=(evidence_seed,))
     original = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
 
     assert len(original) == len(repeated.condition_results) == 3
@@ -243,16 +237,14 @@ def test_aggregate_intervals_use_matched_seed_differences(
     }
     reward_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "frozen")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "frozen")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
     )
     coadaptation_differences = np.asarray(
         [
-            prequential[(seed, "joint_adaptive")]
-            - prequential[(seed, "learner_only")]
+            prequential[(seed, "joint_adaptive")] - prequential[(seed, "learner_only")]
             for seed in benchmark_report.aggregate.seeds
         ],
         dtype=np.float64,
@@ -271,9 +263,7 @@ def test_public_aggregation_rejects_duplicate_seed_weighting(
 ) -> None:
     evidence_seed = benchmark_report.aggregate.seeds[0]
     one_seed = tuple(
-        result
-        for result in benchmark_report.condition_results
-        if result.seed == evidence_seed
+        result for result in benchmark_report.condition_results if result.seed == evidence_seed
     )
     with pytest.raises(ValueError, match="unique"):
         aggregate_evidence(one_seed + one_seed)
@@ -299,10 +289,7 @@ def test_artifact_has_deterministic_scientific_content_and_digest(
     operational = changed_diagnostics["operational_diagnostics"]
     assert isinstance(operational, dict)
     operational["maximum_update_latency_ms"] = 123_456.0
-    assert (
-        changed_diagnostics["content_digest"]["sha256"]
-        == first["content_digest"]["sha256"]
-    )
+    assert changed_diagnostics["content_digest"]["sha256"] == first["content_digest"]["sha256"]
     validation = validate_evidence_artifact(changed_diagnostics)
     assert not validation.valid
     assert not validation.accepted
@@ -326,24 +313,15 @@ def test_artifact_is_strict_json_with_narrow_claim_and_seed_evidence(
     content = loaded["content"]
     assert content["protocol"]["protocol_version"] == PROTOCOL_VERSION
     assert len(content["seed_summaries"]) == 30
-    assert (
-        "coadaptation_uplift_over_learner_only"
-        in content["aggregate"]
-    )
+    assert "coadaptation_uplift_over_learner_only" in content["aggregate"]
     excluded = content["protocol"]["excluded_claims"]
     assert "general feature discovery" in excluded
     assert "intelligence amplification or recommendation intervention" in excluded
-    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(
-        range(30, 60)
-    )
-    recovery_interval = content["aggregate"][
-        "recurrence_recovery_fraction_interval"
-    ]
+    assert content["protocol"]["seed_roles"]["promoted_held_out_evidence"] == list(range(30, 60))
+    recovery_interval = content["aggregate"]["recurrence_recovery_fraction_interval"]
     assert recovery_interval["method"] == "wilson-score"
     assert recovery_interval["sample_size"] == 30
-    assert recovery_interval["lower"] < content["aggregate"][
-        "recurrence_recovery_fraction"
-    ]
+    assert recovery_interval["lower"] < content["aggregate"]["recurrence_recovery_fraction"]
 
 
 def test_artifact_loader_rejects_duplicate_object_keys(tmp_path) -> None:
@@ -430,12 +408,9 @@ def test_rehashed_incomplete_seed_payload_still_fails_closed(
     assert not validation.valid
     assert not validation.accepted
     assert any(
-        "must contain exactly unique held-out seeds 30-59" in error
-        for error in validation.errors
+        "must contain exactly unique held-out seeds 30-59" in error for error in validation.errors
     )
-    assert any(
-        "aggregate.seeds must match" in error for error in validation.errors
-    )
+    assert any("aggregate.seeds must match" in error for error in validation.errors)
 
 
 def test_rehashed_interval_with_wrong_sample_size_fails_closed(
@@ -511,9 +486,7 @@ def test_cli_fails_for_underpowered_smoke_without_rerun(
     content = artifact["content"]
     assert content["acceptance"]["passed"] is False
     seed_check = next(
-        check
-        for check in content["acceptance"]["checks"]
-        if check["name"] == "seed_count"
+        check for check in content["acceptance"]["checks"] if check["name"] == "seed_count"
     )
     assert seed_check["actual"] == 3.0
     assert seed_check["passed"] is False
@@ -543,11 +516,7 @@ def test_cli_rechecks_impossible_thresholds_without_rerun(
     assert validation.valid
     assert not validation.accepted
     content = artifact["content"]
-    failed = {
-        check["name"]
-        for check in content["acceptance"]["checks"]
-        if not check["passed"]
-    }
+    failed = {check["name"] for check in content["acceptance"]["checks"] if not check["passed"]}
     assert "reward_uplift_over_frozen" in failed
 
 
@@ -572,3 +541,46 @@ def test_cli_rejects_weaker_than_canonical_thresholds_without_rerun(
     assert emitted["accepted"] is False
     assert emitted["valid"] is False
     assert not path.exists()
+
+
+def test_continual_multiagent_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase_steps"):
+        ContinualMultiAgentConfig(phase_steps=64.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nuisance_dim"):
+        ContinualMultiAgentConfig(nuisance_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
+        ContinualMultiAgentConfig(bootstrap_resamples=1000.5)  # type: ignore[arg-type]
+
+
+def test_continual_multiagent_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = ContinualMultiAgentConfig(
+        phase_steps=np.int32(64),
+        nuisance_dim=np.int64(4),
+        probe_horizon=np.uint16(12),
+        probe_tail_steps=np.uint8(4),
+        recovery_window=np.int32(4),
+        bootstrap_resamples=np.int64(10_000),
+        bootstrap_seed=np.uint32(2_026_073_000),
+    )
+    assert type(cfg.phase_steps) is int
+    assert type(cfg.nuisance_dim) is int
+    assert type(cfg.probe_horizon) is int
+    assert type(cfg.probe_tail_steps) is int
+    assert type(cfg.recovery_window) is int
+    assert type(cfg.bootstrap_resamples) is int
+    assert type(cfg.bootstrap_seed) is int
+    assert cfg.phase_steps == 64
+    assert cfg.nuisance_dim == 4
+
+
+def test_acceptance_thresholds_accepts_and_canonicalizes_numpy_integers() -> None:
+    thresholds = AcceptanceThresholds(
+        minimum_seed_count=np.int32(30),
+        evidence_seed_start=np.int64(30),
+    )
+    assert type(thresholds.minimum_seed_count) is int
+    assert type(thresholds.evidence_seed_start) is int
+    assert thresholds.minimum_seed_count == 30
+    assert thresholds.evidence_seed_start == 30

--- a/tests/test_continual_multiagent_validation.py
+++ b/tests/test_continual_multiagent_validation.py
@@ -46,6 +46,24 @@ _THRESHOLD_INTEGER_VALUES = {
     "minimum_seed_count": 30,
     "evidence_seed_start": 30,
 }
+_CONFIG_FLOAT_VALUES = {
+    "learning_rate": 0.15,
+    "exploration_rate": 0.20,
+    "recovery_reward_threshold": 0.70,
+    "stability_reference_reward": 0.75,
+    "confidence_level": 0.95,
+}
+_THRESHOLD_FLOAT_FIELDS = (
+    "minimum_reward_uplift_over_frozen",
+    "minimum_partner_uplift",
+    "minimum_recurrent_a_probe_reward",
+    "maximum_mean_forgetting",
+    "maximum_interference_forgetting",
+    "minimum_recurrence_recovery_fraction",
+    "maximum_mean_recurrence_recovery_steps",
+    "maximum_mean_stability_gap",
+    "maximum_update_latency_ms",
+)
 
 
 class _HostileInt(int):
@@ -63,6 +81,14 @@ class _ClassSpoof:
     @property
     def __class__(self) -> type[int]:  # pragma: no cover - validator must ignore
         return int
+
+    def __repr__(self) -> str:  # pragma: no cover - must not run
+        raise AssertionError("untrusted repr hook executed")
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover - normalized error
+        raise RuntimeError("hostile ratio hook")
 
     def __repr__(self) -> str:  # pragma: no cover - must not run
         raise AssertionError("untrusted repr hook executed")
@@ -125,6 +151,35 @@ def test_thresholds_reject_noncanonical_integer_scalars_without_hooks(
         AcceptanceThresholds(  # type: ignore[arg-type]
             **{field: _bad_integer_scalar(bad_kind)}
         )
+
+
+@pytest.mark.parametrize("field,value", _CONFIG_FLOAT_VALUES.items())
+def test_config_float32_sinks_canonicalize_numpy_scalars(field: str, value: float) -> None:
+    config = ContinualMultiAgentConfig(**{field: np.float64(value)})  # type: ignore[arg-type]
+    assert type(getattr(config, field)) is float
+    assert getattr(config, field) == float(np.float32(value))
+
+
+@pytest.mark.parametrize("field", tuple(_CONFIG_FLOAT_VALUES))
+@pytest.mark.parametrize("bad_kind", ("bool", "nonfinite", "hostile", "class_spoof"))
+def test_config_float32_sinks_fail_closed(field: str, bad_kind: str) -> None:
+    bad = {
+        "bool": True,
+        "nonfinite": float("inf"),
+        "hostile": _HostileFloat(0.5),
+        "class_spoof": _ClassSpoof(),
+    }[bad_kind]
+    with pytest.raises(ValueError, match=field):
+        ContinualMultiAgentConfig(**{field: bad})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("field", _THRESHOLD_FLOAT_FIELDS)
+def test_threshold_float32_sinks_are_finite_and_canonical(field: str) -> None:
+    thresholds = AcceptanceThresholds(**{field: np.float64(0.25)})  # type: ignore[arg-type]
+    assert type(getattr(thresholds, field)) is float
+    assert getattr(thresholds, field) == 0.25
+    with pytest.raises(ValueError, match=field):
+        AcceptanceThresholds(**{field: _HostileFloat(0.25)})  # type: ignore[arg-type]
 
 
 def test_phase_resource_boundary_is_exact_and_allocation_free() -> None:

--- a/tests/test_continual_multiagent_validation.py
+++ b/tests/test_continual_multiagent_validation.py
@@ -1,0 +1,216 @@
+"""Adversarial configuration and resource gates for the multi-agent benchmark."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent import (
+    _MAX_CONFIGURED_ARRAY_NBYTES,
+    AcceptanceThresholds,
+    ContinualMultiAgentConfig,
+    _bootstrap_working_nbytes,
+    _condition_result_array_nbytes,
+    _condition_working_nbytes,
+    _world_array_nbytes,
+    paired_bootstrap_mean_interval,
+    run_continual_multiagent_benchmark,
+)
+
+_INT32_MAX = 2**31 - 1
+_NUMPY_INTEGER_TYPES = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+_CONFIG_INTEGER_VALUES = {
+    "phase_steps": 64,
+    "nuisance_dim": 4,
+    "probe_horizon": 12,
+    "probe_tail_steps": 4,
+    "recovery_window": 4,
+    "bootstrap_resamples": 10_000,
+    "bootstrap_seed": 123,
+}
+_THRESHOLD_INTEGER_VALUES = {
+    "minimum_seed_count": 30,
+    "evidence_seed_start": 30,
+}
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover - must not run
+        raise AssertionError("untrusted index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover - must not run
+        raise AssertionError("untrusted int hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover - must not run
+        raise AssertionError("untrusted repr hook executed")
+
+
+class _ClassSpoof:
+    @property
+    def __class__(self) -> type[int]:  # pragma: no cover - validator must ignore
+        return int
+
+    def __repr__(self) -> str:  # pragma: no cover - must not run
+        raise AssertionError("untrusted repr hook executed")
+
+
+def _bad_integer_scalar(kind: str) -> object:
+    return {
+        "bool": True,
+        "numpy_bool": np.bool_(True),
+        "float": 4.0,
+        "string": "4",
+        "int_subclass": _HostileInt(4),
+        "class_spoof": _ClassSpoof(),
+    }[kind]
+
+
+@pytest.mark.parametrize("field,value", _CONFIG_INTEGER_VALUES.items())
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_config_accepts_every_numpy_integer_family(
+    field: str, value: int, integer_type: type[np.integer],
+) -> None:
+    if value > np.iinfo(integer_type).max:
+        pytest.skip("field domain has no value representable by this NumPy dtype")
+    config = ContinualMultiAgentConfig(**{field: integer_type(value)})  # type: ignore[arg-type]
+    assert getattr(config, field) == value
+    assert type(getattr(config, field)) is int
+
+
+@pytest.mark.parametrize("field,value", _THRESHOLD_INTEGER_VALUES.items())
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_thresholds_accept_every_numpy_integer_family(
+    field: str, value: int, integer_type: type[np.integer],
+) -> None:
+    thresholds = AcceptanceThresholds(**{field: integer_type(value)})  # type: ignore[arg-type]
+    assert getattr(thresholds, field) == value
+    assert type(getattr(thresholds, field)) is int
+
+
+@pytest.mark.parametrize("field", tuple(_CONFIG_INTEGER_VALUES))
+@pytest.mark.parametrize(
+    "bad_kind", ("bool", "numpy_bool", "float", "string", "int_subclass", "class_spoof")
+)
+def test_config_rejects_noncanonical_integer_scalars_without_hooks(
+    field: str, bad_kind: str,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        ContinualMultiAgentConfig(  # type: ignore[arg-type]
+            **{field: _bad_integer_scalar(bad_kind)}
+        )
+
+
+@pytest.mark.parametrize("field", tuple(_THRESHOLD_INTEGER_VALUES))
+@pytest.mark.parametrize(
+    "bad_kind", ("bool", "numpy_bool", "float", "string", "int_subclass", "class_spoof")
+)
+def test_thresholds_reject_noncanonical_integer_scalars_without_hooks(
+    field: str, bad_kind: str,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        AcceptanceThresholds(  # type: ignore[arg-type]
+            **{field: _bad_integer_scalar(bad_kind)}
+        )
+
+
+def test_phase_resource_boundary_is_exact_and_allocation_free() -> None:
+    maximum = _MAX_CONFIGURED_ARRAY_NBYTES // 48
+    assert _condition_working_nbytes(maximum) <= _MAX_CONFIGURED_ARRAY_NBYTES
+    assert _condition_working_nbytes(maximum + 1) > _MAX_CONFIGURED_ARRAY_NBYTES
+    assert ContinualMultiAgentConfig(
+        phase_steps=maximum,
+        probe_horizon=1,
+        probe_tail_steps=1,
+        recovery_window=1,
+    ).phase_steps == maximum
+    with pytest.raises(ValueError, match="phase work arrays"):
+        ContinualMultiAgentConfig(
+            phase_steps=maximum + 1,
+            probe_horizon=1,
+            probe_tail_steps=1,
+            recovery_window=1,
+        )
+
+
+def test_world_resource_boundary_is_exact_and_allocation_free() -> None:
+    maximum = (_MAX_CONFIGURED_ARRAY_NBYTES - 48) // 8
+    state_nbytes, observation_nbytes = _world_array_nbytes(maximum)
+    assert state_nbytes <= _MAX_CONFIGURED_ARRAY_NBYTES
+    assert observation_nbytes <= _MAX_CONFIGURED_ARRAY_NBYTES
+    assert ContinualMultiAgentConfig(nuisance_dim=maximum).nuisance_dim == maximum
+    with pytest.raises(ValueError, match="recurring world observation"):
+        ContinualMultiAgentConfig(nuisance_dim=maximum + 1)
+
+
+def test_bootstrap_resource_formula_and_resample_boundary_are_exact() -> None:
+    maximum = _MAX_CONFIGURED_ARRAY_NBYTES // 24
+    assert _bootstrap_working_nbytes(maximum, 1) <= _MAX_CONFIGURED_ARRAY_NBYTES
+    assert _bootstrap_working_nbytes(maximum + 1, 1) > _MAX_CONFIGURED_ARRAY_NBYTES
+    assert ContinualMultiAgentConfig(bootstrap_resamples=maximum).bootstrap_resamples == maximum
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
+        ContinualMultiAgentConfig(bootstrap_resamples=maximum + 1)
+
+    values = np.ones((2,), dtype=np.float64)
+    overflowing_resamples = _MAX_CONFIGURED_ARRAY_NBYTES // (40) + 1
+    with pytest.raises(ValueError, match="paired bootstrap working arrays"):
+        paired_bootstrap_mean_interval(
+            values,
+            confidence_level=0.95,
+            resamples=overflowing_resamples,
+            seed=0,
+        )
+
+
+def test_retained_result_resource_gate_precedes_seed_materialization() -> None:
+    bytes_per_seed = 3 * _condition_result_array_nbytes(64)
+    first_overflowing_count = _MAX_CONFIGURED_ARRAY_NBYTES // bytes_per_seed + 1
+    with pytest.raises(ValueError, match="retained condition-result arrays"):
+        run_continual_multiagent_benchmark(seeds=range(first_overflowing_count))
+
+
+def test_seed_container_and_scalars_are_hostile_safe() -> None:
+    class HostileTuple(tuple):
+        def __len__(self) -> int:  # pragma: no cover - must not run
+            raise AssertionError("untrusted length hook executed")
+
+        def __repr__(self) -> str:  # pragma: no cover - must not run
+            raise AssertionError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match="actual list, tuple, or range"):
+        run_continual_multiagent_benchmark(seeds=HostileTuple((0,)))
+    with pytest.raises(ValueError, match="seed"):
+        run_continual_multiagent_benchmark(seeds=(_HostileInt(0),))
+
+
+def test_threshold_seed_schedule_stays_inside_signed_jax_seed_domain() -> None:
+    accepted = AcceptanceThresholds(
+        evidence_seed_start=_INT32_MAX,
+        minimum_seed_count=1,
+    )
+    assert accepted.evidence_seed_start + accepted.minimum_seed_count == 2**31
+    with pytest.raises(ValueError, match=r"evidence_seed_start \+ minimum_seed_count"):
+        AcceptanceThresholds(
+            evidence_seed_start=_INT32_MAX,
+            minimum_seed_count=2,
+        )
+
+
+def test_default_configuration_and_thresholds_round_trip_through_canonical_json() -> None:
+    config_payload = json.loads(json.dumps(asdict(ContinualMultiAgentConfig()), sort_keys=True))
+    threshold_payload = json.loads(json.dumps(asdict(AcceptanceThresholds()), sort_keys=True))
+    assert ContinualMultiAgentConfig(**config_payload) == ContinualMultiAgentConfig()
+    assert AcceptanceThresholds(**threshold_payload) == AcceptanceThresholds()


### PR DESCRIPTION
Supersedes #731 while preserving its contributor commit and exact integer-type hardening.

This successor completes the execution-domain audit: the A-B-A phase horizon, recurring-world persistent/observation arrays, per-condition work arrays, retained per-seed result payload, and paired-bootstrap peak arrays are all checked before allocation. Bootstrap seeds use the deliberate uint32 domain; held-out seed schedule arithmetic remains inside the signed JAX-key domain and comparison no longer materializes an attacker-sized expected tuple. Exact list/tuple/range and scalar gates reject hostile subclasses, class spoofing, booleans, and conversion/repr hooks while accepting and canonicalizing every NumPy integer family that intersects each field's valid range. Unrelated test reformatting from the source branch was removed.

This edits the registered `recurring_multiagent_coadaptation` evaluation source and therefore intentionally makes the pinned accepted artifact report source drift until its frozen protocol is separately rerun and strictly validated. No outputs were run, modified, or rehashed.

Verification:
- `pytest tests/test_continual_multiagent_validation.py tests/test_continual_multiagent_benchmark.py tests/test_recurring_multiagent_stream.py -q` (200 passed, 2 representational-domain skips)
- post-final-patch evaluation panel: 179 passed, 2 skips
- scoped Ruff clean
- strict source mypy clean
- diff hygiene clean
