### PR TITLE
fix(options): restore historical deserialization compatibility

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1593,60 +1593,34 @@ class STOMPConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("STOMPConfig mapping could not be read") from error
-        if payload.pop("type", None) != "STOMPConfig":
-            raise ValueError("STOMPConfig type is invalid")
-        expected = {field.name for field in dataclasses.fields(cls)}
-        legacy_optional = {
-            "subtask_specs",
-            "base_hidden_sizes",
-            "option_planning_backups_per_step",
-        }
-        if set(payload) - expected or (expected - legacy_optional) - set(payload):
-            raise ValueError("STOMPConfig fields do not match its schema")
+        payload.pop("type", None)
         specs_raw = payload.pop("subtask_specs", [])
-        if type(specs_raw) is not list or any(type(spec) is not dict for spec in specs_raw):
-            raise ValueError("serialized subtask_specs must be an actual list of actual dicts")
-        spec_fields = {field.name for field in dataclasses.fields(SubtaskSpec)}
-        if any(set(spec) != spec_fields for spec in specs_raw):
-            raise ValueError("serialized SubtaskSpec fields do not match its schema")
-        if any(
-            type(spec["feature_index"]) is not int
-            or type(spec["max_option_steps"]) is not int
-            or type(spec["threshold"]) is not float
-            or type(spec["pseudo_reward_scale"]) is not float
-            for spec in specs_raw
-        ):
-            raise ValueError("serialized SubtaskSpec scalars must be canonical JSON scalars")
-        specs = tuple(SubtaskSpec(**spec) for spec in specs_raw)
-        hidden_raw = payload.pop("base_hidden_sizes", [])
-        if type(hidden_raw) is not list or any(type(size) is not int for size in hidden_raw):
-            raise ValueError("serialized base_hidden_sizes must be an actual list of JSON integers")
-        payload["base_hidden_sizes"] = tuple(hidden_raw)
-        for name in ("observation_dim", "n_primitive_actions", "option_planning_backups_per_step"):
-            if name in payload and type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        for name in (
-            "base_step_size",
-            "base_avg_reward_step_size",
-            "base_trace_decay",
-            "option_step_size",
-            "option_avg_reward_step_size",
-            "option_trace_decay",
-            "option_gamma",
-            "option_model_decay",
-            "option_model_step_size",
-            "epsilon_base",
-            "epsilon_option",
-            "option_importance_clip",
-        ):
-            if type(payload[name]) is not float:
-                raise ValueError(f"serialized {name} must be a JSON number")
-        if payload["option_target_epsilon"] is not None and type(
-            payload["option_target_epsilon"]
-        ) is not float:
-            raise ValueError("serialized option_target_epsilon must be null or a JSON number")
+        if type(specs_raw) not in (list, tuple):
+            raise ValueError("serialized subtask_specs must be an actual list or tuple")
+        specs: list[SubtaskSpec] = []
+        for raw in specs_raw:
+            if not issubclass(type(raw), Mapping):
+                raise ValueError("serialized subtask_specs entries must be mappings")
+            try:
+                decoded = dict(raw)
+            except Exception as error:
+                raise ValueError("serialized SubtaskSpec mapping could not be read") from error
+            try:
+                specs.append(SubtaskSpec(**decoded))
+            except ValueError:
+                raise
+            except Exception as error:
+                raise ValueError("serialized SubtaskSpec is invalid") from error
+        if "base_hidden_sizes" in payload:
+            raw_hidden = payload["base_hidden_sizes"]
+            if type(raw_hidden) not in (list, tuple):
+                raise ValueError(
+                    "serialized base_hidden_sizes must be an actual list or tuple"
+                )
+            sequence = cast(list[object] | tuple[object, ...], raw_hidden)
+            payload["base_hidden_sizes"] = tuple(sequence)
         try:
-            return cls(subtask_specs=specs, **payload)
+            return cls(subtask_specs=tuple(specs), **payload)
         except ValueError:
             raise
         except Exception as error:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -479,7 +479,7 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
 
 
 @pytest.mark.unit
