### PR TITLE
fix(options): preserve config mapping compatibility

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -1584,52 +1585,35 @@ class STOMPConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> STOMPConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> STOMPConfig:
         """Reconstruct from :meth:`to_config` output."""
-        if type(config) is not dict:
-            raise ValueError("STOMP config must be an actual dict")
-        payload = dict(config)
-        if payload.pop("type", None) != "STOMPConfig":
-            raise ValueError("STOMP config type is invalid")
-        expected = {field.name for field in dataclasses.fields(cls)}
-        legacy_optional = {"subtask_specs", "base_hidden_sizes", "option_planning_backups_per_step"}
-        if set(payload) - expected or (expected - legacy_optional) - set(payload):
-            raise ValueError("STOMP config fields do not match its schema")
+        if not issubclass(type(config), Mapping):
+            raise ValueError("STOMPConfig payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("STOMPConfig mapping could not be read") from error
+        payload.pop("type", None)
         specs_raw = payload.pop("subtask_specs", [])
-        if type(specs_raw) is not list or any(type(spec) is not dict for spec in specs_raw):
-            raise ValueError("serialized subtask_specs must be an actual list of actual dicts")
-        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
-        if any(set(spec) != spec_fields for spec in specs_raw):
-            raise ValueError("serialized SubtaskSpec fields do not match its schema")
-        if any(
-            type(spec["feature_index"]) is not int
-            or type(spec["max_option_steps"]) is not int
-            or type(spec["threshold"]) is not float
-            or type(spec["pseudo_reward_scale"]) is not float
-            for spec in specs_raw
-        ):
-            raise ValueError("serialized SubtaskSpec scalars must be canonical JSON scalars")
-        specs = tuple(SubtaskSpec(**s) for s in specs_raw)
-        hidden_raw = payload.pop("base_hidden_sizes", [])
-        if type(hidden_raw) is not list or any(type(size) is not int for size in hidden_raw):
-            raise ValueError("serialized base_hidden_sizes must be an actual list of JSON integers")
-        payload["base_hidden_sizes"] = tuple(hidden_raw)
-        for name in ("observation_dim", "n_primitive_actions", "option_planning_backups_per_step"):
-            if name in payload and type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        for name in (
-            "base_step_size", "base_avg_reward_step_size", "base_trace_decay",
-            "option_step_size", "option_avg_reward_step_size", "option_trace_decay",
-            "option_gamma", "option_model_decay", "option_model_step_size",
-            "epsilon_base", "epsilon_option", "option_importance_clip",
-        ):
-            if type(payload[name]) is not float:
-                raise ValueError(f"serialized {name} must be a JSON number")
-        if payload["option_target_epsilon"] is not None and type(
-            payload["option_target_epsilon"]
-        ) is not float:
-            raise ValueError("serialized option_target_epsilon must be null or a JSON number")
-        return cls(subtask_specs=specs, **payload)
+        if type(specs_raw) not in (list, tuple):
+            raise ValueError("serialized subtask_specs must be an actual list or tuple")
+        specs: list[SubtaskSpec] = []
+        for raw in specs_raw:
+            if not issubclass(type(raw), Mapping):
+                raise ValueError("serialized subtask_specs entries must be mappings")
+            try:
+                specs.append(SubtaskSpec(**dict(raw)))
+            except Exception as error:
+                raise ValueError("serialized SubtaskSpec is invalid") from error
+        if "base_hidden_sizes" in payload:
+            raw_hidden = payload["base_hidden_sizes"]
+            if type(raw_hidden) not in (list, tuple):
+                raise ValueError(
+                    "serialized base_hidden_sizes must be an actual list or tuple"
+                )
+            sequence = cast(list[object] | tuple[object, ...], raw_hidden)
+            payload["base_hidden_sizes"] = tuple(sequence)
+        return cls(subtask_specs=tuple(specs), **payload)
 
 
 # ---------------------------------------------------------------------------

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1602,7 +1602,13 @@ class STOMPConfig:
             if not issubclass(type(raw), Mapping):
                 raise ValueError("serialized subtask_specs entries must be mappings")
             try:
-                specs.append(SubtaskSpec(**dict(raw)))
+                decoded = dict(raw)
+            except Exception as error:
+                raise ValueError("serialized SubtaskSpec mapping could not be read") from error
+            try:
+                specs.append(SubtaskSpec(**decoded))
+            except ValueError:
+                raise
             except Exception as error:
                 raise ValueError("serialized SubtaskSpec is invalid") from error
         if "base_hidden_sizes" in payload:

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1613,7 +1613,12 @@ class STOMPConfig:
                 )
             sequence = cast(list[object] | tuple[object, ...], raw_hidden)
             payload["base_hidden_sizes"] = tuple(sequence)
