### PR TITLE
fix(micro-continual): reject n_steps that overflow signed int32

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -204,6 +204,8 @@ def _require_nonempty_string(value: object, *, context: str) -> str:
 # Configuration
 # =============================================================================
 
+_INT32_MAX: int = 2**31 - 1
+
 
 @dataclass(frozen=True)
 class MicroStreamConfig:
@@ -270,6 +272,17 @@ class MicroStreamConfig:
             value = getattr(self, name)
             if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
                 raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        if self.n_regimes * self.regime_length > _INT32_MAX:
+            # stream() casts the per-step regime index to dtype=jnp.int32
+            # (``jnp.arange(n_steps, dtype=jnp.int32) // regime_length``); an
+            # uncaught n_steps beyond the signed int32 domain would silently
+            # wrap the derived regime index instead of raising, corrupting
+            # every regime assignment past the wraparound point.
+            raise ValueError(
+                "derived n_steps (n_regimes * regime_length) must fit in signed "
+                f"int32, got {self.n_regimes} * {self.regime_length} = "
+                f"{self.n_regimes * self.regime_length} > {_INT32_MAX}"
+            )
         sparsity = self.component_sparsity
         if not isinstance(sparsity, int) or isinstance(sparsity, bool) or sparsity <= 0:
             raise ValueError(

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -227,6 +227,25 @@ class TestConfig:
     def test_n_steps(self):
         assert TINY.n_steps == 4 * 25
 
+    def test_n_steps_int32_overflow_rejected(self):
+        # stream() casts the per-step regime index to dtype=jnp.int32
+        # (``jnp.arange(n_steps, dtype=jnp.int32) // regime_length``). An
+        # n_steps beyond the signed int32 domain must be rejected at
+        # construction instead of silently wrapping every regime index past
+        # the boundary to a negative value.
+        with pytest.raises(ValueError, match="n_steps"):
+            MicroStreamConfig(
+                family="input_permutation",
+                n_regimes=60_000,
+                regime_length=60_000,
+            )
+        # The boundary itself (exactly INT32_MAX) must still be accepted.
+        MicroStreamConfig(
+            family="input_permutation",
+            n_regimes=1,
+            regime_length=2**31 - 1,
+        )
+
     def test_to_config_roundtrip(self):
         rebuilt = MicroStreamConfig(**TINY.to_config())
         assert rebuilt == TINY


### PR DESCRIPTION
<!-- evidence-head:8ed5835c015ea7050ae46947b2a27f26f8ff8b49 -->

Fixes #792.

## What

`MicroStreamConfig.__post_init__` (`alberta_framework/benchmarks/micro_continual.py`)
validated that `n_regimes` and `regime_length` were each a positive int, but
never bounded their product `n_steps = n_regimes * regime_length` against the
signed int32 domain. `stream()` (consumed by every micro-suite arm and the
transfer-validation ladder) casts the per-step regime index with
`jnp.arange(n_steps, dtype=jnp.int32) // regime_length`; once `n_steps`
exceeds `2**31 - 1` that cast silently wraps to negative index values
instead of raising, corrupting the regime schedule for every step past the
boundary rather than failing closed. `micro_continual` is the CLI-exposed
"prototype on the micro suite" lane (`--n-regimes`/`--regime-length` are
direct CLI flags), so this is reachable by a real run, not just a synthetic
input.

This mirrors the exact guard `upgd_ipmnist.IPMNISTConfig` already applies to
its analogous `n_tasks * task_length > _INT32_MAX` product — that config has
the check, its `micro_continual` sibling didn't.

## Fix

Add the same `n_regimes * regime_length > _INT32_MAX` bound, raising
`ValueError` at construction time (before any array is built) instead of
allowing the silent int32 wraparound downstream. One file, one added
invariant — no other behavior changes.

## Evidence

Reproduction of the bug on `origin/main` before the fix (confirms the
config constructed silently):

```
n_steps = 60_000 * 60_000 = 3_600_000_000  # > 2**31 - 1 = 2_147_483_647
MicroStreamConfig(family="input_permutation", n_regimes=60_000, regime_length=60_000)
# constructed without error pre-fix
```

Underlying wraparound mechanism (why this corrupts rather than merely
crashes):

```pycon
>>> import numpy as np
>>> np.int32(2**31)      # one past INT32_MAX
-2147483648
```

Commit under test: `8ed5835c015ea7050ae46947b2a27f26f8ff8b49` (branch rebased onto `origin/main` at
merge of #785 / `76ac5df`).

Focused tests (bounded, scoped — full suite not run per sandbox policy):

```
.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts=""
194 passed, 2 warnings in 100.47s
.venv/bin/python -m pytest tests/test_micro_continual.py -q -o addopts="" -k TestConfig
65 passed, 129 deselected in 3.66s
```

Lint / types (scoped to the two changed files):

```
.venv/bin/python -m ruff check alberta_framework/benchmarks/micro_continual.py tests/test_micro_continual.py
All checks passed!
.venv/bin/python -m mypy alberta_framework/benchmarks/micro_continual.py
Success: no issues found in 1 source file
```

`git diff --check`: clean.

No `outputs/` artifacts, evidence registry entries, or scientific claims are
touched — this is a validation-only fix in an unpromoted development lane.
`alberta-evidence-status` is unaffected (`micro_continual.py` is not a
registered evidence source for any of the 5 claims).

## Deviations / what remains open

None from plan. Scope was kept to the one file / one invariant per the
"one lane, one variable" rule; sibling configs elsewhere in the repo were
not audited or touched here.

Declared identity: `--client claude-code --provider anthropic --model
claude-sonnet-5`, lane `rama0x1-asi-claude-worker-2`. Receipt signing
deferred — operator handling centrally (overnight unattended run).