### PR TITLE
fix(recurrent-actor-critic): restore mapping compatibility

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -36,7 +36,7 @@ import dataclasses
 import functools
 import math
 import operator
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, NamedTuple, Self, SupportsIndex, cast
 
 import jax
@@ -371,6 +371,19 @@ def _preflight_state_resources(
     return resources
 
 
+def _copy_config_mapping(name: str, config: object) -> dict[str, Any]:
+    """Copy a legacy-compatible mapping while normalizing hostile hooks."""
+    if not isinstance(config, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        payload = dict(config)
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+    if any(type(key) is not str for key in payload):
+        raise ValueError(f"{name} fields must be strings")
+    return cast(dict[str, Any], payload)
+
+
 @dataclasses.dataclass(frozen=True)
 class RecurrentTraceActorCriticConfig:
     """Configuration for an RTU-RTRL discrete streaming actor-critic.
@@ -568,37 +581,14 @@ class RecurrentTraceActorCriticConfig:
     @classmethod
     def from_config(
         cls,
-        config: dict[str, Any],
+        config: Mapping[str, Any],
     ) -> RecurrentTraceActorCriticConfig:
         """Reconstruct and validate a configuration mapping."""
-        if type(config) is not dict:
-            raise ValueError("config must be an exact built-in dict")
-        required = {
-            field.name
-            for field in dataclasses.fields(cls)
-            if field.name not in {"adaptive_obgd", "beta2", "epsilon"}
-        }
-        optional = {"adaptive_obgd", "beta2", "epsilon"}
-        if (
-            any(type(key) is not str for key in config)
-            or not required <= set(config)
-            or not set(config) <= required | optional
-        ):
-            raise ValueError("config fields do not match the serialized schema")
-        integer_fields = {"n_actions", "hidden_size", "encoder_width", "output_width"}
-        bool_fields = {
-            "normalize_observations",
-            "normalize_rewards",
-            "rtrl_taylor_correction",
-            "adaptive_obgd",
-        }
-        for name, value in config.items():
-            expected_type = (
-                int if name in integer_fields else bool if name in bool_fields else float
-            )
-            if type(value) is not expected_type:
-                raise ValueError("serialized config values must use exact JSON scalar types")
-        return cls(**dict(config))
+        payload = _copy_config_mapping("config", config)
+        try:
+            return cls(**payload)
+        except TypeError as error:
+            raise ValueError("config fields do not match the serialized schema") from error
 
 
 def parameterless_layer_norm(inputs: Array, epsilon: float = 1e-5) -> Array:
@@ -1845,26 +1835,21 @@ class RecurrentTraceActorCriticAgent:
     @classmethod
     def from_config(
         cls,
-        config: dict[str, Any],
+        config: Mapping[str, Any],
     ) -> RecurrentTraceActorCriticAgent:
         """Reconstruct an agent from :meth:`to_config` output."""
-        if type(config) is not dict:
-            raise ValueError("serialized agent must be an exact built-in dict")
-        if any(type(key) is not str for key in config):
-            raise ValueError("serialized agent fields do not match the schema")
-        # Preserve the historical convenience form while keeping both accepted
-        # schemas exact: a caller may provide either the agent envelope or the
-        # configuration payload emitted by ``RecurrentTraceActorCriticConfig``.
-        if "type" not in config:
-            return cls(RecurrentTraceActorCriticConfig.from_config(config))
-        if set(config) != {"type", "config"}:
-            raise ValueError("serialized agent fields do not match the schema")
-        agent_type = config["type"]
+        payload = _copy_config_mapping("serialized agent", config)
+        agent_type = payload.pop("type", cls.__name__)
         if type(agent_type) is not str or agent_type != cls.__name__:
             raise ValueError("unsupported agent type")
-        raw_config = config["config"]
-        if type(raw_config) is not dict:
-            raise ValueError("serialized config must be an exact built-in dict")
+        if "config" in payload:
+            raw_config = payload.pop("config")
+            if payload:
+                raise ValueError("serialized agent fields do not match the schema")
+        else:
+            raw_config = payload
+        if not isinstance(raw_config, Mapping):
+            raise ValueError("serialized config must be a mapping")
         return cls(RecurrentTraceActorCriticConfig.from_config(raw_config))
 
     def init(self, feature_dim: int, key: Array) -> RecurrentTraceActorCriticState:

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2068,11 +2068,12 @@ def test_config_rejects_hostile_numeric_and_serialized_container_hooks() -> None
     with pytest.raises(ValueError, match="finite normal float32"):
         _small_config(gamma=10**1000)
     payload = _small_config().to_config()
-    with pytest.raises(ValueError, match="exact built-in dict"):
-        RecurrentTraceActorCriticConfig.from_config(DictSubclass(payload))
+    assert RecurrentTraceActorCriticConfig.from_config(DictSubclass(payload)) == _small_config()
     envelope = RecurrentTraceActorCriticAgent(_small_config()).to_config()
-    with pytest.raises(ValueError, match="exact built-in dict"):
-        RecurrentTraceActorCriticAgent.from_config(DictSubclass(envelope))
+    assert (
+        RecurrentTraceActorCriticAgent.from_config(DictSubclass(envelope)).config
+        == _small_config()
+    )
     with pytest.raises(ValueError, match="fields"):
         RecurrentTraceActorCriticConfig.from_config({**payload, "unknown": 1})
 
@@ -2344,19 +2345,16 @@ def test_config_canonicalizes_supported_numpy_float_families(code: str) -> None:
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    (
-        ("n_actions", np.int64(2)),
-        ("gamma", np.float32(0.5)),
-        ("normalize_rewards", np.bool_(True)),
-        ("gamma", 1),
-        ("n_actions", 2.0),
-    ),
+    (("n_actions", np.int64(2)), ("gamma", np.float32(0.5))),
 )
-def test_from_config_requires_exact_json_scalar_types(field: str, value: object) -> None:
+def test_from_config_preserves_supported_runtime_scalar_families(
+    field: str, value: object
+) -> None:
     payload = RecurrentTraceActorCriticConfig(n_actions=2).to_config()
     payload[field] = value
-    with pytest.raises(ValueError, match="exact JSON scalar types"):
-        RecurrentTraceActorCriticConfig.from_config(payload)
+    reconstructed = RecurrentTraceActorCriticConfig.from_config(payload)
+    expected_type = int if field == "n_actions" else float
+    assert type(getattr(reconstructed, field)) is expected_type
 
 
 @pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
@@ -2369,3 +2367,25 @@ def test_init_accepts_supported_numpy_integer_feature_dimensions(code: str) -> N
     )
     state = RecurrentTraceActorCriticAgent(config).init(np.dtype(code).type(3), jr.key(1))
     assert state.last_observation.shape == (3,)
+
+
+@pytest.mark.parametrize(
+    ("taylor", "adaptive"),
+    ((False, False), (True, False), (False, True), (True, True)),
+)
+def test_state_resource_budget_matches_optional_state_trees(
+    taylor: bool, adaptive: bool
+) -> None:
+    config = RecurrentTraceActorCriticConfig(
+        n_actions=3,
+        hidden_size=4,
+        encoder_width=5,
+        output_width=6,
+        rtrl_taylor_correction=taylor,
+        adaptive_obgd=adaptive,
+    )
+    state = RecurrentTraceActorCriticAgent(config).init(7, jr.key(5))
+    leaves = jax.tree_util.tree_leaves(state)
+    budget = config.state_resource_budget(7)
+    assert budget["state_scalars"] == sum(int(leaf.size) for leaf in leaves)
+    assert budget["state_nbytes"] == sum(int(leaf.nbytes) for leaf in leaves)


### PR DESCRIPTION
## Summary
- follows merged #796/#800/#801 and keeps their exact float32 endpoint, underflow, feature-dimension, and corrected logical-state contracts intact
- removes #796s new exact-JSON-scalar/exact-built-in-dict restriction, restoring historical Mapping support and both serialized agent forms: full envelope and legacy flat config
- copies mappings once with ordinary Exception normalization and exact string keys, then delegates scalar validation to the hardened constructor
- measures state scalars and bytes against actual initialized JAX trees for all Taylor/adaptive optional-state combinations
- preserves Kayvan Zahiri contributor attribution and changes no outputs or registered evidence sources

## Verification
- 194 passed: full recurrent actor-critic + Taylor panel before the final current-main rebase
- 28 passed: post-rebase mapping/resource/huge-value/underflow/NumPy feature panel
- Ruff clean
- strict mypy clean
- git diff-check clean

Supersedes the compatibility portion of closed #787; #796/#800/#801 remain the sources of their already-merged scalar and resource fixes.