### PR TITLE
fix(options): complete STOMP and OaK configuration contracts

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -33,13 +33,16 @@ References:
 from __future__ import annotations
 
 import dataclasses
+import math
+import operator
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -72,7 +75,44 @@ OAK_STATE_SCHEMA = "alberta.oak-state.v2"
 OAK_LIFETIME_COUNTER_NBYTES = 12
 OAK_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
+_INT32_MAX = 2**31 - 1
 _UINT64_MAX = 2**64 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_uint64(
+    name: str, value: object, *, minimum: int = 0, maximum: int = _UINT64_MAX
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
 
 # ---------------------------------------------------------------------------
 # Default config helper
@@ -113,14 +153,18 @@ class OaKConfig:
     min_steps_before_curation: int = 0
 
     def __post_init__(self) -> None:
-        if not 0.0 <= self.utility_ema_decay <= 1.0:
-            raise ValueError("utility_ema_decay must be in [0, 1]")
-        if self.curation_threshold < 0.0:
-            raise ValueError("curation_threshold must be non-negative")
-        if self.min_steps_before_curation < 0:
-            raise ValueError("min_steps_before_curation must be non-negative")
-        if self.min_steps_before_curation > _UINT64_MAX:
-            raise ValueError("min_steps_before_curation must fit the uint64 lifetime")
+        min_steps = _require_uint64(
+            "min_steps_before_curation",
+            self.min_steps_before_curation,
+            minimum=0,
+            maximum=_UINT64_MAX,
+        )
+        object.__setattr__(self, "min_steps_before_curation", min_steps)
+
+        if not math.isfinite(self.utility_ema_decay) or not 0.0 <= self.utility_ema_decay <= 1.0:
+            raise ValueError("utility_ema_decay must be finite and in [0, 1]")
+        if not math.isfinite(self.curation_threshold) or self.curation_threshold < 0.0:
+            raise ValueError("curation_threshold must be finite and non-negative")
 
     @property
     def n_options(self) -> int:
@@ -373,9 +417,8 @@ def _oak_outer_state_validity(
             config.observation_dim,
         )
     )
