### PR TITLE
fix(recurrent-actor-critic): validate scalar and resource contracts

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -267,12 +267,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
-def _validated_config_float(name: str, value: object) -> float:
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     if type(value) is bool or type(value) is np.bool_:
         raise ValueError(f"{name} must be numeric, not bool")
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
-    normalized = validated_float32_scalar(name, value)
+    try:
+        magnitude = abs(float(cast(Any, value)))
+    except Exception as error:
+        raise ValueError(
+            f"{name} must be exactly zero or representable as a finite normal float32"
+        ) from error
+    if magnitude > _FLOAT32_MAX or (magnitude != 0.0 and magnitude < _FLOAT32_TINY):
+        raise ValueError(
+            f"{name} must be exactly zero or representable as a finite normal float32"
+        )
+    normalized = validated_float32_scalar(name, value, **bounds)
     _validate_normal_float32_config_value(name, normalized)
     return normalized
 
@@ -334,7 +344,10 @@ def _preflight_state_resources(
         + 4 * width
         + 3
     )
-    logical_scalars = float32_scalars + 7
+    # Four int32 leaves, one typed-key leaf, and one bool leaf are the six
+    # non-float logical scalars. The typed key occupies two uint32 words, so
+    # the independently derived byte count remains one byte above 4 * scalars.
+    logical_scalars = float32_scalars + 6
     state_nbytes = 4 * (float32_scalars + 6) + 1
     resources = {
         "parameter_scalars": parameters,
@@ -426,32 +439,32 @@ class RecurrentTraceActorCriticConfig:
         object.__setattr__(self, "encoder_width", encoder_width)
         object.__setattr__(self, "output_width", output_width)
 
-        numeric_values = (
-            ("gamma", self.gamma),
-            ("actor_lamda", self.actor_lamda),
-            ("critic_lamda", self.critic_lamda),
-            ("actor_alpha", self.actor_alpha),
-            ("critic_alpha", self.critic_alpha),
-            ("actor_kappa", self.actor_kappa),
-            ("critic_kappa", self.critic_kappa),
-            ("entropy_coefficient", self.entropy_coefficient),
-            ("temperature", self.temperature),
-            ("sparsity", self.sparsity),
-            ("r_min", self.r_min),
-            ("r_max", self.r_max),
-            ("max_phase", self.max_phase),
-            ("rtu_epsilon", self.rtu_epsilon),
-            ("layer_norm_epsilon", self.layer_norm_epsilon),
-            ("leaky_relu_slope", self.leaky_relu_slope),
-            ("normalization_epsilon", self.normalization_epsilon),
-            ("beta2", self.beta2),
-            ("epsilon", self.epsilon),
-        )
-        for numeric_name, numeric_value in numeric_values:
+        float_domains: dict[str, dict[str, Any]] = {
+            "gamma": {"lower": 0.0, "upper": 1.0},
+            "actor_lamda": {"lower": 0.0, "upper": 1.0},
+            "critic_lamda": {"lower": 0.0, "upper": 1.0},
+            "actor_alpha": {"lower": 0.0},
+            "critic_alpha": {"lower": 0.0},
+            "actor_kappa": {"positive": True},
+            "critic_kappa": {"positive": True},
+            "entropy_coefficient": {"lower": 0.0},
+            "temperature": {"positive": True},
+            "sparsity": {"lower": 0.0, "upper": 1.0, "upper_inclusive": False},
+            "r_min": {"lower": 0.0, "upper": 1.0},
+            "r_max": {"positive": True, "upper": 1.0},
+            "max_phase": {"positive": True, "upper": 2.0 * math.pi},
+            "rtu_epsilon": {"positive": True, "upper": 1.0, "upper_inclusive": False},
+            "layer_norm_epsilon": {"positive": True},
+            "leaky_relu_slope": {"lower": 0.0},
+            "normalization_epsilon": {"positive": True},
+            "beta2": {"lower": 0.0, "upper": 1.0, "upper_inclusive": False},
+            "epsilon": {"positive": True},
+        }
+        for numeric_name, bounds in float_domains.items():
             object.__setattr__(
                 self,
                 numeric_name,
-                _validated_config_float(numeric_name, numeric_value),
+                _validated_config_float(numeric_name, getattr(self, numeric_name), **bounds),
             )
 
         for interval_name, interval_value in (
@@ -521,7 +534,7 @@ class RecurrentTraceActorCriticConfig:
             ("adaptive_obgd", self.adaptive_obgd),
         ):
             if type(value) is not bool:
-                raise ValueError(f"{name} must be an exact bool")
+                raise ValueError(f"{name} must be a bool")
         _preflight_state_resources(self, 1)
 
     def state_resource_budget(self, feature_dim: object) -> dict[str, int]:

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2083,9 +2083,18 @@ def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
         "parameter_scalars": 124,
         "sensitivity_scalars_per_network": 36,
         "float32_state_scalars": 343,
-        "state_scalars": 350,
+        "state_scalars": 349,
         "state_nbytes": 1397,
     }
