### PR TITLE
fix(experiential-memory): preserve legal age-scale endpoints

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -417,15 +417,6 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         "recency_scale",
         _validated_config_float("recency_scale", config.recency_scale, positive=True),
     )
-    rounded_boundary = np.float32(_INT32_MAX / float(np.finfo(np.float32).max))
-    minimum_safe_scale = float(
-        np.nextafter(rounded_boundary, np.float32(np.inf), dtype=np.float32)
-    )
-    if config.staleness_scale < minimum_safe_scale:
-        raise ValueError("staleness_scale must keep saturated age division finite in float32")
-    if config.recency_scale < minimum_safe_scale:
-        raise ValueError("recency_scale must keep saturated age division finite in float32")
-
 def _saturating_increment(value: Array) -> Array:
     maximum_minus_one = jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
     return jnp.minimum(value, maximum_minus_one) + jnp.asarray(1, dtype=jnp.int32)
@@ -934,10 +925,19 @@ class ExperientialMemory:
             -squared_distance / jnp.asarray(cfg.distance_scale, dtype=jnp.float32)
         )
         safe_ages = jnp.where(entries.ages >= 0, entries.ages, 0)
-        staleness = jnp.exp(
-            -safe_ages.astype(jnp.float32)
-            / jnp.asarray(cfg.staleness_scale, dtype=jnp.float32)
+        staleness_scale = jnp.asarray(cfg.staleness_scale, dtype=jnp.float32)
+        # Every positive float32 scale is legal. Cap the mathematically huge
+        # quotient before division so a tiny scale yields exact zero staleness
+        # without first creating an infinity in the JAX operation graph.
+        maximum_exponent = jnp.asarray(
+            np.finfo(np.float32).max / 2.0,
+            dtype=jnp.float32,
         )
+        bounded_staleness_age = jnp.minimum(
+            safe_ages.astype(jnp.float32),
+            maximum_exponent * jnp.minimum(staleness_scale, 1.0),
+        )
+        staleness = jnp.exp(-bounded_staleness_age / staleness_scale)
         safe_reliabilities = jnp.where(
             jnp.isfinite(entries.reliabilities)
             & (entries.reliabilities >= 0.0)
@@ -1173,10 +1173,11 @@ class ExperientialMemory:
             current_entries = current.entries
             has_empty = jnp.any(~current_entries.valid)
             empty_slot = jnp.argmax((~current_entries.valid).astype(jnp.int32))
-            recency_score = 1.0 / (
-                1.0
-                + current_entries.recency_ages.astype(jnp.float32)
-                / jnp.asarray(cfg.recency_scale, dtype=jnp.float32)
+            recency_scale = jnp.asarray(cfg.recency_scale, dtype=jnp.float32)
+            # Algebraically equivalent to 1 / (1 + age / scale), but remains
+            # finite for every positive float32 scale in the public contract.
+            recency_score = recency_scale / (
+                recency_scale + current_entries.recency_ages.astype(jnp.float32)
             )
             eviction_utilities = jnp.where(
                 current_entries.utility_available,

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -502,6 +502,33 @@ def test_large_relative_eviction_weights_do_not_overflow_priority() -> None:
     assert int(result.evicted_provenance_id) == 10
 
 
+def test_smallest_positive_age_scales_remain_operation_finite() -> None:
+    smallest = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+    memory = ExperientialMemory(
+        _config(
+            capacity=1,
+            top_k=1,
+            staleness_scale=smallest,
+            recency_scale=smallest,
+        )
+    )
+    state = _write(memory, memory.init(), _entry(10, age=2**31 - 1))
+    retrieval = memory.query(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(1, dtype=jnp.int32),
+        jnp.asarray(0.1, dtype=jnp.float32),
+        jnp.asarray(True, dtype=jnp.bool_),
+    )
+    for leaf in jax.tree.leaves(retrieval):
+        if jnp.issubdtype(leaf.dtype, jnp.floating):
+            assert bool(jnp.all(jnp.isfinite(leaf)))
+
+    result = memory.write(state, _entry(20, utility=1.0))
+    assert bool(result.wrote)
+    assert bool(result.evicted)
+
+
 def test_accepted_access_updates_recency_before_deterministic_eviction() -> None:
     memory = ExperientialMemory(
         _config(

--- a/tests/test_experiential_memory_validation.py
+++ b/tests/test_experiential_memory_validation.py
@@ -343,31 +343,10 @@ def test_experiential_memory_exact_serialized_boundaries() -> None:
 
 
 @pytest.mark.parametrize("field", ["staleness_scale", "recency_scale"])
-def test_age_scale_rejects_float32_division_overflow(field: str) -> None:
-    with pytest.raises(ValueError, match=field):
-        ExperientialMemoryConfig(
-            capacity=4,
-            observation_dim=2,
-            key_dim=2,
-            action_dim=1,
-            outcome_dim=1,
-            **{field: np.nextafter(np.float32(0.0), np.float32(1.0))},
-        )
-
-
-@pytest.mark.parametrize("field", ["staleness_scale", "recency_scale"])
-def test_age_scale_accepts_first_float32_value_with_finite_saturated_division(
+def test_age_scale_accepts_smallest_positive_float32_without_operation_overflow(
     field: str,
 ) -> None:
-    maximum = np.float32(np.iinfo(np.int32).max)
-    rounded_boundary = np.float32(
-        np.iinfo(np.int32).max / float(np.finfo(np.float32).max)
-    )
-    safe = np.nextafter(rounded_boundary, np.float32(np.inf), dtype=np.float32)
-    unsafe = np.nextafter(safe, np.float32(0.0), dtype=np.float32)
-    with np.errstate(over="ignore"):
-        assert not np.isfinite(maximum / unsafe)
-        assert np.isfinite(maximum / safe)
+    smallest = np.nextafter(np.float32(0.0), np.float32(1.0))
     common = {
         "capacity": 4,
         "observation_dim": 2,
@@ -375,10 +354,8 @@ def test_age_scale_accepts_first_float32_value_with_finite_saturated_division(
         "action_dim": 1,
         "outcome_dim": 1,
     }
-    with pytest.raises(ValueError, match=field):
-        ExperientialMemoryConfig(**common, **{field: unsafe})
-    config = ExperientialMemoryConfig(**common, **{field: safe})
-    assert getattr(config, field) == float(safe)
+    config = ExperientialMemoryConfig(**common, **{field: smallest})
+    assert getattr(config, field) == float(smallest)
 
 
 def test_aggregate_query_working_set_is_bounded_before_jax_allocation() -> None:


### PR DESCRIPTION
Corrective follow-up to merged #773. Its query/resource and eviction-weight hardening is retained, but its new lower bound rejected legal positive staleness/recency scales solely because the original arithmetic could form an infinite intermediate. The documented scalar contract is positive float32, and both operations have stable finite formulations: staleness caps the exponent argument before division, while recency uses scale/(scale+age). This preserves every positive float32 endpoint without an overflowing intermediate.\n\nTests add the smallest positive float32 configuration and exercise both query and eviction paths at saturated age, requiring every floating retrieval leaf to remain finite.\n\nVerification on current main: 141 focused experiential-memory/policy/validation tests passed; scoped Ruff passed; strict mypy passed for the source module; diff-check clean. No outputs or registered evidence sources change.