### PR TITLE
fix(prototype-memory): restore historical config compatibility

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -176,23 +176,6 @@ def _read_mapping(name: str, value: object) -> dict[str, Any]:
         raise ValueError(f"{name} mapping could not be read") from error
 
 
-def _require_schema(
-    name: str,
-    payload: dict[str, Any],
-    *,
-    keys: frozenset[str],
-    discriminator: str,
-) -> None:
-    try:
-        actual_keys = frozenset(payload)
-    except Exception as error:
-        raise ValueError(f"{name} fields could not be read") from error
-    if actual_keys != keys:
-        raise ValueError(f"{name} must contain exactly the documented fields")
-    if type(payload["type"]) is not str or payload["type"] != discriminator:
-        raise ValueError(f"{name} type discriminator is invalid")
-
-
 def _saturating_increment(value: Array) -> Array:
     one = jnp.asarray(1, dtype=jnp.int32)
     return jnp.minimum(value, jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)) + one
@@ -246,36 +229,13 @@ class PrototypeMemoryConfig:
     def from_config(cls, config: Mapping[str, Any]) -> PrototypeMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
         payload = _read_mapping("PrototypeMemoryConfig payload", config)
-        _require_schema(
-            "PrototypeMemoryConfig payload",
-            payload,
-            keys=frozenset(
-                {
-                    "type",
-                    "feature_dim",
-                    "n_classes",
-                    "slots_per_class",
-                    "update_rate",
-                    "novelty_threshold",
-                    "bandwidth",
-                }
-            ),
-            discriminator="PrototypeMemoryConfig",
-        )
-        for name in ("feature_dim", "n_classes", "slots_per_class"):
-            if type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        for name in ("update_rate", "novelty_threshold", "bandwidth"):
-            if type(payload[name]) is not float:
-                raise ValueError(f"serialized {name} must be a JSON number")
-        return cls(
-            feature_dim=payload["feature_dim"],
-            n_classes=payload["n_classes"],
-            slots_per_class=payload["slots_per_class"],
-            update_rate=payload["update_rate"],
-            novelty_threshold=payload["novelty_threshold"],
-            bandwidth=payload["bandwidth"],
-        )
+        payload.pop("type", None)
+        try:
+            return cls(**payload)
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized PrototypeMemoryConfig is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -376,13 +336,7 @@ class PrototypeMemoryLearner:
     def from_config(cls, config: Mapping[str, Any]) -> PrototypeMemoryLearner:
         """Reconstruct a learner from :meth:`to_config` output."""
         payload = _read_mapping("PrototypeMemoryLearner payload", config)
-        _require_schema(
-            "PrototypeMemoryLearner payload",
-            payload,
-            keys=frozenset({"type", "config"}),
-            discriminator="PrototypeMemoryLearner",
-        )
-        inner = payload["config"]
+        inner = payload.get("config")
         if not issubclass(type(inner), Mapping):
             raise ValueError("PrototypeMemoryLearner config must be a mapping")
         return cls(PrototypeMemoryConfig.from_config(cast(Mapping[str, Any], inner)))

--- a/tests/test_prototype_memory_validation.py
+++ b/tests/test_prototype_memory_validation.py
@@ -280,74 +280,35 @@ def test_prototype_config_mapping_compatibility_rejects_spoofs_before_hooks() ->
         PrototypeMemoryLearner.from_config(HostileMapping())
 
 
-def test_prototype_serialized_schema_is_exact_and_uses_json_scalars() -> None:
+def test_prototype_serialization_preserves_historical_constructor_compatibility() -> None:
     config = PrototypeMemoryConfig(feature_dim=2, n_classes=2)
     payload = config.to_config()
-    for mutation, match in (
-        ({"type": "OtherConfig"}, "type"),
-        ({"feature_dim": np.int32(2)}, "feature_dim"),
-        ({"update_rate": np.float32(0.3)}, "update_rate"),
-        ({"extra": 1}, "fields"),
-    ):
-        invalid = dict(payload)
-        invalid.update(mutation)
-        with pytest.raises(ValueError, match=match):
-            PrototypeMemoryConfig.from_config(invalid)
+    payload["type"] = "historical-marker"
+    payload["feature_dim"] = np.int32(2)
+    payload["n_classes"] = np.uint16(2)
+    payload["update_rate"] = np.float32(0.3)
+    restored = PrototypeMemoryConfig.from_config(MappingProxyType(payload))
+    assert restored.feature_dim == config.feature_dim
+    assert restored.n_classes == config.n_classes
+    assert restored.slots_per_class == config.slots_per_class
+    assert restored.update_rate == float(np.float32(0.3))
+    assert restored.novelty_threshold == config.novelty_threshold
+    assert restored.bandwidth == config.bandwidth
+    assert type(restored.feature_dim) is int
+    assert type(restored.n_classes) is int
+    assert type(restored.update_rate) is float
 