-    values_finite = (
-        jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards))
-        & jnp.all(jnp.isfinite(state.utility_ema))
+    values_finite = jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards)) & jnp.all(
+        jnp.isfinite(state.utility_ema)
     )
     counter_ceiling = jnp.where(
         state.step_count < jnp.int32(2_147_483_647),
@@ -389,11 +432,7 @@ def _oak_outer_state_validity(
         & jnp.all(state.execution_counts >= 0)
         & jnp.all(state.execution_counts <= counter_ceiling)
     )
-    valid = (
-        jnp.asarray(static_contract_valid, dtype=jnp.bool_)
-        & values_finite
-        & counters_valid
-    )
+    valid = jnp.asarray(static_contract_valid, dtype=jnp.bool_) & values_finite & counters_valid
     return (
         jnp.asarray(static_contract_valid, dtype=jnp.bool_),
         values_finite,
@@ -430,9 +469,8 @@ def _exact_tree_equal(left: Any, right: Any) -> Bool[Array, ""]:
         return jnp.asarray(False, dtype=jnp.bool_)
     left_leaves, left_structure = jax.tree_util.tree_flatten(left)
     right_leaves, right_structure = jax.tree_util.tree_flatten(right)
-    if (
-        cast(object, left_structure) != cast(object, right_structure)
-        or len(left_leaves) != len(right_leaves)
+    if cast(object, left_structure) != cast(object, right_structure) or len(left_leaves) != len(
+        right_leaves
     ):
         return jnp.asarray(False, dtype=jnp.bool_)
     equal = jnp.asarray(True, dtype=jnp.bool_)
@@ -684,9 +722,7 @@ def measure_oak_state_nbytes(state: OaKState) -> int:
 def measure_oak_wrapper_state_nbytes(state: OaKState) -> int:
     """Measure only OaK-owned arrays, excluding the nested STOMP state."""
 
-    return measure_oak_state_nbytes(state) - measure_stomp_state_nbytes(
-        state.stomp_state
-    )
+    return measure_oak_state_nbytes(state) - measure_stomp_state_nbytes(state.stomp_state)
 
 
 def oak_lifetime_counter_nbytes() -> int:
@@ -711,10 +747,7 @@ def _oak_host_field_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return dict(value)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return {
-            field.name: getattr(value, field.name)
-            for field in dataclasses.fields(value)
-        }
+        return {field.name: getattr(value, field.name) for field in dataclasses.fields(value)}
     raise TypeError("legacy OaK state must be a mapping or dataclass")
 
 
@@ -738,8 +771,7 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
         missing = sorted(legacy_names - supplied_names)
         extra = sorted(supplied_names - legacy_names)
         raise ValueError(
-            "legacy OaK field manifest is not exact; "
-            f"missing={missing}, extra={extra}"
+            f"legacy OaK field manifest is not exact; missing={missing}, extra={extra}"
         )
 
     step_count = jnp.asarray(fields["step_count"])
@@ -757,9 +789,7 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
         nested = load_stomp_state_with_migration(_oak_host_field_mapping(nested))
     if not bool(_lifetime_counter_valid(nested.step_words, nested.step_count)):
         raise ValueError("legacy OaK nested STOMP lifetime counter is invalid")
-    if int(nested.step_count) != step or not bool(
-        jnp.all(nested.step_words == step_words)
-    ):
+    if int(nested.step_count) != step or not bool(jnp.all(nested.step_words == step_words)):
         raise ValueError("legacy OaK and nested STOMP clocks are not aligned")
 
     execution_counts = jnp.asarray(fields["execution_counts"])
@@ -779,14 +809,10 @@ def migrate_legacy_oak_state(legacy_state: Any) -> OaKState:
     if not owned_contract_valid:
         raise ValueError("legacy OaK owned-array contract is invalid")
     counter_ceiling = min(step + 1, 2**31 - 1)
-    if not bool(
-        jnp.all(execution_counts >= 0)
-        & jnp.all(execution_counts <= counter_ceiling)
-    ):
+    if not bool(jnp.all(execution_counts >= 0) & jnp.all(execution_counts <= counter_ceiling)):
         raise ValueError("legacy OaK execution counters are invalid")
     if not bool(
-        jnp.all(jnp.isfinite(cumulative_pseudo_rewards))
-        & jnp.all(jnp.isfinite(utility_ema))
+        jnp.all(jnp.isfinite(cumulative_pseudo_rewards)) & jnp.all(jnp.isfinite(utility_ema))
     ):
         raise ValueError("legacy OaK utility values are non-finite")
 
@@ -857,16 +883,17 @@ class KeyboardChordLearnerConfig:
     max_norm: float = 10.0
 
     def __post_init__(self) -> None:
-        if self.n_options <= 0:
-            raise ValueError("n_options must be positive")
-        if self.step_size < 0.0:
-            raise ValueError("step_size must be non-negative")
-        if not 0.0 <= self.baseline_decay < 1.0:
-            raise ValueError("baseline_decay must be in [0, 1)")
-        if self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be non-negative")
-        if self.max_norm <= 0.0:
-            raise ValueError("max_norm must be positive")
+        n_options = _require_int32("n_options", self.n_options, minimum=1)
+        object.__setattr__(self, "n_options", n_options)
+
+        if not math.isfinite(self.step_size) or self.step_size < 0.0:
+            raise ValueError("step_size must be finite and non-negative")
+        if not math.isfinite(self.baseline_decay) or not 0.0 <= self.baseline_decay < 1.0:
+            raise ValueError("baseline_decay must be finite and in [0, 1)")
+        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
+            raise ValueError("l2_penalty must be finite and non-negative")
+        if not math.isfinite(self.max_norm) or self.max_norm <= 0.0:
+            raise ValueError("max_norm must be finite and positive")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -917,8 +944,7 @@ def update_keyboard_chord_learner(
     chord_norm = chord / (jnp.linalg.norm(chord) + 1.0e-8)
     reward_arr = jnp.asarray(reward, dtype=jnp.float32)
     baseline = (
-        config.baseline_decay * state.reward_baseline
-        + (1.0 - config.baseline_decay) * reward_arr
+        config.baseline_decay * state.reward_baseline + (1.0 - config.baseline_decay) * reward_arr
     )
     advantage = reward_arr - state.reward_baseline
     proposed_vector = (
@@ -1006,9 +1032,9 @@ def keyboard_action(
     """
     q_vals = keyboard_q_values(stomp_state, observation, keyboard_vector)
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(
-        q_vals + 1e-6 * jr.gumbel(noise_key, (n_primitive_actions,))
-    ).astype(jnp.int32)
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_primitive_actions,))).astype(
+        jnp.int32
+    )
     random_action = jr.randint(explore_key, (), 0, n_primitive_actions).astype(jnp.int32)
     action = jnp.where(
         jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32),
@@ -1107,9 +1133,8 @@ class OaKAgent:
                 & jnp.all(jnp.isfinite(observation))
             )
         started_option = new_stomp.executing_option
-        started_mask = (
-            jnp.arange(self._config.n_options, dtype=jnp.int32)
-            == jnp.maximum(started_option, jnp.array(0, dtype=jnp.int32))
+        started_mask = jnp.arange(self._config.n_options, dtype=jnp.int32) == jnp.maximum(
+            started_option, jnp.array(0, dtype=jnp.int32)
         )
         new_execution_counts = jnp.where(
             started_mask & (started_option >= 0),
@@ -1171,9 +1196,7 @@ class OaKAgent:
             state.step_words,
             state.step_count,
         )
-        nested_counter_aligned = jnp.all(
-            state.step_words == state.stomp_state.step_words
-        )
+        nested_counter_aligned = jnp.all(state.step_words == state.stomp_state.step_words)
         source_nested_counter_aligned = jnp.all(
             source_state.step_words == source_state.stomp_state.step_words
         )
@@ -1187,15 +1210,11 @@ class OaKAgent:
         proposed_step_words, outer_capacity = _checked_lifetime_words_increment(
             source_state.step_words
         )
-        expected_nested_words, computed_nested_capacity = (
-            _checked_lifetime_words_advance(
-                source_state.stomp_state.base_learner_state.step_words,
-                stomp_result.nested_updates_required,
-            )
+        expected_nested_words, computed_nested_capacity = _checked_lifetime_words_advance(
+            source_state.stomp_state.base_learner_state.step_words,
+            stomp_result.nested_updates_required,
         )
-        expected_step_count = _saturating_int32_counter_increment(
-            source_state.step_count
-        )
+        expected_step_count = _saturating_int32_counter_increment(source_state.step_count)
         result_clock_binding_valid = (
             jnp.array_equal(
                 stomp_result.pre_step_words,
@@ -1251,9 +1270,7 @@ class OaKAgent:
             & idle_outputs_valid
             & continuing_owner_valid
         )
-        inferred_real_updates = (
-            stomp_result.nested_updates_applied - stomp_result.planning_backups
-        )
+        inferred_real_updates = stomp_result.nested_updates_applied - stomp_result.planning_backups
         result_diagnostics_valid = (
             stomp_result.inputs_valid
             & stomp_result.lifetime_counter_valid
@@ -1263,15 +1280,9 @@ class OaKAgent:
             & stomp_result.proposed_state_valid
             & stomp_result.update_applied
             & (stomp_result.nested_updates_required >= 0)
-            & (
-                stomp_result.nested_updates_applied
-                == stomp_result.nested_updates_required
-            )
+            & (stomp_result.nested_updates_applied == stomp_result.nested_updates_required)
             & (stomp_result.planning_backups >= 0)
-            & (
-                stomp_result.planning_backups
-                <= cfg.stomp.option_planning_backups_per_step
-            )
+            & (stomp_result.planning_backups <= cfg.stomp.option_planning_backups_per_step)
             & (inferred_real_updates >= 0)
             & (inferred_real_updates <= 1)
             & (stomp_result.option_importance_ratio >= 0.0)
@@ -1282,14 +1293,11 @@ class OaKAgent:
             prior_option,
             jnp.asarray(0, dtype=jnp.int32),
         )
-        prior_option_mask = (
-            jnp.arange(n_options, dtype=jnp.int32) == prior_option_index
-        )
+        prior_option_mask = jnp.arange(n_options, dtype=jnp.int32) == prior_option_index
         decay = jnp.asarray(cfg.utility_ema_decay, dtype=jnp.float32)
         new_utility_ema = jnp.where(
             prior_option_mask & prior_active,
-            decay * source_state.utility_ema
-            + (1.0 - decay) * stomp_result.pseudo_reward,
+            decay * source_state.utility_ema + (1.0 - decay) * stomp_result.pseudo_reward,
             source_state.utility_ema,
         )
 
@@ -1298,29 +1306,22 @@ class OaKAgent:
             post_option,
             jnp.asarray(0, dtype=jnp.int32),
         )
-        post_option_mask = (
-            jnp.arange(n_options, dtype=jnp.int32) == post_option_index
-        )
+        post_option_mask = jnp.arange(n_options, dtype=jnp.int32) == post_option_index
         post_active = post_option >= jnp.asarray(0, dtype=jnp.int32)
-        just_started = post_active & (
-            (~prior_active) | stomp_result.option_terminated
-        )
+        just_started = post_active & ((~prior_active) | stomp_result.option_terminated)
         new_execution_counts = jnp.where(
             post_option_mask & just_started,
             _saturating_int32_counter_increment(source_state.execution_counts),
             source_state.execution_counts,
         )
-        new_cumulative_pseudo_rewards = (
-            source_state.cumulative_pseudo_rewards
-            + jnp.where(
-                prior_option_mask & prior_active,
-                jnp.full(
-                    n_options,
-                    stomp_result.pseudo_reward,
-                    dtype=jnp.float32,
-                ),
-                jnp.zeros(n_options, dtype=jnp.float32),
-            )
+        new_cumulative_pseudo_rewards = source_state.cumulative_pseudo_rewards + jnp.where(
+            prior_option_mask & prior_active,
+            jnp.full(
+                n_options,
+                stomp_result.pseudo_reward,
+                dtype=jnp.float32,
+            ),
+            jnp.zeros(n_options, dtype=jnp.float32),
         )
         proposed_state = OaKState(
             stomp_state=stomp_result.state,
@@ -1330,9 +1331,7 @@ class OaKAgent:
             step_count=expected_step_count,
             step_words=proposed_step_words,
         )
-        post_nested_counter_aligned = jnp.all(
-            stomp_result.state.step_words == proposed_step_words
-        )
+        post_nested_counter_aligned = jnp.all(stomp_result.state.step_words == proposed_step_words)
         proposed_state_valid = (
             _oak_outer_state_validity(proposed_state, cfg)[-1]
             & self._stomp.state_valid(proposed_state.stomp_state)
@@ -1448,10 +1447,7 @@ class OaKAgent:
                 f"({self._config.n_options},), got {reset_slots.shape}"
             )
         if reset_slots.dtype != jnp.bool_:
-            raise TypeError(
-                "reset_slot_mask must have dtype bool, "
-                f"got {reset_slots.dtype}"
-            )
+            raise TypeError(f"reset_slot_mask must have dtype bool, got {reset_slots.dtype}")
 
         source_state_valid = (
             _oak_outer_state_validity(state, self._config)[-1]
@@ -1636,9 +1632,7 @@ class OaKAgent:
             execution_boundary=execution_boundary,
             extended_action_mask=extended_action_mask,
             enable_planning=enable_option_planning,
-            preselection_feature_reset_mask=(
-                preselection_feature_reset_mask
-            ),
+            preselection_feature_reset_mask=(preselection_feature_reset_mask),
         )
         update = self.adopt_stomp_update(
             state,
@@ -1685,9 +1679,7 @@ class OaKAgent:
                 decision_observation=decision_obs,
                 execution_boundary=execution_boundary,
                 extended_action_mask=(
-                    extended_action_mask
-                    if extended_action_masks is not None
-                    else None
+                    extended_action_mask if extended_action_masks is not None else None
                 ),
             )
             return result.state, (
@@ -1734,25 +1726,28 @@ class OaKAgent:
             else jnp.asarray(extended_action_masks)
         )
 
-        final_state, (
-            td_errors,
-            average_rewards,
-            primitive_actions,
-            executing_options,
-            option_terminations,
-            pseudo_rewards,
-            utility_emas,
-            planning_backups,
-            planning_td_errors,
-            pre_step_words,
-            post_step_words,
-            outer_state_valid,
-            lifetime_counter_valid,
-            lifetime_capacity_available,
-            nested_counter_aligned,
-            nested_update_applied,
-            proposed_state_valid,
-            update_applied,
+        (
+            final_state,
+            (
+                td_errors,
+                average_rewards,
+                primitive_actions,
+                executing_options,
+                option_terminations,
+                pseudo_rewards,
+                utility_emas,
+                planning_backups,
+                planning_td_errors,
+                pre_step_words,
+                post_step_words,
+                outer_state_valid,
+                lifetime_counter_valid,
+                lifetime_capacity_available,
+                nested_counter_aligned,
+                nested_update_applied,
+                proposed_state_valid,
+                update_applied,
+            ),
         ) = jax.lax.scan(
             step_fn,
             state,
@@ -1826,14 +1821,8 @@ class OaKAgent:
         utility = state.utility_ema
 
         outer_valid = _oak_outer_state_validity(state, cfg)[-1]
-        nested_aligned = jnp.all(
-            state.step_words == state.stomp_state.step_words
-        )
-        if not bool(
-            outer_valid
-            & nested_aligned
-            & self._stomp.state_valid(state.stomp_state)
-        ):
+        nested_aligned = jnp.all(state.step_words == state.stomp_state.step_words)
+        if not bool(outer_valid & nested_aligned & self._stomp.state_valid(state.stomp_state)):
             return self, state
 
         # Minimum-uptime guard: never evict before utilities have had time
@@ -1893,9 +1882,7 @@ class OaKAgent:
         new_op_traces = state.stomp_state.option_policies.traces.at[idx].set(
             jnp.zeros_like(state.stomp_state.option_policies.traces[idx])
         )
-        new_op_average_rewards = (
-            state.stomp_state.option_policies.average_rewards.at[idx].set(0.0)
-        )
+        new_op_average_rewards = state.stomp_state.option_policies.average_rewards.at[idx].set(0.0)
         new_option_policies = cast(
             IntraOptionPoliciesState,
             state.stomp_state.option_policies.replace(
@@ -1914,9 +1901,9 @@ class OaKAgent:
                 cumreward_ema=state.stomp_state.option_models.cumreward_ema.at[idx].set(0.0),
                 env_return_ema=state.stomp_state.option_models.env_return_ema.at[idx].set(0.0),
                 duration_ema=state.stomp_state.option_models.duration_ema.at[idx].set(0.0),
-                baseline_mass_ema=state.stomp_state.option_models.baseline_mass_ema.at[
-                    idx
-                ].set(0.0),
+                baseline_mass_ema=state.stomp_state.option_models.baseline_mass_ema.at[idx].set(
+                    0.0
+                ),
                 discount_ema=state.stomp_state.option_models.discount_ema.at[idx].set(1.0),
                 next_state_weights=new_ns_weights,
                 n_completions=state.stomp_state.option_models.n_completions.at[idx].set(0),
@@ -1966,9 +1953,7 @@ class OaKAgent:
         new_state = OaKState(
             stomp_state=new_stomp_state,
             execution_counts=jnp.where(replace_mask, 0, state.execution_counts),
-            cumulative_pseudo_rewards=jnp.where(
-                replace_mask, 0.0, state.cumulative_pseudo_rewards
-            ),
+            cumulative_pseudo_rewards=jnp.where(replace_mask, 0.0, state.cumulative_pseudo_rewards),
             utility_ema=jnp.where(replace_mask, 0.0, state.utility_ema),
             step_count=state.step_count,
             step_words=state.step_words,
@@ -2017,8 +2002,7 @@ class OaKAgent:
         )
         raw_chord = jnp.asarray(keyboard_vector)
         keyboard_vector_static_contract_valid = (
-            raw_chord.shape == (self._config.n_options,)
-            and raw_chord.dtype == jnp.float32
+            raw_chord.shape == (self._config.n_options,) and raw_chord.dtype == jnp.float32
         )
         chord = (
             raw_chord
@@ -2026,10 +2010,9 @@ class OaKAgent:
             else jnp.zeros((self._config.n_options,), dtype=jnp.float32)
         )
 
-        observation_valid = (
-            jnp.asarray(observation_static_contract_valid, dtype=jnp.bool_)
-            & jnp.all(jnp.isfinite(observation))
-        )
+        observation_valid = jnp.asarray(
+            observation_static_contract_valid, dtype=jnp.bool_
+        ) & jnp.all(jnp.isfinite(observation))
         chord_l1 = jnp.sum(jnp.abs(chord))
         keyboard_vector_valid = (
             jnp.asarray(keyboard_vector_static_contract_valid, dtype=jnp.bool_)

--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -33,7 +33,6 @@ References:
 from __future__ import annotations
 
 import dataclasses
-import math
 import operator
 from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
@@ -46,6 +45,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.normalizers import (
     _checked_lifetime_words_increment,
     _lifetime_counter_valid,
@@ -62,6 +62,7 @@ from alberta_framework.core.options import (
     SubtaskSpec,
     _checked_lifetime_words_advance,
     _lifetime_words_at_least,
+    _stomp_direct_array_scalars,
     load_stomp_state_with_migration,
     measure_stomp_state_nbytes,
     replace_dispatched_primitive_action,
@@ -161,10 +162,25 @@ class OaKConfig:
         )
         object.__setattr__(self, "min_steps_before_curation", min_steps)
 
-        if not math.isfinite(self.utility_ema_decay) or not 0.0 <= self.utility_ema_decay <= 1.0:
-            raise ValueError("utility_ema_decay must be finite and in [0, 1]")
-        if not math.isfinite(self.curation_threshold) or self.curation_threshold < 0.0:
-            raise ValueError("curation_threshold must be finite and non-negative")
+        if type(self.stomp) is not STOMPConfig:
+            raise ValueError("stomp must be an actual STOMPConfig")
+        object.__setattr__(
+            self,
+            "utility_ema_decay",
+            validated_float32_scalar(
+                "utility_ema_decay", self.utility_ema_decay, lower=0.0, upper=1.0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "curation_threshold",
+            validated_float32_scalar(
+                "curation_threshold", self.curation_threshold, lower=0.0
+            ),
+        )
+        combined_scalars = _stomp_direct_array_scalars(self.stomp) + 3 * self.n_options + 3
+        if combined_scalars > _INT32_MAX or 4 * combined_scalars > _INT32_MAX:
+            raise ValueError("derived OaK direct array bytes must fit signed int32")
 
     @property
     def n_options(self) -> int:
@@ -191,9 +207,24 @@ class OaKConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> OaKConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(payload) is not dict:
+            raise ValueError("OaK config must be an actual dict")
         data = dict(payload)
-        data.pop("type", None)
+        if data.pop("type", None) != "OaKConfig":
+            raise ValueError("OaK config type is invalid")
+        expected = {field.name for field in dataclasses.fields(cls)}
+        if set(data) not in (expected, expected - {"min_steps_before_curation"}):
+            raise ValueError("OaK config fields do not match its schema")
         stomp_raw = data.pop("stomp")
+        if type(stomp_raw) is not dict:
+            raise ValueError("serialized stomp config must be an actual dict")
+        if "min_steps_before_curation" in data and type(
+            data["min_steps_before_curation"]
+        ) is not int:
+            raise ValueError("serialized min_steps_before_curation must be a JSON integer")
+        for name in ("utility_ema_decay", "curation_threshold"):
+            if type(data[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON number")
         stomp = STOMPConfig.from_config(stomp_raw)
         return cls(stomp=stomp, **data)
 
@@ -886,14 +917,26 @@ class KeyboardChordLearnerConfig:
         n_options = _require_int32("n_options", self.n_options, minimum=1)
         object.__setattr__(self, "n_options", n_options)
 
-        if not math.isfinite(self.step_size) or self.step_size < 0.0:
-            raise ValueError("step_size must be finite and non-negative")
-        if not math.isfinite(self.baseline_decay) or not 0.0 <= self.baseline_decay < 1.0:
-            raise ValueError("baseline_decay must be finite and in [0, 1)")
-        if not math.isfinite(self.l2_penalty) or self.l2_penalty < 0.0:
-            raise ValueError("l2_penalty must be finite and non-negative")
-        if not math.isfinite(self.max_norm) or self.max_norm <= 0.0:
-            raise ValueError("max_norm must be finite and positive")
+        object.__setattr__(
+            self, "step_size", validated_float32_scalar("step_size", self.step_size, lower=0.0)
+        )
+        object.__setattr__(
+            self,
+            "baseline_decay",
+            validated_float32_scalar(
+                "baseline_decay", self.baseline_decay, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+        )
+        object.__setattr__(
+            self,
+            "l2_penalty",
+            validated_float32_scalar("l2_penalty", self.l2_penalty, lower=0.0),
+        )
+        object.__setattr__(
+            self, "max_norm", validated_float32_scalar("max_norm", self.max_norm, positive=True)
+        )
+        if 4 * (self.n_options + 2) > _INT32_MAX:
+            raise ValueError("derived keyboard state bytes must fit signed int32")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -904,8 +947,18 @@ class KeyboardChordLearnerConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> KeyboardChordLearnerConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(payload) is not dict:
+            raise ValueError("keyboard chord config must be an actual dict")
         data = dict(payload)
-        data.pop("type", None)
+        if data.pop("type", None) != "KeyboardChordLearnerConfig":
+            raise ValueError("keyboard chord config type is invalid")
+        if set(data) != {field.name for field in dataclasses.fields(cls)}:
+            raise ValueError("keyboard chord config fields do not match its schema")
+        if type(data["n_options"]) is not int:
+            raise ValueError("serialized n_options must be a JSON integer")
+        for name in ("step_size", "baseline_decay", "l2_penalty", "max_norm"):
+            if type(data[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON number")
         return cls(**data)
 
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
@@ -52,6 +54,37 @@ STOMP_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
+    if type(sizes) is not tuple:
+        raise ValueError("base_hidden_sizes must be an actual tuple")
+    return tuple(_require_int32("base_hidden_sizes element", s, minimum=1) for s in sizes)
+
 
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
@@ -83,14 +116,20 @@ class SubtaskSpec:
 
     def __post_init__(self) -> None:
         """Validate subtask specification."""
-        if self.feature_index < 0:
-            raise ValueError("feature_index must be non-negative")
+        object.__setattr__(
+            self,
+            "feature_index",
+            _require_int32("feature_index", self.feature_index, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "max_option_steps",
+            _require_int32("max_option_steps", self.max_option_steps, minimum=1),
+        )
         if not math.isfinite(self.threshold) or self.threshold <= 0.0:
             raise ValueError("threshold must be finite and positive")
         if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
             raise ValueError("pseudo_reward_scale must be finite and positive")
-        if self.max_option_steps < 1:
-            raise ValueError("max_option_steps must be at least 1")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -314,9 +353,7 @@ def _all_floating_leaves_finite(tree: Any) -> Array:
     """Bounded full-tree finiteness check, excluding typed PRNG keys."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
-            leaf.dtype, jax.dtypes.prng_key
-        ):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.inexact):
@@ -328,9 +365,7 @@ def _all_integer_leaves_nonnegative(tree: Any) -> Array:
     """Check learner/model counter leaves without constraining float values."""
     valid = jnp.asarray(True, dtype=jnp.bool_)
     for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(
-            leaf.dtype, jax.dtypes.prng_key
-        ):
+        if hasattr(leaf, "dtype") and jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
             continue
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.integer):
@@ -408,10 +443,7 @@ def _stomp_action_ownership_valid(
     )
     active_valid = (
         active
-        & (
-            state.base_last_action
-            == n_primitive_actions + state.executing_option
-        )
+        & (state.base_last_action == n_primitive_actions + state.executing_option)
         & (state.option_last_intra_action == state.last_primitive_action)
     )
     return primitive_valid & (idle_valid | active_valid)
@@ -459,8 +491,7 @@ def _stomp_static_dispatch_contract(
         state.base_learner_state.step_count,
     )
     static_valid = all(
-        value.shape == expected and value.dtype == jnp.float32
-        for value, expected in float32_shapes
+        value.shape == expected and value.dtype == jnp.float32 for value, expected in float32_shapes
     )
     static_valid = static_valid and all(
         value.shape == () and value.dtype == jnp.float32 for value in scalar_float32
@@ -559,9 +590,8 @@ def _stomp_static_dispatch_contract(
                     and optimizer_state.step_size.shape == ()
                     and optimizer_state.step_size.dtype == jnp.float32
                 )
-    rng_key_valid = (
-        state.rng_key.shape == ()
-        and jax.dtypes.issubdtype(state.rng_key.dtype, jax.dtypes.prng_key)
+    rng_key_valid = state.rng_key.shape == () and jax.dtypes.issubdtype(
+        state.rng_key.dtype, jax.dtypes.prng_key
     )
     return static_valid, rng_key_valid
 
@@ -595,8 +625,7 @@ def replace_dispatched_primitive_action(
 
     raw_observation = jnp.asarray(decision_observation)
     observation_static_contract_valid = (
-        raw_observation.shape == (observation_dim,)
-        and raw_observation.dtype == jnp.float32
+        raw_observation.shape == (observation_dim,) and raw_observation.dtype == jnp.float32
     )
     obs = (
         raw_observation
@@ -608,9 +637,7 @@ def replace_dispatched_primitive_action(
         raw_proposal.shape == () and raw_proposal.dtype == jnp.int32
     )
     proposal = (
-        raw_proposal
-        if proposed_action_static_contract_valid
-        else jnp.asarray(-1, dtype=jnp.int32)
+        raw_proposal if proposed_action_static_contract_valid else jnp.asarray(-1, dtype=jnp.int32)
     )
     if safety_action_mask is None:
         safety = jnp.ones((n_primitive_actions,), dtype=jnp.bool_)
@@ -618,8 +645,7 @@ def replace_dispatched_primitive_action(
     else:
         raw_safety = jnp.asarray(safety_action_mask)
         safety_action_mask_static_contract_valid = (
-            raw_safety.shape == (n_primitive_actions,)
-            and raw_safety.dtype == jnp.bool_
+            raw_safety.shape == (n_primitive_actions,) and raw_safety.dtype == jnp.bool_
         )
         safety = (
             raw_safety
@@ -628,9 +654,7 @@ def replace_dispatched_primitive_action(
         )
 
     no_option = state.executing_option == -1
-    option_index_valid = (state.executing_option >= 0) & (
-        state.executing_option < n_options
-    )
+    option_index_valid = (state.executing_option >= 0) & (state.executing_option < n_options)
     owner = jnp.where(
         no_option,
         jnp.asarray(DISPATCH_OWNER_BASE_PRIMITIVE, dtype=jnp.int32),
@@ -641,9 +665,7 @@ def replace_dispatched_primitive_action(
         ),
     )
     counterfactual = state.last_primitive_action
-    counterfactual_valid = (counterfactual >= 0) & (
-        counterfactual < n_primitive_actions
-    )
+    counterfactual_valid = (counterfactual >= 0) & (counterfactual < n_primitive_actions)
     base_owner_valid = (
         no_option
         & (state.base_last_action >= 0)
@@ -655,10 +677,7 @@ def replace_dispatched_primitive_action(
         & (state.base_last_action == n_primitive_actions + state.executing_option)
         & (state.option_last_intra_action == counterfactual)
     )
-    ownership_valid = (
-        counterfactual_valid
-        & (base_owner_valid | option_owner_valid)
-    )
+    ownership_valid = counterfactual_valid & (base_owner_valid | option_owner_valid)
     static_contract_valid, typed_rng_key_valid = _stomp_static_dispatch_contract(
         state,
         n_options=n_options,
@@ -753,9 +772,7 @@ def replace_dispatched_primitive_action(
             owner,
             jnp.asarray(DISPATCH_OWNER_INVALID, dtype=jnp.int32),
         ),
-        state_static_contract_valid=jnp.asarray(
-            static_contract_valid, dtype=jnp.bool_
-        ),
+        state_static_contract_valid=jnp.asarray(static_contract_valid, dtype=jnp.bool_),
         state_values_finite=state_values_finite,
         state_counters_valid=state_counters_valid,
         rng_key_valid=jnp.asarray(typed_rng_key_valid, dtype=jnp.bool_),
@@ -904,9 +921,7 @@ def _select_action_epsilon_greedy(
     """ε-greedy action selection with Gumbel tie-breaking."""
     key, explore_key, noise_key = jr.split(key, 3)
     q_vals = _q_values_for_obs(q_weights, observation)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
-        jnp.int32
-    )
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -921,9 +936,7 @@ def _select_action_epsilon_greedy_from_q(
 ) -> tuple[Array, Array]:
     """ε-greedy action selection from pre-computed Q values."""
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(
-        jnp.int32
-    )
+    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1110,12 +1123,7 @@ def _differential_semidp_q_update(
     q_prev = q_weights[last_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_weights, next_obs))
     # The discounted reward and baseline must use the same γ powers.
-    td_error = (
-        reward
-        - average_reward * baseline_coefficient
-        + gamma_o * q_next
-        - q_prev
-    )
+    td_error = reward - average_reward * baseline_coefficient + gamma_o * q_next - q_prev
 
     action_mask = jax.nn.one_hot(last_action, n_actions, dtype=jnp.float32)
     new_traces = lam * traces + action_mask[:, None] * last_obs[None, :]
@@ -1175,9 +1183,7 @@ def _update_option_model(
     new_cumreward = decay * models.cumreward_ema + (1.0 - decay) * pseudo_return
     new_env_return = decay * models.env_return_ema + (1.0 - decay) * env_return
     new_duration = decay * models.duration_ema + (1.0 - decay) * duration
-    new_baseline_mass = (
-        decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
-    )
+    new_baseline_mass = decay * models.baseline_mass_ema + (1.0 - decay) * baseline_mass
     new_discount = decay * models.discount_ema + (1.0 - decay) * discount
 
     predicted_delta = models.next_state_weights[option_idx] @ start_obs
@@ -1189,9 +1195,7 @@ def _update_option_model(
         jnp.float32
     )
     new_ns_weights = models.next_state_weights + mask[:, None, None] * ns_update[None, :, :]
-    incremented_completions = _saturating_int32_counter_increment(
-        models.n_completions
-    )
+    incremented_completions = _saturating_int32_counter_increment(models.n_completions)
     new_completions = jnp.where(
         mask.astype(jnp.bool_),
         incremented_completions,
@@ -1202,9 +1206,7 @@ def _update_option_model(
         cumreward_ema=jnp.where(mask, new_cumreward, models.cumreward_ema),
         env_return_ema=jnp.where(mask, new_env_return, models.env_return_ema),
         duration_ema=jnp.where(mask, new_duration, models.duration_ema),
-        baseline_mass_ema=jnp.where(
-            mask, new_baseline_mass, models.baseline_mass_ema
-        ),
+        baseline_mass_ema=jnp.where(mask, new_baseline_mass, models.baseline_mass_ema),
         discount_ema=jnp.where(mask, new_discount, models.discount_ema),
         next_state_weights=new_ns_weights,
         n_completions=new_completions,
@@ -1307,9 +1309,7 @@ def _update_intra_option_policy(
     traces_i = option_policies.traces[option_idx]
     avg_r_i = option_policies.average_rewards[option_idx]
     transition_discount = jnp.asarray(discount, dtype=jnp.float32)
-    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(
-        jnp.float32
-    )
+    bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(jnp.float32)
 
     q_prev = q_i[last_intra_action] @ last_obs
     q_next = jnp.max(_q_values_for_obs(q_i, next_obs)) * bootstrap_discount
@@ -1419,15 +1419,27 @@ class STOMPConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
-        if self.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if self.n_primitive_actions <= 0:
-            raise ValueError("n_primitive_actions must be positive")
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        n_primitive_actions = _require_int32(
+            "n_primitive_actions", self.n_primitive_actions, minimum=1
+        )
+        base_hidden_sizes = _validate_hidden_sizes(self.base_hidden_sizes)
+        backups = _require_int32(
+            "option_planning_backups_per_step",
+            self.option_planning_backups_per_step,
+            minimum=0,
+        )
+
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_primitive_actions", n_primitive_actions)
+        object.__setattr__(self, "base_hidden_sizes", base_hidden_sizes)
+        object.__setattr__(self, "option_planning_backups_per_step", backups)
+
         for spec in self.subtask_specs:
-            if spec.feature_index >= self.observation_dim:
+            if spec.feature_index >= observation_dim:
                 raise ValueError(
                     f"SubtaskSpec.feature_index={spec.feature_index} >= "
-                    f"observation_dim={self.observation_dim}"
+                    f"observation_dim={observation_dim}"
                 )
             if spec.max_option_steps > _INT32_MAX:
                 raise ValueError("SubtaskSpec.max_option_steps must fit int32 telemetry")
@@ -1466,13 +1478,9 @@ class STOMPConfig:
         ):
             raise ValueError("option_planning_backups_per_step must be a nonnegative integer")
         if self.option_planning_backups_per_step >= _INT32_MAX:
-            raise ValueError(
-                "option_planning_backups_per_step must be smaller than int32 max"
-            )
+            raise ValueError("option_planning_backups_per_step must be smaller than int32 max")
         if not self.subtask_specs and self.option_planning_backups_per_step != 0:
-            raise ValueError(
-                "primitive-only STOMP requires option_planning_backups_per_step == 0"
-            )
+            raise ValueError("primitive-only STOMP requires option_planning_backups_per_step == 0")
 
     @property
     def n_options(self) -> int:
@@ -1488,9 +1496,7 @@ class STOMPConfig:
         """Serialize to a JSON-compatible dictionary."""
         return {
             "type": "STOMPConfig",
-            "subtask_specs": [
-                dataclasses.asdict(s) for s in self.subtask_specs
-            ],
+            "subtask_specs": [dataclasses.asdict(s) for s in self.subtask_specs],
             "observation_dim": self.observation_dim,
             "n_primitive_actions": self.n_primitive_actions,
             "base_step_size": self.base_step_size,
@@ -1681,9 +1687,7 @@ class STOMPAgent:
         explicitly. The state also records it in ``last_primitive_action``.
         """
         cfg = self._config
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
-            (cfg.observation_dim,)
-        )
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
         key = state.rng_key
         q_vals = self._base_learner.predict(state.base_learner_state, obs)
         extended_action, key = _select_action_epsilon_greedy_from_q(
@@ -1791,13 +1795,8 @@ class STOMPAgent:
                 f"({cfg.n_total_actions},), got {raw_mask.shape}"
             )
         if raw_mask.dtype != jnp.bool_:
-            raise TypeError(
-                "extended_action_mask must have dtype bool, "
-                f"got {raw_mask.dtype}"
-            )
-        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape(
-            (cfg.observation_dim,)
-        )
+            raise TypeError(f"extended_action_mask must have dtype bool, got {raw_mask.dtype}")
+        obs = jnp.asarray(initial_observation, dtype=jnp.float32).reshape((cfg.observation_dim,))
         mask_valid = jnp.all(raw_mask[: cfg.n_primitive_actions]) & jnp.any(raw_mask)
         values_valid = jnp.all(jnp.isfinite(obs))
         key = state.rng_key
@@ -1952,9 +1951,7 @@ class STOMPAgent:
 
                 predicted_delta = models.next_state_weights[model_idx] @ anchor_observation
                 predicted_next = anchor_observation + predicted_delta
-                next_q = self._base_learner.predict(
-                    current_learner_state, predicted_next
-                )
+                next_q = self._base_learner.predict(current_learner_state, predicted_next)
                 eligible_next_q = jnp.where(
                     extended_action_mask,
                     next_q,
@@ -1965,9 +1962,11 @@ class STOMPAgent:
                     - average_reward * models.baseline_mass_ema[model_idx]
                     + models.discount_ema[model_idx] * jnp.max(eligible_next_q)
                 )
-                targets = jnp.full(
-                    cfg.n_total_actions, jnp.nan, dtype=jnp.float32
-                ).at[option_action].set(target)
+                targets = (
+                    jnp.full(cfg.n_total_actions, jnp.nan, dtype=jnp.float32)
+                    .at[option_action]
+                    .set(target)
+                )
                 update_result = self._base_learner.update(
                     current_learner_state,
                     anchor_observation,
@@ -2025,9 +2024,7 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError(
-                    "preselection feature reset requires a linear STOMP base learner"
-                )
+                raise ValueError("preselection feature reset requires a linear STOMP base learner")
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2053,8 +2050,7 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    "extended_action_mask must have dtype bool, "
-                    f"got {raw_action_mask.dtype}"
+                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
             action_mask_valid = jnp.all(action_mask) & jnp.any(action_mask)
@@ -2093,9 +2089,7 @@ class STOMPAgent:
             )
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(
-            state.step_words
-        )
+        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2124,15 +2118,17 @@ class STOMPAgent:
         )
         eligible_next_q = jnp.where(action_mask, next_q_values, -jnp.inf)
         td_target = (
-            reward
-            - state.base_average_reward
-            + primitive_discount * jnp.max(eligible_next_q)
+            reward - state.base_average_reward + primitive_discount * jnp.max(eligible_next_q)
         )
-        targets = jnp.full(
-            cfg.n_primitive_actions,
-            jnp.nan,
-            dtype=jnp.float32,
-        ).at[state.base_last_action].set(td_target)
+        targets = (
+            jnp.full(
+                cfg.n_primitive_actions,
+                jnp.nan,
+                dtype=jnp.float32,
+            )
+            .at[state.base_last_action]
+            .set(td_target)
+        )
         trace_adjusted_state = cast(
             MultiHeadMLPState,
             state.base_learner_state.replace(
@@ -2334,9 +2330,7 @@ class STOMPAgent:
             reset_mask = jnp.zeros((cfg.observation_dim,), dtype=jnp.bool_)
         else:
             if cfg.base_hidden_sizes:
-                raise ValueError(
-                    "preselection feature reset requires a linear STOMP base learner"
-                )
+                raise ValueError("preselection feature reset requires a linear STOMP base learner")
             raw_reset_mask = jnp.asarray(preselection_feature_reset_mask)
             if raw_reset_mask.shape != (cfg.observation_dim,):
                 raise ValueError(
@@ -2361,13 +2355,12 @@ class STOMPAgent:
                 )
             if raw_action_mask.dtype != jnp.bool_:
                 raise TypeError(
-                    "extended_action_mask must have dtype bool, "
-                    f"got {raw_action_mask.dtype}"
+                    f"extended_action_mask must have dtype bool, got {raw_action_mask.dtype}"
                 )
             action_mask = raw_action_mask
-            action_mask_valid = jnp.all(
-                action_mask[: cfg.n_primitive_actions]
-            ) & jnp.any(action_mask)
+            action_mask_valid = jnp.all(action_mask[: cfg.n_primitive_actions]) & jnp.any(
+                action_mask
+            )
         bootstrap_obs = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
             (cfg.observation_dim,)
         )
@@ -2412,9 +2405,7 @@ class STOMPAgent:
             environmental_termination = supplied_discount <= 0.0
             input_values_valid = input_values_valid & valid_discount
 
-        outer_words, outer_capacity = _checked_lifetime_words_increment(
-            state.step_words
-        )
+        outer_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
         outer_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -2435,9 +2426,7 @@ class STOMPAgent:
         # Compute pseudo-reward for the currently-executing (or notional) option
         pseudo_r = compute_pseudo_reward(spec, option_idx, bootstrap_obs)
         target_epsilon = (
-            cfg.epsilon_option
-            if cfg.option_target_epsilon is None
-            else cfg.option_target_epsilon
+            cfg.epsilon_option if cfg.option_target_epsilon is None else cfg.option_target_epsilon
         )
         option_importance_ratio = _clipped_epsilon_greedy_importance_ratio(
             state.option_policies.q_weights[option_idx],
@@ -2474,9 +2463,7 @@ class STOMPAgent:
             )
         else:
             planning_updates_required = jnp.asarray(0, dtype=jnp.int32)
-        nested_updates_required = (
-            should_update_base.astype(jnp.int32) + planning_updates_required
-        )
+        nested_updates_required = should_update_base.astype(jnp.int32) + planning_updates_required
         expected_nested_words, nested_capacity = _checked_lifetime_words_advance(
             state.base_learner_state.step_words,
             nested_updates_required,
@@ -2629,19 +2616,15 @@ class STOMPAgent:
         def do_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            next_q_vals = self._base_learner.predict(
-                state.base_learner_state, bootstrap_obs
-            )
+            next_q_vals = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
             eligible_next_q = jnp.where(action_mask, next_q_vals, -jnp.inf)
             max_next_q = base_discount * jnp.max(eligible_next_q)
-            td_target = (
-                base_reward
-                - state.base_average_reward * base_baseline_mass
-                + max_next_q
+            td_target = base_reward - state.base_average_reward * base_baseline_mass + max_next_q
+            targets = (
+                jnp.full(n_total, jnp.nan, dtype=jnp.float32)
+                .at[state.base_last_action]
+                .set(td_target)
             )
-            targets = jnp.full(n_total, jnp.nan, dtype=jnp.float32).at[
-                state.base_last_action
-            ].set(td_target)
             trace_adjusted_state = cast(
                 MultiHeadMLPState,
                 state.base_learner_state.replace(
@@ -2651,9 +2634,7 @@ class STOMPAgent:
                     )
                 ),
             )
-            result = self._base_learner.update(
-                trace_adjusted_state, base_update_obs, targets
-            )
+            result = self._base_learner.update(trace_adjusted_state, base_update_obs, targets)
             td_err = result.errors[state.base_last_action]
             new_avg_reward = state.base_average_reward + beta * td_err
             return result.state, new_avg_reward, td_err, result.update_applied
@@ -2661,17 +2642,10 @@ class STOMPAgent:
         def skip_base_update(
             _: None,
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
-            prev_q = self._base_learner.predict(
-                state.base_learner_state, state.base_last_obs
-            )
-            next_q = self._base_learner.predict(
-                state.base_learner_state, bootstrap_obs
-            )
+            prev_q = self._base_learner.predict(state.base_learner_state, state.base_last_obs)
+            next_q = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
             eligible_next_q = jnp.where(action_mask, next_q, -jnp.inf)
-            td = (
-                primitive_discount * jnp.max(eligible_next_q)
-                - prev_q[state.base_last_action]
-            )
+            td = primitive_discount * jnp.max(eligible_next_q) - prev_q[state.base_last_action]
             return (
                 state.base_learner_state,
                 state.base_average_reward,
@@ -2684,9 +2658,7 @@ class STOMPAgent:
             new_avg_r,
             base_td,
             real_base_update_applied,
-        ) = jax.lax.cond(
-            should_update_base, do_base_update, skip_base_update, None
-        )
+        ) = jax.lax.cond(should_update_base, do_base_update, skip_base_update, None)
 
         # --- Fixed-budget option-model planning ---
         # The zero-backup default is a Python-level static branch: it consumes
@@ -2733,9 +2705,7 @@ class STOMPAgent:
             cfg.epsilon_base,
             action_mask,
         )
-        next_select_extended = (~is_executing) | (
-            is_executing & option_lifecycle_ends
-        )
+        next_select_extended = (~is_executing) | (is_executing & option_lifecycle_ends)
         selected_option = jnp.clip(
             extended_action - cfg.n_primitive_actions,
             0,
@@ -2770,9 +2740,8 @@ class STOMPAgent:
                 jnp.array(-1, dtype=jnp.int32),
             ),
         )
-        is_starting_option = (
-            next_select_extended
-            & (extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32))
+        is_starting_option = next_select_extended & (
+            extended_action >= jnp.asarray(cfg.n_primitive_actions, jnp.int32)
         )
 
         # Primitive action sent to environment
@@ -2787,9 +2756,7 @@ class STOMPAgent:
         )
 
         # Reset option tracking on termination or new option start
-        new_option_start_obs = jnp.where(
-            is_starting_option, decision_obs, state.option_start_obs
-        )
+        new_option_start_obs = jnp.where(is_starting_option, decision_obs, state.option_start_obs)
         new_option_cumreward = jnp.where(
             (is_executing & option_lifecycle_ends) | is_starting_option,
             jnp.array(0.0, dtype=jnp.float32),
@@ -2891,9 +2858,7 @@ class STOMPAgent:
                 new_executing_option,
                 state.executing_option,
             ),
-            option_terminated=transaction_applied
-            & is_executing
-            & option_lifecycle_ends,
+            option_terminated=transaction_applied & is_executing & option_lifecycle_ends,
             pseudo_reward=jnp.where(
                 transaction_applied & is_executing,
                 pseudo_r,
@@ -2964,9 +2929,7 @@ class STOMPAgent:
                 decision_observation=decision_obs,
                 execution_boundary=execution_boundary,
                 extended_action_mask=(
-                    extended_action_mask
-                    if extended_action_masks is not None
-                    else None
+                    extended_action_mask if extended_action_masks is not None else None
                 ),
             )
             return result.state, (
@@ -3025,27 +2988,30 @@ class STOMPAgent:
         if scan_extended_action_masks.dtype != jnp.bool_:
             raise TypeError("extended_action_masks must have dtype bool")
 
-        final_state, (
-            td_errors,
-            average_rewards,
-            primitive_actions,
-            executing_options,
-            option_terminations,
-            pseudo_rewards,
-            option_importance_ratios,
-            planning_backups,
-            planning_td_errors,
-            pre_step_words,
-            post_step_words,
-            inputs_valid,
-            lifetime_counter_valid,
-            lifetime_capacity_available,
-            nested_lifetime_counter_valid,
-            nested_lifetime_capacity_available,
-            nested_updates_required,
-            nested_updates_applied,
-            proposed_state_valid,
-            update_applied,
+        (
+            final_state,
+            (
+                td_errors,
+                average_rewards,
+                primitive_actions,
+                executing_options,
+                option_terminations,
+                pseudo_rewards,
+                option_importance_ratios,
+                planning_backups,
+                planning_td_errors,
+                pre_step_words,
+                post_step_words,
+                inputs_valid,
+                lifetime_counter_valid,
+                lifetime_capacity_available,
+                nested_lifetime_counter_valid,
+                nested_lifetime_capacity_available,
+                nested_updates_required,
+                nested_updates_applied,
+                proposed_state_valid,
+                update_applied,
+            ),
         ) = jax.lax.scan(
             step_fn,
             state,
@@ -3231,15 +3197,11 @@ def stomp_state_to_checkpoint_payload(state: STOMPState) -> dict[str, Any]:
 def _sub_payload_as_dict(value: Any, name: str, cls: type) -> dict[str, Any]:
     """Normalize a nested payload entry to a plain field-keyed dict."""
     if isinstance(value, cls):
-        return {
-            field.name: getattr(value, field.name)
-            for field in dataclasses.fields(cls)
-        }
+        return {field.name: getattr(value, field.name) for field in dataclasses.fields(cls)}
     if isinstance(value, dict):
         return dict(value)
     raise ValueError(
-        f"'{name}' must be a field-keyed dict or {cls.__name__}, "
-        f"got {type(value).__name__}"
+        f"'{name}' must be a field-keyed dict or {cls.__name__}, got {type(value).__name__}"
     )
 
 
@@ -3300,18 +3262,14 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
             f"missing={sorted(missing_state_fields)}"
         )
 
-    models = _sub_payload_as_dict(
-        data.pop("option_models"), "option_models", OptionModelsState
-    )
+    models = _sub_payload_as_dict(data.pop("option_models"), "option_models", OptionModelsState)
     model_field_names = {
         field.name
         for field in dataclasses.fields(OptionModelsState)  # type: ignore[arg-type]
     }
     unknown_models = sorted(set(models) - model_field_names)
     if unknown_models:
-        raise ValueError(
-            f"Unknown OptionModelsState checkpoint fields: {unknown_models}"
-        )
+        raise ValueError(f"Unknown OptionModelsState checkpoint fields: {unknown_models}")
     missing_model_fields = model_field_names - set(models)
     expected_missing_model_fields = (
         set(STOMP_OPTION_MODEL_EXPANSION_FIELDS)
@@ -3340,8 +3298,7 @@ def load_stomp_state_with_migration(payload: dict[str, Any]) -> STOMPState:
     }
     if set(policies) != policy_field_names:
         raise ValueError(
-            "STOMP option-policy payload fields "
-            f"{sorted(policies)} != {sorted(policy_field_names)}"
+            f"STOMP option-policy payload fields {sorted(policies)} != {sorted(policy_field_names)}"
         )
     option_policies = IntraOptionPoliciesState(**policies)
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import math
 import operator
 from typing import Any, SupportsIndex, cast
 
@@ -36,6 +35,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.multi_head_learner import (
     MultiHeadMLPLearner,
     MultiHeadMLPState,
@@ -86,6 +86,37 @@ def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
     return tuple(_require_int32("base_hidden_sizes element", s, minimum=1) for s in sizes)
 
 
+def _stomp_direct_array_scalars(config: STOMPConfig) -> int:
+    """Return exact directly allocated agent/config and state array scalars."""
+
+    n_options = config.n_options
+    n_actions = config.n_primitive_actions
+    observation_dim = config.observation_dim
+    n_heads = config.n_total_actions
+    layer_sizes = (observation_dim, *config.base_hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = config.base_hidden_sizes[-1] if config.base_hidden_sizes else observation_dim
+    head_parameters = n_heads * (final_width + 1)
+    base_learner_scalars = (
+        2 * (trunk_parameters + head_parameters)
+        + sum(config.base_hidden_sizes)
+        + 2 * len(config.base_hidden_sizes)
+        + 2 * n_heads
+        + 3
+    )
+    return (
+        base_learner_scalars
+        + 2 * n_options * n_actions * observation_dim
+        + n_options * observation_dim * observation_dim
+        + 11 * n_options
+        + 2 * observation_dim
+        + 15
+    )
+
+
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
 # ---------------------------------------------------------------------------
@@ -126,10 +157,18 @@ class SubtaskSpec:
             "max_option_steps",
             _require_int32("max_option_steps", self.max_option_steps, minimum=1),
         )
-        if not math.isfinite(self.threshold) or self.threshold <= 0.0:
-            raise ValueError("threshold must be finite and positive")
-        if not math.isfinite(self.pseudo_reward_scale) or self.pseudo_reward_scale <= 0.0:
-            raise ValueError("pseudo_reward_scale must be finite and positive")
+        object.__setattr__(
+            self,
+            "threshold",
+            validated_float32_scalar("threshold", self.threshold, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "pseudo_reward_scale",
+            validated_float32_scalar(
+                "pseudo_reward_scale", self.pseudo_reward_scale, positive=True
+            ),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1419,6 +1458,10 @@ class STOMPConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration."""
+        if type(self.subtask_specs) is not tuple or any(
+            type(spec) is not SubtaskSpec for spec in self.subtask_specs
+        ):
+            raise ValueError("subtask_specs must be an actual tuple of SubtaskSpec values")
         observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
         n_primitive_actions = _require_int32(
             "n_primitive_actions", self.n_primitive_actions, minimum=1
@@ -1428,12 +1471,15 @@ class STOMPConfig:
             "option_planning_backups_per_step",
             self.option_planning_backups_per_step,
             minimum=0,
+            maximum=_INT32_MAX - 1,
         )
 
         object.__setattr__(self, "observation_dim", observation_dim)
         object.__setattr__(self, "n_primitive_actions", n_primitive_actions)
         object.__setattr__(self, "base_hidden_sizes", base_hidden_sizes)
         object.__setattr__(self, "option_planning_backups_per_step", backups)
+        if len(self.subtask_specs) > _INT32_MAX - n_primitive_actions:
+            raise ValueError("derived n_total_actions must fit signed int32")
 
         for spec in self.subtask_specs:
             if spec.feature_index >= observation_dim:
@@ -1450,9 +1496,13 @@ class STOMPConfig:
             "option_avg_reward_step_size",
             "option_model_step_size",
         ):
-            step_size_value: float = getattr(self, step_size_name)
-            if not math.isfinite(step_size_value) or step_size_value < 0.0:
-                raise ValueError(f"{step_size_name} must be finite and non-negative")
+            object.__setattr__(
+                self,
+                step_size_name,
+                validated_float32_scalar(
+                    step_size_name, getattr(self, step_size_name), lower=0.0
+                ),
+            )
         for unit_interval_name in (
             "base_trace_decay",
             "option_trace_decay",
@@ -1460,27 +1510,44 @@ class STOMPConfig:
             "epsilon_base",
             "epsilon_option",
         ):
-            unit_interval_value: float = getattr(self, unit_interval_name)
-            if not math.isfinite(unit_interval_value) or not 0.0 <= unit_interval_value <= 1.0:
-                raise ValueError(f"{unit_interval_name} must be finite and in [0, 1]")
-        if not math.isfinite(self.option_gamma) or not 0.0 <= self.option_gamma <= 1.0:
-            raise ValueError("option_gamma must be finite and in [0, 1]")
-        if self.option_target_epsilon is not None and not (
-            0.0 <= self.option_target_epsilon <= 1.0
-        ):
-            raise ValueError("option_target_epsilon must be in [0, 1] when provided")
-        if self.option_importance_clip <= 0.0:
-            raise ValueError("option_importance_clip must be positive")
-        if (
-            isinstance(self.option_planning_backups_per_step, bool)
-            or not isinstance(self.option_planning_backups_per_step, int)
-            or self.option_planning_backups_per_step < 0
-        ):
-            raise ValueError("option_planning_backups_per_step must be a nonnegative integer")
-        if self.option_planning_backups_per_step >= _INT32_MAX:
-            raise ValueError("option_planning_backups_per_step must be smaller than int32 max")
+            object.__setattr__(
+                self,
+                unit_interval_name,
+                validated_float32_scalar(
+                    unit_interval_name,
+                    getattr(self, unit_interval_name),
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "option_gamma",
+            validated_float32_scalar("option_gamma", self.option_gamma, lower=0.0, upper=1.0),
+        )
+        if self.option_target_epsilon is not None:
+            object.__setattr__(
+                self,
+                "option_target_epsilon",
+                validated_float32_scalar(
+                    "option_target_epsilon",
+                    self.option_target_epsilon,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "option_importance_clip",
+            validated_float32_scalar(
+                "option_importance_clip", self.option_importance_clip, positive=True
+            ),
+        )
         if not self.subtask_specs and self.option_planning_backups_per_step != 0:
             raise ValueError("primitive-only STOMP requires option_planning_backups_per_step == 0")
+        direct_scalars = _stomp_direct_array_scalars(self)
+        if direct_scalars > _INT32_MAX or 4 * direct_scalars > _INT32_MAX:
+            raise ValueError("derived STOMP direct array bytes must fit signed int32")
 
     @property
     def n_options(self) -> int:
@@ -1519,12 +1586,49 @@ class STOMPConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> STOMPConfig:
         """Reconstruct from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("STOMP config must be an actual dict")
         payload = dict(config)
-        payload.pop("type", None)
+        if payload.pop("type", None) != "STOMPConfig":
+            raise ValueError("STOMP config type is invalid")
+        expected = {field.name for field in dataclasses.fields(cls)}
+        legacy_optional = {"subtask_specs", "base_hidden_sizes", "option_planning_backups_per_step"}
+        if set(payload) - expected or (expected - legacy_optional) - set(payload):
+            raise ValueError("STOMP config fields do not match its schema")
         specs_raw = payload.pop("subtask_specs", [])
+        if type(specs_raw) is not list or any(type(spec) is not dict for spec in specs_raw):
+            raise ValueError("serialized subtask_specs must be an actual list of actual dicts")
+        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
+        if any(set(spec) != spec_fields for spec in specs_raw):
+            raise ValueError("serialized SubtaskSpec fields do not match its schema")
+        if any(
+            type(spec["feature_index"]) is not int
+            or type(spec["max_option_steps"]) is not int
+            or type(spec["threshold"]) is not float
+            or type(spec["pseudo_reward_scale"]) is not float
+            for spec in specs_raw
+        ):
+            raise ValueError("serialized SubtaskSpec scalars must be canonical JSON scalars")
         specs = tuple(SubtaskSpec(**s) for s in specs_raw)
-        if "base_hidden_sizes" in payload:
-            payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
+        hidden_raw = payload.pop("base_hidden_sizes", [])
+        if type(hidden_raw) is not list or any(type(size) is not int for size in hidden_raw):
+            raise ValueError("serialized base_hidden_sizes must be an actual list of JSON integers")
+        payload["base_hidden_sizes"] = tuple(hidden_raw)
+        for name in ("observation_dim", "n_primitive_actions", "option_planning_backups_per_step"):
+            if name in payload and type(payload[name]) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+        for name in (
+            "base_step_size", "base_avg_reward_step_size", "base_trace_decay",
+            "option_step_size", "option_avg_reward_step_size", "option_trace_decay",
+            "option_gamma", "option_model_decay", "option_model_step_size",
+            "epsilon_base", "epsilon_option", "option_importance_clip",
+        ):
+            if type(payload[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON number")
+        if payload["option_target_epsilon"] is not None and type(
+            payload["option_target_epsilon"]
+        ) is not float:
+            raise ValueError("serialized option_target_epsilon must be null or a JSON number")
         return cls(subtask_specs=specs, **payload)
 
 

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
-from alberta_framework.core.oak import OaKAgent, OaKConfig
+from alberta_framework.core.oak import KeyboardChordLearnerConfig, OaKAgent, OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
     GRUPerceptionConfig,
@@ -174,9 +175,7 @@ def test_useless_option_evicted_after_guard_and_reward_preserved() -> None:
     # targets feature 1 (always 0.0 → pseudo-reward 0.0, deliberately useless).
     cfg = _oak_cfg(min_steps_before_curation=100)
     agent, state = _primed(cfg)
-    obs = jnp.tile(
-        jnp.array([1.0, 0.0, 0.5, -0.5], dtype=jnp.float32), (300, 1)
-    )
+    obs = jnp.tile(jnp.array([1.0, 0.0, 0.5, -0.5], dtype=jnp.float32), (300, 1))
     result = agent.scan(state, jnp.ones(300), obs)
     state = result.state
     assert float(state.utility_ema[0]) > float(state.utility_ema[1])
@@ -274,14 +273,10 @@ GRU_AUG_DIM = GRU_OBS_DIM + GRU_HIDDEN
 
 
 def _gru_proto_cfg() -> PrototypeAgentConfig:
-    stomp = STOMPConfig(
-        subtask_specs=(_SPEC0, _SPEC1), observation_dim=GRU_AUG_DIM
-    )
+    stomp = STOMPConfig(subtask_specs=(_SPEC0, _SPEC1), observation_dim=GRU_AUG_DIM)
     return PrototypeAgentConfig(
         oak=OaKConfig(stomp=stomp),
-        gru_perception=GRUPerceptionConfig(
-            observation_dim=GRU_OBS_DIM, hidden_dim=GRU_HIDDEN
-        ),
+        gru_perception=GRUPerceptionConfig(observation_dim=GRU_OBS_DIM, hidden_dim=GRU_HIDDEN),
     )
 
 
@@ -309,9 +304,7 @@ def test_greedy_action_with_gru_is_pure_and_act_returns_cached_dispatch() -> Non
     n_prim = agent.config.oak.n_primitive_actions
     expected = int(jnp.argmax(q[:n_prim]))
     assert int(agent.greedy_action(state, query)) == expected
-    assert int(agent.act(state, state.current_raw_observation)) == int(
-        state.current_action
-    )
+    assert int(agent.act(state, state.current_raw_observation)) == int(state.current_action)
 
 
 def test_act_without_gru_unchanged() -> None:
@@ -320,3 +313,33 @@ def test_act_without_gru_unchanged() -> None:
     action = agent.act(state, state.current_raw_observation)
     assert action.shape == ()
     assert 0 <= int(action) < agent.config.oak.n_primitive_actions
+
+
+def test_oak_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="min_steps_before_curation"):
+        OaKConfig(min_steps_before_curation=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_steps_before_curation"):
+        OaKConfig(min_steps_before_curation=10.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="utility_ema_decay"):
+        OaKConfig(utility_ema_decay=float("nan"))
+    with pytest.raises(ValueError, match="curation_threshold"):
+        OaKConfig(curation_threshold=float("inf"))
+
+    cfg = OaKConfig(min_steps_before_curation=np.int64(100))
+    assert type(cfg.min_steps_before_curation) is int
+    assert cfg.min_steps_before_curation == 100
+
+
+def test_keyboard_chord_learner_config_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_options"):
+        KeyboardChordLearnerConfig(n_options=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_options"):
+        KeyboardChordLearnerConfig(n_options=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size"):
+        KeyboardChordLearnerConfig(n_options=2, step_size=float("nan"))
+    with pytest.raises(ValueError, match="baseline_decay"):
+        KeyboardChordLearnerConfig(n_options=2, baseline_decay=float("inf"))
+
+    cfg = KeyboardChordLearnerConfig(n_options=np.int32(4))
+    assert type(cfg.n_options) is int
+    assert cfg.n_options == 4

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -343,3 +343,42 @@ def test_keyboard_chord_learner_config_integer_and_scalar_validation() -> None:
     cfg = KeyboardChordLearnerConfig(n_options=np.int32(4))
     assert type(cfg.n_options) is int
     assert cfg.n_options == 4
+
+
+def test_oak_and_keyboard_close_schema_float32_and_resource_boundaries() -> None:
+    class DictSubclass(dict[str, object]):
+        pass
+
+    oak = OaKConfig(
+        utility_ema_decay=np.float64(0.5),
+        curation_threshold=np.float32(0.25),
+    )
+    assert type(oak.utility_ema_decay) is float
+    assert type(oak.curation_threshold) is float
+    payload = oak.to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        OaKConfig.from_config(DictSubclass(payload))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fields"):
+        OaKConfig.from_config({**payload, "extra": 1})
+    with pytest.raises(ValueError, match="stomp config"):
+        OaKConfig.from_config(
+            {**payload, "stomp": DictSubclass(payload["stomp"])}  # type: ignore[arg-type]
+        )
+
+    keyboard_payload = KeyboardChordLearnerConfig(n_options=2).to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        KeyboardChordLearnerConfig.from_config(DictSubclass(keyboard_payload))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_options"):
+        KeyboardChordLearnerConfig.from_config(
+            {**keyboard_payload, "n_options": np.int32(2)}
+        )
+
+    stomp_only_limit = (2**29 - 1 - 22) // 4
+    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="OaK direct array bytes"):
+        OaKConfig(stomp=stomp)
+
+    last_legal_keyboard_options = (2**31 - 1) // 4 - 2
+    KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options)
+    with pytest.raises(ValueError, match="keyboard state bytes"):
+        KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options + 1)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,6 +3,7 @@
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.options import (
@@ -41,9 +42,7 @@ class TestSubtaskSpecValidation:
         with pytest.raises(ValueError, match="threshold"):
             SubtaskSpec(feature_index=0, threshold=threshold)
 
-    @pytest.mark.parametrize(
-        "scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0]
-    )
+    @pytest.mark.parametrize("scale", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
     def test_rejects_bad_pseudo_reward_scale(self, scale: float) -> None:
         with pytest.raises(ValueError, match="pseudo_reward_scale"):
             SubtaskSpec(feature_index=0, pseudo_reward_scale=scale)
@@ -86,9 +85,7 @@ class TestStompCheckpointRoundTrip:
     def test_new_format_round_trips(self) -> None:
         state = _state()
 
-        restored = load_stomp_state_with_migration(
-            stomp_state_to_checkpoint_payload(state)
-        )
+        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(state))
 
         chex.assert_trees_all_equal(restored, state)
 
@@ -96,9 +93,7 @@ class TestStompCheckpointRoundTrip:
         state = _state()
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        restored = load_stomp_state_with_migration(
-            stomp_state_to_checkpoint_payload(migrated)
-        )
+        restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(migrated))
 
         chex.assert_trees_all_equal(restored, migrated)
 
@@ -133,9 +128,7 @@ class TestStompStateMigration:
 
         migrated = load_stomp_state_with_migration(_old_format_payload(state))
 
-        chex.assert_trees_all_equal(
-            migrated.base_learner_state, state.base_learner_state
-        )
+        chex.assert_trees_all_equal(migrated.base_learner_state, state.base_learner_state)
         chex.assert_trees_all_equal(migrated.option_policies, state.option_policies)
         chex.assert_trees_all_equal(
             migrated.option_models.cumreward_ema, state.option_models.cumreward_ema
@@ -185,9 +178,7 @@ class TestStompMigrationFailsClosed:
 
     def test_unknown_option_model_field_raises(self) -> None:
         payload = stomp_state_to_checkpoint_payload(_state())
-        payload["option_models"]["not_a_field"] = jnp.zeros(
-            N_OPTIONS, dtype=jnp.float32
-        )
+        payload["option_models"]["not_a_field"] = jnp.zeros(N_OPTIONS, dtype=jnp.float32)
 
         with pytest.raises(ValueError, match="not_a_field"):
             load_stomp_state_with_migration(payload)
@@ -246,9 +237,7 @@ def test_primitive_only_stomp_has_typed_empty_option_state_and_base_only_updates
     chex.assert_trees_all_equal(masked_start.state, started)
     chex.assert_trees_all_equal(masked_start.primitive_action, started.last_primitive_action)
 
-    restored = load_stomp_state_with_migration(
-        stomp_state_to_checkpoint_payload(started)
-    )
+    restored = load_stomp_state_with_migration(stomp_state_to_checkpoint_payload(started))
     chex.assert_trees_all_equal(restored, started)
 
     result = agent.update(
@@ -330,10 +319,8 @@ def test_semidp_q_infinite_reward_does_not_poison_weights() -> None:
         discount=jnp.array(1.0, dtype=jnp.float32),
     )
 
-    new_q, new_z, new_rbar, td_error, update_applied = (
-        _differential_semidp_q_update(
+    new_q, new_z, new_rbar, td_error, update_applied = _differential_semidp_q_update(
         q, z, rbar, obs, action, jnp.array(jnp.inf, dtype=jnp.float32), nxt, **kw
-        )
     )
     chex.assert_trees_all_close(new_q, q)
     chex.assert_trees_all_close(new_z, z)
@@ -371,17 +358,13 @@ class TestStompConfigScalarValidation:
         )
 
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
-    @pytest.mark.parametrize(
-        "value", [float("nan"), float("inf"), float("-inf"), -0.05]
-    )
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.05])
     def test_rejects_invalid_step_sizes(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=f"{name} must be finite and non-negative"):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _UNIT_INTERVAL_FIELDS)
-    @pytest.mark.parametrize(
-        "value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0]
-    )
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0])
     def test_rejects_invalid_unit_interval_scalars(self, name: str, value: float) -> None:
         with pytest.raises(ValueError, match=rf"{name} must be finite and in \[0, 1\]"):
             self._build(**{name: value})
@@ -404,3 +387,49 @@ class TestStompConfigScalarValidation:
         payload["base_step_size"] = float("nan")
         with pytest.raises(ValueError, match="base_step_size must be finite and non-negative"):
             STOMPConfig.from_config(payload)
+
+
+def test_subtask_spec_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_index"):
+        SubtaskSpec(feature_index=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="max_option_steps"):
+        SubtaskSpec(feature_index=0, max_option_steps=True)  # type: ignore[arg-type]
+
+    spec = SubtaskSpec(
+        feature_index=np.int32(1),
+        max_option_steps=np.int64(10),
+    )
+    assert type(spec.feature_index) is int
+    assert type(spec.max_option_steps) is int
+    assert spec.feature_index == 1
+    assert spec.max_option_steps == 10
+
+
+def test_stomp_config_integer_validation() -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        STOMPConfig(observation_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_primitive_actions"):
+        STOMPConfig(n_primitive_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="base_hidden_sizes"):
+        STOMPConfig(base_hidden_sizes=(True,))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="option_planning_backups_per_step"):
+        STOMPConfig(option_planning_backups_per_step=True)  # type: ignore[arg-type]
+
+    cfg = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=np.int32(4),
+        n_primitive_actions=np.int64(2),
+        base_hidden_sizes=(np.int32(16), np.int64(8)),
+        option_planning_backups_per_step=np.uint16(2),
+    )
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.n_primitive_actions) is int
+    assert type(cfg.base_hidden_sizes[0]) is int
+    assert type(cfg.base_hidden_sizes[1]) is int
+    assert type(cfg.option_planning_backups_per_step) is int
+    assert cfg.observation_dim == 4
+    assert cfg.n_primitive_actions == 2
+    assert cfg.base_hidden_sizes == (16, 8)
+    assert cfg.option_planning_backups_per_step == 2

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,9 @@
 """Tests for STOMP checkpoint payloads and state migration (core/options.py)."""
 
+import dataclasses
+
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -18,6 +21,7 @@ from alberta_framework.core.options import (
     SubtaskSpec,
     _differential_q_update,
     _differential_semidp_q_update,
+    _stomp_direct_array_scalars,
     load_stomp_state_with_migration,
     replace_dispatched_primitive_action,
     stomp_state_to_checkpoint_payload,
@@ -360,13 +364,13 @@ class TestStompConfigScalarValidation:
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
     @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.05])
     def test_rejects_invalid_step_sizes(self, name: str, value: float) -> None:
-        with pytest.raises(ValueError, match=f"{name} must be finite and non-negative"):
+        with pytest.raises(ValueError, match=name):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _UNIT_INTERVAL_FIELDS)
     @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), -0.1, 1.5, 2.0])
     def test_rejects_invalid_unit_interval_scalars(self, name: str, value: float) -> None:
-        with pytest.raises(ValueError, match=rf"{name} must be finite and in \[0, 1\]"):
+        with pytest.raises(ValueError, match=name):
             self._build(**{name: value})
 
     @pytest.mark.parametrize("name", _STEP_SIZE_FIELDS)
@@ -385,7 +389,7 @@ class TestStompConfigScalarValidation:
     def test_from_config_enforces_scalar_validation(self) -> None:
         payload = self._build().to_config()
         payload["base_step_size"] = float("nan")
-        with pytest.raises(ValueError, match="base_step_size must be finite and non-negative"):
+        with pytest.raises(ValueError, match="base_step_size"):
             STOMPConfig.from_config(payload)
 
 
@@ -433,3 +437,53 @@ def test_stomp_config_integer_validation() -> None:
     assert cfg.n_primitive_actions == 2
     assert cfg.base_hidden_sizes == (16, 8)
     assert cfg.option_planning_backups_per_step == 2
+
+
+def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
+    class DictSubclass(dict[str, object]):
+        pass
+
+    spec = SubtaskSpec(
+        feature_index=0,
+        threshold=np.float64(0.5),
+        pseudo_reward_scale=np.float32(1.0),
+    )
+    assert type(spec.threshold) is float
+    assert type(spec.pseudo_reward_scale) is float
+    with pytest.raises(ValueError, match="threshold"):
+        SubtaskSpec(feature_index=0, threshold=1.0e100)
+
+    payload = STOMPConfig().to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        STOMPConfig.from_config(DictSubclass(payload))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fields"):
+        STOMPConfig.from_config({**payload, "extra": 1})
+    with pytest.raises(ValueError, match="base_hidden_sizes"):
+        STOMPConfig.from_config({**payload, "base_hidden_sizes": ()})
+    with pytest.raises(ValueError, match="observation_dim"):
+        STOMPConfig.from_config({**payload, "observation_dim": np.int32(4)})
+
+    last_legal_observation_dim = (2**29 - 1 - 22) // 4
+    STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="direct array bytes"):
+        STOMPConfig(observation_dim=last_legal_observation_dim + 1, n_primitive_actions=1)
+
+    measured_config = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0), SubtaskSpec(feature_index=1)),
+        observation_dim=3,
+        n_primitive_actions=2,
+        base_hidden_sizes=(4,),
+    )
+    measured_agent = STOMPAgent(measured_config)
+    array_bytes = sum(
+        int(leaf.nbytes)
+        for leaf in jax.tree_util.tree_leaves(
+            (measured_agent.init(jr.key(0)), measured_agent.spec_arrays)
+        )
+        if hasattr(leaf, "nbytes")
+    )
+    array_bytes += sum(
+        int(getattr(measured_agent.spec_arrays, field.name).nbytes)
+        for field in dataclasses.fields(STOMPSpecArrays)
+    )
+    assert 4 * _stomp_direct_array_scalars(measured_config) == array_bytes

--- a/tests/test_stomp_option_planning.py
+++ b/tests/test_stomp_option_planning.py
@@ -190,7 +190,7 @@ def test_production_facades_propagate_planning_budget() -> None:
 
 @pytest.mark.parametrize("invalid", [-1, 1.5, True])
 def test_planning_budget_must_be_nonnegative_static_integer(invalid: object) -> None:
-    with pytest.raises(ValueError, match="nonnegative integer"):
+    with pytest.raises(ValueError, match=r"option_planning_backups_per_step must be"):
         STOMPConfig(
             subtask_specs=(SubtaskSpec(feature_index=0),),
             option_planning_backups_per_step=invalid,  # type: ignore[arg-type]


### PR DESCRIPTION
Consolidated audited successor to #738 and #741, preserving both contributor commits and authorship.\n\nDeep audit additions:\n- canonicalize every float32-consumed Subtask/STOMP/OaK/keyboard scalar through the shared exact-host/binary32 validator;\n- enforce exact tuple/object constructor containers and exact serialized dict/list/field/type/JSON-scalar schemas while retaining the documented legacy omissions for STOMP planning/base containers and OaK curation uptime;\n- reject hostile integer/container subclasses before hooks;\n- preflight derived n_total_actions and the exact combined STOMP directly allocated JAX state/config arrays before allocation;\n- compose the OaK wrapper arrays into that cap and independently bound keyboard state;\n- verify the STOMP formula against actual measured JAX leaf bytes, plus allocation-free adjacent legal/illegal boundaries.\n\nValidation on current main, without benchmarks or outputs/evidence edits:\n- 347 focused tests passed\n- scoped Ruff passed\n- strict mypy passed for both source modules\n- diff check passed