### PR TITLE
fix(recurrent-actor-critic): close exact scalar residuals

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -267,12 +267,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
-def _validated_config_float(name: str, value: object) -> float:
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     if type(value) is bool or type(value) is np.bool_:
         raise ValueError(f"{name} must be numeric, not bool")
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
-    normalized = validated_float32_scalar(name, value)
+    host_value = float(cast(Any, value))
+    magnitude = abs(host_value)
+    if (
+        not math.isfinite(host_value)
+        or magnitude > _FLOAT32_MAX
+        or (magnitude != 0.0 and magnitude < _FLOAT32_TINY)
+    ):
+        raise ValueError(
+            f"{name} must be exactly zero or representable as a finite normal float32"
+        )
+    normalized = validated_float32_scalar(name, value, **bounds)
     _validate_normal_float32_config_value(name, normalized)
     return normalized
 
@@ -426,32 +436,32 @@ class RecurrentTraceActorCriticConfig:
         object.__setattr__(self, "encoder_width", encoder_width)
         object.__setattr__(self, "output_width", output_width)
 
-        numeric_values = (
-            ("gamma", self.gamma),
-            ("actor_lamda", self.actor_lamda),
-            ("critic_lamda", self.critic_lamda),
-            ("actor_alpha", self.actor_alpha),
-            ("critic_alpha", self.critic_alpha),
-            ("actor_kappa", self.actor_kappa),
-            ("critic_kappa", self.critic_kappa),
-            ("entropy_coefficient", self.entropy_coefficient),
-            ("temperature", self.temperature),
-            ("sparsity", self.sparsity),
-            ("r_min", self.r_min),
-            ("r_max", self.r_max),
-            ("max_phase", self.max_phase),
-            ("rtu_epsilon", self.rtu_epsilon),
-            ("layer_norm_epsilon", self.layer_norm_epsilon),
-            ("leaky_relu_slope", self.leaky_relu_slope),
-            ("normalization_epsilon", self.normalization_epsilon),
-            ("beta2", self.beta2),
-            ("epsilon", self.epsilon),
-        )
-        for numeric_name, numeric_value in numeric_values:
+        float_domains: dict[str, dict[str, Any]] = {
+            "gamma": {"lower": 0.0, "upper": 1.0},
+            "actor_lamda": {"lower": 0.0, "upper": 1.0},
+            "critic_lamda": {"lower": 0.0, "upper": 1.0},
+            "actor_alpha": {"lower": 0.0},
+            "critic_alpha": {"lower": 0.0},
+            "actor_kappa": {"positive": True},
+            "critic_kappa": {"positive": True},
+            "entropy_coefficient": {"lower": 0.0},
+            "temperature": {"positive": True},
+            "sparsity": {"lower": 0.0, "upper": 1.0, "upper_inclusive": False},
+            "r_min": {"lower": 0.0, "upper": 1.0},
+            "r_max": {"positive": True, "upper": 1.0},
+            "max_phase": {"positive": True, "upper": 2.0 * math.pi},
+            "rtu_epsilon": {"positive": True, "upper": 1.0, "upper_inclusive": False},
+            "layer_norm_epsilon": {"positive": True},
+            "leaky_relu_slope": {"lower": 0.0},
+            "normalization_epsilon": {"positive": True},
+            "beta2": {"lower": 0.0, "upper": 1.0, "upper_inclusive": False},
+            "epsilon": {"positive": True},
+        }
+        for name, bounds in float_domains.items():
             object.__setattr__(
                 self,
-                numeric_name,
-                _validated_config_float(numeric_name, numeric_value),
+                name,
+                _validated_config_float(name, getattr(self, name), **bounds),
             )
 
         for interval_name, interval_value in (
@@ -521,7 +531,7 @@ class RecurrentTraceActorCriticConfig:
             ("adaptive_obgd", self.adaptive_obgd),
         ):
             if type(value) is not bool:
-                raise ValueError(f"{name} must be an exact bool")
+                raise ValueError(f"{name} must be a bool")
         _preflight_state_resources(self, 1)
 
     def state_resource_budget(self, feature_dim: object) -> dict[str, int]:
