### PR TITLE
fix(closed-loop): close spoofable and missing scalar validation gaps

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="call-arg"
+# mypy: disable-error-code="call-arg,attr-defined"
 """Closed-loop micro-MDPs where actions affect observations.
 
 Every other stream in this package is open-loop: the observation sequence is
@@ -81,6 +81,32 @@ _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
     np.float64,
     np.longdouble,
 )
+
+
+def _require_builtin_int(
+    value: object,
+    *,
+    name: str,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
+    """Return a built-in int at or above ``minimum``; reject bool and numpy ints.
+
+    ``type(value) is not int`` is deliberate: ``isinstance(value, int)``
+    consults the overridable ``__class__`` attribute, so an object whose
+    ``__class__`` property returns ``int`` would pass an isinstance check
+    even though its true type never implements the integer protocol,
+    letting it reach downstream integer-only sinks (``range``, JAX array
+    construction) and raise an undocumented, unclean exception there
+    instead of the ``ValueError`` this contract promises.
+    """
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return value
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -227,16 +253,7 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        if (
-            isinstance(config.phase_length, bool)
-            or not isinstance(config.phase_length, int)
-            or config.phase_length < 1
-            or config.phase_length > _INT32_MAX
-        ):
-            raise ValueError(
-                "phase_length must be a positive integer in "
-                f"[1, {_INT32_MAX}], got {config.phase_length!r}"
-            )
+        _require_builtin_int(config.phase_length, name="phase_length", minimum=1)
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -427,8 +444,7 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
-        if config.n_states < 2:
-            raise ValueError(f"n_states must be at least 2, got {config.n_states}")
+        n_states = _require_builtin_int(config.n_states, name="n_states", minimum=2)
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,
@@ -466,17 +482,12 @@ class RiverSwimMDP:
                 "p_right_up + p_right_down must not exceed 1, got "
                 f"{config.p_right_up} + {config.p_right_down}"
             )
-        if not 0 <= config.initial_state < config.n_states:
-            raise ValueError(
-                f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
-            )
-        if isinstance(config.initial_state, bool) or not isinstance(
-            config.initial_state, Integral
-        ):
-            raise ValueError(
-                "initial_state must be an integer, got "
-                f"{config.initial_state!r}"
-            )
+        _require_builtin_int(
+            config.initial_state,
+            name="initial_state",
+            minimum=0,
+            maximum=n_states - 1,
+        )
         config = cast(
             RiverSwimConfig,
             config.replace(
@@ -487,7 +498,7 @@ class RiverSwimMDP:
             ),
         )
         self._config: RiverSwimConfig = config
-        self._n_states: int = int(config.n_states)
+        self._n_states: int = n_states
         self._transitions_np: np.ndarray = self._build_transitions(config)
         self._rewards_np: np.ndarray = self._build_rewards(config)
         self._transition_logits: Array = jnp.where(

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -148,12 +148,35 @@ class TestSwitchingTwoStateDynamics:
     @pytest.mark.parametrize("phase_length", _INVALID_PHASE_LENGTHS)
     def test_invalid_phase_length_raises(self, phase_length):
         """Schedule divisors must be built-in positive JAX-int32 integers."""
-        with pytest.raises(
-            ValueError,
-            match=rf"phase_length must be a positive integer in \[1, {_INT32_MAX}\]",
-        ):
+        with pytest.raises(ValueError, match=r"phase_length must be"):
             SwitchingTwoStateMDP(
                 SwitchingTwoStateConfig(phase_length=phase_length)  # type: ignore[arg-type]
+            )
+
+    def test_phase_length_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        ``isinstance(value, int)`` consults the overridable ``__class__``
+        property, so a non-int object could previously spoof the isinstance
+        check and reach ``int(config.phase_length)`` unvalidated, raising an
+        undocumented ``TypeError`` from deep inside JAX construction instead
+        of the clean ``ValueError`` this constructor promises.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __lt__(self, other: object) -> bool:
+                return False
+
+            def __gt__(self, other: object) -> bool:
+                return False
+
+        with pytest.raises(ValueError, match=r"phase_length must be a built-in integer"):
+            SwitchingTwoStateMDP(
+                SwitchingTwoStateConfig(phase_length=_SpoofedInt())  # type: ignore[arg-type]
             )
 
     def test_int32_max_phase_length_runs_first_eager_and_jit_query(self):
@@ -376,8 +399,42 @@ class TestRiverSwim:
     @pytest.mark.parametrize("initial_state", [1.5, True, 2.0])
     def test_non_integer_initial_state_raises(self, initial_state):
         """initial_state must be a canonical integer in range."""
-        with pytest.raises(ValueError, match="initial_state must be an integer"):
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
             RiverSwimMDP(RiverSwimConfig(initial_state=initial_state))  # type: ignore[arg-type]
+
+    def test_initial_state_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        Previously ``isinstance(config.initial_state, Integral)`` consulted
+        the overridable ``__class__`` property, so this object would pass
+        validation and reach ``jnp.array(self._config.initial_state, ...)``
+        inside :meth:`RiverSwimMDP.init` unvalidated.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __ge__(self, other: object) -> bool:
+                return True
+
+            def __lt__(self, other: object) -> bool:
+                return True
+
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(initial_state=_SpoofedInt()))  # type: ignore[arg-type]
+
+    def test_non_integer_n_states_raises(self):
+        """n_states must be a canonical built-in integer, not merely numeric.
+
+        Previously ``n_states`` had no type check at all: a float such as
+        ``6.5`` passed the ``config.n_states < 2`` comparison and then raised
+        an undocumented ``TypeError`` from ``range(n)`` deep inside
+        ``_build_transitions`` instead of a clean ``ValueError``.
+        """
+        with pytest.raises(ValueError, match="n_states must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(n_states=6.5))  # type: ignore[arg-type]
 
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""


### PR DESCRIPTION
Fixes #799.

## Summary

`alberta_framework/streams/closed_loop.py` had three config-scalar
validation gaps in this recurring family:

- `SwitchingTwoStateConfig.phase_length` and `RiverSwimConfig.initial_state`
  were checked with `isinstance(value, int)` / `isinstance(value, Integral)`.
  `isinstance` consults the overridable `__class__` attribute, so an object
  whose `__class__` property returns `int` passes validation even though its
  real type implements no integer protocol at all. `phase_length` then
  reached `int(config.phase_length)` unguarded, raising a raw undocumented
  `TypeError` instead of the `ValueError` the constructor promises;
  `initial_state` bypassed validation entirely and reached
  `jnp.array(self._config.initial_state, dtype=jnp.int32)` inside
  `RiverSwimMDP.init` unvalidated.
- `RiverSwimConfig.n_states` had **no type check at all** — only
  `if config.n_states < 2`. A plain `float` such as `6.5` silently passes
  that comparison and only fails much later inside `_build_transitions`'s
  `range(n)` call, with an opaque
  `TypeError: 'float' object cannot be interpreted as an integer` instead
  of a clean, documented `ValueError`.

This is the same recurring pattern already closed in
`alberta_framework/streams/pavlovian.py` (see its `_require_finite_real` /
`_require_builtin_int` helpers) and in the ongoing "complete scalar/resource
contracts" wave across `alberta_framework/core/*`.

## Fix

Added `_require_builtin_int(value, *, name, minimum, maximum=_INT32_MAX)`,
matching the non-spoofable `type(value) is not int` convention already
established in `pavlovian.py`, and used it for all three fields — including
adding the previously-missing type/bounds check on `n_states`. Also fixed
the validation order for `initial_state` (type checked before the bounds
comparison that uses it).

Reproduction before the fix (commit `dd04906`):

```python
class SpoofInt:
    @property
    def __class__(self): return int
    def __lt__(self, other): return False
    def __gt__(self, other): return False

SwitchingTwoStateMDP(SwitchingTwoStateConfig(phase_length=SpoofInt()))
# TypeError: int() argument must be a string, a bytes-like object or a real number, not 'SpoofInt'

RiverSwimMDP(RiverSwimConfig(n_states=6.5))
# TypeError: 'float' object cannot be interpreted as an integer

RiverSwimMDP(RiverSwimConfig(initial_state=SpoofInt()))
# constructs successfully with an unvalidated initial_state
```

All three now raise a clean, documented `ValueError`.

One incidental mypy fix: the removed `isinstance(x, Integral)` check (on a
field statically typed `int`, where typeshed does not model `int` as a
subtype of `numbers.Integral`) was accidentally causing mypy to treat the
following `config.replace(...)` call as unreachable, silently masking that
chex's dynamically-injected `.replace()` isn't visible to mypy without a
plugin. Removing that check exposed the real (pre-existing, harmless) gap;
extended this file's existing `# mypy: disable-error-code="call-arg"`
directive to also cover `attr-defined`, consistent with how this exact
chex/mypy limitation is already handled elsewhere in the file.

## Verification

- `tests/test_closed_loop_env.py`: 85 passed (4 new regression tests added:
  spoofed `phase_length`/`initial_state` via `__class__` override, a bare
  float `n_states`, and updated message-text expectations for the two
  existing negative tests whose error messages became more specific).
- Downstream callers exercised: `tests/test_control_learning_gates.py`
  (21 passed), `tests/test_prototype_reference_adapter.py` (included above),
  `tests/test_ia_amplification.py::test_recommendation_channel_amplifies_partner`
  and `::test_ia_configs_reject_booleans_and_non_integers` (4 passed) — these
  construct `SwitchingTwoStateMDP` through `evaluation/continual_ia.py`'s
  `_make_env`, which already normalizes `phase_length` to a plain `int` via
  `operator.index`, so behavior is unchanged for real callers.
- `ruff check .`: all checks passed.
- `mypy` (full project, strict): 168 source files, no issues.
- `git diff --check`: clean.
- No `outputs/` artifacts touched; this module is not a registered evidence
  source.

Commit: b289ab3e076a533711b5812ba1c779c746b59a2b

Receipt signing deferred — operator handling centrally (unattended overnight
run).