### PR TITLE
fix(streams): reject class-spoofed non-real mask_prob in PartialObservationWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Required `PartialObservationWrapper`'s RANDOM-mode `mask_prob` to be a
+  concrete, non-bool real number in `[0, 1]` before use. The prior check
+  compared the raw value directly (`0.0 <= mask_prob <= 1.0`) with no type
+  gate at all, so any object supporting `__le__`/`__ge__` — including a
+  `__class__`-spoofed non-real whose comparison hooks raise — reached that
+  comparison and could leak an uncaught exception instead of the documented
+  `ValueError`, or silently pass through as a non-canonical value.
 - Required persisted micro-stream scalar fields to be concrete real values and
   canonicalized them to built-in floats, preventing numeric strings or custom
   conversion objects from crossing the strict development-artifact boundary.

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -21,8 +21,7 @@ just receives less information about the underlying state.
 from __future__ import annotations
 
 import enum
-from numbers import Real
-from typing import TypeVar, cast
+from typing import TypeVar
 
 import chex
 import jax.numpy as jnp
@@ -30,6 +29,7 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import Bool, PRNGKeyArray
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -50,25 +50,8 @@ class MaskMode(enum.Enum):
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
-    """Return a real number in ``[0, 1]``, rejecting non-real and bool values.
-
-    Uses ``type(value)`` rather than ``isinstance(value, Real)``: ``isinstance``
-    consults the overridable ``__class__`` attribute, so an object whose
-    ``__class__`` property reports ``float`` would otherwise pass the check
-    while still routing the raw ``<=`` comparison to its own (potentially
-    raising) dunder hooks, leaking an uncaught exception instead of the
-    documented ``ValueError``.
-    """
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number in [0, 1]; got {value!r}")
-    try:
-        number = float(cast(Real, value))
-    except (OverflowError, TypeError, ValueError) as error:
-        raise ValueError(f"{name} must be a real number in [0, 1]; got {value!r}") from error
-    if not (0.0 <= number <= 1.0):
-        raise ValueError(f"{name} must lie in [0, 1]; got {value!r}")
-    return number
+    """Return a canonical probability valid at the float32 execution sink."""
+    return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
 
 
 # =============================================================================

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -21,7 +21,8 @@ just receives less information about the underlying state.
 from __future__ import annotations
 
 import enum
-from typing import TypeVar
+from numbers import Real
+from typing import TypeVar, cast
 
 import chex
 import jax.numpy as jnp
@@ -46,6 +47,28 @@ class MaskMode(enum.Enum):
     FIXED = "fixed"
     RANDOM = "random"
     PERIODIC = "periodic"
+
+
+def _require_unit_interval_probability(name: str, value: object) -> float:
+    """Return a real number in ``[0, 1]``, rejecting non-real and bool values.
+
+    Uses ``type(value)`` rather than ``isinstance(value, Real)``: ``isinstance``
+    consults the overridable ``__class__`` attribute, so an object whose
+    ``__class__`` property reports ``float`` would otherwise pass the check
+    while still routing the raw ``<=`` comparison to its own (potentially
+    raising) dunder hooks, leaking an uncaught exception instead of the
+    documented ``ValueError``.
+    """
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a real number in [0, 1]; got {value!r}")
+    try:
+        number = float(cast(Real, value))
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a real number in [0, 1]; got {value!r}") from error
+    if not (0.0 <= number <= 1.0):
+        raise ValueError(f"{name} must lie in [0, 1]; got {value!r}")
+    return number
 
 
 # =============================================================================
@@ -148,8 +171,7 @@ class PartialObservationWrapper[InnerStateT]:
             self._schedule = None
 
         if mode == MaskMode.RANDOM:
-            if not (0.0 <= mask_prob <= 1.0):
-                raise ValueError(f"mask_prob must lie in [0, 1]; got {mask_prob}")
+            self._mask_prob = _require_unit_interval_probability("mask_prob", mask_prob)
 
     @property
     def feature_dim(self) -> int:

--- a/tests/test_partial_observation.py
+++ b/tests/test_partial_observation.py
@@ -123,6 +123,22 @@ class TestRandom:
         with pytest.raises(ValueError, match="mask_prob"):
             PartialObservationWrapper(inner, mode=MaskMode.RANDOM, mask_prob=Spoof())
 
+    def test_random_normalizes_hostile_real_failure_without_repr(self) -> None:
+        class HostileFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                raise RuntimeError("untrusted ratio hook")
+
+            def __repr__(self) -> str:
+                raise AssertionError("repr hook executed")
+
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        with pytest.raises(ValueError, match="mask_prob"):
+            PartialObservationWrapper(
+                inner,
+                mode=MaskMode.RANDOM,
+                mask_prob=HostileFloat(0.5),
+            )
+
 
 class TestPeriodic:
     def test_periodic_cycles(self) -> None:

--- a/tests/test_partial_observation.py
+++ b/tests/test_partial_observation.py
@@ -74,6 +74,55 @@ class TestRandom:
                 inner, mode=MaskMode.RANDOM, mask_prob=1.5
             )
 
