### PR TITLE
feat(prereg): add fail-closed issue184 launch path

### DIFF
--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -63,6 +63,9 @@ class Protocol:
     control: str
     candidate: str
     seeds: tuple[int, ...]
+    summary_filename: str
+    requires_amendment: bool
+    prerequisite: str | None
 
 
 PROTOCOLS: Final = {
@@ -73,6 +76,20 @@ PROTOCOLS: Final = {
         control="sigma0_shiftnorm_d099",
         candidate="rls_head_resid_l1_preset005",
         seeds=(0, 1, 2),
+        summary_filename="summary.json",
+        requires_amendment=False,
+        prerequisite=None,
+    ),
+    "issue184": Protocol(
+        key="issue184",
+        issue=184,
+        namespace="rls_preset_ablation_r1",
+        control="rls_head_resid_l1_preset005",
+        candidate="rls_head_resid_l1_noreset",
+        seeds=(0, 1, 2),
+        summary_filename="summary.json",
+        requires_amendment=True,
+        prerequisite="issue51",
     ),
     "issue188": Protocol(
         key="issue188",
@@ -81,6 +98,9 @@ PROTOCOLS: Final = {
         control="rls_head_resid_l1_preset005",
         candidate="rls_head_resid_l1_preset005_nogate",
         seeds=tuple(range(3, 13)),
+        summary_filename="summary_resid_gate_ablation_r3.json",
+        requires_amendment=True,
+        prerequisite=None,
     ),
 }
 
@@ -164,8 +184,8 @@ def registration_amendment_line(
     driver_blob_sha1: str,
     ref_name: str,
 ) -> str:
-    if protocol.key != "issue188":
-        raise ValueError("a separate registration amendment is required only for issue188")
+    if not protocol.requires_amendment:
+        raise ValueError(f"protocol {protocol.key} does not require a registration amendment")
     binding = _launch_binding(
         protocol,
         source=source,
@@ -185,12 +205,27 @@ def classify_outcome(
         raise ValueError("paired summary statistics must be finite and stderr non-negative")
     if not per_seed_diff or not all(math.isfinite(value) for value in per_seed_diff):
         raise ValueError("paired per-seed differences must be non-empty and finite")
+    protocol = protocol_for(protocol_key)
+    if len(per_seed_diff) != len(protocol.seeds):
+        raise ValueError(
+            f"paired per-seed differences must contain exactly {len(protocol.seeds)} values"
+        )
     if protocol_key == "issue51":
         if any(value <= 0.0 for value in per_seed_diff):
             return "not_replicated"
         if 0.004882 <= mean_diff <= 0.005950:
             return "replicated"
         return "directionally_replicated"
+    if protocol_key == "issue184":
+        if mean_diff > 0.002 and all(value > 0.0 for value in per_seed_diff):
+            return "no_reset_win"
+        if mean_diff < -0.002 and all(value < 0.0 for value in per_seed_diff):
+            return "reset_load_bearing"
+        if abs(mean_diff) <= 0.001 and all(
+            abs(value) <= 0.0015 for value in per_seed_diff
+        ):
+            return "practical_equivalence"
+        return "inconclusive"
     if protocol_key == "issue188":
         margin = 0.0015
         if mean_diff - 2.0 * stderr_diff > -margin:
@@ -352,6 +387,7 @@ def verify_launch_authorization(
     run_id: int,
     run_attempt: int,
     token: str,
+    root: Path | None = None,
 ) -> dict[str, Any]:
     if repository != AUTHORIZED_REPOSITORY:
         raise RuntimeError(f"repository must be exactly {AUTHORIZED_REPOSITORY}")
@@ -360,6 +396,18 @@ def verify_launch_authorization(
     if type(run_attempt) is not int or run_attempt != 1:
         raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
     protocol = protocol_for(protocol_key)
+    source = _lower_hex(source, 40, name="source")
+    prerequisite = (
+        _verify_prerequisite_completion(
+            protocol,
+            repository=repository,
+            launch_source=source,
+            root=root,
+            token=token,
+        )
+        if protocol.prerequisite is not None
+        else None
+    )
     expected_line = authorization_line(
         protocol,
         source=source,
@@ -379,7 +427,7 @@ def verify_launch_authorization(
             driver_blob_sha1=driver_blob_sha1,
             ref_name=ref_name,
         )
-        if protocol.key == "issue188"
+        if protocol.requires_amendment
         else None
     )
     current = _github_json(f"/repos/{repository}/actions/runs/{run_id}", token=token)
@@ -453,7 +501,7 @@ def verify_launch_authorization(
         )
         if len(amendment_matches) != 1:
             raise RuntimeError(
-                "expected exactly one standalone issue188 registration amendment comment; "
+                "expected exactly one standalone registration amendment comment; "
                 f"found {len(amendment_matches)}"
             )
         amendment = amendment_matches[0]
@@ -465,14 +513,21 @@ def verify_launch_authorization(
         )
         if amendment_comment_id == authorization_comment_id:
             raise RuntimeError(
-                "issue188 registration amendment and final authorization must be distinct records"
+                "registration amendment and final authorization must be distinct records"
             )
         amendment_created_at, amendment_time = _unchanged_comment_timestamp(
             amendment, label="registration amendment"
         )
         if amendment_time >= authorization_time:
             raise RuntimeError(
-                "issue188 registration amendment must be durable before final authorization"
+                "registration amendment must be durable before final authorization"
+            )
+        if (
+            prerequisite is not None
+            and _parse_utc(prerequisite["issue_closed_at"]) >= amendment_time
+        ):
+            raise RuntimeError(
+                "prerequisite issue must be closed before the registration amendment"
             )
     return {
         "schema": "asi.ipmnist_prereg.launch_preflight.v2",
@@ -503,6 +558,7 @@ def verify_launch_authorization(
             if expected_amendment is not None
             else None
         ),
+        "prerequisite_completion": prerequisite,
     }
 
 
@@ -789,9 +845,7 @@ def validate_result_bundle(
     runner, runner_raw = _strict_json_bytes(runner_receipt)
     _validate_runner_receipt(runner, environment=environment)
 
-    summary_path = namespace / (
-        "summary.json" if protocol.key == "issue51" else "summary_resid_gate_ablation_r3.json"
-    )
+    summary_path = namespace / protocol.summary_filename
     if summary_path.is_symlink() or not summary_path.is_file():
         raise ValueError("summary must be one regular non-symlink file")
     summary, summary_raw = _strict_json_bytes(summary_path)
@@ -912,6 +966,198 @@ def validate_result_bundle(
     }
 
 
+def seal_completion_bundle(
+    *,
+    protocol_key: str,
+    root: Path,
+    launch_preflight: Path,
+    result_validation: Path,
+    runner_receipt: Path,
+) -> Path:
+    """Publish a self-contained, append-only completion record after validation."""
+
+    protocol = protocol_for(protocol_key)
+    launch = _strict_json(launch_preflight)
+    result = _strict_json(result_validation)
+    runner, runner_raw = _strict_json_bytes(runner_receipt)
+    if launch.get("schema") != "asi.ipmnist_prereg.launch_preflight.v2":
+        raise ValueError("launch preflight has the wrong schema")
+    if result.get("schema") != "asi.ipmnist_prereg.result_validation.v1":
+        raise ValueError("result validation has the wrong schema")
+    expected_protocol = asdict(protocol)
+    if (
+        _canonical_json(launch.get("protocol")) != _canonical_json(expected_protocol)
+        or _canonical_json(result.get("protocol")) != _canonical_json(expected_protocol)
+    ):
+        raise ValueError("completion inputs do not bind the selected protocol")
+    for name in ("source", "tree", "uv_lock_sha256"):
+        if launch.get(name) != result.get(name):
+            raise ValueError(f"completion inputs disagree on {name}")
+    recomputed = validate_result_bundle(
+        protocol_key=protocol_key,
+        root=root,
+        runner_receipt=runner_receipt,
+        source=cast(str, result["source"]),
+        tree=cast(str, result["tree"]),
+        uv_lock_sha256=cast(str, result["uv_lock_sha256"]),
+    )
+    if _canonical_json(result) != _canonical_json(recomputed):
+        raise ValueError("stored result validation does not match a fresh reconstruction")
+    resolved_root = root.resolve(strict=True)
+    namespace = resolved_root / "outputs" / "ipmnist_screening" / protocol.namespace
+    committed_runner = namespace / "runner.v2.json"
+    completion_path = namespace / "completion.v1.json"
+    if committed_runner.exists() or committed_runner.is_symlink():
+        raise FileExistsError(f"runner receipt already exists: {committed_runner}")
+    if completion_path.exists() or completion_path.is_symlink():
+        raise FileExistsError(f"completion record already exists: {completion_path}")
+    with committed_runner.open("xb") as stream:
+        stream.write(runner_raw)
+    completion = {
+        "schema": "asi.ipmnist_prereg.completion.v1",
+        "launch_preflight": launch,
+        "result_validation": result,
+        "runner_receipt": committed_runner.relative_to(resolved_root).as_posix(),
+        "runner_receipt_sha256": hashlib.sha256(runner_raw).hexdigest(),
+    }
+    _write_json(completion_path, completion)
+    return completion_path
+
+
+def _verify_prerequisite_completion(
+    protocol: Protocol,
+    *,
+    repository: str,
+    launch_source: str,
+    root: Path | None,
+    token: str,
+) -> dict[str, Any]:
+    """Verify a committed predecessor result before a dependent dispatch."""
+
+    if protocol.prerequisite is None:
+        raise RuntimeError("protocol has no prerequisite")
+    if root is None:
+        raise RuntimeError("repository root is required for prerequisite verification")
+    if root.is_symlink():
+        raise RuntimeError("repository root must not be a symlink")
+    prerequisite = protocol_for(protocol.prerequisite)
+    resolved_root = root.resolve(strict=True)
+    namespace = resolved_root / "outputs" / "ipmnist_screening" / prerequisite.namespace
+    completion_path = namespace / "completion.v1.json"
+    if completion_path.is_symlink() or not completion_path.is_file():
+        raise RuntimeError("prerequisite completion record is missing")
+    completion, completion_raw = _strict_json_bytes(completion_path)
+    _require_exact_keys(
+        completion,
+        {
+            "schema",
+            "launch_preflight",
+            "result_validation",
+            "runner_receipt",
+            "runner_receipt_sha256",
+        },
+        context="prerequisite completion",
+    )
+    launch = completion["launch_preflight"]
+    stored_result = completion["result_validation"]
+    runner_path_text = completion["runner_receipt"]
+    if (
+        completion["schema"] != "asi.ipmnist_prereg.completion.v1"
+        or not isinstance(launch, dict)
+        or not isinstance(stored_result, dict)
+        or not isinstance(runner_path_text, str)
+    ):
+        raise RuntimeError("prerequisite completion record is malformed")
+    expected_runner_path = (
+        Path("outputs") / "ipmnist_screening" / prerequisite.namespace / "runner.v2.json"
+    )
+    if runner_path_text != expected_runner_path.as_posix():
+        raise RuntimeError("prerequisite runner receipt path is not canonical")
+    runner_path = resolved_root / expected_runner_path
+    if runner_path.is_symlink() or not runner_path.is_file():
+        raise RuntimeError("prerequisite runner receipt is missing")
+    runner_raw = runner_path.read_bytes()
+    if completion["runner_receipt_sha256"] != hashlib.sha256(runner_raw).hexdigest():
+        raise RuntimeError("prerequisite runner receipt digest mismatch")
+    if _canonical_json(launch.get("protocol")) != _canonical_json(asdict(prerequisite)):
+        raise RuntimeError("prerequisite launch record binds the wrong protocol")
+    source = launch.get("source")
+    tree = launch.get("tree")
+    uv_lock_sha256 = launch.get("uv_lock_sha256")
+    if not all(isinstance(value, str) for value in (source, tree, uv_lock_sha256)):
+        raise RuntimeError("prerequisite launch source identity is malformed")
+    recomputed = validate_result_bundle(
+        protocol_key=prerequisite.key,
+        root=resolved_root,
+        runner_receipt=runner_path,
+        source=cast(str, source),
+        tree=cast(str, tree),
+        uv_lock_sha256=cast(str, uv_lock_sha256),
+    )
+    if _canonical_json(stored_result) != _canonical_json(recomputed):
+        raise RuntimeError("prerequisite result does not match a fresh reconstruction")
+    run_id = launch.get("run_id")
+    run_url = launch.get("run_url")
+    if type(run_id) is not int or run_id <= 0:
+        raise RuntimeError("prerequisite workflow run ID is malformed")
+    expected_run_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    if run_url != expected_run_url:
+        raise RuntimeError("prerequisite workflow run URL is not canonical")
+    run = _github_json(f"/repos/{repository}/actions/runs/{run_id}", token=token)
+    if not isinstance(run, dict) or {
+        "id": run.get("id"),
+        "event": run.get("event"),
+        "head_sha": run.get("head_sha"),
+        "path": run.get("path"),
+        "display_title": run.get("display_title"),
+        "run_attempt": run.get("run_attempt"),
+        "status": run.get("status"),
+        "conclusion": run.get("conclusion"),
+        "html_url": run.get("html_url"),
+    } != {
+        "id": run_id,
+        "event": "workflow_dispatch",
+        "head_sha": source,
+        "path": WORKFLOW_PATH,
+        "display_title": f"ipmnist-{prerequisite.key}-{source}",
+        "run_attempt": 1,
+        "status": "completed",
+        "conclusion": "success",
+        "html_url": expected_run_url,
+    }:
+        raise RuntimeError("prerequisite workflow run is not a canonical successful run")
+    issue = _github_json(f"/repos/{repository}/issues/{prerequisite.issue}", token=token)
+    if not isinstance(issue, dict) or issue.get("state") != "closed":
+        raise RuntimeError("prerequisite issue is not closed")
+    issue_closed_at = issue.get("closed_at")
+    if not isinstance(issue_closed_at, str):
+        raise RuntimeError("prerequisite issue closure timestamp is missing")
+    _parse_utc(issue_closed_at)
+    run_updated_at = run.get("updated_at")
+    if not isinstance(run_updated_at, str) or _parse_utc(run_updated_at) >= _parse_utc(
+        issue_closed_at
+    ):
+        raise RuntimeError("prerequisite issue must close after the successful workflow run")
+    comparison = _github_json(
+        f"/repos/{repository}/compare/{source}...{launch_source}", token=token
+    )
+    if not isinstance(comparison, dict) or comparison.get("status") != "ahead":
+        raise RuntimeError("prerequisite source is not an ancestor of the launch source")
+    return {
+        "schema": "asi.ipmnist_prereg.prerequisite.v1",
+        "protocol": prerequisite.key,
+        "completion": completion_path.relative_to(resolved_root).as_posix(),
+        "completion_sha256": hashlib.sha256(completion_raw).hexdigest(),
+        "source": source,
+        "run_id": run_id,
+        "run_url": expected_run_url,
+        "issue": prerequisite.issue,
+        "issue_closed_at": issue_closed_at,
+        "outcome": recomputed["outcome"],
+        "summary_sha256": recomputed["summary_sha256"],
+    }
+
+
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("x", encoding="utf-8") as stream:
@@ -934,6 +1180,7 @@ def _preflight_command(args: argparse.Namespace) -> int:
         run_id=args.run_id,
         run_attempt=args.run_attempt,
         token=token,
+        root=args.root,
     )
     _write_json(args.output, payload)
     print(json.dumps(payload, allow_nan=False, sort_keys=True))
@@ -954,6 +1201,18 @@ def _validate_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _seal_command(args: argparse.Namespace) -> int:
+    path = seal_completion_bundle(
+        protocol_key=args.protocol,
+        root=args.root,
+        launch_preflight=args.launch_preflight,
+        result_validation=args.result_validation,
+        runner_receipt=args.runner_receipt,
+    )
+    print(path)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -968,6 +1227,7 @@ def build_parser() -> argparse.ArgumentParser:
     preflight.add_argument("--ref-name", required=True)
     preflight.add_argument("--run-id", type=int, required=True)
     preflight.add_argument("--run-attempt", type=int, required=True)
+    preflight.add_argument("--root", type=Path, required=True)
     preflight.add_argument("--output", type=Path, required=True)
     preflight.set_defaults(handler=_preflight_command)
 
@@ -980,6 +1240,13 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("--uv-lock-sha256", required=True)
     validate.add_argument("--output", type=Path, required=True)
     validate.set_defaults(handler=_validate_command)
+    seal = subparsers.add_parser("seal")
+    seal.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
+    seal.add_argument("--root", type=Path, required=True)
+    seal.add_argument("--launch-preflight", type=Path, required=True)
+    seal.add_argument("--result-validation", type=Path, required=True)
+    seal.add_argument("--runner-receipt", type=Path, required=True)
+    seal.set_defaults(handler=_seal_command)
     return parser
 
 

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -3,7 +3,7 @@ name: IPMNIST preregistration
 run-name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}
 
 # This workflow is deliberately manual-only. It is launch infrastructure for
-# two permanently nonpromoting development protocols, not a CI benchmark lane.
+# three permanently nonpromoting development protocols, not a CI benchmark lane.
 "on":
   workflow_dispatch:
     inputs:
@@ -13,6 +13,7 @@ run-name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}
         type: choice
         options:
           - issue51
+          - issue184
           - issue188
       launch_sha:
         description: Full 40-character commit SHA of the reviewed launch tag
@@ -121,6 +122,7 @@ jobs:
           set -euo pipefail
           case "$PROTOCOL" in
             issue51) namespace="replication_r1" ;;
+            issue184) namespace="rls_preset_ablation_r1" ;;
             issue188) namespace="gate_ablation_r3" ;;
             *) echo "unsupported protocol" >&2; exit 1 ;;
           esac