-        return cls(subtask_specs=tuple(specs), **payload)
+        try:
+            return cls(subtask_specs=tuple(specs), **payload)
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized STOMPConfig is invalid") from error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,7 @@
 """Tests for STOMP checkpoint payloads and state migration (core/options.py)."""
 
 import dataclasses
+from types import MappingProxyType
 
 import chex
 import jax
@@ -440,9 +441,6 @@ def test_stomp_config_integer_validation() -> None:
 
 
 def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
-    class DictSubclass(dict[str, object]):
-        pass
-
     spec = SubtaskSpec(
         feature_index=0,
         threshold=np.float64(0.5),
@@ -452,16 +450,6 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
     assert type(spec.pseudo_reward_scale) is float
     with pytest.raises(ValueError, match="threshold"):
         SubtaskSpec(feature_index=0, threshold=1.0e100)
-
-    payload = STOMPConfig().to_config()
-    with pytest.raises(ValueError, match="actual dict"):
-        STOMPConfig.from_config(DictSubclass(payload))  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="fields"):
-        STOMPConfig.from_config({**payload, "extra": 1})
-    with pytest.raises(ValueError, match="base_hidden_sizes"):
-        STOMPConfig.from_config({**payload, "base_hidden_sizes": ()})
-    with pytest.raises(ValueError, match="observation_dim"):
-        STOMPConfig.from_config({**payload, "observation_dim": np.int32(4)})
 
     last_legal_observation_dim = (2**29 - 1 - 22) // 4
     STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
@@ -487,3 +475,45 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
         for field in dataclasses.fields(STOMPSpecArrays)
     )
     assert 4 * _stomp_direct_array_scalars(measured_config) == array_bytes
+
+
+@pytest.mark.unit
+def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -> None:
+    class MappingSpoof:
+        @property
+        def __class__(self) -> type:  # type: ignore[override]
+            return dict
+
+        def __iter__(self) -> object:
+            raise AssertionError("iteration hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook executed")
+
+    config = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=2,
+    )
+    payload = config.to_config()
+    payload["subtask_specs"] = tuple(payload["subtask_specs"])
+    payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
+    payload["type"] = "historical-marker"
+    assert STOMPConfig.from_config(MappingProxyType(payload)) == config
+
+    partial = STOMPConfig.from_config(
+        {"subtask_specs": ({"feature_index": 0},), "observation_dim": 2}
+    )
+    assert partial.subtask_specs == (SubtaskSpec(feature_index=0),)
+    assert partial.option_planning_backups_per_step == 0
+
+    with pytest.raises(ValueError, match="mapping"):
+        STOMPConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
+
+    for field, value in (
+        ("subtask_specs", "not-a-sequence"),
+        ("base_hidden_sizes", "not-a-sequence"),
+    ):
+        invalid = config.to_config()
+        invalid[field] = value
+        with pytest.raises(ValueError, match=field):
+            STOMPConfig.from_config(invalid)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -512,6 +512,15 @@ def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -
     with pytest.raises(ValueError, match="STOMPConfig"):
         STOMPConfig.from_config({"unexpected_field": 1})
 
+    with pytest.raises(ValueError, match="feature_index"):
+        STOMPConfig.from_config(
+            {"subtask_specs": ({"feature_index": True},), "observation_dim": 2}
+        )
+    with pytest.raises(ValueError, match="threshold"):
+        STOMPConfig.from_config(
+            {"subtask_specs": ({"feature_index": 0, "threshold": "invalid"},)}
+        )
+
     for field, value in (
         ("subtask_specs", "not-a-sequence"),
         ("base_hidden_sizes", "not-a-sequence"),

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -509,6 +509,9 @@ def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -
     with pytest.raises(ValueError, match="mapping"):
         STOMPConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
 
+    with pytest.raises(ValueError, match="STOMPConfig"):
+        STOMPConfig.from_config({"unexpected_field": 1})
+
     for field, value in (
         ("subtask_specs", "not-a-sequence"),
         ("base_hidden_sizes", "not-a-sequence"),


### PR DESCRIPTION
Follow-up to the combined #775 integration. The integration correctly landed the exact scalar/resource contracts, but also narrowed `STOMPConfig.from_config` beyond its established compatibility surface.

This residual restores ordinary `Mapping`/`MappingProxyType` inputs, partial/default payloads, historical type-marker tolerance, and exact list-or-tuple nested sequence forms. It still rejects arbitrary sequence subclasses and class-spoofed mappings before iterator/repr hooks, and delegates every decoded scalar to the hardened constructors already on main.

Verification on the post-#775 base:
- 159 options/STOMP tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

No registered evidence source or output artifact is changed.
