### PR TITLE
fix(reward-model): complete scalar and state contracts

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -54,6 +54,14 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _preflight_state_resources(feature_dim: int) -> None:
+    state_scalars = feature_dim * feature_dim + feature_dim + 2
+    if state_scalars > _INT32_MAX:
+        raise ValueError("reward-model state scalars must fit signed int32")
+    if 4 * state_scalars > _INT32_MAX:
+        raise ValueError("reward-model state bytes must fit signed int32")
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Skip ``0 * inf`` so a disabled error EMA does not poison the diagnostic."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -80,6 +88,7 @@ class RLSRewardModelConfig:
 
     def __post_init__(self) -> None:
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+        _preflight_state_resources(feature_dim)
         forgetting = validated_float32_scalar(
             "forgetting", self.forgetting, positive=True, upper=1.0
         )
@@ -143,7 +152,7 @@ class RLSRewardModel:
 
     def __init__(self, config: RLSRewardModelConfig):
         """Initialize the model."""
-        if not isinstance(config, RLSRewardModelConfig):
+        if type(config) is not RLSRewardModelConfig:
             raise TypeError("config must be an RLSRewardModelConfig")
         self._config = config
 
@@ -216,7 +225,15 @@ class RLSRewardModel:
             raise ValueError(
                 f"features must have shape ({self._config.feature_dim},), got {x.shape}"
             )
-        target = jnp.asarray(reward, dtype=jnp.float32)
+        raw_target = jnp.asarray(reward)
+        if raw_target.shape != ():
+            raise ValueError("reward must be a scalar")
+        if not (
+            jnp.issubdtype(raw_target.dtype, jnp.floating)
+            or jnp.issubdtype(raw_target.dtype, jnp.integer)
+        ):
+            raise TypeError("reward must be real numeric")
+        target = raw_target.astype(jnp.float32)
         prediction = jnp.dot(state.weights, x)
         error = target - prediction
         covariance_features = state.covariance @ x
@@ -270,10 +287,6 @@ class RLSRewardModel:
             gain=jnp.where(update_applied, gain, jnp.zeros_like(gain)),
             update_applied=update_applied,
         )