@@ -188,6 +190,7 @@ jobs:
             --ref-name "$GITHUB_REF_NAME" \
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --root "$GITHUB_WORKSPACE" \
             --output "$metadata"
 
       - name: Synchronize the committed environment
@@ -379,6 +382,13 @@ jobs:
               seeds=(0 1 2)
               summary="summary.json"
               ;;
+            issue184)
+              namespace="rls_preset_ablation_r1"
+              control="rls_head_resid_l1_preset005"
+              candidate="rls_head_resid_l1_noreset"
+              seeds=(0 1 2)
+              summary="summary.json"
+              ;;
             issue188)
               namespace="gate_ablation_r3"
               control="rls_head_resid_l1_preset005"
@@ -451,6 +461,19 @@ jobs:
             echo "- Validation metadata: result-validation.json"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Seal a committed-ready completion record
+        shell: bash
+        env:
+          PROTOCOL: ${{ inputs.protocol }}
+        run: |
+          set -euo pipefail
+          uv run --no-sync python .github/scripts/ipmnist_prereg.py seal \
+            --protocol "$PROTOCOL" \
+            --root "$GITHUB_WORKSPACE" \
+            --launch-preflight "$RUNNER_TEMP/prereg-metadata/launch-preflight.json" \
+            --result-validation "$RUNNER_TEMP/prereg-metadata/result-validation.json" \
+            --runner-receipt "$RUNNER_TEMP/prereg-metadata/runner.json"
+
       - name: Upload 90-day result or partial recovery bundle
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -458,6 +481,7 @@ jobs:
           name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}-${{ github.run_id }}
           path: |
             outputs/ipmnist_screening/replication_r1
