### PR TITLE
fix(core): close SARSA and stacked-Horde transaction residuals

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -403,8 +403,26 @@ class SARSAAgent:
         if type(sarsa_config) is not SARSAConfig:
             raise ValueError("sarsa_config must be an actual SARSAConfig")
         lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+        step_size = validated_float32_scalar("step_size", step_size, lower=0.0)
+        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
+        leaky_relu_slope = validated_float32_scalar("leaky_relu_slope", leaky_relu_slope, lower=0.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay",
+            utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        if type(use_layer_norm) is not bool:
+            raise ValueError("use_layer_norm must be an actual bool")
+        if type(trace_mode) is not TraceMode:
+            raise ValueError("trace_mode must be an actual TraceMode")
         if prediction_demons is not None and type(prediction_demons) is not list:
             raise ValueError("prediction_demons must be an actual list or None")
+        if prediction_demons is not None and any(
+            type(demon) is not GVFSpec for demon in prediction_demons
+        ):
+            raise ValueError("prediction_demons entries must be actual GVFSpec values")
         n_predictions = len(prediction_demons) if prediction_demons is not None else 0
         total_heads = _require_int32(
             "total control and prediction demons",
@@ -490,7 +508,7 @@ class SARSAAgent:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "SARSAAgent":
+    def from_config(cls, config: Mapping[str, Any]) -> "SARSAAgent":
         """Reconstruct from config dict."""
         from alberta_framework.core.normalizers import normalizer_from_config
         from alberta_framework.core.optimizers import (
@@ -503,7 +521,8 @@ class SARSAAgent:
         if not all(type(key) is str for key in config) or set(config) != _SARSA_AGENT_CONFIG_FIELDS:
             raise ValueError("SARSA agent config fields do not match the schema")
         config = dict(config)
-        if config.pop("type") != "SARSAAgent":
+        serialized_type = config.pop("type")
+        if type(serialized_type) is not str or serialized_type != "SARSAAgent":
             raise ValueError("unexpected SARSA agent config type")
         state_schema = config.pop("state_schema")
         if type(state_schema) is not str or state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
@@ -518,6 +537,8 @@ class SARSAAgent:
             and type(config["prediction_demons"]) is not list
         ):
             raise ValueError("serialized prediction_demons must be an actual list or None")
+        if type(config["trace_mode"]) is not str:
+            raise ValueError("serialized trace_mode must be an actual string")
 
         sarsa_config = SARSAConfig.from_config(config.pop("sarsa_config"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
@@ -547,6 +568,46 @@ class SARSAAgent:
             prediction_demons=prediction_demons,
             trace_mode=trace_mode,
             **config,
+        )
+
+    def _require_state_contract(self, state: SARSAState) -> int:
+        """Validate SARSA-owned static state leaves and return feature width."""
+
+        if type(state) is not SARSAState:
+            raise TypeError("state must be an actual SARSAState")
+        if type(state.learner_state) is not MultiHeadMLPState:
+            raise TypeError("learner_state must be an actual MultiHeadMLPState")
+        last_observation = jnp.asarray(state.last_observation)
+        if last_observation.ndim != 1 or last_observation.shape[0] < 1:
+            raise ValueError("SARSA last_observation must be a nonempty vector")
+        if last_observation.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("SARSA last_observation must have dtype float32")
+        for name, value, dtype in (
+            ("last_action", state.last_action, jnp.int32),
+            ("epsilon", state.epsilon, jnp.float32),
+            ("step_count", state.step_count, jnp.int32),
+        ):
+            array = jnp.asarray(value)
+            if array.shape != ():
+                raise ValueError(f"SARSA {name} must be scalar")
+            if array.dtype != jnp.dtype(dtype):
+                raise TypeError(f"SARSA {name} has the wrong dtype")
+        key_words = jnp.asarray(jr.key_data(state.rng_key))
+        if key_words.shape != (2,) or key_words.dtype != jnp.dtype(jnp.uint32):
+            raise TypeError("SARSA rng_key must be a scalar Threefry key")
+        return int(last_observation.shape[0])
+
+    def _state_values_valid(self, state: SARSAState) -> Array:
+        """Return dynamic validity for the complete source transaction."""
+
+        return (
+            jnp.all(jnp.isfinite(state.last_observation))
+            & jnp.isfinite(state.epsilon)
+            & (state.epsilon >= 0.0)
+            & (state.epsilon <= 1.0)
+            & (state.last_action >= -1)
+            & (state.last_action < self.n_actions)
+            & (state.step_count >= 0)
         )
 
     def init(self, feature_dim: int, key: Array) -> SARSAState:
@@ -595,11 +656,20 @@ class SARSAAgent:
         Returns:
             Tuple of (action, new_rng_key)
         """
+        feature_dim = self._require_state_contract(state)
+        raw_observation = jnp.asarray(observation)
+        if raw_observation.shape != (feature_dim,):
+            raise ValueError(f"SARSA observation must have shape ({feature_dim},)")
+        if raw_observation.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("SARSA observation must have dtype float32")
+        input_valid = self._state_values_valid(state) & jnp.all(jnp.isfinite(raw_observation))
+        safe_observation = jnp.where(input_valid, raw_observation, jnp.zeros_like(raw_observation))
         key, explore_key, noise_key, random_key = jr.split(state.rng_key, 4)
 
         # Get Q-values (first n_actions heads are control demons)
-        all_preds = self._horde.predict(state.learner_state, observation)
+        all_preds = self._horde.predict(state.learner_state, safe_observation)
         q_values = all_preds[: self._sarsa_config.n_actions]
+        policy_valid = input_valid & jnp.all(jnp.isfinite(q_values))
 
         # Greedy action with Gumbel tie-breaking
         # Add small noise only to max-valued actions for uniform tie-breaking
@@ -615,7 +685,10 @@ class SARSAAgent:
         explore = jr.uniform(explore_key) < state.epsilon
         action = jax.lax.select(explore, random_action, greedy_action)
 
-        return action, key
+        return (
+            jnp.where(policy_valid, action, jnp.asarray(-1, dtype=jnp.int32)),
+            jax.lax.cond(policy_valid, lambda: key, lambda: state.rng_key),
+        )
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def update(
@@ -647,9 +720,60 @@ class SARSAAgent:
         """
         n_actions = self._sarsa_config.n_actions
         gamma = self._sarsa_config.gamma
+        feature_dim = self._require_state_contract(state)
+        raw_observation = jnp.asarray(observation)
+        if raw_observation.shape != (feature_dim,):
+            raise ValueError(f"SARSA observation must have shape ({feature_dim},)")
+        if raw_observation.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("SARSA observation must have dtype float32")
+        raw_reward = jnp.asarray(reward)
+        if raw_reward.shape != ():
+            raise ValueError("SARSA reward must be scalar")
+        if raw_reward.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("SARSA reward must have dtype float32")
+        raw_terminated = jnp.asarray(terminated)
+        if raw_terminated.shape != ():
+            raise ValueError("SARSA terminated must be scalar")
+        if raw_terminated.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
+            raise TypeError("SARSA terminated must have dtype bool or float32")
+        raw_next_action = jnp.asarray(next_action)
+        if raw_next_action.shape != ():
+            raise ValueError("SARSA next_action must be scalar")
+        if raw_next_action.dtype != jnp.dtype(jnp.int32):
+            raise TypeError("SARSA next_action must have dtype int32")
+        prediction_values = None
+        prediction_values_valid = jnp.asarray(True, dtype=jnp.bool_)
+        if prediction_cumulants is not None:
+            prediction_values = jnp.asarray(prediction_cumulants)
+            if prediction_values.shape != (self._n_prediction_demons,):
+                raise ValueError(
+                    f"SARSA prediction_cumulants must have shape ({self._n_prediction_demons},)"
+                )
+            if prediction_values.dtype != jnp.dtype(jnp.float32):
+                raise TypeError("SARSA prediction_cumulants must have dtype float32")
+            prediction_values_valid = jnp.all(~jnp.isinf(prediction_values))
+
+        state_valid = self._state_values_valid(state)
+        next_action_valid = (raw_next_action >= 0) & (raw_next_action < n_actions)
+        terminated_valid = (raw_terminated == 0) | (raw_terminated == 1)
+        inputs_valid = (
+            jnp.all(jnp.isfinite(raw_observation))
+            & jnp.isfinite(raw_reward)
+            & terminated_valid
+            & next_action_valid
+            & prediction_values_valid
+        )
+        safe_observation = jnp.where(
+            jnp.all(jnp.isfinite(raw_observation)),
+            raw_observation,
+            jnp.zeros_like(raw_observation),
+        )
+        safe_reward = jnp.where(jnp.isfinite(raw_reward), raw_reward, jnp.zeros_like(raw_reward))
+        safe_terminated = jnp.where(terminated_valid, raw_terminated, jnp.ones_like(raw_terminated))
+        safe_next_action = jnp.clip(raw_next_action, 0, n_actions - 1)
 
         # Q(s', :) for all actions
-        all_preds = self._horde.predict(state.learner_state, observation)
+        all_preds = self._horde.predict(state.learner_state, safe_observation)
         q_next = all_preds[:n_actions]
         q_previous = self._horde.predict(
             state.learner_state,
@@ -659,15 +783,15 @@ class SARSAAgent:
         # SARSA target: r + gamma * Q(s', a') with terminal handling.
         # A terminal or zero-gamma transition must not multiply Q(s', a');
         # jnp.where still evaluates 0 * inf, which is NaN.
-        q_sa_next = q_next[next_action]
+        q_sa_next = q_next[safe_next_action]
         gamma_arr = jnp.asarray(gamma, dtype=q_sa_next.dtype)
-        skip_bootstrap = (terminated != 0) | (gamma_arr == 0.0)
+        skip_bootstrap = (safe_terminated != 0) | (gamma_arr == 0.0)
         bootstrap = jnp.where(
             skip_bootstrap,
             jnp.zeros_like(q_sa_next),
             gamma_arr * q_sa_next,
         )
-        sarsa_target = reward + bootstrap
+        sarsa_target = safe_reward + bootstrap
 
         # Build cumulants: NaN for all except last_action gets sarsa_target
         cumulants = jnp.full(self._horde.n_demons, jnp.nan, dtype=jnp.float32)
@@ -685,12 +809,12 @@ class SARSAAgent:
         cumulants = jnp.where(action_valid, updated_cumulants, cumulants)
 
         # Add prediction demon cumulants if any
-        if prediction_cumulants is not None:
+        if prediction_values is not None:
             cumulants = cumulants.at[n_actions:].set(
                 jnp.where(
-                    action_valid,
-                    prediction_cumulants,
-                    jnp.full_like(prediction_cumulants, jnp.nan),
+                    action_valid & inputs_valid,
+                    prediction_values,
+                    jnp.full_like(prediction_values, jnp.nan),
                 )
             )
 
@@ -704,7 +828,7 @@ class SARSAAgent:
             state.learner_state,
             state.last_observation,
             cumulants,
-            observation,
+            safe_observation,
             discounts,
         )
 
@@ -721,8 +845,8 @@ class SARSAAgent:
                 decay = jnp.where(state.last_action == i, 1.0, gl)
                 skipped_w = jnp.where(decay == 0.0, jnp.zeros_like(w_trace), decay * w_trace)
                 skipped_b = jnp.where(decay == 0.0, jnp.zeros_like(b_trace), decay * b_trace)
-                new_w = jnp.where(terminated, jnp.zeros_like(w_trace), skipped_w)
-                new_b = jnp.where(terminated, jnp.zeros_like(b_trace), skipped_b)
+                new_w = jnp.where(safe_terminated, jnp.zeros_like(w_trace), skipped_w)
+                new_b = jnp.where(safe_terminated, jnp.zeros_like(b_trace), skipped_b)
                 head_traces[i] = (new_w, new_b)
             new_learner_state = new_learner_state.replace(head_traces=tuple(head_traces))
 
@@ -743,22 +867,42 @@ class SARSAAgent:
             lambda: state.epsilon,
         )
 
-        new_state = SARSAState(  # type: ignore[call-arg]
+        proposed_state = SARSAState(  # type: ignore[call-arg]
             learner_state=new_learner_state,
-            last_action=next_action,
-            last_observation=observation,
+            last_action=safe_next_action,
+            last_observation=safe_observation,
             epsilon=new_epsilon,
             rng_key=state.rng_key,
             step_count=new_step_count,
         )
-        new_state = jax.lax.cond(action_valid, lambda: new_state, lambda: state)
+        candidate_valid = _floating_tree_is_finite(proposed_state)
+        zero_decay_trace_recovery = jnp.asarray(
+            self._lamda > 0.0 and gamma == 0.0,
+            dtype=jnp.bool_,
+        )
+        transaction_applied = (
+            state_valid
+            & action_valid
+            & inputs_valid
+            & (horde_result.update_applied | zero_decay_trace_recovery)
+            & candidate_valid
+        )
+        diagnostic_valid = (
+            action_valid
+            & next_action_valid
+            & jnp.isfinite(raw_reward)
+            & terminated_valid
+            & (jnp.all(jnp.isfinite(raw_observation)) | skip_bootstrap)
+            & jnp.isfinite(td_error)
+        )
+        new_state = jax.lax.cond(transaction_applied, lambda: proposed_state, lambda: state)
 
         return SARSAUpdateResult(  # type: ignore[call-arg]
             state=new_state,
-            action=next_action,
-            q_values=q_next,
-            td_error=td_error,
-            reward=reward,
+            action=jnp.where(transaction_applied, safe_next_action, -1),
+            q_values=jnp.where(transaction_applied, q_next, jnp.zeros_like(q_next)),
+            td_error=jnp.where(diagnostic_valid, td_error, 0.0),
+            reward=jnp.where(jnp.isfinite(raw_reward), raw_reward, 0.0),
         )
 
 

--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -22,6 +22,7 @@ import dataclasses
 import functools
 import operator
 import time
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -51,6 +52,9 @@ from alberta_framework.core.types import (
     TraceMode,
     create_horde_spec,
 )
+from alberta_framework.core.update_safety import (
+    floating_tree_is_finite as _floating_tree_is_finite,
+)
 
 # =============================================================================
 # Types
@@ -58,6 +62,30 @@ from alberta_framework.core.types import (
 
 
 _INT32_MAX = 2**31 - 1
+_SARSA_CONFIG_FIELDS = {
+    "n_actions",
+    "gamma",
+    "epsilon_start",
+    "epsilon_end",
+    "epsilon_decay_steps",
+}
+_SARSA_AGENT_CONFIG_FIELDS = {
+    "type",
+    "state_schema",
+    "sarsa_config",
+    "hidden_sizes",
+    "optimizer",
+    "bounder",
+    "normalizer",
+    "head_optimizer",
+    "sparsity",
+    "leaky_relu_slope",
+    "use_layer_norm",
+    "lamda",
+    "prediction_demons",
+    "trace_mode",
+    "utility_decay",
+}
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -73,9 +101,6 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
-_ACTUAL_FLOAT_TYPES = frozenset(
-    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
-)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -87,20 +112,29 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
-def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
-        raise ValueError(f"{name} must be a finite real scalar")
-    return validated_float32_scalar(name, value, **bounds)
-
-
-def _preflight_sarsa_resources(n_actions: int, feature_dim: object) -> None:
-    width = _require_int32("feature_dim", feature_dim, minimum=1)
-    # The wrapper retains one observation and scalar lifecycle leaves while
-    # exposing one float32 policy/Q vector. The nested Horde owns its budget.
-    logical_scalars = n_actions + width + 5
-    state_nbytes = 4 * (width + 5)
-    if logical_scalars > _INT32_MAX or state_nbytes > _INT32_MAX:
-        raise ValueError("derived SARSA wrapper resources must fit signed int32")
+def _preflight_sarsa_direct_state(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> None:
+    """Bound the Horde arrays plus SARSA-owned state before JAX allocation."""
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_parameters = n_heads * (final_width + 1)
+    horde_direct_scalars = 2 * (trunk_parameters + head_parameters) + sum(hidden_sizes) + 3
+    # last_observation, last_action, epsilon, step_count, and the two-word
+    # Threefry key are all four-byte public-state leaves.
+    aggregate_scalars = horde_direct_scalars + feature_dim + 5
+    for name, value in (
+        ("aggregate_direct_state_scalars", aggregate_scalars),
+        ("aggregate_direct_state_bytes", 4 * aggregate_scalars),
+    ):
+        if not 1 <= value <= _INT32_MAX:
+            raise ValueError(f"derived SARSA {name} must be at most {_INT32_MAX}")
 
 
 @chex.dataclass(frozen=True)
@@ -128,11 +162,11 @@ class SARSAConfig:
         epsilon_decay_steps = _require_int32(
             "epsilon_decay_steps", self.epsilon_decay_steps, minimum=0
         )
-        gamma = _validated_config_float("gamma", self.gamma, lower=0.0, upper=1.0)
-        epsilon_start = _validated_config_float(
+        gamma = validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0)
+        epsilon_start = validated_float32_scalar(
             "epsilon_start", self.epsilon_start, lower=0.0, upper=1.0
         )
-        epsilon_end = _validated_config_float(
+        epsilon_end = validated_float32_scalar(
             "epsilon_end", self.epsilon_end, lower=0.0, upper=1.0
         )
         if epsilon_decay_steps > 0 and epsilon_end > epsilon_start:
@@ -142,7 +176,6 @@ class SARSAConfig:
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "epsilon_start", epsilon_start)
         object.__setattr__(self, "epsilon_end", epsilon_end)
-        _preflight_sarsa_resources(n_actions, 1)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict."""
@@ -155,13 +188,12 @@ class SARSAConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "SARSAConfig":
+    def from_config(cls, config: Mapping[str, Any]) -> "SARSAConfig":
         """Reconstruct from config dict."""
         if type(config) is not dict:
-            raise ValueError("config must be an exact built-in dict")
-        expected = {"n_actions", "gamma", "epsilon_start", "epsilon_end", "epsilon_decay_steps"}
-        if any(type(key) is not str for key in config) or set(config) != expected:
-            raise ValueError("config fields do not match the serialized schema")
+            raise ValueError("SARSA config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _SARSA_CONFIG_FIELDS:
+            raise ValueError("SARSA config fields do not match the compatibility schema")
         return cls(**config)
 
 
@@ -369,14 +401,30 @@ class SARSAAgent:
             utility_decay: EMA decay for hidden-unit utility diagnostics.
         """
         if type(sarsa_config) is not SARSAConfig:
-            raise ValueError("sarsa_config must be an exact SARSAConfig")
-        if prediction_demons is not None:
-            if type(prediction_demons) is not list:
-                raise ValueError("prediction_demons must be an exact list or None")
-            if any(type(demon) is not GVFSpec for demon in prediction_demons):
-                raise ValueError("prediction_demons entries must be exact GVFSpec values")
+            raise ValueError("sarsa_config must be an actual SARSAConfig")
+        lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+        if prediction_demons is not None and type(prediction_demons) is not list:
+            raise ValueError("prediction_demons must be an actual list or None")
+        n_predictions = len(prediction_demons) if prediction_demons is not None else 0
+        total_heads = _require_int32(
+            "total control and prediction demons",
+            sarsa_config.n_actions + n_predictions,
+            minimum=1,
+        )
+        # MultiHeadMLPLearner canonicalizes the tuple and its elements. This
+        # minimum-dimension preflight happens before constructing one Python
+        # GVF object per action, so an impossible state cannot first exhaust
+        # host memory in `_make_control_demons`.
+        if type(hidden_sizes) is not tuple:
+            raise ValueError("hidden_sizes must be an actual tuple")
+        canonical_hidden = tuple(
+            _require_int32(f"hidden_sizes[{index}]", width, minimum=1)
+            for index, width in enumerate(hidden_sizes)
+        )
+        _preflight_sarsa_direct_state(total_heads, canonical_hidden, 1)
+
         self._sarsa_config = sarsa_config
-        self._hidden_sizes = hidden_sizes
+        self._hidden_sizes = canonical_hidden
         self._lamda = lamda
 
         # Build HordeSpec: control demons first, then prediction demons
@@ -386,13 +434,13 @@ class SARSAAgent:
         all_demons: list[GVFSpec] = list(control_demons)
         if prediction_demons is not None:
             all_demons.extend(prediction_demons)
-        self._n_prediction_demons = len(prediction_demons) if prediction_demons else 0
+        self._n_prediction_demons = n_predictions
 
         horde_spec = create_horde_spec(all_demons)
 
         self._horde = HordeLearner(
             horde_spec=horde_spec,
-            hidden_sizes=hidden_sizes,
+            hidden_sizes=canonical_hidden,
             optimizer=optimizer,
             step_size=step_size,
             bounder=bounder,
@@ -451,42 +499,25 @@ class SARSAAgent:
         )
 
         if type(config) is not dict:
-            raise ValueError("serialized SARSA agent must be an exact built-in dict")
-        expected = {
-            "type",
-            "sarsa_config",
-            "lamda",
-            "prediction_demons",
-            "state_schema",
-            "hidden_sizes",
-            "optimizer",
-            "bounder",
-            "normalizer",
-            "head_optimizer",
-            "sparsity",
-            "leaky_relu_slope",
-            "use_layer_norm",
-            "trace_mode",
-            "utility_decay",
-        }
-        if any(type(key) is not str for key in config) or set(config) != expected:
-            raise ValueError("serialized SARSA agent fields do not match the schema")
-        if type(config["type"]) is not str or config["type"] != "SARSAAgent":
-            raise ValueError("unsupported SARSA agent type")
-        state_schema = config["state_schema"]
+            raise ValueError("SARSA agent config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _SARSA_AGENT_CONFIG_FIELDS:
+            raise ValueError("SARSA agent config fields do not match the schema")
+        config = dict(config)
+        if config.pop("type") != "SARSAAgent":
+            raise ValueError("unexpected SARSA agent config type")
+        state_schema = config.pop("state_schema")
         if type(state_schema) is not str or state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
             raise ValueError("unsupported SARSA Horde state schema")
-        if type(config["sarsa_config"]) is not dict:
-            raise ValueError("serialized sarsa_config must be an exact built-in dict")
-        if type(config["hidden_sizes"]) is not list:
-            raise ValueError("serialized hidden_sizes must be an exact list")
-        raw_prediction_demons = config["prediction_demons"]
-        if raw_prediction_demons is not None and type(raw_prediction_demons) is not list:
-            raise ValueError("serialized prediction_demons must be an exact list or None")
 
-        config = dict(config)
-        config.pop("type")
-        config.pop("state_schema")
+        if type(config["sarsa_config"]) is not dict:
+            raise ValueError("serialized sarsa_config must be an actual dict")
+        if type(config["hidden_sizes"]) is not list:
+            raise ValueError("serialized hidden_sizes must be an actual list")
+        if (
+            config["prediction_demons"] is not None
+            and type(config["prediction_demons"]) is not list
+        ):
+            raise ValueError("serialized prediction_demons must be an actual list or None")
 
         sarsa_config = SARSAConfig.from_config(config.pop("sarsa_config"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
@@ -496,17 +527,15 @@ class SARSAAgent:
         normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
         head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        pred_demons_cfg = config.pop("prediction_demons")
+        pred_demons_cfg = config.pop("prediction_demons", None)
         prediction_demons = None
         if pred_demons_cfg is not None:
-            if any(type(demon) is not dict for demon in pred_demons_cfg):
-                raise ValueError("serialized prediction demon must be an exact built-in dict")
             prediction_demons = [GVFSpec.from_config(d) for d in pred_demons_cfg]
 
-        trace_mode_str = config.pop("trace_mode")
-        if type(trace_mode_str) is not str:
-            raise ValueError("serialized trace_mode must be an exact string")
-        trace_mode = TraceMode(trace_mode_str)
+        trace_mode_str = config.pop("trace_mode", None)
+        trace_mode = (
+            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
+        )
 
         return cls(
             sarsa_config=sarsa_config,
@@ -530,7 +559,12 @@ class SARSAAgent:
         Returns:
             Initial SARSAState with zeroed last_action/observation
         """
-        _preflight_sarsa_resources(self.n_actions, feature_dim)
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_sarsa_direct_state(
+            self._horde.n_demons,
+            self._hidden_sizes,
+            feature_dim,
+        )
         key, subkey = jr.split(key)
         learner_state = self._horde.init(feature_dim, subkey)
 
@@ -698,7 +732,7 @@ class SARSAAgent:
 
         # Epsilon decay
         cfg = self._sarsa_config
-        new_step_count = state.step_count + 1
+        new_step_count = jnp.minimum(state.step_count, _INT32_MAX - 1) + 1
         new_epsilon = jax.lax.cond(
             cfg.epsilon_decay_steps > 0,
             lambda: jnp.maximum(

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -38,6 +38,7 @@ the NaN-masking convention of the loop-based hordes.
 
 import math
 import operator
+from collections.abc import Mapping
 from dataclasses import dataclass
 from fractions import Fraction
 from numbers import Real
@@ -131,6 +132,15 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_CONFIG_FIELDS = {
+    "type",
+    "n_demons",
+    "feature_dim",
+    "gammas",
+    "lamdas",
+    "cumulant_indices",
+    "step_size",
+}
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -145,9 +155,6 @@ _ACTUAL_INT_TYPES = frozenset(
         np.longlong,
         np.ulonglong,
     }
-)
-_ACTUAL_FLOAT_TYPES = frozenset(
-    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
 )
 
 
@@ -167,17 +174,9 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
-    if type(value) is list:
-        return tuple(cast(list[object], value))
-    if type(value) is tuple:
-        return cast(tuple[object, ...], value)
-    raise ValueError(f"serialized {name} must be an actual list or tuple")
-
-
-def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
-        raise ValueError(f"{name} must be a finite real scalar")
-    return validated_float32_scalar(name, value, **bounds)
+    if type(value) not in (list, tuple):
+        raise ValueError(f"{name} must be an actual list or tuple")
+    return tuple(cast(list[object] | tuple[object, ...], value))
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -190,6 +189,17 @@ def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
         raise ValueError("stacked Horde aggregate scalars must fit signed int32")
     if aggregate_nbytes > _INT32_MAX:
         raise ValueError("stacked Horde aggregate bytes must fit signed int32")
+
+
+def _require_scan_result_resources(num_updates: int, n_demons: int) -> None:
+    result_scalars = num_updates * n_demons
+    if result_scalars > _INT32_MAX or 4 * result_scalars > _INT32_MAX:
+        raise ValueError("stacked Horde scan result bytes must fit signed int32")
+
+
+def _saturating_int32_increment(value: Array) -> Array:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(value, 0), maximum - 1) + 1
 
 
 @dataclass(frozen=True)
@@ -232,13 +242,13 @@ class StackedHordeConfig:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
 
         gammas = tuple(
-            _validated_config_float(
+            validated_float32_scalar(
                 f"gammas[{i}]", value, lower=0.0, upper=1.0
             )
             for i, value in enumerate(raw_sequences["gammas"])
         )
         lamdas = tuple(
-            _validated_config_float(
+            validated_float32_scalar(
                 f"lamdas[{i}]", value, lower=0.0, upper=1.0
             )
             for i, value in enumerate(raw_sequences["lamdas"])
@@ -275,25 +285,16 @@ class StackedHordeConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "StackedHordeConfig":
+    def from_config(cls, config: Mapping[str, Any]) -> "StackedHordeConfig":
         """Reconstruct a config from :meth:`to_config` output."""
         if type(config) is not dict:
-            raise ValueError("config must be an exact built-in dict")
-        expected = {
-            "type",
-            "n_demons",
-            "feature_dim",
-            "gammas",
-            "lamdas",
-            "cumulant_indices",
-            "step_size",
-        }
-        if any(type(key) is not str for key in config) or set(config) != expected:
-            raise ValueError("config fields do not match the serialized schema")
-        if type(config["type"]) is not str or config["type"] != "StackedHordeConfig":
-            raise ValueError("config type differs")
+            raise ValueError("stacked Horde config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != _CONFIG_FIELDS:
+            raise ValueError("stacked Horde config fields do not match the schema")
         config = dict(config)
-        config.pop("type")
+        serialized_type = config.pop("type")
+        if type(serialized_type) is not str or serialized_type != "StackedHordeConfig":
+            raise ValueError("unexpected stacked Horde config type")
         for key in ("gammas", "lamdas", "cumulant_indices"):
             config[key] = _decode_sequence(key, config[key])
         return cls(**config)
@@ -328,10 +329,10 @@ def nexting_spec(
         for i, value in enumerate(raw_indices)
     )
     canonical_gammas = tuple(
-        _validated_config_float(f"gammas[{i}]", value, lower=0.0, upper=1.0)
+        validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
         for i, value in enumerate(raw_gammas)
     )
-    canonical_lamda = _validated_config_float("lamda", lamda, lower=0.0, upper=1.0)
+    canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
     if n_demons < 1 or n_demons > _INT32_MAX:
         raise ValueError("derived n_demons must be in the signed int32 domain")
@@ -406,17 +407,33 @@ class StackedLinearHorde:
         return {"type": "StackedLinearHorde", "config": self._config.to_config()}
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "StackedLinearHorde":
+    def from_config(cls, config: Mapping[str, Any]) -> "StackedLinearHorde":
         """Reconstruct a horde from :meth:`to_config` output."""
         if type(config) is not dict:
-            raise ValueError("config must be an exact built-in dict")
-        if any(type(key) is not str for key in config) or set(config) != {"type", "config"}:
-            raise ValueError("config fields do not match the serialized schema")
-        if type(config["type"]) is not str or config["type"] != "StackedLinearHorde":
-            raise ValueError("config type differs")
-        if type(config["config"]) is not dict:
-            raise ValueError("nested config must be an exact built-in dict")
-        return cls(StackedHordeConfig.from_config(config["config"]))
+            raise ValueError("stacked linear Horde config must be an actual dict")
+        if not all(type(key) is str for key in config) or set(config) != {"type", "config"}:
+            raise ValueError("stacked linear Horde config fields do not match the schema")
+        serialized_type = config["type"]
+        if type(serialized_type) is not str or serialized_type != "StackedLinearHorde":
+            raise ValueError("unexpected stacked linear Horde config type")
+        nested = config["config"]
+        if type(nested) is not dict:
+            raise ValueError("stacked linear Horde nested config must be an actual dict")
+        return cls(StackedHordeConfig.from_config(nested))
+
+    def _require_state_contract(self, state: StackedHordeState) -> None:
+        if type(state) is not StackedHordeState:
+            raise TypeError("state must be an actual StackedHordeState")
+        expected = (self._config.n_demons, self._config.feature_dim)
+        for name, value in (("weights", state.weights), ("traces", state.traces)):
+            if value.shape != expected:
+                raise ValueError(f"state {name} must have shape {expected}")
+            if value.dtype != jnp.dtype(jnp.float32):
+                raise TypeError(f"state {name} must have dtype float32")
+        if state.step_count.shape != ():
+            raise ValueError("state step_count must be scalar")
+        if state.step_count.dtype != jnp.dtype(jnp.int32):
+            raise TypeError("state step_count must have dtype int32")
 
     def init(self) -> StackedHordeState:
         """Initialize zero weights and traces."""
@@ -430,6 +447,11 @@ class StackedLinearHorde:
 
     def predict(self, state: StackedHordeState, features: Array) -> Array:
         """All demons' predictions for one feature vector, shape ``(n_demons,)``."""
+        self._require_state_contract(state)
+        if features.shape != (self._config.feature_dim,):
+            raise ValueError("features must match configured feature_dim")
+        if features.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("features must have dtype float32")
         return state.weights @ features
 
     def update(
@@ -460,6 +482,14 @@ class StackedLinearHorde:
             TD errors (TD errors are NaN for inactive demons).
         """
         cfg = self._config
+        self._require_state_contract(state)
+        for name, value in (("features", features), ("next_features", next_features)):
+            if value.shape != (cfg.feature_dim,):
+                raise ValueError(f"{name} must match configured feature_dim")
+            if value.dtype != jnp.dtype(jnp.float32):
+                raise TypeError(f"{name} must have dtype float32")
+        if cumulant_source.dtype != jnp.dtype(jnp.float32):
+            raise TypeError("cumulant_source must have dtype float32")
         source_shape = jnp.shape(cumulant_source)
         # JAX clips out-of-range positive gather indices instead of raising,
         # so a short source would silently train demons on the wrong channel.
@@ -528,7 +558,7 @@ class StackedLinearHorde:
         proposed_state = StackedHordeState(
             weights=new_weights,
             traces=new_traces,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_increment(state.step_count),
         )
         new_state = jax.lax.cond(
             update_applied,
@@ -586,6 +616,12 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
+    if features.ndim != 2:
+        raise ValueError("features must be rank-two")
+    if features.dtype != jnp.dtype(jnp.float32):
+        raise TypeError("features must have dtype float32")
+    if features.shape[1] != horde.config.feature_dim:
+        raise ValueError("features must match configured feature_dim")
     sources_shape = jnp.shape(cumulant_sources)
     if len(sources_shape) != 2:
         raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
@@ -596,8 +632,15 @@ def run_stacked_horde_scan(
             f"config.cumulant_indices requires index {max_index}"
         )
     num_steps = features.shape[0]
+    if sources_shape[0] != num_steps:
+        raise ValueError("features and cumulant_sources must have the same number of rows")
+    if cumulant_sources.dtype != jnp.dtype(jnp.float32):
+        raise TypeError("cumulant_sources must have dtype float32")
+    _require_scan_result_resources(max(num_steps - 1, 0), horde.config.n_demons)
     if rhos is None:
         rhos = jnp.ones((num_steps,), dtype=jnp.float32)
+    elif rhos.shape != (num_steps,):
+        raise ValueError("rhos must have shape (num_steps,)")
 
     def step_fn(
         carry: StackedHordeState,

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -1341,3 +1341,136 @@ def test_sarsa_step_count_saturates_without_wrapping_under_jit() -> None:
         next_action=jnp.array(0, dtype=jnp.int32),
     )
     assert int(result.state.step_count) == 2**31 - 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("step_size", float("inf")),
+        ("sparsity", 1.1),
+        ("leaky_relu_slope", -0.1),
+        ("utility_decay", 1.0),
+        ("use_layer_norm", np.bool_(True)),
+    ],
+)
+def test_sarsa_agent_validates_all_direct_scalar_fields(field, value) -> None:
+    with pytest.raises(ValueError, match=field):
+        SARSAAgent(SARSAConfig(n_actions=2), **{field: value})
+
+
+def test_sarsa_agent_rejects_spoofed_static_types_and_prediction_entries() -> None:
+    class TraceModeSubclass(str):
+        pass
+
+    with pytest.raises(ValueError, match="trace_mode"):
+        SARSAAgent(
+            SARSAConfig(n_actions=2),
+            trace_mode=TraceModeSubclass("accumulating"),  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="GVFSpec"):
+        SARSAAgent(SARSAConfig(n_actions=2), prediction_demons=[object()])  # type: ignore[list-item]
+
+
+def test_sarsa_serialized_discriminators_reject_string_subclasses() -> None:
+    class StringSubclass(str):
+        pass
+
+    payload = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=()).to_config()
+    payload["type"] = StringSubclass("SARSAAgent")
+    with pytest.raises(ValueError, match="type"):
+        SARSAAgent.from_config(payload)
+    payload = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=()).to_config()
+    payload["state_schema"] = StringSubclass(payload["state_schema"])
+    with pytest.raises(ValueError, match="state schema"):
+        SARSAAgent.from_config(payload)
+    payload = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=()).to_config()
+    payload["trace_mode"] = StringSubclass(payload["trace_mode"])
+    with pytest.raises(ValueError, match="trace_mode"):
+        SARSAAgent.from_config(payload)
+
+
+def _assert_sarsa_state_exact_ignoring_host_time(actual, expected) -> None:
+    actual_learner = actual.learner_state.replace(birth_timestamp=0.0, uptime_s=0.0)
+    expected_learner = expected.learner_state.replace(birth_timestamp=0.0, uptime_s=0.0)
+    chex.assert_trees_all_equal(
+        actual.replace(learner_state=actual_learner),
+        expected.replace(learner_state=expected_learner),
+    )
+
+
+@pytest.mark.parametrize("next_action", [-1, 2])
+def test_sarsa_invalid_next_action_is_an_exact_noop(next_action: int) -> None:
+    agent = _make_agent(n_actions=2, hidden_sizes=(), epsilon_start=0.0)
+    observation = jnp.ones(3, dtype=jnp.float32)
+    action, key = agent.select_action(agent.init(3, jr.key(0)), observation)
+    state = agent.init(3, jr.key(1)).replace(
+        last_action=action,
+        last_observation=observation,
+        rng_key=key,
+    )
+    result = agent.update(
+        state,
+        jnp.asarray(1.0, dtype=jnp.float32),
+        observation,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(next_action, dtype=jnp.int32),
+    )
+    _assert_sarsa_state_exact_ignoring_host_time(result.state, state)
+    assert int(result.action) == -1
+    assert float(result.td_error) == 0.0
+    assert bool(jnp.all(result.q_values == 0.0))
+
+
+@pytest.mark.parametrize(
+    ("reward", "terminated"),
+    [
+        (float("nan"), 0.0),
+        (float("inf"), 0.0),
+        (1.0, float("nan")),
+        (1.0, 0.5),
+    ],
+)
+def test_sarsa_invalid_dynamic_transition_is_an_exact_noop(reward, terminated) -> None:
+    agent = _make_agent(n_actions=2, hidden_sizes=(), epsilon_start=0.0)
+    observation = jnp.ones(3, dtype=jnp.float32)
+    state = agent.init(3, jr.key(0)).replace(
+        last_action=jnp.asarray(0, dtype=jnp.int32),
+        last_observation=observation,
+    )
+    result = agent.update(
+        state,
+        jnp.asarray(reward, dtype=jnp.float32),
+        observation,
+        jnp.asarray(terminated, dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    _assert_sarsa_state_exact_ignoring_host_time(result.state, state)
+    assert int(result.action) == -1
+
+
+def test_sarsa_public_array_shapes_and_dtypes_fail_before_transaction() -> None:
+    agent = _make_agent(n_actions=2, hidden_sizes=(), epsilon_start=0.0)
+    state = agent.init(3, jr.key(0))
+    with pytest.raises(ValueError, match="observation must have shape"):
+        agent.select_action(state, jnp.ones(4, dtype=jnp.float32))
+    with pytest.raises(TypeError, match="observation must have dtype float32"):
+        agent.select_action(state, jnp.ones(3, dtype=jnp.int32))
+    with pytest.raises(TypeError, match="next_action must have dtype int32"):
+        agent.update(
+            state,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.asarray(False),
+            jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+
+def test_sarsa_select_action_rejects_nonfinite_without_consuming_rng() -> None:
+    agent = _make_agent(n_actions=2, hidden_sizes=(), epsilon_start=0.0)
+    state = agent.init(3, jr.key(0))
+    action, key = agent.select_action(
+        state,
+        jnp.asarray([0.0, float("nan"), 1.0], dtype=jnp.float32),
+    )
+    assert int(action) == -1
+    chex.assert_trees_all_equal(key, state.rng_key)

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -1236,40 +1236,108 @@ def test_sarsa_config_accepts_and_canonicalizes_numpy_integers() -> None:
     assert cfg.epsilon_decay_steps == 100
 
 
-def test_sarsa_config_rejects_hostile_scalars_and_nonexact_schema() -> None:
-    class HostileFloat(float):
-        def __float__(self) -> float:
-            raise AssertionError("float hook must not run")
+@pytest.mark.parametrize(
+    "integer_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ],
+)
+def test_sarsa_config_accepts_full_numpy_integer_family(integer_type) -> None:
+    config = SARSAConfig(
+        n_actions=integer_type(2),
+        epsilon_decay_steps=integer_type(3),
+    )
+    assert type(config.n_actions) is int
+    assert type(config.epsilon_decay_steps) is int
+
+
+def test_sarsa_config_rejects_hostile_integer_hook_without_calling_it() -> None:
+    class HostileIndex:
+        def __index__(self) -> int:
+            raise AssertionError("untrusted __index__ must not run")
 
         def __repr__(self) -> str:
-            raise AssertionError("repr hook must not run")
+            raise AssertionError("untrusted __repr__ must not run")
 
-    class DictSubclass(dict[str, object]):
+    with pytest.raises(ValueError, match="n_actions"):
+        SARSAConfig(n_actions=HostileIndex())  # type: ignore[arg-type]
+
+
+def test_sarsa_config_from_config_requires_exact_compatibility_schema() -> None:
+    class DictSubclass(dict):
         pass
 
-    with pytest.raises(ValueError, match="gamma"):
-        SARSAConfig(n_actions=2, gamma=HostileFloat(0.9))
     payload = SARSAConfig(n_actions=2).to_config()
-    with pytest.raises(ValueError, match="exact built-in dict"):
+    assert SARSAConfig.from_config(payload).to_config() == payload
+    with pytest.raises(ValueError, match="actual dict"):
         SARSAConfig.from_config(DictSubclass(payload))
     with pytest.raises(ValueError, match="fields"):
-        SARSAConfig.from_config({**payload, "unknown": 1})
+        SARSAConfig.from_config({**payload, "extra": 1})
 
 
-def test_sarsa_config_preflights_wrapper_resource_endpoint() -> None:
-    assert SARSAConfig(n_actions=2**31 - 7).n_actions == 2**31 - 7
-    with pytest.raises(ValueError, match="wrapper resources"):
-        SARSAConfig(n_actions=2**31 - 6)
+def test_sarsa_agent_rejects_hostile_lambda_before_horde_construction() -> None:
+    class HostileFloat:
+        def __float__(self) -> float:
+            raise AssertionError("untrusted __float__ must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted __repr__ must not run")
+
+    with pytest.raises(ValueError, match="lamda"):
+        SARSAAgent(SARSAConfig(n_actions=2), lamda=HostileFloat())  # type: ignore[arg-type]
 
 
-def test_sarsa_agent_from_config_rejects_nonexact_outer_containers() -> None:
-    class DictSubclass(dict[str, object]):
+def test_sarsa_agent_roundtrip_and_exact_schema() -> None:
+    class DictSubclass(dict):
         pass
 
-    payload = _make_agent(n_actions=2).to_config()
-    with pytest.raises(ValueError, match="exact built-in dict"):
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    payload = agent.to_config()
+    restored = SARSAAgent.from_config(payload)
+    assert restored.to_config() == payload
+    with pytest.raises(ValueError, match="fields"):
+        SARSAAgent.from_config({**payload, "extra": None})
+    with pytest.raises(ValueError, match="actual dict"):
         SARSAAgent.from_config(DictSubclass(payload))
-    hostile = dict(payload)
-    hostile["hidden_sizes"] = tuple(hostile["hidden_sizes"])
-    with pytest.raises(ValueError, match="hidden_sizes"):
-        SARSAAgent.from_config(hostile)
+
+
+def test_sarsa_init_rejects_aggregate_state_overflow_before_jax_allocation() -> None:
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    # Linear two-head state uses (5 * feature_dim + 12) direct scalars.
+    first_overflow = ((2**31 - 1) // 4 - 12) // 5 + 1
+    with pytest.raises(ValueError, match="aggregate_direct_state_bytes"):
+        agent.init(feature_dim=first_overflow, key=jr.key(0))
+
+
+def test_sarsa_constructor_rejects_impossible_hidden_state_before_demon_list() -> None:
+    with pytest.raises(ValueError, match="aggregate_direct_state"):
+        SARSAAgent(
+            SARSAConfig(n_actions=1),
+            hidden_sizes=(2**31 - 1,),
+        )
+
+
+def test_sarsa_step_count_saturates_without_wrapping_under_jit() -> None:
+    agent = _make_agent(n_actions=2, hidden_sizes=(), epsilon_start=0.0)
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(
+        last_action=jnp.array(0, dtype=jnp.int32),
+        last_observation=jnp.ones(2, dtype=jnp.float32),
+        step_count=jnp.array(2**31 - 1, dtype=jnp.int32),
+    )
+    result = agent.update(
+        state,
+        reward=jnp.array(0.0, dtype=jnp.float32),
+        observation=jnp.ones(2, dtype=jnp.float32),
+        terminated=jnp.array(0.0, dtype=jnp.float32),
+        next_action=jnp.array(0, dtype=jnp.int32),
+    )
+    assert int(result.state.step_count) == 2**31 - 1

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -887,3 +887,54 @@ def test_nexting_spec_preflights_before_materializing_derived_demons() -> None:
             cumulant_indices=(0,),
             gammas=(0.9,),
         )
+
+
+def test_stacked_horde_deserializers_require_exact_schemas() -> None:
+    class DictSubclass(dict):
+        pass
+
+    config_payload = _simple_config().to_config()
+    with pytest.raises(ValueError, match="actual dict"):
+        StackedHordeConfig.from_config(DictSubclass(config_payload))
+    with pytest.raises(ValueError, match="fields"):
+        StackedHordeConfig.from_config({**config_payload, "extra": None})
+    with pytest.raises(ValueError, match="config type"):
+        StackedHordeConfig.from_config({**config_payload, "type": "wrong"})
+
+    horde_payload = StackedLinearHorde(_simple_config()).to_config()
+    with pytest.raises(ValueError, match="fields"):
+        StackedLinearHorde.from_config({**horde_payload, "extra": None})
+    with pytest.raises(ValueError, match="nested config"):
+        StackedLinearHorde.from_config({**horde_payload, "config": DictSubclass()})
+
+
+def test_stacked_horde_step_count_saturates_without_jit_wraparound() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=1, feature_dim=2))
+    state = horde.init().replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    result = jax.jit(horde.update)(
+        state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_stacked_horde_scan_rejects_derived_result_overflow_without_allocation() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=2, feature_dim=3))
+    state = horde.init()
+    first_overflowing_steps = (2**31 - 1) // (4 * horde.config.n_demons) + 2
+    features = jax.ShapeDtypeStruct(
+        (first_overflowing_steps, horde.config.feature_dim),
+        jnp.float32,
+    )
+    sources = jax.ShapeDtypeStruct((first_overflowing_steps, 2), jnp.float32)
+    with pytest.raises(ValueError, match="scan result bytes"):
+        run_stacked_horde_scan(horde, state, features, sources)  # type: ignore[arg-type]
+
+
+def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
+    horde = StackedLinearHorde(_simple_config(n_demons=1, feature_dim=2))
+    state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="weights"):
+        horde.predict(state, jnp.ones(2, dtype=jnp.float32))


### PR DESCRIPTION
## Summary

Follow-up audit to merged #788. That integration retained the scalar/resource core of #767/#774 but omitted their outer exact-schema, wrapper/scan allocation, saturating-counter, public shape/dtype, and fail-closed transaction residuals. This focused successor restores those gates on current main.

SARSA now validates exact config and agent schemas, all SARSA-owned constructor scalars/static types, aggregate wrapper resources before GVF/JAX construction, public state/input contracts, saturating step telemetry, and atomic invalid-input/update rejection. It preserves established terminal/zero-gamma diagnostics and disabled zero-decay trace recovery.

Stacked Horde now validates exact nested/outer schemas and public state/input shapes/dtypes, bounds scan result allocation before `lax.scan`, and saturates step telemetry.

## Verification

- 228 focused SARSA, differential-SARSA compatibility, and stacked-Horde tests passed
- scoped Ruff clean
- strict mypy clean for both source modules
- diff-check clean

Supersedes the remaining non-merged residuals in #767 and #774.