### PR TITLE
fix(streams): validate gymnasium probabilities

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -31,6 +31,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.learners import LinearLearner
 from alberta_framework.core.types import LearnerState, TimeStep
 
@@ -183,6 +184,7 @@ def make_epsilon_greedy_policy(
     Returns:
         Epsilon-greedy policy
     """
+    epsilon = validated_float32_scalar("epsilon", epsilon, lower=0.0, upper=1.0)
     random_policy = make_random_policy(env, seed + 1)
     rng = jr.key(seed)
 
@@ -233,6 +235,7 @@ def collect_trajectory(
         Tuple of (observations, targets) as JAX arrays with shape
         (num_steps, feature_dim) and (num_steps, target_dim)
     """
+    gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
     if policy is None:
         policy = make_random_policy(env, seed)
 
@@ -391,7 +394,9 @@ class GymnasiumStream:
         """
         self._env = env
         self._mode = mode
-        self._gamma = gamma
+        self._gamma = validated_float32_scalar(
+            "gamma", gamma, lower=0.0, upper=1.0
+        )
         self._include_action_in_features = include_action_in_features
         self._seed = seed
         self._reset_count = 0
@@ -553,7 +558,9 @@ class TDStream:
             seed: Random seed
         """
         self._env = env
-        self._gamma = gamma
+        self._gamma = validated_float32_scalar(
+            "gamma", gamma, lower=0.0, upper=1.0
+        )
         self._include_action_in_features = include_action_in_features
         self._seed = seed
         self._reset_count = 0
@@ -675,6 +682,8 @@ def make_gymnasium_stream(
         GymnasiumStream wrapping the environment
     """
     import gymnasium
+
+    gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
 
     env = gymnasium.make(env_id, **env_kwargs)
     return GymnasiumStream(

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -28,6 +28,48 @@ class TestPredictionMode:
         assert PredictionMode.VALUE.value == "value"
 
 
+@pytest.mark.parametrize("invalid", (True, float("nan"), float("inf"), -0.1, 1.1))
+def test_gamma_entry_points_reject_invalid_float32_probabilities(invalid: object) -> None:
+    env = gymnasium.make("CartPole-v1")
+    try:
+        with pytest.raises(ValueError, match="gamma"):
+            GymnasiumStream(env, gamma=invalid)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="gamma"):
+            TDStream(env, gamma=invalid)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="gamma"):
+            collect_trajectory(  # type: ignore[arg-type]
+                env, None, num_steps=1, gamma=invalid
+            )
+        with pytest.raises(ValueError, match="gamma"):
+            make_gymnasium_stream(  # type: ignore[arg-type]
+                "CartPole-v1", gamma=invalid
+            )
+    finally:
+        env.close()
+
+
+def test_probability_entry_points_normalize_hostile_real_failures_without_repr() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("untrusted ratio hook")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook executed")
+
+    env = gymnasium.make("CartPole-v1")
+    try:
+        with pytest.raises(ValueError, match="gamma"):
+            GymnasiumStream(env, gamma=HostileFloat(0.5))
+        with pytest.raises(ValueError, match="epsilon"):
+            make_epsilon_greedy_policy(
+                lambda _observation: 0,
+                env,
+                epsilon=HostileFloat(0.5),
+            )
+    finally:
+        env.close()
+
+
 class TestGymnasiumStreamRewardMode:
     """Tests for GymnasiumStream with REWARD prediction mode."""
 


### PR DESCRIPTION
Closes #777.

Routes gamma through the shared exact-host/float32 unit-interval validator at every public collector, stream, TD stream, and factory entry point, and validates epsilon at policy construction. Values are canonicalized once before closure capture or TD arithmetic; booleans, nonfinite/out-of-range values, float32-domain violations, hostile Real failures, and repr hooks fail closed.

Verification: 44 Gymnasium/bootstrap tests, scoped Ruff, strict source mypy, and diff check pass. No outputs/evidence changes.