+            outputs/ipmnist_screening/rls_preset_ablation_r1
             outputs/ipmnist_screening/gate_ablation_r3
             ${{ runner.temp }}/prereg-metadata
           if-no-files-found: warn

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -42,6 +42,15 @@ def test_prereg_protocols_pin_exact_arms_and_seeds() -> None:
     assert issue188.seeds == tuple(range(3, 13))
 
 
+def test_issue184_protocol_pins_exact_arms_namespace_and_seeds() -> None:
+    issue184 = _PROTOCOLS["issue184"]
+    assert issue184.issue == 184
+    assert issue184.namespace == "rls_preset_ablation_r1"
+    assert issue184.control == "rls_head_resid_l1_preset005"
+    assert issue184.candidate == "rls_head_resid_l1_noreset"
+    assert issue184.seeds == (0, 1, 2)
+
+
 def test_authorization_line_binds_every_launch_identity() -> None:
     line = _authorization_line(
         _PROTOCOLS["issue51"],
@@ -139,6 +148,34 @@ def test_issue188_outcomes_are_frozen(mean_diff: float, stderr_diff: float, expe
             mean_diff=mean_diff,
             stderr_diff=stderr_diff,
             per_seed_diff=(mean_diff,) * 10,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("mean_diff", "diffs", "expected"),
+    [
+        (0.002000001, (0.001, 0.002, 0.003), "no_reset_win"),
+        (0.002, (0.001, 0.002, 0.003), "inconclusive"),
+        (0.003, (0.001, 0.0, 0.003), "inconclusive"),
+        (-0.002000001, (-0.001, -0.002, -0.003), "reset_load_bearing"),
+        (-0.002, (-0.001, -0.002, -0.003), "inconclusive"),
+        (-0.003, (-0.001, 0.0, -0.003), "inconclusive"),
+        (0.001, (0.0015, -0.0015, 0.0), "practical_equivalence"),
+        (-0.001, (0.0015, -0.0015, 0.0), "practical_equivalence"),
+        (0.0005, (0.001500001, -0.001, 0.0), "inconclusive"),
+    ],
+)
+def test_issue184_outcomes_are_frozen(
+    mean_diff: float, diffs: tuple[float, ...], expected: str
+) -> None:
+    assert (
+        _classify_outcome(
+            "issue184",
+            mean_diff=mean_diff,
+            stderr_diff=0.0,
+            per_seed_diff=diffs,
         )
         == expected
     )

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import runpy
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 
@@ -10,9 +12,11 @@ import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
 _DRIVER = runpy.run_path(_ROOT / ".github" / "scripts" / "ipmnist_prereg.py")
+_LOCAL_DRIVER = runpy.run_path(_ROOT / ".github" / "scripts" / "ipmnist_local_prereg.py")
 _PROTOCOLS = cast(dict[str, Any], _DRIVER["PROTOCOLS"])
 _authorization_line = cast(Any, _DRIVER["authorization_line"])
 _registration_amendment_line = cast(Any, _DRIVER["registration_amendment_line"])
+_seal_completion_bundle = cast(Any, _DRIVER["seal_completion_bundle"])
 _classify_outcome = cast(Any, _DRIVER["classify_outcome"])
 _strict_json = cast(Any, _DRIVER["_strict_json"])
 _validate_runner_receipt = cast(Any, _DRIVER["_validate_runner_receipt"])
@@ -20,10 +24,13 @@ _validate_runtime = cast(Any, _DRIVER["_validate_runtime"])
 _validate_summary_reconstruction = cast(Any, _DRIVER["_validate_summary_reconstruction"])
 _validate_result_bundle = cast(Any, _DRIVER["validate_result_bundle"])
 _verify_launch_authorization = cast(Any, _DRIVER["verify_launch_authorization"])
+_verify_prerequisite_completion = cast(Any, _DRIVER["_verify_prerequisite_completion"])
 _workflow_runs = cast(Any, _DRIVER["_workflow_runs"])
 _write_json = cast(Any, _DRIVER["_write_json"])
 _DRIVER_GLOBALS = cast(dict[str, Any], _verify_launch_authorization.__globals__)
 _WORKFLOW_RUN_GLOBALS = cast(dict[str, Any], _workflow_runs.__globals__)
+_PREREQUISITE_GLOBALS = cast(dict[str, Any], _verify_prerequisite_completion.__globals__)
+_SEAL_GLOBALS = cast(dict[str, Any], _seal_completion_bundle.__globals__)
 
 
 def test_prereg_protocols_pin_exact_arms_and_seeds() -> None:
@@ -49,6 +56,47 @@ def test_issue184_protocol_pins_exact_arms_namespace_and_seeds() -> None:
     assert issue184.control == "rls_head_resid_l1_preset005"
     assert issue184.candidate == "rls_head_resid_l1_noreset"
     assert issue184.seeds == (0, 1, 2)
+    assert issue184.summary_filename == "summary.json"
+    assert issue184.requires_amendment is True
+    assert issue184.prerequisite == "issue51"
+
+
+def test_issue184_workflow_pins_every_shell_mapping() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "ipmnist-prereg.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "          - issue184\n" in workflow
+    assert 'issue184) namespace="rls_preset_ablation_r1" ;;' in workflow
+    assert 'candidate="rls_head_resid_l1_noreset"' in workflow
+    assert 'seeds=(0 1 2)' in workflow
+    assert "outputs/ipmnist_screening/rls_preset_ablation_r1" in workflow
+    assert ".github/scripts/ipmnist_prereg.py seal" in workflow
+
+
+def test_issue184_github_and_local_protocols_cannot_drift() -> None:
+    github = _PROTOCOLS["issue184"]
+    local = cast(dict[str, Any], _LOCAL_DRIVER["LOCAL_PROTOCOLS"])["issue184"]
+    assert (github.issue, github.namespace, github.control, github.candidate, github.seeds) == (
+        local.issue,
+        local.namespace,
+        local.control,
+        local.candidate,
+        local.stages[0].seeds,
+    )
+    classify_local = cast(Any, _LOCAL_DRIVER["classify_issue184"])
+    cases = (
+        (0.003, (0.002, 0.003, 0.004)),
+        (-0.003, (-0.002, -0.003, -0.004)),
+        (0.001, (0.0015, -0.0015, 0.0)),
+        (0.002, (0.002, 0.002, 0.002)),
+    )
+    for mean, differences in cases:
+        assert _classify_outcome(
+            "issue184",
+            mean_diff=mean,
+            stderr_diff=0.0,
+            per_seed_diff=differences,
+        ) == classify_local(mean, differences)
 
 
 def test_authorization_line_binds_every_launch_identity() -> None:
@@ -111,6 +159,26 @@ def test_issue188_amendment_line_binds_the_complete_registered_change() -> None:
         "ref=ipmnist-prereg-example "
         "runner=github-hosted-macos-14-arm64-apple-m1 seeds=3,4,5,6,7,8,9,10,11,12 "
         "n=10 compute=uncompensated"
+    )
+
+
+def test_issue184_amendment_line_binds_the_complete_registered_change() -> None:
+    line = _registration_amendment_line(
+        _PROTOCOLS["issue184"],
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="3" * 64,
+        workflow_blob_sha1="4" * 40,
+        driver_blob_sha1="5" * 40,
+        ref_name="ipmnist-prereg-example",
+    )
+    assert line == (
+        "ASI_PREREG_AMENDMENT_V1 issue=184 protocol=issue184 "
+        f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
+        f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
+        "ref=ipmnist-prereg-example "
+        "runner=github-hosted-macos-14-arm64-apple-m1 seeds=0,1,2 n=3 "
+        "compute=uncompensated"
     )
 
 
