### PR TITLE
fix(sigreg): complete scalar and representation contracts

### DIFF
--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import dataclasses
 import math
 import numbers
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -35,10 +36,35 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float
 
-_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
-_KERNEL_WIDTH_ERROR = (
-    "kernel_width must be positive and finite in float32 kernel arithmetic"
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
 )
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_KERNEL_WIDTH_ERROR = "kernel_width must be positive and finite in float32 kernel arithmetic"
 _SAMPLES_FINITE_ERROR = "samples must be finite"
 _EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
 _DIRECTIONS_FINITE_ERROR = "directions must be finite"
@@ -67,9 +93,7 @@ def _normalized_positive_float32(
         squared32 = np.float32(value32 * value32)
     if not math.isfinite(float(value32)) or float(value32) < _FLOAT32_TINY:
         raise ValueError(message)
-    if squared and (
-        not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY
-    ):
+    if squared and (not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY):
         raise ValueError(message)
     return concrete
 
@@ -93,14 +117,14 @@ class SIGRegConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        if type(self.n_projections) is not int or self.n_projections <= 0:
-            raise ValueError("n_projections must be positive")
+        n_projections = _require_int32("n_projections", self.n_projections, minimum=1)
         kernel_width = _normalized_positive_float32(
             "kernel_width",
             self.kernel_width,
             squared=True,
         )
         eps = _normalized_positive_float32("eps", self.eps, squared=False)
+        object.__setattr__(self, "n_projections", n_projections)
         object.__setattr__(self, "kernel_width", kernel_width)
         object.__setattr__(self, "eps", eps)
 
@@ -183,8 +207,7 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     if uncast.shape != ():
         raise ValueError(_KERNEL_WIDTH_ERROR)
     if not (
-        jnp.issubdtype(uncast.dtype, jnp.integer)
-        or jnp.issubdtype(uncast.dtype, jnp.floating)
+        jnp.issubdtype(uncast.dtype, jnp.integer) or jnp.issubdtype(uncast.dtype, jnp.floating)
     ):
         raise ValueError(_KERNEL_WIDTH_ERROR)
 
@@ -221,9 +244,7 @@ def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     diffs = x[:, None] - x[None, :]
     empirical = jnp.mean(jnp.exp(-(diffs**2) / (2.0 * width_squared)))
     cross_scale = jnp.sqrt(width_squared / (width_squared + 1.0))
-    cross = jnp.mean(
-        cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0)))
-    )
+    cross = jnp.mean(cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0))))
     target = jnp.sqrt(width_squared / (width_squared + 2.0))
     return jnp.maximum(empirical - 2.0 * cross + target, 0.0)
 

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -36,39 +36,40 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
+        *(np.dtype(code).type
+          for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
     }
 )
