### PR TITLE
fix(dual-replay): normalize hostile scalar hooks

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -478,11 +478,15 @@ def _require_float32_real(
         if not in_domain(real_value):
             raise ValueError
         narrowed = round_real_to_float32(real_value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+    except Exception as error:
         raise ValueError(f"{name} must be finite and {domain}") from error
     if not math.isfinite(narrowed):
         raise ValueError(f"{name} must narrow to a finite float32")
-    if real_value != 0 and narrowed == 0.0:
+    try:
+        exact_nonzero = bool(real_value != 0)
+    except Exception as error:
+        raise ValueError(f"{name} must be finite and {domain}") from error
+    if exact_nonzero and narrowed == 0.0:
         raise ValueError(f"{name} must not underflow to zero in float32")
     if not in_domain(narrowed):
         raise ValueError(f"{name} must remain {domain} once narrowed to float32")

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -747,6 +747,26 @@ class _FloatSpoof:
     __hash__ = None  # type: ignore[assignment]
 
 
+class _HostileFloat(float):
+    """An actual Real whose untrusted exact-ratio hook raises."""
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("untrusted ratio hook")
+
+    def __repr__(self) -> str:
+        raise AssertionError("repr hook executed")
+
+
+class _HostileNonzeroFloat(float):
+    """A Real whose ratio is readable but whose nonzero hook raises."""
+
+    def __ne__(self, other: object) -> bool:
+        raise RuntimeError("untrusted nonzero hook")
+
+    def __repr__(self) -> str:
+        raise AssertionError("repr hook executed")
+
+
 @pytest.mark.parametrize(
     ("field", "ratio"),
     [
@@ -780,6 +800,15 @@ def test_config_accepts_honest_float_subclasses_as_canonical_floats() -> None:
     payload = memory.to_config()
     json.dumps(payload, allow_nan=False)
     assert DualReplayMemory.from_config(payload).config == memory.config
+
+
+@pytest.mark.parametrize("field", _FLOAT32_SCALARS)
+def test_config_normalizes_hostile_float_hook_failures_without_repr(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: _HostileFloat(0.5)})
+
+    with pytest.raises(ValueError, match=field):
+        _strict_memory(**{field: _HostileNonzeroFloat(0.5)})
 
 
 def test_config_rejects_calibration_weights_whose_float32_sum_overflows_without_warnings() -> None:


### PR DESCRIPTION
Retains the unique hostile-scalar correction from #778 while omitting its unsupported signed-int32 allocation ceiling. Dual replay records persistent byte accounting in uint32, so rejecting otherwise valid states above signed-int32 bytes would arbitrarily halve the documented domain.

The exact-ratio scalar contract now normalizes ordinary exceptions from both `as_integer_ratio` and the subsequent nonzero comparison to field-scoped `ValueError`, without evaluating hostile `repr`. The added regression covers both hook positions across every float32 configuration field.

Contributor authorship is preserved on the commit. Supersedes #778.

Validation:
- `pytest tests/test_dual_replay.py -q` (168 passed)
- `ruff check alberta_framework/core/dual_replay.py tests/test_dual_replay.py`
- `mypy alberta_framework/core/dual_replay.py`

No benchmarks were run and no outputs were modified.