### PR TITLE
fix(prototype-memory): restore historical config compatibility

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -202,25 +202,13 @@ class PrototypeMemoryConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("PrototypeMemoryConfig mapping could not be read") from error
-        if payload.pop("type", None) != "PrototypeMemoryConfig":
-            raise ValueError("PrototypeMemoryConfig type is invalid")
-        expected = {
-            "feature_dim",
-            "n_classes",
-            "slots_per_class",
-            "update_rate",
-            "novelty_threshold",
-            "bandwidth",
-        }
-        if set(payload) != expected:
-            raise ValueError("PrototypeMemoryConfig fields do not match its schema")
-        for name in ("feature_dim", "n_classes", "slots_per_class"):
-            if type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        for name in ("update_rate", "novelty_threshold", "bandwidth"):
-            if type(payload[name]) is not float:
-                raise ValueError(f"serialized {name} must be a JSON number")
-        return cls(**payload)
+        payload.pop("type", None)
+        try:
+            return cls(**payload)
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized PrototypeMemoryConfig is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -326,11 +314,7 @@ class PrototypeMemoryLearner:
             payload = dict(config)
         except Exception as error:
             raise ValueError("PrototypeMemoryLearner mapping could not be read") from error
-        if set(payload) != {"type", "config"}:
-            raise ValueError("PrototypeMemoryLearner fields do not match its schema")
-        if payload["type"] != "PrototypeMemoryLearner":
-            raise ValueError("PrototypeMemoryLearner type is invalid")
-        inner_raw = payload["config"]
+        inner_raw = payload.get("config")
         if not issubclass(type(inner_raw), Mapping):
             raise ValueError("PrototypeMemoryLearner config must be a mapping")
         try:

--- a/tests/test_prototype_memory_validation.py
+++ b/tests/test_prototype_memory_validation.py
@@ -281,30 +281,35 @@ def test_prototype_config_mapping_compatibility_rejects_spoofs_before_hooks() ->
         PrototypeMemoryLearner.from_config(HostileMapping())
 
 
-def test_prototype_serialized_schema_is_exact_and_uses_json_scalars() -> None:
+def test_prototype_serialization_preserves_historical_constructor_compatibility() -> None:
     config = PrototypeMemoryConfig(feature_dim=2, n_classes=2)
     payload = config.to_config()
-    for mutation, match in (
-        ({"type": "OtherConfig"}, "type"),
-        ({"feature_dim": np.int32(2)}, "feature_dim"),
-        ({"update_rate": np.float32(0.3)}, "update_rate"),
-        ({"extra": 1}, "fields"),
-    ):
-        invalid = dict(payload)
-        invalid.update(mutation)
-        with pytest.raises(ValueError, match=match):
-            PrototypeMemoryConfig.from_config(invalid)
+    payload["type"] = "historical-marker"
+    payload["feature_dim"] = np.int32(2)
+    payload["n_classes"] = np.uint16(2)
+    payload["update_rate"] = np.float32(0.3)
+    restored = PrototypeMemoryConfig.from_config(MappingProxyType(payload))
+    assert restored.feature_dim == config.feature_dim
+    assert restored.n_classes == config.n_classes
+    assert restored.slots_per_class == config.slots_per_class
+    assert restored.update_rate == float(np.float32(0.3))
+    assert restored.novelty_threshold == config.novelty_threshold
+    assert restored.bandwidth == config.bandwidth
+    assert type(restored.feature_dim) is int
+    assert type(restored.n_classes) is int
+    assert type(restored.update_rate) is float
 
-    missing = dict(payload)
-    missing.pop("bandwidth")
-    with pytest.raises(ValueError, match="fields"):
-        PrototypeMemoryConfig.from_config(missing)
+    partial = PrototypeMemoryConfig.from_config({"feature_dim": 2, "n_classes": 2})
+    assert partial == config
+
+    with pytest.raises(ValueError, match="extra"):
+        PrototypeMemoryConfig.from_config({**config.to_config(), "extra": 1})
 
     learner_payload = PrototypeMemoryLearner(config).to_config()
-    with pytest.raises(ValueError, match="type"):
-        PrototypeMemoryLearner.from_config({**learner_payload, "type": "OtherLearner"})
-    with pytest.raises(ValueError, match="fields"):
-        PrototypeMemoryLearner.from_config({**learner_payload, "extra": 1})
+    learner_payload["type"] = "historical-marker"
+    learner_payload["extra"] = "ignored legacy metadata"
+    learner = PrototypeMemoryLearner.from_config(MappingProxyType(learner_payload))
+    assert learner.config == config
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Corrects only the serialization compatibility regression in merged #815 while retaining all of #815's stronger query/update working-set bounds, pre-conversion wrappers, exact operand/state contracts, saturating counters, and atomic transaction behavior.

Before the schema-tightening commits, both loaders copied mappings, ignored optional type markers, delegated scalar normalization to constructors, allowed omitted defaulted config fields, and tolerated outer learner metadata. Exact full JSON schemas and built-in-only scalar admission were therefore new breaking policies, not established serialized contracts.

This residual keeps genuine Mapping/MappingProxy intake and hostile-hook normalization, restores optional markers/default fields/outer metadata, permits NumPy scalars through the hardened canonical constructors, still rejects unknown constructor fields and non-Mapping nested configs, and never weakens any resource or runtime boundary.

Verification on the rebased head:
- 195 PrototypeMemory + late-wave transaction tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

No registered evidence source or output artifact is changed.
