### PR TITLE
fix(micro-continual): make resource contracts exact

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -105,6 +105,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     atomic_write_new,
     init_mlp_params,
 )
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 logger = logging.getLogger(__name__)
 
@@ -239,18 +240,15 @@ def _require_float32_resource(name: str, scalars: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
-def _validate_stream_resources(
+def _materialized_stream_scalars(
     *, n_regimes: int, regime_length: int, dim: int, n_classes: int, n_components: int
-) -> None:
-    """Preflight the materialized stream and its worst-case generation work."""
+) -> int:
+    """Return the exact scalar count of all retained GaussianMicroStream leaves."""
     n_steps = n_regimes * regime_length
-    class_dim = n_classes * dim
     component_dim = n_classes * n_components * dim
     regime_dim = n_regimes * dim
     regime_class = n_regimes * n_classes
-
-    # Every returned GaussianMicroStream leaf is four bytes (float32/int32).
-    persistent_scalars = (
+    return (
         2 * n_steps * dim
         + 3 * n_steps
         + component_dim
@@ -258,23 +256,6 @@ def _validate_stream_resources(
         + regime_dim
         + regime_class
         + 2 * n_regimes
-    )
-    _require_float32_resource("GaussianMicroStream outputs", persistent_scalars)
-
-    # Conservative simultaneous-generation allowance: base component IDs,
-    # noise, per-step gathers/scales, regime work, and all geometry workspaces.
-    work_scalars = (
-        2 * n_steps * dim
-        + 2 * n_steps
-        + n_regimes
-        + regime_dim
-        + 2 * dim
-        + 2 * class_dim
-        + 3 * component_dim
-    )
-    _require_float32_resource(
-        "GaussianMicroStream outputs and generation work",
-        persistent_scalars + work_scalars,
     )
 
 
@@ -355,41 +336,30 @@ class MicroStreamConfig:
             raise ValueError(
                 f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})"
             )
-        real_fields = (
-            "spectrum_decades",
-            "mean_separation",
-            "component_scale",
-            "class_sparsity",
-            "noise_scale",
-            "offset_scale",
-            "scale_shift_min",
-            "scale_shift_max",
-        )
-        normalized_reals = {
-            name: _require_finite_real(getattr(self, name), name) for name in real_fields
+        float_domains: dict[str, dict[str, object]] = {
+            "spectrum_decades": {"lower": 0.0},
+            "mean_separation": {"positive": True},
+            "component_scale": {"lower": 0.0},
+            "class_sparsity": {"positive": True, "upper": 1.0},
+            "noise_scale": {"positive": True},
+            "offset_scale": {"lower": 0.0},
+            "scale_shift_min": {"positive": True},
+            "scale_shift_max": {"positive": True},
         }
-        for name, number in normalized_reals.items():
-            object.__setattr__(self, name, number)
-
-        class_sparsity = normalized_reals["class_sparsity"]
-        if not 0.0 < class_sparsity <= 1.0:
-            raise ValueError(
-                f"class_sparsity must be in (0, 1], got {self.class_sparsity!r}"
+        for name, domain in float_domains.items():
+            canonical = validated_float32_scalar(
+                name,
+                getattr(self, name),
+                **cast(dict[str, Any], domain),
             )
-        for name in ("mean_separation", "noise_scale"):
-            if not normalized_reals[name] > 0.0:
-                raise ValueError(f"{name} must be positive, got {getattr(self, name)!r}")
-        for name in ("offset_scale", "spectrum_decades", "component_scale"):
-            if normalized_reals[name] < 0.0:
-                raise ValueError(
-                    f"{name} must be non-negative, got {getattr(self, name)!r}"
-                )
-        scale_min = normalized_reals["scale_shift_min"]
-        scale_max = normalized_reals["scale_shift_max"]
-        if not 0.0 < scale_min < scale_max:
+            object.__setattr__(self, name, canonical)
+
+        scale_min_sink = float(np.float32(self.scale_shift_min))
+        scale_max_sink = float(np.float32(self.scale_shift_max))
+        if not scale_min_sink < scale_max_sink:
             raise ValueError(
                 "scale_shift bounds must satisfy 0 < scale_shift_min < "
-                f"scale_shift_max, got [{self.scale_shift_min}, {self.scale_shift_max}]"
+                "scale_shift_max after float32 narrowing"
             )
         if self.family == "recurrence":
             if pool > self.n_regimes:
@@ -397,7 +367,24 @@ class MicroStreamConfig:
                     f"recurrence_pool ({pool}) must not exceed n_regimes "
                     f"({self.n_regimes})"
                 )
-        _validate_stream_resources(
+        _require_float32_resource(
+            "GaussianMicroStream outputs", self.materialized_stream_scalars
+        )
+
+    @property
+    def n_steps(self) -> int:
+        """Total online steps in one run."""
+        return self.n_regimes * self.regime_length
+
+    @property
+    def materialized_stream_scalars(self) -> int:
+        """Exact retained scalar count of the materialized stream.
+
+        Every named generation-work array is bounded by one of these returned
+        shapes. Compiler-internal and transient allocator buffers are not part
+        of this persistent-output contract.
+        """
+        return _materialized_stream_scalars(
             n_regimes=self.n_regimes,
             regime_length=self.regime_length,
             dim=self.dim,
@@ -406,9 +393,9 @@ class MicroStreamConfig:
         )
 
     @property
-    def n_steps(self) -> int:
-        """Total online steps in one run."""
-        return self.n_regimes * self.regime_length
+    def materialized_stream_bytes(self) -> int:
+        """Exact retained bytes; every returned leaf is float32 or int32."""
+        return 4 * self.materialized_stream_scalars
 
     def to_config(self) -> dict[str, Any]:
         """JSON-serializable configuration (roundtrips through the constructor)."""
@@ -444,9 +431,17 @@ class MicroStreamConfig:
         if not _is_registered_subclass(type(mapping), Mapping):
             raise ValueError(f"{source} must be an object")
         try:
-            payload = dict(cast(Mapping[str, Any], mapping))
+            items = list(cast(Mapping[object, object], mapping).items())
         except Exception as exc:
-            raise ValueError(f"{source} must be an object") from exc
+            raise ValueError(f"{source} must be a readable object") from exc
+        try:
+            if any(type(key) is not str for key, _ in items):
+                raise ValueError(f"{source} keys must be exact strings")
+            payload = dict(cast(list[tuple[str, Any]], items))
+        except ValueError:
+            raise
+        except Exception as exc:
+            raise ValueError(f"{source} must be a readable object") from exc
         expected = {field.name for field in fields(cls)}
         actual = set(payload)
         if actual != expected:
@@ -725,13 +720,27 @@ def bayes_reference(
     """
     n_samples = _require_positive_int32(n_samples, name="n_samples")
     seed = require_jax_seed(seed, name="seed")
+    chunk_size = min(20_000, n_samples)
+    class_components = config.n_classes * config.n_components
+    # Exact named host-visible arrays retained at the peak of bayes_predict:
+    # geometry + whitened geometry, y/z/eps/x, whitened x, cross/d2,
+    # their norms, scores, and predictions. Expression/compiler temporaries
+    # are intentionally outside this explicitly named work contract.
+    bayes_work_scalars = (
+        2 * class_components * config.dim
+        + config.dim
+        + 3 * chunk_size * config.dim
+        + 2 * chunk_size * class_components
+        + chunk_size * config.n_classes
+        + class_components
+        + 4 * chunk_size
+    )
+    _require_float32_resource(
+        "Bayes-reference named array work",
+        bayes_work_scalars,
+    )
     component_means, dim_sigma = class_geometry(config, seed)
     key = jr.fold_in(jr.key(seed), _BAYES_DOMAIN)
-    chunk_size = 20_000
-    _require_float32_resource(
-        "Bayes-reference chunk work",
-        min(chunk_size, n_samples) * (config.dim + 3),
-    )
     n_correct = 0
     drawn = 0
     chunk_index = 0

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -210,6 +210,12 @@ class TestConfig:
             tiny("scale_shift", scale_shift_min=0.0)
         with pytest.raises(ValueError, match="scale_shift"):
             tiny("scale_shift", scale_shift_min=2.0, scale_shift_max=2.0)
+        with pytest.raises(ValueError, match="float32"):
+            tiny(
+                "scale_shift",
+                scale_shift_min=1.0,
+                scale_shift_max=np.nextafter(1.0, 2.0),
+            )
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -232,9 +238,9 @@ class TestConfig:
             raise AssertionError("JAX allocation ran during config preflight")
 
         monkeypatch.setattr(jnp, "arange", forbidden)
-        # For R=C=K=D=1 the conservative output+work aggregate is 9*n + 15
-        # four-byte scalars. Pin the exact last accepted signed-int32 byte edge.
-        last_legal = ((2**31 - 1) // 4 - 15) // 9
+        # For R=C=K=D=1 the exact returned aggregate is 5*n + 6 four-byte
+        # scalars. Pin its last accepted signed-int32 byte edge without allocating.
+        last_legal = ((2**31 - 1) - 24) // 20
         config = MicroStreamConfig(
             family="input_permutation",
             n_regimes=1,
@@ -245,7 +251,8 @@ class TestConfig:
             component_sparsity=1,
         )
         assert config.n_steps == last_legal
-        with pytest.raises(ValueError, match="outputs and generation work.*byte count"):
+        assert config.materialized_stream_bytes == 20 * last_legal + 24
+        with pytest.raises(ValueError, match="GaussianMicroStream outputs.*byte count"):
             MicroStreamConfig(
                 family="input_permutation",
                 n_regimes=1,
@@ -255,6 +262,16 @@ class TestConfig:
                 n_components=1,
                 component_sparsity=1,
             )
+
+    def test_materialized_stream_accounting_is_exact(self):
+        stream = generate_stream(TINY, seed=0)
+        exact_bytes = sum(
+            int(leaf.size) * int(leaf.dtype.itemsize)
+            for leaf in (
+                getattr(stream, field.name) for field in dataclasses.fields(stream)
+            )
+        )
+        assert exact_bytes == TINY.materialized_stream_bytes
 
     @pytest.mark.parametrize(
         "integer_type",
@@ -321,6 +338,26 @@ class TestConfig:
             with pytest.raises(ValueError, match="n_regimes"):
                 tiny("input_permutation", n_regimes=value)
 
+    def test_float_and_family_hooks_normalize_without_repr(self):
+        class HostileFloat(float):
+            def as_integer_ratio(self) -> tuple[int, int]:
+                raise RuntimeError("ratio hook")
+
+            def __repr__(self) -> str:
+                raise AssertionError("repr hook executed")
+
+        class HostileFamily(str):
+            def __eq__(self, other: object) -> bool:
+                raise AssertionError("equality hook executed")
+
+            def __repr__(self) -> str:
+                raise AssertionError("repr hook executed")
+
+        with pytest.raises(ValueError, match="class_sparsity"):
+            tiny("input_permutation", class_sparsity=HostileFloat(0.5))
+        with pytest.raises(ValueError, match="family"):
+            tiny(HostileFamily("input_permutation"))
+
     def test_public_seed_boundaries_are_exact(self):
         for seed in (True, np.uint32(1), -1, 2**32):
             with pytest.raises(ValueError, match="seed"):
@@ -330,6 +367,27 @@ class TestConfig:
         for value in (True, 1.0, "1", 0, -1, 2**31):
             with pytest.raises(ValueError, match="n_samples"):
                 bayes_reference(TINY, seed=0, n_samples=value)
+
+    def test_bayes_named_work_preflights_before_geometry_allocation(self, monkeypatch):
+        config = MicroStreamConfig(
+            family="input_permutation",
+            n_regimes=1,
+            regime_length=1,
+            dim=1,
+            n_classes=20_000,
+            n_components=1,
+            component_sparsity=1,
+        )
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("geometry allocated before Bayes work preflight")
+
+        monkeypatch.setattr(
+            "alberta_framework.benchmarks.micro_continual.class_geometry",
+            forbidden,
+        )
+        with pytest.raises(ValueError, match="Bayes-reference named array work"):
+            bayes_reference(config, seed=0, n_samples=20_000)
 
     def test_to_config_roundtrip(self):
         rebuilt = MicroStreamConfig(**TINY.to_config())
@@ -400,6 +458,26 @@ class TestConfig:
             MicroStreamConfig.from_mapping(extra)
         with pytest.raises(ValueError, match="stream_config"):
             MicroStreamConfig.from_mapping(["not", "an", "object"])
+
+    def test_from_mapping_normalizes_hostile_hooks_and_requires_exact_keys(self):
+        class HostileMapping(dict[object, object]):
+            def items(self):  # type: ignore[no-untyped-def]
+                raise RuntimeError("items hook")
+
+            def __repr__(self) -> str:
+                raise AssertionError("repr hook executed")
+
+        class StringSubclass(str):
+            pass
+
+        with pytest.raises(ValueError, match="readable object"):
+            MicroStreamConfig.from_mapping(HostileMapping(TINY.to_config()))
+
+        payload: dict[object, object] = dict(TINY.to_config())
+        family = payload.pop("family")
+        payload[StringSubclass("family")] = family
+        with pytest.raises(ValueError, match="exact strings"):
+            MicroStreamConfig.from_mapping(payload)
 
     @pytest.mark.parametrize(
         "field",


### PR DESCRIPTION
Corrective follow-up to merged #808, retaining rama0x1’s original #793 authorship in main.

The merged replacement improved the integer/seed boundary, but its combined “output + generation work” formula mixed non-simultaneous/compiler-transient assumptions while missing the dominant Bayes `chunk × classes × components` tensors. It also left stream scalars validated only in host float64 and allowed string-subclass serialized keys.

This patch:
- exposes and gates the exact retained `GaussianMicroStream` scalar/byte formula; every explicit generation array is individually dominated by a returned shape, while compiler/transient buffers are explicitly outside this persistent-output contract;
- gates the exact named Python-visible Bayes arrays before geometry allocation, including cross/distance score tensors;
- validates every float32-consumed config scalar in both exact and narrowed domains, including cross-field scale bounds after narrowing;
- requires exact serialized string keys and normalizes hostile mapping/scalar hooks without `repr`;
- pins the adjacent exact byte boundary and checks accounting against an actually materialized tiny stream.

Validation on current main:
- `pytest tests/test_micro_continual.py -q` — 211 passed (2 upstream sklearn deprecation warnings)
- config-focused lane — 82 passed
- Ruff clean
- targeted strict mypy clean
- diff check clean

No benchmarks were run and no outputs or registered evidence sources were modified.