### PR TITLE
fix(core): integrate reward, memory, and SIGReg contracts

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -25,18 +25,35 @@ from __future__ import annotations
 
 import functools
 import math
+import operator
 from dataclasses import asdict, dataclass
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2_147_483_647
 _UINT32_MAX = 4_294_967_295
 
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
 
 @dataclass(frozen=True)
 class ExperientialMemoryConfig:
@@ -89,6 +106,9 @@ class ExperientialMemoryConfig:
     eviction_recency_weight: float = 1.0
     recency_scale: float = 100.0
 
+    def __post_init__(self) -> None:
+        _validate_config(self)
+
     def to_config(self) -> dict[str, object]:
         """Return a JSON-serializable configuration."""
         payload = asdict(self)
@@ -105,7 +125,6 @@ class ExperientialMemoryConfig:
         result = cls(**payload)
         _validate_config(result)
         return result
-
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryEntry:
@@ -128,7 +147,6 @@ class ExperientialMemoryEntry:
     age: Int[Array, ""]
     provenance_id: Int[Array, ""]
     source_id: Int[Array, ""]
-
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryEntries:
@@ -159,7 +177,6 @@ class ExperientialMemoryEntries:
     source_ids: Int[Array, " capacity"]
     retrieval_counts: Int[Array, " capacity"]
 
-
 @chex.dataclass(frozen=True)
 class ExperientialMemoryState:
     """Complete fixed-shape persistent memory state."""
@@ -173,7 +190,6 @@ class ExperientialMemoryState:
     rejected_write_count: Int[Array, ""]
     eviction_count: Int[Array, ""]
     persistent_bytes: Array
-
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryRetrieval:
@@ -208,7 +224,6 @@ class ExperientialMemoryRetrieval:
     safety_ok: Bool[Array, ""]
     has_neighbors: Bool[Array, ""]
 
-
 @chex.dataclass(frozen=True)
 class ExperientialMemoryWriteResult:
     """State and accounting returned by one bounded write."""
@@ -218,7 +233,6 @@ class ExperientialMemoryWriteResult:
     slot: Int[Array, ""]
     evicted: Bool[Array, ""]
     evicted_provenance_id: Int[Array, ""]
-
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryStepResult:
@@ -230,7 +244,6 @@ class ExperientialMemoryStepResult:
     slot: Int[Array, ""]
     evicted: Bool[Array, ""]
     evicted_provenance_id: Int[Array, ""]
-
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryAccounting:
@@ -246,13 +259,40 @@ class ExperientialMemoryAccounting:
     rejected_writes: Int[Array, ""]
     evictions: Int[Array, ""]
 
+def _require_positive_int(name: str, value: object) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a positive integer in [1, {_INT32_MAX}]")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < 1 or number > _INT32_MAX:
+        raise ValueError(f"{name} must be a positive integer in [1, {_INT32_MAX}]")
+    return number
+
+def _require_nonnegative_int(name: str, value: object) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [0, {_INT32_MAX}]")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < 0 or number > _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [0, {_INT32_MAX}]")
+    return number
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
 
 def _validate_finite(name: str, value: float) -> None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError(f"{name} must be a real number")
     if not math.isfinite(value):
         raise ValueError(f"{name} must be finite")
-
 
 def _validate_config(config: ExperientialMemoryConfig) -> None:
     for name in (
@@ -264,70 +304,96 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         "top_k",
         "min_neighbors",
     ):
-        value = getattr(config, name)
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise ValueError(f"{name} must be an integer")
-        if value < 1:
-            raise ValueError(f"{name} must be positive")
+        canonical = _require_positive_int(name, getattr(config, name))
+        object.__setattr__(config, name, canonical)
     if config.top_k > config.capacity:
         raise ValueError("top_k must be <= capacity")
     if config.min_neighbors > config.top_k:
         raise ValueError("min_neighbors must be <= top_k")
-    if isinstance(config.max_age, bool) or not isinstance(config.max_age, int):
-        raise ValueError("max_age must be an integer")
-    if config.max_age < 0:
-        raise ValueError("max_age must be non-negative")
-    if config.max_age > _INT32_MAX:
-        raise ValueError(
-            "max_age must be <= int32 max; ages saturate there, so larger values cannot be met"
-        )
+    canonical_max_age = _require_nonnegative_int("max_age", config.max_age)
+    object.__setattr__(config, "max_age", canonical_max_age)
 