-def test_stomp_from_config_preserves_mapping_api_without_relaxing_schema() -> None:
+def test_stomp_from_config_preserves_historical_mapping_and_sequence_compatibility() -> None:
     class MappingSpoof:
         @property
         def __class__(self) -> type:  # type: ignore[override]
@@ -506,34 +506,43 @@ def test_stomp_from_config_preserves_mapping_api_without_relaxing_schema() -> No
         observation_dim=2,
     )
     payload = config.to_config()
+    payload["subtask_specs"] = tuple(payload["subtask_specs"])
+    payload["base_hidden_sizes"] = tuple(payload["base_hidden_sizes"])
+    payload["type"] = "historical-marker"
     assert STOMPConfig.from_config(MappingProxyType(payload)) == config
+
+    partial = STOMPConfig.from_config(
+        {
+            "subtask_specs": ({"feature_index": np.int32(0)},),
+            "observation_dim": np.int32(2),
+            "base_step_size": np.float32(0.05),
+        }
+    )
+    assert partial.subtask_specs == (SubtaskSpec(feature_index=0),)
+    assert type(partial.observation_dim) is int
+    assert type(partial.base_step_size) is float
+    assert partial.option_planning_backups_per_step == 0
 
     with pytest.raises(ValueError, match="mapping"):
         STOMPConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="mapping could not be read"):
         STOMPConfig.from_config(HostileMapping())
 
-    with pytest.raises(ValueError, match="STOMPConfig"):
+    with pytest.raises(ValueError, match="invalid"):
         STOMPConfig.from_config({"unexpected_field": 1})
 
-    for mutation, match in (
-        ({"type": "historical-marker"}, "type"),
-        ({"base_step_size": np.float32(0.01)}, "base_step_size"),
-        ({"observation_dim": np.int32(2)}, "observation_dim"),
-        ({"base_hidden_sizes": tuple(payload["base_hidden_sizes"])}, "base_hidden_sizes"),
-        ({"subtask_specs": tuple(payload["subtask_specs"])}, "subtask_specs"),
+    for field, value in (
+        ("subtask_specs", "not-a-sequence"),
+        ("base_hidden_sizes", "not-a-sequence"),
     ):
         invalid = config.to_config()
-        invalid.update(mutation)
-        with pytest.raises(ValueError, match=match):
+        invalid[field] = value
+        with pytest.raises(ValueError, match=field):
             STOMPConfig.from_config(invalid)
 
-    missing = config.to_config()
-    missing.pop("base_step_size")
-    with pytest.raises(ValueError, match="fields"):
-        STOMPConfig.from_config(missing)
-
-    invalid_spec = config.to_config()
-    invalid_spec["subtask_specs"] = [{"feature_index": 0}]
-    with pytest.raises(ValueError, match="SubtaskSpec fields"):
-        STOMPConfig.from_config(invalid_spec)
+    for bad_spec, match in (
+        ({"feature_index": True}, "feature_index"),
+        ({"feature_index": 0, "threshold": "invalid"}, "threshold"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            STOMPConfig.from_config({"subtask_specs": (bad_spec,)})


### PR DESCRIPTION
Corrects the compatibility regression introduced by #802 while retaining its hostile-safe Mapping intake and all constructor-level scalar/resource hardening.

The pre-hardening implementation at main ancestor `8c1d33c` explicitly copied any ordinary mapping, ignored an optional type marker, defaulted omitted fields, iterated either list or tuple nested sequences, and delegated scalar validation to the constructors. Therefore exact full JSON schema/list-only admission is a new breaking policy, not a preserved historical contract.

This restores that established behavior safely: genuine Mapping/MappingProxy inputs are copied once with ordinary exceptions normalized; class-spoofed and hostile mappings are rejected without repr leakage; only exact list or tuple nested containers are accepted; nested mappings are copied safely; and all decoded integers/floats still pass through the current exact host + float32 + resource validators. Unknown constructor fields and malformed nested values remain fail-closed ValueError.

Verification at `8d96c39a1f354c509c592b8fe4ab511849c882d3` on current main:
- 159 options/STOMP tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

No registered evidence source or output artifact is changed.
