### PR TITLE
fix(stacked-horde): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -51,6 +51,7 @@ from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 __all__ = [
     "StackedHordeConfig",
@@ -156,6 +157,30 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_sequence(name: str, value: object) -> tuple[object, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be an actual tuple")
+    return cast(tuple[object, ...], value)
+
+
+def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
+    if type(value) not in (list, tuple):
+        raise ValueError(f"{name} must be an actual list or tuple")
+    return tuple(cast(list[object] | tuple[object, ...], value))
+
+
+def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
+    parameter_scalars = n_demons * feature_dim
+    # Static gamma/lambda/index arrays, dynamic weights/traces, and all public
+    # per-step result leaves can coexist at the update boundary.
+    aggregate_scalars = 2 * parameter_scalars + 6 * n_demons + 2
+    aggregate_nbytes = 8 * parameter_scalars + 21 * n_demons + 5
+    if aggregate_scalars > _INT32_MAX:
+        raise ValueError("stacked Horde aggregate scalars must fit signed int32")
+    if aggregate_nbytes > _INT32_MAX:
+        raise ValueError("stacked Horde aggregate bytes must fit signed int32")
+
+
 @dataclass(frozen=True)
 class StackedHordeConfig:
     """Static configuration for :class:`StackedLinearHorde`.
@@ -184,25 +209,41 @@ class StackedHordeConfig:
         n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
-        for name, seq in (
-            ("gammas", self.gammas),
-            ("lamdas", self.lamdas),
-            ("cumulant_indices", self.cumulant_indices),
-        ):
+        raw_sequences = {
+            "gammas": _require_sequence("gammas", self.gammas),
+            "lamdas": _require_sequence("lamdas", self.lamdas),
+            "cumulant_indices": _require_sequence(
+                "cumulant_indices", self.cumulant_indices
+            ),
+        }
+        for name, seq in raw_sequences.items():
             if len(seq) != n_demons:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
-        if any(not 0.0 <= g <= 1.0 for g in self.gammas):
-            raise ValueError("every gamma must be in [0, 1]")
-        if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
-            raise ValueError("every lamda must be in [0, 1]")
+
+        gammas = tuple(
+            validated_float32_scalar(
+                f"gammas[{i}]", value, lower=0.0, upper=1.0
+            )
+            for i, value in enumerate(raw_sequences["gammas"])
+        )
+        lamdas = tuple(
+            validated_float32_scalar(
+                f"lamdas[{i}]", value, lower=0.0, upper=1.0
+            )
+            for i, value in enumerate(raw_sequences["lamdas"])
+        )
 
         cumulant_indices = tuple(
             _require_int32(f"cumulant_indices[{i}]", idx, minimum=0)
-            for i, idx in enumerate(self.cumulant_indices)
+            for i, idx in enumerate(raw_sequences["cumulant_indices"])
         )
+
+        _preflight_horde_resources(n_demons, feature_dim)
 
         object.__setattr__(self, "n_demons", n_demons)
         object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "gammas", gammas)
+        object.__setattr__(self, "lamdas", lamdas)
         object.__setattr__(self, "cumulant_indices", cumulant_indices)
         object.__setattr__(
             self,
@@ -228,7 +269,7 @@ class StackedHordeConfig:
         config = dict(config)
         config.pop("type", None)
         for key in ("gammas", "lamdas", "cumulant_indices"):
-            config[key] = tuple(config[key])
+            config[key] = _decode_sequence(key, config[key])
         return cls(**config)
 
 
@@ -253,10 +294,26 @@ def nexting_spec(
         lamda: Shared trace decay.
         step_size: Shared TD step-size.
     """
+    feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+    raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
+    raw_gammas = _require_sequence("gammas", gammas)
+    canonical_indices = tuple(
+        _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
+        for i, value in enumerate(raw_indices)
+    )
+    canonical_gammas = tuple(
+        validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
+        for i, value in enumerate(raw_gammas)
+    )
+    canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+    n_demons = len(canonical_indices) * len(canonical_gammas)
+    if n_demons < 1 or n_demons > _INT32_MAX:
+        raise ValueError("derived n_demons must be in the signed int32 domain")
+    _preflight_horde_resources(n_demons, feature_dim)
     idxs: list[int] = []
     gs: list[float] = []
-    for c in cumulant_indices:
-        for g in gammas:
+    for c in canonical_indices:
+        for g in canonical_gammas:
             idxs.append(c)
             gs.append(g)
     n = len(idxs)
@@ -264,7 +321,7 @@ def nexting_spec(
         n_demons=n,
         feature_dim=feature_dim,
         gammas=tuple(gs),
-        lamdas=(lamda,) * n,
+        lamdas=(canonical_lamda,) * n,
         cumulant_indices=tuple(idxs),
         step_size=step_size,
     )

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -38,6 +38,7 @@ the NaN-masking convention of the loop-based hordes.
 
 import math
 import operator
+from collections.abc import Mapping
 from dataclasses import dataclass
 from fractions import Fraction
 from numbers import Real
@@ -131,6 +132,15 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_CONFIG_FIELDS = {
+    "type",
+    "n_demons",
+    "feature_dim",
+    "gammas",
+    "lamdas",
+    "cumulant_indices",
+    "step_size",
+}
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -179,6 +189,17 @@ def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
         raise ValueError("stacked Horde aggregate scalars must fit signed int32")
     if aggregate_nbytes > _INT32_MAX:
         raise ValueError("stacked Horde aggregate bytes must fit signed int32")
+
+
+def _require_scan_result_resources(num_updates: int, n_demons: int) -> None:
+    result_scalars = num_updates * n_demons
+    if result_scalars > _INT32_MAX or 4 * result_scalars > _INT32_MAX:
+        raise ValueError("stacked Horde scan result bytes must fit signed int32")
+
+
+def _saturating_int32_increment(value: Array) -> Array:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(value, 0), maximum - 1) + 1
 
 
 @dataclass(frozen=True)
@@ -264,10 +285,16 @@ class StackedHordeConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "StackedHordeConfig":
+    def from_config(cls, config: Mapping[str, Any]) -> "StackedHordeConfig":
         """Reconstruct a config from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("stacked Horde config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CONFIG_FIELDS:
+            raise ValueError("stacked Horde config fields do not match the schema")
         config = dict(config)
-        config.pop("type", None)
+        serialized_type = config.pop("type")
+        if type(serialized_type) is not str or serialized_type != "StackedHordeConfig":
+            raise ValueError("unexpected stacked Horde config type")
         for key in ("gammas", "lamdas", "cumulant_indices"):
             config[key] = _decode_sequence(key, config[key])
         return cls(**config)
@@ -380,9 +407,33 @@ class StackedLinearHorde:
         return {"type": "StackedLinearHorde", "config": self._config.to_config()}
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "StackedLinearHorde":
+    def from_config(cls, config: Mapping[str, Any]) -> "StackedLinearHorde":
         """Reconstruct a horde from :meth:`to_config` output."""
-        return cls(StackedHordeConfig.from_config(dict(config)["config"]))
+        if type(config) is not dict:
+            raise ValueError("stacked linear Horde config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != {"type", "config"}:
+            raise ValueError("stacked linear Horde config fields do not match the schema")
+        serialized_type = config["type"]
+        if type(serialized_type) is not str or serialized_type != "StackedLinearHorde":
+            raise ValueError("unexpected stacked linear Horde config type")
+        nested = config["config"]
+        if type(nested) is not dict:
+            raise ValueError("stacked linear Horde nested config must be an actual dict")
+        return cls(StackedHordeConfig.from_config(nested))
+
+    def _require_state_contract(self, state: StackedHordeState) -> None:
+        if type(state) is not StackedHordeState:
+            raise TypeError("state must be an actual StackedHordeState")
+        expected = (self._config.n_demons, self._config.feature_dim)
+        for name, value in (("weights", state.weights), ("traces", state.traces)):
+            if value.shape != expected:
+                raise ValueError(f"state {name} must have shape {expected}")
+            if value.dtype != jnp.dtype(jnp.float32):
+                raise TypeError(f"state {name} must have dtype float32")
+        if state.step_count.shape != ():
+            raise ValueError("state step_count must be scalar")
+        if state.step_count.dtype != jnp.dtype(jnp.int32):
+            raise TypeError("state step_count must have dtype int32")
 
     def init(self) -> StackedHordeState:
         """Initialize zero weights and traces."""
@@ -396,6 +447,11 @@ class StackedLinearHorde:
 
     def predict(self, state: StackedHordeState, features: Array) -> Array:
         """All demons' predictions for one feature vector, shape ``(n_demons,)``."""
+        self._require_state_contract(state)
+        if features.shape != (self._config.feature_dim,):
+            raise ValueError("features must match configured feature_dim")
+        if features.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("features must have dtype float32")
         return state.weights @ features
 
     def update(
@@ -426,6 +482,14 @@ class StackedLinearHorde:
             TD errors (TD errors are NaN for inactive demons).
         """
         cfg = self._config
+        self._require_state_contract(state)
+        for name, value in (("features", features), ("next_features", next_features)):
+            if value.shape != (cfg.feature_dim,):
+                raise ValueError(f"{name} must match configured feature_dim")
+            if value.dtype != jnp.dtype(jnp.float32):
+                raise TypeError(f"{name} must have dtype float32")
+        if cumulant_source.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("cumulant_source must have dtype float32")
         source_shape = jnp.shape(cumulant_source)
         # JAX clips out-of-range positive gather indices instead of raising,
         # so a short source would silently train demons on the wrong channel.
@@ -494,7 +558,7 @@ class StackedLinearHorde:
         proposed_state = StackedHordeState(
             weights=new_weights,
             traces=new_traces,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_increment(state.step_count),
         )
         new_state = jax.lax.cond(
             update_applied,
@@ -552,6 +616,12 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
+    if features.ndim != 2:
+        raise ValueError("features must be rank-two")
+    if features.dtype != jnp.dtype(jnp.float32):
+        raise TypeError("features must have dtype float32")
+    if features.shape[1] != horde.config.feature_dim:
+        raise ValueError("features must match configured feature_dim")
     sources_shape = jnp.shape(cumulant_sources)
     if len(sources_shape) != 2:
         raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
@@ -562,8 +632,15 @@ def run_stacked_horde_scan(
             f"config.cumulant_indices requires index {max_index}"
         )
     num_steps = features.shape[0]
+    if sources_shape[0] != num_steps:
+        raise ValueError("features and cumulant_sources must have the same number of rows")
+    if cumulant_sources.dtype != jnp.dtype(jnp.float32):
+        raise TypeError("cumulant_sources must have dtype float32")
+    _require_scan_result_resources(max(num_steps - 1, 0), horde.config.n_demons)
     if rhos is None:
         rhos = jnp.ones((num_steps,), dtype=jnp.float32)
+    elif rhos.shape != (num_steps,):
+        raise ValueError("rhos must have shape (num_steps,)")
 
     def step_fn(
         carry: StackedHordeState,

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -37,10 +37,11 @@ the NaN-masking convention of the loop-based hordes.
 """
 
 import math
+import operator
 from dataclasses import dataclass
 from fractions import Fraction
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -90,11 +91,7 @@ def _snapshot_exact_fraction(value: Fraction) -> Fraction:
         denominator = value.denominator
     except AttributeError:
         raise ValueError(_STEP_SIZE_ERROR) from None
-    if (
-        type(numerator) is not int
-        or type(denominator) is not int
-        or denominator <= 0
-    ):
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         raise ValueError(_STEP_SIZE_ERROR)
     return Fraction(numerator, denominator)
 
@@ -132,6 +129,33 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
     return cast(float, value) if preserve_builtin_float else narrowed
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @dataclass(frozen=True)
 class StackedHordeConfig:
     """Static configuration for :class:`StackedLinearHorde`.
@@ -157,25 +181,29 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        if self.n_demons < 1:
-            raise ValueError("n_demons must be positive")
-        if self.feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+
         for name, seq in (
             ("gammas", self.gammas),
             ("lamdas", self.lamdas),
             ("cumulant_indices", self.cumulant_indices),
         ):
-            if len(seq) != self.n_demons:
-                raise ValueError(f"{name} must have length n_demons={self.n_demons}")
+            if len(seq) != n_demons:
+                raise ValueError(f"{name} must have length n_demons={n_demons}")
         if any(not 0.0 <= g <= 1.0 for g in self.gammas):
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
-        # Identity-only check: bools and numpy integers are refused so a JAX
-        # gather can never wrap (negative) or reinterpret the channel.
-        if any(type(idx) is not int or idx < 0 for idx in self.cumulant_indices):
-            raise ValueError("cumulant_indices entries must be nonnegative builtin ints")
+
+        cumulant_indices = tuple(
+            _require_int32(f"cumulant_indices[{i}]", idx, minimum=0)
+            for i, idx in enumerate(self.cumulant_indices)
+        )
+
+        object.__setattr__(self, "n_demons", n_demons)
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "cumulant_indices", cumulant_indices)
         object.__setattr__(
             self,
             "step_size",
@@ -346,9 +374,7 @@ class StackedLinearHorde:
         # so a short source would silently train demons on the wrong channel.
         # Shapes are static, so these checks also fire at jit/scan trace time.
         if len(source_shape) != 1:
-            raise ValueError(
-                f"cumulant_source must be rank-one, got shape {source_shape}"
-            )
+            raise ValueError(f"cumulant_source must be rank-one, got shape {source_shape}")
         if source_shape[0] <= self._max_cumulant_index:
             raise ValueError(
                 f"cumulant_source has {source_shape[0]} channels but "
@@ -365,12 +391,8 @@ class StackedLinearHorde:
         # gamma=0 must not multiply an inf bootstrap (0*inf).
         bootstrap = jnp.where(self._gammas == 0.0, 0.0, self._gammas * v_next)
         raw_td_errors = cumulants + bootstrap - v
-        prediction_valid = jnp.isfinite(v) & (
-            (self._gammas == 0.0) | jnp.isfinite(v_next)
-        )
-        channel_valid = (
-            active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
-        )
+        prediction_valid = jnp.isfinite(v) & ((self._gammas == 0.0) | jnp.isfinite(v_next))
+        channel_valid = active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
         safe_cumulants = jnp.where(channel_valid, cumulants, 0.0)
         td_errors = safe_cumulants + bootstrap - v
 
@@ -382,15 +404,10 @@ class StackedLinearHorde:
         # Inactive demons: trace decays but the current gradient is withheld.
         decayed_only = carried
         safe_rho = jnp.where(rho_valid, rho_vec, 0.0)
-        proposed_traces = safe_rho[:, None] * jnp.where(
-            active[:, None], accumulated, decayed_only
-        )
+        proposed_traces = safe_rho[:, None] * jnp.where(active[:, None], accumulated, decayed_only)
 
         masked_delta = jnp.where(channel_valid, td_errors, 0.0)
-        proposed_weights = (
-            state.weights
-            + cfg.step_size * masked_delta[:, None] * proposed_traces
-        )
+        proposed_weights = state.weights + cfg.step_size * masked_delta[:, None] * proposed_traces
         source_weights_finite = jnp.all(jnp.isfinite(state.weights))
         traces_needed = decay[:, 0] != 0.0
         traces_usable = (~traces_needed) | jnp.all(jnp.isfinite(state.traces), axis=1)
@@ -414,12 +431,8 @@ class StackedLinearHorde:
             & traces_usable
         )
         accepted_channels = head_updates_applied | inactive_trace_applied
-        new_weights = jnp.where(
-            head_updates_applied[:, None], proposed_weights, state.weights
-        )
-        new_traces = jnp.where(
-            accepted_channels[:, None], proposed_traces, state.traces
-        )
+        new_weights = jnp.where(head_updates_applied[:, None], proposed_weights, state.weights)
+        new_traces = jnp.where(accepted_channels[:, None], proposed_traces, state.traces)
         update_applied = jnp.any(accepted_channels)
         proposed_state = StackedHordeState(
             weights=new_weights,
@@ -484,9 +497,7 @@ def run_stacked_horde_scan(
     """
     sources_shape = jnp.shape(cumulant_sources)
     if len(sources_shape) != 2:
-        raise ValueError(
-            f"cumulant_sources must be rank-two, got shape {sources_shape}"
-        )
+        raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
     max_index = max(horde.config.cumulant_indices)
     if sources_shape[-1] <= max_index:
         raise ValueError(

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -801,3 +801,89 @@ def test_stacked_horde_config_accepts_and_canonicalizes_numpy_integers() -> None
     assert cfg.n_demons == 2
     assert cfg.feature_dim == 4
     assert cfg.cumulant_indices == (0, 1)
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_stacked_horde_config_canonicalizes_every_numpy_integer_family(
+    integer_type: type,
+) -> None:
+    config = StackedHordeConfig(
+        n_demons=integer_type(1),
+        feature_dim=integer_type(2),
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(integer_type(0),),
+    )
+
+    assert type(config.n_demons) is int
+    assert type(config.feature_dim) is int
+    assert type(config.cumulant_indices[0]) is int
+
+
+def test_stacked_horde_rejects_hostile_containers_and_float_values() -> None:
+    class TupleSubclass(tuple):
+        pass
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:
+            return float
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    with pytest.raises(ValueError, match="gammas"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=2,
+            gammas=TupleSubclass((0.9,)),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match=r"gammas\[0\]"):
+        _simple_config(n_demons=1, gammas=(ClassSpoof(),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"lamdas\[0\]"):
+        _simple_config(n_demons=1, lamdas=(True,))  # type: ignore[arg-type]
+
+
+def test_stacked_horde_from_config_accepts_only_exact_list_or_tuple_sequences() -> None:
+    payload = _simple_config().to_config()
+    payload["gammas"] = tuple(payload["gammas"])
+    assert StackedHordeConfig.from_config(payload).gammas == (0.9, 0.9)
+
+    payload = _simple_config().to_config()
+    payload["gammas"] = "0.9"
+    with pytest.raises(ValueError, match="gammas"):
+        StackedHordeConfig.from_config(payload)
+
+
+def test_stacked_horde_preflights_aggregate_resources_before_allocation() -> None:
+    last_feature_dim = (2**31 - 1 - 26) // 8
+    StackedHordeConfig(
+        n_demons=1,
+        feature_dim=last_feature_dim,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    )
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=last_feature_dim + 1,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+
+
+def test_nexting_spec_preflights_before_materializing_derived_demons() -> None:
+    last_feature_dim = (2**31 - 1 - 26) // 8
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        nexting_spec(
+            feature_dim=last_feature_dim + 1,
+            cumulant_indices=(0,),
+            gammas=(0.9,),
+        )

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -75,9 +75,7 @@ class TestConfig:
             Fraction(1, 2),
         ],
     )
-    def test_step_size_supported_reals_canonicalize_for_json(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_supported_reals_canonicalize_for_json(self, step_size: object) -> None:
         cfg = _simple_config(step_size=step_size)
         payload = cfg.to_config()
 
@@ -92,9 +90,7 @@ class TestConfig:
         assert cfg.step_size == 0.1
 
     def test_fraction_step_size_rounds_directly_to_float32(self) -> None:
-        above_half_midpoint = (
-            Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
-        )
+        above_half_midpoint = Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
         expected = float(np.nextafter(np.float32(0.5), np.float32(1.0)))
 
         cfg = _simple_config(step_size=above_half_midpoint)
@@ -124,9 +120,7 @@ class TestConfig:
             float(np.nextafter(np.finfo(np.float32).tiny, np.float32(0.0))),
         ],
     )
-    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(self, step_size: object) -> None:
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=step_size)
 