-    for name in (
+    vector_values = (
+        config.observation_dim + config.key_dim + config.action_dim + config.outcome_dim
+    )
+    if vector_values > _INT32_MAX:
+        raise ValueError("ExperientialMemoryConfig dimensions must fit signed int32")
+    _require_float32_resource(
+        "ExperientialMemoryConfig state",
+        vector_scalars=config.capacity * vector_values,
+        fixed_scalars=config.capacity * 11 + 8,
+    )
+    persistent_bytes = config.capacity * (4 * (vector_values + 11) + 4) + 32
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("ExperientialMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("persistent memory allocation exceeds uint32 byte accounting")
+
+    object.__setattr__(
+        config,
         "distance_scale",
+        validated_float32_scalar("distance_scale", config.distance_scale, positive=True),
+    )
+    object.__setattr__(
+        config,
         "min_similarity",
+        validated_float32_scalar("min_similarity", config.min_similarity, lower=0, upper=1),
+    )
+    object.__setattr__(
+        config,
         "min_effective_reliability",
+        validated_float32_scalar(
+            "min_effective_reliability", config.min_effective_reliability, positive=True, upper=1
+        ),
+    )
+    object.__setattr__(
+        config,
         "max_uncertainty",
+        validated_float32_scalar("max_uncertainty", config.max_uncertainty, lower=0),
+    )
+    object.__setattr__(
+        config,
         "max_safety_cost",
+        validated_float32_scalar("max_safety_cost", config.max_safety_cost, lower=0),
+    )
+    object.__setattr__(
+        config,
         "staleness_scale",
+        validated_float32_scalar("staleness_scale", config.staleness_scale, positive=True),
+    )
+    object.__setattr__(
+        config,
         "utility_decay",
+        validated_float32_scalar("utility_decay", config.utility_decay, lower=0, upper=1),
+    )
+    object.__setattr__(
+        config,
         "eviction_utility_weight",
+        validated_float32_scalar(
+            "eviction_utility_weight", config.eviction_utility_weight, lower=0
+        ),
+    )
+    object.__setattr__(
+        config,
         "eviction_recency_weight",
-        "recency_scale",
-    ):
-        _validate_finite(name, cast(float, getattr(config, name)))
-
-    if config.distance_scale <= 0.0:
-        raise ValueError("distance_scale must be positive")
-    if not 0.0 <= config.min_similarity <= 1.0:
-        raise ValueError("min_similarity must be in [0, 1]")
-    if not 0.0 < config.min_effective_reliability <= 1.0:
-        raise ValueError("min_effective_reliability must be in (0, 1]")
-    if config.max_uncertainty < 0.0:
-        raise ValueError("max_uncertainty must be non-negative")
-    if config.max_safety_cost < 0.0:
-        raise ValueError("max_safety_cost must be non-negative")
-    if config.staleness_scale <= 0.0:
-        raise ValueError("staleness_scale must be positive")
-    if not 0.0 <= config.utility_decay <= 1.0:
-        raise ValueError("utility_decay must be in [0, 1]")
-    if config.eviction_utility_weight < 0.0:
-        raise ValueError("eviction_utility_weight must be non-negative")
-    if config.eviction_recency_weight < 0.0:
-        raise ValueError("eviction_recency_weight must be non-negative")
+        validated_float32_scalar(
+            "eviction_recency_weight", config.eviction_recency_weight, lower=0
+        ),
+    )
     if config.eviction_utility_weight + config.eviction_recency_weight <= 0.0:
         raise ValueError("at least one eviction retention weight must be positive")
-    if config.recency_scale <= 0.0:
-        raise ValueError("recency_scale must be positive")
-
+    object.__setattr__(
+        config,
+        "recency_scale",
+        validated_float32_scalar("recency_scale", config.recency_scale, positive=True),
+    )
 
 def _saturating_increment(value: Array) -> Array:
     maximum_minus_one = jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
     return jnp.minimum(value, maximum_minus_one) + jnp.asarray(1, dtype=jnp.int32)
 
-
 def _tree_nbytes(tree: Any) -> int:
     return sum(int(leaf.size) * int(leaf.dtype.itemsize) for leaf in jax.tree.leaves(tree))
-
 
 def _configured_nbytes(config: ExperientialMemoryConfig) -> tuple[int, int]:
     vector_values = config.observation_dim + config.key_dim + config.action_dim + config.outcome_dim
@@ -336,7 +402,6 @@ def _configured_nbytes(config: ExperientialMemoryConfig) -> tuple[int, int]:
     # Seven int32 counters and the uint32 byte-count scalar live beside slots.
     persistent_bytes = config.capacity * slot_bytes + 8 * 4
     return persistent_bytes, slot_bytes
-
 
 def _require_array(
     value: Any,
@@ -354,7 +419,6 @@ def _require_array(
     actual_dtype = jnp.dtype(value.dtype)
     if actual_dtype != expected_dtype:
         raise TypeError(f"{name} must have dtype {expected_dtype}; got {actual_dtype}")
-
 
 class ExperientialMemory:
     """Fixed-capacity episodic memory with conservative retrieval.
@@ -1329,7 +1393,6 @@ class ExperientialMemory:
             rejected_writes=state.rejected_write_count,
             evictions=state.eviction_count,
         )
-
 
 __all__ = [
     "ExperientialMemory",

--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -24,9 +24,8 @@ References:
 from __future__ import annotations
 
 import functools
-import math
 import operator
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -53,6 +52,9 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.uint64,
     np.longlong,
     np.ulonglong,
+)
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
 )
 
 @dataclass(frozen=True)
@@ -118,13 +120,16 @@ class ExperientialMemoryConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> ExperientialMemoryConfig:
         """Reconstruct and validate a configuration dictionary."""
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        expected = {field.name for field in fields(cls)} | {"type"}
+        if any(type(key) is not str for key in config) or set(config) != expected:
+            raise ValueError("config fields do not match the serialized schema")
+        if type(config["type"]) is not str or config["type"] != "ExperientialMemoryConfig":
+            raise ValueError("config type differs")
         payload = dict(config)
-        type_name = payload.pop("type", None)
-        if type_name not in {None, "ExperientialMemoryConfig"}:
-            raise ValueError(f"unexpected config type: {type_name!r}")
-        result = cls(**payload)
-        _validate_config(result)
-        return result
+        payload.pop("type")
+        return cls(**payload)
 
 @chex.dataclass(frozen=True)
 class ExperientialMemoryEntry:
@@ -275,24 +280,10 @@ def _require_nonnegative_int(name: str, value: object) -> int:
         raise ValueError(f"{name} must be an integer in [0, {_INT32_MAX}]")
     return number
 
-def _require_float32_resource(
-    name: str,
-    *,
-    vector_scalars: int,
-    fixed_scalars: int = 0,
-) -> None:
-    total_scalars = vector_scalars + fixed_scalars
-    if total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} byte count must fit signed int32")
-
-
-def _validate_finite(name: str, value: float) -> None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError(f"{name} must be a real number")
-    if not math.isfinite(value):
-        raise ValueError(f"{name} must be finite")
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (frozenset(_ACTUAL_INT_TYPES) | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
 
 def _validate_config(config: ExperientialMemoryConfig) -> None:
     for name in (
@@ -318,12 +309,10 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
     )
     if vector_values > _INT32_MAX:
         raise ValueError("ExperientialMemoryConfig dimensions must fit signed int32")
-    _require_float32_resource(
-        "ExperientialMemoryConfig state",
-        vector_scalars=config.capacity * vector_values,
-        fixed_scalars=config.capacity * 11 + 8,
-    )
+    logical_scalars = config.capacity * (vector_values + 15) + 8
     persistent_bytes = config.capacity * (4 * (vector_values + 11) + 4) + 32
+    if logical_scalars > _INT32_MAX:
+        raise ValueError("ExperientialMemoryConfig state scalar count must fit signed int32")
     if persistent_bytes > _INT32_MAX:
         raise ValueError("ExperientialMemoryConfig state byte count must fit signed int32")
     if persistent_bytes > _UINT32_MAX:
@@ -332,51 +321,51 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
     object.__setattr__(
         config,
         "distance_scale",
-        validated_float32_scalar("distance_scale", config.distance_scale, positive=True),
+        _validated_config_float("distance_scale", config.distance_scale, positive=True),
     )
     object.__setattr__(
         config,
         "min_similarity",
-        validated_float32_scalar("min_similarity", config.min_similarity, lower=0, upper=1),
+        _validated_config_float("min_similarity", config.min_similarity, lower=0, upper=1),
     )
     object.__setattr__(
         config,
         "min_effective_reliability",
-        validated_float32_scalar(
+        _validated_config_float(
             "min_effective_reliability", config.min_effective_reliability, positive=True, upper=1
         ),
     )
     object.__setattr__(
         config,
         "max_uncertainty",
-        validated_float32_scalar("max_uncertainty", config.max_uncertainty, lower=0),
+        _validated_config_float("max_uncertainty", config.max_uncertainty, lower=0),
     )
     object.__setattr__(
         config,
         "max_safety_cost",
-        validated_float32_scalar("max_safety_cost", config.max_safety_cost, lower=0),
+        _validated_config_float("max_safety_cost", config.max_safety_cost, lower=0),
     )
     object.__setattr__(
         config,
         "staleness_scale",
-        validated_float32_scalar("staleness_scale", config.staleness_scale, positive=True),
+        _validated_config_float("staleness_scale", config.staleness_scale, positive=True),
     )
     object.__setattr__(
         config,
         "utility_decay",
-        validated_float32_scalar("utility_decay", config.utility_decay, lower=0, upper=1),
+        _validated_config_float("utility_decay", config.utility_decay, lower=0, upper=1),
     )
     object.__setattr__(
         config,
         "eviction_utility_weight",
-        validated_float32_scalar(
+        _validated_config_float(
             "eviction_utility_weight", config.eviction_utility_weight, lower=0
         ),
     )
     object.__setattr__(
         config,
         "eviction_recency_weight",
-        validated_float32_scalar(
+        _validated_config_float(
             "eviction_recency_weight", config.eviction_recency_weight, lower=0
         ),
     )
@@ -385,7 +374,7 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
     object.__setattr__(
         config,
         "recency_scale",
-        validated_float32_scalar("recency_scale", config.recency_scale, positive=True),
+        _validated_config_float("recency_scale", config.recency_scale, positive=True),
     )
 
 def _saturating_increment(value: Array) -> Array:
@@ -463,8 +452,14 @@ class ExperientialMemory:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> ExperientialMemory:
         """Reconstruct a memory from :meth:`to_config` output."""
-        if config.get("type") not in {None, "ExperientialMemory"}:
-            raise ValueError(f"unexpected memory type: {config.get('type')!r}")
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        if any(type(key) is not str for key in config) or set(config) != {"type", "config"}:
+            raise ValueError("config fields do not match the serialized schema")
+        if type(config["type"]) is not str or config["type"] != "ExperientialMemory":
+            raise ValueError("config type differs")
+        if type(config["config"]) is not dict:
+            raise ValueError("nested config must be an exact built-in dict")
         inner = cast(dict[str, Any], config["config"])
         return cls(ExperientialMemoryConfig.from_config(inner))
 

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -54,6 +54,14 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _preflight_state_resources(feature_dim: int) -> None:
+    state_scalars = feature_dim * feature_dim + feature_dim + 2
+    if state_scalars > _INT32_MAX:
+        raise ValueError("reward-model state scalars must fit signed int32")
+    if 4 * state_scalars > _INT32_MAX:
+        raise ValueError("reward-model state bytes must fit signed int32")
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Skip ``0 * inf`` so a disabled error EMA does not poison the diagnostic."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -80,6 +88,7 @@ class RLSRewardModelConfig:
 
     def __post_init__(self) -> None:
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+        _preflight_state_resources(feature_dim)
         forgetting = validated_float32_scalar(
             "forgetting", self.forgetting, positive=True, upper=1.0
         )
@@ -143,7 +152,7 @@ class RLSRewardModel:
 
     def __init__(self, config: RLSRewardModelConfig):
         """Initialize the model."""
-        if not isinstance(config, RLSRewardModelConfig):
+        if type(config) is not RLSRewardModelConfig:
             raise TypeError("config must be an RLSRewardModelConfig")
         self._config = config
 
@@ -216,7 +225,15 @@ class RLSRewardModel:
             raise ValueError(
                 f"features must have shape ({self._config.feature_dim},), got {x.shape}"
             )
-        target = jnp.asarray(reward, dtype=jnp.float32)
+        raw_target = jnp.asarray(reward)
+        if raw_target.shape != ():
+            raise ValueError("reward must be a scalar")
+        if not (
+            jnp.issubdtype(raw_target.dtype, jnp.floating)
+            or jnp.issubdtype(raw_target.dtype, jnp.integer)
+        ):
+            raise TypeError("reward must be real numeric")
+        target = raw_target.astype(jnp.float32)
         prediction = jnp.dot(state.weights, x)
         error = target - prediction
         covariance_features = state.covariance @ x
@@ -270,10 +287,6 @@ class RLSRewardModel:
             gain=jnp.where(update_applied, gain, jnp.zeros_like(gain)),
             update_applied=update_applied,
         )
-
-    def _validated_config(self, config: RLSRewardModelConfig) -> RLSRewardModelConfig:
-        return config
-
 
 __all__ = [
     "RLSRewardModel",

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -14,16 +14,44 @@ trustworthy — the "selective" part of selective model-based updates.
 from __future__ import annotations
 
 import functools
-from dataclasses import dataclass, replace
-from typing import Any
+import operator
+from dataclasses import dataclass
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -49,6 +77,21 @@ class RLSRewardModelConfig:
     forgetting: float = 0.995
     ridge: float = 10.0
     error_decay: float = 0.99
+
+    def __post_init__(self) -> None:
+        feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+        forgetting = validated_float32_scalar(
+            "forgetting", self.forgetting, positive=True, upper=1.0
+        )
+        ridge = validated_float32_scalar("ridge", self.ridge, positive=True)
+        error_decay = validated_float32_scalar(
+            "error_decay", self.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "forgetting", forgetting)
+        object.__setattr__(self, "ridge", ridge)
+        object.__setattr__(self, "error_decay", error_decay)
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-compatible representation."""
@@ -100,7 +143,9 @@ class RLSRewardModel:
 
     def __init__(self, config: RLSRewardModelConfig):
         """Initialize the model."""
-        self._config = self._validated_config(config)
+        if not isinstance(config, RLSRewardModelConfig):
+            raise TypeError("config must be an RLSRewardModelConfig")
+        self._config = config
 
     @property
     def config(self) -> RLSRewardModelConfig:
@@ -127,9 +172,7 @@ class RLSRewardModel:
         feature_dim = self._config.feature_dim
         return RLSRewardModelState(
             weights=jnp.zeros((feature_dim,), dtype=jnp.float32),
-            covariance=(
-                jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge
-            ),
+            covariance=(jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge),
             abs_error_ema=jnp.array(0.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
@@ -181,17 +224,14 @@ class RLSRewardModel:
         denominator = forgetting + jnp.dot(x, covariance_features)
         gain = covariance_features / denominator
         next_weights = state.weights + gain * error
-        next_covariance = (
-            state.covariance - jnp.outer(gain, covariance_features)
-        ) / forgetting
+        next_covariance = (state.covariance - jnp.outer(gain, covariance_features)) / forgetting
 
         error_decay = jnp.asarray(self._config.error_decay, dtype=jnp.float32)
         abs_error = jnp.abs(error)
         next_abs_error_ema = jnp.where(
             state.step_count == 0,
             abs_error,
-            _skip_zero_scale(error_decay, state.abs_error_ema)
-            + (1.0 - error_decay) * abs_error,
+            _skip_zero_scale(error_decay, state.abs_error_ema) + (1.0 - error_decay) * abs_error,
         )
         next_state = RLSRewardModelState(
             weights=next_weights,
@@ -232,21 +272,7 @@ class RLSRewardModel:
         )
 
     def _validated_config(self, config: RLSRewardModelConfig) -> RLSRewardModelConfig:
-        if type(config.feature_dim) is not int or config.feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive builtin integer")
-        forgetting = validated_float32_scalar(
-            "forgetting", config.forgetting, positive=True, upper=1.0
-        )
-        ridge = validated_float32_scalar("ridge", config.ridge, positive=True)
-        error_decay = validated_float32_scalar(
-            "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
-        )
-        return replace(
-            config,
-            forgetting=forgetting,
-            ridge=ridge,
-            error_decay=error_decay,
-        )
+        return config
 
 
 __all__ = [

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -43,6 +43,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -60,6 +63,12 @@ def _preflight_state_resources(feature_dim: int) -> None:
         raise ValueError("reward-model state scalars must fit signed int32")
     if 4 * state_scalars > _INT32_MAX:
         raise ValueError("reward-model state bytes must fit signed int32")
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -89,11 +98,11 @@ class RLSRewardModelConfig:
     def __post_init__(self) -> None:
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
         _preflight_state_resources(feature_dim)
-        forgetting = validated_float32_scalar(
+        forgetting = _validated_config_float(
             "forgetting", self.forgetting, positive=True, upper=1.0
         )
-        ridge = validated_float32_scalar("ridge", self.ridge, positive=True)
-        error_decay = validated_float32_scalar(
+        ridge = _validated_config_float("ridge", self.ridge, positive=True)
+        error_decay = _validated_config_float(
             "error_decay", self.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
         )
 
@@ -115,8 +124,15 @@ class RLSRewardModelConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> RLSRewardModelConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(payload) is not dict:
+            raise ValueError("payload must be an exact built-in dict")
+        expected = {"type", "feature_dim", "forgetting", "ridge", "error_decay"}
+        if any(type(key) is not str for key in payload) or set(payload) != expected:
+            raise ValueError("payload fields do not match the serialized schema")
+        if type(payload["type"]) is not str or payload["type"] != "RLSRewardModelConfig":
+            raise ValueError("payload type differs")
         data = dict(payload)
-        data.pop("type", None)
+        data.pop("type")
         return cls(**data)
 
 
@@ -171,9 +187,15 @@ class RLSRewardModel:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> RLSRewardModel:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
-        return cls(RLSRewardModelConfig.from_config(data["config"]))
+        if type(payload) is not dict:
+            raise ValueError("payload must be an exact built-in dict")
+        if any(type(key) is not str for key in payload) or set(payload) != {"type", "config"}:
+            raise ValueError("payload fields do not match the serialized schema")
+        if type(payload["type"]) is not str or payload["type"] != "RLSRewardModel":
+            raise ValueError("payload type differs")
+        if type(payload["config"]) is not dict:
+            raise ValueError("payload config must be an exact built-in dict")
+        return cls(RLSRewardModelConfig.from_config(payload["config"]))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def init(self) -> RLSRewardModelState:

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import dataclasses
 import math
 import numbers
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -35,10 +36,35 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float
 
-_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
-_KERNEL_WIDTH_ERROR = (
-    "kernel_width must be positive and finite in float32 kernel arithmetic"
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
 )
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_KERNEL_WIDTH_ERROR = "kernel_width must be positive and finite in float32 kernel arithmetic"
 _SAMPLES_FINITE_ERROR = "samples must be finite"
 _EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
 _DIRECTIONS_FINITE_ERROR = "directions must be finite"
@@ -67,9 +93,7 @@ def _normalized_positive_float32(
         squared32 = np.float32(value32 * value32)
     if not math.isfinite(float(value32)) or float(value32) < _FLOAT32_TINY:
         raise ValueError(message)
-    if squared and (
-        not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY
-    ):
+    if squared and (not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY):
         raise ValueError(message)
     return concrete
 
@@ -93,14 +117,14 @@ class SIGRegConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        if type(self.n_projections) is not int or self.n_projections <= 0:
-            raise ValueError("n_projections must be positive")
+        n_projections = _require_int32("n_projections", self.n_projections, minimum=1)
         kernel_width = _normalized_positive_float32(
             "kernel_width",
             self.kernel_width,
             squared=True,
         )
         eps = _normalized_positive_float32("eps", self.eps, squared=False)
+        object.__setattr__(self, "n_projections", n_projections)
         object.__setattr__(self, "kernel_width", kernel_width)
         object.__setattr__(self, "eps", eps)
 
@@ -183,8 +207,7 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     if uncast.shape != ():
         raise ValueError(_KERNEL_WIDTH_ERROR)
     if not (
-        jnp.issubdtype(uncast.dtype, jnp.integer)
-        or jnp.issubdtype(uncast.dtype, jnp.floating)
+        jnp.issubdtype(uncast.dtype, jnp.integer) or jnp.issubdtype(uncast.dtype, jnp.floating)
     ):
         raise ValueError(_KERNEL_WIDTH_ERROR)
 
@@ -221,9 +244,7 @@ def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     diffs = x[:, None] - x[None, :]
     empirical = jnp.mean(jnp.exp(-(diffs**2) / (2.0 * width_squared)))
     cross_scale = jnp.sqrt(width_squared / (width_squared + 1.0))
-    cross = jnp.mean(
-        cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0)))
-    )
+    cross = jnp.mean(cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0))))
     target = jnp.sqrt(width_squared / (width_squared + 2.0))
     return jnp.maximum(empirical - 2.0 * cross + target, 0.0)
 

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -36,39 +36,40 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
+        *(np.dtype(code).type
+          for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
     }
 )
-
-
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    return canonical
-
-
-_FLOAT32_TINY = float(np.finfo(np.float32).tiny)
-_KERNEL_WIDTH_ERROR = "kernel_width must be positive and finite in float32 kernel arithmetic"
+_FLOAT32_TINY = float.fromhex("0x1.000000p-126")
+_MIN_KERNEL_WIDTH = float.fromhex("0x1.000000p-63")
+_MAX_KERNEL_WIDTH = float.fromhex("0x1.fffffep+63")
+_KERNEL_WIDTH_ERROR = (
+    "kernel_width must be positive and finite in float32 kernel arithmetic"
+)
 _SAMPLES_FINITE_ERROR = "samples must be finite"
 _EMBEDDINGS_FINITE_ERROR = "embeddings must be finite"
 _DIRECTIONS_FINITE_ERROR = "directions must be finite"
 _PROJECTIONS_FINITE_ERROR = "projected samples must be finite"
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
+
+
+def _require_float32_resource(name: str, scalar_count: int) -> None:
+    if not 1 <= scalar_count <= _INT32_MAX or scalar_count > _INT32_MAX // 4:
+        raise ValueError(f"derived {name} float32 allocation must fit in signed int32 bytes")
 
 
 def _normalized_positive_float32(
@@ -77,25 +78,17 @@ def _normalized_positive_float32(
     *,
     squared: bool,
 ) -> float:
-    """Return a concrete real as ``float`` after float32-domain validation."""
+    """Return one operation-safe exact-host and float32 scalar."""
     message = f"{name} must be positive and finite in float32 arithmetic"
-    if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        raise ValueError(message)
     try:
-        concrete = float(value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
-    if not math.isfinite(concrete) or concrete <= 0.0:
-        raise ValueError(message)
-
-    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-        value32 = np.float32(concrete)
-        squared32 = np.float32(value32 * value32)
-    if not math.isfinite(float(value32)) or float(value32) < _FLOAT32_TINY:
-        raise ValueError(message)
-    if squared and (not math.isfinite(float(squared32)) or float(squared32) < _FLOAT32_TINY):
-        raise ValueError(message)
-    return concrete
+        return validated_float32_scalar(
+            name,
+            value,
+            lower=_MIN_KERNEL_WIDTH if squared else _FLOAT32_TINY,
+            upper=_MAX_KERNEL_WIDTH if squared else None,
+        )
+    except ValueError as error:
+        raise ValueError(message) from error
 
 
 @dataclasses.dataclass(frozen=True)
@@ -137,8 +130,14 @@ class SIGRegConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> SIGRegConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("SIGRegConfig must be an actual dict")
         payload = dict(config)
-        payload.pop("type", None)
+        if set(payload) != {"type", "n_projections", "kernel_width", "eps"}:
+            raise ValueError("SIGRegConfig fields do not match its schema")
+        type_name = payload.pop("type")
+        if type(type_name) is not str or type_name != "SIGRegConfig":
+            raise ValueError("type must be SIGRegConfig")
         return cls(**payload)
 
 
@@ -207,7 +206,8 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     if uncast.shape != ():
         raise ValueError(_KERNEL_WIDTH_ERROR)
     if not (
-        jnp.issubdtype(uncast.dtype, jnp.integer) or jnp.issubdtype(uncast.dtype, jnp.floating)
+        jnp.issubdtype(uncast.dtype, jnp.integer)
+        or jnp.issubdtype(uncast.dtype, jnp.floating)
     ):
         raise ValueError(_KERNEL_WIDTH_ERROR)
 
@@ -237,6 +237,37 @@ def _require_finite_array(values: Array, message: str) -> Array:
     return _runtime_checked_value(array, predicate, message)
 
 
+def _preflight_projected_statistic(
+    embeddings: Array,
+    directions: Array,
+) -> tuple[Array, Array, int, int]:
+    z = jnp.asarray(embeddings, dtype=jnp.float32)
+    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    if z.ndim < 2:
+        raise ValueError("embeddings must have shape (..., latent_dim)")
+    if dirs.ndim != 2 or dirs.shape[0] < 1 or dirs.shape[1] != z.shape[-1]:
+        raise ValueError("directions must have shape (n_projections, latent_dim)")
+    sample_count = math.prod(z.shape[:-1])
+    if sample_count < 1:
+        raise ValueError("embeddings must contain at least one sample")
+    n_projections = dirs.shape[0]
+    projection_scalars = sample_count * n_projections
+    pairwise_scalars = sample_count * sample_count * n_projections
+    _require_float32_resource(
+        "projected pairwise workspace",
+        projection_scalars + 3 * pairwise_scalars,
+    )
+    return z, dirs, sample_count, n_projections
+
+
+def _stable_std(values: Array, *, axis: int) -> Array:
+    """Compute float32 standard deviation without overflowing finite inputs."""
+    scale = jnp.max(jnp.abs(values), axis=axis, keepdims=True)
+    safe_scale = jnp.where(scale == 0.0, jnp.ones_like(scale), scale)
+    normalized = values / safe_scale
+    return jnp.std(normalized, axis=axis) * jnp.squeeze(scale, axis=axis)
+
+
 def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     """Compute the statistic after ``width`` has passed boundary validation."""
     x = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
@@ -244,7 +275,9 @@ def _epps_pulley_gaussian_statistic(samples: Array, width: Array) -> Array:
     diffs = x[:, None] - x[None, :]
     empirical = jnp.mean(jnp.exp(-(diffs**2) / (2.0 * width_squared)))
     cross_scale = jnp.sqrt(width_squared / (width_squared + 1.0))
-    cross = jnp.mean(cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0))))
+    cross = jnp.mean(
+        cross_scale * jnp.exp(-(x**2) / (2.0 * (width_squared + 1.0)))
+    )
     target = jnp.sqrt(width_squared / (width_squared + 2.0))
     return jnp.maximum(empirical - 2.0 * cross + target, 0.0)
 
@@ -256,8 +289,8 @@ def sample_sigreg_directions(
 ) -> Float[Array, "n_projections latent_dim"]:
     """Sample random unit directions for sliced SIGReg."""
     cfg = config or SIGRegConfig()
-    if latent_dim <= 0:
-        raise ValueError("latent_dim must be positive")
+    latent_dim = _require_int32("latent_dim", latent_dim, minimum=1)
+    _require_float32_resource("SIGReg directions", cfg.n_projections * latent_dim)
     directions = jax.random.normal(
         key,
         (cfg.n_projections, latent_dim),
@@ -284,10 +317,13 @@ def epps_pulley_gaussian_statistic(
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
     width = _validated_kernel_width(kernel_width)
-    checked = _require_finite_array(
-        jnp.asarray(samples, dtype=jnp.float32),
-        _SAMPLES_FINITE_ERROR,
+    flattened = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
+    if flattened.size < 1:
+        raise ValueError("samples must be non-empty")
+    _require_float32_resource(
+        "Epps-Pulley pairwise workspace", 3 * flattened.size * flattened.size
     )
+    checked = _require_finite_array(flattened, _SAMPLES_FINITE_ERROR)
     return _epps_pulley_gaussian_statistic(checked, width)
 
 
@@ -308,10 +344,7 @@ def sliced_sigreg_loss(
     Returns:
         Mean one-dimensional Epps-Pulley/BHEP statistic across directions.
     """
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
-    if z.ndim < 2:
-        raise ValueError("embeddings must have shape (..., latent_dim)")
+    z, dirs, _, _ = _preflight_projected_statistic(embeddings, directions)
     width = _validated_kernel_width(kernel_width)
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
@@ -331,14 +364,13 @@ def sigreg_diagnostics(
 ) -> SIGRegDiagnostics:
     """Return SIGReg loss plus simple latent distribution diagnostics."""
     cfg = config or SIGRegConfig()
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    z, dirs, _, _ = _preflight_projected_statistic(embeddings, directions)
     z = _require_finite_array(z, _EMBEDDINGS_FINITE_ERROR)
     dirs = _require_finite_array(dirs, _DIRECTIONS_FINITE_ERROR)
     flat = jnp.reshape(z, (-1, z.shape[-1]))
     projected = _require_finite_array(flat @ dirs.T, _PROJECTIONS_FINITE_ERROR)
-    latent_std = jnp.std(flat, axis=0)
-    projected_std = jnp.std(projected, axis=0)
+    latent_std = _stable_std(flat, axis=0)
+    projected_std = _stable_std(projected, axis=0)
     return SIGRegDiagnostics(
         loss=sliced_sigreg_loss(flat, dirs, kernel_width=cfg.kernel_width),
         latent_mean_abs=jnp.mean(jnp.abs(jnp.mean(flat, axis=0))),

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -46,6 +46,9 @@ _ACTUAL_INT_TYPES = frozenset(
           for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 _FLOAT32_TINY = float.fromhex("0x1.000000p-126")
 _MIN_KERNEL_WIDTH = float.fromhex("0x1.000000p-63")
 _MAX_KERNEL_WIDTH = float.fromhex("0x1.fffffep+63")
@@ -80,6 +83,8 @@ def _normalized_positive_float32(
 ) -> float:
     """Return one operation-safe exact-host and float32 scalar."""
     message = f"{name} must be positive and finite in float32 arithmetic"
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(message)
     try:
         return validated_float32_scalar(
             name,
@@ -111,6 +116,7 @@ class SIGRegConfig:
     def __post_init__(self) -> None:
         """Validate the configuration."""
         n_projections = _require_int32("n_projections", self.n_projections, minimum=1)
+        _require_float32_resource("SIGReg directions", n_projections)
         kernel_width = _normalized_positive_float32(
             "kernel_width",
             self.kernel_width,
@@ -133,7 +139,12 @@ class SIGRegConfig:
         if type(config) is not dict:
             raise ValueError("SIGRegConfig must be an actual dict")
         payload = dict(config)
-        if set(payload) != {"type", "n_projections", "kernel_width", "eps"}:
+        if any(type(key) is not str for key in payload) or set(payload) != {
+            "type",
+            "n_projections",
+            "kernel_width",
+            "eps",
+        }:
             raise ValueError("SIGRegConfig fields do not match its schema")
         type_name = payload.pop("type")
         if type(type_name) is not str or type_name != "SIGRegConfig":

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -205,7 +205,7 @@ def test_config_rejects_inconsistent_neighbor_and_eviction_settings() -> None:
 
 
 def test_config_rejects_allocation_larger_than_exact_byte_counter() -> None:
-    with pytest.raises(ValueError, match="uint32"):
+    with pytest.raises(ValueError, match="uint32|int32"):
         ExperientialMemory(_config(capacity=100_000_000, top_k=1))
 
 

--- a/tests/test_experiential_memory_validation.py
+++ b/tests/test_experiential_memory_validation.py
@@ -1,0 +1,309 @@
+"""Validation hardening for experiential memory (int/float bounds)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.experiential_memory import ExperientialMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: ExperientialMemoryConfig(
+            capacity=v, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=v, key_dim=2, action_dim=1, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=v, action_dim=1, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=v, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=v
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1, top_k=v
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1, min_neighbors=v
+        ),
+    ],
+)
+def test_experiential_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1, max_age=v
+        ),
+    ],
+)
+def test_experiential_max_age_rejects_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match=r"must be an integer in \[0, 2147483647\]"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"must be an integer in \[0, 2147483647\]"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: ExperientialMemoryConfig(
+            capacity=v, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1, max_age=v
+        ),
+    ],
+)
+def test_experiential_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_experiential_int_validators_canonicalize_numpy_scalars(np_type: type) -> None:
+    cfg = ExperientialMemoryConfig(
+        capacity=np_type(8),
+        observation_dim=np_type(2),
+        key_dim=np_type(2),
+        action_dim=np_type(1),
+        outcome_dim=np_type(1),
+        top_k=np_type(2),
+        min_neighbors=np_type(1),
+        max_age=np_type(5),
+    )
+    assert cfg.capacity == 8
+    assert type(cfg.capacity) is int
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.max_age) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: ExperientialMemoryConfig(
+            capacity=v, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1
+        ),
+        lambda v: ExperientialMemoryConfig(
+            capacity=4, observation_dim=v, key_dim=2, action_dim=1, outcome_dim=1
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "value", [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1, 10**100]
+)
+def test_experiential_int_validators_reject_non_integer_and_out_of_range(
+    ctor, value: object
+) -> None:
+    with pytest.raises(ValueError, match=r"must be a positive integer in \[1, 2147483647\]"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value", [True, np.bool_(True), 4.0, "4", None, -1, _INT32_MAX + 1]
+)
+def test_experiential_max_age_rejects_non_integer_and_out_of_range(value: object) -> None:
+    with pytest.raises(ValueError, match=r"must be an integer in \[0, 2147483647\]"):
+        ExperientialMemoryConfig(
+            capacity=4, observation_dim=2, key_dim=2, action_dim=1, outcome_dim=1, max_age=value  # type: ignore[arg-type]
+        )
+
+
+def test_experiential_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("distance_scale", float("nan")),
+        ("distance_scale", float("inf")),
+        ("distance_scale", 0.0),
+        ("distance_scale", -1.0),
+        ("distance_scale", HostileFloat(0.5)),
+        ("min_similarity", -0.1),
+        ("min_similarity", 1.5),
+        ("min_similarity", ClassSpoof()),  # type: ignore[arg-type]
+        ("min_effective_reliability", 0.0),
+        ("min_effective_reliability", 1.5),
+        ("max_uncertainty", -0.1),
+        ("max_uncertainty", float("nan")),
+        ("max_safety_cost", -1.0),
+        ("staleness_scale", 0.0),
+        ("utility_decay", -0.1),
+        ("utility_decay", 1.5),
+        ("eviction_utility_weight", -0.1),
+        ("recency_scale", 0.0),
+        ("recency_scale", float("inf")),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            ExperientialMemoryConfig(
+                capacity=4,
+                observation_dim=2,
+                key_dim=2,
+                action_dim=1,
+                outcome_dim=1,
+                **{field: bad},  # type: ignore[arg-type]
+            )
+
+
+def test_experiential_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="distance_scale"):
+        ExperientialMemoryConfig(
+            capacity=4,
+            observation_dim=2,
+            key_dim=2,
+            action_dim=1,
+            outcome_dim=1,
+            distance_scale=HostileFloat(1.0),  # type: ignore[arg-type]
+        )
+
+
+def test_experiential_eviction_weights_require_positive_sum() -> None:
+    with pytest.raises(ValueError, match="retention weight"):
+        ExperientialMemoryConfig(
+            capacity=4,
+            observation_dim=2,
+            key_dim=2,
+            action_dim=1,
+            outcome_dim=1,
+            eviction_utility_weight=0.0,
+            eviction_recency_weight=0.0,
+        )
+
+
+def test_experiential_float_validators_accept_valid_values() -> None:
+    cfg = ExperientialMemoryConfig(
+        capacity=4,
+        observation_dim=2,
+        key_dim=2,
+        action_dim=1,
+        outcome_dim=1,
+        distance_scale=1.0,
+        min_similarity=0.5,
+        min_effective_reliability=0.5,
+        max_uncertainty=1.0,
+        max_safety_cost=1.0,
+        staleness_scale=100.0,
+        utility_decay=0.9,
+        eviction_utility_weight=1.0,
+        eviction_recency_weight=1.0,
+        recency_scale=10.0,
+    )
+    assert cfg.distance_scale == 1.0
+    assert cfg.min_similarity == 0.5
+def test_experiential_dimensions_preflight_without_allocation() -> None:
+    # Derived vector sum would overflow signed int32.
+    with pytest.raises(ValueError, match="dimensions must fit signed int32"):
+        ExperientialMemoryConfig(
+            capacity=4,
+            observation_dim=_INT32_MAX,
+            key_dim=2,
+            action_dim=1,
+            outcome_dim=1,
+        )
+    # Scalar-count preflight via capacity * vector overflow.
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        ExperientialMemoryConfig(
+            capacity=1,
+            observation_dim=_INT32_MAX - 18,
+            key_dim=1,
+            action_dim=1,
+            outcome_dim=1,
+            top_k=1,
+            min_neighbors=1,
+        )
+
+
+def test_experiential_state_preflight_bytes_without_allocation() -> None:
+    # Minimal vector=4 (1,1,1,1) -> slot=64, persistent=capacity*64+32.
+    last_legal = (2**31 - 1 - 32) // 64
+    ExperientialMemoryConfig(
+        capacity=last_legal,
+        observation_dim=1,
+        key_dim=1,
+        action_dim=1,
+        outcome_dim=1,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        ExperientialMemoryConfig(
+            capacity=last_legal + 1,
+            observation_dim=1,
+            key_dim=1,
+            action_dim=1,
+            outcome_dim=1,
+        )
+    # Non-minimal vector should also be allocation-free.
+    with pytest.raises(ValueError, match="byte count|scalar count"):
+        ExperientialMemoryConfig(
+            capacity=100_000_000,
+            observation_dim=2,
+            key_dim=2,
+            action_dim=2,
+            outcome_dim=1,
+        )
+

--- a/tests/test_experiential_memory_validation.py
+++ b/tests/test_experiential_memory_validation.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from alberta_framework.core.experiential_memory import ExperientialMemoryConfig
+from alberta_framework.core.experiential_memory import (
+    ExperientialMemory,
+    ExperientialMemoryConfig,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -209,7 +212,10 @@ def test_experiential_float_validators_reject_nonfinite_and_hostile() -> None:
 
 def test_experiential_float_validators_reject_hostile_ratio() -> None:
     class HostileFloat(float):
+        calls = 0
+
         def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
             raise RuntimeError("ratio hook")
 
     with pytest.raises(ValueError, match="distance_scale"):
@@ -221,6 +227,7 @@ def test_experiential_float_validators_reject_hostile_ratio() -> None:
             outcome_dim=1,
             distance_scale=HostileFloat(1.0),  # type: ignore[arg-type]
         )
+    assert HostileFloat.calls == 0
 
 
 def test_experiential_eviction_weights_require_positive_sum() -> None:
@@ -307,3 +314,28 @@ def test_experiential_state_preflight_bytes_without_allocation() -> None:
             outcome_dim=1,
         )
 
