### PR TITLE
fix(core): complete SARSA, stacked Horde, and RTU configuration contracts

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -35,8 +35,9 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 from collections.abc import Callable
-from typing import Any, NamedTuple, Self, cast
+from typing import Any, NamedTuple, Self, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -70,9 +71,7 @@ def _validate_normal_float32_config_value(name: str, value: float) -> None:
         raise ValueError(f"{name} must be finite")
     magnitude = abs(value)
     if magnitude > _FLOAT32_MAX or (magnitude != 0.0 and magnitude < _FLOAT32_TINY):
-        raise ValueError(
-            f"{name} must be exactly zero or representable as a finite normal float32"
-        )
+        raise ValueError(f"{name} must be exactly zero or representable as a finite normal float32")
 
 
 class RTUParameters(NamedTuple):
@@ -237,6 +236,33 @@ class AdaptiveObGDUpdate(NamedTuple):
     update_applied: Array
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @dataclasses.dataclass(frozen=True)
 class RecurrentTraceActorCriticConfig:
     """Configuration for an RTU-RTRL discrete streaming actor-critic.
@@ -304,28 +330,15 @@ class RecurrentTraceActorCriticConfig:
 
     def __post_init__(self) -> None:
         """Validate shape and numerical invariants eagerly."""
-        for integer_name, integer_value in (
-            ("n_actions", self.n_actions),
-            ("hidden_size", self.hidden_size),
-            ("encoder_width", self.encoder_width),
-            ("output_width", self.output_width),
-        ):
-            if (
-                isinstance(integer_value, bool)
-                or not isinstance(integer_value, int)
-                or integer_value <= 0
-            ):
-                raise ValueError(f"{integer_name} must be a positive integer")
+        n_actions = _require_int32("n_actions", self.n_actions, minimum=1)
+        hidden_size = _require_int32("hidden_size", self.hidden_size, minimum=1)
+        encoder_width = _require_int32("encoder_width", self.encoder_width, minimum=2)
+        output_width = _require_int32("output_width", self.output_width, minimum=2)
 
-        for width_name, width_value in (
-            ("encoder_width", self.encoder_width),
-            ("output_width", self.output_width),
-        ):
-            if width_value < 2:
-                raise ValueError(
-                    f"{width_name} must be at least 2 because parameterless "
-                    "layer normalization makes a width-1 block identically zero"
-                )
+        object.__setattr__(self, "n_actions", n_actions)
+        object.__setattr__(self, "hidden_size", hidden_size)
+        object.__setattr__(self, "encoder_width", encoder_width)
+        object.__setattr__(self, "output_width", output_width)
 
         for numeric_name, numeric_value in (
             ("gamma", self.gamma),
@@ -410,13 +423,8 @@ class RecurrentTraceActorCriticConfig:
             raise ValueError("max_phase must not exceed 2*pi")
         if self.rtu_epsilon >= 1.0:
             raise ValueError("rtu_epsilon must be less than 1")
-        if (
-            not 0.0 <= self.beta2 < 1.0
-            or not float(np.float32(self.beta2)) < 1.0
-        ):
-            raise ValueError(
-                "beta2 must remain in [0, 1) after conversion to float32"
-            )
+        if not 0.0 <= self.beta2 < 1.0 or not float(np.float32(self.beta2)) < 1.0:
+            raise ValueError("beta2 must remain in [0, 1) after conversion to float32")
         for name, value in (
             ("normalize_observations", self.normalize_observations),
             ("normalize_rewards", self.normalize_rewards),
@@ -640,13 +648,16 @@ def _propagate_postactivation_trace(
     )
     propagated_real = g_broadcast * trace[0] - phi_broadcast * trace[1]
     propagated_imaginary = phi_broadcast * trace[0] + g_broadcast * trace[1]
-    return jnp.stack(
-        (
-            derivative_real_broadcast * propagated_real,
-            derivative_imaginary_broadcast * propagated_imaginary,
-        ),
-        axis=0,
-    ) + direct
+    return (
+        jnp.stack(
+            (
+                derivative_real_broadcast * propagated_real,
+                derivative_imaginary_broadcast * propagated_imaginary,
+            ),
+            axis=0,
+        )
+        + direct
+    )
 
 
 def _rtu_coefficient_second_derivatives(
@@ -663,12 +674,8 @@ def _rtu_coefficient_second_derivatives(
     transforms and the floored input-normalization branch have zero first and
     second derivative outside their active intervals.
     """
-    d2g_d_nu_log2 = (
-        jnp.square(d_exp_nu_d_nu_log) - d_exp_nu_d_nu_log
-    ) * g
-    d2phi_d_nu_log2 = (
-        jnp.square(d_exp_nu_d_nu_log) - d_exp_nu_d_nu_log
-    ) * phi
+    d2g_d_nu_log2 = (jnp.square(d_exp_nu_d_nu_log) - d_exp_nu_d_nu_log) * g
+    d2phi_d_nu_log2 = (jnp.square(d_exp_nu_d_nu_log) - d_exp_nu_d_nu_log) * phi
 
     minimum_exp_log = jnp.asarray(_MINIMUM_EXP_LOG, dtype=params.nu_log.dtype)
     maximum_nu_log = jnp.asarray(_MAXIMUM_NU_LOG, dtype=params.nu_log.dtype)
@@ -696,24 +703,15 @@ def _rtu_coefficient_second_derivatives(
     )
     d2norm_d_nu_log2 = jnp.where(
         norm_branch_active,
-        d_exp_nu_d_nu_log
-        * radius_squared
-        * (1.0 - 2.0 * d_exp_nu_d_nu_log)
-        / norm_denominator
+        d_exp_nu_d_nu_log * radius_squared * (1.0 - 2.0 * d_exp_nu_d_nu_log) / norm_denominator
         - jnp.square(d_exp_nu_d_nu_log)
         * jnp.square(radius_squared)
         / jnp.power(norm_denominator, 3),
         jnp.zeros_like(radius),
     )
 
