### PR TITLE
fix(micro-continual): complete stream resource contracts

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -204,6 +204,8 @@ def _require_nonempty_string(value: object, *, context: str) -> str:
 # Configuration
 # =============================================================================
 
+_INT32_MAX: int = 2**31 - 1
+
 
 @dataclass(frozen=True)
 class MicroStreamConfig:
@@ -270,6 +272,17 @@ class MicroStreamConfig:
             value = getattr(self, name)
             if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
                 raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        if self.n_regimes * self.regime_length > _INT32_MAX:
+            # stream() casts the per-step regime index to dtype=jnp.int32
+            # (``jnp.arange(n_steps, dtype=jnp.int32) // regime_length``); an
+            # uncaught n_steps beyond the signed int32 domain would silently
+            # wrap the derived regime index instead of raising, corrupting
+            # every regime assignment past the wraparound point.
+            raise ValueError(
+                "derived n_steps (n_regimes * regime_length) must fit in signed "
+                f"int32, got {self.n_regimes} * {self.regime_length} = "
+                f"{self.n_regimes * self.regime_length} > {_INT32_MAX}"
+            )
         sparsity = self.component_sparsity
         if not isinstance(sparsity, int) or isinstance(sparsity, bool) or sparsity <= 0:
             raise ValueError(

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -64,6 +64,7 @@ import argparse
 import json
 import logging
 import math
+import operator
 import os
 import platform
 import tempfile
@@ -74,7 +75,7 @@ from functools import lru_cache
 from numbers import Real
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -205,6 +206,51 @@ def _require_nonempty_string(value: object, *, context: str) -> str:
 # =============================================================================
 
 _INT32_MAX: int = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_positive_int32(value: object, name: str) -> int:
+    """Canonicalize one trusted host integer without invoking foreign hooks."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a positive integer")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not 1 <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be a positive integer no greater than {_INT32_MAX}")
+    return canonical
+
+
+def _preflight_stream_resources(config: MicroStreamConfig) -> None:
+    """Bound the complete materialized stream's persistent numeric payload."""
+    steps = config.n_regimes * config.regime_length
+    persistent_scalars = (
+        2 * steps * config.dim  # x and base_x
+        + 2 * steps  # base_y and regime_ids
+        + config.n_classes * config.n_components * config.dim  # component_means
+        + config.dim  # dim_sigma
+        + config.n_regimes * config.dim  # permutations
+        + config.n_regimes * config.n_classes  # label_maps
+        + 2 * config.n_regimes  # scale_factors and regime_pool_ids
+    )
+    persistent_bytes = 4 * persistent_scalars
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError(
+            "derived persistent stream bytes must fit in signed int32; "
+            f"got {persistent_bytes}"
+        )
 
 
 @dataclass(frozen=True)
@@ -264,14 +310,20 @@ class MicroStreamConfig:
     recurrence_pool: int = 5
 
     def __post_init__(self) -> None:
-        if self.family not in FAMILIES:
-            raise ValueError(
-                f"family must be one of {FAMILIES}, got {self.family!r}"
+        if type(self.family) is not str or self.family not in FAMILIES:
+            raise ValueError(f"family must be one of {FAMILIES}")
+        for name in (
+            "n_regimes",
+            "regime_length",
+            "dim",
+            "n_classes",
+            "n_components",
+            "component_sparsity",
+            "recurrence_pool",
+        ):
+            object.__setattr__(
+                self, name, _require_positive_int32(getattr(self, name), name)
             )
-        for name in ("n_regimes", "regime_length", "dim", "n_classes", "n_components"):
-            value = getattr(self, name)
-            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-                raise ValueError(f"{name} must be a positive integer, got {value!r}")
         if self.n_regimes * self.regime_length > _INT32_MAX:
             # stream() casts the per-step regime index to dtype=jnp.int32
             # (``jnp.arange(n_steps, dtype=jnp.int32) // regime_length``); an
@@ -284,10 +336,6 @@ class MicroStreamConfig:
                 f"{self.n_regimes * self.regime_length} > {_INT32_MAX}"
             )
         sparsity = self.component_sparsity
-        if not isinstance(sparsity, int) or isinstance(sparsity, bool) or sparsity <= 0:
-            raise ValueError(
-                f"component_sparsity must be a positive integer, got {sparsity!r}"
-            )
         if sparsity > self.dim:
             raise ValueError(
                 f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})"
@@ -330,13 +378,14 @@ class MicroStreamConfig:
             )
         if self.family == "recurrence":
             pool = self.recurrence_pool
-            if not isinstance(pool, int) or isinstance(pool, bool) or pool < 2:
-                raise ValueError(f"recurrence_pool must be an integer >= 2, got {pool!r}")
+            if pool < 2:
+                raise ValueError("recurrence_pool must be an integer >= 2")
             if pool > self.n_regimes:
                 raise ValueError(
                     f"recurrence_pool ({pool}) must not exceed n_regimes "
                     f"({self.n_regimes})"
                 )