+    def test_random_rejects_bool_mask_prob(self) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        with pytest.raises(ValueError, match="mask_prob"):
+            PartialObservationWrapper(inner, mode=MaskMode.RANDOM, mask_prob=True)
+
+    def test_random_rejects_non_real_mask_prob(self) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        with pytest.raises(ValueError, match="mask_prob"):
+            PartialObservationWrapper(
+                inner,
+                mode=MaskMode.RANDOM,
+                mask_prob="0.5",  # type: ignore[arg-type]
+            )
+
+    def test_random_rejects_nan_mask_prob(self) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        with pytest.raises(ValueError, match="mask_prob"):
+            PartialObservationWrapper(
+                inner, mode=MaskMode.RANDOM, mask_prob=float("nan")
+            )
+
+    def test_random_rejects_class_spoofed_non_real_mask_prob(self) -> None:
+        """A ``__class__``-spoofed object must not bypass validation.
+
+        ``isinstance(value, Real)`` consults the overridable ``__class__``
+        attribute, so an object that fakes ``__class__ == float`` would pass
+        an ``isinstance``-based gate. The gate must instead check
+        ``type(value)`` directly. A spoof whose comparison dunder hooks raise
+        must still surface a clean ``ValueError``, not the raw exception.
+        """
+
+        class Spoof:
+            @property
+            def __class__(self) -> type:  # type: ignore[override]
+                return float
+
+            def __le__(self, other: object) -> bool:
+                raise RuntimeError("untrusted __le__ hook executed")
+
+            def __ge__(self, other: object) -> bool:
+                raise RuntimeError("untrusted __ge__ hook executed")
+
+            def __float__(self) -> float:
+                raise RuntimeError("untrusted __float__ hook executed")
+
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        with pytest.raises(ValueError, match="mask_prob"):
+            PartialObservationWrapper(inner, mode=MaskMode.RANDOM, mask_prob=Spoof())
+
 
 class TestPeriodic:
     def test_periodic_cycles(self) -> None:


### PR DESCRIPTION
Closes #766.

## What changed

Same isinstance/type-spoofing defect class as the `_require_int`/`_require_real` family fixes across the step files, `types.py` (#573/#574), `representation_gradient_mixer.py` (#569), and `partner_policy_fusion.py` (#571) — but here the RANDOM-mode `mask_prob` guard in `alberta_framework/streams/partial_observation.py` had no type gate whatsoever, not even a spoofable `isinstance`:

```python
if not (0.0 <= mask_prob <= 1.0):
    raise ValueError(f"mask_prob must lie in [0, 1]; got {mask_prob}")
```

Any object supporting `__le__`/`__ge__` reaches that comparison directly, including a `__class__`-spoofed non-real (`__class__` is an overridable `@property`, so `isinstance(value, Real)` would have passed such an object anyway) whose comparison dunder hooks raise — leaking a raw uncaught exception instead of the documented `ValueError`. A plain `bool` also passed through uncanonicalized since `0.0 <= True <= 1.0` is true.

Added `_require_unit_interval_probability`, matching the established `type(value)`-gate pattern in `_float32_validation.py`/`out_of_class.py`: `actual_type = type(value)` (bypasses the overridable `__class__` slot), reject `bool` and non-`Real` by `issubclass` on the real type, only then convert with `float()` inside a narrow `try/except (OverflowError, TypeError, ValueError)`, and re-check the `[0, 1]` bound on the canonical float.

## Reachability

`PartialObservationWrapper` is exported at package root (`alberta_framework/__init__.py`) and constructed directly by callers with ordinary concrete inputs — publicly reachable. No other production call site passes `mask_prob`; the only internal use is the module's own docstring example, which uses `mode=FIXED` and never touches this code path.

## Verification

Commit under review: `00f6994561c61228d7644d089562aa9a279048ef`.

```bash
.venv/bin/python -m pytest tests/test_partial_observation.py -q -o addopts=""
# 17 passed in 4.23s

.venv/bin/python -m ruff check .
# All checks passed!

.venv/bin/python -m mypy
# Success: no issues found in 168 source files

git diff --check
# (clean, exit 0)

.venv/bin/python -m pytest tests/ -k "partial_observation or streams" -q -o addopts=""
# 435 passed, 7968 deselected in 191.58s   (collateral check: no regression in the streams module)
```

**Mutation check** (reverted just the source fix, kept the new tests, reran):

```text
FAILED tests/test_partial_observation.py::TestRandom::test_random_rejects_bool_mask_prob
FAILED tests/test_partial_observation.py::TestRandom::test_random_rejects_non_real_mask_prob
FAILED tests/test_partial_observation.py::TestRandom::test_random_rejects_class_spoofed_non_real_mask_prob
E   RuntimeError: untrusted __ge__ hook executed
3 failed, 14 passed in 4.30s
```

confirming the spoofed object's own `__ge__` hook is what raises through the unpatched comparison — exactly the symptom the fix closes. Restoring the fix returns all 17 tests to passing.

New tests added next to the existing `TestRandom` cases: bool rejection, non-real (`str`) rejection, NaN rejection, and a `__class__`-spoofed object whose `__le__`/`__ge__`/`__float__` all raise `RuntimeError` if invoked — proving the gate rejects it via `type()` before any of those hooks ever run.

## Provenance

AI-assisted (Claude Code, `claude-sonnet-5`, Anthropic). Spoofing/leak behavior reproduced empirically against the unpatched code (mutation check above) before and after the fix, by me, in this session. All verification above performed and independently confirmed by me before pushing.

Attribution status: self-reported.

<!-- evidence-head:00f6994561c61228d7644d089562aa9a279048ef -->
<!-- evidence-row:logs -->
- [x] logs: full command output reproduced in the Verification section above (mutation check + full test/lint/type-check output); this is a correctness fix with no benchmark artifact to attach.