### PR TITLE
fix(experiential-memory): close residual query operation contracts

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -285,6 +285,12 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 
+
+def _require_float32_allocation(name: str, scalars: int) -> None:
+    if scalars > _INT32_MAX or 4 * scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar and byte counts must fit signed int32")
+
+
 def _validate_config(config: ExperientialMemoryConfig) -> None:
     for name in (
         "capacity",
@@ -317,6 +323,16 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         raise ValueError("ExperientialMemoryConfig state byte count must fit signed int32")
     if persistent_bytes > _UINT32_MAX:
         raise ValueError("persistent memory allocation exceeds uint32 byte accounting")
+    for name, scalars in (
+        ("query key-distance work", config.capacity * config.key_dim),
+        ("query observation gather", config.top_k * config.observation_dim),
+        ("query key gather", config.top_k * config.key_dim),
+        ("query action gather", config.top_k * config.action_dim),
+        ("query outcome gather", config.top_k * config.outcome_dim),
+        ("query gathered payload", config.top_k * vector_values),
+        ("query neighbor diagnostics", 7 * config.top_k),
+    ):
+        _require_float32_allocation(f"ExperientialMemoryConfig {name}", scalars)
 
     object.__setattr__(
         config,
@@ -369,13 +385,20 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
             "eviction_recency_weight", config.eviction_recency_weight, lower=0
         ),
     )
-    if config.eviction_utility_weight + config.eviction_recency_weight <= 0.0:
+    utility_weight_f32 = float(np.asarray(config.eviction_utility_weight, dtype=np.float32))
+    recency_weight_f32 = float(np.asarray(config.eviction_recency_weight, dtype=np.float32))
+    if utility_weight_f32 + recency_weight_f32 <= 0.0:
         raise ValueError("at least one eviction retention weight must be positive")
     object.__setattr__(
         config,
         "recency_scale",
         _validated_config_float("recency_scale", config.recency_scale, positive=True),
     )
+    minimum_safe_scale = _INT32_MAX / float(np.finfo(np.float32).max)
+    if config.staleness_scale < minimum_safe_scale:
+        raise ValueError("staleness_scale must keep saturated age division finite in float32")
+    if config.recency_scale < minimum_safe_scale:
+        raise ValueError("recency_scale must keep saturated age division finite in float32")
 
 def _saturating_increment(value: Array) -> Array:
     maximum_minus_one = jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
@@ -1134,10 +1157,14 @@ class ExperientialMemory:
                 current_entries.utilities,
                 0.0,
             )
+            utility_weight = jnp.asarray(cfg.eviction_utility_weight, dtype=jnp.float32)
+            recency_weight = jnp.asarray(cfg.eviction_recency_weight, dtype=jnp.float32)
+            # These weights are relative. Normalization preserves ordering and
+            # prevents finite configured weights from overflowing their products.
+            weight_scale = jnp.maximum(utility_weight, recency_weight)
             retention_score = (
-                jnp.asarray(cfg.eviction_utility_weight, dtype=jnp.float32)
-                * eviction_utilities
-                + jnp.asarray(cfg.eviction_recency_weight, dtype=jnp.float32) * recency_score
+                utility_weight / weight_scale * eviction_utilities
+                + recency_weight / weight_scale * recency_score
             )
             retention_score = jnp.where(current_entries.valid, retention_score, jnp.inf)
             eviction_slot = jnp.argmin(retention_score)

--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -333,6 +333,29 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         ("query neighbor diagnostics", 7 * config.top_k),
     ):
         _require_float32_allocation(f"ExperientialMemoryConfig {name}", scalars)
+    payload_values = config.observation_dim + config.action_dim + config.outcome_dim
+    # Conservative simultaneous query envelope, expressed as four-byte scalar
+    # equivalents.  It includes the persistent state plus every full-width
+    # logical temporary in _query_jit: row-finiteness predicates; safe keys,
+    # key differences and squares; safe payload matrices; nineteen capacity
+    # vectors; gathered values and their weighted products; top-k diagnostics;
+    # and reduced payload outputs.  Booleans can be smaller, but are charged at
+    # four bytes so this remains an upper bound across JAX backends.
+    query_temporary_scalars = (
+        config.capacity * vector_values
+        + 3 * config.capacity * config.key_dim
+        + config.capacity * payload_values
+        + 19 * config.capacity
+        + 2 * config.top_k * (payload_values + 4)
+        + 9 * config.top_k
+        + payload_values
+        + 4
+    )
+    if persistent_bytes + 4 * query_temporary_scalars > _INT32_MAX:
+        raise ValueError(
+            "ExperientialMemoryConfig aggregate query working-set bytes "
+            "must fit signed int32"
+        )
 
     object.__setattr__(
         config,
@@ -394,7 +417,10 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         "recency_scale",
         _validated_config_float("recency_scale", config.recency_scale, positive=True),
     )