+        _preflight_stream_resources(self)
 
     @property
     def n_steps(self) -> int:

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -198,6 +198,76 @@ class TestConfig:
         with pytest.raises(ValueError, match="n_regimes"):
             MicroStreamConfig(family="input_permutation", n_regimes=True)
 
+    @pytest.mark.parametrize(
+        "integer_type",
+        [
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.longlong,
+            np.ulonglong,
+        ],
+    )
+    def test_full_numpy_integer_family_is_canonicalized(self, integer_type):
+        config = MicroStreamConfig(
+            family="input_permutation",
+            n_regimes=integer_type(4),
+            regime_length=integer_type(25),
+            dim=integer_type(6),
+            n_classes=integer_type(3),
+            n_components=integer_type(2),
+            component_sparsity=integer_type(2),
+            recurrence_pool=integer_type(2),
+        )
+        assert all(
+            type(getattr(config, field)) is int
+            for field in (
+                "n_regimes",
+                "regime_length",
+                "dim",
+                "n_classes",
+                "n_components",
+                "component_sparsity",
+                "recurrence_pool",
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "n_regimes",
+            "regime_length",
+            "dim",
+            "n_classes",
+            "n_components",
+            "component_sparsity",
+            "recurrence_pool",
+        ],
+    )
+    def test_integer_subclasses_are_rejected_without_calling_hooks(self, field: str):
+        class HostileInt(int):
+            def __index__(self) -> int:
+                raise AssertionError("untrusted __index__ must not run")
+
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
+        with pytest.raises(ValueError, match=field):
+            tiny("input_permutation", **{field: HostileInt(2)})
+
+    def test_family_subclasses_are_rejected_without_calling_repr(self):
+        class HostileString(str):
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
+        with pytest.raises(ValueError, match="family"):
+            MicroStreamConfig(family=HostileString("input_permutation"))
+
     def test_recurrence_pool_bounds(self):
         with pytest.raises(ValueError, match="recurrence_pool"):
             tiny("recurrence", recurrence_pool=1)
@@ -239,12 +309,42 @@ class TestConfig:
                 n_regimes=60_000,
                 regime_length=60_000,
             )
-        # The boundary itself (exactly INT32_MAX) must still be accepted.
+        # Even an int32-representable schedule must be rejected when the
+        # complete materialized stream would exceed the byte budget.
+        with pytest.raises(ValueError, match="persistent stream bytes"):
+            MicroStreamConfig(
+                family="input_permutation",
+                n_regimes=1,
+                regime_length=2**31 - 1,
+                dim=1,
+                n_classes=1,
+                n_components=1,
+                component_sparsity=1,
+            )
+
+    def test_persistent_stream_byte_boundary_is_allocation_free(self):
+        # With each non-schedule dimension equal to one, the returned stream
+        # owns 4 * n_steps + 6 four-byte scalars.
+        last_valid_steps = ((2**31 - 1) // 4 - 6) // 4
         MicroStreamConfig(
             family="input_permutation",
             n_regimes=1,
-            regime_length=2**31 - 1,
+            regime_length=last_valid_steps,
+            dim=1,
+            n_classes=1,
+            n_components=1,
+            component_sparsity=1,
         )
+        with pytest.raises(ValueError, match="persistent stream bytes"):
+            MicroStreamConfig(
+                family="input_permutation",
+                n_regimes=1,
+                regime_length=last_valid_steps + 1,
+                dim=1,
+                n_classes=1,
+                n_components=1,
+                component_sparsity=1,
+            )
 
     def test_to_config_roundtrip(self):
         rebuilt = MicroStreamConfig(**TINY.to_config())

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -227,6 +227,25 @@ class TestConfig:
     def test_n_steps(self):
         assert TINY.n_steps == 4 * 25
 
+    def test_n_steps_int32_overflow_rejected(self):
+        # stream() casts the per-step regime index to dtype=jnp.int32
+        # (``jnp.arange(n_steps, dtype=jnp.int32) // regime_length``). An
+        # n_steps beyond the signed int32 domain must be rejected at
+        # construction instead of silently wrapping every regime index past
+        # the boundary to a negative value.
+        with pytest.raises(ValueError, match="n_steps"):
+            MicroStreamConfig(
+                family="input_permutation",
+                n_regimes=60_000,
+                regime_length=60_000,
+            )
+        # The boundary itself (exactly INT32_MAX) must still be accepted.
+        MicroStreamConfig(
+            family="input_permutation",
+            n_regimes=1,
+            regime_length=2**31 - 1,
+        )
+
     def test_to_config_roundtrip(self):
         rebuilt = MicroStreamConfig(**TINY.to_config())
         assert rebuilt == TINY


### PR DESCRIPTION
Preserves contributor commit 8ed5835 from #793 and extends its valid n_steps guard to the actual materialized-stream contract: exact built-in/NumPy integer families, canonical ints, hostile subclass containment, signed-int32 dimensions, and aggregate persistent numeric byte preflight across all returned arrays. Replaces the unsafe claimed INT32_MAX schedule endpoint with an allocation-free exact aggregate byte boundary/adjacent test. Validation: full test_micro_continual.py 213 passed; TestConfig 84 passed; Ruff and strict mypy passed; diff check clean.