@@ -255,9 +249,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_sizes[attack]
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_sizes[attack])
 
@@ -278,9 +270,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -313,18 +303,14 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
         assert calls == []
 
     @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
-    def test_step_size_rejects_exact_fraction_with_zero_denominator(
-        self, serialized: bool
-    ) -> None:
+    def test_step_size_rejects_exact_fraction_with_zero_denominator(self, serialized: bool) -> None:
         property_calls: list[str] = []
 
         class Carrier(Fraction):
@@ -347,9 +333,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -366,9 +350,7 @@ class TestConfig:
         payload["step_size"] = step_size
 
         with pytest.raises(ValueError, match="step_size"):
-            StackedLinearHorde.from_config(
-                {"type": "StackedLinearHorde", "config": payload}
-            )
+            StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
 
     def test_minimum_normal_step_size_survives_jit_execution(self) -> None:
         minimum = float(np.finfo(np.float32).tiny)
@@ -419,8 +401,8 @@ class TestCumulantSourceDomain:
 
     @pytest.mark.parametrize(
         "bad_index",
-        [-1, True, False, np.int32(1), 1.0, "1"],
-        ids=("negative", "true", "false", "numpy-int", "float", "str"),
+        [-1, True, False, 1.5, 1.0, "1"],
+        ids=("negative", "true", "false", "float-fraction", "float-int", "str"),
     )
     def test_config_rejects_non_builtin_or_negative_indices(self, bad_index: object) -> None:
         with pytest.raises(ValueError, match="cumulant_indices"):