+
+    state = RecurrentTraceActorCriticAgent(config).init(2, jr.key(7))
+    leaves = jax.tree_util.tree_leaves(state)
+    assert config.state_resource_budget(2)["state_scalars"] == sum(
+        int(leaf.size) for leaf in leaves
+    )
+    assert config.state_resource_budget(2)["state_nbytes"] == sum(
+        int(leaf.nbytes) for leaf in leaves
+    )
 
     def forbidden_split(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("RNG split must not run before resource validation")
@@ -2093,6 +2102,89 @@ def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
     monkeypatch.setattr(recurrent_trace_module.jr, "split", forbidden_split)
     with pytest.raises(ValueError, match="derived"):
         RecurrentTraceActorCriticAgent(config).init(2**31 - 1, jr.key(0))
+
+
+@pytest.mark.parametrize("field", ("n_actions", "hidden_size", "encoder_width", "output_width"))
+@pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_config_accepts_every_representable_numpy_integer_family(
+    field: str, code: str
+) -> None:
+    arguments: dict[str, Any] = {"n_actions": 2, field: np.dtype(code).type(3)}
+    config = RecurrentTraceActorCriticConfig(**arguments)
+    assert type(getattr(config, field)) is int
+    assert getattr(config, field) == 3
+
+
+@pytest.mark.parametrize(
+    ("field", "valid"),
+    (
+        ("gamma", 0.5),
+        ("actor_lamda", 0.5),
+        ("critic_lamda", 0.5),
+        ("actor_alpha", 0.5),
+        ("critic_alpha", 0.5),
+        ("actor_kappa", 0.5),
+        ("critic_kappa", 0.5),
+        ("entropy_coefficient", 0.5),
+        ("temperature", 0.5),
+        ("sparsity", 0.5),
+        ("r_min", 0.25),
+        ("r_max", 0.75),
+        ("max_phase", 0.5),
+        ("rtu_epsilon", 0.5),
+        ("layer_norm_epsilon", 0.5),
+        ("leaky_relu_slope", 0.5),
+        ("normalization_epsilon", 0.5),
+        ("beta2", 0.5),
+        ("epsilon", 0.5),
+    ),
+)
+@pytest.mark.parametrize("code", ("e", "f", "d", "g"))
+def test_config_accepts_and_canonicalizes_numpy_float_families(
+    field: str, valid: float, code: str
+) -> None:
+    config = RecurrentTraceActorCriticConfig(
+        n_actions=2,
+        **{field: np.dtype(code).type(valid)},
+    )
+    assert type(getattr(config, field)) is float
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("gamma", np.nextafter(np.float64(1.0), np.float64(2.0))),
+        ("sparsity", np.nextafter(np.float64(1.0), np.float64(0.0))),
+        ("beta2", np.nextafter(np.float64(1.0), np.float64(0.0))),
+    ),
+)
+def test_config_rejects_exact_host_values_that_round_across_float32_bounds(
+    field: str, value: np.float64
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        RecurrentTraceActorCriticConfig(n_actions=2, **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("taylor", "adaptive"),
+    ((False, False), (True, False), (False, True), (True, True)),
+)
+def test_state_resource_budget_matches_optional_state_trees(
+    taylor: bool, adaptive: bool
+) -> None:
+    config = RecurrentTraceActorCriticConfig(
+        n_actions=3,
+        hidden_size=4,
+        encoder_width=5,
+        output_width=6,
+        rtrl_taylor_correction=taylor,
+        adaptive_obgd=adaptive,
+    )
+    state = RecurrentTraceActorCriticAgent(config).init(7, jr.key(5))
+    leaves = jax.tree_util.tree_leaves(state)
+    budget = config.state_resource_budget(7)
+    assert budget["state_scalars"] == sum(int(leaf.size) for leaf in leaves)
+    assert budget["state_nbytes"] == sum(int(leaf.nbytes) for leaf in leaves)
 
 
 def test_canonical_discrete_architecture_defaults_and_core_export() -> None:


### PR DESCRIPTION
## Summary
- supersedes #756 while preserving Kayvan Zahiri contributor attribution
- rebased after main integrated the original narrow integer patch; this branch now contains only residual hardening missing from current main
- validates exact host and narrowed float32 endpoint domains for every recurrent actor-critic scalar, including NumPy values that otherwise round across closed or half-open bounds
- corrects the logical state-scalar budget for the typed JAX key representation while retaining the independently exact byte formula and existing state_resource_budget API
- preserves current serialization schemas, default canonical JSON hashes, valid eager/JIT behavior, and all current-main integrated contracts

## Audit result
Current main already contains the direct integer validation, resource preflight, and serialization work integrated from the original PR. The residual audit found two concrete gaps: NumPy host values outside an endpoint could round into an accepted float32 value, and state_scalars counted one more logical leaf than the initialized state actually owns. Tests measure all four Taylor/adaptive state-tree variants directly. No registered evidence source or pinned output is changed.

## Verification
- 290 tests passed in the full recurrent_trace_actor_critic + rtu_taylor_correction rerun; the sole compatibility-message failure exposed by that run was fixed and its targeted rerun passed
- 127 focused scalar/resource/hostile/default tests passed after the current-main rebase
- Ruff clean
- strict mypy clean
- git diff --check clean
- earlier pre-integration Forager consumer panel: 16 passed

Supersedes #756.