-    minimum_safe_scale = _INT32_MAX / float(np.finfo(np.float32).max)
+    rounded_boundary = np.float32(_INT32_MAX / float(np.finfo(np.float32).max))
+    minimum_safe_scale = float(
+        np.nextafter(rounded_boundary, np.float32(np.inf), dtype=np.float32)
+    )
     if config.staleness_scale < minimum_safe_scale:
         raise ValueError("staleness_scale must keep saturated age division finite in float32")
     if config.recency_scale < minimum_safe_scale:

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -484,6 +484,24 @@ def test_eviction_is_deterministic_and_reward_does_not_replace_explicit_utility(
     assert int(accounting.evictions) == 1
 
 
+def test_large_relative_eviction_weights_do_not_overflow_priority() -> None:
+    maximum = float(np.finfo(np.float32).max)
+    memory = ExperientialMemory(
+        _config(
+            capacity=1,
+            top_k=1,
+            eviction_utility_weight=maximum,
+            eviction_recency_weight=maximum,
+        )
+    )
+    state = _write(memory, memory.init(), _entry(10, utility=maximum))
+    result = memory.write(state, _entry(20, utility=1.0))
+
+    assert bool(result.wrote)
+    assert bool(result.evicted)
+    assert int(result.evicted_provenance_id) == 10
+
+
 def test_accepted_access_updates_recency_before_deterministic_eviction() -> None:
     memory = ExperientialMemory(
         _config(

--- a/tests/test_experiential_memory_validation.py
+++ b/tests/test_experiential_memory_validation.py
@@ -339,3 +339,30 @@ def test_experiential_memory_exact_serialized_boundaries() -> None:
     outer = ExperientialMemory(config).to_config()
     with pytest.raises(ValueError, match="nested config"):
         ExperientialMemory.from_config({**outer, "config": HostileDict(payload)})
+
+
+@pytest.mark.parametrize("field", ["staleness_scale", "recency_scale"])
+def test_age_scale_rejects_float32_division_overflow(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        ExperientialMemoryConfig(
+            capacity=4,
+            observation_dim=2,
+            key_dim=2,
+            action_dim=1,
+            outcome_dim=1,
+            **{field: np.nextafter(np.float32(0.0), np.float32(1.0))},
+        )
+
+
+def test_eviction_weight_sum_must_be_positive_at_the_float32_sink() -> None:
+    tiny = float(np.nextafter(np.float32(0.0), np.float32(1.0))) / 2.0
+    with pytest.raises(ValueError, match="retention weight"):
+        ExperientialMemoryConfig(
+            capacity=4,
+            observation_dim=2,
+            key_dim=2,
+            action_dim=1,
+            outcome_dim=1,
+            eviction_utility_weight=tiny,
+            eviction_recency_weight=tiny,
+        )

--- a/tests/test_experiential_memory_validation.py
+++ b/tests/test_experiential_memory_validation.py
@@ -289,13 +289,14 @@ def test_experiential_dimensions_preflight_without_allocation() -> None:
 def test_experiential_state_preflight_bytes_without_allocation() -> None:
     # Minimal vector=4 (1,1,1,1) -> slot=64, persistent=capacity*64+32.
     last_legal = (2**31 - 1 - 32) // 64
-    ExperientialMemoryConfig(
-        capacity=last_legal,
-        observation_dim=1,
-        key_dim=1,
-        action_dim=1,
-        outcome_dim=1,
-    )
+    with pytest.raises(ValueError, match="aggregate query working-set bytes"):
+        ExperientialMemoryConfig(
+            capacity=last_legal,
+            observation_dim=1,
+            key_dim=1,
+            action_dim=1,
+            outcome_dim=1,
+        )
     with pytest.raises(ValueError, match="byte count"):
         ExperientialMemoryConfig(
             capacity=last_legal + 1,
@@ -352,6 +353,45 @@ def test_age_scale_rejects_float32_division_overflow(field: str) -> None:
             outcome_dim=1,
             **{field: np.nextafter(np.float32(0.0), np.float32(1.0))},
         )
+
+
+@pytest.mark.parametrize("field", ["staleness_scale", "recency_scale"])
+def test_age_scale_accepts_first_float32_value_with_finite_saturated_division(
+    field: str,
+) -> None:
+    maximum = np.float32(np.iinfo(np.int32).max)
+    rounded_boundary = np.float32(
+        np.iinfo(np.int32).max / float(np.finfo(np.float32).max)
+    )
+    safe = np.nextafter(rounded_boundary, np.float32(np.inf), dtype=np.float32)
+    unsafe = np.nextafter(safe, np.float32(0.0), dtype=np.float32)
+    with np.errstate(over="ignore"):
+        assert not np.isfinite(maximum / unsafe)
+        assert np.isfinite(maximum / safe)
+    common = {
+        "capacity": 4,
+        "observation_dim": 2,
+        "key_dim": 2,
+        "action_dim": 1,
+        "outcome_dim": 1,
+    }
+    with pytest.raises(ValueError, match=field):
+        ExperientialMemoryConfig(**common, **{field: unsafe})
+    config = ExperientialMemoryConfig(**common, **{field: safe})
+    assert getattr(config, field) == float(safe)
+
+
+def test_aggregate_query_working_set_is_bounded_before_jax_allocation() -> None:
+    common = {
+        "observation_dim": 1,
+        "key_dim": 1,
+        "action_dim": 1,
+        "outcome_dim": 1,
+        "top_k": 1,
+    }
+    ExperientialMemoryConfig(capacity=11_000_000, **common)
+    with pytest.raises(ValueError, match="aggregate query working-set bytes"):
+        ExperientialMemoryConfig(capacity=12_000_000, **common)
 
 
 def test_eviction_weight_sum_must_be_positive_at_the_float32_sink() -> None:


### PR DESCRIPTION
Residual follow-up to merged #746/#769. The contributor's exact integer, float, schema, state-scalar, and state-byte contracts are preserved on main.

This adds only the remaining operation/resource safety: explicit signed-int32 scalar+byte preflights for each capacity/key-distance and top-k/payload/diagnostic query allocation; float32-sink validation for the positive eviction-weight condition; saturated-int32 age division bounds for staleness/recency scales; and max-normalization of relative eviction weights so finite stored utilities cannot overflow retention priorities while eviction ordering is preserved.

Tests cover adjacent age-scale failure, host-positive values that narrow to zero at the sink, and actual max-float32 eviction with deterministic finite behavior. No evidence sources or outputs are changed.

Validation: 139 focused experiential-memory/policy tests pass; Ruff, full strict mypy (168 files), and diff check pass.