### PR TITLE
fix(recurrent-actor-critic): reject exact nonzero underflow

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -46,7 +46,7 @@ import numpy as np
 from jax import Array
 from jax.nn.initializers import lecun_normal
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
@@ -282,7 +282,12 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
         raise ValueError(
             f"{name} must be exactly zero or representable as a finite normal float32"
         )
-    normalized = validated_float32_scalar(name, value, **bounds)
+    normalized, numerator, _ = validated_float32_scalar_with_ratio(name, value, **bounds)
+    narrowed_magnitude = abs(float(np.float32(normalized)))
+    if numerator != 0 and narrowed_magnitude < _FLOAT32_TINY:
+        raise ValueError(
+            f"{name} must be exactly zero or representable as a finite normal float32"
+        )
     _validate_normal_float32_config_value(name, normalized)
     return normalized
 

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2306,6 +2306,27 @@ def test_float32_endpoints_check_exact_numpy_value(field: str) -> None:
         RecurrentTraceActorCriticConfig(n_actions=2, **{field: above_one})
 
 
+@pytest.mark.parametrize(
+    "field",
+    (
+        "gamma",
+        "actor_lamda",
+        "critic_lamda",
+        "actor_alpha",
+        "critic_alpha",
+        "entropy_coefficient",
+        "sparsity",
+        "r_min",
+        "leaky_relu_slope",
+        "beta2",
+    ),
+)
+def test_nonzero_longdouble_cannot_underflow_into_legal_zero(field: str) -> None:
+    nonzero = np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
+    with pytest.raises(ValueError, match=rf"{field}.*finite normal float32"):
+        RecurrentTraceActorCriticConfig(n_actions=2, **{field: nonzero})
+
+
 @pytest.mark.parametrize("code", ("e", "f", "d", "g"))
 def test_config_canonicalizes_supported_numpy_float_families(code: str) -> None:
     value = np.dtype(code).type(0.5)


### PR DESCRIPTION
Narrow follow-up to merged #796. The smallest nonzero `np.longdouble` converts to Python `0.0`; the precheck therefore allowed it through zero-legal RTU fields before it narrowed to float32 zero. Reuse the shared exact-ratio result and reject every nonzero exact numerator whose float32 sink is below the normal floor.

The diff is limited to the helper swap/check and a 10-field zero-legal regression panel.

Verification: 15 focused tests passed; scoped Ruff passed; strict mypy passed; diff-check passed.