@@ -179,6 +247,16 @@ def test_issue184_outcomes_are_frozen(
         )
         == expected
     )
+
+
+def test_issue184_outcome_rejects_incomplete_seed_coverage() -> None:
+    with pytest.raises(ValueError, match="exactly 3"):
+        _classify_outcome(
+            "issue184",
+            mean_diff=0.003,
+            stderr_diff=0.0,
+            per_seed_diff=(0.003, 0.003),
+        )
 
 
 def test_outcome_validation_rejects_nonfinite_values() -> None:
@@ -540,6 +618,86 @@ def test_issue188_amendment_must_be_valid_utc_and_precede_authorization(
         )
 
 
+def test_issue184_requires_prerequisite_closure_before_amendment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol = _PROTOCOLS["issue184"]
+    binding = {
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "workflow_blob_sha1": "4" * 40,
+        "driver_blob_sha1": "5" * 40,
+        "ref_name": "ipmnist-prereg-example",
+    }
+    amendment = _registration_amendment_line(protocol, **binding)
+    authorization = _authorization_line(protocol, **binding)
+    comments = [
+        {
+            "id": 455,
+            "body": amendment,
+            "user": {"id": 18_633_264, "login": "lalalune"},
+            "author_association": "MEMBER",
+            "created_at": "2026-08-16T09:00:00Z",
+            "updated_at": "2026-08-16T09:00:00Z",
+            "html_url": "https://github.com/elizaOS/asi/issues/184#issuecomment-455",
+        },
+        {
+            "id": 456,
+            "body": authorization,
+            "user": {"id": 18_633_264, "login": "lalalune"},
+            "author_association": "MEMBER",
+            "created_at": "2026-08-16T09:30:00Z",
+            "updated_at": "2026-08-16T09:30:00Z",
+            "html_url": "https://github.com/elizaOS/asi/issues/184#issuecomment-456",
+        },
+    ]
+    current = {
+        "id": 123,
+        "event": "workflow_dispatch",
+        "head_sha": "1" * 40,
+        "display_title": f"ipmnist-issue184-{'1' * 40}",
+        "run_attempt": 1,
+        "path": ".github/workflows/ipmnist-prereg.yml",
+        "created_at": "2026-08-16T10:00:00Z",
+        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+    }
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
+    monkeypatch.setitem(_DRIVER_GLOBALS, "_github_pages", lambda *_args, **_kwargs: comments)
+    prerequisite = {
+        "issue_closed_at": "2026-08-16T08:59:59Z",
+        "protocol": "issue51",
+    }
+    monkeypatch.setitem(
+        _DRIVER_GLOBALS,
+        "_verify_prerequisite_completion",
+        lambda *_args, **_kwargs: prerequisite,
+    )
+    payload = _verify_launch_authorization(
+        protocol_key="issue184",
+        repository="elizaOS/asi",
+        run_id=123,
+        run_attempt=1,
+        token="token",
+        root=Path("."),
+        **binding,
+    )
+    assert payload["prerequisite_completion"] == prerequisite
+
+    prerequisite["issue_closed_at"] = "2026-08-16T09:00:00Z"
+    with pytest.raises(RuntimeError, match="closed before"):
+        _verify_launch_authorization(
+            protocol_key="issue184",
+            repository="elizaOS/asi",
+            run_id=123,
+            run_attempt=1,
+            token="token",
+            root=Path("."),
+            **binding,
+        )
+
+
 def _searched_workflow_run(run_id: int) -> dict[str, Any]:
     return {
         "id": run_id,
@@ -728,6 +886,141 @@ def test_metadata_writer_refuses_overwrite(tmp_path: Path) -> None:
     assert json.loads(path.read_text(encoding="utf-8")) == {"value": 1}
 
 
+def test_completion_seal_copies_runner_and_binds_fresh_reconstruction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    protocol = _PROTOCOLS["issue51"]
+    namespace = tmp_path / "outputs" / "ipmnist_screening" / protocol.namespace
+    namespace.mkdir(parents=True)
+    launch = {
+        "schema": "asi.ipmnist_prereg.launch_preflight.v2",
+        "protocol": asdict(protocol),
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "run_id": 123,
+        "run_url": "https://github.com/elizaOS/asi/actions/runs/123",
+    }
+    result = {
+        "schema": "asi.ipmnist_prereg.result_validation.v1",
+        "protocol": asdict(protocol),
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "outcome": "replicated",
+        "summary_sha256": "4" * 64,
+    }
+    launch_path = tmp_path / "launch.json"
+    result_path = tmp_path / "result.json"
+    runner_path = tmp_path / "runner.json"
+    _write_json(launch_path, launch)
+    _write_json(result_path, result)
+    _write_json(runner_path, {"runner": "exact"})
+    monkeypatch.setitem(
+        _SEAL_GLOBALS,
+        "validate_result_bundle",
+        lambda **_kwargs: result,
+    )
+
+    completion_path = _seal_completion_bundle(
+        protocol_key="issue51",
+        root=tmp_path,
+        launch_preflight=launch_path,
+        result_validation=result_path,
+        runner_receipt=runner_path,
+    )
+
+    completion = _strict_json(completion_path)
+    committed_runner = namespace / "runner.v2.json"
+    assert completion["launch_preflight"] == json.loads(json.dumps(launch))
+    assert completion["result_validation"] == json.loads(json.dumps(result))
+    assert completion["runner_receipt"] == (
+        "outputs/ipmnist_screening/replication_r1/runner.v2.json"
+    )
+    assert completion["runner_receipt_sha256"] == hashlib.sha256(
+        committed_runner.read_bytes()
+    ).hexdigest()
+    with pytest.raises(FileExistsError):
+        _seal_completion_bundle(
+            protocol_key="issue51",
+            root=tmp_path,
+            launch_preflight=launch_path,
+            result_validation=result_path,
+            runner_receipt=runner_path,
+        )
+
+
+def test_issue184_prerequisite_requires_committed_result_live_success_and_closure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    issue51 = _PROTOCOLS["issue51"]
+    namespace = tmp_path / "outputs" / "ipmnist_screening" / issue51.namespace
+    namespace.mkdir(parents=True)
+    runner_path = namespace / "runner.v2.json"
+    _write_json(runner_path, {"runner": "exact"})
+    result = {
+        "schema": "asi.ipmnist_prereg.result_validation.v1",
+        "protocol": asdict(issue51),
+        "source": "1" * 40,
+        "tree": "2" * 40,
+        "uv_lock_sha256": "3" * 64,
+        "outcome": "replicated",
+        "summary_sha256": "4" * 64,
+    }
+    completion = {
+        "schema": "asi.ipmnist_prereg.completion.v1",
+        "launch_preflight": {
+            "protocol": asdict(issue51),
+            "source": "1" * 40,
+            "tree": "2" * 40,
+            "uv_lock_sha256": "3" * 64,
+            "run_id": 123,
+            "run_url": "https://github.com/elizaOS/asi/actions/runs/123",
+        },
+        "result_validation": result,
+        "runner_receipt": "outputs/ipmnist_screening/replication_r1/runner.v2.json",
+        "runner_receipt_sha256": hashlib.sha256(runner_path.read_bytes()).hexdigest(),
+    }
+    _write_json(namespace / "completion.v1.json", completion)
+    monkeypatch.setitem(
+        _PREREQUISITE_GLOBALS,
+        "validate_result_bundle",
+        lambda **_kwargs: result,
+    )
+
+    def fake_github_json(path: str, *, token: str) -> dict[str, Any]:
+        assert token == "token"
+        if path.endswith("/actions/runs/123"):
+            return {
+                "id": 123,
+                "event": "workflow_dispatch",
+                "head_sha": "1" * 40,
+                "path": ".github/workflows/ipmnist-prereg.yml",
+                "display_title": f"ipmnist-issue51-{'1' * 40}",
+                "run_attempt": 1,
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+                "updated_at": "2026-08-16T08:59:00Z",
+            }
+        if path.endswith("/issues/51"):
+            return {"state": "closed", "closed_at": "2026-08-16T09:00:00Z"}
+        assert "/compare/" in path
+        return {"status": "ahead"}
+
+    monkeypatch.setitem(_PREREQUISITE_GLOBALS, "_github_json", fake_github_json)
+    receipt = _verify_prerequisite_completion(
+        _PROTOCOLS["issue184"],
+        repository="elizaOS/asi",
+        launch_source="5" * 40,
+        root=tmp_path,
+        token="token",
+    )
+    assert receipt["protocol"] == "issue51"
+    assert receipt["issue_closed_at"] == "2026-08-16T09:00:00Z"
+    assert receipt["outcome"] == "replicated"
+
+
 def _source_provenance() -> dict[str, object]:
     return {
         "schema": "alberta.ipmnist_screening.source_provenance.v1",
@@ -857,7 +1150,13 @@ def test_runtime_rejects_equal_but_wrong_type_jax_config(
         _validate_runtime(environment)
 
 
-def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def _write_protocol_bundle(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    protocol_key: str,
+    candidate_accuracy: float,
+) -> Path:
     from alberta_framework.benchmarks.ipmnist_screening import (
         ScreeningRunResult,
         merge_shards,
@@ -866,7 +1165,8 @@ def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     )
     from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 
-    namespace = root / "outputs" / "ipmnist_screening" / "replication_r1"
+    protocol = _PROTOCOLS[protocol_key]
+    namespace = root / "outputs" / "ipmnist_screening" / protocol.namespace
     shards_dir = namespace / "shards"
     shards_dir.mkdir(parents=True)
     config = IPMNISTConfig(
@@ -880,8 +1180,8 @@ def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     relative_paths: list[Path] = []
     for seed in (0, 1, 2):
         for arm, accuracy in (
-            ("sigma0_shiftnorm_d099", 0.5),
-            ("rls_head_resid_l1_preset005", 0.505),
+            (protocol.control, 0.5),
+            (protocol.candidate, candidate_accuracy),
         ):
             spec = screening_spec(arm)
             result = ScreeningRunResult(
@@ -912,12 +1212,21 @@ def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.chdir(root)
     summary = merge_shards(
         relative_paths,
-        control_name="sigma0_shiftnorm_d099",
+        control_name=protocol.control,
         slope_window=15,
     )
-    summary_path = namespace / "summary.json"
+    summary_path = namespace / protocol.summary_filename
     summary_path.write_text(json.dumps(summary, allow_nan=False), encoding="utf-8")
     return summary_path
+
+
+def _write_issue51_bundle(root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    return _write_protocol_bundle(
+        root,
+        monkeypatch,
+        protocol_key="issue51",
+        candidate_accuracy=0.505,
+    )
 
 
 def _write_runner_receipt(root: Path) -> Path:
@@ -1003,6 +1312,29 @@ def test_result_bundle_recomputes_summary_from_exact_shards(
     )
     assert result["outcome"] == "replicated"
     assert result["mean_diff"] == pytest.approx(0.005)
+
+
+def test_issue184_result_bundle_reconstructs_exact_six_shard_protocol(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_protocol_bundle(
+        tmp_path,
+        monkeypatch,
+        protocol_key="issue184",
+        candidate_accuracy=0.503,
+    )
+    runner_receipt = _write_runner_receipt(tmp_path)
+    result = _validate_result_bundle(
+        protocol_key="issue184",
+        root=tmp_path,
+        runner_receipt=runner_receipt,
+        source="1" * 40,
+        tree="2" * 40,
+        uv_lock_sha256="4" * 64,
+    )
+    assert result["outcome"] == "no_reset_win"
+    assert result["mean_diff"] == pytest.approx(0.003)
+    assert result["protocol"]["seeds"] == (0, 1, 2)
 
 
 def test_result_bundle_rejects_consistently_resigned_jax_config_drift(


### PR DESCRIPTION
Closes the remaining engineering gap for #184 without launching either scientific run.

This adds the frozen #184 protocol, exact outcome classifier, workflow dispatch and artifact recovery path, immutable amendment/authorization checks, and a durable prerequisite proof requiring a committed, reconstructable, successful #51 result before #184 can dispatch. It also adds a sealed completion record tying the live GitHub run, launch preflight, result validation, and runner receipt digest together.

Important: merging this PR authorizes no compute, creates no tag, dispatches no workflow, consumes no seed, and writes no output. Both #51 and #184 must be repinned to the final post-merge source, then receive their exact owner authorization. #51 must run and its reviewed result must merge before #184 can pass preflight.

Verification on current main:
- prereg workflow/local suites: 225 passed
- scoped Ruff: clean
- strict mypy on driver: clean
- diff check: clean

No benchmark or output artifact was created or modified.