### PR TITLE
fix(closed-loop): complete integer and resource contracts

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -101,12 +101,21 @@ def _require_builtin_int(
     instead of the ``ValueError`` this contract promises.
     """
     if type(value) is not int:
-        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+        raise ValueError(f"{name} must be a built-in integer")
     if value < minimum:
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}")
     if value > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return value
+
+
+def _preflight_riverswim_resources(n_states: int) -> None:
+    """Bound all persistent NumPy/JAX transition and reward payloads."""
+    # NumPy transitions/rewards plus their persistent JAX logits/rewards.
+    persistent_scalars = 4 * n_states * n_states + 4 * n_states
+    persistent_bytes = 4 * persistent_scalars
+    if persistent_scalars > _INT32_MAX or persistent_bytes > _INT32_MAX:
+        raise ValueError("derived RiverSwim persistent resources must fit signed int32")
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -253,7 +262,11 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        _require_builtin_int(config.phase_length, name="phase_length", minimum=1)
+        if type(config) is not SwitchingTwoStateConfig:
+            raise ValueError("config must be an actual SwitchingTwoStateConfig")
+        phase_length = _require_builtin_int(
+            config.phase_length, name="phase_length", minimum=1
+        )
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -264,7 +277,7 @@ class SwitchingTwoStateMDP:
             phase_payoffs.append(payoff)
         payoffs = np.stack(phase_payoffs)
         self._config = config
-        self._phase_length = int(config.phase_length)
+        self._phase_length = phase_length
         self._payoffs_np = payoffs
         self._payoffs = jnp.asarray(payoffs)
 
@@ -444,7 +457,10 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
+        if type(config) is not RiverSwimConfig:
+            raise ValueError("config must be an actual RiverSwimConfig")
         n_states = _require_builtin_int(config.n_states, name="n_states", minimum=2)
+        _preflight_riverswim_resources(n_states)
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,

--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="call-arg"
+# mypy: disable-error-code="call-arg,attr-defined"
 """Closed-loop micro-MDPs where actions affect observations.
 
 Every other stream in this package is open-loop: the observation sequence is
@@ -81,6 +81,32 @@ _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
     np.float64,
     np.longdouble,
 )
+
+
+def _require_builtin_int(
+    value: object,
+    *,
+    name: str,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
+    """Return a built-in int at or above ``minimum``; reject bool and numpy ints.
+
+    ``type(value) is not int`` is deliberate: ``isinstance(value, int)``
+    consults the overridable ``__class__`` attribute, so an object whose
+    ``__class__`` property returns ``int`` would pass an isinstance check
+    even though its true type never implements the integer protocol,
+    letting it reach downstream integer-only sinks (``range``, JAX array
+    construction) and raise an undocumented, unclean exception there
+    instead of the ``ValueError`` this contract promises.
+    """
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return value
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -227,16 +253,7 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        if (
-            isinstance(config.phase_length, bool)
-            or not isinstance(config.phase_length, int)
-            or config.phase_length < 1
-            or config.phase_length > _INT32_MAX
-        ):
-            raise ValueError(
-                "phase_length must be a positive integer in "
-                f"[1, {_INT32_MAX}], got {config.phase_length!r}"
-            )
+        _require_builtin_int(config.phase_length, name="phase_length", minimum=1)
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -427,8 +444,7 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
-        if config.n_states < 2:
-            raise ValueError(f"n_states must be at least 2, got {config.n_states}")
+        n_states = _require_builtin_int(config.n_states, name="n_states", minimum=2)
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,
@@ -466,17 +482,12 @@ class RiverSwimMDP:
                 "p_right_up + p_right_down must not exceed 1, got "
                 f"{config.p_right_up} + {config.p_right_down}"
             )