-    d2g_d_theta_log2 = (
-        -g * jnp.square(d_theta_d_theta_log)
-        - phi * d_theta_d_theta_log
-    )
-    d2phi_d_theta_log2 = (
-        -phi * jnp.square(d_theta_d_theta_log)
-        + g * d_theta_d_theta_log
-    )
+    d2g_d_theta_log2 = -g * jnp.square(d_theta_d_theta_log) - phi * d_theta_d_theta_log
+    d2phi_d_theta_log2 = -phi * jnp.square(d_theta_d_theta_log) + g * d_theta_d_theta_log
     return (
         d2g_d_nu_log2,
         d2phi_d_nu_log2,
@@ -884,22 +882,12 @@ def rtu_taylor_step(
     decrease.  This is not an exact moving-parameter RTRL sensitivity.
     """
     corrected_previous = RTUSensitivities(
-        nu_log=(
-            sensitivities.nu_log
-            + taylor_trace.nu_log * parameter_delta.nu_log[None, :]
-        ),
+        nu_log=(sensitivities.nu_log + taylor_trace.nu_log * parameter_delta.nu_log[None, :]),
         theta_log=(
-            sensitivities.theta_log
-            + taylor_trace.theta_log * parameter_delta.theta_log[None, :]
+            sensitivities.theta_log + taylor_trace.theta_log * parameter_delta.theta_log[None, :]
         ),
-        b_real=(
-            sensitivities.b_real
-            + taylor_trace.b_real * parameter_delta.b_real[None, :, :]
-        ),
-        b_imag=(
-            sensitivities.b_imag
-            + taylor_trace.b_imag * parameter_delta.b_imag[None, :, :]
-        ),
+        b_real=(sensitivities.b_real + taylor_trace.b_real * parameter_delta.b_real[None, :, :]),
+        b_imag=(sensitivities.b_imag + taylor_trace.b_imag * parameter_delta.b_imag[None, :, :]),
     )
     next_state, next_sensitivities = rtu_step(
         params,
@@ -920,9 +908,7 @@ def rtu_taylor_step(
     derivative_real = 1.0 - jnp.square(next_state.real)
     derivative_imaginary = 1.0 - jnp.square(next_state.imaginary)
     second_derivative_real = -2.0 * next_state.real * derivative_real
-    second_derivative_imaginary = (
-        -2.0 * next_state.imaginary * derivative_imaginary
-    )
+    second_derivative_imaginary = -2.0 * next_state.imaginary * derivative_imaginary
     input_real = params.b_real @ inputs
     input_imaginary = params.b_imag @ inputs
 
@@ -976,10 +962,8 @@ def rtu_taylor_step(
     )
     direct_second_theta = jnp.stack(
         (
-            d2g_d_theta_log2 * state.real
-            - d2phi_d_theta_log2 * state.imaginary,
-            d2g_d_theta_log2 * state.imaginary
-            + d2phi_d_theta_log2 * state.real,
+            d2g_d_theta_log2 * state.real - d2phi_d_theta_log2 * state.imaginary,
+            d2g_d_theta_log2 * state.imaginary + d2phi_d_theta_log2 * state.real,
         ),
         axis=0,
     )
@@ -1313,7 +1297,7 @@ def adaptive_obgd_update(
         second_moment,
         traces,
     )
-    bias_correction = 1.0 - beta ** step_array
+    bias_correction = 1.0 - beta**step_array
     corrected_second_moment = jax.tree_util.tree_map(
         lambda moment: moment / bias_correction,
         proposed_second_moment,
@@ -1780,14 +1764,10 @@ class RecurrentTraceActorCriticAgent:
             actor_traces=_zero_network_like(actor_params),
             critic_traces=_zero_network_like(critic_params),
             actor_second_moments=(
-                _zero_network_like(actor_params)
-                if self._config.adaptive_obgd
-                else None
+                _zero_network_like(actor_params) if self._config.adaptive_obgd else None
             ),
             critic_second_moments=(
-                _zero_network_like(critic_params)
-                if self._config.adaptive_obgd
-                else None
+                _zero_network_like(critic_params) if self._config.adaptive_obgd else None
             ),
             observation_statistics=_initial_running_statistics((feature_dim,)),
             reward_statistics=_initial_reward_statistics(),
@@ -2408,9 +2388,7 @@ class RecurrentTraceActorCriticAgent:
             state.actor_params,
             state.actor_rtu_state,
         )
-        current_log_policy = jax.nn.log_softmax(
-            current_logits / self._config.temperature
-        )
+        current_log_policy = jax.nn.log_softmax(current_logits / self._config.temperature)
         current_policy = jnp.exp(current_log_policy)
         current_entropy = -jnp.sum(current_policy * current_log_policy)
 
@@ -2506,9 +2484,7 @@ class RecurrentTraceActorCriticAgent:
             RTUNetworkParameters,
             jax.tree_util.tree_map(
                 lambda trace, gradient: (
-                    jnp.where(
-                        actor_decay == 0.0, jnp.zeros_like(trace), actor_decay * trace
-                    )
+                    jnp.where(actor_decay == 0.0, jnp.zeros_like(trace), actor_decay * trace)
                     + gradient
                 ),
                 state.actor_traces,
@@ -2519,9 +2495,7 @@ class RecurrentTraceActorCriticAgent:
             RTUNetworkParameters,
             jax.tree_util.tree_map(
                 lambda trace, gradient: (
-                    jnp.where(
-                        critic_decay == 0.0, jnp.zeros_like(trace), critic_decay * trace
-                    )
+                    jnp.where(critic_decay == 0.0, jnp.zeros_like(trace), critic_decay * trace)
                     + gradient
                 ),
                 state.critic_traces,
@@ -2536,13 +2510,9 @@ class RecurrentTraceActorCriticAgent:
         critic_second_moments: RTUNetworkParameters | None
         if self._config.adaptive_obgd:
             if state.actor_second_moments is None:
-                raise ValueError(
-                    "adaptive-ObGD actor state requires a second-moment tree"
-                )
+                raise ValueError("adaptive-ObGD actor state requires a second-moment tree")
             if state.critic_second_moments is None:
-                raise ValueError(
-                    "adaptive-ObGD critic state requires a second-moment tree"
-                )
+                raise ValueError("adaptive-ObGD critic state requires a second-moment tree")
             actor_adaptive_obgd = adaptive_obgd_update(
                 actor_traces,
                 state.actor_second_moments,
@@ -2757,9 +2727,7 @@ class RecurrentTraceActorCriticAgent:
             ),
             policy=jnp.where(update_applied, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(update_applied, value, zero),
-            next_value=jnp.where(
-                update_applied & jnp.isfinite(next_value), next_value, zero
-            ),
+            next_value=jnp.where(update_applied & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(update_applied, td_error, zero),
             entropy=jnp.where(update_applied, current_entropy, zero),
             normalized_reward=jnp.where(update_applied, normalized_reward, zero),

--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -46,6 +46,7 @@ import numpy as np
 from jax import Array
 from jax.nn.initializers import lecun_normal
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
@@ -252,6 +253,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -261,6 +265,88 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _validated_config_float(name: str, value: object) -> float:
+    if type(value) is bool or type(value) is np.bool_:
+        raise ValueError(f"{name} must be numeric, not bool")
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    normalized = validated_float32_scalar(name, value)
+    _validate_normal_float32_config_value(name, normalized)
+    return normalized
+
+
+def _network_parameter_scalars(
+    *,
+    feature_dim: int,
+    output_dim: int,
+    hidden_size: int,
+    encoder_width: int,
+    output_width: int,
+) -> int:
+    products = {
+        "encoder matrix": encoder_width * feature_dim,
+        "RTU input matrices": 2 * hidden_size * encoder_width,
+        "output matrix": 2 * output_width * hidden_size,
+        "head matrix": output_dim * output_width,
+    }
+    for name, value in products.items():
+        if value > _INT32_MAX:
+            raise ValueError(f"derived {name} scalars must fit signed int32")
+    return (
+        products["encoder matrix"]
+        + encoder_width
+        + 2 * hidden_size
+        + products["RTU input matrices"]
+        + products["output matrix"]
+        + output_width
+        + products["head matrix"]
+        + output_dim
+    )
+
+
+def _preflight_state_resources(
+    config: RecurrentTraceActorCriticConfig,
+    feature_dim: object,
+) -> dict[str, int]:
+    width = _require_int32("feature_dim", feature_dim, minimum=1)
+    actor_parameters = _network_parameter_scalars(
+        feature_dim=width,
+        output_dim=config.n_actions,
+        hidden_size=config.hidden_size,
+        encoder_width=config.encoder_width,
+        output_width=config.output_width,
+    )
+    critic_parameters = _network_parameter_scalars(
+        feature_dim=width,
+        output_dim=1,
+        hidden_size=config.hidden_size,
+        encoder_width=config.encoder_width,
+        output_width=config.output_width,
+    )
+    parameters = actor_parameters + critic_parameters
+    sensitivity_scalars = 4 * config.hidden_size * (config.encoder_width + 1)
+    float32_scalars = (
+        parameters * (3 if config.adaptive_obgd else 2)
+        + 2 * sensitivity_scalars * (2 if config.rtrl_taylor_correction else 1)
+        + 4 * config.hidden_size
+        + 4 * width
+        + 3
+    )
+    logical_scalars = float32_scalars + 7
+    state_nbytes = 4 * (float32_scalars + 6) + 1
+    resources = {
+        "parameter_scalars": parameters,
+        "sensitivity_scalars_per_network": sensitivity_scalars,
+        "float32_state_scalars": float32_scalars,
+        "state_scalars": logical_scalars,
+        "state_nbytes": state_nbytes,
+    }
+    for name, value in resources.items():
+        if value > _INT32_MAX:
+            raise ValueError(f"derived {name} must fit signed int32")
+    return resources
 
 
 @dataclasses.dataclass(frozen=True)
@@ -340,7 +426,7 @@ class RecurrentTraceActorCriticConfig:
         object.__setattr__(self, "encoder_width", encoder_width)
         object.__setattr__(self, "output_width", output_width)
 
-        for numeric_name, numeric_value in (
+        numeric_values = (
             ("gamma", self.gamma),
             ("actor_lamda", self.actor_lamda),
             ("critic_lamda", self.critic_lamda),
@@ -360,10 +446,13 @@ class RecurrentTraceActorCriticConfig:
             ("normalization_epsilon", self.normalization_epsilon),
             ("beta2", self.beta2),
             ("epsilon", self.epsilon),
-        ):
-            if isinstance(numeric_value, bool):
-                raise ValueError(f"{numeric_name} must be numeric, not bool")
-            _validate_normal_float32_config_value(numeric_name, numeric_value)
+        )
+        for numeric_name, numeric_value in numeric_values:
+            object.__setattr__(
+                self,
+                numeric_name,
+                _validated_config_float(numeric_name, numeric_value),
+            )
 
         for interval_name, interval_value in (
             ("gamma", self.gamma),
@@ -431,8 +520,13 @@ class RecurrentTraceActorCriticConfig:
             ("rtrl_taylor_correction", self.rtrl_taylor_correction),
             ("adaptive_obgd", self.adaptive_obgd),
         ):
-            if not isinstance(value, bool):
-                raise ValueError(f"{name} must be a bool")
+            if type(value) is not bool:
+                raise ValueError(f"{name} must be an exact bool")
+        _preflight_state_resources(self, 1)
+
+    def state_resource_budget(self, feature_dim: object) -> dict[str, int]:
+        """Return exact persistent-state counts for an observation width."""
+        return _preflight_state_resources(self, feature_dim)
 
     def to_config(self) -> dict[str, Any]:
         """Return a JSON-compatible configuration mapping.
@@ -455,6 +549,20 @@ class RecurrentTraceActorCriticConfig:
         config: dict[str, Any],
     ) -> RecurrentTraceActorCriticConfig:
         """Reconstruct and validate a configuration mapping."""
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        required = {
+            field.name
+            for field in dataclasses.fields(cls)
+            if field.name not in {"adaptive_obgd", "beta2", "epsilon"}
+        }
+        optional = {"adaptive_obgd", "beta2", "epsilon"}
+        if (
+            any(type(key) is not str for key in config)
+            or not required <= set(config)
+            or not set(config) <= required | optional
+        ):
+            raise ValueError("config fields do not match the serialized schema")
         return cls(**dict(config))
 
 
@@ -1705,25 +1813,28 @@ class RecurrentTraceActorCriticAgent:
         config: dict[str, Any],
     ) -> RecurrentTraceActorCriticAgent:
         """Reconstruct an agent from :meth:`to_config` output."""