+
+def test_experiential_memory_exact_serialized_boundaries() -> None:
+    config = ExperientialMemoryConfig(
+        capacity=4,
+        observation_dim=2,
+        key_dim=2,
+        action_dim=1,
+        outcome_dim=1,
+    )
+    payload = config.to_config()
+
+    class HostileDict(dict[str, object]):
+        def __iter__(self):
+            raise AssertionError("iteration must not run")
+
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        ExperientialMemoryConfig.from_config(HostileDict(payload))
+    with pytest.raises(ValueError, match="serialized schema"):
+        ExperientialMemoryConfig.from_config({**payload, "extra": 1})
+    with pytest.raises(ValueError, match="config type"):
+        ExperientialMemoryConfig.from_config({**payload, "type": "wrong"})
+
+    outer = ExperientialMemory(config).to_config()
+    with pytest.raises(ValueError, match="nested config"):
+        ExperientialMemory.from_config({**outer, "config": HostileDict(payload)})

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -256,3 +258,59 @@ def test_rls_reward_model_config_integer_and_scalar_validation() -> None:
     assert type(cfg.ridge) is float
     assert type(cfg.error_decay) is float
     assert cfg.feature_dim == 8
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_rls_reward_model_config_canonicalizes_every_numpy_integer_family(
+    integer_type: type,
+) -> None:
+    config = RLSRewardModelConfig(feature_dim=integer_type(4))
+
+    assert type(config.feature_dim) is int
+    assert config.feature_dim == 4
+
+
+def test_rls_reward_model_config_rejects_hostile_integer_types_without_repr() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    for value in (HostileInt(4), ClassSpoof()):
+        with pytest.raises(ValueError, match="feature_dim"):
+            RLSRewardModelConfig(feature_dim=value)  # type: ignore[arg-type]
+
+
+def test_rls_reward_model_preflights_quadratic_state_before_allocation() -> None:
+    scalar_limit = (2**31 - 1) // 4
+    last_legal = (math.isqrt(1 + 4 * (scalar_limit - 2)) - 1) // 2
+
+    RLSRewardModelConfig(feature_dim=last_legal)
+    with pytest.raises(ValueError, match="state bytes"):
+        RLSRewardModelConfig(feature_dim=last_legal + 1)
+
+
+@pytest.mark.parametrize("shape", ((1,), (1, 1)))
+def test_rls_reward_model_rejects_non_scalar_rewards_eager_and_outer_jit(
+    shape: tuple[int, ...],
+) -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=2))
+    state = model.init()
+    features = jnp.ones((2,), dtype=jnp.float32)
+    reward = jnp.zeros(shape, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="reward must be a scalar"):
+        model.update(state, features, reward)
+    compiled = jax.jit(lambda value: model.update(state, features, value).state)
+    with pytest.raises(ValueError, match="reward must be a scalar"):
+        compiled(reward)

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -33,11 +33,13 @@ def test_rls_reward_model_feature_shape_guard_is_jit_stable() -> None:
     state = model.init()
     predict = jax.jit(lambda features: model.predict(state, features))
     update = jax.jit(
-        lambda features: model.update(
-            state,
-            features,
-            jnp.array(0.0, dtype=jnp.float32),
-        ).state.weights
+        lambda features: (
+            model.update(
+                state,
+                features,
+                jnp.array(0.0, dtype=jnp.float32),
+            ).state.weights
+        )
     )
 
     chex.assert_shape(predict(jnp.ones((4,), dtype=jnp.float32)), ())
