### PR TITLE
fix(scale-robust-feature): validate seeds against the canonical JAX key domain

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -33,6 +33,7 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
+from alberta_framework._seed_validation import require_unique_jax_seeds
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
 )
@@ -589,15 +590,19 @@ def run_scale_robust_feature_evaluation(
     The public default is the fresh namespace-derived 30-seed schedule.
     Alternate schedules are useful only for development diagnostics; the v2
     evidence validator will not accept them.
+
+    Raises:
+        ValueError: If ``seeds`` is empty, contains a non-canonical-``int``
+            value (a ``bool``, a ``float`` that would otherwise be silently
+            truncated by ``int()``, a numpy/JAX scalar, or a numeric
+            string), a duplicate, or a value outside the JAX uint32 scalar
+            key domain ``[0, 2**32 - 1]`` -- ``jax.random.key`` reduces an
+            out-of-range seed modulo ``2**32``, so two distinct declared
+            seeds could otherwise silently execute the identical random
+            stream while being recorded as different identities.
     """
 
-    seed_schedule = tuple(int(seed) for seed in seeds)
-    if not seed_schedule:
-        raise ValueError("seeds must be non-empty")
-    if len(set(seed_schedule)) != len(seed_schedule):
-        raise ValueError("seeds must be unique")
-    if any(seed < 0 for seed in seed_schedule):
-        raise ValueError("seeds must be non-negative")
+    seed_schedule = require_unique_jax_seeds(seeds, name="seeds")
 
     stream = GauntletStream(frozen_stream_config())
     records: list[ConditionSeedRecord] = []

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -1,0 +1,100 @@
+"""Seed-domain contract for the scale-robust pair-feature evaluation entrypoint.
+
+``run_scale_robust_feature_evaluation`` is the executable protocol behind the
+registered ``scale_robust_pair_features`` evidence claim.  Its ``seeds``
+argument used to be canonicalized with a bare ``int(seed)`` call plus manual
+non-empty/unique/non-negative checks -- silently truncating floats, silently
+coercing ``bool``/numeric-string/other numeric types, and never bounding a
+seed to the JAX uint32 scalar-key domain.  ``jax.random.key`` reduces an
+out-of-range seed modulo ``2**32``, so two distinct declared seeds could
+silently execute the identical random stream while being recorded as
+different identities in the evidence artifact.
+
+These tests exercise only the validation boundary, which runs before any JAX
+computation starts, so they stay fast: a rejection must be raised before the
+(expensive) protocol would ever begin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework._seed_validation import JAX_KEY_SEED_MAX
+from alberta_framework.evaluation.scale_robust_feature import (
+    DEVELOPMENT_SEEDS,
+    EVIDENCE_SEEDS,
+    run_scale_robust_feature_evaluation,
+)
+
+
+class _ProtocolStartedError(Exception):
+    """Raised by the patched stream constructor once validation has passed."""
+
+
+@pytest.fixture(autouse=True)
+def _fail_if_protocol_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make any post-validation progress fail loudly and cheaply.
+
+    ``run_scale_robust_feature_evaluation`` constructs a ``GauntletStream``
+    immediately after validating ``seeds``.  Patching the constructor to
+    raise turns "validation silently passed" into a clear test failure
+    instead of a multi-minute JAX run.
+    """
+
+    import alberta_framework.evaluation.scale_robust_feature as module
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise _ProtocolStartedError("seed validation passed; protocol would have started")
+
+    monkeypatch.setattr(module, "GauntletStream", _boom)
+
+
+@pytest.mark.parametrize(
+    "bad_seeds",
+    [
+        pytest.param((True,), id="bool"),
+        pytest.param((False,), id="bool_false"),
+        pytest.param((5.9,), id="float_would_silently_truncate"),
+        pytest.param((5.0,), id="float_exact_value"),
+        pytest.param(("5",), id="numeric_string"),
+        pytest.param((JAX_KEY_SEED_MAX + 1,), id="above_uint32_domain"),
+        pytest.param((JAX_KEY_SEED_MAX + 1 + (1 << 40),), id="far_above_uint32_domain"),
+        pytest.param((-1,), id="negative"),
+    ],
+)
+def test_rejects_non_canonical_seed(bad_seeds: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError, match="seeds"):
+        run_scale_robust_feature_evaluation(seeds=bad_seeds)  # type: ignore[arg-type]
+
+
+def test_rejects_empty_seeds() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        run_scale_robust_feature_evaluation(seeds=())
+
+
+def test_rejects_duplicate_seeds() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        run_scale_robust_feature_evaluation(seeds=(5, 5))
+
+
+def test_out_of_range_seed_would_alias_an_in_range_seed() -> None:
+    """Document the exact corruption the domain bound prevents.
+
+    Without the ``[0, 2**32 - 1]`` bound, seed ``2**32`` would construct the
+    identical JAX key as seed ``0`` -- two declared identities, one actual
+    random stream.
+    """
+    import jax.random as jr
+
+    aliasing_seed = JAX_KEY_SEED_MAX + 1  # == 2**32, wraps to 0 mod 2**32
+    assert bool(jr.key_data(jr.key(0)).tolist() == jr.key_data(jr.key(aliasing_seed)).tolist())
+    with pytest.raises(ValueError):
+        run_scale_robust_feature_evaluation(seeds=(aliasing_seed,))
+
+
+def test_canonical_evidence_and_development_seeds_pass_validation() -> None:
+    """The frozen seed schedules validate cleanly (protocol start is stubbed)."""
+    with pytest.raises(_ProtocolStartedError):
+        run_scale_robust_feature_evaluation(seeds=EVIDENCE_SEEDS)
+    with pytest.raises(_ProtocolStartedError):
+        run_scale_robust_feature_evaluation(seeds=DEVELOPMENT_SEEDS)


### PR DESCRIPTION
## Summary

Fixes #779.

`run_scale_robust_feature_evaluation` (`alberta_framework/evaluation/scale_robust_feature.py`) — the executable protocol behind the registered `scale_robust_pair_features` accepted L2 evidence claim — validated its `seeds` argument with a bare `int(seed)` coercion plus manual non-empty/unique/non-negative checks:

```python
seed_schedule = tuple(int(seed) for seed in seeds)
if not seed_schedule:
    raise ValueError("seeds must be non-empty")
if len(set(seed_schedule)) != len(seed_schedule):
    raise ValueError("seeds must be unique")
if any(seed < 0 for seed in seed_schedule):
    raise ValueError("seeds must be non-negative")
```

This is weaker than the codebase's own canonical seed-domain contract (`alberta_framework._seed_validation.require_unique_jax_seeds`), used by sibling entrypoints such as `upgd_ipmnist.run_ipmnist`:

- `int(seed)` silently truncates a float (`int(5.9) == 5`) instead of rejecting it.
- `int(seed)` silently coerces `bool`/numeric strings instead of rejecting them.
- There is no upper bound, but the seeds feed straight into `jax.random.key(seed)` (`keys = jnp.stack([jr.key(seed) for seed in seeds])`), and `jax.random.key` reduces an out-of-range seed modulo `2**32`. Live-confirmed on this commit:

```
>>> import jax.random as jr
>>> jr.key_data(jr.key(5)).tolist() == jr.key_data(jr.key(5 + 2**32)).tolist()
True
```

So two seeds recorded as *distinct* identities in an evidence artifact (e.g. `5` and `4294967301`) could silently execute the *identical* random stream — exactly the failure mode `_seed_validation.py`'s own module docstring exists to prevent.

`run_scale_robust_feature_evaluation` is public API (`__all__`) and its docstring explicitly documents that callers may pass "alternate schedules ... for development diagnostics," so this is a reachable validation gap, not a theoretical one. No test exercised this function directly before this PR — the existing `tests/test_scale_robust_feature_artifact.py` / `tests/test_scale_robust_feature_cli.py` construct `ScaleRobustFeatureReport` synthetically to avoid running the JAX protocol.

## Change

- `alberta_framework/evaluation/scale_robust_feature.py`: replace the inline seed checks with `require_unique_jax_seeds(seeds, name="seeds")`, matching the pattern already used elsewhere in this codebase. One import, one line replacing four; no other behavior changes.
- `tests/test_scale_robust_feature.py` (new file): failing-test-first regression coverage for the seed-validation boundary only (a `GauntletStream` monkeypatch makes any post-validation progress raise immediately, so the tests stay fast and never run the expensive JAX protocol). Covers `bool`, `float` (including exact and truncating values), numeric strings, seeds above/at/around the uint32 domain boundary, negative seeds, empty, duplicate, and confirms the frozen `EVIDENCE_SEEDS`/`DEVELOPMENT_SEEDS` constants still validate cleanly.

## Evidence compatibility

No pinned `outputs/` artifact was modified. `scale_robust_feature.py` is a registered source for the `scale_robust_pair_features` claim (see `evaluation/evidence_manifest.py`), so editing it correctly leaves that claim's frozen artifact fail-closed `invalid` until the frozen v2 protocol is rerun — this PR does not promote or reinterpret the historical accepted result. On a pristine `origin/main` checkout (before this change), `alberta-evidence-status` already reported the *entire* registry as `invalid` (exit 2) for pre-existing, unrelated reasons; this PR does not change that overall picture.

## Verification

Commands run from the repo root, `.venv/bin/python` (Python 3.12), at commit `5954ead9641ae3638e86e42f10a9ce2633414fb0`:

```
$ .venv/bin/python -m pytest tests/test_scale_robust_feature.py -q -o addopts=""
............
12 passed in 1.20s

$ .venv/bin/python -m pytest tests/test_scale_robust_feature.py tests/test_scale_robust_feature_artifact.py tests/test_scale_robust_feature_cli.py -q -o addopts=""
........................................................................ [ 94%]
....                                                                     [100%]
76 passed in 6.41s

$ .venv/bin/python -m ruff check alberta_framework/evaluation/scale_robust_feature.py tests/test_scale_robust_feature.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/evaluation/scale_robust_feature.py tests/test_scale_robust_feature.py
Success: no issues found in 2 source files

$ git diff --check
(clean)
```

**Mutation check** — reverted only the source fix (kept the new tests) and reran: 8 of the 12 new tests fail against the pre-fix code, each failing exactly where expected — validation silently passed and reached the (stubbed) protocol start:

```
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[bool]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[bool_false]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[float_would_silently_truncate]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[float_exact_value]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[numeric_string]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[above_uint32_domain]
FAILED tests/test_scale_robust_feature.py::test_rejects_non_canonical_seed[far_above_uint32_domain]
FAILED tests/test_scale_robust_feature.py::test_out_of_range_seed_would_alias_an_in_range_seed
8 failed, 4 passed in 1.32s
```

I did not run the full ~7000-test suite (known to OOM in bounded sandboxes) or the ~30-seed JAX protocol itself — this change only touches the pre-flight validation boundary, which the mutation check exercises directly and cheaply.

## Deviations / open items

- This is a narrow, single-variable fix (one validation call swapped for the codebase's own canonical helper); no new mechanism or knob is introduced.
- Receipt signing is being handled centrally by the orchestrating session for this contribution pipeline; not attempted from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)