-
-
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    return canonical
-
-
-_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
-_KERNEL_WIDTH_ERROR = "kernel_width must be positive and finite in float32 kernel arithmetic"
+_FLOAT32_TINY = float.fromhex("0x1.000000p-126")
+_MIN_KERNEL_WIDTH = float.fromhex("0x1.000000p-63")
+_MAX_KERNEL_WIDTH = float.fromhex("0x1.fffffep+63")
+_KERNEL_WIDTH_ERROR = (
+    "kernel_width must be positive and finite in float32 kernel arithmetic"
+)
 _SAMPLES_FINITE_ERROR = "samples must be finite"
 _EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
 _DIRECTIONS_FINITE_ERROR = "directions must be finite"
 _PROJECTIONS_FINITE_ERROR = "projected samples must be finite"
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
+
+
+def _require_float32_resource(name: str, scalar_count: int) -> None:
+    if not 1 <= scalar_count <= _INT32_MAX or scalar_count > _INT32_MAX // 4:
+        raise ValueError(f"derived {name} float32 allocation must fit in signed int32 bytes")
 
 
 def _normalized_positive_float32(
@@ -77,25 +78,17 @@ def _normalized_positive_float32(
     *,
     squared: bool,
 ) -> float:
-    """Return a concrete real as ``float`` after float32-domain validation."""
+    """Return one operation-safe exact-host and float32 scalar."""
     message = f"{name} must be positive and finite in float32 arithmetic"
-    if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        raise ValueError(message)
     try:
-        concrete = float(value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
-    if not math.isfinite(concrete) or concrete <= 0.0:
-        raise ValueError(message)
-
-    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-        value32 = np.float32(concrete)
-        squared32 = np.float32(value32 * value32)
-    if not math.isfinite(float(value32)) or float(value32) < _FLOAT32_TINY:
-        raise ValueError(message)
-    if squared and (not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY):
-        raise ValueError(message)
-    return concrete
+        return validated_float32_scalar(
+            name,
+            value,
+            lower=_MIN_KERNEL_WIDTH if squared else _FLOAT32_TINY,
+            upper=_MAX_KERNEL_WIDTH if squared else None,
+        )
+    except ValueError as error:
+        raise ValueError(message) from error
 
 
 @dataclasses.dataclass(frozen=True)
@@ -137,8 +130,14 @@ class SIGRegConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> SIGRegConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("SIGRegConfig must be an actual dict")
         payload = dict(config)
-        payload.pop("type", None)
+        if set(payload) != {"type", "n_projections", "kernel_width", "eps"}:
+            raise ValueError("SIGRegConfig fields do not match its schema")
+        type_name = payload.pop("type")
+        if type(type_name) is not str or type_name != "SIGRegConfig":
+            raise ValueError("type must be SIGRegConfig")
         return cls(**payload)
 
 
@@ -207,7 +206,8 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     if uncast.shape != ():
         raise ValueError(_KERNEL_WIDTH_ERROR)
     if not (
-        jnp.issubdtype(uncast.dtype, jnp.integer) or jnp.issubdtype(uncast.dtype, jnp.floating)
+        jnp.issubdtype(uncast.dtype, jnp.integer)
+        or jnp.issubdtype(uncast.dtype, jnp.floating)
     ):
         raise ValueError(_KERNEL_WIDTH_ERROR)
 
@@ -237,6 +237,37 @@ def _require_finite_array(values: Array, message: str) -> Array:
     return _runtime_checked_value(array, predicate, message)
 
 
+def _preflight_projected_statistic(
+    embeddings: Array,
+    directions: Array,
+) -> tuple[Array, Array, int, int]:
+    z = jnp.asarray(embeddings, dtype=jnp.float32)
+    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    if z.ndim < 2:
+        raise ValueError("embeddings must have shape (..., latent_dim)")
+    if dirs.ndim != 2 or dirs.shape[0] < 1 or dirs.shape[1] != z.shape[-1]:
+        raise ValueError("directions must have shape (n_projections, latent_dim)")
+    sample_count = math.prod(z.shape[:-1])
+    if sample_count < 1:
+        raise ValueError("embeddings must contain at least one sample")
+    n_projections = dirs.shape[0]
+    projection_scalars = sample_count * n_projections
+    pairwise_scalars = sample_count * sample_count * n_projections
+    _require_float32_resource(
+        "projected pairwise workspace",
+        projection_scalars + 3 * pairwise_scalars,
+    )
+    return z, dirs, sample_count, n_projections
+
+
+def _stable_std(values: Array, *, axis: int) -> Array:
+    """Compute float32 standard deviation without overflowing finite inputs."""
+    scale = jnp.max(jnp.abs(values), axis=axis, keepdims=True)
+    safe_scale = jnp.where(scale == 0.0, jnp.ones_like(scale), scale)
+    normalized = values / safe_scale
+    return jnp.std(normalized, axis=axis) * jnp.squeeze(scale, axis=axis)
+
+
 def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     """Compute the statistic after ``width`` has passed boundary validation."""
     x = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
@@ -244,7 +275,9 @@ def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     diffs = x[:, None] - x[None, :]
     empirical = jnp.mean(jnp.exp(-(diffs**2) / (2.0 * width_squared)))
     cross_scale = jnp.sqrt(width_squared / (width_squared + 1.0))
-    cross = jnp.mean(cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0))))
+    cross = jnp.mean(
+        cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0)))
+    )
     target = jnp.sqrt(width_squared / (width_squared + 2.0))
     return jnp.maximum(empirical - 2.0 * cross + target, 0.0)
 