-
-    def _validated_config(self, config: RLSRewardModelConfig) -> RLSRewardModelConfig:
-        return config
-
 
 __all__ = [
     "RLSRewardModel",

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -14,16 +14,44 @@ trustworthy — the "selective" part of selective model-based updates.
 from __future__ import annotations
 
 import functools
-from dataclasses import dataclass, replace
-from typing import Any
+import operator
+from dataclasses import dataclass
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -49,6 +77,21 @@ class RLSRewardModelConfig:
     forgetting: float = 0.995
     ridge: float = 10.0
     error_decay: float = 0.99
+
+    def __post_init__(self) -> None:
+        feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+        forgetting = validated_float32_scalar(
+            "forgetting", self.forgetting, positive=True, upper=1.0
+        )
+        ridge = validated_float32_scalar("ridge", self.ridge, positive=True)
+        error_decay = validated_float32_scalar(
+            "error_decay", self.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "forgetting", forgetting)
+        object.__setattr__(self, "ridge", ridge)
+        object.__setattr__(self, "error_decay", error_decay)
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-compatible representation."""
@@ -100,7 +143,9 @@ class RLSRewardModel:
 
     def __init__(self, config: RLSRewardModelConfig):
         """Initialize the model."""
-        self._config = self._validated_config(config)
+        if not isinstance(config, RLSRewardModelConfig):
+            raise TypeError("config must be an RLSRewardModelConfig")
+        self._config = config
 
     @property
     def config(self) -> RLSRewardModelConfig:
@@ -127,9 +172,7 @@ class RLSRewardModel:
         feature_dim = self._config.feature_dim
         return RLSRewardModelState(
             weights=jnp.zeros((feature_dim,), dtype=jnp.float32),
-            covariance=(
-                jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge
-            ),
+            covariance=(jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge),
             abs_error_ema=jnp.array(0.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
@@ -181,17 +224,14 @@ class RLSRewardModel:
         denominator = forgetting + jnp.dot(x, covariance_features)
         gain = covariance_features / denominator
         next_weights = state.weights + gain * error
-        next_covariance = (
-            state.covariance - jnp.outer(gain, covariance_features)
-        ) / forgetting
+        next_covariance = (state.covariance - jnp.outer(gain, covariance_features)) / forgetting
 
         error_decay = jnp.asarray(self._config.error_decay, dtype=jnp.float32)
         abs_error = jnp.abs(error)
         next_abs_error_ema = jnp.where(
             state.step_count == 0,
             abs_error,
-            _skip_zero_scale(error_decay, state.abs_error_ema)
-            + (1.0 - error_decay) * abs_error,
+            _skip_zero_scale(error_decay, state.abs_error_ema) + (1.0 - error_decay) * abs_error,
         )
         next_state = RLSRewardModelState(
             weights=next_weights,
@@ -232,21 +272,7 @@ class RLSRewardModel:
         )
 
     def _validated_config(self, config: RLSRewardModelConfig) -> RLSRewardModelConfig:
-        if type(config.feature_dim) is not int or config.feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive builtin integer")
-        forgetting = validated_float32_scalar(
-            "forgetting", config.forgetting, positive=True, upper=1.0
-        )
-        ridge = validated_float32_scalar("ridge", config.ridge, positive=True)
-        error_decay = validated_float32_scalar(
-            "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
-        )
-        return replace(
-            config,
-            forgetting=forgetting,
-            ridge=ridge,
-            error_decay=error_decay,
-        )
+        return config
 
 
 __all__ = [

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -256,3 +258,59 @@ def test_rls_reward_model_config_integer_and_scalar_validation() -> None:
     assert type(cfg.ridge) is float
     assert type(cfg.error_decay) is float
     assert cfg.feature_dim == 8
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_rls_reward_model_config_canonicalizes_every_numpy_integer_family(
+    integer_type: type,
+) -> None:
+    config = RLSRewardModelConfig(feature_dim=integer_type(4))
+
+    assert type(config.feature_dim) is int
+    assert config.feature_dim == 4
+
+
+def test_rls_reward_model_config_rejects_hostile_integer_types_without_repr() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    for value in (HostileInt(4), ClassSpoof()):
+        with pytest.raises(ValueError, match="feature_dim"):
+            RLSRewardModelConfig(feature_dim=value)  # type: ignore[arg-type]
+
+
+def test_rls_reward_model_preflights_quadratic_state_before_allocation() -> None:
+    scalar_limit = (2**31 - 1) // 4
+    last_legal = (math.isqrt(1 + 4 * (scalar_limit - 2)) - 1) // 2
+
+    RLSRewardModelConfig(feature_dim=last_legal)
+    with pytest.raises(ValueError, match="state bytes"):
+        RLSRewardModelConfig(feature_dim=last_legal + 1)
+
+
+@pytest.mark.parametrize("shape", ((1,), (1, 1)))
+def test_rls_reward_model_rejects_non_scalar_rewards_eager_and_outer_jit(
+    shape: tuple[int, ...],
+) -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=2))
+    state = model.init()
+    features = jnp.ones((2,), dtype=jnp.float32)
+    reward = jnp.zeros(shape, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="reward must be a scalar"):
+        model.update(state, features, reward)
+    compiled = jax.jit(lambda value: model.update(state, features, value).state)
+    with pytest.raises(ValueError, match="reward must be a scalar"):
+        compiled(reward)

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -33,11 +33,13 @@ def test_rls_reward_model_feature_shape_guard_is_jit_stable() -> None:
     state = model.init()
     predict = jax.jit(lambda features: model.predict(state, features))
     update = jax.jit(
-        lambda features: model.update(
-            state,
-            features,
-            jnp.array(0.0, dtype=jnp.float32),
-        ).state.weights
+        lambda features: (
+            model.update(
+                state,
+                features,
+                jnp.array(0.0, dtype=jnp.float32),
+            ).state.weights
+        )
     )
 
     chex.assert_shape(predict(jnp.ones((4,), dtype=jnp.float32)), ())
@@ -63,9 +65,7 @@ def test_rls_reward_model_config_roundtrip() -> None:
 
 def test_rls_reward_model_learns_linear_reward() -> None:
     """RLS should quickly fit a deterministic linear reward surface."""
-    model = RLSRewardModel(
-        RLSRewardModelConfig(feature_dim=3, forgetting=1.0, ridge=0.1)
-    )
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=3, forgetting=1.0, ridge=0.1))
     state = model.init()
     true_weights = jnp.array([0.25, -0.5, 0.75], dtype=jnp.float32)
     features = jnp.array(
@@ -94,23 +94,19 @@ def test_rls_reward_model_learns_linear_reward() -> None:
 
 def test_rls_reward_model_rejects_invalid_config() -> None:
     """Invalid numerical settings should fail early."""
-    for config in (
-        RLSRewardModelConfig(feature_dim=0),
-        RLSRewardModelConfig(feature_dim=1, forgetting=0.0),
-        RLSRewardModelConfig(feature_dim=1, ridge=0.0),
-        RLSRewardModelConfig(feature_dim=1, error_decay=1.0),
+    for kwargs in (
+        {"feature_dim": 0},
+        {"feature_dim": 1, "forgetting": 0.0},
+        {"feature_dim": 1, "ridge": 0.0},
+        {"feature_dim": 1, "error_decay": 1.0},
     ):
-        try:
-            RLSRewardModel(config)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError(f"expected ValueError for {config}")
+        with pytest.raises(ValueError):
+            RLSRewardModelConfig(**kwargs)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("value", [True, 1.0, "1", np.int64(1)])
+@pytest.mark.parametrize("value", [True, 1.0, "1", [1]])
 def test_rls_reward_model_rejects_non_builtin_feature_dim(value: object) -> None:
-    """Dimensions must not accept bool or integer-like aliases."""
+    """Dimensions must not accept bool or non-integer aliases."""
     payload = RLSRewardModelConfig(feature_dim=1).to_config()
     payload["feature_dim"] = value
 
@@ -202,9 +198,7 @@ def test_rls_reward_model_canonicalizes_numpy_scalars() -> None:
 
 def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     """Inf reward * a silent feature's zero gain is 0*inf = NaN."""
-    model = RLSRewardModel(
-        RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0)
-    )
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0))
     state = model.init()
     features = jnp.array([0.0, 1.0], dtype=jnp.float32)
 