-        if not 0 <= config.initial_state < config.n_states:
-            raise ValueError(
-                f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
-            )
-        if isinstance(config.initial_state, bool) or not isinstance(
-            config.initial_state, Integral
-        ):
-            raise ValueError(
-                "initial_state must be an integer, got "
-                f"{config.initial_state!r}"
-            )
+        _require_builtin_int(
+            config.initial_state,
+            name="initial_state",
+            minimum=0,
+            maximum=n_states - 1,
+        )
         config = cast(
             RiverSwimConfig,
             config.replace(
@@ -487,7 +498,7 @@ class RiverSwimMDP:
             ),
         )
         self._config: RiverSwimConfig = config
-        self._n_states: int = int(config.n_states)
+        self._n_states: int = n_states
         self._transitions_np: np.ndarray = self._build_transitions(config)
         self._rewards_np: np.ndarray = self._build_rewards(config)
         self._transition_logits: Array = jnp.where(

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -148,12 +148,35 @@ class TestSwitchingTwoStateDynamics:
     @pytest.mark.parametrize("phase_length", _INVALID_PHASE_LENGTHS)
     def test_invalid_phase_length_raises(self, phase_length):
         """Schedule divisors must be built-in positive JAX-int32 integers."""
-        with pytest.raises(
-            ValueError,
-            match=rf"phase_length must be a positive integer in \[1, {_INT32_MAX}\]",
-        ):
+        with pytest.raises(ValueError, match=r"phase_length must be"):
             SwitchingTwoStateMDP(
                 SwitchingTwoStateConfig(phase_length=phase_length)  # type: ignore[arg-type]
+            )
+
+    def test_phase_length_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        ``isinstance(value, int)`` consults the overridable ``__class__``
+        property, so a non-int object could previously spoof the isinstance
+        check and reach ``int(config.phase_length)`` unvalidated, raising an
+        undocumented ``TypeError`` from deep inside JAX construction instead
+        of the clean ``ValueError`` this constructor promises.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __lt__(self, other: object) -> bool:
+                return False
+
+            def __gt__(self, other: object) -> bool:
+                return False
+
+        with pytest.raises(ValueError, match=r"phase_length must be a built-in integer"):
+            SwitchingTwoStateMDP(
+                SwitchingTwoStateConfig(phase_length=_SpoofedInt())  # type: ignore[arg-type]
             )
 
     def test_int32_max_phase_length_runs_first_eager_and_jit_query(self):
@@ -376,8 +399,42 @@ class TestRiverSwim:
     @pytest.mark.parametrize("initial_state", [1.5, True, 2.0])
     def test_non_integer_initial_state_raises(self, initial_state):
         """initial_state must be a canonical integer in range."""
-        with pytest.raises(ValueError, match="initial_state must be an integer"):
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
             RiverSwimMDP(RiverSwimConfig(initial_state=initial_state))  # type: ignore[arg-type]
+
+    def test_initial_state_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        Previously ``isinstance(config.initial_state, Integral)`` consulted
+        the overridable ``__class__`` property, so this object would pass
+        validation and reach ``jnp.array(self._config.initial_state, ...)``
+        inside :meth:`RiverSwimMDP.init` unvalidated.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __ge__(self, other: object) -> bool:
+                return True
+
+            def __lt__(self, other: object) -> bool:
+                return True
+
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(initial_state=_SpoofedInt()))  # type: ignore[arg-type]
+
+    def test_non_integer_n_states_raises(self):
+        """n_states must be a canonical built-in integer, not merely numeric.
+
+        Previously ``n_states`` had no type check at all: a float such as
+        ``6.5`` passed the ``config.n_states < 2`` comparison and then raised
+        an undocumented ``TypeError`` from ``range(n)`` deep inside
+        ``_build_transitions`` instead of a clean ``ValueError``.
+        """
+        with pytest.raises(ValueError, match="n_states must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(n_states=6.5))  # type: ignore[arg-type]
 
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -1,5 +1,6 @@
 """Tests for the closed-loop micro-MDPs (actions affect observations)."""
 
+import math
 from fractions import Fraction
 from numbers import Real
 
@@ -10,6 +11,7 @@ import jax.random as jr
 import numpy as np
 import pytest
 
+import alberta_framework.streams.closed_loop as closed_loop
 from alberta_framework.streams import (
     LEFT_ACTION,
     PHASE_A,
@@ -174,10 +176,30 @@ class TestSwitchingTwoStateDynamics:
             def __gt__(self, other: object) -> bool:
                 return False
 
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
         with pytest.raises(ValueError, match=r"phase_length must be a built-in integer"):
             SwitchingTwoStateMDP(
                 SwitchingTwoStateConfig(phase_length=_SpoofedInt())  # type: ignore[arg-type]
             )
+
+    def test_phase_length_int_subclass_rejected_without_hooks(self):
+        class _HostileInt(int):
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
+        with pytest.raises(ValueError, match="phase_length"):
+            SwitchingTwoStateMDP(
+                SwitchingTwoStateConfig(phase_length=_HostileInt(2))
+            )
+
+    def test_switching_config_requires_exact_type(self):
+        class _ConfigSubclass(SwitchingTwoStateConfig):
+            pass
+
+        with pytest.raises(ValueError, match="actual SwitchingTwoStateConfig"):
+            SwitchingTwoStateMDP(_ConfigSubclass())
 
     def test_int32_max_phase_length_runs_first_eager_and_jit_query(self):
         """The largest JAX-int32 phase divisor is accepted without overflow."""
@@ -422,6 +444,9 @@ class TestRiverSwim:
             def __lt__(self, other: object) -> bool:
                 return True
 
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
         with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
             RiverSwimMDP(RiverSwimConfig(initial_state=_SpoofedInt()))  # type: ignore[arg-type]
 
@@ -435,6 +460,36 @@ class TestRiverSwim:
         """
         with pytest.raises(ValueError, match="n_states must be a built-in integer"):
             RiverSwimMDP(RiverSwimConfig(n_states=6.5))  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("field", ["n_states", "initial_state"])
+    def test_riverswim_integer_subclasses_rejected_without_hooks(self, field: str):
+        class _HostileInt(int):
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted __repr__ must not run")
+
+        with pytest.raises(ValueError, match=field):
+            RiverSwimMDP(RiverSwimConfig(**{field: _HostileInt(2)}))
+
+    def test_riverswim_config_requires_exact_type(self):
+        class _ConfigSubclass(RiverSwimConfig):
+            pass
+
+        with pytest.raises(ValueError, match="actual RiverSwimConfig"):
+            RiverSwimMDP(_ConfigSubclass())
+
+    def test_riverswim_resource_boundary_is_allocation_free(self, monkeypatch):
+        # Persistent numeric bytes are 16 * n_states * (n_states + 1).
+        last_valid = (math.isqrt(1 + 4 * (_INT32_MAX // 16)) - 1) // 2
+        closed_loop._preflight_riverswim_resources(last_valid)
+        with pytest.raises(ValueError, match="persistent resources"):
+            closed_loop._preflight_riverswim_resources(last_valid + 1)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("allocation ran before resource preflight")
+
+        monkeypatch.setattr(np, "zeros", forbidden)
+        with pytest.raises(ValueError, match="persistent resources"):
+            RiverSwimMDP(RiverSwimConfig(n_states=last_valid + 1))
 
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""


### PR DESCRIPTION
Supersedes #803 while preserving its contributor commit and authorship. The original integer-gap diagnosis is correct, but its error path still invoked hostile repr and n_states could reach quadratic NumPy/JAX transition allocations at INT32_MAX. This successor removes value formatting from integer failures, requires exact config records, uses the canonical validated phase value, and preflights the complete persistent RiverSwim NumPy transitions/rewards plus JAX logits/rewards before allocation. Adds hostile spoof/subclass/repr, exact config, and allocation-free resource boundary/adjacent tests. Validation on rebased current main: 91 closed-loop tests passed; scoped Ruff, strict mypy, root imports, and diff check passed.