@@ -563,6 +573,19 @@ class RecurrentTraceActorCriticConfig:
             or not set(config) <= required | optional
         ):
             raise ValueError("config fields do not match the serialized schema")
+        integer_fields = {"n_actions", "hidden_size", "encoder_width", "output_width"}
+        bool_fields = {
+            "normalize_observations",
+            "normalize_rewards",
+            "rtrl_taylor_correction",
+            "adaptive_obgd",
+        }
+        for name, value in config.items():
+            expected_type = (
+                int if name in integer_fields else bool if name in bool_fields else float
+            )
+            if type(value) is not expected_type:
+                raise ValueError("serialized config values must use exact JSON scalar types")
         return cls(**dict(config))
 
 
@@ -1834,6 +1857,7 @@ class RecurrentTraceActorCriticAgent:
 
     def init(self, feature_dim: int, key: Array) -> RecurrentTraceActorCriticState:
         """Initialize independent actor/critic parameters and streaming state."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         self._config.state_resource_budget(feature_dim)
         actor_key, critic_key, policy_key = jr.split(key, 3)
         actor_params = initialize_rtu_network_parameters(

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2294,3 +2294,50 @@ def test_rtac_config_accepts_and_canonicalizes_numpy_integers() -> None:
     assert cfg.hidden_size == 64
     assert cfg.encoder_width == 32
     assert cfg.output_width == 32
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("gamma", "actor_lamda", "critic_lamda", "sparsity", "beta2"),
+)
+def test_float32_endpoints_check_exact_numpy_value(field: str) -> None:
+    above_one = np.nextafter(np.longdouble(1.0), np.longdouble(2.0))
+    with pytest.raises(ValueError, match=field):
+        RecurrentTraceActorCriticConfig(n_actions=2, **{field: above_one})
+
+
+@pytest.mark.parametrize("code", ("e", "f", "d", "g"))
+def test_config_canonicalizes_supported_numpy_float_families(code: str) -> None:
+    value = np.dtype(code).type(0.5)
+    config = RecurrentTraceActorCriticConfig(n_actions=2, gamma=value)
+    assert type(config.gamma) is float
+    assert config.gamma == 0.5
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("n_actions", np.int64(2)),
+        ("gamma", np.float32(0.5)),
+        ("normalize_rewards", np.bool_(True)),
+        ("gamma", 1),
+        ("n_actions", 2.0),
+    ),
+)
+def test_from_config_requires_exact_json_scalar_types(field: str, value: object) -> None:
+    payload = RecurrentTraceActorCriticConfig(n_actions=2).to_config()
+    payload[field] = value
+    with pytest.raises(ValueError, match="exact JSON scalar types"):
+        RecurrentTraceActorCriticConfig.from_config(payload)
+
+
+@pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_init_accepts_supported_numpy_integer_feature_dimensions(code: str) -> None:
+    config = RecurrentTraceActorCriticConfig(
+        n_actions=2,
+        hidden_size=2,
+        encoder_width=2,
+        output_width=2,
+    )
+    state = RecurrentTraceActorCriticAgent(config).init(np.dtype(code).type(3), jr.key(1))
+    assert state.last_observation.shape == (3,)


### PR DESCRIPTION
## Summary
- follows merged #788 and supersedes conflicting #787; #788 remains the source of the preserved #756 contributor commit and exact RTU resource formula
- validates all 19 float fields in both the exact trusted host domain and the float32 sink, preventing NumPy values just outside closed/half-open endpoints from narrowing into legality
- requires exact JSON scalar types during config reconstruction while retaining the documented full-envelope and legacy-flat schemas
- reuses the canonicalized signed-int32 `feature_dim` for every allocation, and restores the established exact-bool error contract without weakening validation
- adds NumPy float endpoint/family, serialized scalar, and all supported NumPy integer init regressions

## Verification
- 192 passed: complete `test_recurrent_trace_actor_critic.py` + `test_rtu_taylor_correction.py` panel on the #791 base
- 27 passed: post-final-rebase residual/Taylor smoke selection
- scoped Ruff passed
- strict mypy passed
- git diff-check passed

No outputs or registered evidence sources are changed.