### PR TITLE
fix(options): complete exact scalar and resource contracts

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -24,16 +24,18 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.multi_head_learner import (
     MultiHeadMLPLearner,
     MultiHeadMLPState,
@@ -52,6 +54,77 @@ STOMP_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+
+
+def _require_int32(
+    name: str,
+    value: object,
+    *,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
+    """Return a canonical exact integer in the signed-int32 domain."""
+
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _stomp_resource_counts(
+    n_options: int,
+    observation_dim: int,
+    n_primitive_actions: int,
+    hidden_sizes: tuple[int, ...],
+) -> dict[str, int]:
+    """Preflight exact config/state counts before STOMP constructs any JAX array."""
+
+    n_total_actions = n_primitive_actions + n_options
+    layer_sizes = (observation_dim, *hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else observation_dim
+    base_parameters = trunk_parameters + n_total_actions * (final_width + 1)
+    base_optimizer_scalars = 2 * len(hidden_sizes) + 2 * n_total_actions
+    base_state_scalars = (
+        2 * base_parameters + base_optimizer_scalars + sum(hidden_sizes) + 3
+    )
+    wrapper_float32_scalars = (
+        n_options * observation_dim * observation_dim
+        + 2 * n_options * n_primitive_actions * observation_dim
+        + 6 * n_options
+        + 2 * observation_dim
+        + 5
+    )
+    wrapper_int32_scalars = n_options + 6
+    wrapper_uint32_scalars = 4
+    wrapper_state_scalars = (
+        wrapper_float32_scalars + wrapper_int32_scalars + wrapper_uint32_scalars
+    )
+    resources = {
+        "n_total_actions": n_total_actions,
+        "spec_array_scalars": 4 * n_options,
+        "spec_array_bytes": 16 * n_options,
+        "base_parameter_scalars": base_parameters,
+        "base_optimizer_scalars": base_optimizer_scalars,
+        "base_state_scalars": base_state_scalars,
+        "base_state_bytes": 4 * base_state_scalars,
+        "wrapper_state_scalars": wrapper_state_scalars,
+        "wrapper_state_bytes": 4 * wrapper_state_scalars,
+        "persistent_state_scalars": base_state_scalars + wrapper_state_scalars,
+        "persistent_state_bytes": 4 * (base_state_scalars + wrapper_state_scalars),
+    }
+    for name, count in resources.items():
+        if not 0 <= count <= _INT32_MAX:
+            raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
+    return resources
 
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
@@ -83,14 +156,30 @@ class SubtaskSpec:
 
     def __post_init__(self) -> None:
         """Validate subtask specification."""
-        if self.feature_index < 0:
-            raise ValueError("feature_index must be non-negative")
-        if not math.isfinite(self.threshold) or self.threshold <= 0.0:
-            raise ValueError("threshold must be finite and positive")
-        if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
-            raise ValueError("pseudo_reward_scale must be finite and positive")
-        if self.max_option_steps < 1:
-            raise ValueError("max_option_steps must be at least 1")
+        object.__setattr__(
+            self,
+            "feature_index",
+            _require_int32("feature_index", self.feature_index, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "threshold",
+            validated_float32_scalar("threshold", self.threshold, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "pseudo_reward_scale",
+            validated_float32_scalar(
+                "pseudo_reward_scale",
+                self.pseudo_reward_scale,
+                positive=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_option_steps",
+            _require_int32("max_option_steps", self.max_option_steps, minimum=1),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1419,18 +1508,50 @@ class STOMPConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        if self.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if self.n_primitive_actions <= 0:
-            raise ValueError("n_primitive_actions must be positive")
+        if type(self.subtask_specs) is not tuple:
+            raise ValueError("subtask_specs must be an actual tuple")
+        if not all(type(spec) is SubtaskSpec for spec in self.subtask_specs):
+            raise ValueError("subtask_specs entries must be actual SubtaskSpec values")
+        if type(self.base_hidden_sizes) is not tuple:
+            raise ValueError("base_hidden_sizes must be an actual tuple")
+
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        n_primitive_actions = _require_int32(
+            "n_primitive_actions", self.n_primitive_actions, minimum=1
+        )
+        hidden_sizes = tuple(
+            _require_int32(f"base_hidden_sizes[{index}]", width, minimum=1)
+            for index, width in enumerate(self.base_hidden_sizes)
+        )
+        try:
+            backups = _require_int32(
+                "option_planning_backups_per_step",
+                self.option_planning_backups_per_step,
+                minimum=0,
+                maximum=_INT32_MAX - 1,
+            )
+        except ValueError as error:
+            raise ValueError(
+                "option_planning_backups_per_step must be a nonnegative integer "
+                "smaller than int32 max"
+            ) from error
+        _stomp_resource_counts(
+            len(self.subtask_specs),
+            observation_dim,
+            n_primitive_actions,
+            hidden_sizes,
+        )
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_primitive_actions", n_primitive_actions)
+        object.__setattr__(self, "base_hidden_sizes", hidden_sizes)
+        object.__setattr__(self, "option_planning_backups_per_step", backups)
+
         for spec in self.subtask_specs:
-            if spec.feature_index >= self.observation_dim:
+            if spec.feature_index >= observation_dim:
                 raise ValueError(
                     f"SubtaskSpec.feature_index={spec.feature_index} >= "
-                    f"observation_dim={self.observation_dim}"
+                    f"observation_dim={observation_dim}"
                 )
-            if spec.max_option_steps > _INT32_MAX:
-                raise ValueError("SubtaskSpec.max_option_steps must fit int32 telemetry")
         for step_size_name in (
             "base_step_size",
             "base_avg_reward_step_size",
@@ -1438,9 +1559,15 @@ class STOMPConfig:
             "option_avg_reward_step_size",
             "option_model_step_size",
         ):
-            step_size_value: float = getattr(self, step_size_name)
-            if not math.isfinite(step_size_value) or step_size_value < 0.0:
-                raise ValueError(f"{step_size_name} must be finite and non-negative")
+            object.__setattr__(
+                self,
+                step_size_name,
+                validated_float32_scalar(
+                    step_size_name,
+                    getattr(self, step_size_name),
+                    lower=0.0,
+                ),
+            )
         for unit_interval_name in (
             "base_trace_decay",
             "option_trace_decay",
@@ -1448,28 +1575,42 @@ class STOMPConfig:
             "epsilon_base",
             "epsilon_option",
         ):
-            unit_interval_value: float = getattr(self, unit_interval_name)
-            if not math.isfinite(unit_interval_value) or not 0.0 <= unit_interval_value <= 1.0:
-                raise ValueError(f"{unit_interval_name} must be finite and in [0, 1]")
-        if not math.isfinite(self.option_gamma) or not 0.0 <= self.option_gamma <= 1.0:
-            raise ValueError("option_gamma must be finite and in [0, 1]")
-        if self.option_target_epsilon is not None and not (
-            0.0 <= self.option_target_epsilon <= 1.0
-        ):
-            raise ValueError("option_target_epsilon must be in [0, 1] when provided")
-        if self.option_importance_clip <= 0.0:
-            raise ValueError("option_importance_clip must be positive")
-        if (
-            isinstance(self.option_planning_backups_per_step, bool)
-            or not isinstance(self.option_planning_backups_per_step, int)
-            or self.option_planning_backups_per_step < 0
-        ):
-            raise ValueError("option_planning_backups_per_step must be a nonnegative integer")
-        if self.option_planning_backups_per_step >= _INT32_MAX:
-            raise ValueError(
-                "option_planning_backups_per_step must be smaller than int32 max"
+            object.__setattr__(
+                self,
+                unit_interval_name,
+                validated_float32_scalar(
+                    unit_interval_name,
+                    getattr(self, unit_interval_name),
+                    lower=0.0,
+                    upper=1.0,
+                ),
             )
-        if not self.subtask_specs and self.option_planning_backups_per_step != 0:
+        object.__setattr__(
+            self,
+            "option_gamma",
+            validated_float32_scalar(
+                "option_gamma", self.option_gamma, lower=0.0, upper=1.0
+            ),
+        )
+        if self.option_target_epsilon is not None:
+            object.__setattr__(
+                self,
+                "option_target_epsilon",
+                validated_float32_scalar(
+                    "option_target_epsilon",
+                    self.option_target_epsilon,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "option_importance_clip",
+            validated_float32_scalar(
+                "option_importance_clip", self.option_importance_clip, positive=True
+            ),
+        )
+        if not self.subtask_specs and backups != 0:
             raise ValueError(
                 "primitive-only STOMP requires option_planning_backups_per_step == 0"
             )
@@ -1513,13 +1654,66 @@ class STOMPConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> STOMPConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
-        payload.pop("type", None)
-        specs_raw = payload.pop("subtask_specs", [])
-        specs = tuple(SubtaskSpec(**s) for s in specs_raw)
-        if "base_hidden_sizes" in payload:
-            payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
-        return cls(subtask_specs=specs, **payload)
+        if type(config) is not dict or not all(type(key) is str for key in config):
+            raise ValueError("STOMPConfig payload must be an actual string-keyed dict")
+        payload = config.copy()
+        expected = {field.name for field in dataclasses.fields(cls)} | {"type"}
+        legacy_expected = expected - {"option_planning_backups_per_step"}
+        if set(payload) not in (expected, legacy_expected):
+            raise ValueError("STOMPConfig fields do not match the schema")
+        config_type = payload.pop("type")
+        if type(config_type) is not str or config_type != "STOMPConfig":
+            raise ValueError("unexpected STOMPConfig type")
+        specs_raw = payload.pop("subtask_specs")
+        if type(specs_raw) is not list:
+            raise ValueError("serialized subtask_specs must be a list")
+        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
+        specs: list[SubtaskSpec] = []
+        for raw in specs_raw:
+            if type(raw) is not dict or not all(type(key) is str for key in raw):
+                raise ValueError("serialized subtask_specs entries must be actual dicts")
+            if set(raw) != spec_fields:
+                raise ValueError("serialized SubtaskSpec fields do not match the schema")
+            if type(raw["feature_index"]) is not int or type(raw["max_option_steps"]) is not int:
+                raise ValueError("serialized SubtaskSpec integer fields must be JSON integers")
+            if type(raw["threshold"]) is not float or type(raw["pseudo_reward_scale"]) is not float:
+                raise ValueError("serialized SubtaskSpec scalar fields must be JSON floats")
+            specs.append(SubtaskSpec(**raw))
+        raw_hidden = payload.pop("base_hidden_sizes")
+        if type(raw_hidden) is not list:
+            raise ValueError("serialized base_hidden_sizes must be a list")
+        if not all(type(width) is int for width in raw_hidden):
+            raise ValueError("serialized base_hidden_sizes entries must be JSON integers")
+        if "option_planning_backups_per_step" not in payload:
+            payload["option_planning_backups_per_step"] = 0
+        for name in (
+            "observation_dim",
+            "n_primitive_actions",
+            "option_planning_backups_per_step",
+        ):
+            if type(payload[name]) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+        for name in (
+            "base_step_size",
+            "base_avg_reward_step_size",
+            "base_trace_decay",
+            "option_step_size",
+            "option_avg_reward_step_size",
+            "option_trace_decay",
+            "option_gamma",
+            "option_model_decay",
+            "option_model_step_size",
+            "epsilon_base",
+            "epsilon_option",
+            "option_importance_clip",
+        ):
+            if type(payload[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON float")
+        target_epsilon = payload["option_target_epsilon"]
+        if target_epsilon is not None and type(target_epsilon) is not float:
+            raise ValueError("serialized option_target_epsilon must be null or a JSON float")
+        payload["base_hidden_sizes"] = tuple(raw_hidden)
+        return cls(subtask_specs=tuple(specs), **payload)
 
 
 # ---------------------------------------------------------------------------

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -25,14 +25,12 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
-import operator
-from typing import Any, SupportsIndex, cast
+from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -54,37 +52,6 @@ STOMP_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
-
-
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    return canonical
-
-
-def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
-    if type(sizes) is not tuple:
-        raise ValueError("base_hidden_sizes must be an actual tuple")
-    return tuple(_require_int32("base_hidden_sizes element", s, minimum=1) for s in sizes)
-
 
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
@@ -116,20 +83,14 @@ class SubtaskSpec:
 
     def __post_init__(self) -> None:
         """Validate subtask specification."""
-        object.__setattr__(
-            self,
-            "feature_index",
-            _require_int32("feature_index", self.feature_index, minimum=0),
-        )
-        object.__setattr__(
-            self,
-            "max_option_steps",
-            _require_int32("max_option_steps", self.max_option_steps, minimum=1),
-        )
+        if self.feature_index < 0:
+            raise ValueError("feature_index must be non-negative")
         if not math.isfinite(self.threshold) or self.threshold <= 0.0:
             raise ValueError("threshold must be finite and positive")
         if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
             raise ValueError("pseudo_reward_scale must be finite and positive")
+        if self.max_option_steps < 1:
+            raise ValueError("max_option_steps must be at least 1")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -353,7 +314,9 @@ def _all_floating_leaves_finite(tree: Any) -> Array:
     """Bounded full-tree finiteness check, excluding typed PRNG keys."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
+            leaf.dtype, jax.dtypes.prng_key
+        ):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.inexact):
@@ -365,7 +328,9 @@ def _all_integer_leaves_nonnegative(tree: Any) -> Array:
     """Check learner/model counter leaves without constraining float values."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
+            leaf.dtype, jax.dtypes.prng_key
+        ):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.integer):
@@ -443,7 +408,10 @@ def _stomp_action_ownership_valid(
     )
     active_valid = (
         active
-        & (state.base_last_action == n_primitive_actions + state.executing_option)
+        & (
+            state.base_last_action
+            == n_primitive_actions + state.executing_option
+        )
         & (state.option_last_intra_action == state.last_primitive_action)
     )
     return primitive_valid & (idle_valid | active_valid)
@@ -491,7 +459,8 @@ def _stomp_static_dispatch_contract(
         state.base_learner_state.step_count,
     )
     static_valid = all(
-        value.shape == expected and value.dtype == jnp.float32 for value, expected in float32_shapes
+        value.shape == expected and value.dtype == jnp.float32
+        for value, expected in float32_shapes
     )
     static_valid = static_valid and all(
         value.shape == () and value.dtype == jnp.float32 for value in scalar_float32
@@ -590,8 +559,9 @@ def _stomp_static_dispatch_contract(
                     and optimizer_state.step_size.shape == ()
                     and optimizer_state.step_size.dtype == jnp.float32
                 )
-    rng_key_valid = state.rng_key.shape == () and jax.dtypes.issubdtype(
-        state.rng_key.dtype, jax.dtypes.prng_key
+    rng_key_valid = (
+        state.rng_key.shape == ()
+        and jax.dtypes.issubdtype(state.rng_key.dtype, jax.dtypes.prng_key)
     )
     return static_valid, rng_key_valid
 
@@ -625,7 +595,8 @@ def replace_dispatched_primitive_action(
 
     raw_observation = jnp.asarray(decision_observation)
     observation_static_contract_valid = (
-        raw_observation.shape == (observation_dim,) and raw_observation.dtype == jnp.float32
+        raw_observation.shape == (observation_dim,)
+        and raw_observation.dtype == jnp.float32
     )
     obs = (
         raw_observation
@@ -637,7 +608,9 @@ def replace_dispatched_primitive_action(
         raw_proposal.shape == () and raw_proposal.dtype == jnp.int32
     )
     proposal = (
-        raw_proposal if proposed_action_static_contract_valid else jnp.asarray(-1, dtype=jnp.int32)
+        raw_proposal
+        if proposed_action_static_contract_valid
+        else jnp.asarray(-1, dtype=jnp.int32)
     )
     if safety_action_mask is None:
         safety = jnp.ones((n_primitive_actions,), dtype=jnp.bool_)
@@ -645,7 +618,8 @@ def replace_dispatched_primitive_action(
     else:
         raw_safety = jnp.asarray(safety_action_mask)
         safety_action_mask_static_contract_valid = (
-            raw_safety.shape == (n_primitive_actions,) and raw_safety.dtype == jnp.bool_
+            raw_safety.shape == (n_primitive_actions,)
+            and raw_safety.dtype == jnp.bool_
         )
         safety = (
             raw_safety
@@ -654,7 +628,9 @@ def replace_dispatched_primitive_action(
         )
 
     no_option = state.executing_option == -1
-    option_index_valid = (state.executing_option >= 0) & (state.executing_option < n_options)
+    option_index_valid = (state.executing_option >= 0) & (
+        state.executing_option < n_options
+    )
     owner = jnp.where(
         no_option,
         jnp.asarray(DISPATCH_OWNER_BASE_PRIMITIVE, dtype=jnp.int32),
@@ -665,7 +641,9 @@ def replace_dispatched_primitive_action(
         ),
     )
     counterfactual = state.last_primitive_action
-    counterfactual_valid = (counterfactual >= 0) & (counterfactual < n_primitive_actions)
+    counterfactual_valid = (counterfactual >= 0) & (
+        counterfactual < n_primitive_actions
+    )
     base_owner_valid = (
         no_option
         & (state.base_last_action >= 0)
@@ -677,7 +655,10 @@ def replace_dispatched_primitive_action(
         & (state.base_last_action == n_primitive_actions + state.executing_option)
         & (state.option_last_intra_action == counterfactual)
     )
-    ownership_valid = counterfactual_valid & (base_owner_valid | option_owner_valid)
+    ownership_valid = (
+        counterfactual_valid
+        & (base_owner_valid | option_owner_valid)
+    )
     static_contract_valid, typed_rng_key_valid = _stomp_static_dispatch_contract(
         state,
         n_options=n_options,
@@ -772,7 +753,9 @@ def replace_dispatched_primitive_action(
             owner,
             jnp.asarray(DISPATCH_OWNER_INVALID, dtype=jnp.int32),
         ),
-        state_static_contract_valid=jnp.asarray(static_contract_valid, dtype=jnp.bool_),
+        state_static_contract_valid=jnp.asarray(
+            static_contract_valid, dtype=jnp.bool_
+        ),
         state_values_finite=state_values_finite,
         state_counters_valid=state_counters_valid,
         rng_key_valid=jnp.asarray(typed_rng_key_valid, dtype=jnp.bool_),
@@ -921,7 +904,9 @@ def _select_action_epsilon_greedy(
     """ε-greedy action selection with Gumbel tie-breaking."""
     key, explore_key, noise_key = jr.split(key, 3)
     q_vals = _q_values_for_obs(q_weights, observation)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
+        jnp.int32
+    )
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -936,7 +921,9 @@ def _select_action_epsilon_greedy_from_q(
 ) -> tuple[Array, Array]:
     """ε-greedy action selection from pre-computed Q values."""
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
+        jnp.int32
+    )
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1123,7 +1110,12 @@ def _differential_semidp_q_update(
     q_prev = q_weights[last_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_weights, next_obs))
     # The discounted reward and baseline must use the same γ powers.
-    td_error = reward - average_reward * baseline_coefficient + gamma_o * q_next - q_prev
+    td_error = (
+        reward
+        - average_reward * baseline_coefficient
+        + gamma_o * q_next
+        - q_prev
+    )
 
     action_mask = jax.nn.one_hot(last_action, n_actions, dtype=jnp.float32)
     new_traces = lam * traces + action_mask[:, None] * last_obs[None, :]
@@ -1183,7 +1175,9 @@ def _update_option_model(
     new_cumreward = decay * models.cumreward_ema + (1.0 - decay) * pseudo_return
     new_env_return = decay * models.env_return_ema + (1.0 - decay) * env_return
     new_duration = decay * models.duration_ema + (1.0 - decay) * duration
-    new_baseline_mass = decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
+    new_baseline_mass = (
+        decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
+    )
     new_discount = decay * models.discount_ema + (1.0 - decay) * discount
 
     predicted_delta = models.next_state_weights[option_idx] @ start_obs
@@ -1195,7 +1189,9 @@ def _update_option_model(
         jnp.float32
     )
     new_ns_weights = models.next_state_weights + mask[:, None, None] * ns_update[None, :, :]
-    incremented_completions = _saturating_int32_counter_increment(models.n_completions)
+    incremented_completions = _saturating_int32_counter_increment(
+        models.n_completions
+    )
     new_completions = jnp.where(
         mask.astype(jnp.bool_),
         incremented_completions,
@@ -1206,7 +1202,9 @@ def _update_option_model(
         cumreward_ema=jnp.where(mask, new_cumreward, models.cumreward_ema),
         env_return_ema=jnp.where(mask, new_env_return, models.env_return_ema),
         duration_ema=jnp.where(mask, new_duration, models.duration_ema),
-        baseline_mass_ema=jnp.where(mask, new_baseline_mass, models.baseline_mass_ema),
+        baseline_mass_ema=jnp.where(
+            mask, new_baseline_mass, models.baseline_mass_ema
+        ),
         discount_ema=jnp.where(mask, new_discount, models.discount_ema),
         next_state_weights=new_ns_weights,
         n_completions=new_completions,
@@ -1309,7 +1307,9 @@ def _update_intra_option_policy(
     traces_i = option_policies.traces[option_idx]
     avg_r_i = option_policies.average_rewards[option_idx]
     transition_discount = jnp.asarray(discount, dtype=jnp.float32)
-    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(jnp.float32)
+    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(
+        jnp.float32
+    )
 
     q_prev = q_i[last_intra_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_i, next_obs)) * bootstrap_discount
@@ -1419,27 +1419,15 @@ class STOMPConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
-        n_primitive_actions = _require_int32(
-            "n_primitive_actions", self.n_primitive_actions, minimum=1
-        )
-        base_hidden_sizes = _validate_hidden_sizes(self.base_hidden_sizes)
-        backups = _require_int32(
-            "option_planning_backups_per_step",
-            self.option_planning_backups_per_step,
-            minimum=0,
-        )
-
-        object.__setattr__(self, "observation_dim", observation_dim)
-        object.__setattr__(self, "n_primitive_actions", n_primitive_actions)
-        object.__setattr__(self, "base_hidden_sizes", base_hidden_sizes)
-        object.__setattr__(self, "option_planning_backups_per_step", backups)
-
+        if self.observation_dim <= 0:
+            raise ValueError("observation_dim must be positive")
+        if self.n_primitive_actions <= 0:
+            raise ValueError("n_primitive_actions must be positive")
         for spec in self.subtask_specs:
-            if spec.feature_index >= observation_dim:
+            if spec.feature_index >= self.observation_dim:
                 raise ValueError(
                     f"SubtaskSpec.feature_index={spec.feature_index} >= "
-                    f"observation_dim={observation_dim}"
+                    f"observation_dim={self.observation_dim}"
                 )
             if spec.max_option_steps > _INT32_MAX:
                 raise ValueError("SubtaskSpec.max_option_steps must fit int32 telemetry")
@@ -1478,9 +1466,13 @@ class STOMPConfig:
         ):
             raise ValueError("option_planning_backups_per_step must be a nonnegative integer")
         if self.option_planning_backups_per_step >= _INT32_MAX:
-            raise ValueError("option_planning_backups_per_step must be smaller than int32 max")
+            raise ValueError(
+                "option_planning_backups_per_step must be smaller than int32 max"
+            )
         if not self.subtask_specs and self.option_planning_backups_per_step != 0:
-            raise ValueError("primitive-only STOMP requires option_planning_backups_per_step == 0")
+            raise ValueError(
+                "primitive-only STOMP requires option_planning_backups_per_step == 0"
+            )
 
     @property
     def n_options(self) -> int:
@@ -1496,7 +1488,9 @@ class STOMPConfig:
         """Serialize to a JSON-compatible dictionary."""
         return {
             "type": "STOMPConfig",
-            "subtask_specs": [dataclasses.asdict(s) for s in self.subtask_specs],
+            "subtask_specs": [
+                dataclasses.asdict(s) for s in self.subtask_specs
+            ],
             "observation_dim": self.observation_dim,
             "n_primitive_actions": self.n_primitive_actions,
             "base_step_size": self.base_step_size,
@@ -1687,7 +1681,9 @@ class STOMPAgent:
         explicitly. The state also records it in ``last_primitive_action``.
         """
         cfg = self._config
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
+            (cfg.observation_dim,)
+        )
         key = state.rng_key
         q_vals = self._base_learner.predict(state.base_learner_state, obs)
         extended_action, key = _select_action_epsilon_greedy_from_q(
@@ -1795,8 +1791,13 @@ class STOMPAgent:
                 f"({cfg.n_total_actions},), got {raw_mask.shape}"
             )
         if raw_mask.dtype != jnp.bool_:
-            raise TypeError(f"extended_action_mask must have dtype bool, got {raw_mask.dtype}")
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
+            raise TypeError(
+                "extended_action_mask must have dtype bool, "
+                f"got {raw_mask.dtype}"
+            )
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
+            (cfg.observation_dim,)
+        )
         mask_valid = jnp.all(raw_mask[: cfg.n_primitive_actions]) & jnp.any(raw_mask)
         values_valid = jnp.all(jnp.isfinite(obs))
         key = state.rng_key
@@ -1951,7 +1952,9 @@ class STOMPAgent:
 
                 predicted_delta = models.next_state_weights[model_idx] @ anchor_observation
                 predicted_next = anchor_observation + predicted_delta
-                next_q = self._base_learner.predict(current_learner_state, predicted_next)
+                next_q = self._base_learner.predict(
+                    current_learner_state, predicted_next
+                )
                 eligible_next_q = jnp.where(
                     extended_action_mask,
                     next_q,
@@ -1962,11 +1965,9 @@ class STOMPAgent:
                     - average_reward * models.baseline_mass_ema[model_idx]
                     + models.discount_ema[model_idx] * jnp.max(eligible_next_q)
                 )
-                targets = (
-                    jnp.full(cfg.n_total_actions, jnp.nan, dtype=jnp.float32)
-                    .at[option_action]
-                    .set(target)
-                )
+                targets = jnp.full(
+                    cfg.n_total_actions, jnp.nan, dtype=jnp.float32
+                ).at[option_action].set(target)
                 update_result = self._base_learner.update(
                     current_learner_state,
                     anchor_observation,
@@ -2024,7 +2025,9 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError("preselection feature reset requires a linear STOMP base learner")
+                raise ValueError(
+                    "preselection feature reset requires a linear STOMP base learner"
+                )
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2050,7 +2053,8 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
+                    "extended_action_mask must have dtype bool, "
+                    f"got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
             action_mask_valid = jnp.all(action_mask) & jnp.any(action_mask)
@@ -2089,7 +2093,9 @@ class STOMPAgent:
             )
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
+        outer_words, outer_capacity = _checked_lifetime_words_increment(
+            state.step_words
+        )
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2118,17 +2124,15 @@ class STOMPAgent:
         )
         eligible_next_q = jnp.where(action_mask, next_q_values, -jnp.inf)
         td_target = (
-            reward - state.base_average_reward + primitive_discount * jnp.max(eligible_next_q)
+            reward
+            - state.base_average_reward
+            + primitive_discount * jnp.max(eligible_next_q)
         )
-        targets = (
-            jnp.full(
-                cfg.n_primitive_actions,
-                jnp.nan,
-                dtype=jnp.float32,
-            )
-            .at[state.base_last_action]
-            .set(td_target)
-        )
+        targets = jnp.full(
+            cfg.n_primitive_actions,
+            jnp.nan,
+            dtype=jnp.float32,
+        ).at[state.base_last_action].set(td_target)
         trace_adjusted_state = cast(
             MultiHeadMLPState,
             state.base_learner_state.replace(
@@ -2330,7 +2334,9 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError("preselection feature reset requires a linear STOMP base learner")
+                raise ValueError(
+                    "preselection feature reset requires a linear STOMP base learner"
+                )
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2355,12 +2361,13 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
+                    "extended_action_mask must have dtype bool, "
+                    f"got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
-            action_mask_valid = jnp.all(action_mask[: cfg.n_primitive_actions]) & jnp.any(
-                action_mask
-            )
+            action_mask_valid = jnp.all(
+                action_mask[: cfg.n_primitive_actions]
+            ) & jnp.any(action_mask)
         bootstrap_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
             (cfg.observation_dim,)
         )
@@ -2405,7 +2412,9 @@ class STOMPAgent:
             environmental_termination = supplied_discount <= 0.0
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
+        outer_words, outer_capacity = _checked_lifetime_words_increment(
+            state.step_words
+        )
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2426,7 +2435,9 @@ class STOMPAgent:
         # Compute pseudo-reward for the currently-executing (or notional) option
         pseudo_r = compute_pseudo_reward(spec, option_idx, bootstrap_obs)
         target_epsilon = (
-            cfg.epsilon_option if cfg.option_target_epsilon is None else cfg.option_target_epsilon
+            cfg.epsilon_option
+            if cfg.option_target_epsilon is None
+            else cfg.option_target_epsilon
         )
         option_importance_ratio = _clipped_epsilon_greedy_importance_ratio(
             state.option_policies.q_weights[option_idx],
@@ -2463,7 +2474,9 @@ class STOMPAgent:
             )
         else:
             planning_updates_required = jnp.asarray(0, dtype=jnp.int32)
-        nested_updates_required = should_update_base.astype(jnp.int32) + planning_updates_required
+        nested_updates_required = (
+            should_update_base.astype(jnp.int32) + planning_updates_required
+        )
         expected_nested_words, nested_capacity = _checked_lifetime_words_advance(
             state.base_learner_state.step_words,
             nested_updates_required,
@@ -2616,15 +2629,19 @@ class STOMPAgent:
         def do_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            next_q_vals = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
+            next_q_vals = self._base_learner.predict(
+                state.base_learner_state, bootstrap_obs
+            )
             eligible_next_q = jnp.where(action_mask, next_q_vals, -jnp.inf)
             max_next_q = base_discount * jnp.max(eligible_next_q)
-            td_target = base_reward - state.base_average_reward * base_baseline_mass + max_next_q
-            targets = (
-                jnp.full(n_total, jnp.nan, dtype=jnp.float32)
-                .at[state.base_last_action]
-                .set(td_target)
+            td_target = (
+                base_reward
+                - state.base_average_reward * base_baseline_mass
+                + max_next_q
             )
+            targets = jnp.full(n_total, jnp.nan, dtype=jnp.float32).at[
+                state.base_last_action
+            ].set(td_target)
             trace_adjusted_state = cast(
                 MultiHeadMLPState,
                 state.base_learner_state.replace(
@@ -2634,7 +2651,9 @@ class STOMPAgent:
                     )
                 ),
             )
-            result = self._base_learner.update(trace_adjusted_state, base_update_obs, targets)
+            result = self._base_learner.update(
+                trace_adjusted_state, base_update_obs, targets
+            )
             td_err = result.errors[state.base_last_action]
             new_avg_reward = state.base_average_reward + beta * td_err
             return result.state, new_avg_reward, td_err, result.update_applied
@@ -2642,10 +2661,17 @@ class STOMPAgent:
         def skip_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            prev_q = self._base_learner.predict(state.base_learner_state, state.base_last_obs)
-            next_q = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
+            prev_q = self._base_learner.predict(
+                state.base_learner_state, state.base_last_obs
+            )
+            next_q = self._base_learner.predict(
+                state.base_learner_state, bootstrap_obs
+            )
             eligible_next_q = jnp.where(action_mask, next_q, -jnp.inf)
-            td = primitive_discount * jnp.max(eligible_next_q) - prev_q[state.base_last_action]
+            td = (
+                primitive_discount * jnp.max(eligible_next_q)
+                - prev_q[state.base_last_action]
+            )
             return (
                 state.base_learner_state,
                 state.base_average_reward,
@@ -2658,7 +2684,9 @@ class STOMPAgent:
             new_avg_r,
             base_td,
             real_base_update_applied,
-        ) = jax.lax.cond(should_update_base, do_base_update, skip_base_update, None)
+        ) = jax.lax.cond(
+            should_update_base, do_base_update, skip_base_update, None
+        )
 
         # --- Fixed-budget option-model planning ---
         # The zero-backup default is a Python-level static branch: it consumes
@@ -2705,7 +2733,9 @@ class STOMPAgent:
             cfg.epsilon_base,
             action_mask,
         )
-        next_select_extended = (~is_executing) | (is_executing & option_lifecycle_ends)
+        next_select_extended = (~is_executing) | (
+            is_executing & option_lifecycle_ends
+        )
         selected_option = jnp.clip(
             extended_action - cfg.n_primitive_actions,
             0,
@@ -2740,8 +2770,9 @@ class STOMPAgent:
                 jnp.array(-1, dtype=jnp.int32),
             ),
         )
-        is_starting_option = next_select_extended & (
-            extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32)
+        is_starting_option = (
+            next_select_extended
+            & (extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32))
         )
 
         # Primitive action sent to environment
@@ -2756,7 +2787,9 @@ class STOMPAgent:
         )
 
         # Reset option tracking on termination or new option start
-        new_option_start_obs = jnp.where(is_starting_option, decision_obs, state.option_start_obs)
+        new_option_start_obs = jnp.where(
+            is_starting_option, decision_obs, state.option_start_obs
+        )
         new_option_cumreward = jnp.where(
             (is_executing & option_lifecycle_ends) | is_starting_option,
             jnp.array(0.0, dtype=jnp.float32),
@@ -2858,7 +2891,9 @@ class STOMPAgent:
                 new_executing_option,
                 state.executing_option,
             ),
-            option_terminated=transaction_applied & is_executing & option_lifecycle_ends,
+            option_terminated=transaction_applied
+            & is_executing
+            & option_lifecycle_ends,
             pseudo_reward=jnp.where(
                 transaction_applied & is_executing,
                 pseudo_r,
@@ -2929,7 +2964,9 @@ class STOMPAgent:
                 decision_observation=decision_obs,
                 execution_boundary=execution_boundary,
                 extended_action_mask=(
-                    extended_action_mask if extended_action_masks is not None else None
+                    extended_action_mask
+                    if extended_action_masks is not None
+                    else None
                 ),
             )
             return result.state, (
@@ -2988,30 +3025,27 @@ class STOMPAgent:
         if scan_extended_action_masks.dtype != jnp.bool_:
             raise TypeError("extended_action_masks must have dtype bool")
 
-        (
-            final_state,
-            (
-                td_errors,
-                average_rewards,
-                primitive_actions,
-                executing_options,
-                option_terminations,
-                pseudo_rewards,
-                option_importance_ratios,
-                planning_backups,
-                planning_td_errors,
-                pre_step_words,
-                post_step_words,
-                inputs_valid,
-                lifetime_counter_valid,
-                lifetime_capacity_available,
-                nested_lifetime_counter_valid,
-                nested_lifetime_capacity_available,
-                nested_updates_required,
-                nested_updates_applied,
-                proposed_state_valid,
-                update_applied,
-            ),
+        final_state, (
+            td_errors,
+            average_rewards,
+            primitive_actions,
+            executing_options,
+            option_terminations,
+            pseudo_rewards,
+            option_importance_ratios,
+            planning_backups,
+            planning_td_errors,
+            pre_step_words,
+            post_step_words,
+            inputs_valid,
+            lifetime_counter_valid,
+            lifetime_capacity_available,
+            nested_lifetime_counter_valid,
+            nested_lifetime_capacity_available,
+            nested_updates_required,
+            nested_updates_applied,
+            proposed_state_valid,
+            update_applied,
         ) = jax.lax.scan(
             step_fn,
             state,
@@ -3197,11 +3231,15 @@ def stomp_state_to_checkpoint_payload(state: STOMPState) -> dict[str, Any]:
 def _sub_payload_as_dict(value: Any, name: str, cls: type) -> dict[str, Any]:
     """Normalize a nested payload entry to a plain field-keyed dict."""
     if isinstance(value, cls):
-        return {field.name: getattr(value, field.name) for field in dataclasses.fields(cls)}
+        return {
+            field.name: getattr(value, field.name)
+            for field in dataclasses.fields(cls)
+        }
     if isinstance(value, dict):
         return dict(value)
     raise ValueError(
-        f"'{name}' must be a field-keyed dict or {cls.__name__}, got {type(value).__name__}"
+        f"'{name}' must be a field-keyed dict or {cls.__name__}, "
+        f"got {type(value).__name__}"
     )
 
 
@@ -3262,14 +3300,18 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
             f"missing={sorted(missing_state_fields)}"
         )
 
-    models = _sub_payload_as_dict(data.pop("option_models"), "option_models", OptionModelsState)
+    models = _sub_payload_as_dict(
+        data.pop("option_models"), "option_models", OptionModelsState
+    )
     model_field_names = {
         field.name
         for field in dataclasses.fields(OptionModelsState)  # type: ignore[arg-type]
     }
     unknown_models = sorted(set(models) - model_field_names)
     if unknown_models:
-        raise ValueError(f"Unknown OptionModelsState checkpoint fields: {unknown_models}")
+        raise ValueError(
+            f"Unknown OptionModelsState checkpoint fields: {unknown_models}"
+        )
     missing_model_fields = model_field_names - set(models)
     expected_missing_model_fields = (
         set(STOMP_OPTION_MODEL_EXPANSION_FIELDS)
@@ -3298,7 +3340,8 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
     }
     if set(policies) != policy_field_names:
         raise ValueError(
-            f"STOMP option-policy payload fields {sorted(policies)} != {sorted(policy_field_names)}"
+            "STOMP option-policy payload fields "
+            f"{sorted(policies)} != {sorted(policy_field_names)}"
         )
     option_policies = IntraOptionPoliciesState(**policies)
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -52,6 +54,37 @@ STOMP_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
+    if type(sizes) is not tuple:
+        raise ValueError("base_hidden_sizes must be an actual tuple")
+    return tuple(_require_int32("base_hidden_sizes element", s, minimum=1) for s in sizes)
+
 
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
@@ -83,14 +116,20 @@ class SubtaskSpec:
 
     def __post_init__(self) -> None:
         """Validate subtask specification."""
-        if self.feature_index < 0:
-            raise ValueError("feature_index must be non-negative")
+        object.__setattr__(
+            self,
+            "feature_index",
+            _require_int32("feature_index", self.feature_index, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "max_option_steps",
+            _require_int32("max_option_steps", self.max_option_steps, minimum=1),
+        )
         if not math.isfinite(self.threshold) or self.threshold <= 0.0:
             raise ValueError("threshold must be finite and positive")
         if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
             raise ValueError("pseudo_reward_scale must be finite and positive")
-        if self.max_option_steps < 1:
-            raise ValueError("max_option_steps must be at least 1")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -314,9 +353,7 @@ def _all_floating_leaves_finite(tree: Any) -> Array:
     """Bounded full-tree finiteness check, excluding typed PRNG keys."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
-            leaf.dtype, jax.dtypes.prng_key
-        ):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.inexact):
@@ -328,9 +365,7 @@ def _all_integer_leaves_nonnegative(tree: Any) -> Array:
     """Check learner/model counter leaves without constraining float values."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
-            leaf.dtype, jax.dtypes.prng_key
-        ):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.integer):
@@ -408,10 +443,7 @@ def _stomp_action_ownership_valid(
     )
     active_valid = (
         active
-        & (
-            state.base_last_action
-            == n_primitive_actions + state.executing_option
-        )
+        & (state.base_last_action == n_primitive_actions + state.executing_option)
         & (state.option_last_intra_action == state.last_primitive_action)
     )
     return primitive_valid & (idle_valid | active_valid)
@@ -459,8 +491,7 @@ def _stomp_static_dispatch_contract(
         state.base_learner_state.step_count,
     )
     static_valid = all(
-        value.shape == expected and value.dtype == jnp.float32
-        for value, expected in float32_shapes
+        value.shape == expected and value.dtype == jnp.float32 for value, expected in float32_shapes
     )
     static_valid = static_valid and all(
         value.shape == () and value.dtype == jnp.float32 for value in scalar_float32
@@ -559,9 +590,8 @@ def _stomp_static_dispatch_contract(
                     and optimizer_state.step_size.shape == ()
                     and optimizer_state.step_size.dtype == jnp.float32
                 )
-    rng_key_valid = (
-        state.rng_key.shape == ()
-        and jax.dtypes.issubdtype(state.rng_key.dtype, jax.dtypes.prng_key)
+    rng_key_valid = state.rng_key.shape == () and jax.dtypes.issubdtype(
+        state.rng_key.dtype, jax.dtypes.prng_key
     )
     return static_valid, rng_key_valid
 
@@ -595,8 +625,7 @@ def replace_dispatched_primitive_action(
 
     raw_observation = jnp.asarray(decision_observation)
     observation_static_contract_valid = (
-        raw_observation.shape == (observation_dim,)
-        and raw_observation.dtype == jnp.float32
+        raw_observation.shape == (observation_dim,) and raw_observation.dtype == jnp.float32
     )
     obs = (
         raw_observation
@@ -608,9 +637,7 @@ def replace_dispatched_primitive_action(
         raw_proposal.shape == () and raw_proposal.dtype == jnp.int32
     )
     proposal = (
-        raw_proposal
-        if proposed_action_static_contract_valid
-        else jnp.asarray(-1, dtype=jnp.int32)
+        raw_proposal if proposed_action_static_contract_valid else jnp.asarray(-1, dtype=jnp.int32)
     )
     if safety_action_mask is None:
         safety = jnp.ones((n_primitive_actions,), dtype=jnp.bool_)
@@ -618,8 +645,7 @@ def replace_dispatched_primitive_action(
     else:
         raw_safety = jnp.asarray(safety_action_mask)
         safety_action_mask_static_contract_valid = (
-            raw_safety.shape == (n_primitive_actions,)
-            and raw_safety.dtype == jnp.bool_
+            raw_safety.shape == (n_primitive_actions,) and raw_safety.dtype == jnp.bool_
         )
         safety = (
             raw_safety
@@ -628,9 +654,7 @@ def replace_dispatched_primitive_action(
         )
 
     no_option = state.executing_option == -1
-    option_index_valid = (state.executing_option >= 0) & (
-        state.executing_option < n_options
-    )
+    option_index_valid = (state.executing_option >= 0) & (state.executing_option < n_options)
     owner = jnp.where(
         no_option,
         jnp.asarray(DISPATCH_OWNER_BASE_PRIMITIVE, dtype=jnp.int32),
@@ -641,9 +665,7 @@ def replace_dispatched_primitive_action(
         ),
     )
     counterfactual = state.last_primitive_action
-    counterfactual_valid = (counterfactual >= 0) & (
-        counterfactual < n_primitive_actions
-    )
+    counterfactual_valid = (counterfactual >= 0) & (counterfactual < n_primitive_actions)
     base_owner_valid = (
         no_option
         & (state.base_last_action >= 0)
@@ -655,10 +677,7 @@ def replace_dispatched_primitive_action(
         & (state.base_last_action == n_primitive_actions + state.executing_option)
         & (state.option_last_intra_action == counterfactual)
     )
-    ownership_valid = (
-        counterfactual_valid
-        & (base_owner_valid | option_owner_valid)
-    )
+    ownership_valid = counterfactual_valid & (base_owner_valid | option_owner_valid)
     static_contract_valid, typed_rng_key_valid = _stomp_static_dispatch_contract(
         state,
         n_options=n_options,
@@ -753,9 +772,7 @@ def replace_dispatched_primitive_action(
             owner,
             jnp.asarray(DISPATCH_OWNER_INVALID, dtype=jnp.int32),
         ),
-        state_static_contract_valid=jnp.asarray(
-            static_contract_valid, dtype=jnp.bool_
-        ),
+        state_static_contract_valid=jnp.asarray(static_contract_valid, dtype=jnp.bool_),
         state_values_finite=state_values_finite,
         state_counters_valid=state_counters_valid,
         rng_key_valid=jnp.asarray(typed_rng_key_valid, dtype=jnp.bool_),
@@ -904,9 +921,7 @@ def _select_action_epsilon_greedy(
     """ε-greedy action selection with Gumbel tie-breaking."""
     key, explore_key, noise_key = jr.split(key, 3)
     q_vals = _q_values_for_obs(q_weights, observation)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
-        jnp.int32
-    )
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -921,9 +936,7 @@ def _select_action_epsilon_greedy_from_q(
 ) -> tuple[Array, Array]:
     """ε-greedy action selection from pre-computed Q values."""
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
-        jnp.int32
-    )
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1110,12 +1123,7 @@ def _differential_semidp_q_update(
     q_prev = q_weights[last_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_weights, next_obs))
     # The discounted reward and baseline must use the same γ powers.
-    td_error = (
-        reward
-        - average_reward * baseline_coefficient
-        + gamma_o * q_next
-        - q_prev
-    )
+    td_error = reward - average_reward * baseline_coefficient + gamma_o * q_next - q_prev
 
     action_mask = jax.nn.one_hot(last_action, n_actions, dtype=jnp.float32)
     new_traces = lam * traces + action_mask[:, None] * last_obs[None, :]
@@ -1175,9 +1183,7 @@ def _update_option_model(
     new_cumreward = decay * models.cumreward_ema + (1.0 - decay) * pseudo_return
     new_env_return = decay * models.env_return_ema + (1.0 - decay) * env_return
     new_duration = decay * models.duration_ema + (1.0 - decay) * duration
-    new_baseline_mass = (
-        decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
-    )
+    new_baseline_mass = decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
     new_discount = decay * models.discount_ema + (1.0 - decay) * discount
 
     predicted_delta = models.next_state_weights[option_idx] @ start_obs
@@ -1189,9 +1195,7 @@ def _update_option_model(
         jnp.float32
     )
     new_ns_weights = models.next_state_weights + mask[:, None, None] * ns_update[None, :, :]
-    incremented_completions = _saturating_int32_counter_increment(
-        models.n_completions
-    )
+    incremented_completions = _saturating_int32_counter_increment(models.n_completions)
     new_completions = jnp.where(
         mask.astype(jnp.bool_),
         incremented_completions,
@@ -1202,9 +1206,7 @@ def _update_option_model(
         cumreward_ema=jnp.where(mask, new_cumreward, models.cumreward_ema),
         env_return_ema=jnp.where(mask, new_env_return, models.env_return_ema),
         duration_ema=jnp.where(mask, new_duration, models.duration_ema),
-        baseline_mass_ema=jnp.where(
-            mask, new_baseline_mass, models.baseline_mass_ema
-        ),
+        baseline_mass_ema=jnp.where(mask, new_baseline_mass, models.baseline_mass_ema),
         discount_ema=jnp.where(mask, new_discount, models.discount_ema),
         next_state_weights=new_ns_weights,
         n_completions=new_completions,
@@ -1307,9 +1309,7 @@ def _update_intra_option_policy(
     traces_i = option_policies.traces[option_idx]
     avg_r_i = option_policies.average_rewards[option_idx]
     transition_discount = jnp.asarray(discount, dtype=jnp.float32)
-    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(
-        jnp.float32
-    )
+    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(jnp.float32)
 
     q_prev = q_i[last_intra_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_i, next_obs)) * bootstrap_discount
@@ -1419,15 +1419,27 @@ class STOMPConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        if self.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if self.n_primitive_actions <= 0:
-            raise ValueError("n_primitive_actions must be positive")
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        n_primitive_actions = _require_int32(
+            "n_primitive_actions", self.n_primitive_actions, minimum=1
+        )
+        base_hidden_sizes = _validate_hidden_sizes(self.base_hidden_sizes)
+        backups = _require_int32(
+            "option_planning_backups_per_step",
+            self.option_planning_backups_per_step,
+            minimum=0,
+        )
+
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_primitive_actions", n_primitive_actions)
+        object.__setattr__(self, "base_hidden_sizes", base_hidden_sizes)
+        object.__setattr__(self, "option_planning_backups_per_step", backups)
+
         for spec in self.subtask_specs:
-            if spec.feature_index >= self.observation_dim:
+            if spec.feature_index >= observation_dim:
                 raise ValueError(
                     f"SubtaskSpec.feature_index={spec.feature_index} >= "
-                    f"observation_dim={self.observation_dim}"
+                    f"observation_dim={observation_dim}"
                 )
             if spec.max_option_steps > _INT32_MAX:
                 raise ValueError("SubtaskSpec.max_option_steps must fit int32 telemetry")
@@ -1466,13 +1478,9 @@ class STOMPConfig:
         ):
             raise ValueError("option_planning_backups_per_step must be a nonnegative integer")
         if self.option_planning_backups_per_step >= _INT32_MAX:
-            raise ValueError(
-                "option_planning_backups_per_step must be smaller than int32 max"
-            )
+            raise ValueError("option_planning_backups_per_step must be smaller than int32 max")
         if not self.subtask_specs and self.option_planning_backups_per_step != 0:
-            raise ValueError(
-                "primitive-only STOMP requires option_planning_backups_per_step == 0"
-            )
+            raise ValueError("primitive-only STOMP requires option_planning_backups_per_step == 0")
 
     @property
     def n_options(self) -> int:
@@ -1488,9 +1496,7 @@ class STOMPConfig:
         """Serialize to a JSON-compatible dictionary."""
         return {
             "type": "STOMPConfig",
-            "subtask_specs": [
-                dataclasses.asdict(s) for s in self.subtask_specs
-            ],
+            "subtask_specs": [dataclasses.asdict(s) for s in self.subtask_specs],
             "observation_dim": self.observation_dim,
             "n_primitive_actions": self.n_primitive_actions,
             "base_step_size": self.base_step_size,
@@ -1681,9 +1687,7 @@ class STOMPAgent:
         explicitly. The state also records it in ``last_primitive_action``.
         """
         cfg = self._config
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
-            (cfg.observation_dim,)
-        )
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
         key = state.rng_key
         q_vals = self._base_learner.predict(state.base_learner_state, obs)
         extended_action, key = _select_action_epsilon_greedy_from_q(
@@ -1791,13 +1795,8 @@ class STOMPAgent:
                 f"({cfg.n_total_actions},), got {raw_mask.shape}"
             )
         if raw_mask.dtype != jnp.bool_:
-            raise TypeError(
-                "extended_action_mask must have dtype bool, "
-                f"got {raw_mask.dtype}"
-            )
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
-            (cfg.observation_dim,)
-        )
+            raise TypeError(f"extended_action_mask must have dtype bool, got {raw_mask.dtype}")
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
         mask_valid = jnp.all(raw_mask[: cfg.n_primitive_actions]) & jnp.any(raw_mask)
         values_valid = jnp.all(jnp.isfinite(obs))
         key = state.rng_key
@@ -1952,9 +1951,7 @@ class STOMPAgent:
 
                 predicted_delta = models.next_state_weights[model_idx] @ anchor_observation
                 predicted_next = anchor_observation + predicted_delta
-                next_q = self._base_learner.predict(
-                    current_learner_state, predicted_next
-                )
+                next_q = self._base_learner.predict(current_learner_state, predicted_next)
                 eligible_next_q = jnp.where(
                     extended_action_mask,
                     next_q,
@@ -1965,9 +1962,11 @@ class STOMPAgent:
                     - average_reward * models.baseline_mass_ema[model_idx]
                     + models.discount_ema[model_idx] * jnp.max(eligible_next_q)
                 )
-                targets = jnp.full(
-                    cfg.n_total_actions, jnp.nan, dtype=jnp.float32
-                ).at[option_action].set(target)
+                targets = (
+                    jnp.full(cfg.n_total_actions, jnp.nan, dtype=jnp.float32)
+                    .at[option_action]
+                    .set(target)
+                )
                 update_result = self._base_learner.update(
                     current_learner_state,
                     anchor_observation,
@@ -2025,9 +2024,7 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError(
-                    "preselection feature reset requires a linear STOMP base learner"
-                )
+                raise ValueError("preselection feature reset requires a linear STOMP base learner")
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2053,8 +2050,7 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    "extended_action_mask must have dtype bool, "
-                    f"got {raw_action_mask.dtype}"
+                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
             action_mask_valid = jnp.all(action_mask) & jnp.any(action_mask)
@@ -2093,9 +2089,7 @@ class STOMPAgent:
             )
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(
-            state.step_words
-        )
+        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2124,15 +2118,17 @@ class STOMPAgent:
         )
         eligible_next_q = jnp.where(action_mask, next_q_values, -jnp.inf)
         td_target = (
-            reward
-            - state.base_average_reward
-            + primitive_discount * jnp.max(eligible_next_q)
+            reward - state.base_average_reward + primitive_discount * jnp.max(eligible_next_q)
         )
-        targets = jnp.full(
-            cfg.n_primitive_actions,
-            jnp.nan,
-            dtype=jnp.float32,
-        ).at[state.base_last_action].set(td_target)
+        targets = (
+            jnp.full(
+                cfg.n_primitive_actions,
+                jnp.nan,
+                dtype=jnp.float32,
+            )
+            .at[state.base_last_action]
+            .set(td_target)
+        )
         trace_adjusted_state = cast(
             MultiHeadMLPState,
             state.base_learner_state.replace(
@@ -2334,9 +2330,7 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError(
-                    "preselection feature reset requires a linear STOMP base learner"
-                )
+                raise ValueError("preselection feature reset requires a linear STOMP base learner")
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2361,13 +2355,12 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    "extended_action_mask must have dtype bool, "
-                    f"got {raw_action_mask.dtype}"
+                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
-            action_mask_valid = jnp.all(
-                action_mask[: cfg.n_primitive_actions]
-            ) & jnp.any(action_mask)
+            action_mask_valid = jnp.all(action_mask[: cfg.n_primitive_actions]) & jnp.any(
+                action_mask
+            )
         bootstrap_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
             (cfg.observation_dim,)
         )
@@ -2412,9 +2405,7 @@ class STOMPAgent:
             environmental_termination = supplied_discount <= 0.0
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(
-            state.step_words
-        )
+        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2435,9 +2426,7 @@ class STOMPAgent:
         # Compute pseudo-reward for the currently-executing (or notional) option
         pseudo_r = compute_pseudo_reward(spec, option_idx, bootstrap_obs)
         target_epsilon = (
-            cfg.epsilon_option
-            if cfg.option_target_epsilon is None
-            else cfg.option_target_epsilon
+            cfg.epsilon_option if cfg.option_target_epsilon is None else cfg.option_target_epsilon
         )
         option_importance_ratio = _clipped_epsilon_greedy_importance_ratio(
             state.option_policies.q_weights[option_idx],
@@ -2474,9 +2463,7 @@ class STOMPAgent:
             )
         else:
             planning_updates_required = jnp.asarray(0, dtype=jnp.int32)
-        nested_updates_required = (
-            should_update_base.astype(jnp.int32) + planning_updates_required
-        )
+        nested_updates_required = should_update_base.astype(jnp.int32) + planning_updates_required
         expected_nested_words, nested_capacity = _checked_lifetime_words_advance(
             state.base_learner_state.step_words,
             nested_updates_required,
@@ -2629,19 +2616,15 @@ class STOMPAgent:
         def do_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            next_q_vals = self._base_learner.predict(
-                state.base_learner_state, bootstrap_obs
-            )
+            next_q_vals = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
             eligible_next_q = jnp.where(action_mask, next_q_vals, -jnp.inf)
             max_next_q = base_discount * jnp.max(eligible_next_q)
-            td_target = (
-                base_reward
-                - state.base_average_reward * base_baseline_mass
-                + max_next_q
+            td_target = base_reward - state.base_average_reward * base_baseline_mass + max_next_q
+            targets = (
+                jnp.full(n_total, jnp.nan, dtype=jnp.float32)
+                .at[state.base_last_action]
+                .set(td_target)
             )
-            targets = jnp.full(n_total, jnp.nan, dtype=jnp.float32).at[
-                state.base_last_action
-            ].set(td_target)
             trace_adjusted_state = cast(
                 MultiHeadMLPState,
                 state.base_learner_state.replace(
@@ -2651,9 +2634,7 @@ class STOMPAgent:
                     )
                 ),
             )
-            result = self._base_learner.update(
-                trace_adjusted_state, base_update_obs, targets
-            )
+            result = self._base_learner.update(trace_adjusted_state, base_update_obs, targets)
             td_err = result.errors[state.base_last_action]
             new_avg_reward = state.base_average_reward + beta * td_err
             return result.state, new_avg_reward, td_err, result.update_applied
@@ -2661,17 +2642,10 @@ class STOMPAgent:
         def skip_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            prev_q = self._base_learner.predict(
-                state.base_learner_state, state.base_last_obs
-            )
-            next_q = self._base_learner.predict(
-                state.base_learner_state, bootstrap_obs
-            )
+            prev_q = self._base_learner.predict(state.base_learner_state, state.base_last_obs)
+            next_q = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
             eligible_next_q = jnp.where(action_mask, next_q, -jnp.inf)
-            td = (
-                primitive_discount * jnp.max(eligible_next_q)
-                - prev_q[state.base_last_action]
-            )
+            td = primitive_discount * jnp.max(eligible_next_q) - prev_q[state.base_last_action]
             return (
                 state.base_learner_state,
                 state.base_average_reward,
@@ -2684,9 +2658,7 @@ class STOMPAgent:
             new_avg_r,
             base_td,
             real_base_update_applied,
-        ) = jax.lax.cond(
-            should_update_base, do_base_update, skip_base_update, None
-        )
+        ) = jax.lax.cond(should_update_base, do_base_update, skip_base_update, None)
 
         # --- Fixed-budget option-model planning ---
         # The zero-backup default is a Python-level static branch: it consumes
@@ -2733,9 +2705,7 @@ class STOMPAgent:
             cfg.epsilon_base,
             action_mask,
         )
-        next_select_extended = (~is_executing) | (
-            is_executing & option_lifecycle_ends
-        )
+        next_select_extended = (~is_executing) | (is_executing & option_lifecycle_ends)
         selected_option = jnp.clip(
             extended_action - cfg.n_primitive_actions,
             0,
@@ -2770,9 +2740,8 @@ class STOMPAgent:
                 jnp.array(-1, dtype=jnp.int32),
             ),
         )
-        is_starting_option = (
-            next_select_extended
-            & (extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32))
+        is_starting_option = next_select_extended & (
+            extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32)
         )
 
         # Primitive action sent to environment
@@ -2787,9 +2756,7 @@ class STOMPAgent:
         )
 
         # Reset option tracking on termination or new option start
-        new_option_start_obs = jnp.where(
-            is_starting_option, decision_obs, state.option_start_obs
-        )
+        new_option_start_obs = jnp.where(is_starting_option, decision_obs, state.option_start_obs)
         new_option_cumreward = jnp.where(
             (is_executing & option_lifecycle_ends) | is_starting_option,
             jnp.array(0.0, dtype=jnp.float32),
@@ -2891,9 +2858,7 @@ class STOMPAgent:
                 new_executing_option,
                 state.executing_option,
             ),
-            option_terminated=transaction_applied
-            & is_executing
-            & option_lifecycle_ends,
+            option_terminated=transaction_applied & is_executing & option_lifecycle_ends,
             pseudo_reward=jnp.where(
                 transaction_applied & is_executing,
                 pseudo_r,
@@ -2964,9 +2929,7 @@ class STOMPAgent:
                 decision_observation=decision_obs,
                 execution_boundary=execution_boundary,
                 extended_action_mask=(
-                    extended_action_mask
-                    if extended_action_masks is not None
-                    else None
+                    extended_action_mask if extended_action_masks is not None else None
                 ),
             )
             return result.state, (
@@ -3025,27 +2988,30 @@ class STOMPAgent:
         if scan_extended_action_masks.dtype != jnp.bool_:
             raise TypeError("extended_action_masks must have dtype bool")
 
-        final_state, (
-            td_errors,
-            average_rewards,
-            primitive_actions,
-            executing_options,
-            option_terminations,
-            pseudo_rewards,
-            option_importance_ratios,
-            planning_backups,
-            planning_td_errors,
-            pre_step_words,
-            post_step_words,
-            inputs_valid,
-            lifetime_counter_valid,
-            lifetime_capacity_available,
-            nested_lifetime_counter_valid,
-            nested_lifetime_capacity_available,
-            nested_updates_required,
-            nested_updates_applied,
-            proposed_state_valid,
-            update_applied,
+        (
+            final_state,
+            (
+                td_errors,
+                average_rewards,
+                primitive_actions,
+                executing_options,
+                option_terminations,
+                pseudo_rewards,
+                option_importance_ratios,
+                planning_backups,
+                planning_td_errors,
+                pre_step_words,
+                post_step_words,
+                inputs_valid,
+                lifetime_counter_valid,
+                lifetime_capacity_available,
+                nested_lifetime_counter_valid,
+                nested_lifetime_capacity_available,
+                nested_updates_required,
+                nested_updates_applied,
+                proposed_state_valid,
+                update_applied,
+            ),
         ) = jax.lax.scan(
             step_fn,
             state,
@@ -3231,15 +3197,11 @@ def stomp_state_to_checkpoint_payload(state: STOMPState) -> dict[str, Any]:
 def _sub_payload_as_dict(value: Any, name: str, cls: type) -> dict[str, Any]:
     """Normalize a nested payload entry to a plain field-keyed dict."""
     if isinstance(value, cls):
-        return {
-            field.name: getattr(value, field.name)
-            for field in dataclasses.fields(cls)
-        }
+        return {field.name: getattr(value, field.name) for field in dataclasses.fields(cls)}
     if isinstance(value, dict):
         return dict(value)
     raise ValueError(
-        f"'{name}' must be a field-keyed dict or {cls.__name__}, "
-        f"got {type(value).__name__}"
+        f"'{name}' must be a field-keyed dict or {cls.__name__}, got {type(value).__name__}"
     )
 
 
@@ -3300,18 +3262,14 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
             f"missing={sorted(missing_state_fields)}"
         )
 
-    models = _sub_payload_as_dict(
-        data.pop("option_models"), "option_models", OptionModelsState
-    )
+    models = _sub_payload_as_dict(data.pop("option_models"), "option_models", OptionModelsState)
     model_field_names = {
         field.name
         for field in dataclasses.fields(OptionModelsState)  # type: ignore[arg-type]
     }
     unknown_models = sorted(set(models) - model_field_names)
     if unknown_models:
-        raise ValueError(
-            f"Unknown OptionModelsState checkpoint fields: {unknown_models}"
-        )
+        raise ValueError(f"Unknown OptionModelsState checkpoint fields: {unknown_models}")
     missing_model_fields = model_field_names - set(models)
     expected_missing_model_fields = (
         set(STOMP_OPTION_MODEL_EXPANSION_FIELDS)
@@ -3340,8 +3298,7 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
     }
     if set(policies) != policy_field_names:
         raise ValueError(
-            "STOMP option-policy payload fields "
-            f"{sorted(policies)} != {sorted(policy_field_names)}"
+            f"STOMP option-policy payload fields {sorted(policies)} != {sorted(policy_field_names)}"
         )
     option_policies = IntraOptionPoliciesState(**policies)
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -1652,67 +1653,34 @@ class STOMPConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> STOMPConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> STOMPConfig:
         """Reconstruct from :meth:`to_config` output."""
-        if type(config) is not dict or not all(type(key) is str for key in config):
-            raise ValueError("STOMPConfig payload must be an actual string-keyed dict")
-        payload = config.copy()
-        expected = {field.name for field in dataclasses.fields(cls)} | {"type"}
-        legacy_expected = expected - {"option_planning_backups_per_step"}
-        if set(payload) not in (expected, legacy_expected):
-            raise ValueError("STOMPConfig fields do not match the schema")
-        config_type = payload.pop("type")
-        if type(config_type) is not str or config_type != "STOMPConfig":
-            raise ValueError("unexpected STOMPConfig type")
-        specs_raw = payload.pop("subtask_specs")
-        if type(specs_raw) is not list:
-            raise ValueError("serialized subtask_specs must be a list")
-        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
+        if not isinstance(config, Mapping):
+            raise ValueError("STOMPConfig payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("STOMPConfig mapping could not be read") from error
+        payload.pop("type", None)
+        specs_raw = payload.pop("subtask_specs", [])
+        if type(specs_raw) not in (list, tuple):
+            raise ValueError("serialized subtask_specs must be an actual list or tuple")
         specs: list[SubtaskSpec] = []
         for raw in specs_raw:
-            if type(raw) is not dict or not all(type(key) is str for key in raw):
-                raise ValueError("serialized subtask_specs entries must be actual dicts")
-            if set(raw) != spec_fields:
-                raise ValueError("serialized SubtaskSpec fields do not match the schema")
-            if type(raw["feature_index"]) is not int or type(raw["max_option_steps"]) is not int:
-                raise ValueError("serialized SubtaskSpec integer fields must be JSON integers")
-            if type(raw["threshold"]) is not float or type(raw["pseudo_reward_scale"]) is not float:
-                raise ValueError("serialized SubtaskSpec scalar fields must be JSON floats")
-            specs.append(SubtaskSpec(**raw))
-        raw_hidden = payload.pop("base_hidden_sizes")
-        if type(raw_hidden) is not list:
-            raise ValueError("serialized base_hidden_sizes must be a list")
-        if not all(type(width) is int for width in raw_hidden):
-            raise ValueError("serialized base_hidden_sizes entries must be JSON integers")
-        if "option_planning_backups_per_step" not in payload:
-            payload["option_planning_backups_per_step"] = 0
-        for name in (
-            "observation_dim",
-            "n_primitive_actions",
-            "option_planning_backups_per_step",
-        ):
-            if type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        for name in (
-            "base_step_size",
-            "base_avg_reward_step_size",
-            "base_trace_decay",
-            "option_step_size",
-            "option_avg_reward_step_size",
-            "option_trace_decay",
-            "option_gamma",
-            "option_model_decay",
-            "option_model_step_size",
-            "epsilon_base",
-            "epsilon_option",
-            "option_importance_clip",
-        ):
-            if type(payload[name]) is not float:
-                raise ValueError(f"serialized {name} must be a JSON float")
-        target_epsilon = payload["option_target_epsilon"]
-        if target_epsilon is not None and type(target_epsilon) is not float:
-            raise ValueError("serialized option_target_epsilon must be null or a JSON float")
-        payload["base_hidden_sizes"] = tuple(raw_hidden)
+            if not isinstance(raw, Mapping):
+                raise ValueError("serialized subtask_specs entries must be mappings")
+            try:
+                specs.append(SubtaskSpec(**dict(raw)))
+            except Exception as error:
+                raise ValueError("serialized SubtaskSpec is invalid") from error
+        if "base_hidden_sizes" in payload:
+            raw_hidden = payload["base_hidden_sizes"]
+            if type(raw_hidden) not in (list, tuple):
+                raise ValueError(
+                    "serialized base_hidden_sizes must be an actual list or tuple"
+                )
+            sequence = cast(list[object] | tuple[object, ...], raw_hidden)
+            payload["base_hidden_sizes"] = tuple(sequence)
         return cls(subtask_specs=tuple(specs), **payload)
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,7 +3,6 @@
 import chex
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 import pytest
 
 from alberta_framework.core.options import (
@@ -42,7 +41,9 @@ class TestSubtaskSpecValidation:
         with pytest.raises(ValueError, match="threshold"):
             SubtaskSpec(feature_index=0, threshold=threshold)
 
-    @pytest.mark.parametrize("scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
+    @pytest.mark.parametrize(
+        "scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0]
+    )
     def test_rejects_bad_pseudo_reward_scale(self, scale: float) -> None:
         with pytest.raises(ValueError, match="pseudo_reward_scale"):
             SubtaskSpec(feature_index=0, pseudo_reward_scale=scale)
@@ -85,7 +86,9 @@ class TestStompCheckpointRoundTrip:
     def test_new_format_round_trips(self) -> None:
         state = _state()
 
-        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(state))
+        restored = load_stomp_state_with_migration(
+            stomp_state_to_checkpoint_payload(state)
+        )
 
         chex.assert_trees_all_equal(restored, state)
 
@@ -93,7 +96,9 @@ class TestStompCheckpointRoundTrip:
         state = _state()
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(migrated))
+        restored = load_stomp_state_with_migration(
+            stomp_state_to_checkpoint_payload(migrated)
+        )
 
         chex.assert_trees_all_equal(restored, migrated)
 
@@ -128,7 +133,9 @@ class TestStompStateMigration:
 
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        chex.assert_trees_all_equal(migrated.base_learner_state, state.base_learner_state)
+        chex.assert_trees_all_equal(
+            migrated.base_learner_state, state.base_learner_state
+        )
         chex.assert_trees_all_equal(migrated.option_policies, state.option_policies)
         chex.assert_trees_all_equal(
             migrated.option_models.cumreward_ema, state.option_models.cumreward_ema
@@ -178,7 +185,9 @@ class TestStompMigrationFailsClosed:
 
     def test_unknown_option_model_field_raises(self) -> None:
         payload = stomp_state_to_checkpoint_payload(_state())
-        payload["option_models"]["not_a_field"] = jnp.zeros(N_OPTIONS, dtype=jnp.float32)
+        payload["option_models"]["not_a_field"] = jnp.zeros(
+            N_OPTIONS, dtype=jnp.float32
+        )
 
         with pytest.raises(ValueError, match="not_a_field"):
             load_stomp_state_with_migration(payload)
@@ -237,7 +246,9 @@ def test_primitive_only_stomp_has_typed_empty_option_state_and_base_only_updates
     chex.assert_trees_all_equal(masked_start.state, started)
     chex.assert_trees_all_equal(masked_start.primitive_action, started.last_primitive_action)
 
-    restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(started))
+    restored = load_stomp_state_with_migration(
+        stomp_state_to_checkpoint_payload(started)
+    )
     chex.assert_trees_all_equal(restored, started)
 
     result = agent.update(
@@ -319,8 +330,10 @@ def test_semidp_q_infinite_reward_does_not_poison_weights() -> None:
         discount=jnp.array(1.0, dtype=jnp.float32),
     )
 
-    new_q, new_z, new_rbar, td_error, update_applied = _differential_semidp_q_update(
+    new_q, new_z, new_rbar, td_error, update_applied = (
+        _differential_semidp_q_update(
         q, z, rbar, obs, action, jnp.array(jnp.inf, dtype=jnp.float32), nxt, **kw
+        )
     )
     chex.assert_trees_all_close(new_q, q)
     chex.assert_trees_all_close(new_z, z)
@@ -358,13 +371,17 @@ class TestStompConfigScalarValidation:
         )
 
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
-    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.05])
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), float("-inf"), -0.05]
+    )
     def test_rejects_invalid_step_sizes(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=f"{name} must be finite and non-negative"):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _UNIT_INTERVAL_FIELDS)
-    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0])
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0]
+    )
     def test_rejects_invalid_unit_interval_scalars(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=rf"{name} must be finite and in \[0, 1\]"):
             self._build(**{name: value})
@@ -387,49 +404,3 @@ class TestStompConfigScalarValidation:
         payload["base_step_size"] = float("nan")
         with pytest.raises(ValueError, match="base_step_size must be finite and non-negative"):
             STOMPConfig.from_config(payload)
-
-
-def test_subtask_spec_scalar_validation() -> None:
-    with pytest.raises(ValueError, match="feature_index"):
-        SubtaskSpec(feature_index=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_index"):
-        SubtaskSpec(feature_index=2.5)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="max_option_steps"):
-        SubtaskSpec(feature_index=0, max_option_steps=True)  # type: ignore[arg-type]
-
-    spec = SubtaskSpec(
-        feature_index=np.int32(1),
-        max_option_steps=np.int64(10),
-    )
-    assert type(spec.feature_index) is int
-    assert type(spec.max_option_steps) is int
-    assert spec.feature_index == 1
-    assert spec.max_option_steps == 10
-
-
-def test_stomp_config_integer_validation() -> None:
-    with pytest.raises(ValueError, match="observation_dim"):
-        STOMPConfig(observation_dim=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_primitive_actions"):
-        STOMPConfig(n_primitive_actions=2.5)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="base_hidden_sizes"):
-        STOMPConfig(base_hidden_sizes=(True,))  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="option_planning_backups_per_step"):
-        STOMPConfig(option_planning_backups_per_step=True)  # type: ignore[arg-type]
-
-    cfg = STOMPConfig(
-        subtask_specs=(SubtaskSpec(feature_index=0),),
-        observation_dim=np.int32(4),
-        n_primitive_actions=np.int64(2),
-        base_hidden_sizes=(np.int32(16), np.int64(8)),
-        option_planning_backups_per_step=np.uint16(2),
-    )
-    assert type(cfg.observation_dim) is int
-    assert type(cfg.n_primitive_actions) is int
-    assert type(cfg.base_hidden_sizes[0]) is int
-    assert type(cfg.base_hidden_sizes[1]) is int
-    assert type(cfg.option_planning_backups_per_step) is int
-    assert cfg.observation_dim == 4
-    assert cfg.n_primitive_actions == 2
-    assert cfg.base_hidden_sizes == (16, 8)
-    assert cfg.option_planning_backups_per_step == 2

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,8 +1,13 @@
 """Tests for STOMP checkpoint payloads and state migration (core/options.py)."""
 
+import json
+from fractions import Fraction
+from typing import Any
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.options import (
@@ -17,7 +22,9 @@ from alberta_framework.core.options import (
     SubtaskSpec,
     _differential_q_update,
     _differential_semidp_q_update,
+    _stomp_resource_counts,
     load_stomp_state_with_migration,
+    measure_stomp_state_nbytes,
     replace_dispatched_primitive_action,
     stomp_state_to_checkpoint_payload,
 )
@@ -375,7 +382,7 @@ class TestStompConfigScalarValidation:
         "value", [float("nan"), float("inf"), float("-inf"), -0.05]
     )
     def test_rejects_invalid_step_sizes(self, name: str, value: float) -> None:
-        with pytest.raises(ValueError, match=f"{name} must be finite and non-negative"):
+        with pytest.raises(ValueError, match=name):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _UNIT_INTERVAL_FIELDS)
@@ -383,7 +390,7 @@ class TestStompConfigScalarValidation:
         "value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0]
     )
     def test_rejects_invalid_unit_interval_scalars(self, name: str, value: float) -> None:
-        with pytest.raises(ValueError, match=rf"{name} must be finite and in \[0, 1\]"):
+        with pytest.raises(ValueError, match=name):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
@@ -402,5 +409,125 @@ class TestStompConfigScalarValidation:
     def test_from_config_enforces_scalar_validation(self) -> None:
         payload = self._build().to_config()
         payload["base_step_size"] = float("nan")
-        with pytest.raises(ValueError, match="base_step_size must be finite and non-negative"):
+        with pytest.raises(ValueError, match="base_step_size"):
             STOMPConfig.from_config(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("dtype", [np.dtype(code).type for code in "bBhHiIlLqQ"])
+def test_stomp_integer_fields_accept_every_supported_numpy_dtype(dtype: type[Any]) -> None:
+    spec = SubtaskSpec(feature_index=dtype(0), max_option_steps=dtype(8))
+    config = STOMPConfig(
+        subtask_specs=(spec,),
+        observation_dim=dtype(2),
+        n_primitive_actions=dtype(2),
+        base_hidden_sizes=(dtype(3),),
+        option_planning_backups_per_step=dtype(0),
+    )
+
+    assert type(spec.feature_index) is int
+    assert type(spec.max_option_steps) is int
+    assert type(config.observation_dim) is int
+    assert type(config.n_primitive_actions) is int
+    assert type(config.base_hidden_sizes[0]) is int
+    assert type(config.option_planning_backups_per_step) is int
+    assert STOMPConfig.from_config(config.to_config()) == config
+    json.dumps(config.to_config(), allow_nan=False)
+
+
+@pytest.mark.unit
+def test_stomp_rejects_hostile_integer_and_container_impostors() -> None:
+    class IntSubclass(int):
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type[int]:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    for value in (True, np.bool_(True), IntSubclass(1), ClassSpoof()):
+        with pytest.raises(ValueError, match="feature_index"):
+            SubtaskSpec(feature_index=value)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="observation_dim"):
+            STOMPConfig(observation_dim=value)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="subtask_specs"):
+        STOMPConfig(subtask_specs=[])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="base_hidden_sizes"):
+        STOMPConfig(base_hidden_sizes=[3])  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_stomp_float32_boundaries_are_canonical_and_exact() -> None:
+    spec = SubtaskSpec(
+        feature_index=0,
+        threshold=Fraction(1, 2),
+        pseudo_reward_scale=np.float64(0.5),
+    )
+    config = STOMPConfig(
+        subtask_specs=(spec,),
+        observation_dim=1,
+        base_step_size=Fraction(0),
+        option_gamma=Fraction(1),
+        option_importance_clip=Fraction(1, 2),
+    )
+    assert type(spec.threshold) is float
+    assert type(spec.pseudo_reward_scale) is float
+    assert type(config.base_step_size) is float
+    assert type(config.option_gamma) is float
+    assert type(config.option_importance_clip) is float
+
+    for field, value in (
+        ("base_step_size", Fraction(-1, 10**100)),
+        ("option_gamma", Fraction(1) + Fraction(1, 10**100)),
+        ("option_importance_clip", Fraction(0)),
+    ):
+        with pytest.raises(ValueError, match=field):
+            STOMPConfig(**{field: value})
+
+
+@pytest.mark.unit
+def test_stomp_resource_preflight_matches_state_and_rejects_before_allocation() -> None:
+    config = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0), SubtaskSpec(feature_index=1)),
+        observation_dim=3,
+        n_primitive_actions=2,
+        base_hidden_sizes=(4,),
+    )
+    resources = _stomp_resource_counts(2, 3, 2, (4,))
+    state = STOMPAgent(config).init(jr.key(0))
+    assert resources["persistent_state_bytes"] == measure_stomp_state_nbytes(state)
+
+    with pytest.raises(ValueError, match="derived .*state"):
+        STOMPConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0),),
+            observation_dim=50_000,
+            n_primitive_actions=1,
+        )
+
+
+@pytest.mark.unit
+def test_stomp_from_config_requires_exact_json_containers_and_schema() -> None:
+    config = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=2,
+    )
+    payload = config.to_config()
+    for mutation, message in (
+        ({**payload, "type": "wrong"}, "type"),
+        ({**payload, "subtask_specs": tuple(payload["subtask_specs"])}, "subtask_specs"),
+        ({**payload, "base_hidden_sizes": tuple(payload["base_hidden_sizes"])}, "hidden"),
+        ({**payload, "observation_dim": np.int32(2)}, "observation_dim"),
+        ({**payload, "base_step_size": np.float32(0.05)}, "base_step_size"),
+        ({**payload, "extra": 1}, "fields"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            STOMPConfig.from_config(mutation)
+
+    legacy = payload.copy()
+    legacy.pop("option_planning_backups_per_step")
+    assert STOMPConfig.from_config(legacy).option_planning_backups_per_step == 0

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,6 +3,7 @@
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.options import (
@@ -41,9 +42,7 @@ class TestSubtaskSpecValidation:
         with pytest.raises(ValueError, match="threshold"):
             SubtaskSpec(feature_index=0, threshold=threshold)
 
-    @pytest.mark.parametrize(
-        "scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0]
-    )
+    @pytest.mark.parametrize("scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
     def test_rejects_bad_pseudo_reward_scale(self, scale: float) -> None:
         with pytest.raises(ValueError, match="pseudo_reward_scale"):
             SubtaskSpec(feature_index=0, pseudo_reward_scale=scale)
@@ -86,9 +85,7 @@ class TestStompCheckpointRoundTrip:
     def test_new_format_round_trips(self) -> None:
         state = _state()
 
-        restored = load_stomp_state_with_migration(
-            stomp_state_to_checkpoint_payload(state)
-        )
+        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(state))
 
         chex.assert_trees_all_equal(restored, state)
 
@@ -96,9 +93,7 @@ class TestStompCheckpointRoundTrip:
         state = _state()
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        restored = load_stomp_state_with_migration(
-            stomp_state_to_checkpoint_payload(migrated)
-        )
+        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(migrated))
 
         chex.assert_trees_all_equal(restored, migrated)
 
@@ -133,9 +128,7 @@ class TestStompStateMigration:
 
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        chex.assert_trees_all_equal(
-            migrated.base_learner_state, state.base_learner_state
-        )
+        chex.assert_trees_all_equal(migrated.base_learner_state, state.base_learner_state)
         chex.assert_trees_all_equal(migrated.option_policies, state.option_policies)
         chex.assert_trees_all_equal(
             migrated.option_models.cumreward_ema, state.option_models.cumreward_ema
@@ -185,9 +178,7 @@ class TestStompMigrationFailsClosed:
 
     def test_unknown_option_model_field_raises(self) -> None:
         payload = stomp_state_to_checkpoint_payload(_state())
-        payload["option_models"]["not_a_field"] = jnp.zeros(
-            N_OPTIONS, dtype=jnp.float32
-        )
+        payload["option_models"]["not_a_field"] = jnp.zeros(N_OPTIONS, dtype=jnp.float32)
 
         with pytest.raises(ValueError, match="not_a_field"):
             load_stomp_state_with_migration(payload)
@@ -246,9 +237,7 @@ def test_primitive_only_stomp_has_typed_empty_option_state_and_base_only_updates
     chex.assert_trees_all_equal(masked_start.state, started)
     chex.assert_trees_all_equal(masked_start.primitive_action, started.last_primitive_action)
 
-    restored = load_stomp_state_with_migration(
-        stomp_state_to_checkpoint_payload(started)
-    )
+    restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(started))
     chex.assert_trees_all_equal(restored, started)
 
     result = agent.update(
@@ -330,10 +319,8 @@ def test_semidp_q_infinite_reward_does_not_poison_weights() -> None:
         discount=jnp.array(1.0, dtype=jnp.float32),
     )
 
-    new_q, new_z, new_rbar, td_error, update_applied = (
-        _differential_semidp_q_update(
+    new_q, new_z, new_rbar, td_error, update_applied = _differential_semidp_q_update(
         q, z, rbar, obs, action, jnp.array(jnp.inf, dtype=jnp.float32), nxt, **kw
-        )
     )
     chex.assert_trees_all_close(new_q, q)
     chex.assert_trees_all_close(new_z, z)
@@ -371,17 +358,13 @@ class TestStompConfigScalarValidation:
         )
 
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
-    @pytest.mark.parametrize(
-        "value", [float("nan"), float("inf"), float("-inf"), -0.05]
-    )
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.05])
     def test_rejects_invalid_step_sizes(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=f"{name} must be finite and non-negative"):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _UNIT_INTERVAL_FIELDS)
