### PR TITLE
fix(rtu): retain exact schemas for mapping payloads

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -585,10 +585,28 @@ class RecurrentTraceActorCriticConfig:
     ) -> RecurrentTraceActorCriticConfig:
         """Reconstruct and validate a configuration mapping."""
         payload = _copy_config_mapping("config", config)
-        try:
-            return cls(**payload)
-        except TypeError as error:
-            raise ValueError("config fields do not match the serialized schema") from error
+        required = {
+            field.name
+            for field in dataclasses.fields(cls)
+            if field.name not in {"adaptive_obgd", "beta2", "epsilon"}
+        }
+        optional = {"adaptive_obgd", "beta2", "epsilon"}
+        if not required <= set(payload) or not set(payload) <= required | optional:
+            raise ValueError("config fields do not match the serialized schema")
+        integer_fields = {"n_actions", "hidden_size", "encoder_width", "output_width"}
+        bool_fields = {
+            "normalize_observations",
+            "normalize_rewards",
+            "rtrl_taylor_correction",
+            "adaptive_obgd",
+        }
+        for name, value in payload.items():
+            expected_type = (
+                int if name in integer_fields else bool if name in bool_fields else float
+            )
+            if type(value) is not expected_type:
+                raise ValueError("serialized config values must use exact JSON scalar types")
+        return cls(**payload)
 
 
 def parameterless_layer_norm(inputs: Array, epsilon: float = 1e-5) -> Array:
@@ -1839,13 +1857,13 @@ class RecurrentTraceActorCriticAgent:
     ) -> RecurrentTraceActorCriticAgent:
         """Reconstruct an agent from :meth:`to_config` output."""
         payload = _copy_config_mapping("serialized agent", config)
-        agent_type = payload.pop("type", cls.__name__)
-        if type(agent_type) is not str or agent_type != cls.__name__:
-            raise ValueError("unsupported agent type")
-        if "config" in payload:
-            raw_config = payload.pop("config")
-            if payload:
+        if "type" in payload or "config" in payload:
+            if set(payload) != {"type", "config"}:
                 raise ValueError("serialized agent fields do not match the schema")
+            agent_type = payload["type"]
+            if type(agent_type) is not str or agent_type != cls.__name__:
+                raise ValueError("unsupported agent type")
+            raw_config = payload["config"]
         else:
             raw_config = payload
         if not isinstance(raw_config, Mapping):

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import pickle
 from collections.abc import Callable
+from types import MappingProxyType
 from typing import Any, cast
 
 import chex
@@ -2069,13 +2070,20 @@ def test_config_rejects_hostile_numeric_and_serialized_container_hooks() -> None
         _small_config(gamma=10**1000)
     payload = _small_config().to_config()
     assert RecurrentTraceActorCriticConfig.from_config(DictSubclass(payload)) == _small_config()
+    assert RecurrentTraceActorCriticConfig.from_config(MappingProxyType(payload)) == _small_config()
     envelope = RecurrentTraceActorCriticAgent(_small_config()).to_config()
     assert (
         RecurrentTraceActorCriticAgent.from_config(DictSubclass(envelope)).config
         == _small_config()
     )
+    proxied_envelope = MappingProxyType(
+        {**envelope, "config": MappingProxyType(envelope["config"])}
+    )
+    assert RecurrentTraceActorCriticAgent.from_config(proxied_envelope).config == _small_config()
     with pytest.raises(ValueError, match="fields"):
         RecurrentTraceActorCriticConfig.from_config({**payload, "unknown": 1})
+    with pytest.raises(ValueError, match="fields"):
+        RecurrentTraceActorCriticAgent.from_config({"config": payload})
 
 
 def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
@@ -2345,16 +2353,19 @@ def test_config_canonicalizes_supported_numpy_float_families(code: str) -> None:
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    (("n_actions", np.int64(2)), ("gamma", np.float32(0.5))),
+    (
+        ("n_actions", np.int64(2)),
+        ("gamma", np.float32(0.5)),
+        ("normalize_rewards", np.bool_(True)),
+        ("gamma", 1),
+        ("n_actions", 2.0),
+    ),
 )
-def test_from_config_preserves_supported_runtime_scalar_families(
-    field: str, value: object
-) -> None:
+def test_from_config_requires_exact_json_scalar_types(field: str, value: object) -> None:
     payload = RecurrentTraceActorCriticConfig(n_actions=2).to_config()
     payload[field] = value
-    reconstructed = RecurrentTraceActorCriticConfig.from_config(payload)
-    expected_type = int if field == "n_actions" else float
-    assert type(getattr(reconstructed, field)) is expected_type
+    with pytest.raises(ValueError, match="exact JSON scalar types"):
+        RecurrentTraceActorCriticConfig.from_config(payload)
 
 
 @pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))


### PR DESCRIPTION
Corrective audit of merged #807. Mapping compatibility is valid and retained for config payloads, agent envelopes, and nested config mappings, with one normalized copy before validation. However, #807 weakened the serialized contract: missing config fields began default-injecting, non-JSON NumPy scalars were admitted, and a config-only envelope was accepted as a full agent payload.\n\nThis restores the complete required/optional field set and exact JSON scalar types after the Mapping copy, distinguishes the exact full envelope from the documented legacy-flat form, and rejects partial/ambiguous envelopes. Direct constructors continue accepting the full trusted built-in/NumPy scalar families; only serialized payloads remain exact. Resource accounting from #800 and exact nonzero underflow from #801 are unchanged.\n\nVerification on current main: 11 targeted mapping/schema/resource/Taylor tests passed; scoped Ruff passed; strict mypy passed; diff-check clean. No outputs or registered evidence sources change.