### PR TITLE
fix(streams): sample full finite Box domain safely

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -153,6 +153,10 @@ def _flatten_observation(obs: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     """
     import gymnasium
 
+    if isinstance(space, (gymnasium.spaces.Box, gymnasium.spaces.MultiDiscrete)):
+        _require_runtime_shape("observation", obs, tuple(space.shape))
+    elif isinstance(space, gymnasium.spaces.Discrete):
+        _require_runtime_shape("observation", obs, ())
     try:
         if isinstance(space, gymnasium.spaces.Box):
             flattened = jnp.asarray(obs, dtype=jnp.float32).reshape((-1,))
@@ -182,6 +186,10 @@ def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     """
     import gymnasium
 
+    if isinstance(space, (gymnasium.spaces.Box, gymnasium.spaces.MultiDiscrete)):
+        _require_runtime_shape("action", action, tuple(space.shape))
+    elif isinstance(space, gymnasium.spaces.Discrete):
+        _require_runtime_shape("action", action, ())
     try:
         if isinstance(space, gymnasium.spaces.Box):
             flattened = jnp.asarray(action, dtype=jnp.float32).reshape((-1,))
@@ -197,6 +205,28 @@ def _flatten_action(action: Any, space: gymnasium.spaces.Space[Any]) -> Array:
     if flattened.shape != (expected,) or not bool(jnp.all(jnp.isfinite(flattened))):
         raise ValueError("action must match its declared flattened shape and be finite")
     return flattened
+
+
+def _require_runtime_shape(name: str, value: object, expected: tuple[int, ...]) -> None:
+    """Check host shape metadata before conversion can allocate a device array."""
+    try:
+        metadata = getattr(value, "shape", None)
+        actual = tuple(metadata) if metadata is not None else tuple(np.shape(cast(Any, value)))
+    except Exception as error:
+        raise ValueError(f"{name} shape metadata could not be read") from error
+    if actual != expected:
+        raise ValueError(f"{name} must have declared shape {expected}; got {actual}")
+
+
+def _sample_finite_box(key: Array, low: Array, high: Array) -> Array:
+    """Sample a finite float32 Box without forming the possibly-overflowing full span."""
+    unit = jr.uniform(key, low.shape, dtype=jnp.float32)
+    midpoint = low / 2.0 + high / 2.0
+    lower = low + (midpoint - low) * (2.0 * unit)
+    upper = midpoint + (high - midpoint) * (2.0 * unit - 1.0)
+    sample = jnp.where(unit < 0.5, lower, upper)
+    upper_open = jnp.nextafter(high, low)
+    return jnp.where(low < high, jnp.minimum(sample, upper_open), low)
 
 
 def _make_random_policy(
@@ -219,21 +249,16 @@ def _make_random_policy(
             raise ValueError("Discrete action bounds must fit JAX signed int32")
     elif isinstance(action_space, gymnasium.spaces.Box):
         _require_float32_allocation("random Box bounds and action", 3 * action_dim)
-        with np.errstate(over="ignore", invalid="ignore"):
-            low_array = np.asarray(action_space.low, dtype=np.float32)
-            high_array = np.asarray(action_space.high, dtype=np.float32)
-            finite_span = np.isfinite(high_array - low_array)
+        low_array = np.asarray(action_space.low, dtype=np.float32)
+        high_array = np.asarray(action_space.high, dtype=np.float32)
         if not bool(
             np.all(
                 np.isfinite(low_array)
                 & np.isfinite(high_array)
-                & finite_span
                 & (low_array <= high_array)
             )
         ):
-            raise ValueError(
-                "Box random actions require finite ordered bounds with a finite float32 span"
-            )
+            raise ValueError("Box random actions require finite ordered float32 bounds")
         low = jnp.asarray(low_array)
         high = jnp.asarray(high_array)
     elif isinstance(action_space, gymnasium.spaces.MultiDiscrete):
@@ -263,7 +288,7 @@ def _make_random_policy(
         if isinstance(action_space, gymnasium.spaces.Discrete):
             return int(jr.randint(key, (), discrete_low, discrete_high))
         if isinstance(action_space, gymnasium.spaces.Box):
-            return jr.uniform(key, action_space.shape, minval=low, maxval=high)
+            return _sample_finite_box(key, low, high)
         if isinstance(action_space, gymnasium.spaces.MultiDiscrete):
             samples = np.fromiter(
                 (

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -203,16 +203,22 @@ def test_random_box_policy_rejects_nonfinite_bounds() -> None:
         make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
 
 
-def test_random_box_policy_rejects_float32_span_overflow() -> None:
+def test_random_box_policy_samples_full_finite_float32_domain() -> None:
     maximum = np.finfo(np.float32).max
 
     class StubEnv:
         action_space = gymnasium.spaces.Box(
-            -maximum, maximum, shape=(1,), dtype=np.float32
+            np.asarray((-maximum, -maximum, maximum / 2), dtype=np.float32),
+            np.asarray((maximum, -maximum / 2, maximum), dtype=np.float32),
+            dtype=np.float32,
         )
 
-    with pytest.raises(ValueError, match="finite float32 span"):
-        make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
+    policy = make_random_policy(StubEnv(), seed=0)  # type: ignore[arg-type]
+    for _ in range(20):
+        action = policy(jnp.zeros(1, dtype=jnp.float32))
+        assert bool(jnp.all(jnp.isfinite(action)))
+        assert bool(jnp.all(action >= StubEnv.action_space.low))
+        assert bool(jnp.all(action < StubEnv.action_space.high))
 
 
 def test_random_box_preflights_dimension_before_jax_bound_conversion(
@@ -257,6 +263,30 @@ def test_runtime_values_must_match_declared_flattened_shapes_and_be_finite() -> 
         _flatten_observation(np.asarray((0.0, np.nan), dtype=np.float32), box)
     with pytest.raises(ValueError, match="action.*finite"):
         _flatten_action(np.asarray((0.0, np.inf), dtype=np.float32), box)
+
+
+def test_runtime_shape_metadata_rejects_before_jax_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    box = gymnasium.spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
+
+    class OversizedStub:
+        shape = (2**31 - 1,)
+
+        def __array__(self, *_args: object, **_kwargs: object) -> np.ndarray:
+            raise AssertionError("array conversion ran before shape preflight")
+
+    monkeypatch.setattr(
+        gymnasium_stream_module.jnp,
+        "asarray",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("JAX conversion ran before shape preflight")
+        ),
+    )
+    with pytest.raises(ValueError, match="observation.*declared shape"):
+        _flatten_observation(OversizedStub(), box)
+    with pytest.raises(ValueError, match="action.*declared shape"):
+        _flatten_action(OversizedStub(), box)
 
 
 def test_factory_rejects_noncallable_policy_before_environment_construction(


### PR DESCRIPTION
Corrective follow-up to merged #790. The held independent audit found two residuals in the merged head: individually finite ordered Box endpoints such as `[-float32_max, +float32_max]` were rejected because the full-width subtraction overflows, and runtime observation/action values were converted to JAX before their declared host shape was checked.\n\nThis preserves all #790 resource and cleanup work, samples every finite ordered float32 Box with a stable two-half mapping around `low / 2 + high / 2` without forming the overflowing full span, clamps the exclusive upper endpoint, and checks host shape metadata before device conversion. Regressions cover the full ±float32 range, asymmetric and same-sign large ranges, finiteness/bounds, and an oversized hostile stub whose conversion must never run.\n\nVerification on current main: 76 focused Gymnasium/bootstrap/package-boundary tests passed; Ruff clean; strict mypy clean; diff check clean.