@@ -63,9 +65,7 @@ def test_rls_reward_model_config_roundtrip() -> None:
 
 def test_rls_reward_model_learns_linear_reward() -> None:
     """RLS should quickly fit a deterministic linear reward surface."""
-    model = RLSRewardModel(
-        RLSRewardModelConfig(feature_dim=3, forgetting=1.0, ridge=0.1)
-    )
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=3, forgetting=1.0, ridge=0.1))
     state = model.init()
     true_weights = jnp.array([0.25, -0.5, 0.75], dtype=jnp.float32)
     features = jnp.array(
@@ -94,23 +94,19 @@ def test_rls_reward_model_learns_linear_reward() -> None:
 
 def test_rls_reward_model_rejects_invalid_config() -> None:
     """Invalid numerical settings should fail early."""
-    for config in (
-        RLSRewardModelConfig(feature_dim=0),
-        RLSRewardModelConfig(feature_dim=1, forgetting=0.0),
-        RLSRewardModelConfig(feature_dim=1, ridge=0.0),
-        RLSRewardModelConfig(feature_dim=1, error_decay=1.0),
+    for kwargs in (
+        {"feature_dim": 0},
+        {"feature_dim": 1, "forgetting": 0.0},
+        {"feature_dim": 1, "ridge": 0.0},
+        {"feature_dim": 1, "error_decay": 1.0},
     ):
-        try:
-            RLSRewardModel(config)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError(f"expected ValueError for {config}")
+        with pytest.raises(ValueError):
+            RLSRewardModelConfig(**kwargs)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("value", [True, 1.0, "1", np.int64(1)])
+@pytest.mark.parametrize("value", [True, 1.0, "1", [1]])
 def test_rls_reward_model_rejects_non_builtin_feature_dim(value: object) -> None:
-    """Dimensions must not accept bool or integer-like aliases."""
+    """Dimensions must not accept bool or non-integer aliases."""
     payload = RLSRewardModelConfig(feature_dim=1).to_config()
     payload["feature_dim"] = value
 
@@ -202,9 +198,7 @@ def test_rls_reward_model_canonicalizes_numpy_scalars() -> None:
 
 def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     """Inf reward * a silent feature's zero gain is 0*inf = NaN."""
-    model = RLSRewardModel(
-        RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0)
-    )
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0))
     state = model.init()
     features = jnp.array([0.0, 1.0], dtype=jnp.float32)
 
