### PR TITLE
fix(streams): complete Gymnasium schedule and shape contracts

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -149,14 +149,21 @@ def _flatten_observation(obs: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     """
     import gymnasium
 
-    if isinstance(space, gymnasium.spaces.Box):
-        return jnp.asarray(obs, dtype=jnp.float32).flatten()
-    elif isinstance(space, gymnasium.spaces.Discrete):
-        return jnp.array([float(obs)], dtype=jnp.float32)
-    elif isinstance(space, gymnasium.spaces.MultiDiscrete):
-        return jnp.asarray(obs, dtype=jnp.float32).reshape((-1,))
-    else:
-        raise ValueError(f"Unsupported space type: {type(space).__name__}")
+    try:
+        if isinstance(space, gymnasium.spaces.Box):
+            flattened = jnp.asarray(obs, dtype=jnp.float32).reshape((-1,))
+        elif isinstance(space, gymnasium.spaces.Discrete):
+            flattened = jnp.asarray([obs], dtype=jnp.float32)
+        elif isinstance(space, gymnasium.spaces.MultiDiscrete):
+            flattened = jnp.asarray(obs, dtype=jnp.float32).reshape((-1,))
+        else:
+            raise ValueError(f"Unsupported space type: {type(space).__name__}")
+    except Exception as error:
+        raise ValueError("observation could not be converted to float32") from error
+    expected = _flatten_space(space)
+    if flattened.shape != (expected,) or not bool(jnp.all(jnp.isfinite(flattened))):
+        raise ValueError("observation must match its declared flattened shape and be finite")
+    return flattened
 
 
 def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
@@ -171,14 +178,21 @@ def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     """
     import gymnasium
 
-    if isinstance(space, gymnasium.spaces.Box):
-        return jnp.asarray(action, dtype=jnp.float32).flatten()
-    elif isinstance(space, gymnasium.spaces.Discrete):
-        return jnp.array([float(action)], dtype=jnp.float32)
-    elif isinstance(space, gymnasium.spaces.MultiDiscrete):
-        return jnp.asarray(action, dtype=jnp.float32).reshape((-1,))
-    else:
-        raise ValueError(f"Unsupported space type: {type(space).__name__}")
+    try:
+        if isinstance(space, gymnasium.spaces.Box):
+            flattened = jnp.asarray(action, dtype=jnp.float32).reshape((-1,))
+        elif isinstance(space, gymnasium.spaces.Discrete):
+            flattened = jnp.asarray([action], dtype=jnp.float32)
+        elif isinstance(space, gymnasium.spaces.MultiDiscrete):
+            flattened = jnp.asarray(action, dtype=jnp.float32).reshape((-1,))
+        else:
+            raise ValueError(f"Unsupported space type: {type(space).__name__}")
+    except Exception as error:
+        raise ValueError("action could not be converted to float32") from error
+    expected = _flatten_space(space)
+    if flattened.shape != (expected,) or not bool(jnp.all(jnp.isfinite(flattened))):
+        raise ValueError("action must match its declared flattened shape and be finite")
+    return flattened
 
 
 def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[[Array], Any]:
@@ -208,6 +222,8 @@ def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[
         if not bool(jnp.all(jnp.isfinite(low) & jnp.isfinite(high) & (low <= high))):
             raise ValueError("Box random actions require finite ordered float32 bounds")
     elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
+        dimension = _flatten_space(action_space)
+        _require_float32_allocation("MultiDiscrete action bounds", 2 * dimension)
         starts = tuple(int(value) for value in np.asarray(action_space.start).reshape((-1,)))
         counts = tuple(int(value) for value in np.asarray(action_space.nvec).reshape((-1,)))
         bounds = tuple(zip(starts, counts, strict=True))
@@ -792,8 +808,6 @@ def make_gymnasium_stream(
     Returns:
         GymnasiumStream wrapping the environment
     """
-    import gymnasium
-
     if type(env_id) is not str or not env_id:
         raise ValueError("env_id must be a non-empty exact string")
     mode = _require_mode(mode)
@@ -802,6 +816,10 @@ def make_gymnasium_stream(
     )
     seed = require_jax_seed(seed)
     gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+    if policy is not None and not callable(policy):
+        raise ValueError("policy must be callable or None")
+
+    import gymnasium
 
     env = gymnasium.make(env_id, **env_kwargs)
     return GymnasiumStream(

--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -21,22 +21,70 @@ Supports multiple prediction modes:
 
 from __future__ import annotations
 
+import math
+import operator
 import time
 from collections.abc import Callable, Iterator
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
+from alberta_framework._seed_validation import JAX_KEY_SEED_MAX, require_jax_seed
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.learners import LinearLearner
 from alberta_framework.core.types import LearnerState, TimeStep
 
 if TYPE_CHECKING:
     import gymnasium
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_positive_int32(name: str, value: object) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [1, {_INT32_MAX}]")
+    return canonical
+
+
+def _require_float32_allocation(name: str, scalars: int) -> None:
+    if scalars > _INT32_MAX or 4 * scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} scalar and byte counts must fit signed int32")
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
+def _require_mode(mode: object) -> PredictionMode:
+    if type(mode) is not PredictionMode:
+        raise ValueError("mode must be an exact PredictionMode")
+    return mode
 
 
 class PredictionMode(Enum):
@@ -76,11 +124,12 @@ def _flatten_space(space: gymnasium.spaces.Space[Any]) -> int:
     import gymnasium
 
     if isinstance(space, gymnasium.spaces.Box):
-        return int(jnp.prod(jnp.array(space.shape)))
+        dimension = math.prod(space.shape)
+        return _require_positive_int32("flattened Box dimension", dimension)
     elif isinstance(space, gymnasium.spaces.Discrete):
         return 1
     elif isinstance(space, gymnasium.spaces.MultiDiscrete):
-        return len(space.nvec)
+        return _require_positive_int32("flattened MultiDiscrete dimension", int(space.nvec.size))
     else:
         raise ValueError(
             f"Unsupported space type: {type(space).__name__}. "
@@ -105,7 +154,7 @@ def _flatten_observation(obs: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     elif isinstance(space, gymnasium.spaces.Discrete):
         return jnp.array([float(obs)], dtype=jnp.float32)
     elif isinstance(space, gymnasium.spaces.MultiDiscrete):
-        return jnp.asarray(obs, dtype=jnp.float32)
+        return jnp.asarray(obs, dtype=jnp.float32).reshape((-1,))
     else:
         raise ValueError(f"Unsupported space type: {type(space).__name__}")
 
@@ -127,7 +176,7 @@ def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     elif isinstance(space, gymnasium.spaces.Discrete):
         return jnp.array([float(action)], dtype=jnp.float32)
     elif isinstance(space, gymnasium.spaces.MultiDiscrete):
-        return jnp.asarray(action, dtype=jnp.float32)
+        return jnp.asarray(action, dtype=jnp.float32).reshape((-1,))
     else:
         raise ValueError(f"Unsupported space type: {type(space).__name__}")
 
@@ -144,25 +193,47 @@ def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[
     """
     import gymnasium
 
+    seed = require_jax_seed(seed)
     rng = jr.key(seed)
     action_space = env.action_space
+
+    if isinstance(action_space, gymnasium.spaces.Discrete):
+        discrete_low = int(action_space.start)
+        discrete_high = discrete_low + int(action_space.n)
+        if not _INT32_MIN <= discrete_low < discrete_high <= _INT32_MAX:
+            raise ValueError("Discrete action bounds must fit JAX signed int32")
+    elif isinstance(action_space, gymnasium.spaces.Box):
+        low = jnp.asarray(action_space.low, dtype=jnp.float32)
+        high = jnp.asarray(action_space.high, dtype=jnp.float32)
+        if not bool(jnp.all(jnp.isfinite(low) & jnp.isfinite(high) & (low <= high))):
+            raise ValueError("Box random actions require finite ordered float32 bounds")
+    elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
+        starts = tuple(int(value) for value in np.asarray(action_space.start).reshape((-1,)))
+        counts = tuple(int(value) for value in np.asarray(action_space.nvec).reshape((-1,)))
+        bounds = tuple(zip(starts, counts, strict=True))
+        if any(
+            not _INT32_MIN <= start < start + count <= _INT32_MAX
+            for start, count in bounds
+        ):
+            raise ValueError("MultiDiscrete action bounds must fit JAX signed int32")
+    else:
+        raise ValueError(f"Unsupported action space: {type(action_space).__name__}")
 
     def policy(_obs: Array) -> Any:
         nonlocal rng
         rng, key = jr.split(rng)
 
         if isinstance(action_space, gymnasium.spaces.Discrete):
-            return int(jr.randint(key, (), 0, int(action_space.n)))
+            return int(jr.randint(key, (), discrete_low, discrete_high))
         elif isinstance(action_space, gymnasium.spaces.Box):
-            # Sample uniformly between low and high
-            low = jnp.asarray(action_space.low, dtype=jnp.float32)
-            high = jnp.asarray(action_space.high, dtype=jnp.float32)
             return jr.uniform(key, action_space.shape, minval=low, maxval=high)
         elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
-            nvec = action_space.nvec
-            return [int(jr.randint(jr.fold_in(key, i), (), 0, n)) for i, n in enumerate(nvec)]
-        else:
-            raise ValueError(f"Unsupported action space: {type(action_space).__name__}")
+            samples = [
+                int(jr.randint(jr.fold_in(key, index), (), start, start + count))
+                for index, (start, count) in enumerate(bounds)
+            ]
+            return np.asarray(samples, dtype=action_space.dtype).reshape(action_space.shape)
+        raise AssertionError("action-space validation and dispatch diverged")
 
     return policy
 
@@ -185,6 +256,9 @@ def make_epsilon_greedy_policy(
         Epsilon-greedy policy
     """
     epsilon = validated_float32_scalar("epsilon", epsilon, lower=0.0, upper=1.0)
+    seed = require_jax_seed(seed)
+    if seed == JAX_KEY_SEED_MAX:
+        raise ValueError("seed must leave room for the epsilon-greedy random-policy subkey")
     random_policy = make_random_policy(env, seed + 1)
     rng = jr.key(seed)
 
@@ -235,7 +309,24 @@ def collect_trajectory(
         Tuple of (observations, targets) as JAX arrays with shape
         (num_steps, feature_dim) and (num_steps, target_dim)
     """
+    num_steps = _require_positive_int32("num_steps", num_steps)
+    mode = _require_mode(mode)
+    include_action_in_features = _require_exact_bool(
+        "include_action_in_features", include_action_in_features
+    )
+    seed = require_jax_seed(seed)
     gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+    if policy is not None and not callable(policy):
+        raise ValueError("policy must be callable or None")
+    if value_estimator is not None and not callable(value_estimator):
+        raise ValueError("value_estimator must be callable or None")
+    observation_dim = _flatten_space(env.observation_space)
+    action_dim = _flatten_space(env.action_space)
+    feature_dim = observation_dim + action_dim if include_action_in_features else observation_dim
+    target_dim = observation_dim if mode is PredictionMode.NEXT_STATE else 1
+    _require_float32_allocation(
+        "trajectory output", num_steps * (feature_dim + target_dim)
+    )
     if policy is None:
         policy = make_random_policy(env, seed)
 
@@ -392,6 +483,13 @@ class GymnasiumStream:
                 If False, features = obs only
             seed: Random seed for environment resets and random policy
         """
+        mode = _require_mode(mode)
+        include_action_in_features = _require_exact_bool(
+            "include_action_in_features", include_action_in_features
+        )
+        seed = require_jax_seed(seed)
+        if policy is not None and not callable(policy):
+            raise ValueError("policy must be callable or None")
         self._env = env
         self._mode = mode
         self._gamma = validated_float32_scalar(
@@ -418,6 +516,8 @@ class GymnasiumStream:
             self._target_dim = self._obs_dim
         else:
             self._target_dim = 1
+        _require_float32_allocation("stream feature vector", self._feature_dim)
+        _require_float32_allocation("stream target vector", self._target_dim)
 
         self._current_obs: Array | None = None
         self._episode_count = 0
@@ -451,6 +551,8 @@ class GymnasiumStream:
 
     def set_value_estimator(self, estimator: Callable[[Array], float]) -> None:
         """Set the value estimator for proper TD learning in VALUE mode."""
+        if not callable(estimator):
+            raise ValueError("estimator must be callable")
         self._value_estimator = estimator
 
     def _get_reset_seed(self) -> int:
@@ -557,6 +659,12 @@ class TDStream:
             include_action_in_features: If True, learn Q(s,a). If False, learn V(s)
             seed: Random seed
         """
+        include_action_in_features = _require_exact_bool(
+            "include_action_in_features", include_action_in_features
+        )
+        seed = require_jax_seed(seed)
+        if policy is not None and not callable(policy):
+            raise ValueError("policy must be callable or None")
         self._env = env
         self._gamma = validated_float32_scalar(
             "gamma", gamma, lower=0.0, upper=1.0
@@ -577,6 +685,7 @@ class TDStream:
             self._feature_dim = self._obs_dim + self._action_dim
         else:
             self._feature_dim = self._obs_dim
+        _require_float32_allocation("TD stream feature vector", self._feature_dim)
 
         self._current_obs: Array | None = None
         self._episode_count = 0
@@ -600,6 +709,8 @@ class TDStream:
 
     def update_value_function(self, value_fn: Callable[[Array], float]) -> None:
         """Update the value function used for TD bootstrapping."""
+        if not callable(value_fn):
+            raise ValueError("value_fn must be callable")
         self._value_fn = value_fn
 
     def _get_reset_seed(self) -> int:
@@ -683,6 +794,13 @@ def make_gymnasium_stream(
     """
     import gymnasium
 
+    if type(env_id) is not str or not env_id:
+        raise ValueError("env_id must be a non-empty exact string")
+    mode = _require_mode(mode)
+    include_action_in_features = _require_exact_bool(
+        "include_action_in_features", include_action_in_features
+    )
+    seed = require_jax_seed(seed)
     gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
 
     env = gymnasium.make(env_id, **env_kwargs)

--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -70,9 +70,13 @@ def _require_positive_int32(name: str, value: object) -> int:
     return canonical
 
 
-def _require_float32_allocation(name: str, scalars: int) -> None:
-    if scalars > _INT32_MAX or 4 * scalars > _INT32_MAX:
+def _require_allocation(name: str, scalars: int, *, itemsize: int) -> None:
+    if scalars > _INT32_MAX or itemsize * scalars > _INT32_MAX:
         raise ValueError(f"derived {name} scalar and byte counts must fit signed int32")
+
+
+def _require_float32_allocation(name: str, scalars: int) -> None:
+    _require_allocation(name, scalars, itemsize=4)
 
 
 def _require_exact_bool(name: str, value: object) -> bool:
@@ -195,6 +199,93 @@ def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     return flattened
 
 
+def _make_random_policy(
+    env: gymnasium.Env[Any, Any], rng: Array
+) -> Callable[[Array], Any]:
+    """Build a bounded random policy from one already validated JAX key."""
+    import gymnasium
+
+    action_space = env.action_space
+    action_dim = _flatten_space(action_space)
+
+    if isinstance(action_space, gymnasium.spaces.Discrete):
+        discrete_low = int(action_space.start)
+        discrete_count = int(action_space.n)
+        discrete_high = discrete_low + discrete_count
+        if not (
+            1 <= discrete_count <= _INT32_MAX
+            and _INT32_MIN <= discrete_low < discrete_high <= _INT32_MAX
+        ):
+            raise ValueError("Discrete action bounds must fit JAX signed int32")
+    elif isinstance(action_space, gymnasium.spaces.Box):
+        _require_float32_allocation("random Box bounds and action", 3 * action_dim)
+        with np.errstate(over="ignore", invalid="ignore"):
+            low_array = np.asarray(action_space.low, dtype=np.float32)
+            high_array = np.asarray(action_space.high, dtype=np.float32)
+            finite_span = np.isfinite(high_array - low_array)
+        if not bool(
+            np.all(
+                np.isfinite(low_array)
+                & np.isfinite(high_array)
+                & finite_span
+                & (low_array <= high_array)
+            )
+        ):
+            raise ValueError(
+                "Box random actions require finite ordered bounds with a finite float32 span"
+            )
+        low = jnp.asarray(low_array)
+        high = jnp.asarray(high_array)
+    elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
+        starts = np.asarray(action_space.start).reshape((-1,))
+        counts = np.asarray(action_space.nvec).reshape((-1,))
+        action_dtype = np.dtype(action_space.dtype)
+        _require_allocation(
+            "random MultiDiscrete action",
+            action_dim,
+            itemsize=action_dtype.itemsize,
+        )
+        for index in range(action_dim):
+            start = int(starts[index])
+            count = int(counts[index])
+            if not (
+                1 <= count <= _INT32_MAX
+                and _INT32_MIN <= start < start + count <= _INT32_MAX
+            ):
+                raise ValueError("MultiDiscrete action bounds must fit JAX signed int32")
+    else:
+        raise ValueError(f"Unsupported action space: {type(action_space).__name__}")
+
+    def policy(_obs: Array) -> Any:
+        nonlocal rng
+        rng, key = jr.split(rng)
+
+        if isinstance(action_space, gymnasium.spaces.Discrete):
+            return int(jr.randint(key, (), discrete_low, discrete_high))
+        if isinstance(action_space, gymnasium.spaces.Box):
+            return jr.uniform(key, action_space.shape, minval=low, maxval=high)
+        if isinstance(action_space, gymnasium.spaces.MultiDiscrete):
+            samples = np.fromiter(
+                (
+                    int(
+                        jr.randint(
+                            jr.fold_in(key, index),
+                            (),
+                            int(starts[index]),
+                            int(starts[index]) + int(counts[index]),
+                        )
+                    )
+                    for index in range(action_dim)
+                ),
+                dtype=action_dtype,
+                count=action_dim,
+            )
+            return samples.reshape(action_space.shape)
+        raise AssertionError("action-space validation and dispatch diverged")
+
+    return policy
+
+
 def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[[Array], Any]:
     """Create a random action policy for an environment.
 
@@ -205,66 +296,8 @@ def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[
     Returns:
         A callable that takes an observation and returns a random action
     """
-    import gymnasium
-
     seed = require_jax_seed(seed)
-    rng = jr.key(seed)
-    action_space = env.action_space
-
-    if isinstance(action_space, gymnasium.spaces.Discrete):
-        _require_float32_allocation("random Discrete action", _flatten_space(action_space))
-        discrete_low = int(action_space.start)
-        discrete_high = discrete_low + int(action_space.n)
-        if not _INT32_MIN <= discrete_low < discrete_high <= _INT32_MAX:
-            raise ValueError("Discrete action bounds must fit JAX signed int32")
-    elif isinstance(action_space, gymnasium.spaces.Box):
-        action_dim = _flatten_space(action_space)
-        _require_float32_allocation("random Box bounds and action", 3 * action_dim)
-        low = jnp.asarray(action_space.low, dtype=jnp.float32)
-        high = jnp.asarray(action_space.high, dtype=jnp.float32)
-        span = high - low
-        if not bool(
-            jnp.all(
-                jnp.isfinite(low)
-                & jnp.isfinite(high)
-                & (low <= high)
-                & jnp.isfinite(span)
-            )
-        ):
-            raise ValueError(
-                "Box random actions require finite ordered bounds with a finite float32 span"
-            )
-    elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
-        dimension = _flatten_space(action_space)
-        _require_float32_allocation("MultiDiscrete action bounds", 2 * dimension)
-        starts = tuple(int(value) for value in np.asarray(action_space.start).reshape((-1,)))
-        counts = tuple(int(value) for value in np.asarray(action_space.nvec).reshape((-1,)))
-        bounds = tuple(zip(starts, counts, strict=True))
-        if any(
-            not _INT32_MIN <= start < start + count <= _INT32_MAX
-            for start, count in bounds
-        ):
-            raise ValueError("MultiDiscrete action bounds must fit JAX signed int32")
-    else:
-        raise ValueError(f"Unsupported action space: {type(action_space).__name__}")
-
-    def policy(_obs: Array) -> Any:
-        nonlocal rng
-        rng, key = jr.split(rng)
-
-        if isinstance(action_space, gymnasium.spaces.Discrete):
-            return int(jr.randint(key, (), discrete_low, discrete_high))
-        elif isinstance(action_space, gymnasium.spaces.Box):
-            return jr.uniform(key, action_space.shape, minval=low, maxval=high)
-        elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
-            samples = [
-                int(jr.randint(jr.fold_in(key, index), (), start, start + count))
-                for index, (start, count) in enumerate(bounds)
-            ]
-            return np.asarray(samples, dtype=action_space.dtype).reshape(action_space.shape)
-        raise AssertionError("action-space validation and dispatch diverged")
-
-    return policy
+    return _make_random_policy(env, jr.key(seed))
 
 
 def make_epsilon_greedy_policy(
@@ -288,10 +321,9 @@ def make_epsilon_greedy_policy(
         raise ValueError("base_policy must be callable")
     epsilon = validated_float32_scalar("epsilon", epsilon, lower=0.0, upper=1.0)
     seed = require_jax_seed(seed)
-    if seed == JAX_KEY_SEED_MAX:
-        raise ValueError("seed must leave room for the epsilon-greedy random-policy subkey")
-    random_policy = make_random_policy(env, seed + 1)
     rng = jr.key(seed)
+    random_rng = jr.key(seed + 1) if seed < JAX_KEY_SEED_MAX else jr.fold_in(rng, 1)
+    random_policy = _make_random_policy(env, random_rng)
 
     def policy(obs: Array) -> Any:
         nonlocal rng
@@ -521,34 +553,30 @@ class GymnasiumStream:
         seed = require_jax_seed(seed)
         if policy is not None and not callable(policy):
             raise ValueError("policy must be callable or None")
+        gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        observation_dim = _flatten_space(env.observation_space)
+        action_dim = _flatten_space(env.action_space)
+        feature_dim = (
+            observation_dim + action_dim
+            if include_action_in_features
+            else observation_dim
+        )
+        target_dim = observation_dim if mode is PredictionMode.NEXT_STATE else 1
+        _require_float32_allocation("stream feature vector", feature_dim)
+        _require_float32_allocation("stream target vector", target_dim)
+
+        selected_policy = make_random_policy(env, seed) if policy is None else policy
         self._env = env
         self._mode = mode
-        self._gamma = validated_float32_scalar(
-            "gamma", gamma, lower=0.0, upper=1.0
-        )
+        self._gamma = gamma
         self._include_action_in_features = include_action_in_features
         self._seed = seed
         self._reset_count = 0
-
-        if policy is None:
-            self._policy = make_random_policy(env, seed)
-        else:
-            self._policy = policy
-
-        self._obs_dim = _flatten_space(env.observation_space)
-        self._action_dim = _flatten_space(env.action_space)
-
-        if include_action_in_features:
-            self._feature_dim = self._obs_dim + self._action_dim
-        else:
-            self._feature_dim = self._obs_dim
-
-        if mode == PredictionMode.NEXT_STATE:
-            self._target_dim = self._obs_dim
-        else:
-            self._target_dim = 1
-        _require_float32_allocation("stream feature vector", self._feature_dim)
-        _require_float32_allocation("stream target vector", self._target_dim)
+        self._policy = selected_policy
+        self._obs_dim = observation_dim
+        self._action_dim = action_dim
+        self._feature_dim = feature_dim
+        self._target_dim = target_dim
 
         self._current_obs: Array | None = None
         self._episode_count = 0
@@ -696,27 +724,26 @@ class TDStream:
         seed = require_jax_seed(seed)
         if policy is not None and not callable(policy):
             raise ValueError("policy must be callable or None")
-        self._env = env
-        self._gamma = validated_float32_scalar(
-            "gamma", gamma, lower=0.0, upper=1.0
+        gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        observation_dim = _flatten_space(env.observation_space)
+        action_dim = _flatten_space(env.action_space)
+        feature_dim = (
+            observation_dim + action_dim
+            if include_action_in_features
+            else observation_dim
         )
+        _require_float32_allocation("TD stream feature vector", feature_dim)
+
+        selected_policy = make_random_policy(env, seed) if policy is None else policy
+        self._env = env
+        self._gamma = gamma
         self._include_action_in_features = include_action_in_features
         self._seed = seed
         self._reset_count = 0
-
-        if policy is None:
-            self._policy = make_random_policy(env, seed)
-        else:
-            self._policy = policy
-
-        self._obs_dim = _flatten_space(env.observation_space)
-        self._action_dim = _flatten_space(env.action_space)
-
-        if include_action_in_features:
-            self._feature_dim = self._obs_dim + self._action_dim
-        else:
-            self._feature_dim = self._obs_dim
-        _require_float32_allocation("TD stream feature vector", self._feature_dim)
+        self._policy = selected_policy
+        self._obs_dim = observation_dim
+        self._action_dim = action_dim
+        self._feature_dim = feature_dim
 
         self._current_obs: Array | None = None
         self._episode_count = 0
@@ -837,11 +864,18 @@ def make_gymnasium_stream(
     import gymnasium
 
     env = gymnasium.make(env_id, **env_kwargs)
-    return GymnasiumStream(
-        env=env,
-        mode=mode,
-        policy=policy,
-        gamma=gamma,
-        include_action_in_features=include_action_in_features,
-        seed=seed,
-    )
+    try:
+        return GymnasiumStream(
+            env=env,
+            mode=mode,
+            policy=policy,
+            gamma=gamma,
+            include_action_in_features=include_action_in_features,
+            seed=seed,
+        )
+    except Exception:
+        try:
+            env.close()
+        except Exception:
+            pass
+        raise

--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -212,15 +212,28 @@ def make_random_policy(env: gymnasium.Env[Any, Any], seed: int = 0) -> Callable[
     action_space = env.action_space
 
     if isinstance(action_space, gymnasium.spaces.Discrete):
+        _require_float32_allocation("random Discrete action", _flatten_space(action_space))
         discrete_low = int(action_space.start)
         discrete_high = discrete_low + int(action_space.n)
         if not _INT32_MIN <= discrete_low < discrete_high <= _INT32_MAX:
             raise ValueError("Discrete action bounds must fit JAX signed int32")
     elif isinstance(action_space, gymnasium.spaces.Box):
+        action_dim = _flatten_space(action_space)
+        _require_float32_allocation("random Box bounds and action", 3 * action_dim)
         low = jnp.asarray(action_space.low, dtype=jnp.float32)
         high = jnp.asarray(action_space.high, dtype=jnp.float32)
-        if not bool(jnp.all(jnp.isfinite(low) & jnp.isfinite(high) & (low <= high))):
-            raise ValueError("Box random actions require finite ordered float32 bounds")
+        span = high - low
+        if not bool(
+            jnp.all(
+                jnp.isfinite(low)
+                & jnp.isfinite(high)
+                & (low <= high)
+                & jnp.isfinite(span)
+            )
+        ):
+            raise ValueError(
+                "Box random actions require finite ordered bounds with a finite float32 span"
+            )
     elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
         dimension = _flatten_space(action_space)
         _require_float32_allocation("MultiDiscrete action bounds", 2 * dimension)
@@ -271,6 +284,8 @@ def make_epsilon_greedy_policy(
     Returns:
         Epsilon-greedy policy
     """
+    if not callable(base_policy):
+        raise ValueError("base_policy must be callable")
     epsilon = validated_float32_scalar("epsilon", epsilon, lower=0.0, upper=1.0)
     seed = require_jax_seed(seed)
     if seed == JAX_KEY_SEED_MAX:

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -1,6 +1,7 @@
 """Tests for Gymnasium experience streams."""
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 # Skip all tests if gymnasium is not installed
@@ -11,6 +12,9 @@ from alberta_framework.streams.gymnasium import (  # noqa: E402
     GymnasiumStream,
     PredictionMode,
     TDStream,
+    _flatten_action,
+    _flatten_observation,
+    _flatten_space,
     collect_trajectory,
     make_epsilon_greedy_policy,
     make_gymnasium_stream,
@@ -68,6 +72,112 @@ def test_probability_entry_points_normalize_hostile_real_failures_without_repr()
             )
     finally:
         env.close()
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    tuple(
+        dict.fromkeys(
+            (
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+                np.longlong,
+                np.ulonglong,
+            )
+        )
+    ),
+)
+def test_num_steps_accepts_all_numpy_integer_families(integer_type: type[np.integer]) -> None:
+    env = gymnasium.make("CartPole-v1")
+    try:
+        observations, targets = collect_trajectory(env, None, integer_type(1))
+        assert observations.shape == (1, 5)
+        assert targets.shape == (1, 1)
+    finally:
+        env.close()
+
+
+def test_schedule_and_shape_contracts_fail_before_environment_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = gymnasium.make("CartPole-v1")
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("environment executed before trajectory preflight")
+
+    monkeypatch.setattr(env, "reset", forbidden)
+    try:
+        for num_steps in (0, -1, True, 1.5, "1"):
+            with pytest.raises(ValueError, match="num_steps"):
+                collect_trajectory(env, None, num_steps)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="trajectory output"):
+            collect_trajectory(env, None, 2**31 - 1)
+        with pytest.raises(ValueError, match="exact bool"):
+            collect_trajectory(env, None, 1, include_action_in_features=1)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="PredictionMode"):
+            collect_trajectory(env, None, 1, mode="reward")  # type: ignore[arg-type]
+    finally:
+        env.close()
+
+
+def test_seed_contracts_reject_aliases_spoofs_and_epsilon_subkey_overflow() -> None:
+    class Spoof:
+        @property
+        def __class__(self) -> type[int]:  # type: ignore[override,misc]
+            return int
+
+        def __index__(self) -> int:
+            raise AssertionError("unapproved index hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("error path invoked repr")
+
+    env = gymnasium.make("CartPole-v1")
+    try:
+        for seed in (True, np.uint32(1), -1, 2**32, Spoof()):
+            with pytest.raises(ValueError, match="seed"):
+                make_random_policy(env, seed=seed)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="leave room"):
+            make_epsilon_greedy_policy(lambda _observation: 0, env, seed=2**32 - 1)
+    finally:
+        env.close()
+
+
+def test_random_policy_respects_nonzero_and_multiaxis_discrete_starts() -> None:
+    class StubEnv:
+        def __init__(self, action_space: object):
+            self.action_space = action_space
+
+    discrete = gymnasium.spaces.Discrete(3, start=5)
+    discrete_policy = make_random_policy(StubEnv(discrete), seed=1)  # type: ignore[arg-type]
+    assert {discrete_policy(jnp.zeros(1)) for _ in range(20)} <= {5, 6, 7}
+
+    multi = gymnasium.spaces.MultiDiscrete(
+        np.asarray(((2, 3), (4, 5))),
+        start=np.asarray(((10, 20), (30, 40))),
+    )
+    multi_policy = make_random_policy(StubEnv(multi), seed=2)  # type: ignore[arg-type]
+    action = multi_policy(jnp.zeros(1))
+    assert action.shape == (2, 2)
+    assert np.all(action >= multi.start)
+    assert np.all(action < multi.start + multi.nvec)
+    assert _flatten_space(multi) == 4
+    assert _flatten_observation(multi.start, multi).shape == (4,)
+    assert _flatten_action(action, multi).shape == (4,)
+
+
+def test_random_box_policy_rejects_nonfinite_bounds() -> None:
+    class StubEnv:
+        action_space = gymnasium.spaces.Box(-np.inf, np.inf, shape=(1,), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="finite ordered"):
+        make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
 
 
 class TestGymnasiumStreamRewardMode:

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -180,6 +180,34 @@ def test_random_box_policy_rejects_nonfinite_bounds() -> None:
         make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
 
 
+def test_runtime_values_must_match_declared_flattened_shapes_and_be_finite() -> None:
+    box = gymnasium.spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
+    with pytest.raises(ValueError, match="observation.*shape"):
+        _flatten_observation(np.zeros((1,), dtype=np.float32), box)
+    with pytest.raises(ValueError, match="action.*shape"):
+        _flatten_action(np.zeros((3,), dtype=np.float32), box)
+    with pytest.raises(ValueError, match="observation.*finite"):
+        _flatten_observation(np.asarray((0.0, np.nan), dtype=np.float32), box)
+    with pytest.raises(ValueError, match="action.*finite"):
+        _flatten_action(np.asarray((0.0, np.inf), dtype=np.float32), box)
+
+
+def test_factory_rejects_noncallable_policy_before_environment_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden_make(*_args: object, **_kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("environment constructed before policy validation")
+
+    monkeypatch.setattr(gymnasium, "make", forbidden_make)
+    with pytest.raises(ValueError, match="policy"):
+        make_gymnasium_stream("CartPole-v1", policy=object())  # type: ignore[arg-type]
+    assert calls == 0
+
+
 class TestGymnasiumStreamRewardMode:
     """Tests for GymnasiumStream with REWARD prediction mode."""
 

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -7,6 +7,7 @@ import pytest
 # Skip all tests if gymnasium is not installed
 gymnasium = pytest.importorskip("gymnasium")
 
+import alberta_framework.streams.gymnasium as gymnasium_stream_module  # noqa: E402
 from alberta_framework import TimeStep  # noqa: E402
 from alberta_framework.streams.gymnasium import (  # noqa: E402
     GymnasiumStream,
@@ -178,6 +179,50 @@ def test_random_box_policy_rejects_nonfinite_bounds() -> None:
 
     with pytest.raises(ValueError, match="finite ordered"):
         make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
+
+
+def test_random_box_policy_rejects_float32_span_overflow() -> None:
+    maximum = np.finfo(np.float32).max
+
+    class StubEnv:
+        action_space = gymnasium.spaces.Box(
+            -maximum, maximum, shape=(1,), dtype=np.float32
+        )
+
+    with pytest.raises(ValueError, match="finite float32 span"):
+        make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
+
+
+def test_random_box_preflights_dimension_before_jax_bound_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubEnv:
+        action_space = gymnasium.spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+
+    monkeypatch.setattr(
+        gymnasium_stream_module,
+        "_flatten_space",
+        lambda _space: (_ for _ in ()).throw(ValueError("dimension preflight")),
+    )
+    monkeypatch.setattr(
+        gymnasium_stream_module.jnp,
+        "asarray",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("JAX conversion ran before dimension preflight")
+        ),
+    )
+    with pytest.raises(ValueError, match="dimension preflight"):
+        make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
+
+
+def test_epsilon_wrapper_rejects_base_policy_before_environment_access() -> None:
+    class HostileEnv:
+        @property
+        def action_space(self) -> object:
+            raise AssertionError("environment accessed before base-policy validation")
+
+    with pytest.raises(ValueError, match="base_policy"):
+        make_epsilon_greedy_policy(object(), HostileEnv())  # type: ignore[arg-type]
 
 
 def test_runtime_values_must_match_declared_flattened_shapes_and_be_finite() -> None:

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -127,7 +127,7 @@ def test_schedule_and_shape_contracts_fail_before_environment_execution(
         env.close()
 
 
-def test_seed_contracts_reject_aliases_spoofs_and_epsilon_subkey_overflow() -> None:
+def test_seed_contracts_reject_aliases_and_spoofs_without_shrinking_uint32_domain() -> None:
     class Spoof:
         @property
         def __class__(self) -> type[int]:  # type: ignore[override,misc]
@@ -144,8 +144,13 @@ def test_seed_contracts_reject_aliases_spoofs_and_epsilon_subkey_overflow() -> N
         for seed in (True, np.uint32(1), -1, 2**32, Spoof()):
             with pytest.raises(ValueError, match="seed"):
                 make_random_policy(env, seed=seed)  # type: ignore[arg-type]
-        with pytest.raises(ValueError, match="leave room"):
-            make_epsilon_greedy_policy(lambda _observation: 0, env, seed=2**32 - 1)
+        policy = make_epsilon_greedy_policy(
+            lambda _observation: 0,
+            env,
+            epsilon=1.0,
+            seed=2**32 - 1,
+        )
+        assert env.action_space.contains(policy(jnp.zeros(4)))
     finally:
         env.close()
 
@@ -171,6 +176,23 @@ def test_random_policy_respects_nonzero_and_multiaxis_discrete_starts() -> None:
     assert _flatten_space(multi) == 4
     assert _flatten_observation(multi.start, multi).shape == (4,)
     assert _flatten_action(action, multi).shape == (4,)
+
+
+def test_random_policy_rejects_discrete_ranges_wider_than_jax_int32() -> None:
+    class StubEnv:
+        def __init__(self, action_space: object):
+            self.action_space = action_space
+
+    discrete = gymnasium.spaces.Discrete(2**31, start=-(2**30))
+    with pytest.raises(ValueError, match="signed int32"):
+        make_random_policy(StubEnv(discrete), seed=0)  # type: ignore[arg-type]
+
+    multi = gymnasium.spaces.MultiDiscrete(
+        np.asarray([2**31], dtype=np.uint32),
+        start=np.asarray([-(2**30)], dtype=np.int64),
+    )
+    with pytest.raises(ValueError, match="signed int32"):
+        make_random_policy(StubEnv(multi), seed=0)  # type: ignore[arg-type]
 
 
 def test_random_box_policy_rejects_nonfinite_bounds() -> None:
@@ -251,6 +273,26 @@ def test_factory_rejects_noncallable_policy_before_environment_construction(
     with pytest.raises(ValueError, match="policy"):
         make_gymnasium_stream("CartPole-v1", policy=object())  # type: ignore[arg-type]
     assert calls == 0
+
+
+def test_factory_closes_environment_when_stream_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class InvalidEnv:
+        observation_space = gymnasium.spaces.Tuple(
+            (gymnasium.spaces.Discrete(2), gymnasium.spaces.Discrete(2))
+        )
+        action_space = gymnasium.spaces.Discrete(2)
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    env = InvalidEnv()
+    monkeypatch.setattr(gymnasium, "make", lambda *args, **kwargs: env)
+    with pytest.raises(ValueError, match="Unsupported space type"):
+        make_gymnasium_stream("invalid-v0")
+    assert env.closed
 
 
 class TestGymnasiumStreamRewardMode:


### PR DESCRIPTION
Residual successor to #780 after its gamma/epsilon scalar fix was integrated through #782. Contributor rama0x1 is retained as a co-author.

The deep audit found remaining reachable failures: coercive/empty/oversized `num_steps`, JAX seed aliasing and epsilon sub-seed overflow, environment execution before output-allocation validation, truthy non-bool feature flags and non-enum modes, ignored nonzero `Discrete.start`, multidimensional `MultiDiscrete` shape drift, and invalid uniform sampling from nonfinite Box bounds.

This adds exact schedule/seed/bool/mode/callable gates; signed-int32 scalar+byte preflight for trajectory and stream shapes before reset/step; exact Python shape arithmetic; correct Discrete/MultiDiscrete starts and flattening; and finite ordered float32 Box bounds.

Validation: 68 focused Gymnasium/bootstrap/package-boundary tests pass; Ruff, full strict mypy (168 files), and diff check pass. No evidence sources or outputs changed.