### PR TITLE
fix(working-memory): complete resource and state contracts

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -214,6 +214,22 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return number
 
 
+_UINT32_MAX: int = 4294967295
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
@@ -273,6 +289,24 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError(
             f"configuration feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
         )
+    trace_scalars = (
+        observation_dim * len(observation_decay_rates)
+        + action_dim * len(action_decay_rates)
+        + reward_dim * len(reward_decay_rates)
+    )
+    if trace_scalars > _INT32_MAX:
+        raise ValueError("WorkingMemoryConfig dimensions must fit signed int32")
+    total_state_scalars = trace_scalars + 4
+    _require_float32_resource(
+        "WorkingMemoryConfig state",
+        vector_scalars=trace_scalars,
+        fixed_scalars=4,
+    )
+    persistent_bytes = 4 * total_state_scalars
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("working memory allocation exceeds uint32 byte accounting")
 
 
 def _empty_or_vector(value: Array, dim: int) -> Array:

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -11,8 +11,8 @@ updates.
 from __future__ import annotations
 
 import functools
-from collections.abc import Iterator
-from dataclasses import asdict, dataclass
+from collections.abc import Iterator, Mapping
+from dataclasses import asdict, dataclass, fields
 from typing import Any, cast
 
 import chex
@@ -104,10 +104,18 @@ class WorkingMemoryConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> WorkingMemoryConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> WorkingMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
-        payload.pop("type", None)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("WorkingMemoryConfig payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("WorkingMemoryConfig mapping could not be read") from error
+        if payload.pop("type", None) != "WorkingMemoryConfig":
+            raise ValueError("WorkingMemoryConfig type is invalid")
+        if set(payload) != {field.name for field in fields(cls)}:
+            raise ValueError("WorkingMemoryConfig fields do not match its schema")
         for key in (
             "observation_decay_rates",
             "action_decay_rates",
@@ -119,6 +127,24 @@ class WorkingMemoryConfig:
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                if any(type(item) is not float for item in payload[key]):
+                    raise ValueError(f"serialized {key} values must be JSON numbers")
+        for key in ("observation_dim", "action_dim", "reward_dim"):
+            if type(payload[key]) is not int:
+                raise ValueError(f"serialized {key} must be a JSON integer")
+        for key in (
+            "include_current_observation",
+            "include_current_action",
+            "include_current_reward",
+            "include_traces",
+            "include_innovations",
+            "gated_update",
+        ):
+            if type(payload[key]) is not bool:
+                raise ValueError(f"serialized {key} must be a JSON boolean")
+        for key in ("gate_threshold", "gate_temperature"):
+            if type(payload[key]) is not float:
+                raise ValueError(f"serialized {key} must be a JSON number")
         return cls(**payload)
 
 
@@ -190,6 +216,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -230,6 +257,13 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _require_sequence_resource(name: str, *, float32_scalars: int, bool_scalars: int) -> None:
+    if float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
@@ -262,7 +296,7 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         "gate_threshold", config.gate_threshold, lower=0.0
     )
     gate_temperature = validated_float32_scalar(
-        "gate_temperature", config.gate_temperature, positive=True
+        "gate_temperature", config.gate_temperature, lower=_FLOAT32_MIN_NORMAL
     )
     for name in (
         "include_current_observation",
@@ -378,9 +412,66 @@ class WorkingMemoryFeaturizer:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> WorkingMemoryFeaturizer:
+    def from_config(cls, config: Mapping[str, Any]) -> WorkingMemoryFeaturizer:
         """Reconstruct a featurizer from :meth:`to_config` output."""
-        return cls(WorkingMemoryConfig.from_config(dict(config["config"])))
+        if not issubclass(type(config), Mapping):
+            raise ValueError("WorkingMemoryFeaturizer payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("WorkingMemoryFeaturizer mapping could not be read") from error
+        if set(payload) != {"type", "config"}:
+            raise ValueError("WorkingMemoryFeaturizer fields do not match its schema")
+        if payload["type"] != "WorkingMemoryFeaturizer":
+            raise ValueError("WorkingMemoryFeaturizer type is invalid")
+        inner = payload["config"]
+        if not issubclass(type(inner), Mapping):
+            raise ValueError("WorkingMemoryFeaturizer config must be a mapping")
+        return cls(WorkingMemoryConfig.from_config(cast(Mapping[str, Any], inner)))
+
+    def _validate_state_static_contract(self, state: WorkingMemoryState) -> None:
+        """Reject malformed adopted state before traced computation."""
+        if type(state) is not WorkingMemoryState:
+            raise TypeError("state must be a WorkingMemoryState")
+        cfg = self._config
+        expected = (
+            (
+                "state.observation_traces",
+                state.observation_traces,
+                (len(cfg.observation_decay_rates), cfg.observation_dim),
+                jnp.float32,
+            ),
+            (
+                "state.action_traces",
+                state.action_traces,
+                (len(cfg.action_decay_rates), cfg.action_dim),
+                jnp.float32,
+            ),
+            (
+                "state.reward_traces",
+                state.reward_traces,
+                (len(cfg.reward_decay_rates), cfg.reward_dim),
+                jnp.float32,
+            ),
+            ("state.step_count", state.step_count, (), jnp.int32),
+            ("state.last_gate", state.last_gate, (3,), jnp.float32),
+        )
+        for name, value, shape, dtype in expected:
+            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+                raise TypeError(f"{name} must expose array shape and dtype metadata")
+            if tuple(value.shape) != shape:
+                raise ValueError(f"{name} must have shape {shape}; got {tuple(value.shape)}")
+            if jnp.dtype(value.dtype) != jnp.dtype(dtype):
+                raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
+
+    @staticmethod
+    def _state_is_valid(state: WorkingMemoryState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & (state.step_count >= 0)
+            & jnp.all(state.last_gate >= 0.0)
+            & jnp.all(state.last_gate <= 1.0)
+        )
 
     def init(self) -> WorkingMemoryState:
         """Return an all-zero memory state."""
@@ -443,6 +534,7 @@ class WorkingMemoryFeaturizer:
         reward: Float[Array, " reward_dim"],
     ) -> Float[Array, " feature_dim"]:
         """Return current working-memory features without advancing state."""
+        self._validate_state_static_contract(state)
         cfg = self._config
         obs = _empty_or_vector(observation, cfg.observation_dim)
         act = _empty_or_vector(action, cfg.action_dim)
@@ -482,11 +574,16 @@ class WorkingMemoryFeaturizer:
         external_gate: Float[Array, ""] | float = 1.0,
     ) -> WorkingMemoryUpdateResult:
         """Advance one event and report whether the transaction committed."""
+        self._validate_state_static_contract(state)
         cfg = self._config
         obs = _empty_or_vector(observation, cfg.observation_dim)
         act = _empty_or_vector(action, cfg.action_dim)
         rew = _empty_or_vector(reward, cfg.reward_dim)
         raw_outer_gate = jnp.asarray(external_gate, dtype=jnp.float32)
+        if raw_outer_gate.shape != ():
+            raise ValueError(
+                f"external_gate must have scalar shape (); got {raw_outer_gate.shape}"
+            )
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
             & jnp.all(jnp.isfinite(act))
@@ -538,7 +635,11 @@ class WorkingMemoryFeaturizer:
                 cfg.reward_decay_rates,
                 reward_gate,
             ),
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(
+                state.step_count,
+                jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32),
+            )
+            + jnp.asarray(1, dtype=jnp.int32),
             last_gate=jnp.stack([observation_gate, action_gate, reward_gate]),
         )
         previous_checked = state