@@ -217,9 +211,7 @@ def test_rls_infinite_reward_on_zero_feature_does_not_poison_weights() -> None:
     assert float(poisoned.error) == 0.0
     chex.assert_trees_all_close(poisoned.gain, jnp.zeros_like(poisoned.gain))
 
-    recovered = model.update(
-        poisoned.state, features, jnp.array(1.0, dtype=jnp.float32)
-    )
+    recovered = model.update(poisoned.state, features, jnp.array(1.0, dtype=jnp.float32))
     chex.assert_tree_all_finite(recovered.state.weights)
     chex.assert_tree_all_finite(recovered.state.covariance)
     assert bool(recovered.update_applied)
@@ -231,9 +223,7 @@ def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
         RLSRewardModelConfig(feature_dim=2, forgetting=1.0, ridge=1.0, error_decay=0.0)
     )
     features = jnp.array([0.0, 1.0], dtype=jnp.float32)
-    state = model.update(
-        model.init(), features, jnp.array(1.0, dtype=jnp.float32)
-    ).state
+    state = model.update(model.init(), features, jnp.array(1.0, dtype=jnp.float32)).state
     state = state.replace(abs_error_ema=jnp.asarray(jnp.inf, dtype=jnp.float32))
     raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
     assert not bool(jnp.isfinite(raw))
