### PR TITLE
fix(prototype-memory): complete exact resource and transaction contracts

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -93,6 +93,22 @@ def _require_int(
     return number
 
 
+_UINT32_MAX: int = 4294967295
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 @chex.dataclass(frozen=True)
 class PrototypeMemoryConfig:
     """Configuration for :class:`PrototypeMemoryLearner`.
@@ -197,6 +213,22 @@ def _validate_config(config: PrototypeMemoryConfig) -> None:
     object.__setattr__(config, "update_rate", update_rate)
     object.__setattr__(config, "novelty_threshold", novelty_threshold)
     object.__setattr__(config, "bandwidth", bandwidth)
+    if n_classes * slots_per_class > _INT32_MAX:
+        raise ValueError("PrototypeMemoryConfig dimensions must fit signed int32")
+    if n_classes * slots_per_class * feature_dim > _INT32_MAX:
+        raise ValueError("PrototypeMemoryConfig dimensions must fit signed int32")
+    total_means_scalars = n_classes * slots_per_class * feature_dim
+    total_state_scalars = total_means_scalars + 2 * n_classes * slots_per_class + 1
+    _require_float32_resource(
+        "PrototypeMemoryConfig state",
+        vector_scalars=total_means_scalars,
+        fixed_scalars=2 * n_classes * slots_per_class + 1,
+    )
+    persistent_bytes = 4 * total_state_scalars
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("PrototypeMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("prototype memory allocation exceeds uint32 byte accounting")
 
 
 def _softmax(logits: Array) -> Array:

--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -36,6 +37,7 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX: int = 2**31 - 1
+_FLOAT32_MIN_NORMAL: float = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -68,8 +70,8 @@ def _require_nonnegative_real(name: str, value: object) -> float:
     return validated_float32_scalar(name, value, lower=0.0)
 
 
-def _require_positive_real(name: str, value: object) -> float:
-    return validated_float32_scalar(name, value, positive=True)
+def _require_positive_normal_real(name: str, value: object) -> float:
+    return validated_float32_scalar(name, value, lower=_FLOAT32_MIN_NORMAL)
 
 
 def _require_int(
@@ -93,9 +95,6 @@ def _require_int(
     return number
 
 
-_UINT32_MAX: int = 4294967295
-
-
 def _require_float32_resource(
     name: str,
     *,
@@ -107,6 +106,47 @@ def _require_float32_resource(
         raise ValueError(f"{name} scalar count must fit signed int32")
     if 4 * total_scalars > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_sequence_resource(
+    name: str,
+    *,
+    float32_scalars: int,
+    bool_scalars: int,
+) -> None:
+    if float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_array(
+    value: Any,
+    *,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> None:
+    if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+        raise TypeError(f"{name} must be an array with shape and dtype metadata")
+    actual_shape = tuple(value.shape)
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}; got {actual_shape}")
+    expected_dtype = jnp.dtype(dtype)
+    actual_dtype = jnp.dtype(value.dtype)
+    if actual_dtype != expected_dtype:
+        raise TypeError(f"{name} must have dtype {expected_dtype}; got {actual_dtype}")
+
+
+def _require_shape(name: str, value: Array, shape: tuple[int, ...]) -> None:
+    actual_shape = tuple(value.shape)
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}; got {actual_shape}")
+
+
+def _saturating_increment(value: Array) -> Array:
+    one = jnp.asarray(1, dtype=jnp.int32)
+    return jnp.minimum(value, jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)) + one
 
 
 @chex.dataclass(frozen=True)
@@ -154,11 +194,16 @@ class PrototypeMemoryConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> PrototypeMemoryConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> PrototypeMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        config = dict(config)
-        config.pop("type", None)
-        return cls(**config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("PrototypeMemoryConfig payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("PrototypeMemoryConfig mapping could not be read") from error
+        payload.pop("type", None)
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -206,7 +251,7 @@ def _validate_config(config: PrototypeMemoryConfig) -> None:
     novelty_threshold = _require_nonnegative_real(
         "novelty_threshold", config.novelty_threshold
     )
-    bandwidth = _require_positive_real("bandwidth", config.bandwidth)
+    bandwidth = _require_positive_normal_real("bandwidth", config.bandwidth)
     object.__setattr__(config, "feature_dim", feature_dim)
     object.__setattr__(config, "n_classes", n_classes)
     object.__setattr__(config, "slots_per_class", slots_per_class)
@@ -218,17 +263,11 @@ def _validate_config(config: PrototypeMemoryConfig) -> None:
     if n_classes * slots_per_class * feature_dim > _INT32_MAX:
         raise ValueError("PrototypeMemoryConfig dimensions must fit signed int32")
     total_means_scalars = n_classes * slots_per_class * feature_dim
-    total_state_scalars = total_means_scalars + 2 * n_classes * slots_per_class + 1
     _require_float32_resource(
         "PrototypeMemoryConfig state",
         vector_scalars=total_means_scalars,
         fixed_scalars=2 * n_classes * slots_per_class + 1,
     )
-    persistent_bytes = 4 * total_state_scalars
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("PrototypeMemoryConfig state byte count must fit signed int32")
-    if persistent_bytes > _UINT32_MAX:
-        raise ValueError("prototype memory allocation exceeds uint32 byte accounting")
 
 
 def _softmax(logits: Array) -> Array:
@@ -262,10 +301,63 @@ class PrototypeMemoryLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> PrototypeMemoryLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> PrototypeMemoryLearner:
         """Reconstruct a learner from :meth:`to_config` output."""
-        inner = dict(config["config"])
+        if not issubclass(type(config), Mapping):
+            raise ValueError("PrototypeMemoryLearner payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("PrototypeMemoryLearner mapping could not be read") from error
+        inner_raw = payload.get("config")
+        if not issubclass(type(inner_raw), Mapping):
+            raise ValueError("PrototypeMemoryLearner config must be a mapping")
+        try:
+            inner = dict(cast(Mapping[str, Any], inner_raw))
+        except Exception as error:
+            raise ValueError("PrototypeMemoryLearner config could not be read") from error
         return cls(PrototypeMemoryConfig.from_config(inner))
+
+    def _validate_state_static_contract(self, state: PrototypeMemoryState) -> None:
+        """Reject malformed adopted state before any traced computation."""
+        if type(state) is not PrototypeMemoryState:
+            raise TypeError("state must be a PrototypeMemoryState")
+        cfg = self._config
+        slot_shape = (cfg.n_classes, cfg.slots_per_class)
+        _require_array(
+            state.means,
+            name="state.means",
+            shape=(*slot_shape, cfg.feature_dim),
+            dtype=jnp.float32,
+        )
+        _require_array(
+            state.counts,
+            name="state.counts",
+            shape=slot_shape,
+            dtype=jnp.float32,
+        )
+        _require_array(
+            state.last_update,
+            name="state.last_update",
+            shape=slot_shape,
+            dtype=jnp.int32,
+        )
+        _require_array(
+            state.step_count,
+            name="state.step_count",
+            shape=(),
+            dtype=jnp.int32,
+        )
+
+    @staticmethod
+    def _state_is_valid(state: PrototypeMemoryState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & jnp.all(state.counts >= 0.0)
+            & jnp.all(state.last_update >= 0)
+            & (state.step_count >= 0)
+            & jnp.all(state.last_update <= state.step_count)
+        )
 
     def init(self) -> PrototypeMemoryState:
         """Create an empty fixed-budget memory."""
@@ -287,7 +379,9 @@ class PrototypeMemoryLearner:
         observation: Float[Array, " feature_dim"],
     ) -> Float[Array, " n_classes"]:
         """Return class logits from nearest active prototype distances."""
+        self._validate_state_static_contract(state)
         x = jnp.asarray(observation, dtype=jnp.float32)
+        _require_shape("observation", x, (self._config.feature_dim,))
         diffs = state.means - x[None, None, :]
         distances = jnp.mean(diffs * diffs, axis=2)
         slot_logits = -distances / jnp.asarray(self._config.bandwidth, dtype=jnp.float32)
@@ -296,7 +390,7 @@ class PrototypeMemoryLearner:
         any_active = jnp.any(state.counts > 0.0, axis=1)
         logits = jnp.where(any_active, logits, -1e9)
         logits = jnp.where(jnp.any(any_active), logits, jnp.zeros_like(logits))
-        inputs_valid = floating_tree_is_finite(state) & jnp.all(jnp.isfinite(x))
+        inputs_valid = self._state_is_valid(state) & jnp.all(jnp.isfinite(x))
         return jnp.where(inputs_valid, logits, jnp.full_like(logits, jnp.nan))
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -341,17 +435,24 @@ class PrototypeMemoryLearner:
         novelty_threshold: Float[Array, ""],
     ) -> PrototypeMemoryUpdateResult:
         """Perform one causal update with a runtime novelty threshold."""
+        self._validate_state_static_contract(state)
         observation_arr = jnp.asarray(observation, dtype=jnp.float32)
+        target_arr = jnp.asarray(target, dtype=jnp.float32)
         threshold_arr = jnp.asarray(novelty_threshold, dtype=jnp.float32)
-        inputs_valid = jnp.all(jnp.isfinite(observation_arr)) & jnp.isfinite(
-            threshold_arr
+        _require_shape("observation", observation_arr, (self._config.feature_dim,))
+        _require_shape("target", target_arr, (self._config.n_classes,))
+        _require_shape("novelty_threshold", threshold_arr, ())
+        inputs_valid = (
+            jnp.all(jnp.isfinite(observation_arr))
+            & jnp.isfinite(threshold_arr)
+            & (threshold_arr >= 0.0)
         )
         safe_observation = jnp.where(
             inputs_valid, observation_arr, jnp.zeros_like(observation_arr)
         )
         prediction = self.predict(state, safe_observation)
-        valid_target = self.valid_one_hot_target(target)
-        safe_target = jnp.where(jnp.isfinite(target), target, 0.0)
+        valid_target = self.valid_one_hot_target(target_arr)
+        safe_target = jnp.where(jnp.isfinite(target_arr), target_arr, 0.0)
         errors = prediction - safe_target
         mse = jnp.mean(errors * errors)
         confidence = jnp.max(prediction)
@@ -393,23 +494,23 @@ class PrototypeMemoryLearner:
                 old_mean + eta * (safe_observation - old_mean),
             )
             new_count = jnp.where(novel, 1.0, current.counts[head, slot] + 1.0)
+            next_step = _saturating_increment(current.step_count)
             next_state = PrototypeMemoryState(
                 means=current.means.at[head, slot].set(new_mean),
                 counts=current.counts.at[head, slot].set(new_count),
-                last_update=current.last_update.at[head, slot].set(
-                    current.step_count + 1
-                ),
-                step_count=current.step_count + 1,
+                last_update=current.last_update.at[head, slot].set(next_step),
+                step_count=next_step,
             )
             return next_state, novel.astype(jnp.float32)
 
         def skip_update(current: PrototypeMemoryState) -> tuple[PrototypeMemoryState, Array]:
+            next_step = _saturating_increment(current.step_count)
             return (
                 PrototypeMemoryState(
                     means=current.means,
                     counts=current.counts,
                     last_update=current.last_update,
-                    step_count=current.step_count + 1,
+                    step_count=next_step,
                 ),
                 jnp.array(0.0, dtype=jnp.float32),
             )
@@ -431,8 +532,8 @@ class PrototypeMemoryLearner:
         )
         update_applied = (
             inputs_valid
-            & floating_tree_is_finite(state)
-            & floating_tree_is_finite(candidate_state)
+            & self._state_is_valid(state)
+            & self._state_is_valid(candidate_state)
             & jnp.all(jnp.isfinite(prediction))
             & jnp.all(jnp.isfinite(errors))
             & jnp.all(jnp.isfinite(metrics))
@@ -476,8 +577,29 @@ def run_prototype_memory_arrays(
     Metric columns are ``mse, correct, confidence, active_prototypes,
     valid_update, allocated``.
     """
+    observation_array = jnp.asarray(observations, dtype=jnp.float32)
+    target_array = jnp.asarray(targets, dtype=jnp.float32)
+    if observation_array.ndim != 2 or observation_array.shape[1] != learner.config.feature_dim:
+        raise ValueError(
+            "observations must have shape "
+            f"(steps, {learner.config.feature_dim}); got {tuple(observation_array.shape)}"
+        )
+    if target_array.ndim != 2 or target_array.shape[1] != learner.config.n_classes:
+        raise ValueError(
+            "targets must have shape "
+            f"(steps, {learner.config.n_classes}); got {tuple(target_array.shape)}"
+        )
+    if observation_array.shape[0] != target_array.shape[0]:
+        raise ValueError("observations and targets must have the same step count")
+    steps = int(observation_array.shape[0])
+    _require_sequence_resource(
+        "prototype memory scan outputs",
+        float32_scalars=steps * (learner.config.n_classes + 6),
+        bool_scalars=steps,
+    )
     if state is None:
         state = learner.init()
+    learner._validate_state_static_contract(state)
 
     def step_fn(
         carry: PrototypeMemoryState,
@@ -494,7 +616,7 @@ def run_prototype_memory_arrays(
     final_state, (predictions, metrics, updates_applied) = jax.lax.scan(
         step_fn,
         state,
-        (observations, targets),
+        (observation_array, target_array),
     )
     return PrototypeMemoryLearningResult(
         state=final_state,

--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -202,7 +202,24 @@ class PrototypeMemoryConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("PrototypeMemoryConfig mapping could not be read") from error
-        payload.pop("type", None)
+        if payload.pop("type", None) != "PrototypeMemoryConfig":
+            raise ValueError("PrototypeMemoryConfig type is invalid")
+        expected = {
+            "feature_dim",
+            "n_classes",
+            "slots_per_class",
+            "update_rate",
+            "novelty_threshold",
+            "bandwidth",
+        }
+        if set(payload) != expected:
+            raise ValueError("PrototypeMemoryConfig fields do not match its schema")
+        for name in ("feature_dim", "n_classes", "slots_per_class"):
+            if type(payload[name]) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+        for name in ("update_rate", "novelty_threshold", "bandwidth"):
+            if type(payload[name]) is not float:
+                raise ValueError(f"serialized {name} must be a JSON number")
         return cls(**payload)
 
 
@@ -309,7 +326,11 @@ class PrototypeMemoryLearner:
             payload = dict(config)
         except Exception as error:
             raise ValueError("PrototypeMemoryLearner mapping could not be read") from error
-        inner_raw = payload.get("config")
+        if set(payload) != {"type", "config"}:
+            raise ValueError("PrototypeMemoryLearner fields do not match its schema")
+        if payload["type"] != "PrototypeMemoryLearner":
+            raise ValueError("PrototypeMemoryLearner type is invalid")
+        inner_raw = payload["config"]
         if not issubclass(type(inner_raw), Mapping):
             raise ValueError("PrototypeMemoryLearner config must be a mapping")
         try:

--- a/tests/test_prototype_memory_validation.py
+++ b/tests/test_prototype_memory_validation.py
@@ -1,0 +1,222 @@
+"""Validation hardening for prototype memory (int/float bounds + resource preflights)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.prototype_memory import PrototypeMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: PrototypeMemoryConfig(feature_dim=v, n_classes=2, slots_per_class=2),
+        lambda v: PrototypeMemoryConfig(feature_dim=2, n_classes=v, slots_per_class=2),
+        lambda v: PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=v),
+    ],
+)
+def test_prototype_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: PrototypeMemoryConfig(feature_dim=v, n_classes=2, slots_per_class=2),
+        lambda v: PrototypeMemoryConfig(feature_dim=2, n_classes=v, slots_per_class=2),
+        lambda v: PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=v),
+    ],
+)
+def test_prototype_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_prototype_int_validators_canonicalize_numpy_scalars(np_type: type) -> None:
+    cfg = PrototypeMemoryConfig(
+        feature_dim=np_type(4),
+        n_classes=np_type(3),
+        slots_per_class=np_type(5),
+    )
+    assert cfg.feature_dim == 4
+    assert cfg.n_classes == 3
+    assert cfg.slots_per_class == 5
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.n_classes) is int
+    assert type(cfg.slots_per_class) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: PrototypeMemoryConfig(feature_dim=v, n_classes=2, slots_per_class=2),
+        lambda v: PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value", [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1, 10**100]
+)
+def test_prototype_int_validators_reject_non_integer_and_out_of_range(
+    ctor, value: object
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "value", [True, np.bool_(True), 4.0, "4", None, 1, 0, -1, _INT32_MAX + 1]
+)
+def test_prototype_n_classes_rejects_out_of_range(value: object) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        PrototypeMemoryConfig(feature_dim=2, n_classes=value, slots_per_class=2)  # type: ignore[arg-type]
+
+
+def test_prototype_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("update_rate", float("nan")),
+        ("update_rate", float("inf")),
+        ("update_rate", -0.1),
+        ("update_rate", 0.0),
+        ("update_rate", 2.0),
+        ("update_rate", HostileFloat(0.5)),
+        ("novelty_threshold", -0.1),
+        ("novelty_threshold", float("nan")),
+        ("novelty_threshold", HostileFloat(0.5)),
+        ("bandwidth", 0.0),
+        ("bandwidth", -1.0),
+        ("bandwidth", float("nan")),
+        ("bandwidth", float("inf")),
+        ("bandwidth", HostileFloat(0.5)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            PrototypeMemoryConfig(
+                feature_dim=2,
+                n_classes=2,
+                slots_per_class=2,
+                **{field: bad},  # type: ignore[arg-type]
+            )
+
+
+def test_prototype_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="update_rate"):
+        PrototypeMemoryConfig(
+            feature_dim=2,
+            n_classes=2,
+            slots_per_class=2,
+            update_rate=HostileFloat(0.5),  # type: ignore[arg-type]
+        )
+    assert HostileFloat.calls == 1
+
+
+def test_prototype_float_validators_accept_valid_values() -> None:
+    cfg = PrototypeMemoryConfig(
+        feature_dim=2,
+        n_classes=2,
+        slots_per_class=2,
+        update_rate=0.3,
+        novelty_threshold=0.08,
+        bandwidth=0.01,
+    )
+    assert cfg.update_rate == pytest.approx(0.3)
+    assert cfg.novelty_threshold == pytest.approx(0.08)
+
+
+def test_prototype_dimensions_preflight_without_allocation() -> None:
+    # n_classes * slots_per_class overflows signed int32.
+    with pytest.raises(ValueError, match="dimensions must fit signed int32"):
+        PrototypeMemoryConfig(
+            feature_dim=2, n_classes=_INT32_MAX, slots_per_class=2
+        )
+    # n_classes * slots_per_class * feature_dim overflows.
+    with pytest.raises(ValueError, match="dimensions must fit signed int32"):
+        PrototypeMemoryConfig(
+            feature_dim=_INT32_MAX, n_classes=2, slots_per_class=2
+        )
+    # Scalar-count preflight via large product but individual dims legal.
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        PrototypeMemoryConfig(
+            feature_dim=1, n_classes=50000, slots_per_class=50000
+        )
+
+
+def test_prototype_state_preflight_bytes_without_allocation() -> None:
+    # Minimal sizes: n_classes=2, feature_dim=1, vary slots_per_class.
+    # total = 6*slots +1, byte = 24*slots+4
+    last_legal = (2**31 - 1 - 4) // 24
+    PrototypeMemoryConfig(feature_dim=1, n_classes=2, slots_per_class=last_legal)
+    with pytest.raises(ValueError, match="byte count"):
+        PrototypeMemoryConfig(feature_dim=1, n_classes=2, slots_per_class=last_legal + 1)
+    # Non-minimal vector should also be allocation-free.
+    with pytest.raises(ValueError, match="byte count|scalar count|dimensions"):
+        PrototypeMemoryConfig(feature_dim=5000, n_classes=5000, slots_per_class=5000)
+
+
+def test_prototype_state_preflight_feature_dim_boundary() -> None:
+    # Vary feature_dim with n_classes=2, slots=1: byte = 8*fd+20
+    last_legal = (2**31 - 1 - 20) // 8
+    PrototypeMemoryConfig(feature_dim=last_legal, n_classes=2, slots_per_class=1)
+    with pytest.raises(ValueError, match="byte count"):
+        PrototypeMemoryConfig(feature_dim=last_legal + 1, n_classes=2, slots_per_class=1)

--- a/tests/test_prototype_memory_validation.py
+++ b/tests/test_prototype_memory_validation.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+import dataclasses
+from types import MappingProxyType
+
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.core.prototype_memory import PrototypeMemoryConfig
+from alberta_framework.core.prototype_memory import (
+    PrototypeMemoryConfig,
+    PrototypeMemoryLearner,
+    run_prototype_memory_arrays,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -220,3 +229,208 @@ def test_prototype_state_preflight_feature_dim_boundary() -> None:
     PrototypeMemoryConfig(feature_dim=last_legal, n_classes=2, slots_per_class=1)
     with pytest.raises(ValueError, match="byte count"):
         PrototypeMemoryConfig(feature_dim=last_legal + 1, n_classes=2, slots_per_class=1)
+
+
+def test_prototype_bandwidth_must_remain_normal_at_float32_sink() -> None:
+    minimum_normal = float.fromhex("0x1.0p-126")
+    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2, bandwidth=minimum_normal)
+    assert config.bandwidth == minimum_normal
+    with pytest.raises(ValueError, match="bandwidth"):
+        PrototypeMemoryConfig(
+            feature_dim=2,
+            n_classes=2,
+            bandwidth=float.fromhex("0x1.0p-149"),
+        )
+
+
+def test_prototype_config_mapping_compatibility_rejects_spoofs_before_hooks() -> None:
+    class MappingSpoof:
+        @property  # type: ignore[misc]
+        def __class__(self) -> type:
+            return dict
+
+        def __iter__(self) -> object:
+            raise AssertionError("iteration hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook executed")
+
+    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2)
+    assert PrototypeMemoryConfig.from_config(MappingProxyType(config.to_config())) == config
+    learner = PrototypeMemoryLearner(config)
+    restored = PrototypeMemoryLearner.from_config(MappingProxyType(learner.to_config()))
+    assert restored.config == config
+    with pytest.raises(ValueError, match="mapping"):
+        PrototypeMemoryConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="mapping"):
+        PrototypeMemoryLearner.from_config(MappingSpoof())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("means", jnp.zeros((2, 2, 2), dtype=jnp.float32), "state.means"),
+        ("counts", jnp.zeros((2, 2), dtype=jnp.float16), "state.counts"),
+        ("last_update", jnp.zeros((2, 2), dtype=jnp.float32), "state.last_update"),
+        ("step_count", jnp.zeros((1,), dtype=jnp.int32), "state.step_count"),
+    ],
+)
+def test_prototype_public_methods_reject_malformed_state_before_tracing(
+    field: str,
+    replacement: jax.Array,
+    message: str,
+) -> None:
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=3, n_classes=2, slots_per_class=2)
+    )
+    state = dataclasses.replace(learner.init(), **{field: replacement})
+    observation = jnp.zeros((3,), dtype=jnp.float32)
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    for call in (
+        lambda: learner.predict(state, observation),
+        lambda: learner.update(state, observation, target),
+        lambda: jax.jit(lambda s: learner.predict(s, observation))(state),
+        lambda: jax.jit(lambda s: learner.update(s, observation, target))(state),
+    ):
+        with pytest.raises((TypeError, ValueError), match=message):
+            call()
+
+
+@pytest.mark.parametrize(
+    ("operand", "shape", "message"),
+    [
+        ("observation", (), "observation"),
+        ("observation", (1, 3), "observation"),
+        ("target", (), "target"),
+        ("target", (1, 2), "target"),
+        ("threshold", (1,), "novelty_threshold"),
+    ],
+)
+def test_prototype_update_rejects_scalar_and_vector_shape_aliases(
+    operand: str,
+    shape: tuple[int, ...],
+    message: str,
+) -> None:
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=3, n_classes=2, slots_per_class=2)
+    )
+    state = learner.init()
+    observation = jnp.zeros((3,), dtype=jnp.float32)
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    threshold = jnp.asarray(0.1, dtype=jnp.float32)
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    if operand == "observation":
+        observation = malformed
+    elif operand == "target":
+        target = malformed
+    else:
+        threshold = malformed
+    for call in (
+        lambda: learner.update_with_novelty_threshold(
+            state, observation, target, threshold
+        ),
+        lambda: jax.jit(
+            lambda s, x, y, value: learner.update_with_novelty_threshold(
+                s, x, y, value
+            )
+        )(state, observation, target, threshold),
+    ):
+        with pytest.raises(ValueError, match=message):
+            call()
+
+
+def test_prototype_invalid_state_and_threshold_are_atomic_noops() -> None:
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=2)
+    )
+    state = learner.init()
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    invalid_states = (
+        dataclasses.replace(state, counts=state.counts.at[0, 0].set(-1.0)),
+        dataclasses.replace(state, last_update=state.last_update.at[0, 0].set(-1)),
+        dataclasses.replace(state, last_update=state.last_update.at[0, 0].set(1)),
+        dataclasses.replace(state, step_count=jnp.asarray(-1, dtype=jnp.int32)),
+    )
+    for invalid_state in invalid_states:
+        result = learner.update(invalid_state, observation, target)
+        assert not bool(result.update_applied)
+        assert all(
+            bool(equal)
+            for equal in jax.tree.leaves(
+                jax.tree.map(
+                    lambda left, right: jnp.array_equal(left, right),
+                    result.state,
+                    invalid_state,
+                )
+            )
+        )
+    negative_threshold = learner.update_with_novelty_threshold(
+        state,
+        observation,
+        target,
+        jnp.asarray(-0.1, dtype=jnp.float32),
+    )
+    assert not bool(negative_threshold.update_applied)
+    assert all(
+        bool(equal)
+        for equal in jax.tree.leaves(
+            jax.tree.map(
+                lambda left, right: jnp.array_equal(left, right),
+                negative_threshold.state,
+                state,
+            )
+        )
+    )
+
+
+def test_prototype_step_counter_saturates_without_invalidating_state() -> None:
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=2)
+    )
+    state = dataclasses.replace(
+        learner.init(),
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    result = learner.update(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.last_update[0, 0]) == _INT32_MAX
+
+
+def test_prototype_array_runner_preflights_shapes_and_output_resources() -> None:
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=2)
+    )
+    with pytest.raises(ValueError, match="observations"):
+        run_prototype_memory_arrays(
+            learner,
+            jnp.zeros((3, 1, 2), dtype=jnp.float32),
+            jnp.zeros((3, 2), dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="targets"):
+        run_prototype_memory_arrays(
+            learner,
+            jnp.zeros((3, 2), dtype=jnp.float32),
+            jnp.zeros((3, 1, 2), dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="same step count"):
+        run_prototype_memory_arrays(
+            learner,
+            jnp.zeros((3, 2), dtype=jnp.float32),
+            jnp.zeros((2, 2), dtype=jnp.float32),
+        )
+
+    first_overflow = _INT32_MAX // (4 * (learner.config.n_classes + 6) + 1) + 1
+    observations = jax.ShapeDtypeStruct((first_overflow, 2), jnp.float32)
+    targets = jax.ShapeDtypeStruct((first_overflow, 2), jnp.float32)
+    with pytest.raises(ValueError, match="byte count"):
+        jax.eval_shape(
+            lambda x, y: run_prototype_memory_arrays(learner, x, y),
+            observations,
+            targets,
+        )

--- a/tests/test_prototype_memory_validation.py
+++ b/tests/test_prototype_memory_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 
 import jax
@@ -255,6 +256,16 @@ def test_prototype_config_mapping_compatibility_rejects_spoofs_before_hooks() ->
         def __repr__(self) -> str:
             raise AssertionError("repr hook executed")
 
+    class HostileMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError("getitem hook")
+
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError("iteration hook")
+
+        def __len__(self) -> int:
+            return 1
+
     config = PrototypeMemoryConfig(feature_dim=2, n_classes=2)
     assert PrototypeMemoryConfig.from_config(MappingProxyType(config.to_config())) == config
     learner = PrototypeMemoryLearner(config)
@@ -264,6 +275,36 @@ def test_prototype_config_mapping_compatibility_rejects_spoofs_before_hooks() ->
         PrototypeMemoryConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="mapping"):
         PrototypeMemoryLearner.from_config(MappingSpoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="mapping could not be read"):
+        PrototypeMemoryConfig.from_config(HostileMapping())
+    with pytest.raises(ValueError, match="mapping could not be read"):
+        PrototypeMemoryLearner.from_config(HostileMapping())
+
+
+def test_prototype_serialized_schema_is_exact_and_uses_json_scalars() -> None:
+    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2)
+    payload = config.to_config()
+    for mutation, match in (
+        ({"type": "OtherConfig"}, "type"),
+        ({"feature_dim": np.int32(2)}, "feature_dim"),
+        ({"update_rate": np.float32(0.3)}, "update_rate"),
+        ({"extra": 1}, "fields"),
+    ):
+        invalid = dict(payload)
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            PrototypeMemoryConfig.from_config(invalid)
+
+    missing = dict(payload)
+    missing.pop("bandwidth")
+    with pytest.raises(ValueError, match="fields"):
+        PrototypeMemoryConfig.from_config(missing)
+
+    learner_payload = PrototypeMemoryLearner(config).to_config()
+    with pytest.raises(ValueError, match="type"):
+        PrototypeMemoryLearner.from_config({**learner_payload, "type": "OtherLearner"})
+    with pytest.raises(ValueError, match="fields"):
+        PrototypeMemoryLearner.from_config({**learner_payload, "extra": 1})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Supersedes #798 (and its closed predecessor #784) while preserving both contributor commits and authorship.

The resource, state, runtime operand, atomic transaction, saturating lifetime counter, scan-output, positive-normal bandwidth, and genuine Mapping fixes from #798 are retained. This successor closes the remaining deserialization gap with exact config and learner type markers, exact field schemas, canonical JSON integer/number scalar types, nested schema validation, and hostile Mapping normalization tests.

Checks after latest-main rebase:
- 142 focused prototype-memory tests passed
- Ruff passed
- strict targeted mypy passed
- diff check passed
- broader prototype feature-lifecycle panel: 173 passed, 1 unrelated current-main failure because OaKConfig now rejects a STOMP subclass before the lifecycle-level expected rejection (the same pre-existing mismatch noted on #798)

No registered evidence source or output artifact changed.