@@ -556,8 +657,8 @@ class WorkingMemoryFeaturizer:
             )
         update_applied = (
             inputs_valid
-            & floating_tree_is_finite(previous_checked)
-            & floating_tree_is_finite(candidate)
+            & self._state_is_valid(previous_checked)
+            & self._state_is_valid(candidate)
         )
         return WorkingMemoryUpdateResult(
             state=select_transaction(update_applied, candidate, state),
@@ -609,6 +710,7 @@ class WorkingMemoryFeaturizer:
     @functools.partial(jax.jit, static_argnums=(0,))
     def diagnostics(self, state: WorkingMemoryState) -> WorkingMemoryDiagnostics:
         """Return memory energy, participation-ratio dimension, and gates."""
+        self._validate_state_static_contract(state)
         flat = _flatten_traces(state)
         return WorkingMemoryDiagnostics(
             step_count=state.step_count,
@@ -653,8 +755,14 @@ def transform_working_memory_arrays(
             "observations/actions/rewards leading dims must match "
             f"(got {_obs.shape[0]}, {_act.shape[0]}, {_rew.shape[0]})"
         )
+    _require_sequence_resource(
+        "working memory transform outputs",
+        float32_scalars=int(steps) * cfg.feature_dim(),
+        bool_scalars=int(steps),
+    )
     if state is None:
         state = featurizer.init()
+    featurizer._validate_state_static_contract(state)
     gates = (
         jnp.ones((steps,), dtype=jnp.float32)
         if external_gates is None

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -1,0 +1,252 @@
+"""Validation hardening for working memory (int/float/bool bounds + resource)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.working_memory import WorkingMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides):
+    cfg = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        "reward_dim": 1,
+    }
+    cfg.update(overrides)
+    return WorkingMemoryConfig(**cfg)
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(observation_dim=v),
+        lambda v: _base_cfg(action_dim=v),
+        lambda v: _base_cfg(reward_dim=v),
+    ],
+)
+def test_working_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(observation_dim=v),
+        lambda v: _base_cfg(action_dim=v),
+    ],
+)
+def test_working_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_working_int_validators_canonicalize_numpy_scalars(np_type: type) -> None:
+    cfg = _base_cfg(
+        observation_dim=np_type(4),
+        action_dim=np_type(2),
+        reward_dim=np_type(2),
+    )
+    assert cfg.observation_dim == 4
+    assert cfg.action_dim == 2
+    assert cfg.reward_dim == 2
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.action_dim) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1, 10**100],
+)
+def test_working_observation_dim_rejects_non_integer_and_out_of_range(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(observation_dim=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [True, np.bool_(True), 4.0, "4", None, -1, _INT32_MAX + 1])
+def test_working_action_reward_rejects_non_integer_and_out_of_range(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(action_dim=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(reward_dim=value)  # type: ignore[arg-type]
+
+
+def test_working_decay_rates_reject_not_tuple() -> None:
+    with pytest.raises(ValueError, match="must be an actual tuple"):
+        _base_cfg(observation_decay_rates=[0.5])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an actual tuple"):
+        _base_cfg(action_decay_rates="0.5")  # type: ignore[arg-type]
+
+
+def test_working_decay_rates_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("ratio hook")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.5
+
+    for bad in [float("nan"), float("inf"), -0.1, 1.0, 2.0, HostileFloat(0.5), ClassSpoof()]:
+        with pytest.raises(ValueError):
+            _base_cfg(observation_decay_rates=(bad,))  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            _base_cfg(action_decay_rates=(bad,))  # type: ignore[arg-type]
+
+
+def test_working_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("ratio hook")
+
+    for field, bad in [
+        ("gate_threshold", float("nan")),
+        ("gate_threshold", float("inf")),
+        ("gate_threshold", -0.1),
+        ("gate_threshold", HostileFloat(0.5)),
+        ("gate_temperature", 0.0),
+        ("gate_temperature", -1.0),
+        ("gate_temperature", float("nan")),
+        ("gate_temperature", float("inf")),
+        ("gate_temperature", HostileFloat(0.5)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_working_bool_exact_type() -> None:
+    for field in [
+        "include_current_observation",
+        "include_current_action",
+        "include_current_reward",
+        "include_traces",
+        "include_innovations",
+        "gated_update",
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: 1})  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: np.bool_(True)})  # type: ignore[arg-type]
+
+
+def test_working_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(gate_threshold=0.0, gate_temperature=1.0)
+    assert cfg.gate_threshold == pytest.approx(0.0)
+    cfg2 = _base_cfg(
+        observation_decay_rates=(0.5, 0.9),
+        action_decay_rates=(0.5,),
+        reward_decay_rates=(0.9,),
+    )
+    assert cfg2.observation_decay_rates == (0.5, 0.9)
+
+
+def test_working_dimensions_preflight_without_allocation() -> None:
+    # Single product overflow: observation_dim * len > INT32
+    # Use len=3 default, so need obs_dim > INT32//3
+    big = _INT32_MAX // 3 + 10
+    with pytest.raises(
+        ValueError,
+        match="dimensions must fit signed|scalar count|byte count|configuration feature_dim",
+    ):
+        _base_cfg(observation_dim=big)
+    # Scalar count via trace_scalars overflow
+    with pytest.raises(
+        ValueError,
+        match="dimensions must fit signed|scalar count|byte count|configuration feature_dim",
+    ):
+        _base_cfg(observation_dim=_INT32_MAX, action_dim=1, reward_dim=1)
+
+
+def test_working_state_preflight_bytes_without_allocation() -> None:
+    # Minimal custom decays to make math tractable: len_obs=3 default
+    # Use observation_dim variation with other dims 0 to isolate
+    # With obs_dim variable, trace = 3*obs, total_state=3*obs+4, byte=12*obs+16
+    last_legal = (_INT32_MAX - 16) // 12
+    # Need to set action/reward 0 to keep trace minimal
+    cfg = WorkingMemoryConfig(
+        observation_dim=last_legal,
+        action_dim=0,
+        reward_dim=0,
+        observation_decay_rates=(0.5, 0.9, 0.99),
+        action_decay_rates=(),
+        reward_decay_rates=(),
+    )
+    assert cfg.observation_dim == last_legal
+    with pytest.raises(ValueError, match="byte count"):
+        WorkingMemoryConfig(
+            observation_dim=last_legal + 1,
+            action_dim=0,
+            reward_dim=0,
+            observation_decay_rates=(0.5, 0.9, 0.99),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+        )
+    # Non-minimal should also be allocation-free
+    with pytest.raises(ValueError, match="byte count|scalar count|dimensions"):
+        _base_cfg(
+            observation_dim=200_000_000,
+            action_dim=200_000_000,
+            reward_dim=200_000_000,
+        )
+
+
+def test_working_state_preflight_feature_dim_boundary() -> None:
+    # Feature dim boundary with default config (obs=2, act=1, rew=1)
+    # Just ensure large dims overflow
+    with pytest.raises(
+        ValueError,
+        match="configuration feature_dim|byte count|scalar count|dimensions",
+    ):
+        _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
+import dataclasses
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
+
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.core.working_memory import WorkingMemoryConfig
+from alberta_framework.core.working_memory import (
+    WorkingMemoryConfig,
+    WorkingMemoryFeaturizer,
+    transform_working_memory_arrays,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -250,3 +260,143 @@ def test_working_state_preflight_feature_dim_boundary() -> None:
         match="configuration feature_dim|byte count|scalar count|dimensions",
     ):
         _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)
+
+
+def test_working_serialized_schema_preserves_only_exact_list_tuple_compatibility() -> None:
+    config = _base_cfg()
+    payload = config.to_config()
+    payload["observation_decay_rates"] = tuple(payload["observation_decay_rates"])
+    assert WorkingMemoryConfig.from_config(MappingProxyType(payload)) == config
+
+    for mutation, match in (
+        ({"type": "OtherConfig"}, "type"),
+        ({"observation_dim": np.int32(2)}, "observation_dim"),
+        ({"gate_threshold": np.float32(0.0)}, "gate_threshold"),
+        ({"include_traces": 1}, "include_traces"),
+        ({"observation_decay_rates": [np.float32(0.5)]}, "JSON numbers"),
+        ({"extra": 1}, "fields"),
+    ):
+        invalid = config.to_config()
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            WorkingMemoryConfig.from_config(invalid)
+    missing = config.to_config()
+    missing.pop("gate_temperature")
+    with pytest.raises(ValueError, match="fields"):
+        WorkingMemoryConfig.from_config(missing)
+
+
+def test_working_mapping_hooks_are_normalized_without_class_spoofing() -> None:
+    class HostileMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError("getitem hook")
+
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError("iteration hook")
+
+        def __len__(self) -> int:
+            return 1
+
+    class MappingSpoof:
+        @property
+        def __class__(self) -> type:
+            return dict
+
+        def __iter__(self) -> object:
+            raise AssertionError("iteration hook executed")
+
+    for loader in (WorkingMemoryConfig.from_config, WorkingMemoryFeaturizer.from_config):
+        with pytest.raises(ValueError, match="mapping"):
+            loader(HostileMapping())
+        with pytest.raises(ValueError, match="mapping"):
+            loader(MappingSpoof())  # type: ignore[arg-type]
+
+
+def test_working_featurizer_serialized_envelope_is_exact() -> None:
+    memory = WorkingMemoryFeaturizer(_base_cfg())
+    payload = memory.to_config()
+    assert WorkingMemoryFeaturizer.from_config(MappingProxyType(payload)).config == memory.config
+    with pytest.raises(ValueError, match="type"):
+        WorkingMemoryFeaturizer.from_config({**payload, "type": "OtherFeaturizer"})
+    with pytest.raises(ValueError, match="fields"):
+        WorkingMemoryFeaturizer.from_config({**payload, "extra": 1})
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "match"),
+    [
+        ("observation_traces", jnp.zeros((3, 1), dtype=jnp.float32), "observation_traces"),
+        ("action_traces", jnp.zeros((2, 1), dtype=jnp.float16), "action_traces"),
+        ("reward_traces", jnp.zeros((2,), dtype=jnp.float32), "reward_traces"),
+        ("step_count", jnp.zeros((1,), dtype=jnp.int32), "step_count"),
+        ("last_gate", jnp.zeros((1, 3), dtype=jnp.float32), "last_gate"),
+    ],
+)
+def test_working_public_methods_reject_malformed_state_static_contract(
+    field: str, replacement: jax.Array, match: str
+) -> None:
+    memory = WorkingMemoryFeaturizer(_base_cfg())
+    state = dataclasses.replace(memory.init(), **{field: replacement})
+    args = (state, jnp.zeros((2,)), jnp.zeros((1,)), jnp.zeros((1,)))
+    for call in (
+        lambda: memory.features(*args),
+        lambda: memory.update_checked(*args),
+        lambda: memory.step(*args),
+        lambda: jax.jit(memory.update_checked)(*args),
+    ):
+        with pytest.raises((TypeError, ValueError), match=match):
+            call()
+
+
+def test_working_invalid_state_rolls_back_and_lifetime_counter_saturates() -> None:
+    memory = WorkingMemoryFeaturizer(_base_cfg())
+    args = (jnp.zeros((2,)), jnp.zeros((1,)), jnp.zeros((1,)))
+    invalid = dataclasses.replace(
+        memory.init(),
+        step_count=jnp.asarray(-1, dtype=jnp.int32),
+    )
+    rejected = memory.update_checked(invalid, *args)
+    assert not bool(rejected.update_applied)
+    assert int(rejected.state.step_count) == -1
+
+    maximum = dataclasses.replace(
+        memory.init(),
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    accepted = memory.update_checked(maximum, *args)
+    assert bool(accepted.update_applied)
+    assert int(accepted.state.step_count) == _INT32_MAX
+    with pytest.raises(ValueError, match="external_gate"):
+        memory.update_checked(memory.init(), *args, external_gate=jnp.ones((1,)))
+
+
+def test_working_transform_preflights_output_bytes_without_allocation() -> None:
+    memory = WorkingMemoryFeaturizer(
+        WorkingMemoryConfig(
+            observation_dim=1,
+            action_dim=0,
+            reward_dim=0,
+            observation_decay_rates=(),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+            include_current_action=False,
+            include_current_reward=False,
+            include_traces=False,
+        )
+    )
+    first_overflow = _INT32_MAX // 5 + 1
+    observations = jax.ShapeDtypeStruct((first_overflow, 1), jnp.float32)
+    empty = jax.ShapeDtypeStruct((first_overflow, 0), jnp.float32)
+    with pytest.raises(ValueError, match="byte count"):
+        jax.eval_shape(
+            lambda obs, zero: transform_working_memory_arrays(memory, obs, zero, zero),
+            observations,
+            empty,
+        )
+
+
+def test_working_gate_temperature_must_be_positive_normal_float32() -> None:
+    minimum_normal = float.fromhex("0x1.0p-126")
+    assert _base_cfg(gate_temperature=minimum_normal).gate_temperature == minimum_normal
+    with pytest.raises(ValueError, match="gate_temperature"):
+        _base_cfg(gate_temperature=float.fromhex("0x1.0p-149"))


### PR DESCRIPTION
Supersedes #812 while preserving byt61’s contributor commit and authorship.

Retains the correct derived persistent-state allocation preflight and completes the public contract: genuine Mapping/MappingProxy compatibility with normalized hostile hooks; exact config/featurizer markers, fields, JSON scalars, and the established exact-list-or-tuple decay compatibility from #692/#708; positive-normal gate temperature; exact adopted-state shape/dtype gates; dynamic state invariants and invalid-state rollback; saturating int32 lifetime accounting; exact scalar external gates; and transform-output scalar/byte preflight.

Checks after latest-main rebase: 151 focused working-memory tests; Ruff; strict targeted mypy; diff check. No outputs/evidence changes.