@@ -241,3 +231,28 @@ def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
     result = model.update(state, features, jnp.array(0.5, dtype=jnp.float32))
     assert bool(result.update_applied)
     assert bool(jnp.isfinite(result.state.abs_error_ema))
+
+
+def test_rls_reward_model_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        RLSRewardModelConfig(feature_dim=0)
+    with pytest.raises(ValueError, match="forgetting"):
+        RLSRewardModelConfig(feature_dim=2, forgetting=float("nan"))
+    with pytest.raises(ValueError, match="ridge"):
+        RLSRewardModelConfig(feature_dim=2, ridge=0.0)
+
+    cfg = RLSRewardModelConfig(
+        feature_dim=np.int32(8),
+        forgetting=np.float32(0.95),
+        ridge=np.float32(5.0),
+        error_decay=np.float32(0.8),
+    )
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.forgetting) is float
+    assert type(cfg.ridge) is float
+    assert type(cfg.error_decay) is float
+    assert cfg.feature_dim == 8

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -291,6 +291,32 @@ def test_rls_reward_model_config_rejects_hostile_integer_types_without_repr() ->
             RLSRewardModelConfig(feature_dim=value)  # type: ignore[arg-type]
 
 
+def test_reward_model_exact_schema_and_hostile_float_hooks() -> None:
+    config = RLSRewardModelConfig(feature_dim=4)
+    payload = config.to_config()
+
+    class HostileDict(dict[str, object]):
+        def __iter__(self):
+            raise AssertionError("iteration must not run")
+
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise AssertionError("ratio must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        RLSRewardModelConfig.from_config(HostileDict(payload))
+    with pytest.raises(ValueError, match="serialized schema"):
+        RLSRewardModelConfig.from_config({**payload, "extra": 1})
+    with pytest.raises(ValueError, match="payload type"):
+        RLSRewardModelConfig.from_config({**payload, "type": "wrong"})
+    for field in ("forgetting", "ridge", "error_decay"):
+        with pytest.raises(ValueError, match=field):
+            RLSRewardModelConfig(feature_dim=1, **{field: HostileFloat(0.5)})
+
+
 def test_rls_reward_model_preflights_quadratic_state_before_allocation() -> None:
     scalar_limit = (2**31 - 1) // 4
     last_legal = (math.isqrt(1 + 4 * (scalar_limit - 2)) - 1) // 2

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -72,9 +72,7 @@ def test_epps_pulley_rejects_invalid_static_kernel_width(kernel_width: object) -
 
 def test_epps_pulley_dynamic_jit_keeps_valid_width_and_signals_invalid_widths() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
-    compiled = jax.jit(
-        lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
-    )
+    compiled = jax.jit(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
 
     eager = epps_pulley_gaussian_statistic(samples, kernel_width=1.0)
     chex.assert_trees_all_close(compiled(jnp.asarray(1.0)), eager, atol=1.0e-6)
@@ -103,9 +101,7 @@ def test_epps_pulley_accepts_supported_concrete_real_scalars() -> None:
 def test_epps_pulley_vmap_preserves_valid_widths_and_signals_invalid_lanes() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
     mapped = jax.jit(
-        jax.vmap(
-            lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
-        )
+        jax.vmap(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
     )
     valid_widths = jnp.asarray([0.5, 1.0, 2.0], dtype=jnp.float32)
     expected = jnp.asarray(
@@ -178,7 +174,7 @@ def test_sigreg_config_rejects_invalid_static_numeric_contracts() -> None:
     ):
         with pytest.raises(ValueError):
             SIGRegConfig(eps=bad_eps)  # type: ignore[arg-type]
-    for bad_count in (0, -1, True, 1.0, np.int64(1)):
+    for bad_count in (0, -1, True, 1.0, "1", [1]):
         with pytest.raises(ValueError):
             SIGRegConfig(n_projections=bad_count)  # type: ignore[arg-type]
 
@@ -300,3 +296,24 @@ def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
     assert bool(jnp.isfinite(directions).all())
     with pytest.raises(ValueError, match="projected samples must be finite"):
         sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sigreg_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=32.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=0)
+
+
+def test_sigreg_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = SIGRegConfig(
+        n_projections=np.int32(64),
+        kernel_width=np.float32(1.5),
+        eps=np.float32(1e-7),
+    )
+    assert type(cfg.n_projections) is int
+    assert type(cfg.kernel_width) is float
+    assert type(cfg.eps) is float
+    assert cfg.n_projections == 64

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -33,6 +33,95 @@ def test_sigreg_config_roundtrip_and_direction_shapes() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "integer_type",
+    sorted(
+        {np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")},
+        key=lambda value: value.__name__,
+    ),
+)
+def test_sigreg_accepts_every_numpy_integer_family(integer_type) -> None:
+    config = SIGRegConfig(n_projections=integer_type(2))
+    assert type(config.n_projections) is int
+    directions = sample_sigreg_directions(jr.key(0), integer_type(3), config)
+    assert directions.shape == (2, 3)
+
+
+def test_sigreg_rejects_integer_spoofs_without_hooks_or_repr() -> None:
+    class HostileInt(int):
+        def __index__(self):
+            raise AssertionError("subclass hook executed")
+
+        def __repr__(self):
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="n_projections"):
+        SIGRegConfig(n_projections=HostileInt(2))
+    with pytest.raises(ValueError, match="latent_dim"):
+        sample_sigreg_directions(jr.key(0), HostileInt(2))
+
+
+def test_sigreg_config_schema_is_exact() -> None:
+    config = SIGRegConfig(n_projections=np.int32(3))
+    payload = config.to_config()
+    assert SIGRegConfig.from_config(payload) == config
+    with pytest.raises(ValueError, match="actual dict"):
+        SIGRegConfig.from_config(type("DictSubclass", (dict,), {})(payload))
+    with pytest.raises(ValueError, match="schema"):
+        SIGRegConfig.from_config({**payload, "unknown": 1})
+    with pytest.raises(ValueError, match="type"):
+        SIGRegConfig.from_config({**payload, "type": "wrong"})
+
+
+def test_sigreg_config_float_hooks_fail_closed_once() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self):
+            type(self).calls += 1
+            raise RuntimeError("hostile ratio")
+
+        def __repr__(self):
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="kernel_width"):
+        SIGRegConfig(kernel_width=HostileFloat(1.0))
+    assert HostileFloat.calls == 1
+
+
+def test_sigreg_preflights_direction_and_pairwise_resources_without_allocating() -> None:
+    config = SIGRegConfig(n_projections=(2**31 - 1) // 4 + 1)
+    with pytest.raises(ValueError, match="directions"):
+        sample_sigreg_directions(jr.key(0), 1, config)
+
+    samples = jnp.zeros((23_171,), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="pairwise workspace"):
+        epps_pulley_gaussian_statistic(samples)
+
+    embeddings = jnp.zeros((1_000, 1), dtype=jnp.float32)
+    directions = jnp.ones((600, 1), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="projected pairwise workspace"):
+        sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sigreg_rejects_mismatched_or_empty_representation_shapes() -> None:
+    with pytest.raises(ValueError, match="directions must have shape"):
+        sliced_sigreg_loss(jnp.ones((2, 3)), jnp.ones((2, 2)))
+    with pytest.raises(ValueError, match="at least one sample"):
+        sliced_sigreg_loss(jnp.ones((0, 3)), jnp.ones((2, 3)))
+    with pytest.raises(ValueError, match="non-empty"):
+        epps_pulley_gaussian_statistic(jnp.asarray([], dtype=jnp.float32))
+
+
+def test_sigreg_diagnostics_std_is_finite_at_float32_extremes() -> None:
+    maximum = np.finfo(np.float32).max
+    embeddings = jnp.asarray([[maximum], [-maximum]], dtype=jnp.float32)
+    directions = jnp.ones((1, 1), dtype=jnp.float32)
+    assert not bool(jnp.isfinite(jnp.std(embeddings, axis=0)[0]))
+    diagnostics = sigreg_diagnostics(embeddings, directions, SIGRegConfig(n_projections=1))
+    chex.assert_tree_all_finite(diagnostics)
+
+
 def test_epps_pulley_statistic_penalizes_collapsed_samples() -> None:
     gaussian = jr.normal(jr.key(1), (128,), dtype=jnp.float32)
     collapsed = jnp.zeros((128,), dtype=jnp.float32)
@@ -72,7 +161,9 @@ def test_epps_pulley_rejects_invalid_static_kernel_width(kernel_width: object) -
 
 def test_epps_pulley_dynamic_jit_keeps_valid_width_and_signals_invalid_widths() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
-    compiled = jax.jit(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
+    compiled = jax.jit(
+        lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
+    )
 
     eager = epps_pulley_gaussian_statistic(samples, kernel_width=1.0)
     chex.assert_trees_all_close(compiled(jnp.asarray(1.0)), eager, atol=1.0e-6)
@@ -101,7 +192,9 @@ def test_epps_pulley_accepts_supported_concrete_real_scalars() -> None:
 def test_epps_pulley_vmap_preserves_valid_widths_and_signals_invalid_lanes() -> None:
     samples = jnp.asarray([-1.0, 0.0, 1.0], dtype=jnp.float32)
     mapped = jax.jit(
-        jax.vmap(lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width))
+        jax.vmap(
+            lambda width: epps_pulley_gaussian_statistic(samples, kernel_width=width)
+        )
     )
     valid_widths = jnp.asarray([0.5, 1.0, 2.0], dtype=jnp.float32)
     expected = jnp.asarray(
@@ -174,7 +267,7 @@ def test_sigreg_config_rejects_invalid_static_numeric_contracts() -> None:
     ):
         with pytest.raises(ValueError):
             SIGRegConfig(eps=bad_eps)  # type: ignore[arg-type]
-    for bad_count in (0, -1, True, 1.0, "1", [1]):
+    for bad_count in (0, -1, True, 1.0):
         with pytest.raises(ValueError):
             SIGRegConfig(n_projections=bad_count)  # type: ignore[arg-type]
 
@@ -296,24 +389,3 @@ def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
     assert bool(jnp.isfinite(directions).all())
     with pytest.raises(ValueError, match="projected samples must be finite"):
         sliced_sigreg_loss(embeddings, directions)
-
-
-def test_sigreg_config_rejects_booleans_and_non_integers() -> None:
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=32.5)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_projections"):
-        SIGRegConfig(n_projections=0)
-
-
-def test_sigreg_config_accepts_and_canonicalizes_numpy_integers() -> None:
-    cfg = SIGRegConfig(
-        n_projections=np.int32(64),
-        kernel_width=np.float32(1.5),
-        eps=np.float32(1e-7),
-    )
-    assert type(cfg.n_projections) is int
-    assert type(cfg.kernel_width) is float
-    assert type(cfg.eps) is float
-    assert cfg.n_projections == 64

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -73,7 +73,7 @@ def test_sigreg_config_schema_is_exact() -> None:
         SIGRegConfig.from_config({**payload, "type": "wrong"})
 
 
