### PR TITLE
fix(options): retain exact serialized schema

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1593,34 +1593,60 @@ class STOMPConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("STOMPConfig mapping could not be read") from error
-        payload.pop("type", None)
+        if payload.pop("type", None) != "STOMPConfig":
+            raise ValueError("STOMPConfig type is invalid")
+        expected = {field.name for field in dataclasses.fields(cls)}
+        legacy_optional = {
+            "subtask_specs",
+            "base_hidden_sizes",
+            "option_planning_backups_per_step",
+        }
+        if set(payload) - expected or (expected - legacy_optional) - set(payload):
+            raise ValueError("STOMPConfig fields do not match its schema")
         specs_raw = payload.pop("subtask_specs", [])
-        if type(specs_raw) not in (list, tuple):
-            raise ValueError("serialized subtask_specs must be an actual list or tuple")
-        specs: list[SubtaskSpec] = []
-        for raw in specs_raw:
-            if not issubclass(type(raw), Mapping):
-                raise ValueError("serialized subtask_specs entries must be mappings")
-            try:
-                decoded = dict(raw)
-            except Exception as error:
-                raise ValueError("serialized SubtaskSpec mapping could not be read") from error
-            try:
-                specs.append(SubtaskSpec(**decoded))
-            except ValueError:
-                raise
-            except Exception as error:
-                raise ValueError("serialized SubtaskSpec is invalid") from error
-        if "base_hidden_sizes" in payload:
-            raw_hidden = payload["base_hidden_sizes"]
-            if type(raw_hidden) not in (list, tuple):
-                raise ValueError(
-                    "serialized base_hidden_sizes must be an actual list or tuple"
-                )
-            sequence = cast(list[object] | tuple[object, ...], raw_hidden)
-            payload["base_hidden_sizes"] = tuple(sequence)
+        if type(specs_raw) is not list or any(type(spec) is not dict for spec in specs_raw):
+            raise ValueError("serialized subtask_specs must be an actual list of actual dicts")
+        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
+        if any(set(spec) != spec_fields for spec in specs_raw):
+            raise ValueError("serialized SubtaskSpec fields do not match its schema")
+        if any(
+            type(spec["feature_index"]) is not int
+            or type(spec["max_option_steps"]) is not int
+            or type(spec["threshold"]) is not float
+            or type(spec["pseudo_reward_scale"]) is not float
+            for spec in specs_raw
+        ):
+            raise ValueError("serialized SubtaskSpec scalars must be canonical JSON scalars")
+        specs = tuple(SubtaskSpec(**spec) for spec in specs_raw)
+        hidden_raw = payload.pop("base_hidden_sizes", [])
+        if type(hidden_raw) is not list or any(type(size) is not int for size in hidden_raw):
+            raise ValueError("serialized base_hidden_sizes must be an actual list of JSON integers")
+        payload["base_hidden_sizes"] = tuple(hidden_raw)
+        for name in ("observation_dim", "n_primitive_actions", "option_planning_backups_per_step"):
+            if name in payload and type(payload[name]) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+        for name in (
+            "base_step_size",
+            "base_avg_reward_step_size",
+            "base_trace_decay",
+            "option_step_size",
+            "option_avg_reward_step_size",
+            "option_trace_decay",
+            "option_gamma",
+            "option_model_decay",
+            "option_model_step_size",
+            "epsilon_base",
+            "epsilon_option",
+            "option_importance_clip",
+        ):
+            if type(payload[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON number")
+        if payload["option_target_epsilon"] is not None and type(
+            payload["option_target_epsilon"]
+        ) is not float:
+            raise ValueError("serialized option_target_epsilon must be null or a JSON number")
         try:
-            return cls(subtask_specs=tuple(specs), **payload)
+            return cls(subtask_specs=specs, **payload)
         except ValueError:
             raise
         except Exception as error:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,7 @@
 """Tests for STOMP checkpoint payloads and state migration (core/options.py)."""
 
 import dataclasses
+from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 
 import chex
@@ -478,7 +479,7 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
 
 
 @pytest.mark.unit
-def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -> None:
+def test_stomp_from_config_preserves_mapping_api_without_relaxing_schema() -> None:
     class MappingSpoof:
         @property
         def __class__(self) -> type:  # type: ignore[override]
@@ -490,42 +491,49 @@ def test_stomp_from_config_preserves_mapping_partial_and_tuple_compatibility() -
         def __repr__(self) -> str:
             raise AssertionError("repr hook executed")
 
+    class HostileMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError("getitem hook")
+
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError("iteration hook")
+
+        def __len__(self) -> int:
+            return 1
+
     config = STOMPConfig(
         subtask_specs=(SubtaskSpec(feature_index=0),),
         observation_dim=2,
     )
     payload = config.to_config()
-    payload["subtask_specs"] = tuple(payload["subtask_specs"])
-    payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
-    payload["type"] = "historical-marker"
     assert STOMPConfig.from_config(MappingProxyType(payload)) == config
-
-    partial = STOMPConfig.from_config(
-        {"subtask_specs": ({"feature_index": 0},), "observation_dim": 2}
-    )
-    assert partial.subtask_specs == (SubtaskSpec(feature_index=0),)
-    assert partial.option_planning_backups_per_step == 0
 
     with pytest.raises(ValueError, match="mapping"):
         STOMPConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="mapping could not be read"):
+        STOMPConfig.from_config(HostileMapping())
 
     with pytest.raises(ValueError, match="STOMPConfig"):
         STOMPConfig.from_config({"unexpected_field": 1})
 
-    with pytest.raises(ValueError, match="feature_index"):
-        STOMPConfig.from_config(
-            {"subtask_specs": ({"feature_index": True},), "observation_dim": 2}
-        )
-    with pytest.raises(ValueError, match="threshold"):
-        STOMPConfig.from_config(
-            {"subtask_specs": ({"feature_index": 0, "threshold": "invalid"},)}
-        )
-
-    for field, value in (
-        ("subtask_specs", "not-a-sequence"),
-        ("base_hidden_sizes", "not-a-sequence"),
+    for mutation, match in (
+        ({"type": "historical-marker"}, "type"),
+        ({"base_step_size": np.float32(0.01)}, "base_step_size"),
+        ({"observation_dim": np.int32(2)}, "observation_dim"),
+        ({"base_hidden_sizes": tuple(payload["base_hidden_sizes"])}, "base_hidden_sizes"),
+        ({"subtask_specs": tuple(payload["subtask_specs"])}, "subtask_specs"),
     ):
         invalid = config.to_config()
-        invalid[field] = value
-        with pytest.raises(ValueError, match=field):
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
             STOMPConfig.from_config(invalid)
+
+    missing = config.to_config()
+    missing.pop("base_step_size")
+    with pytest.raises(ValueError, match="fields"):
+        STOMPConfig.from_config(missing)
+
+    invalid_spec = config.to_config()
+    invalid_spec["subtask_specs"] = [{"feature_index": 0}]
+    with pytest.raises(ValueError, match="SubtaskSpec fields"):
+        STOMPConfig.from_config(invalid_spec)


### PR DESCRIPTION
Corrects the schema regression introduced by merged #783.

The documented genuine `Mapping` / `MappingProxyType` input remains supported, and ordinary hostile mapping hooks are normalized to `ValueError`. The serialized contract is fail-closed again: exact `STOMPConfig` marker, required/unknown field gate with only the three preexisting legacy optional fields, canonical JSON scalar types, actual-list containers, actual-dict SubtaskSpec entries, and exact nested fields. Constructor validation continues to enforce the merged float32 and derived-resource contracts.

Checks: 212 options/STOMP integration tests; 105 direct options tests again after rebase; Ruff; strict targeted mypy; diff check. No output artifacts changed.