### PR TITLE
fix(scale-robust-feature): validate exact JAX seed schedules

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -33,6 +33,7 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
+from alberta_framework._seed_validation import require_unique_jax_seeds
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
 )
@@ -589,15 +590,19 @@ def run_scale_robust_feature_evaluation(
     The public default is the fresh namespace-derived 30-seed schedule.
     Alternate schedules are useful only for development diagnostics; the v2
     evidence validator will not accept them.
+
+    Raises:
+        ValueError: If ``seeds`` is empty, contains a non-canonical-``int``
+            value (a ``bool``, a ``float`` that would otherwise be silently
+            truncated by ``int()``, a numpy/JAX scalar, or a numeric
+            string), a duplicate, or a value outside the JAX uint32 scalar
+            key domain ``[0, 2**32 - 1]`` -- ``jax.random.key`` reduces an
+            out-of-range seed modulo ``2**32``, so two distinct declared
+            seeds could otherwise silently execute the identical random
+            stream while being recorded as different identities.
     """
 
-    seed_schedule = tuple(int(seed) for seed in seeds)
-    if not seed_schedule:
-        raise ValueError("seeds must be non-empty")
-    if len(set(seed_schedule)) != len(seed_schedule):
-        raise ValueError("seeds must be unique")
-    if any(seed < 0 for seed in seed_schedule):
-        raise ValueError("seeds must be non-negative")
+    seed_schedule = require_unique_jax_seeds(seeds, name="seeds")
 
     stream = GauntletStream(frozen_stream_config())
     records: list[ConditionSeedRecord] = []

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -602,6 +602,8 @@ def run_scale_robust_feature_evaluation(
             stream while being recorded as different identities.
     """
 
+    if type(seeds) not in (list, tuple):
+        raise ValueError("seeds must be an actual list or tuple")
     seed_schedule = require_unique_jax_seeds(seeds, name="seeds")
 
     stream = GauntletStream(frozen_stream_config())

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -1,0 +1,100 @@
+"""Seed-domain contract for the scale-robust pair-feature evaluation entrypoint.
+
+``run_scale_robust_feature_evaluation`` is the executable protocol behind the
+registered ``scale_robust_pair_features`` evidence claim.  Its ``seeds``
+argument used to be canonicalized with a bare ``int(seed)`` call plus manual
+non-empty/unique/non-negative checks -- silently truncating floats, silently
+coercing ``bool``/numeric-string/other numeric types, and never bounding a
+seed to the JAX uint32 scalar-key domain.  ``jax.random.key`` reduces an
+out-of-range seed modulo ``2**32``, so two distinct declared seeds could
+silently execute the identical random stream while being recorded as
+different identities in the evidence artifact.
+
+These tests exercise only the validation boundary, which runs before any JAX
+computation starts, so they stay fast: a rejection must be raised before the
+(expensive) protocol would ever begin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework._seed_validation import JAX_KEY_SEED_MAX
+from alberta_framework.evaluation.scale_robust_feature import (
+    DEVELOPMENT_SEEDS,
+    EVIDENCE_SEEDS,
+    run_scale_robust_feature_evaluation,
+)
+
+
+class _ProtocolStartedError(Exception):
+    """Raised by the patched stream constructor once validation has passed."""
+
+
+@pytest.fixture(autouse=True)
+def _fail_if_protocol_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make any post-validation progress fail loudly and cheaply.
+
+    ``run_scale_robust_feature_evaluation`` constructs a ``GauntletStream``
+    immediately after validating ``seeds``.  Patching the constructor to
+    raise turns "validation silently passed" into a clear test failure
+    instead of a multi-minute JAX run.
+    """
+
+    import alberta_framework.evaluation.scale_robust_feature as module
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise _ProtocolStartedError("seed validation passed; protocol would have started")
+
+    monkeypatch.setattr(module, "GauntletStream", _boom)
+
+
+@pytest.mark.parametrize(
+    "bad_seeds",
+    [
+        pytest.param((True,), id="bool"),
+        pytest.param((False,), id="bool_false"),
+        pytest.param((5.9,), id="float_would_silently_truncate"),
+        pytest.param((5.0,), id="float_exact_value"),
+        pytest.param(("5",), id="numeric_string"),
+        pytest.param((JAX_KEY_SEED_MAX + 1,), id="above_uint32_domain"),
+        pytest.param((JAX_KEY_SEED_MAX + 1 + (1 << 40),), id="far_above_uint32_domain"),
+        pytest.param((-1,), id="negative"),
+    ],
+)
+def test_rejects_non_canonical_seed(bad_seeds: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError, match="seeds"):
+        run_scale_robust_feature_evaluation(seeds=bad_seeds)  # type: ignore[arg-type]
+
+
+def test_rejects_empty_seeds() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        run_scale_robust_feature_evaluation(seeds=())
+
+
+def test_rejects_duplicate_seeds() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        run_scale_robust_feature_evaluation(seeds=(5, 5))
+
+
+def test_out_of_range_seed_would_alias_an_in_range_seed() -> None:
+    """Document the exact corruption the domain bound prevents.
+
+    Without the ``[0, 2**32 - 1]`` bound, seed ``2**32`` would construct the
+    identical JAX key as seed ``0`` -- two declared identities, one actual
+    random stream.
+    """
+    import jax.random as jr
+
+    aliasing_seed = JAX_KEY_SEED_MAX + 1  # == 2**32, wraps to 0 mod 2**32
+    assert bool(jr.key_data(jr.key(0)).tolist() == jr.key_data(jr.key(aliasing_seed)).tolist())
+    with pytest.raises(ValueError):
+        run_scale_robust_feature_evaluation(seeds=(aliasing_seed,))
+
+
+def test_canonical_evidence_and_development_seeds_pass_validation() -> None:
+    """The frozen seed schedules validate cleanly (protocol start is stubbed)."""
+    with pytest.raises(_ProtocolStartedError):
+        run_scale_robust_feature_evaluation(seeds=EVIDENCE_SEEDS)
+    with pytest.raises(_ProtocolStartedError):
+        run_scale_robust_feature_evaluation(seeds=DEVELOPMENT_SEEDS)

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -77,6 +77,32 @@ def test_rejects_duplicate_seeds() -> None:
         run_scale_robust_feature_evaluation(seeds=(5, 5))
 
 
+def test_rejects_noncanonical_seed_container_before_hooks() -> None:
+    class ListSubclass(list[int]):
+        pass
+
+    class TupleSubclass(tuple[int, ...]):
+        pass
+
+    class SequenceSpoof:
+        @property  # type: ignore[misc]
+        def __class__(self) -> type:
+            return tuple
+
+        def __iter__(self) -> object:
+            raise AssertionError("iteration hook executed")
+
+        def __len__(self) -> int:
+            raise AssertionError("length hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook executed")
+
+    for bad_seeds in (ListSubclass([1]), TupleSubclass((1,)), SequenceSpoof()):
+        with pytest.raises(ValueError, match="actual list or tuple"):
+            run_scale_robust_feature_evaluation(seeds=bad_seeds)  # type: ignore[arg-type]
+
+
 def test_out_of_range_seed_would_alias_an_in_range_seed() -> None:
     """Document the exact corruption the domain bound prevents.
 


### PR DESCRIPTION
Supersedes and completes #781 while preserving its contributor commit and authorship.

The original correctly replaces coercive per-seed handling with the shared uint32 JAX-key validator, preventing bool/float/string acceptance and modulo-2**32 seed aliasing. The repair also closes the container boundary before iteration: only exact list or tuple schedules are admitted, while subclasses and class-spoofed objects are rejected without invoking iterator, length, or repr hooks.

Verification at `09789fcdb285f5a326aff4ecaf5c5d9872f49e86`:
- 77 scale-robust protocol/artifact/CLI tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

This intentionally changes a registered scale-robust evidence source, so the pinned historical claim remains fail-closed invalid until a separately authorized frozen rerun. No output artifact was modified and no run was launched.