-def test_sigreg_config_float_hooks_fail_closed_once() -> None:
+def test_sigreg_config_float_hooks_are_not_run() -> None:
     class HostileFloat(float):
         calls = 0
 
@@ -86,13 +86,15 @@ def test_sigreg_config_float_hooks_fail_closed_once() -> None:
 
     with pytest.raises(ValueError, match="kernel_width"):
         SIGRegConfig(kernel_width=HostileFloat(1.0))
-    assert HostileFloat.calls == 1
+    assert HostileFloat.calls == 0
 
 
 def test_sigreg_preflights_direction_and_pairwise_resources_without_allocating() -> None:
-    config = SIGRegConfig(n_projections=(2**31 - 1) // 4 + 1)
     with pytest.raises(ValueError, match="directions"):
-        sample_sigreg_directions(jr.key(0), 1, config)
+        SIGRegConfig(n_projections=(2**31 - 1) // 4 + 1)
+    config = SIGRegConfig(n_projections=2)
+    with pytest.raises(ValueError, match="directions"):
+        sample_sigreg_directions(jr.key(0), (2**31 - 1) // 4, config)
 
     samples = jnp.zeros((23_171,), dtype=jnp.float32)
     with pytest.raises(ValueError, match="pairwise workspace"):


### PR DESCRIPTION
Supersedes #745/#760, #746, and #748/#762 while preserving all contributor and corrective commits. The combined current-main repair keeps the reward scalar-target and quadratic covariance protections, experiential-memory signed-int32 aggregate state contract, and SIGReg representation/workspace preflights, then closes the remaining exact built-in/NumPy scalar, hostile-hook, complete schema, nested-container, exact logical-scalar/byte, and minimum-direction-allocation gaps.\n\nVerification on current main: 212 focused tests passed; scoped Ruff passed; strict mypy passed; diff check passed. No outputs or registered evidence artifacts changed.