-    @pytest.mark.parametrize(
-        "value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0]
-    )
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0])
     def test_rejects_invalid_unit_interval_scalars(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=rf"{name} must be finite and in \[0, 1\]"):
             self._build(**{name: value})
@@ -404,3 +387,49 @@ class TestStompConfigScalarValidation:
         payload["base_step_size"] = float("nan")
         with pytest.raises(ValueError, match="base_step_size must be finite and non-negative"):
             STOMPConfig.from_config(payload)
+
+
+def test_subtask_spec_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="max_option_steps"):
+        SubtaskSpec(feature_index=0, max_option_steps=True)  # type: ignore[arg-type]
+
+    spec = SubtaskSpec(
+        feature_index=np.int32(1),
+        max_option_steps=np.int64(10),
+    )
+    assert type(spec.feature_index) is int
+    assert type(spec.max_option_steps) is int
+    assert spec.feature_index == 1
+    assert spec.max_option_steps == 10
+
+
+def test_stomp_config_integer_validation() -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        STOMPConfig(observation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_primitive_actions"):
+        STOMPConfig(n_primitive_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="base_hidden_sizes"):
+        STOMPConfig(base_hidden_sizes=(True,))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="option_planning_backups_per_step"):
+        STOMPConfig(option_planning_backups_per_step=True)  # type: ignore[arg-type]
+
+    cfg = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=np.int32(4),
+        n_primitive_actions=np.int64(2),
+        base_hidden_sizes=(np.int32(16), np.int64(8)),
+        option_planning_backups_per_step=np.uint16(2),
+    )
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.n_primitive_actions) is int
+    assert type(cfg.base_hidden_sizes[0]) is int
+    assert type(cfg.base_hidden_sizes[1]) is int
+    assert type(cfg.option_planning_backups_per_step) is int
+    assert cfg.observation_dim == 4
+    assert cfg.n_primitive_actions == 2
+    assert cfg.base_hidden_sizes == (16, 8)
+    assert cfg.option_planning_backups_per_step == 2

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2,6 +2,7 @@
 
 import json
 from fractions import Fraction