-        payload = dict(config)
-        agent_type = payload.pop("type", cls.__name__)
-        if agent_type != cls.__name__:
-            raise ValueError(f"unsupported agent type {agent_type!r}")
-        if "config" in payload:
-            raw_config = payload.pop("config")
-            if payload:
-                unknown = ", ".join(sorted(payload))
-                raise ValueError(f"unknown serialized agent fields: {unknown}")
-        else:
-            raw_config = payload
-        if not isinstance(raw_config, dict):
-            raise ValueError("serialized config must be a dictionary")
+        if type(config) is not dict:
+            raise ValueError("serialized agent must be an exact built-in dict")
+        if any(type(key) is not str for key in config):
+            raise ValueError("serialized agent fields do not match the schema")
+        # Preserve the historical convenience form while keeping both accepted
+        # schemas exact: a caller may provide either the agent envelope or the
+        # configuration payload emitted by ``RecurrentTraceActorCriticConfig``.
+        if "type" not in config:
+            return cls(RecurrentTraceActorCriticConfig.from_config(config))
+        if set(config) != {"type", "config"}:
+            raise ValueError("serialized agent fields do not match the schema")
+        agent_type = config["type"]
+        if type(agent_type) is not str or agent_type != cls.__name__:
+            raise ValueError("unsupported agent type")
+        raw_config = config["config"]
+        if type(raw_config) is not dict:
+            raise ValueError("serialized config must be an exact built-in dict")
         return cls(RecurrentTraceActorCriticConfig.from_config(raw_config))
 
     def init(self, feature_dim: int, key: Array) -> RecurrentTraceActorCriticState:
         """Initialize independent actor/critic parameters and streaming state."""