-    missing = dict(payload)
-    missing.pop("bandwidth")
-    with pytest.raises(ValueError, match="fields"):
-        PrototypeMemoryConfig.from_config(missing)
+    partial = PrototypeMemoryConfig.from_config({"feature_dim": 2, "n_classes": 2})
+    assert partial == config
+
+    with pytest.raises(ValueError, match="extra"):
+        PrototypeMemoryConfig.from_config({**config.to_config(), "extra": 1})
 
     learner_payload = PrototypeMemoryLearner(config).to_config()
-    with pytest.raises(ValueError, match="type"):
-        PrototypeMemoryLearner.from_config({**learner_payload, "type": "OtherLearner"})
-    with pytest.raises(ValueError, match="fields"):
-        PrototypeMemoryLearner.from_config({**learner_payload, "extra": 1})
-
-
-@pytest.mark.parametrize("mutation", ["missing-type", "wrong-type", "extra-field"])
-def test_prototype_config_requires_exact_schema(mutation: str) -> None:
-    payload = PrototypeMemoryConfig(feature_dim=2, n_classes=2).to_config()
-    if mutation == "missing-type":
-        del payload["type"]
-    elif mutation == "wrong-type":
-        payload["type"] = "PrototypeMemoryLearner"
-    else:
-        payload["unknown"] = 1
-    with pytest.raises(ValueError, match="documented fields|discriminator"):
-        PrototypeMemoryConfig.from_config(payload)
-
-
-@pytest.mark.parametrize("mutation", ["missing-type", "wrong-type", "extra-field"])
-def test_prototype_learner_requires_exact_outer_schema(mutation: str) -> None:
-    learner = PrototypeMemoryLearner(PrototypeMemoryConfig(feature_dim=2, n_classes=2))
-    payload = learner.to_config()
-    if mutation == "missing-type":
-        del payload["type"]
-    elif mutation == "wrong-type":
-        payload["type"] = "PrototypeMemoryConfig"
-    else:
-        payload["unknown"] = 1
-    with pytest.raises(ValueError, match="documented fields|discriminator"):
-        PrototypeMemoryLearner.from_config(payload)
-
-
-def test_prototype_schema_errors_do_not_run_hostile_repr() -> None:
-    class Hostile:
-        def __repr__(self) -> str:
-            raise AssertionError("repr hook must not execute")
-
-    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2).to_config()
-    config["type"] = Hostile()
-    with pytest.raises(ValueError, match="discriminator"):
-        PrototypeMemoryConfig.from_config(config)
-
-    learner = PrototypeMemoryLearner(PrototypeMemoryConfig(feature_dim=2, n_classes=2))
-    outer = learner.to_config()
-    outer["type"] = Hostile()
-    with pytest.raises(ValueError, match="discriminator"):
-        PrototypeMemoryLearner.from_config(outer)
+    learner_payload["type"] = "historical-marker"
+    learner_payload["extra"] = "ignored legacy metadata"
+    learner = PrototypeMemoryLearner.from_config(MappingProxyType(learner_payload))
+    assert learner.config == config
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Corrects only the serialization compatibility regression in merged #815 while retaining all of #815's stronger query/update working-set bounds, pre-conversion wrappers, exact operand/state contracts, saturating counters, and atomic transaction behavior.

Before the schema-tightening commits, both loaders copied mappings, ignored optional type markers, delegated scalar normalization to constructors, allowed omitted defaulted config fields, and tolerated outer learner metadata. Exact full JSON schemas and built-in-only scalar admission were therefore new breaking policies, not established serialized contracts.

This residual keeps genuine Mapping/MappingProxy intake and hostile-hook normalization, restores optional markers/default fields/outer metadata, permits NumPy scalars through the hardened canonical constructors, still rejects unknown constructor fields and non-Mapping nested configs, and never weakens any resource or runtime boundary.

Verification on head b12e57a:
- 195 PrototypeMemory + late-wave transaction tests passed
- Ruff passed
- strict targeted mypy passed
- git diff --check passed

No registered evidence source or output artifact is changed.