+from types import MappingProxyType
 from typing import Any
 
 import chex
@@ -511,23 +512,28 @@ def test_stomp_resource_preflight_matches_state_and_rejects_before_allocation() 
 
 
 @pytest.mark.unit
-def test_stomp_from_config_requires_exact_json_containers_and_schema() -> None:
+def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -> None:
     config = STOMPConfig(
         subtask_specs=(SubtaskSpec(feature_index=0),),
         observation_dim=2,
     )
     payload = config.to_config()
-    for mutation, message in (
-        ({**payload, "type": "wrong"}, "type"),
-        ({**payload, "subtask_specs": tuple(payload["subtask_specs"])}, "subtask_specs"),
-        ({**payload, "base_hidden_sizes": tuple(payload["base_hidden_sizes"])}, "hidden"),
-        ({**payload, "observation_dim": np.int32(2)}, "observation_dim"),
-        ({**payload, "base_step_size": np.float32(0.05)}, "base_step_size"),
-        ({**payload, "extra": 1}, "fields"),
-    ):
-        with pytest.raises(ValueError, match=message):
-            STOMPConfig.from_config(mutation)
+    payload["subtask_specs"] = tuple(payload["subtask_specs"])
+    payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
+    payload["type"] = "historical-marker"
+    assert STOMPConfig.from_config(MappingProxyType(payload)) == config
 