@@ -523,9 +505,7 @@ class TestExactSemantics:
         # w += 0.1*2.18*[0.45,1] = [0.2981, 0.218].
         r2 = horde.update(r1.state, x1, x0, c)
         np.testing.assert_allclose(np.asarray(r2.td_errors), [2.18], rtol=1e-6)
-        np.testing.assert_allclose(
-            np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5
-        )
+        np.testing.assert_allclose(np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5)
 
     def test_nan_cumulant_freezes_weights_decays_trace(self):
         cfg = _simple_config()
@@ -550,9 +530,7 @@ class TestExactSemantics:
             rtol=1e-6,
         )
         # Demon 1 weights moved.
-        assert not np.array_equal(
-            np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1])
-        )
+        assert not np.array_equal(np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1]))
 
     def test_rho_composes_into_trace(self):
         """z = rho * (decay * z + x): rho=0 zeroes the trace and the update."""
@@ -738,17 +716,13 @@ class TestDemonAxisScaling:
         sources = jr.normal(rng[1], (num_steps, feature_dim), dtype=jnp.float32)
 
         t0 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         first_call = time.time() - t0
         assert first_call < 30.0, f"compile+run took {first_call:.1f}s"
 
         t1 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         steady = time.time() - t1
         assert steady < 5.0, f"steady-state run took {steady:.1f}s"
