### PR TITLE
fix(prereg): gate setup and bind artifact retention

### DIFF
--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -68,6 +68,7 @@ class Protocol:
     summary_filename: str
     requires_amendment: bool
     prerequisite: str | None
+    prerequisite_artifact_condition: str | None
 
 
 PROTOCOLS: Final = {
@@ -81,6 +82,7 @@ PROTOCOLS: Final = {
         summary_filename="summary.json",
         requires_amendment=False,
         prerequisite=None,
+        prerequisite_artifact_condition=None,
     ),
     "issue184": Protocol(
         key="issue184",
@@ -92,6 +94,7 @@ PROTOCOLS: Final = {
         summary_filename="summary.json",
         requires_amendment=True,
         prerequisite="issue51",
+        prerequisite_artifact_condition="unexpired-90-day-github-actions-artifact",
     ),
     "issue188": Protocol(
         key="issue188",
@@ -103,6 +106,7 @@ PROTOCOLS: Final = {
         summary_filename="summary_resid_gate_ablation_r3.json",
         requires_amendment=True,
         prerequisite=None,
+        prerequisite_artifact_condition=None,
     ),
 }
 
@@ -142,11 +146,17 @@ def _launch_binding(
     ):
         raise ValueError("ref_name must be a non-empty tag name without whitespace")
     seeds = ",".join(str(seed) for seed in protocol.seeds)
+    prerequisite_artifact = (
+        f" prerequisite_artifact={protocol.prerequisite_artifact_condition}"
+        if protocol.prerequisite_artifact_condition is not None
+        else ""
+    )
     return (
         f"issue={protocol.issue} protocol={protocol.key} "
         f"source={source} tree={tree} uv_lock_sha256={uv_lock_sha256} "
         f"workflow_blob_sha1={workflow_blob_sha1} driver_blob_sha1={driver_blob_sha1} "
-        f"ref={ref_name} runner={RUNNER_IDENTITY} seeds={seeds} n={len(protocol.seeds)}"
+        f"ref={ref_name} runner={RUNNER_IDENTITY}{prerequisite_artifact} "
+        f"seeds={seeds} n={len(protocol.seeds)}"
     )
 
 
@@ -392,7 +402,7 @@ def _workflow_runs(repository: str, *, source: str, token: str) -> list[dict[str
     raise RuntimeError("GitHub Actions run search did not complete within the 1,000-result cap")
 
 
-def verify_launch_authorization(
+def verify_owner_authorization(
     *,
     protocol_key: str,
     repository: str,
@@ -405,7 +415,6 @@ def verify_launch_authorization(
     run_id: int,
     run_attempt: int,
     token: str,
-    root: Path | None = None,
 ) -> dict[str, Any]:
     if repository != AUTHORIZED_REPOSITORY:
         raise RuntimeError(f"repository must be exactly {AUTHORIZED_REPOSITORY}")
@@ -415,17 +424,6 @@ def verify_launch_authorization(
         raise RuntimeError("rerun attempts are forbidden; dispatch a new reviewed source instead")
     protocol = protocol_for(protocol_key)
     source = _lower_hex(source, 40, name="source")
-    prerequisite = (
-        _verify_prerequisite_completion(
-            protocol,
-            repository=repository,
-            launch_source=source,
-            root=root,
-            token=token,
-        )
-        if protocol.prerequisite is not None
-        else None
-    )
     expected_line = authorization_line(
         protocol,
         source=source,
@@ -540,15 +538,8 @@ def verify_launch_authorization(
             raise RuntimeError(
                 "registration amendment must be durable before final authorization"
             )
-        if (
-            prerequisite is not None
-            and _parse_utc(prerequisite["issue_closed_at"]) >= amendment_time
-        ):
-            raise RuntimeError(
-                "prerequisite issue must be closed before the registration amendment"
-            )
     return {
-        "schema": "asi.ipmnist_prereg.launch_preflight.v2",
+        "schema": "asi.ipmnist_prereg.owner_authorization.v1",
         "protocol": asdict(protocol),
         "source": source,
         "tree": tree,
@@ -576,6 +567,73 @@ def verify_launch_authorization(
             if expected_amendment is not None
             else None
         ),
+    }
+
+
+def verify_launch_authorization(
+    *,
+    protocol_key: str,
+    repository: str,
+    source: str,
+    tree: str,
+    uv_lock_sha256: str,
+    workflow_blob_sha1: str,
+    driver_blob_sha1: str,
+    ref_name: str,
+    run_id: int,
+    run_attempt: int,
+    token: str,
+    root: Path | None = None,
+    owner_authorization: Path | None = None,
+) -> dict[str, Any]:
+    """Recheck the early owner gate, then reconstruct dependency-backed prerequisites."""
+
+    owner = verify_owner_authorization(
+        protocol_key=protocol_key,
+        repository=repository,
+        source=source,
+        tree=tree,
+        uv_lock_sha256=uv_lock_sha256,
+        workflow_blob_sha1=workflow_blob_sha1,
+        driver_blob_sha1=driver_blob_sha1,
+        ref_name=ref_name,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        token=token,
+    )
+    owner_receipt_sha256: str | None = None
+    if owner_authorization is not None:
+        stored_owner, stored_owner_raw = _strict_json_bytes(owner_authorization)
+        if _canonical_json(stored_owner) != _canonical_json(owner):
+            raise RuntimeError(
+                "early owner authorization receipt differs from the synchronized recheck"
+            )
+        owner_receipt_sha256 = hashlib.sha256(stored_owner_raw).hexdigest()
+    protocol = protocol_for(protocol_key)
+    prerequisite = (
+        _verify_prerequisite_completion(
+            protocol,
+            repository=repository,
+            launch_source=cast(str, owner["source"]),
+            root=root,
+            token=token,
+        )
+        if protocol.prerequisite is not None
+        else None
+    )
+    amendment_created_at = owner["registration_amendment_created_at"]
+    if prerequisite is not None:
+        if not isinstance(amendment_created_at, str):
+            raise RuntimeError("prerequisite protocol requires a registration amendment")
+        if _parse_utc(prerequisite["issue_closed_at"]) >= _parse_utc(amendment_created_at):
+            raise RuntimeError(
+                "prerequisite issue must be closed before the registration amendment"
+            )
+    return {
+        **owner,
+        "schema": "asi.ipmnist_prereg.launch_preflight.v3",
+        "early_owner_authorization_schema": owner["schema"],
+        "early_owner_authorization_sha256": owner_receipt_sha256,
         "prerequisite_completion": prerequisite,
     }
 
@@ -998,7 +1056,7 @@ def seal_completion_bundle(
     launch = _strict_json(launch_preflight)
     result = _strict_json(result_validation)
     runner, runner_raw = _strict_json_bytes(runner_receipt)
-    if launch.get("schema") != "asi.ipmnist_prereg.launch_preflight.v2":
+    if launch.get("schema") != "asi.ipmnist_prereg.launch_preflight.v3":
         raise ValueError("launch preflight has the wrong schema")
     if result.get("schema") != "asi.ipmnist_prereg.result_validation.v1":
         raise ValueError("result validation has the wrong schema")
@@ -1070,6 +1128,8 @@ def _verify_prerequisite_run_artifact(
     artifact_id = artifact.get("id")
     expected_name = f"ipmnist-{protocol.key}-{source}-{run_id}"
     workflow_run = artifact.get("workflow_run")
+    created_at = artifact.get("created_at")
+    expires_at = artifact.get("expires_at")
     if (
         type(artifact_id) is not int
         or artifact_id <= 0
@@ -1078,8 +1138,14 @@ def _verify_prerequisite_run_artifact(
         or not isinstance(workflow_run, dict)
         or workflow_run.get("id") != run_id
         or workflow_run.get("head_sha") != source
+        or not isinstance(created_at, str)
+        or not isinstance(expires_at, str)
     ):
         raise RuntimeError("prerequisite workflow result artifact is not canonical")
+    if _parse_utc(expires_at) - _parse_utc(created_at) != dt.timedelta(days=90):
+        raise RuntimeError(
+            "prerequisite workflow artifact must have the registered 90-day availability window"
+        )
     archive = _github_bytes(
         f"/repos/{repository}/actions/artifacts/{artifact_id}/zip",
         token=token,
@@ -1117,6 +1183,9 @@ def _verify_prerequisite_run_artifact(
     return {
         "artifact_id": artifact_id,
         "artifact_name": expected_name,
+        "artifact_created_at": created_at,
+        "artifact_expires_at": expires_at,
+        "artifact_retention_days": 90,
         "artifact_archive_sha256": hashlib.sha256(archive).hexdigest(),
     }
 
@@ -1292,6 +1361,29 @@ def _preflight_command(args: argparse.Namespace) -> int:
         run_attempt=args.run_attempt,
         token=token,
         root=args.root,
+        owner_authorization=args.owner_authorization,
+    )
+    _write_json(args.output, payload)
+    print(json.dumps(payload, allow_nan=False, sort_keys=True))
+    return 0
+
+
+def _authorize_command(args: argparse.Namespace) -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    payload = verify_owner_authorization(
+        protocol_key=args.protocol,
+        repository=args.repository,
+        source=args.source,
+        tree=args.tree,
+        uv_lock_sha256=args.uv_lock_sha256,
+        workflow_blob_sha1=args.workflow_blob_sha1,
+        driver_blob_sha1=args.driver_blob_sha1,
+        ref_name=args.ref_name,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+        token=token,
     )
     _write_json(args.output, payload)
     print(json.dumps(payload, allow_nan=False, sort_keys=True))
@@ -1327,19 +1419,26 @@ def _seal_command(args: argparse.Namespace) -> int:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
+    def add_launch_arguments(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
+        command.add_argument("--repository", required=True)
+        command.add_argument("--source", required=True)
+        command.add_argument("--tree", required=True)
+        command.add_argument("--uv-lock-sha256", required=True)
+        command.add_argument("--workflow-blob-sha1", required=True)
+        command.add_argument("--driver-blob-sha1", required=True)
+        command.add_argument("--ref-name", required=True)
+        command.add_argument("--run-id", type=int, required=True)
+        command.add_argument("--run-attempt", type=int, required=True)
+        command.add_argument("--output", type=Path, required=True)
+
+    authorize = subparsers.add_parser("authorize")
+    add_launch_arguments(authorize)
+    authorize.set_defaults(handler=_authorize_command)
     preflight = subparsers.add_parser("preflight")
-    preflight.add_argument("--protocol", choices=sorted(PROTOCOLS), required=True)
-    preflight.add_argument("--repository", required=True)
-    preflight.add_argument("--source", required=True)
-    preflight.add_argument("--tree", required=True)
-    preflight.add_argument("--uv-lock-sha256", required=True)
-    preflight.add_argument("--workflow-blob-sha1", required=True)
-    preflight.add_argument("--driver-blob-sha1", required=True)
-    preflight.add_argument("--ref-name", required=True)
-    preflight.add_argument("--run-id", type=int, required=True)
-    preflight.add_argument("--run-attempt", type=int, required=True)
+    add_launch_arguments(preflight)
     preflight.add_argument("--root", type=Path, required=True)
-    preflight.add_argument("--output", type=Path, required=True)
+    preflight.add_argument("--owner-authorization", type=Path, required=True)
     preflight.set_defaults(handler=_preflight_command)
 
     validate = subparsers.add_parser("validate")

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -66,13 +66,6 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.launch_sha }}
 
-      - name: Set up exact uv 0.9.24
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: 0.9.24
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-
       - name: Bind source, tag, workflow, and lock identities
         id: identity
         shell: bash
@@ -117,6 +110,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Refuse occupied output namespaces
+        id: protocol
         shell: bash
         env:
           PROTOCOL: ${{ inputs.protocol }}
@@ -139,6 +133,39 @@ jobs:
             echo "append-only namespace is already occupied: $target" >&2
             exit 1
           fi
+          echo "output_root=$target" >> "$GITHUB_OUTPUT"
+
+      - name: Require exact owner authorization and sole dispatch before setup
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROTOCOL: ${{ inputs.protocol }}
+          SOURCE: ${{ inputs.launch_sha }}
+          TREE: ${{ steps.identity.outputs.tree }}
+          UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
+          WORKFLOW_BLOB_SHA1: ${{ steps.identity.outputs.workflow_blob_sha1 }}
+          DRIVER_BLOB_SHA1: ${{ steps.identity.outputs.driver_blob_sha1 }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/ipmnist_prereg.py authorize \
+            --protocol "$PROTOCOL" \
+            --repository "$GITHUB_REPOSITORY" \
+            --source "$SOURCE" \
+            --tree "$TREE" \
+            --uv-lock-sha256 "$UV_LOCK_SHA256" \
+            --workflow-blob-sha1 "$WORKFLOW_BLOB_SHA1" \
+            --driver-blob-sha1 "$DRIVER_BLOB_SHA1" \
+            --ref-name "$GITHUB_REF_NAME" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$RUNNER_TEMP/prereg-metadata/owner-authorization.json"
+
+      - name: Set up exact uv 0.9.24
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: 0.9.24
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install exact uv-managed CPython 3.12.12
         id: python
@@ -297,7 +324,7 @@ jobs:
               stream.write(encoded)
           PY
 
-      - name: Require one pre-data project-owner authorization and one dispatch
+      - name: Recheck authorization and reconstruct prerequisites after sync
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -322,6 +349,8 @@ jobs:
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --root "$GITHUB_WORKSPACE" \
+            --owner-authorization \
+              "$RUNNER_TEMP/prereg-metadata/owner-authorization.json" \
             --output "$metadata"
 
       - name: Run code-only preregistration preflight tests
@@ -481,9 +510,7 @@ jobs:
         with:
           name: ipmnist-${{ inputs.protocol }}-${{ inputs.launch_sha }}-${{ github.run_id }}
           path: |
-            outputs/ipmnist_screening/replication_r1
-            outputs/ipmnist_screening/rls_preset_ablation_r1
-            outputs/ipmnist_screening/gate_ablation_r3
+            ${{ steps.protocol.outputs.output_root }}
             ${{ runner.temp }}/prereg-metadata
           if-no-files-found: warn
           retention-days: 90

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -61,6 +61,10 @@ def test_issue184_protocol_pins_exact_arms_namespace_and_seeds() -> None:
     assert issue184.summary_filename == "summary.json"
     assert issue184.requires_amendment is True
     assert issue184.prerequisite == "issue51"
+    assert (
+        issue184.prerequisite_artifact_condition
+        == "unexpired-90-day-github-actions-artifact"
+    )
 
 
 def test_issue184_workflow_pins_every_shell_mapping() -> None:
@@ -71,17 +75,35 @@ def test_issue184_workflow_pins_every_shell_mapping() -> None:
     assert 'issue184) namespace="rls_preset_ablation_r1" ;;' in workflow
     assert 'candidate="rls_head_resid_l1_noreset"' in workflow
     assert 'seeds=(0 1 2)' in workflow
-    assert "outputs/ipmnist_screening/rls_preset_ablation_r1" in workflow
+    assert 'echo "output_root=$target" >> "$GITHUB_OUTPUT"' in workflow
     assert ".github/scripts/ipmnist_prereg.py seal" in workflow
     assert "group: ipmnist-prereg-${{ inputs.protocol }}\n" in workflow
+    early_index = workflow.index(
+        "- name: Require exact owner authorization and sole dispatch before setup"
+    )
+    setup_index = workflow.index("- name: Set up exact uv 0.9.24")
     sync_index = workflow.index("- name: Synchronize the committed environment")
     authorization_index = workflow.index(
-        "- name: Require one pre-data project-owner authorization and one dispatch"
+        "- name: Recheck authorization and reconstruct prerequisites after sync"
     )
     test_index = workflow.index("- name: Run code-only preregistration preflight tests")
     measurement_index = workflow.index("- name: Run the frozen arms sequentially and merge once")
-    assert sync_index < authorization_index < test_index < measurement_index
+    assert (
+        early_index
+        < setup_index
+        < sync_index
+        < authorization_index
+        < test_index
+        < measurement_index
+    )
+    assert "python3 .github/scripts/ipmnist_prereg.py authorize" in workflow
     assert "uv run --no-sync python .github/scripts/ipmnist_prereg.py preflight" in workflow
+    upload = workflow[workflow.index("- name: Upload 90-day result or partial recovery bundle") :]
+    assert "${{ steps.protocol.outputs.output_root }}" in upload
+    assert "outputs/ipmnist_screening/replication_r1" not in upload
+    assert "outputs/ipmnist_screening/rls_preset_ablation_r1" not in upload
+    assert "outputs/ipmnist_screening/gate_ablation_r3" not in upload
+    assert "retention-days: 90" in upload
 
 
 def test_issue184_github_and_local_protocols_cannot_drift() -> None:
@@ -188,7 +210,9 @@ def test_issue184_amendment_line_binds_the_complete_registered_change() -> None:
         f"source={'1' * 40} tree={'2' * 40} uv_lock_sha256={'3' * 64} "
         f"workflow_blob_sha1={'4' * 40} driver_blob_sha1={'5' * 40} "
         "ref=ipmnist-prereg-example "
-        "runner=github-hosted-macos-14-arm64-apple-m1 seeds=0,1,2 n=3 "
+        "runner=github-hosted-macos-14-arm64-apple-m1 "
+        "prerequisite_artifact=unexpired-90-day-github-actions-artifact "
+        "seeds=0,1,2 n=3 "
         "compute=uncompensated"
     )
 
@@ -356,6 +380,37 @@ def test_launch_authorization_accepts_exact_unedited_project_owner_comment(
     assert payload["authorization_comment_id"] == 456
     assert payload["authorization_created_at"] == "2026-08-16T09:00:00Z"
     assert payload["authorization_updated_at"] == "2026-08-16T09:00:00Z"
+
+
+def test_synchronized_preflight_binds_the_early_owner_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    comment = _authorization_comment()
+    owner = _verify_with_comment(monkeypatch, comment)
+    owner.pop("prerequisite_completion")
+    owner.pop("early_owner_authorization_schema")
+    owner.pop("early_owner_authorization_sha256")
+    owner["schema"] = "asi.ipmnist_prereg.owner_authorization.v1"
+    receipt = tmp_path / "owner.json"
+    _write_json(receipt, owner)
+    payload = _verify_with_comment(
+        monkeypatch,
+        comment,
+        invocation_overrides={"owner_authorization": receipt},
+    )
+    assert payload["early_owner_authorization_sha256"] == hashlib.sha256(
+        receipt.read_bytes()
+    ).hexdigest()
+
+    owner["authorization_comment_id"] = 999
+    receipt.unlink()
+    _write_json(receipt, owner)
+    with pytest.raises(RuntimeError, match="early owner authorization receipt differs"):
+        _verify_with_comment(
+            monkeypatch,
+            comment,
+            invocation_overrides={"owner_authorization": receipt},
+        )
 
 
 @pytest.mark.parametrize(
@@ -904,7 +959,7 @@ def test_completion_seal_copies_runner_and_binds_fresh_reconstruction(
     namespace = tmp_path / "outputs" / "ipmnist_screening" / protocol.namespace
     namespace.mkdir(parents=True)
     launch = {
-        "schema": "asi.ipmnist_prereg.launch_preflight.v2",
+        "schema": "asi.ipmnist_prereg.launch_preflight.v3",
         "protocol": asdict(protocol),
         "source": "1" * 40,
         "tree": "2" * 40,
@@ -1010,6 +1065,10 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
         "validate_result_bundle",
         lambda **_kwargs: result,
     )
+    artifact_times = {
+        "created_at": "2026-05-18T08:59:00Z",
+        "expires_at": "2026-08-16T08:59:00Z",
+    }
 
     def fake_github_json(path: str, *, token: str) -> dict[str, Any]:
         assert token == "token"
@@ -1036,6 +1095,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
                         "id": 456,
                         "name": f"ipmnist-issue51-{'1' * 40}-123",
                         "expired": False,
+                        **artifact_times,
                         "workflow_run": {"id": 123, "head_sha": "1" * 40},
                     }
                 ],
@@ -1060,7 +1120,20 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     assert receipt["issue_closed_at"] == "2026-08-16T09:00:00Z"
     assert receipt["outcome"] == outcome
     assert receipt["artifact_id"] == 456
+    assert receipt["artifact_retention_days"] == 90
+    assert receipt["artifact_expires_at"] == "2026-08-16T08:59:00Z"
     assert receipt["artifact_archive_sha256"] == hashlib.sha256(archive_bytes).hexdigest()
+
+    artifact_times["expires_at"] = "2026-08-15T08:59:00Z"
+    with pytest.raises(RuntimeError, match="registered 90-day"):
+        _verify_prerequisite_completion(
+            _PROTOCOLS["issue184"],
+            repository="elizaOS/asi",
+            launch_source="5" * 40,
+            root=tmp_path,
+            token="token",
+        )
+    artifact_times["expires_at"] = "2026-08-16T08:59:00Z"
 
     tampered_stream = io.BytesIO()
     with zipfile.ZipFile(tampered_stream, "w") as archive:


### PR DESCRIPTION
Supersedes #776 while preserving its original commit.

Repairs the remaining fail-closed launch gaps:
- checks exact owner authorization, amendment ordering, and sole dispatch with the stdlib before setup-uv or dependency sync
- rechecks that gate after sync and binds the early receipt by exact canonical payload and SHA-256
- retains dependency-backed issue #51 completion reconstruction after sync
- binds issue #184 authorization/amendment to an unexpired GitHub Actions artifact with an exact 90-day retention window
- uploads only the selected protocol namespace plus prereg metadata

No tag, workflow dispatch, benchmark, or outputs mutation was performed.

Checks: 460 focused tests; Ruff; strict mypy; actionlint; diff check.