### PR TITLE
fix(rtu): make state accounting exact

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -272,10 +272,14 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
         raise ValueError(f"{name} must be numeric, not bool")
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
-    host_value = float(cast(Any, value))
-    magnitude = abs(host_value)
+    try:
+        magnitude = abs(float(cast(Any, value)))
+    except (OverflowError, ValueError) as error:
+        raise ValueError(
+            f"{name} must be exactly zero or representable as a finite normal float32"
+        ) from error
     if (
-        not math.isfinite(host_value)
+        not math.isfinite(magnitude)
         or magnitude > _FLOAT32_MAX
         or (magnitude != 0.0 and magnitude < _FLOAT32_TINY)
     ):
@@ -344,7 +348,10 @@ def _preflight_state_resources(
         + 4 * width
         + 3
     )
-    logical_scalars = float32_scalars + 7
+    # Two statistics counters, last action, typed key, step counter, and the
+    # started flag are six logical array elements. The typed key occupies two
+    # uint32 words physically, which is reflected separately in state_nbytes.
+    logical_scalars = float32_scalars + 6
     state_nbytes = 4 * (float32_scalars + 6) + 1
     resources = {
         "parameter_scalars": parameters,

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2065,6 +2065,8 @@ def test_config_rejects_hostile_numeric_and_serialized_container_hooks() -> None
 
     with pytest.raises(ValueError, match="gamma"):
         _small_config(gamma=HostileFloat(0.9))
+    with pytest.raises(ValueError, match="finite normal float32"):
+        _small_config(gamma=10**1000)
     payload = _small_config().to_config()
     with pytest.raises(ValueError, match="exact built-in dict"):
         RecurrentTraceActorCriticConfig.from_config(DictSubclass(payload))
@@ -2079,13 +2081,18 @@ def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config = _small_config()
-    assert config.state_resource_budget(2) == {
+    budget = config.state_resource_budget(2)
+    assert budget == {
         "parameter_scalars": 124,
         "sensitivity_scalars_per_network": 36,
         "float32_state_scalars": 343,
-        "state_scalars": 350,
+        "state_scalars": 349,
         "state_nbytes": 1397,
     }
+    state = RecurrentTraceActorCriticAgent(config).init(2, jr.key(2))
+    leaves = jax.tree.leaves(state)
+    assert budget["state_scalars"] == sum(int(leaf.size) for leaf in leaves)
+    assert budget["state_nbytes"] == sum(int(leaf.nbytes) for leaf in leaves)
 
     def forbidden_split(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("RNG split must not run before resource validation")


### PR DESCRIPTION
Final corrective audit after #788/#796 and the now-closed competing #787. The persistent byte count was exact, but state_scalars counted a typed JAX key as two logical array elements because it occupies two uint32 backing words. JAX exposes that key as one scalar leaf, so the logical count was exactly one high. This separates logical leaf size from physical byte accounting and pins both totals against the actually initialized tree.\n\nThe follow-up also normalizes builtin huge-integer conversion overflow to the established finite-normal-float32 ValueError rather than leaking OverflowError; exact host/sink bounds from #796 are retained.\n\nVerification on current main: 74 focused RTU resource/scalar/Taylor tests passed; scoped Ruff passed; strict mypy passed; diff-check clean. No outputs or registered evidence sources change.