@@ -217,9 +211,7 @@ def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     assert float(poisoned.error) == 0.0
     chex.assert_trees_all_close(poisoned.gain, jnp.zeros_like(poisoned.gain))
 
-    recovered = model.update(
-        poisoned.state, features, jnp.array(1.0, dtype=jnp.float32)
-    )
+    recovered = model.update(poisoned.state, features, jnp.array(1.0, dtype=jnp.float32))
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.covariance)
     assert bool(recovered.update_applied)
@@ -231,9 +223,7 @@ def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
         RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0, error_decay=0.0)
     )
     features = jnp.array([0.0, 1.0], dtype=jnp.float32)
-    state = model.update(
-        model.init(), features, jnp.array(1.0, dtype=jnp.float32)
-    ).state
+    state = model.update(model.init(), features, jnp.array(1.0, dtype=jnp.float32)).state
     state = state.replace(abs_error_ema=jnp.asarray(jnp.inf, dtype=jnp.float32))
     raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
     assert not bool(jnp.isfinite(raw))
@@ -241,3 +231,28 @@ def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
     result = model.update(state, features, jnp.array(0.5, dtype=jnp.float32))
     assert bool(result.update_applied)
     assert bool(jnp.isfinite(result.state.abs_error_ema))
+
+
+def test_rls_reward_model_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=0)
+    with pytest.raises(ValueError, match="forgetting"):
+        RLSRewardModelConfig(feature_dim=2, forgetting=float("nan"))
+    with pytest.raises(ValueError, match="ridge"):
+        RLSRewardModelConfig(feature_dim=2, ridge=0.0)
+
+    cfg = RLSRewardModelConfig(
+        feature_dim=np.int32(8),
+        forgetting=np.float32(0.95),
+        ridge=np.float32(5.0),
+        error_decay=np.float32(0.8),
+    )
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.forgetting) is float
+    assert type(cfg.ridge) is float
+    assert type(cfg.error_decay) is float
+    assert cfg.feature_dim == 8


### PR DESCRIPTION
Supersedes #745 while preserving its contributor commit. The original config hardening correctly adopts shared float32 validation, but an individually legal feature_dim could still request a quadratic covariance larger than the signed-int32 state/byte domain; the model constructor also retained a spoofable isinstance boundary, and update silently accepted vector reward aliases that could alter state shapes. This successor adds exact quadratic state preflight before JAX allocation, an exact config boundary, and scalar reward guards under eager and outer JIT. Tests cover all dtype-derived NumPy integer families, hostile subclasses/spoofs without repr execution, adjacent allocation-free covariance bounds, and row/vector reward aliases. Verification: 60 tests passed; scoped Ruff and strict mypy clean; diff-check clean. No registered evidence source or outputs are changed.