@@ -256,8 +289,8 @@ def sample_sigreg_directions(
 ) -> Float[Array, "n_projections latent_dim"]:
     """Sample random unit directions for sliced SIGReg."""
     cfg = config or SIGRegConfig()
-    if latent_dim <= 0:
-        raise ValueError("latent_dim must be positive")
+    latent_dim = _require_int32("latent_dim", latent_dim, minimum=1)
+    _require_float32_resource("SIGReg directions", cfg.n_projections * latent_dim)
     directions = jax.random.normal(
         key,
         (cfg.n_projections, latent_dim),
@@ -284,10 +317,13 @@ def epps_pulley_gaussian_statistic(
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
     width = _validated_kernel_width(kernel_width)
-    checked = _require_finite_array(
-        jnp.asarray(samples, dtype=jnp.float32),
-        _SAMPLES_FINITE_ERROR,
+    flattened = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
+    if flattened.size < 1:
+        raise ValueError("samples must be non-empty")
+    _require_float32_resource(
+        "Epps-Pulley pairwise workspace", 3 * flattened.size * flattened.size
     )
+    checked = _require_finite_array(flattened, _SAMPLES_FINITE_ERROR)
     return _epps_pulley_gaussian_statistic(checked, width)
 
 
@@ -308,10 +344,7 @@ def sliced_sigreg_loss(
     Returns:
         Mean one-dimensional Epps-Pulley/BHEP statistic across directions.
     """
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
-    if z.ndim < 2:
-        raise ValueError("embeddings must have shape (..., latent_dim)")
+    z, dirs, _, _ = _preflight_projected_statistic(embeddings, directions)
     width = _validated_kernel_width(kernel_width)
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
@@ -331,14 +364,13 @@ def sigreg_diagnostics(
 ) -> SIGRegDiagnostics:
     """Return SIGReg loss plus simple latent distribution diagnostics."""
     cfg = config or SIGRegConfig()
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    z, dirs, _, _ = _preflight_projected_statistic(embeddings, directions)
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
     projected = _require_finite_array(flat @ dirs.T, _PROJECTIONS_FINITE_ERROR)
-    latent_std = jnp.std(flat, axis=0)
-    projected_std = jnp.std(projected, axis=0)
+    latent_std = _stable_std(flat, axis=0)
+    projected_std = _stable_std(projected, axis=0)
     return SIGRegDiagnostics(
         loss=sliced_sigreg_loss(flat, dirs, kernel_width=cfg.kernel_width),
         latent_mean_abs=jnp.mean(jnp.abs(jnp.mean(flat, axis=0))),

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -72,9 +72,7 @@ def test_epps_pulley_rejects_invalid_static_kernel_width(kernel_width: object) -
 
 def test_epps_pulley_dynamic_jit_keeps_valid_width_and_signals_invalid_widths() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
-    compiled = jax.jit(
-        lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
-    )
+    compiled = jax.jit(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
 
     eager = epps_pulley_gaussian_statistic(samples, kernel_width=1.0)
     chex.assert_trees_all_close(compiled(jnp.asarray(1.0)), eager, atol=1.0e-6)
@@ -103,9 +101,7 @@ def test_epps_pulley_accepts_supported_concrete_real_scalars() -> None:
 def test_epps_pulley_vmap_preserves_valid_widths_and_signals_invalid_lanes() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
     mapped = jax.jit(
-        jax.vmap(
-            lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
-        )
+        jax.vmap(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
     )
     valid_widths = jnp.asarray([0.5, 1.0, 2.0], dtype=jnp.float32)
     expected = jnp.asarray(
@@ -178,7 +174,7 @@ def test_sigreg_config_rejects_invalid_static_numeric_contracts() -> None:
     ):
         with pytest.raises(ValueError):
             SIGRegConfig(eps=bad_eps)  # type: ignore[arg-type]
-    for bad_count in (0, -1, True, 1.0, np.int64(1)):
+    for bad_count in (0, -1, True, 1.0, "1", [1]):
         with pytest.raises(ValueError):
             SIGRegConfig(n_projections=bad_count)  # type: ignore[arg-type]
 
@@ -300,3 +296,24 @@ def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
     assert bool(jnp.isfinite(directions).all())
     with pytest.raises(ValueError, match="projected samples must be finite"):
         sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sigreg_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=32.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=0)
+
+
+def test_sigreg_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = SIGRegConfig(
+        n_projections=np.int32(64),
+        kernel_width=np.float32(1.5),
+        eps=np.float32(1e-7),
+    )
+    assert type(cfg.n_projections) is int
+    assert type(cfg.kernel_width) is float
+    assert type(cfg.eps) is float
+    assert cfg.n_projections == 64

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -33,6 +33,95 @@ def test_sigreg_config_roundtrip_and_direction_shapes() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "integer_type",
+    sorted(
+        {np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")},
+        key=lambda value: value.__name__,
+    ),
+)
+def test_sigreg_accepts_every_numpy_integer_family(integer_type) -> None:
+    config = SIGRegConfig(n_projections=integer_type(2))
+    assert type(config.n_projections) is int
+    directions = sample_sigreg_directions(jr.key(0), integer_type(3), config)
+    assert directions.shape == (2, 3)
+
+
+def test_sigreg_rejects_integer_spoofs_without_hooks_or_repr() -> None:
+    class HostileInt(int):
+        def __index__(self):
+            raise AssertionError("subclass hook executed")
+
+        def __repr__(self):
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=HostileInt(2))
+    with pytest.raises(ValueError, match="latent_dim"):
+        sample_sigreg_directions(jr.key(0), HostileInt(2))
+
+
+def test_sigreg_config_schema_is_exact() -> None:
+    config = SIGRegConfig(n_projections=np.int32(3))
+    payload = config.to_config()
+    assert SIGRegConfig.from_config(payload) == config
+    with pytest.raises(ValueError, match="actual dict"):
+        SIGRegConfig.from_config(type("DictSubclass", (dict,), {})(payload))
+    with pytest.raises(ValueError, match="schema"):
+        SIGRegConfig.from_config({**payload, "unknown": 1})
+    with pytest.raises(ValueError, match="type"):
+        SIGRegConfig.from_config({**payload, "type": "wrong"})
+
+
+def test_sigreg_config_float_hooks_fail_closed_once() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self):
+            type(self).calls += 1
+            raise RuntimeError("hostile ratio")
+
+        def __repr__(self):
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="kernel_width"):
+        SIGRegConfig(kernel_width=HostileFloat(1.0))
+    assert HostileFloat.calls == 1
+
+
+def test_sigreg_preflights_direction_and_pairwise_resources_without_allocating() -> None:
+    config = SIGRegConfig(n_projections=(2**31 - 1) // 4 + 1)
+    with pytest.raises(ValueError, match="directions"):
+        sample_sigreg_directions(jr.key(0), 1, config)
+
+    samples = jnp.zeros((23_171,), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="pairwise workspace"):
+        epps_pulley_gaussian_statistic(samples)
+
+    embeddings = jnp.zeros((1_000, 1), dtype=jnp.float32)
+    directions = jnp.ones((600, 1), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="projected pairwise workspace"):
+        sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sigreg_rejects_mismatched_or_empty_representation_shapes() -> None:
+    with pytest.raises(ValueError, match="directions must have shape"):
+        sliced_sigreg_loss(jnp.ones((2, 3)), jnp.ones((2, 2)))
+    with pytest.raises(ValueError, match="at least one sample"):
+        sliced_sigreg_loss(jnp.ones((0, 3)), jnp.ones((2, 3)))
+    with pytest.raises(ValueError, match="non-empty"):
+        epps_pulley_gaussian_statistic(jnp.asarray([], dtype=jnp.float32))
+
+
+def test_sigreg_diagnostics_std_is_finite_at_float32_extremes() -> None:
+    maximum = np.finfo(np.float32).max
+    embeddings = jnp.asarray([[maximum], [-maximum]], dtype=jnp.float32)
+    directions = jnp.ones((1, 1), dtype=jnp.float32)
+    assert not bool(jnp.isfinite(jnp.std(embeddings, axis=0)[0]))
+    diagnostics = sigreg_diagnostics(embeddings, directions, SIGRegConfig(n_projections=1))
+    chex.assert_tree_all_finite(diagnostics)
+
+
 def test_epps_pulley_statistic_penalizes_collapsed_samples() -> None:
     gaussian = jr.normal(jr.key(1), (128,), dtype=jnp.float32)
     collapsed = jnp.zeros((128,), dtype=jnp.float32)
@@ -72,7 +161,9 @@ def test_epps_pulley_rejects_invalid_static_kernel_width(kernel_width: object) -
 
 def test_epps_pulley_dynamic_jit_keeps_valid_width_and_signals_invalid_widths() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
-    compiled = jax.jit(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
+    compiled = jax.jit(
+        lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
+    )
 
     eager = epps_pulley_gaussian_statistic(samples, kernel_width=1.0)
     chex.assert_trees_all_close(compiled(jnp.asarray(1.0)), eager, atol=1.0e-6)
@@ -101,7 +192,9 @@ def test_epps_pulley_accepts_supported_concrete_real_scalars() -> None:
 def test_epps_pulley_vmap_preserves_valid_widths_and_signals_invalid_lanes() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
     mapped = jax.jit(
-        jax.vmap(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
+        jax.vmap(
+            lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
+        )
     )
     valid_widths = jnp.asarray([0.5, 1.0, 2.0], dtype=jnp.float32)
     expected = jnp.asarray(
@@ -174,7 +267,7 @@ def test_sigreg_config_rejects_invalid_static_numeric_contracts() -> None:
     ):
         with pytest.raises(ValueError):
             SIGRegConfig(eps=bad_eps)  # type: ignore[arg-type]
-    for bad_count in (0, -1, True, 1.0, "1", [1]):
+    for bad_count in (0, -1, True, 1.0):
         with pytest.raises(ValueError):
             SIGRegConfig(n_projections=bad_count)  # type: ignore[arg-type]
 
@@ -296,24 +389,3 @@ def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
     assert bool(jnp.isfinite(directions).all())
     with pytest.raises(ValueError, match="projected samples must be finite"):
         sliced_sigreg_loss(embeddings, directions)
-
-
-def test_sigreg_config_rejects_booleans_and_non_integers() -> None:
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=32.5)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=0)
-
-
-def test_sigreg_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    cfg = SIGRegConfig(
-        n_projections=np.int32(64),
-        kernel_width=np.float32(1.5),
-        eps=np.float32(1e-7),
-    )
-    assert type(cfg.n_projections) is int
-    assert type(cfg.kernel_width) is float
-    assert type(cfg.eps) is float
-    assert cfg.n_projections == 64


### PR DESCRIPTION
Supersedes #748 while preserving Kayvan-Zahiri original contributor commit and authorship.\n\nThe original NumPy integer-family admission was correct but left the float32-consumed scalars, exact config schema, runtime `latent_dim`, derived representation/workspace allocations, representation shapes, and extreme-value diagnostics incomplete. This successor adds:\n\n- exact trusted Python/full-NumPy integer admission for projection and latent dimensions;\n- one-read hostile-safe exact-host + float32 validation with operation-safe kernel-width square bounds;\n- exact built-in dict, key set, and type marker roundtrip;\n- signed-int32 byte preflights for generated directions, projections, and aggregate Epps-Pulley pairwise intermediates before allocation;\n- explicit nonempty/matching representation shapes;\n- overflow-safe latent/projected standard deviations while preserving JIT/vmap runtime validation semantics.\n\nVerification after rebase: 46/46 SIGReg tests, targeted resource regression, scoped Ruff, strict source mypy, diff-check, clean merge-tree. No evidence artifacts changed.