@@ -783,3 +757,47 @@ class TestDemonAxisScaling:
         assert bool(jnp.all(late < early))
         # And the late TD error is near zero for all timescales.
         assert float(jnp.max(late)) < 0.01
+
+
+def test_stacked_horde_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=True,  # type: ignore[arg-type]
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="feature_dim"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4.5,  # type: ignore[arg-type]
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="cumulant_indices"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(True,),  # type: ignore[arg-type]
+        )
+
+
+def test_stacked_horde_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = StackedHordeConfig(
+        n_demons=np.int32(2),
+        feature_dim=np.int64(4),
+        gammas=(0.9, 0.5),
+        lamdas=(0.8, 0.7),
+        cumulant_indices=(np.int32(0), np.int64(1)),
+    )
+    assert type(cfg.n_demons) is int
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.cumulant_indices[0]) is int
+    assert type(cfg.cumulant_indices[1]) is int
+    assert cfg.n_demons == 2
+    assert cfg.feature_dim == 4
+    assert cfg.cumulant_indices == (0, 1)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -887,3 +887,54 @@ def test_nexting_spec_preflights_before_materializing_derived_demons() -> None:
             cumulant_indices=(0,),
             gammas=(0.9,),
         )
+
+
+def test_stacked_horde_deserializers_require_exact_schemas() -> None:
+    class DictSubclass(dict):
+        pass
+
+    config_payload = _simple_config().to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        StackedHordeConfig.from_config(DictSubclass(config_payload))
+    with pytest.raises(ValueError, match="fields"):
+        StackedHordeConfig.from_config({**config_payload, "extra": None})
+    with pytest.raises(ValueError, match="config type"):
+        StackedHordeConfig.from_config({**config_payload, "type": "wrong"})
+
+    horde_payload = StackedLinearHorde(_simple_config()).to_config()
+    with pytest.raises(ValueError, match="fields"):
+        StackedLinearHorde.from_config({**horde_payload, "extra": None})
+    with pytest.raises(ValueError, match="nested config"):
+        StackedLinearHorde.from_config({**horde_payload, "config": DictSubclass()})
+
+
+def test_stacked_horde_step_count_saturates_without_jit_wraparound() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=1, feature_dim=2))
+    state = horde.init().replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    result = jax.jit(horde.update)(
+        state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_stacked_horde_scan_rejects_derived_result_overflow_without_allocation() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=2, feature_dim=3))
+    state = horde.init()
+    first_overflowing_steps = (2**31 - 1) // (4 * horde.config.n_demons) + 2
+    features = jax.ShapeDtypeStruct(
+        (first_overflowing_steps, horde.config.feature_dim),
+        jnp.float32,
+    )
+    sources = jax.ShapeDtypeStruct((first_overflowing_steps, 2), jnp.float32)
+    with pytest.raises(ValueError, match="scan result bytes"):
+        run_stacked_horde_scan(horde, state, features, sources)  # type: ignore[arg-type]
+
+
+def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=1, feature_dim=2))
+    state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="weights"):
+        horde.predict(state, jnp.ones(2, dtype=jnp.float32))


### PR DESCRIPTION
Supersedes #752 while preserving its contributor commit. The original integer canonicalization is sound but left gamma/lambda float32 sinks spoofable/noncanonical, accepted arbitrary sequence hooks at serialized boundaries, and permitted n_demons×feature_dim state/config/result allocations beyond signed-int32 resource domains. nexting_spec could also materialize a derived demon cross-product before validation. This successor uses exact tuple constructors plus exact list-or-tuple deserialization, shared exact-host/float32 gamma and lambda validation, and exact aggregate scalar/byte preflights before both direct construction and nexting expansion. Tests cover all NumPy integer families, hostile containers/scalars, compatibility roundtrips, and adjacent allocation-free resource bounds. Verification: 90 full stacked-Horde tests passed after the repair (the one corrected assertion reran green); scoped Ruff and strict mypy clean; diff-check clean. No registered evidence source or outputs are changed.