-    legacy = payload.copy()
-    legacy.pop("option_planning_backups_per_step")
-    assert STOMPConfig.from_config(legacy).option_planning_backups_per_step == 0
+    partial = STOMPConfig.from_config(
+        {"subtask_specs": ({"feature_index": 0},), "observation_dim": 2}
+    )
+    assert partial.subtask_specs == (SubtaskSpec(feature_index=0),)
+    assert partial.option_planning_backups_per_step == 0
+
+    for field, value in (
+        ("subtask_specs", "not-a-sequence"),
+        ("base_hidden_sizes", "not-a-sequence"),
+    ):
+        invalid = config.to_config()
+        invalid[field] = value
+        with pytest.raises(ValueError, match=field):
+            STOMPConfig.from_config(invalid)

--- a/tests/test_stomp_option_planning.py
+++ b/tests/test_stomp_option_planning.py
@@ -190,7 +190,7 @@ def test_production_facades_propagate_planning_budget() -> None:
 
 @pytest.mark.parametrize("invalid", [-1, 1.5, True])
 def test_planning_budget_must_be_nonnegative_static_integer(invalid: object) -> None:
-    with pytest.raises(ValueError, match="nonnegative integer"):
+    with pytest.raises(ValueError, match=r"option_planning_backups_per_step must be"):
         STOMPConfig(
             subtask_specs=(SubtaskSpec(feature_index=0),),
             option_planning_backups_per_step=invalid,  # type: ignore[arg-type]

--- a/tests/test_stomp_option_planning.py
+++ b/tests/test_stomp_option_planning.py
@@ -190,7 +190,7 @@ def test_production_facades_propagate_planning_budget() -> None:
 
 @pytest.mark.parametrize("invalid", [-1, 1.5, True])
 def test_planning_budget_must_be_nonnegative_static_integer(invalid: object) -> None:
-    with pytest.raises(ValueError, match=r"option_planning_backups_per_step must be"):
+    with pytest.raises(ValueError, match="nonnegative integer"):
         STOMPConfig(
             subtask_specs=(SubtaskSpec(feature_index=0),),
             option_planning_backups_per_step=invalid,  # type: ignore[arg-type]


### PR DESCRIPTION
Supersedes and repairs #738 while preserving the contributor commits in this branch.

The replacement completes the public STOMP/options boundary: exact built-in and concrete NumPy integer families, float32-sink scalar validation and canonicalization, hostile-object-safe diagnostics, exact derived allocation/resource preflights, and measured state/resource accounting. It preserves the established deserialization compatibility contract: ordinary mappings, partial/default payloads, historical type markers, and exact list-or-tuple sequence forms remain accepted; arbitrary iterables and sequence subclasses are rejected before hooks.

Verification on the final head:
- 222 focused options/STOMP tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

No registered evidence source or outputs artifact is changed.