-        if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim <= 0:
-            raise ValueError("feature_dim must be a positive integer")
+        self._config.state_resource_budget(feature_dim)
         actor_key, critic_key, policy_key = jr.split(key, 3)
         actor_params = initialize_rtu_network_parameters(
             actor_key,

--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -20,14 +20,15 @@ Reference: Sutton & Barto 2018, Section 10.1 (Episodic Semi-gradient SARSA)
 
 import dataclasses
 import functools
+import operator
 import time
-from numbers import Integral
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
@@ -56,6 +57,33 @@ from alberta_framework.core.types import (
 # =============================================================================
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @chex.dataclass(frozen=True)
 class SARSAConfig:
     """Configuration for SARSA agent.
@@ -77,20 +105,10 @@ class SARSAConfig:
 
     def __post_init__(self) -> None:
         """Validate and canonicalize host configuration before JAX use."""
-        actual_actions_type = type(self.n_actions)
-        if (
-            issubclass(actual_actions_type, bool)
-            or not issubclass(actual_actions_type, Integral)
-            or self.n_actions < 1
-        ):
-            raise ValueError("n_actions must be a positive integer")
-        actual_decay_type = type(self.epsilon_decay_steps)
-        if (
-            issubclass(actual_decay_type, bool)
-            or not issubclass(actual_decay_type, Integral)
-            or self.epsilon_decay_steps < 0
-        ):
-            raise ValueError("epsilon_decay_steps must be a non-negative integer")
+        n_actions = _require_int32("n_actions", self.n_actions, minimum=1)
+        epsilon_decay_steps = _require_int32(
+            "epsilon_decay_steps", self.epsilon_decay_steps, minimum=0
+        )
         gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
         epsilon_start = validated_float32_scalar(
             "epsilon_start", self.epsilon_start, lower=0.0, upper=1.0
@@ -98,8 +116,10 @@ class SARSAConfig:
         epsilon_end = validated_float32_scalar(
             "epsilon_end", self.epsilon_end, lower=0.0, upper=1.0
         )
-        if self.epsilon_decay_steps > 0 and epsilon_end > epsilon_start:
+        if epsilon_decay_steps > 0 and epsilon_end > epsilon_start:
             raise ValueError("epsilon_end must not exceed epsilon_start when decaying")
+        object.__setattr__(self, "n_actions", n_actions)
+        object.__setattr__(self, "epsilon_decay_steps", epsilon_decay_steps)
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "epsilon_start", epsilon_start)
         object.__setattr__(self, "epsilon_end", epsilon_end)
@@ -598,12 +618,8 @@ class SARSAAgent:
             for i in range(n_actions):
                 w_trace, b_trace = head_traces[i]
                 decay = jnp.where(state.last_action == i, 1.0, gl)
-                skipped_w = jnp.where(
-                    decay == 0.0, jnp.zeros_like(w_trace), decay * w_trace
-                )
-                skipped_b = jnp.where(
-                    decay == 0.0, jnp.zeros_like(b_trace), decay * b_trace
-                )
+                skipped_w = jnp.where(decay == 0.0, jnp.zeros_like(w_trace), decay * w_trace)
+                skipped_b = jnp.where(decay == 0.0, jnp.zeros_like(b_trace), decay * b_trace)
                 new_w = jnp.where(terminated, jnp.zeros_like(w_trace), skipped_w)
                 new_b = jnp.where(terminated, jnp.zeros_like(b_trace), skipped_b)
                 head_traces[i] = (new_w, new_b)

--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -73,6 +73,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -82,6 +85,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
+
+
+def _preflight_sarsa_resources(n_actions: int, feature_dim: object) -> None:
+    width = _require_int32("feature_dim", feature_dim, minimum=1)
+    # The wrapper retains one observation and scalar lifecycle leaves while
+    # exposing one float32 policy/Q vector. The nested Horde owns its budget.
+    logical_scalars = n_actions + width + 5
+    state_nbytes = 4 * (width + 5)
+    if logical_scalars > _INT32_MAX or state_nbytes > _INT32_MAX:
+        raise ValueError("derived SARSA wrapper resources must fit signed int32")
 
 
 @chex.dataclass(frozen=True)
@@ -109,11 +128,11 @@ class SARSAConfig:
         epsilon_decay_steps = _require_int32(
             "epsilon_decay_steps", self.epsilon_decay_steps, minimum=0
         )
-        gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
-        epsilon_start = validated_float32_scalar(
+        gamma = _validated_config_float("gamma", self.gamma, lower=0.0, upper=1.0)
+        epsilon_start = _validated_config_float(
             "epsilon_start", self.epsilon_start, lower=0.0, upper=1.0
         )
-        epsilon_end = validated_float32_scalar(
+        epsilon_end = _validated_config_float(
             "epsilon_end", self.epsilon_end, lower=0.0, upper=1.0
         )
         if epsilon_decay_steps > 0 and epsilon_end > epsilon_start:
@@ -123,6 +142,7 @@ class SARSAConfig:
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "epsilon_start", epsilon_start)
         object.__setattr__(self, "epsilon_end", epsilon_end)
+        _preflight_sarsa_resources(n_actions, 1)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""
@@ -137,6 +157,11 @@ class SARSAConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "SARSAConfig":
         """Reconstruct from config dict."""
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        expected = {"n_actions", "gamma", "epsilon_start", "epsilon_end", "epsilon_decay_steps"}
+        if any(type(key) is not str for key in config) or set(config) != expected:
+            raise ValueError("config fields do not match the serialized schema")
         return cls(**config)
 
 
@@ -343,6 +368,13 @@ class SARSAAgent:
             trace_mode: Eligibility trace mode (ACCUMULATING or REPLACING)
             utility_decay: EMA decay for hidden-unit utility diagnostics.
         """
+        if type(sarsa_config) is not SARSAConfig:
+            raise ValueError("sarsa_config must be an exact SARSAConfig")
+        if prediction_demons is not None:
+            if type(prediction_demons) is not list:
+                raise ValueError("prediction_demons must be an exact list or None")
+            if any(type(demon) is not GVFSpec for demon in prediction_demons):
+                raise ValueError("prediction_demons entries must be exact GVFSpec values")
         self._sarsa_config = sarsa_config
         self._hidden_sizes = hidden_sizes
         self._lamda = lamda
@@ -418,11 +450,43 @@ class SARSAAgent:
             optimizer_from_config,
         )
 
+        if type(config) is not dict:
+            raise ValueError("serialized SARSA agent must be an exact built-in dict")
+        expected = {
+            "type",
+            "sarsa_config",
+            "lamda",
+            "prediction_demons",
+            "state_schema",
+            "hidden_sizes",
+            "optimizer",
+            "bounder",
+            "normalizer",
+            "head_optimizer",
+            "sparsity",
+            "leaky_relu_slope",
+            "use_layer_norm",
+            "trace_mode",
+            "utility_decay",
+        }
+        if any(type(key) is not str for key in config) or set(config) != expected:
+            raise ValueError("serialized SARSA agent fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "SARSAAgent":
+            raise ValueError("unsupported SARSA agent type")
+        state_schema = config["state_schema"]
+        if type(state_schema) is not str or state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
+            raise ValueError("unsupported SARSA Horde state schema")
+        if type(config["sarsa_config"]) is not dict:
+            raise ValueError("serialized sarsa_config must be an exact built-in dict")
+        if type(config["hidden_sizes"]) is not list:
+            raise ValueError("serialized hidden_sizes must be an exact list")
+        raw_prediction_demons = config["prediction_demons"]
+        if raw_prediction_demons is not None and type(raw_prediction_demons) is not list:
+            raise ValueError("serialized prediction_demons must be an exact list or None")
+
         config = dict(config)
-        config.pop("type", None)
-        state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
-        if state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(f"unsupported SARSA Horde state schema: {state_schema!r}")
+        config.pop("type")
+        config.pop("state_schema")
 
         sarsa_config = SARSAConfig.from_config(config.pop("sarsa_config"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
@@ -432,15 +496,17 @@ class SARSAAgent:
         normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
         head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        pred_demons_cfg = config.pop("prediction_demons", None)
+        pred_demons_cfg = config.pop("prediction_demons")
         prediction_demons = None
         if pred_demons_cfg is not None:
+            if any(type(demon) is not dict for demon in pred_demons_cfg):
+                raise ValueError("serialized prediction demon must be an exact built-in dict")
             prediction_demons = [GVFSpec.from_config(d) for d in pred_demons_cfg]
 
-        trace_mode_str = config.pop("trace_mode", None)
-        trace_mode = (
-            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
-        )
+        trace_mode_str = config.pop("trace_mode")
+        if type(trace_mode_str) is not str:
+            raise ValueError("serialized trace_mode must be an exact string")
+        trace_mode = TraceMode(trace_mode_str)
 
         return cls(
             sarsa_config=sarsa_config,
@@ -464,6 +530,7 @@ class SARSAAgent:
         Returns:
             Initial SARSAState with zeroed last_action/observation
         """
+        _preflight_sarsa_resources(self.n_actions, feature_dim)
         key, subkey = jr.split(key)
         learner_state = self._horde.init(feature_dim, subkey)
 

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -51,6 +51,7 @@ from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 __all__ = [
     "StackedHordeConfig",
@@ -156,6 +157,30 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_sequence(name: str, value: object) -> tuple[object, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be an actual tuple")
+    return cast(tuple[object, ...], value)
+
+
+def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
+    if type(value) not in (list, tuple):
+        raise ValueError(f"{name} must be an actual list or tuple")
+    return tuple(cast(list[object] | tuple[object, ...], value))
+
+
+def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
+    parameter_scalars = n_demons * feature_dim
+    # Static gamma/lambda/index arrays, dynamic weights/traces, and all public
+    # per-step result leaves can coexist at the update boundary.
+    aggregate_scalars = 2 * parameter_scalars + 6 * n_demons + 2
+    aggregate_nbytes = 8 * parameter_scalars + 21 * n_demons + 5
+    if aggregate_scalars > _INT32_MAX:
+        raise ValueError("stacked Horde aggregate scalars must fit signed int32")
+    if aggregate_nbytes > _INT32_MAX:
+        raise ValueError("stacked Horde aggregate bytes must fit signed int32")
+
+
 @dataclass(frozen=True)
 class StackedHordeConfig:
     """Static configuration for :class:`StackedLinearHorde`.
@@ -184,25 +209,41 @@ class StackedHordeConfig:
         n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
-        for name, seq in (
-            ("gammas", self.gammas),
-            ("lamdas", self.lamdas),
-            ("cumulant_indices", self.cumulant_indices),
-        ):
+        raw_sequences = {
+            "gammas": _require_sequence("gammas", self.gammas),
+            "lamdas": _require_sequence("lamdas", self.lamdas),
+            "cumulant_indices": _require_sequence(
+                "cumulant_indices", self.cumulant_indices
+            ),
+        }
+        for name, seq in raw_sequences.items():
             if len(seq) != n_demons:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
-        if any(not 0.0 <= g <= 1.0 for g in self.gammas):
-            raise ValueError("every gamma must be in [0, 1]")
-        if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
-            raise ValueError("every lamda must be in [0, 1]")
+
+        gammas = tuple(
+            validated_float32_scalar(
+                f"gammas[{i}]", value, lower=0.0, upper=1.0
+            )
+            for i, value in enumerate(raw_sequences["gammas"])
+        )
+        lamdas = tuple(
+            validated_float32_scalar(
+                f"lamdas[{i}]", value, lower=0.0, upper=1.0
+            )
+            for i, value in enumerate(raw_sequences["lamdas"])
+        )
 
         cumulant_indices = tuple(
             _require_int32(f"cumulant_indices[{i}]", idx, minimum=0)
-            for i, idx in enumerate(self.cumulant_indices)
+            for i, idx in enumerate(raw_sequences["cumulant_indices"])
         )
+
+        _preflight_horde_resources(n_demons, feature_dim)
 
         object.__setattr__(self, "n_demons", n_demons)
         object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "gammas", gammas)
+        object.__setattr__(self, "lamdas", lamdas)
         object.__setattr__(self, "cumulant_indices", cumulant_indices)
         object.__setattr__(
             self,
@@ -228,7 +269,7 @@ class StackedHordeConfig:
         config = dict(config)
         config.pop("type", None)
         for key in ("gammas", "lamdas", "cumulant_indices"):
-            config[key] = tuple(config[key])
+            config[key] = _decode_sequence(key, config[key])
         return cls(**config)
 
 
@@ -253,10 +294,26 @@ def nexting_spec(
         lamda: Shared trace decay.
         step_size: Shared TD step-size.
     """
+    feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+    raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
+    raw_gammas = _require_sequence("gammas", gammas)
+    canonical_indices = tuple(
+        _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
+        for i, value in enumerate(raw_indices)
+    )
+    canonical_gammas = tuple(
+        validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
+        for i, value in enumerate(raw_gammas)
+    )
+    canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+    n_demons = len(canonical_indices) * len(canonical_gammas)
+    if n_demons < 1 or n_demons > _INT32_MAX:
+        raise ValueError("derived n_demons must be in the signed int32 domain")
+    _preflight_horde_resources(n_demons, feature_dim)
     idxs: list[int] = []
     gs: list[float] = []
-    for c in cumulant_indices:
-        for g in gammas:
+    for c in canonical_indices:
+        for g in canonical_gammas:
             idxs.append(c)
             gs.append(g)
     n = len(idxs)
@@ -264,7 +321,7 @@ def nexting_spec(
         n_demons=n,
         feature_dim=feature_dim,
         gammas=tuple(gs),
-        lamdas=(lamda,) * n,
+        lamdas=(canonical_lamda,) * n,
         cumulant_indices=tuple(idxs),
         step_size=step_size,
     )

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -37,10 +37,11 @@ the NaN-masking convention of the loop-based hordes.
 """
 
 import math
+import operator
 from dataclasses import dataclass
 from fractions import Fraction
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -90,11 +91,7 @@ def _snapshot_exact_fraction(value: Fraction) -> Fraction:
         denominator = value.denominator
     except AttributeError:
         raise ValueError(_STEP_SIZE_ERROR) from None
-    if (
-        type(numerator) is not int
-        or type(denominator) is not int
-        or denominator <= 0
-    ):
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         raise ValueError(_STEP_SIZE_ERROR)
     return Fraction(numerator, denominator)
 
@@ -132,6 +129,33 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
     return cast(float, value) if preserve_builtin_float else narrowed
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @dataclass(frozen=True)
 class StackedHordeConfig:
     """Static configuration for :class:`StackedLinearHorde`.
@@ -157,25 +181,29 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        if self.n_demons < 1:
-            raise ValueError("n_demons must be positive")
-        if self.feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
+
         for name, seq in (
             ("gammas", self.gammas),
             ("lamdas", self.lamdas),
             ("cumulant_indices", self.cumulant_indices),
         ):
-            if len(seq) != self.n_demons:
-                raise ValueError(f"{name} must have length n_demons={self.n_demons}")
+            if len(seq) != n_demons:
+                raise ValueError(f"{name} must have length n_demons={n_demons}")
         if any(not 0.0 <= g <= 1.0 for g in self.gammas):
             raise ValueError("every gamma must be in [0, 1]")
         if any(not 0.0 <= la <= 1.0 for la in self.lamdas):
             raise ValueError("every lamda must be in [0, 1]")
-        # Identity-only check: bools and numpy integers are refused so a JAX
-        # gather can never wrap (negative) or reinterpret the channel.
-        if any(type(idx) is not int or idx < 0 for idx in self.cumulant_indices):
-            raise ValueError("cumulant_indices entries must be nonnegative builtin ints")
+
+        cumulant_indices = tuple(
+            _require_int32(f"cumulant_indices[{i}]", idx, minimum=0)
+            for i, idx in enumerate(self.cumulant_indices)
+        )
+
+        object.__setattr__(self, "n_demons", n_demons)
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "cumulant_indices", cumulant_indices)
         object.__setattr__(
             self,
             "step_size",
@@ -346,9 +374,7 @@ class StackedLinearHorde:
         # so a short source would silently train demons on the wrong channel.
         # Shapes are static, so these checks also fire at jit/scan trace time.
         if len(source_shape) != 1:
-            raise ValueError(
-                f"cumulant_source must be rank-one, got shape {source_shape}"
-            )
+            raise ValueError(f"cumulant_source must be rank-one, got shape {source_shape}")
         if source_shape[0] <= self._max_cumulant_index:
             raise ValueError(
                 f"cumulant_source has {source_shape[0]} channels but "
@@ -365,12 +391,8 @@ class StackedLinearHorde:
         # gamma=0 must not multiply an inf bootstrap (0*inf).
         bootstrap = jnp.where(self._gammas == 0.0, 0.0, self._gammas * v_next)
         raw_td_errors = cumulants + bootstrap - v
-        prediction_valid = jnp.isfinite(v) & (
-            (self._gammas == 0.0) | jnp.isfinite(v_next)
-        )
-        channel_valid = (
-            active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
-        )
+        prediction_valid = jnp.isfinite(v) & ((self._gammas == 0.0) | jnp.isfinite(v_next))
+        channel_valid = active & rho_valid & prediction_valid & jnp.isfinite(raw_td_errors)
         safe_cumulants = jnp.where(channel_valid, cumulants, 0.0)
         td_errors = safe_cumulants + bootstrap - v
 
@@ -382,15 +404,10 @@ class StackedLinearHorde:
         # Inactive demons: trace decays but the current gradient is withheld.
         decayed_only = carried
         safe_rho = jnp.where(rho_valid, rho_vec, 0.0)
-        proposed_traces = safe_rho[:, None] * jnp.where(
-            active[:, None], accumulated, decayed_only
-        )
+        proposed_traces = safe_rho[:, None] * jnp.where(active[:, None], accumulated, decayed_only)
 
         masked_delta = jnp.where(channel_valid, td_errors, 0.0)
-        proposed_weights = (
-            state.weights
-            + cfg.step_size * masked_delta[:, None] * proposed_traces
-        )
+        proposed_weights = state.weights + cfg.step_size * masked_delta[:, None] * proposed_traces
         source_weights_finite = jnp.all(jnp.isfinite(state.weights))
         traces_needed = decay[:, 0] != 0.0
         traces_usable = (~traces_needed) | jnp.all(jnp.isfinite(state.traces), axis=1)
@@ -414,12 +431,8 @@ class StackedLinearHorde:
             & traces_usable
         )
         accepted_channels = head_updates_applied | inactive_trace_applied
-        new_weights = jnp.where(
-            head_updates_applied[:, None], proposed_weights, state.weights
-        )
-        new_traces = jnp.where(
-            accepted_channels[:, None], proposed_traces, state.traces
-        )
+        new_weights = jnp.where(head_updates_applied[:, None], proposed_weights, state.weights)
+        new_traces = jnp.where(accepted_channels[:, None], proposed_traces, state.traces)
         update_applied = jnp.any(accepted_channels)
         proposed_state = StackedHordeState(
             weights=new_weights,
@@ -484,9 +497,7 @@ def run_stacked_horde_scan(
     """
     sources_shape = jnp.shape(cumulant_sources)
     if len(sources_shape) != 2:
-        raise ValueError(
-            f"cumulant_sources must be rank-two, got shape {sources_shape}"
-        )
+        raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
     max_index = max(horde.config.cumulant_indices)
     if sources_shape[-1] <= max_index:
         raise ValueError(

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -146,6 +146,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -164,9 +167,17 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
-    if type(value) not in (list, tuple):
-        raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    if type(value) is list:
+        return tuple(cast(list[object], value))
+    if type(value) is tuple:
+        return cast(tuple[object, ...], value)
+    raise ValueError(f"serialized {name} must be an actual list or tuple")
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -221,13 +232,13 @@ class StackedHordeConfig:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
 
         gammas = tuple(
-            validated_float32_scalar(
+            _validated_config_float(
                 f"gammas[{i}]", value, lower=0.0, upper=1.0
             )
             for i, value in enumerate(raw_sequences["gammas"])
         )
         lamdas = tuple(
-            validated_float32_scalar(
+            _validated_config_float(
                 f"lamdas[{i}]", value, lower=0.0, upper=1.0
             )
             for i, value in enumerate(raw_sequences["lamdas"])
@@ -266,8 +277,23 @@ class StackedHordeConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "StackedHordeConfig":
         """Reconstruct a config from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        expected = {
+            "type",
+            "n_demons",
+            "feature_dim",
+            "gammas",
+            "lamdas",
+            "cumulant_indices",
+            "step_size",
+        }
+        if any(type(key) is not str for key in config) or set(config) != expected:
+            raise ValueError("config fields do not match the serialized schema")
+        if type(config["type"]) is not str or config["type"] != "StackedHordeConfig":
+            raise ValueError("config type differs")
         config = dict(config)
-        config.pop("type", None)
+        config.pop("type")
         for key in ("gammas", "lamdas", "cumulant_indices"):
             config[key] = _decode_sequence(key, config[key])
         return cls(**config)
@@ -302,10 +328,10 @@ def nexting_spec(
         for i, value in enumerate(raw_indices)
     )
     canonical_gammas = tuple(
-        validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
+        _validated_config_float(f"gammas[{i}]", value, lower=0.0, upper=1.0)
         for i, value in enumerate(raw_gammas)
     )
-    canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+    canonical_lamda = _validated_config_float("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
     if n_demons < 1 or n_demons > _INT32_MAX:
         raise ValueError("derived n_demons must be in the signed int32 domain")
@@ -382,7 +408,15 @@ class StackedLinearHorde:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "StackedLinearHorde":
         """Reconstruct a horde from :meth:`to_config` output."""
-        return cls(StackedHordeConfig.from_config(dict(config)["config"]))
+        if type(config) is not dict:
+            raise ValueError("config must be an exact built-in dict")
+        if any(type(key) is not str for key in config) or set(config) != {"type", "config"}:
+            raise ValueError("config fields do not match the serialized schema")
+        if type(config["type"]) is not str or config["type"] != "StackedLinearHorde":
+            raise ValueError("config type differs")
+        if type(config["config"]) is not dict:
+            raise ValueError("nested config must be an exact built-in dict")
+        return cls(StackedHordeConfig.from_config(config["config"]))
 
     def init(self) -> StackedHordeState:
         """Initialize zero weights and traces."""

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -12,6 +12,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 from jax import Array
 
@@ -624,9 +625,7 @@ def test_obgd_infinite_signal_zeros_bounded_update() -> None:
     assert bool(jnp.allclose(result.scale, 0.0))
     assert not bool(result.update_applied)
 
-    unbounded = obgd_update(
-        traces, jnp.asarray(jnp.inf, dtype=jnp.float32), alpha=0.5, kappa=0.0
-    )
+    unbounded = obgd_update(traces, jnp.asarray(jnp.inf, dtype=jnp.float32), alpha=0.5, kappa=0.0)
     for leaf in jax.tree_util.tree_leaves(unbounded.updates):
         assert bool(jnp.all(jnp.isfinite(leaf)))
         assert bool(jnp.allclose(leaf, 0.0))
@@ -767,9 +766,7 @@ def test_adaptive_obgd_matches_memorax_second_moment_formula() -> None:
         step=step,
     )
     expected_second_moment = jax.tree_util.tree_map(
-        lambda previous, trace: (
-            beta2 * previous + (1.0 - beta2) * jnp.square(signal * trace)
-        ),
+        lambda previous, trace: beta2 * previous + (1.0 - beta2) * jnp.square(signal * trace),
         second_moment,
         traces,
     )
@@ -783,10 +780,7 @@ def test_adaptive_obgd_matches_memorax_second_moment_formula() -> None:
         expected_corrected,
     )
     expected_z_sum = sum(
-        (
-            jnp.sum(jnp.abs(leaf))
-            for leaf in jax.tree_util.tree_leaves(expected_normalized)
-        ),
+        (jnp.sum(jnp.abs(leaf)) for leaf in jax.tree_util.tree_leaves(expected_normalized)),
         start=jnp.asarray(0.0, dtype=jnp.float32),
     )
     expected_denominator = jnp.maximum(
@@ -1122,10 +1116,7 @@ def test_counters_and_welford_moments_saturate_without_wrap_eager_or_jit() -> No
         assert int(result.state.observation_statistics.sample_count) == maximum
         assert int(result.state.reward_statistics.sample_count) == maximum
         assert int(result.state.step_count) == maximum
-        assert jnp.all(
-            result.state.observation_statistics.m2
-            >= state.observation_statistics.m2
-        )
+        assert jnp.all(result.state.observation_statistics.m2 >= state.observation_statistics.m2)
         assert result.state.reward_statistics.m2 >= state.reward_statistics.m2
         _assert_tree_finite(result)
 
@@ -1351,18 +1342,14 @@ def test_adaptive_moments_persist_across_restart_and_checkpoint_resume() -> None
     actor_moment_l1 = sum(
         (
             jnp.sum(jnp.abs(leaf))
-            for leaf in jax.tree_util.tree_leaves(
-                first.state.actor_second_moments
-            )
+            for leaf in jax.tree_util.tree_leaves(first.state.actor_second_moments)
         ),
         start=jnp.asarray(0.0),
     )
     critic_moment_l1 = sum(
         (
             jnp.sum(jnp.abs(leaf))
-            for leaf in jax.tree_util.tree_leaves(
-                first.state.critic_second_moments
-            )
+            for leaf in jax.tree_util.tree_leaves(first.state.critic_second_moments)
         ),
         start=jnp.asarray(0.0),
     )
@@ -2235,3 +2222,31 @@ def test_phase_initialization_matches_upstream_and_ignores_rtu_epsilon() -> None
 
     recovered_phase = jnp.exp(params.rtu.theta_log)
     assert jnp.min(recovered_phase) < config.rtu_epsilon * config.max_phase
+
+
+def test_rtac_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        RecurrentTraceActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        RecurrentTraceActorCriticConfig(n_actions=3.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_size"):
+        RecurrentTraceActorCriticConfig(n_actions=2, hidden_size=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="encoder_width"):
+        RecurrentTraceActorCriticConfig(n_actions=2, encoder_width=1)
+
+
+def test_rtac_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = RecurrentTraceActorCriticConfig(
+        n_actions=np.int32(3),
+        hidden_size=np.int64(64),
+        encoder_width=np.int32(32),
+        output_width=np.int64(32),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.hidden_size) is int
+    assert type(cfg.encoder_width) is int
+    assert type(cfg.output_width) is int
+    assert cfg.n_actions == 3
+    assert cfg.hidden_size == 64
+    assert cfg.encoder_width == 32
+    assert cfg.output_width == 32

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from jax import Array
 
+import alberta_framework.core.recurrent_trace_actor_critic as recurrent_trace_module
 from alberta_framework.core import (
     RecurrentTraceActorCriticAgent as ExportedRecurrentTraceActorCriticAgent,
 )
@@ -2049,6 +2050,49 @@ def test_config_and_agent_serialization_round_trip() -> None:
     assert adaptive_payload["beta2"] == 0.95
     assert adaptive_payload["epsilon"] == 1e-6
     assert RecurrentTraceActorCriticConfig.from_config(adaptive_payload) == adaptive
+
+
+def test_config_rejects_hostile_numeric_and_serialized_container_hooks() -> None:
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("float hook must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    class DictSubclass(dict[str, Any]):
+        pass
+
+    with pytest.raises(ValueError, match="gamma"):
+        _small_config(gamma=HostileFloat(0.9))
+    payload = _small_config().to_config()
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        RecurrentTraceActorCriticConfig.from_config(DictSubclass(payload))
+    envelope = RecurrentTraceActorCriticAgent(_small_config()).to_config()
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        RecurrentTraceActorCriticAgent.from_config(DictSubclass(envelope))
+    with pytest.raises(ValueError, match="fields"):
+        RecurrentTraceActorCriticConfig.from_config({**payload, "unknown": 1})
+
+
+def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _small_config()
+    assert config.state_resource_budget(2) == {
+        "parameter_scalars": 124,
+        "sensitivity_scalars_per_network": 36,
+        "float32_state_scalars": 343,
+        "state_scalars": 350,
+        "state_nbytes": 1397,
+    }
+
+    def forbidden_split(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("RNG split must not run before resource validation")
+
+    monkeypatch.setattr(recurrent_trace_module.jr, "split", forbidden_split)
+    with pytest.raises(ValueError, match="derived"):
+        RecurrentTraceActorCriticAgent(config).init(2**31 - 1, jr.key(0))
 
 
 def test_canonical_discrete_architecture_defaults_and_core_export() -> None:

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -61,9 +61,7 @@ class TestSARSAConfigValidation:
             SARSAConfig(n_actions=2, epsilon_decay_steps=epsilon_decay_steps)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("name", ["gamma", "epsilon_start", "epsilon_end"])
-    @pytest.mark.parametrize(
-        "value", [float("nan"), float("inf"), -0.1, 1.1, True, "0.5"]
-    )
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1, True, "0.5"])
     def test_rejects_invalid_probability(self, name, value):
         with pytest.raises(ValueError, match=name):
             SARSAConfig(n_actions=2, **{name: value})
@@ -233,9 +231,7 @@ class TestSARSAActionSelection:
         expected = n_samples / 4
         chi_sq = np.sum((counts - expected) ** 2 / expected)
         # With df=3, chi_sq < 16.27 at p=0.001 (very conservative)
-        assert chi_sq < 16.27, (
-            f"Action distribution not uniform: {counts}, chi_sq={chi_sq}"
-        )
+        assert chi_sq < 16.27, f"Action distribution not uniform: {counts}, chi_sq={chi_sq}"
 
     def test_action_in_valid_range(self):
         """Selected actions are always in [0, n_actions)."""
@@ -354,9 +350,7 @@ class TestSARSAUpdate:
         actual = result.state.replace(
             learner_state=result.state.learner_state.replace(birth_timestamp=0.0)
         )
-        expected = state.replace(
-            learner_state=state.learner_state.replace(birth_timestamp=0.0)
-        )
+        expected = state.replace(learner_state=state.learner_state.replace(birth_timestamp=0.0))
         chex.assert_trees_all_equal(actual, expected)
         assert float(result.td_error) == 0.0
 
@@ -482,7 +476,6 @@ class TestSARSAUpdate:
         chex.assert_trees_all_close(w_trace, jnp.zeros_like(w_trace))
         chex.assert_trees_all_close(b_trace, jnp.zeros_like(b_trace))
 
-
     def test_nan_masking(self):
         """Only the taken action's head receives a weight update."""
         agent = _make_agent(n_actions=3, gamma=0.9, epsilon_start=0.0)
@@ -499,10 +492,7 @@ class TestSARSAUpdate:
         next_action = jnp.array(0, dtype=jnp.int32)
 
         # Save head params before update
-        old_head_weights = [
-            state.learner_state.head_params.weights[i]
-            for i in range(3)
-        ]
+        old_head_weights = [state.learner_state.head_params.weights[i] for i in range(3)]
 
         result = agent.update(
             state,
@@ -512,10 +502,7 @@ class TestSARSAUpdate:
             next_action=next_action,
         )
 
-        new_head_weights = [
-            result.state.learner_state.head_params.weights[i]
-            for i in range(3)
-        ]
+        new_head_weights = [result.state.learner_state.head_params.weights[i] for i in range(3)]
 
         # Head 1 should have changed (it was the taken action)
         head1_changed = not jnp.allclose(old_head_weights[1], new_head_weights[1])
@@ -950,9 +937,7 @@ class TestSARSAScan:
             rng_key=new_key,
         )
 
-        result = run_sarsa_from_arrays(
-            agent, state, obs, rewards, terminated, next_obs
-        )
+        result = run_sarsa_from_arrays(agent, state, obs, rewards, terminated, next_obs)
 
         assert isinstance(result, SARSAArrayResult)
         chex.assert_shape(result.q_values, (n_steps, 2))
@@ -979,9 +964,7 @@ class TestSARSAScan:
             rng_key=new_key,
         )
 
-        result = run_sarsa_from_arrays(
-            agent, state, obs, rewards, terminated, next_obs
-        )
+        result = run_sarsa_from_arrays(agent, state, obs, rewards, terminated, next_obs)
 
         # Should run without error and produce finite results
         assert jnp.all(jnp.isfinite(result.td_errors))
@@ -1082,12 +1065,8 @@ class TestSARSALambdaTraces:
         # after two visits e_2 = (gamma * lamda) * s_1 + s_2.
         gl = gamma * lamda
         w_trace, b_trace = result.state.learner_state.head_traces[0]
-        chex.assert_trees_all_close(
-            w_trace, (gl * obs1 + obs2).reshape(1, -1), rtol=1e-5
-        )
-        chex.assert_trees_all_close(
-            b_trace, jnp.array([gl + 1.0], dtype=jnp.float32), rtol=1e-5
-        )
+        chex.assert_trees_all_close(w_trace, (gl * obs1 + obs2).reshape(1, -1), rtol=1e-5)
+        chex.assert_trees_all_close(b_trace, jnp.array([gl + 1.0], dtype=jnp.float32), rtol=1e-5)
 
     def test_lambda_changes_multistep_updates(self):
         """lamda in {0.0, 0.9} produce different weights on a 3-step corridor."""
@@ -1110,9 +1089,7 @@ class TestSARSALambdaTraces:
                 last_action=jnp.array(0, dtype=jnp.int32),
                 last_observation=obs[0],
             )
-            result = run_sarsa_from_arrays(
-                agent, state, obs, rewards, terminated, next_obs
-            )
+            result = run_sarsa_from_arrays(agent, state, obs, rewards, terminated, next_obs)
             return result.state.learner_state.head_params.weights[0]
 
         w_one_step = run(0.0)
@@ -1150,9 +1127,7 @@ class TestSARSALambdaTraces:
         gl = gamma * lamda
         w_trace, b_trace = result.state.learner_state.head_traces[0]
         chex.assert_trees_all_close(w_trace, (gl * obs1).reshape(1, -1), rtol=1e-5)
-        chex.assert_trees_all_close(
-            b_trace, jnp.array([gl], dtype=jnp.float32), rtol=1e-5
-        )
+        chex.assert_trees_all_close(b_trace, jnp.array([gl], dtype=jnp.float32), rtol=1e-5)
 
     def test_traces_reset_at_episode_boundary(self):
         """Control-head traces are cleared after a terminated transition."""
@@ -1185,9 +1160,7 @@ class TestSARSALambdaTraces:
     def test_external_target_semantics_intact(self):
         """With lamda>0, the TD target is still r + gamma*Q(s',a') (no
         double-counted internal bootstrap)."""
-        agent = _make_agent(
-            n_actions=2, hidden_sizes=(), gamma=0.9, epsilon_start=0.0, lamda=0.8
-        )
+        agent = _make_agent(n_actions=2, hidden_sizes=(), gamma=0.9, epsilon_start=0.0, lamda=0.8)
         state = agent.init(feature_dim=3, key=jr.key(5))
         obs1 = jnp.array([1.0, -1.0, 0.5], dtype=jnp.float32)
         obs2 = jnp.array([0.5, 2.0, -0.3], dtype=jnp.float32)
@@ -1230,16 +1203,34 @@ class TestSARSAContinuingPseudoBoundary:
         reward = jnp.array(5.0)
 
         # Terminal update: target = r only
-        result_term = agent.update(
-            state, reward, next_obs, jnp.array(1.0), next_action
-        )
+        result_term = agent.update(state, reward, next_obs, jnp.array(1.0), next_action)
 
         # Non-terminal update: target = r + gamma * Q(s', a')
-        result_cont = agent.update(
-            state, reward, next_obs, jnp.array(0.0), next_action
-        )
+        result_cont = agent.update(state, reward, next_obs, jnp.array(0.0), next_action)
 
         # TD errors should differ (terminal strips bootstrap)
         # Both should be finite
         assert jnp.isfinite(result_term.td_error)
         assert jnp.isfinite(result_cont.td_error)
+
+
+def test_sarsa_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        SARSAConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        SARSAConfig(n_actions=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="epsilon_decay_steps"):
+        SARSAConfig(n_actions=2, epsilon_decay_steps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="epsilon_decay_steps"):
+        SARSAConfig(n_actions=2, epsilon_decay_steps=100.5)  # type: ignore[arg-type]
+
+
+def test_sarsa_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = SARSAConfig(
+        n_actions=np.int32(4),
+        epsilon_decay_steps=np.int64(100),
+    )
+    assert type(cfg.n_actions) is int
+    assert type(cfg.epsilon_decay_steps) is int
+    assert cfg.n_actions == 4
+    assert cfg.epsilon_decay_steps == 100

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -1234,3 +1234,42 @@ def test_sarsa_config_accepts_and_canonicalizes_numpy_integers() -> None:
     assert type(cfg.epsilon_decay_steps) is int
     assert cfg.n_actions == 4
     assert cfg.epsilon_decay_steps == 100
+
+
+def test_sarsa_config_rejects_hostile_scalars_and_nonexact_schema() -> None:
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("float hook must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    class DictSubclass(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="gamma"):
+        SARSAConfig(n_actions=2, gamma=HostileFloat(0.9))
+    payload = SARSAConfig(n_actions=2).to_config()
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        SARSAConfig.from_config(DictSubclass(payload))
+    with pytest.raises(ValueError, match="fields"):
+        SARSAConfig.from_config({**payload, "unknown": 1})
+
+
+def test_sarsa_config_preflights_wrapper_resource_endpoint() -> None:
+    assert SARSAConfig(n_actions=2**31 - 7).n_actions == 2**31 - 7
+    with pytest.raises(ValueError, match="wrapper resources"):
+        SARSAConfig(n_actions=2**31 - 6)
+
+
+def test_sarsa_agent_from_config_rejects_nonexact_outer_containers() -> None:
+    class DictSubclass(dict[str, object]):
+        pass
+
+    payload = _make_agent(n_actions=2).to_config()
+    with pytest.raises(ValueError, match="exact built-in dict"):
+        SARSAAgent.from_config(DictSubclass(payload))
+    hostile = dict(payload)
+    hostile["hidden_sizes"] = tuple(hostile["hidden_sizes"])
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        SARSAAgent.from_config(hostile)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -801,3 +801,89 @@ def test_stacked_horde_config_accepts_and_canonicalizes_numpy_integers() -> None
     assert cfg.n_demons == 2
     assert cfg.feature_dim == 4
     assert cfg.cumulant_indices == (0, 1)
+
+
+_NUMPY_INTEGER_TYPES = tuple(dict.fromkeys(np.dtype(code).type for code in "bhilqBHILQpP"))
+
+
+@pytest.mark.parametrize("integer_type", _NUMPY_INTEGER_TYPES)
+def test_stacked_horde_config_canonicalizes_every_numpy_integer_family(
+    integer_type: type,
+) -> None:
+    config = StackedHordeConfig(
+        n_demons=integer_type(1),
+        feature_dim=integer_type(2),
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(integer_type(0),),
+    )
+
+    assert type(config.n_demons) is int
+    assert type(config.feature_dim) is int
+    assert type(config.cumulant_indices[0]) is int
+
+
+def test_stacked_horde_rejects_hostile_containers_and_float_values() -> None:
+    class TupleSubclass(tuple):
+        pass
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:
+            return float
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    with pytest.raises(ValueError, match="gammas"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=2,
+            gammas=TupleSubclass((0.9,)),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match=r"gammas\[0\]"):
+        _simple_config(n_demons=1, gammas=(ClassSpoof(),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"lamdas\[0\]"):
+        _simple_config(n_demons=1, lamdas=(True,))  # type: ignore[arg-type]
+
+
+def test_stacked_horde_from_config_accepts_only_exact_list_or_tuple_sequences() -> None:
+    payload = _simple_config().to_config()
+    payload["gammas"] = tuple(payload["gammas"])
+    assert StackedHordeConfig.from_config(payload).gammas == (0.9, 0.9)
+
+    payload = _simple_config().to_config()
+    payload["gammas"] = "0.9"
+    with pytest.raises(ValueError, match="gammas"):
+        StackedHordeConfig.from_config(payload)
+
+
+def test_stacked_horde_preflights_aggregate_resources_before_allocation() -> None:
+    last_feature_dim = (2**31 - 1 - 26) // 8
+    StackedHordeConfig(
+        n_demons=1,
+        feature_dim=last_feature_dim,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    )
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=last_feature_dim + 1,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+
+
+def test_nexting_spec_preflights_before_materializing_derived_demons() -> None:
+    last_feature_dim = (2**31 - 1 - 26) // 8
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        nexting_spec(
+            feature_dim=last_feature_dim + 1,
+            cumulant_indices=(0,),
+            gammas=(0.9,),
+        )

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -75,9 +75,7 @@ class TestConfig:
             Fraction(1, 2),
         ],
     )
-    def test_step_size_supported_reals_canonicalize_for_json(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_supported_reals_canonicalize_for_json(self, step_size: object) -> None:
         cfg = _simple_config(step_size=step_size)
         payload = cfg.to_config()
 
@@ -92,9 +90,7 @@ class TestConfig:
         assert cfg.step_size == 0.1
 
     def test_fraction_step_size_rounds_directly_to_float32(self) -> None:
-        above_half_midpoint = (
-            Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
-        )
+        above_half_midpoint = Fraction(1, 2) + Fraction(1, 2**25) + Fraction(1, 2**70)
         expected = float(np.nextafter(np.float32(0.5), np.float32(1.0)))
 
         cfg = _simple_config(step_size=above_half_midpoint)
@@ -124,9 +120,7 @@ class TestConfig:
             float(np.nextafter(np.finfo(np.float32).tiny, np.float32(0.0))),
         ],
     )
-    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(
-        self, step_size: object
-    ) -> None:
+    def test_step_size_rejects_nonfinite_or_subnormal_float32_sink(self, step_size: object) -> None:
         with pytest.raises(ValueError, match="step_size"):
             _simple_config(step_size=step_size)
 
@@ -255,9 +249,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_sizes[attack]
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_sizes[attack])
 
@@ -278,9 +270,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -313,18 +303,14 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
         assert calls == []
 
     @pytest.mark.parametrize("serialized", [False, True], ids=("direct", "from-config"))
-    def test_step_size_rejects_exact_fraction_with_zero_denominator(
-        self, serialized: bool
-    ) -> None:
+    def test_step_size_rejects_exact_fraction_with_zero_denominator(self, serialized: bool) -> None:
         property_calls: list[str] = []
 
         class Carrier(Fraction):
@@ -347,9 +333,7 @@ class TestConfig:
             if serialized:
                 payload = _simple_config().to_config()
                 payload["step_size"] = step_size
-                StackedLinearHorde.from_config(
-                    {"type": "StackedLinearHorde", "config": payload}
-                )
+                StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
             else:
                 _simple_config(step_size=step_size)
 
@@ -366,9 +350,7 @@ class TestConfig:
         payload["step_size"] = step_size
 
         with pytest.raises(ValueError, match="step_size"):
-            StackedLinearHorde.from_config(
-                {"type": "StackedLinearHorde", "config": payload}
-            )
+            StackedLinearHorde.from_config({"type": "StackedLinearHorde", "config": payload})
 
     def test_minimum_normal_step_size_survives_jit_execution(self) -> None:
         minimum = float(np.finfo(np.float32).tiny)
@@ -419,8 +401,8 @@ class TestCumulantSourceDomain:
 
     @pytest.mark.parametrize(
         "bad_index",
-        [-1, True, False, np.int32(1), 1.0, "1"],
-        ids=("negative", "true", "false", "numpy-int", "float", "str"),
+        [-1, True, False, 1.5, 1.0, "1"],
+        ids=("negative", "true", "false", "float-fraction", "float-int", "str"),
     )
     def test_config_rejects_non_builtin_or_negative_indices(self, bad_index: object) -> None:
         with pytest.raises(ValueError, match="cumulant_indices"):
@@ -523,9 +505,7 @@ class TestExactSemantics:
         # w += 0.1*2.18*[0.45,1] = [0.2981, 0.218].
         r2 = horde.update(r1.state, x1, x0, c)
         np.testing.assert_allclose(np.asarray(r2.td_errors), [2.18], rtol=1e-6)
-        np.testing.assert_allclose(
-            np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5
-        )
+        np.testing.assert_allclose(np.asarray(r2.state.weights), [[0.2 + 0.0981, 0.218]], rtol=1e-5)
 
     def test_nan_cumulant_freezes_weights_decays_trace(self):
         cfg = _simple_config()
@@ -550,9 +530,7 @@ class TestExactSemantics:
             rtol=1e-6,
         )
         # Demon 1 weights moved.
-        assert not np.array_equal(
-            np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1])
-        )
+        assert not np.array_equal(np.asarray(r2.state.weights[1]), np.asarray(r.state.weights[1]))
 
     def test_rho_composes_into_trace(self):
         """z = rho * (decay * z + x): rho=0 zeroes the trace and the update."""
@@ -738,17 +716,13 @@ class TestDemonAxisScaling:
         sources = jr.normal(rng[1], (num_steps, feature_dim), dtype=jnp.float32)
 
         t0 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         first_call = time.time() - t0
         assert first_call < 30.0, f"compile+run took {first_call:.1f}s"
 
         t1 = time.time()
-        final_state, td_errors = run_stacked_horde_scan(
-            horde, state, features, sources
-        )
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
         td_errors.block_until_ready()
         steady = time.time() - t1
         assert steady < 5.0, f"steady-state run took {steady:.1f}s"
@@ -783,3 +757,47 @@ class TestDemonAxisScaling:
         assert bool(jnp.all(late < early))
         # And the late TD error is near zero for all timescales.
         assert float(jnp.max(late)) < 0.01
+
+
+def test_stacked_horde_config_rejects_booleans_and_non_integers() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=True,  # type: ignore[arg-type]
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="feature_dim"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4.5,  # type: ignore[arg-type]
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    with pytest.raises(ValueError, match="cumulant_indices"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=4,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(True,),  # type: ignore[arg-type]
+        )
+
+
+def test_stacked_horde_config_accepts_and_canonicalizes_numpy_integers() -> None:
+    cfg = StackedHordeConfig(
+        n_demons=np.int32(2),
+        feature_dim=np.int64(4),
+        gammas=(0.9, 0.5),
+        lamdas=(0.8, 0.7),
+        cumulant_indices=(np.int32(0), np.int64(1)),
+    )
+    assert type(cfg.n_demons) is int
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.cumulant_indices[0]) is int
+    assert type(cfg.cumulant_indices[1]) is int
+    assert cfg.n_demons == 2
+    assert cfg.feature_dim == 4
+    assert cfg.cumulant_indices == (0, 1)


### PR DESCRIPTION
Integrates and supersedes #749, #756, and #767 while preserving their contributor commits and the original #752 commit.\n\nThe integer canonicalization in those changes was sound, but the related constructors still had spoofable/noncanonical scalar paths, permissive serialized containers and schemas, and derived allocations that could exceed the signed-int32 resource domain before failing in JAX. This integration adds exact trusted host scalar families, canonical float32 storage, hostile-hook-safe rejection, exact serialized schemas (while retaining the two documented RTU loader forms and exact tuple compatibility for stacked Horde), and allocation-free aggregate preflights. RTU exposes exact persistent-state scalar/byte accounting; SARSA validates its wrapper resources before RNG/allocation; stacked Horde accounts static, state, and public update leaves and validates nexting expansion before materialization.\n\nRegression coverage includes hostile scalar/container subclasses, unknown schema fields, exact resource formulas and endpoints, and pre-allocation rejection.\n\nVerification on current main: 272 focused tests passed; scoped Ruff passed; strict mypy passed for all three source modules; diff-check clean. No outputs or registered evidence sources change.