### PR TITLE
fix(working-memory): complete public resource contracts

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -214,6 +214,22 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return number
 
 
+_UINT32_MAX: int = 4294967295
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
@@ -273,6 +289,24 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError(
             f"configuration feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
         )
+    trace_scalars = (
+        observation_dim * len(observation_decay_rates)
+        + action_dim * len(action_decay_rates)
+        + reward_dim * len(reward_decay_rates)
+    )
+    if trace_scalars > _INT32_MAX:
+        raise ValueError("WorkingMemoryConfig dimensions must fit signed int32")
+    total_state_scalars = trace_scalars + 4
+    _require_float32_resource(
+        "WorkingMemoryConfig state",
+        vector_scalars=trace_scalars,
+        fixed_scalars=4,
+    )
+    persistent_bytes = 4 * total_state_scalars
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("working memory allocation exceeds uint32 byte accounting")
 
 
 def _empty_or_vector(value: Array, dim: int) -> Array:

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -214,9 +214,6 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return number
 
 
-_UINT32_MAX: int = 4294967295
-
-
 def _require_float32_resource(
     name: str,
     *,
@@ -228,6 +225,16 @@ def _require_float32_resource(
         raise ValueError(f"{name} scalar count must fit signed int32")
     if 4 * total_scalars > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _preflight_array_transform_resources(steps: int, feature_dim: int) -> None:
+    """Bound returned scan arrays and the default gate workspace."""
+    feature_scalars = steps * feature_dim
+    if feature_scalars > _INT32_MAX:
+        raise ValueError("working-memory array output scalar count must fit signed int32")
+    # float32 features, bool verdicts, and the possible default float32 gate vector.
+    if 4 * feature_scalars + 5 * steps > _INT32_MAX:
+        raise ValueError("working-memory array output byte count must fit signed int32")
 
 
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
@@ -289,6 +296,13 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError(
             f"configuration feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
         )
+    for name, dimension in (
+        ("observation vector", observation_dim),
+        ("action vector", action_dim),
+        ("reward vector", reward_dim),
+        ("working-memory feature output", feature_dim),
+    ):
+        _require_float32_resource(name, vector_scalars=dimension)
     trace_scalars = (
         observation_dim * len(observation_decay_rates)
         + action_dim * len(action_decay_rates)
@@ -296,17 +310,11 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     )
     if trace_scalars > _INT32_MAX:
         raise ValueError("WorkingMemoryConfig dimensions must fit signed int32")
-    total_state_scalars = trace_scalars + 4
     _require_float32_resource(
         "WorkingMemoryConfig state",
         vector_scalars=trace_scalars,
         fixed_scalars=4,
     )
-    persistent_bytes = 4 * total_state_scalars
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
-    if persistent_bytes > _UINT32_MAX:
-        raise ValueError("working memory allocation exceeds uint32 byte accounting")
 
 
 def _empty_or_vector(value: Array, dim: int) -> Array:
@@ -538,7 +546,11 @@ class WorkingMemoryFeaturizer:
                 cfg.reward_decay_rates,
                 reward_gate,
             ),
-            step_count=state.step_count + 1,
+            step_count=jnp.where(
+                state.step_count < _INT32_MAX,
+                state.step_count + 1,
+                state.step_count,
+            ),
             last_gate=jnp.stack([observation_gate, action_gate, reward_gate]),
         )
         previous_checked = state
@@ -653,6 +665,7 @@ def transform_working_memory_arrays(
             "observations/actions/rewards leading dims must match "
             f"(got {_obs.shape[0]}, {_act.shape[0]}, {_rew.shape[0]})"
         )
+    _preflight_array_transform_resources(steps, cfg.feature_dim())
     if state is None:
         state = featurizer.init()
     gates = (

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -561,9 +561,10 @@ def test_config_rejects_derived_feature_dimension_above_int32() -> None:
         WorkingMemoryConfig(observation_dim=2**31 - 1)
 
 
-def test_config_accepts_exact_int32_max_derived_feature_dimension() -> None:
+def test_config_feature_byte_boundary_is_allocation_free() -> None:
+    last_valid = (2**31 - 1) // 4
     config = WorkingMemoryConfig(
-        observation_dim=2**31 - 1,
+        observation_dim=last_valid,
         action_dim=0,
         reward_dim=0,
         observation_decay_rates=(),
@@ -574,7 +575,32 @@ def test_config_accepts_exact_int32_max_derived_feature_dimension() -> None:
         include_traces=False,
     )
 
-    assert config.feature_dim() == 2**31 - 1
+    assert config.feature_dim() == last_valid
+    with pytest.raises(ValueError, match="feature output byte count"):
+        WorkingMemoryConfig(
+            observation_dim=last_valid,
+            action_dim=1,
+            reward_dim=0,
+            observation_decay_rates=(),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+            include_current_action=True,
+            include_current_reward=False,
+            include_traces=False,
+        )
+
+
+def test_working_memory_step_count_saturates_at_int32_max() -> None:
+    memory = WorkingMemoryFeaturizer(_minimal_config())
+    state = memory.init().replace(step_count=jnp.array(2**31 - 1, dtype=jnp.int32))
+    result = memory.update_checked(
+        state,
+        jnp.ones((2,), dtype=jnp.float32),
+        jnp.empty((0,), dtype=jnp.float32),
+        jnp.empty((0,), dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
 
 
 @pytest.mark.parametrize("method", ["features", "update_checked", "step"])

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from alberta_framework.core.working_memory import WorkingMemoryConfig
+from alberta_framework.core.working_memory import (
+    WorkingMemoryConfig,
+    _preflight_array_transform_resources,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -222,6 +225,7 @@ def test_working_state_preflight_bytes_without_allocation() -> None:
         observation_decay_rates=(0.5, 0.9, 0.99),
         action_decay_rates=(),
         reward_decay_rates=(),
+        include_current_observation=False,
     )
     assert cfg.observation_dim == last_legal
     with pytest.raises(ValueError, match="byte count"):
@@ -232,6 +236,7 @@ def test_working_state_preflight_bytes_without_allocation() -> None:
             observation_decay_rates=(0.5, 0.9, 0.99),
             action_decay_rates=(),
             reward_decay_rates=(),
+            include_current_observation=False,
         )
     # Non-minimal should also be allocation-free
     with pytest.raises(ValueError, match="byte count|scalar count|dimensions"):
@@ -250,3 +255,26 @@ def test_working_state_preflight_feature_dim_boundary() -> None:
         match="configuration feature_dim|byte count|scalar count|dimensions",
     ):
         _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)
+
+
+def test_unused_signal_vector_still_fits_public_zero_allocation() -> None:
+    with pytest.raises(ValueError, match="action vector byte count"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            action_dim=_INT32_MAX // 4 + 1,
+            reward_dim=0,
+            observation_decay_rates=(),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+            include_current_action=False,
+            include_current_reward=False,
+            include_traces=False,
+        )
+
+
+def test_array_transform_output_boundary_is_allocation_free() -> None:
+    feature_dim = 1
+    last_valid = _INT32_MAX // (4 * feature_dim + 5)
+    _preflight_array_transform_resources(last_valid, feature_dim)
+    with pytest.raises(ValueError, match="array output byte count"):
+        _preflight_array_transform_resources(last_valid + 1, feature_dim)

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -1,0 +1,252 @@
+"""Validation hardening for working memory (int/float/bool bounds + resource)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.working_memory import WorkingMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides):
+    cfg = {
+        "observation_dim": 2,
+        "action_dim": 1,
+        "reward_dim": 1,
+    }
+    cfg.update(overrides)
+    return WorkingMemoryConfig(**cfg)
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(observation_dim=v),
+        lambda v: _base_cfg(action_dim=v),
+        lambda v: _base_cfg(reward_dim=v),
+    ],
+)
+def test_working_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(observation_dim=v),
+        lambda v: _base_cfg(action_dim=v),
+    ],
+)
+def test_working_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_working_int_validators_canonicalize_numpy_scalars(np_type: type) -> None:
+    cfg = _base_cfg(
+        observation_dim=np_type(4),
+        action_dim=np_type(2),
+        reward_dim=np_type(2),
+    )
+    assert cfg.observation_dim == 4
+    assert cfg.action_dim == 2
+    assert cfg.reward_dim == 2
+    assert type(cfg.observation_dim) is int
+    assert type(cfg.action_dim) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1, 10**100],
+)
+def test_working_observation_dim_rejects_non_integer_and_out_of_range(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(observation_dim=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [True, np.bool_(True), 4.0, "4", None, -1, _INT32_MAX + 1])
+def test_working_action_reward_rejects_non_integer_and_out_of_range(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(action_dim=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be"):
+        _base_cfg(reward_dim=value)  # type: ignore[arg-type]
+
+
+def test_working_decay_rates_reject_not_tuple() -> None:
+    with pytest.raises(ValueError, match="must be an actual tuple"):
+        _base_cfg(observation_decay_rates=[0.5])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an actual tuple"):
+        _base_cfg(action_decay_rates="0.5")  # type: ignore[arg-type]
+
+
+def test_working_decay_rates_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("ratio hook")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.5
+
+    for bad in [float("nan"), float("inf"), -0.1, 1.0, 2.0, HostileFloat(0.5), ClassSpoof()]:
+        with pytest.raises(ValueError):
+            _base_cfg(observation_decay_rates=(bad,))  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            _base_cfg(action_decay_rates=(bad,))  # type: ignore[arg-type]
+
+
+def test_working_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("ratio hook")
+
+    for field, bad in [
+        ("gate_threshold", float("nan")),
+        ("gate_threshold", float("inf")),
+        ("gate_threshold", -0.1),
+        ("gate_threshold", HostileFloat(0.5)),
+        ("gate_temperature", 0.0),
+        ("gate_temperature", -1.0),
+        ("gate_temperature", float("nan")),
+        ("gate_temperature", float("inf")),
+        ("gate_temperature", HostileFloat(0.5)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_working_bool_exact_type() -> None:
+    for field in [
+        "include_current_observation",
+        "include_current_action",
+        "include_current_reward",
+        "include_traces",
+        "include_innovations",
+        "gated_update",
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: 1})  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: np.bool_(True)})  # type: ignore[arg-type]
+
+
+def test_working_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(gate_threshold=0.0, gate_temperature=1.0)
+    assert cfg.gate_threshold == pytest.approx(0.0)
+    cfg2 = _base_cfg(
+        observation_decay_rates=(0.5, 0.9),
+        action_decay_rates=(0.5,),
+        reward_decay_rates=(0.9,),
+    )
+    assert cfg2.observation_decay_rates == (0.5, 0.9)
+
+
+def test_working_dimensions_preflight_without_allocation() -> None:
+    # Single product overflow: observation_dim * len > INT32
+    # Use len=3 default, so need obs_dim > INT32//3
+    big = _INT32_MAX // 3 + 10
+    with pytest.raises(
+        ValueError,
+        match="dimensions must fit signed|scalar count|byte count|configuration feature_dim",
+    ):
+        _base_cfg(observation_dim=big)
+    # Scalar count via trace_scalars overflow
+    with pytest.raises(
+        ValueError,
+        match="dimensions must fit signed|scalar count|byte count|configuration feature_dim",
+    ):
+        _base_cfg(observation_dim=_INT32_MAX, action_dim=1, reward_dim=1)
+
+
+def test_working_state_preflight_bytes_without_allocation() -> None:
+    # Minimal custom decays to make math tractable: len_obs=3 default
+    # Use observation_dim variation with other dims 0 to isolate
+    # With obs_dim variable, trace = 3*obs, total_state=3*obs+4, byte=12*obs+16
+    last_legal = (_INT32_MAX - 16) // 12
+    # Need to set action/reward 0 to keep trace minimal
+    cfg = WorkingMemoryConfig(
+        observation_dim=last_legal,
+        action_dim=0,
+        reward_dim=0,
+        observation_decay_rates=(0.5, 0.9, 0.99),
+        action_decay_rates=(),
+        reward_decay_rates=(),
+    )
+    assert cfg.observation_dim == last_legal
+    with pytest.raises(ValueError, match="byte count"):
+        WorkingMemoryConfig(
+            observation_dim=last_legal + 1,
+            action_dim=0,
+            reward_dim=0,
+            observation_decay_rates=(0.5, 0.9, 0.99),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+        )
+    # Non-minimal should also be allocation-free
+    with pytest.raises(ValueError, match="byte count|scalar count|dimensions"):
+        _base_cfg(
+            observation_dim=200_000_000,
+            action_dim=200_000_000,
+            reward_dim=200_000_000,
+        )
+
+
+def test_working_state_preflight_feature_dim_boundary() -> None:
+    # Feature dim boundary with default config (obs=2, act=1, rew=1)
+    # Just ensure large dims overflow
+    with pytest.raises(
+        ValueError,
+        match="configuration feature_dim|byte count|scalar count|dimensions",
+    ):
+        _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)


### PR DESCRIPTION
Supersedes #812 while preserving its contributor commit and authorship. The original trace-state preflight is valid but incomplete: its accepted boundary can still allocate a >2 GiB feature vector, unused signal dimensions can allocate oversized zero vectors, batched transform outputs were unbounded, and step_count wrapped at int32 max. This successor retains exact scalar/state checks, removes redundant unreachable uint32 accounting, bounds every signal vector, feature output, trace state, and batch output/default-gate workspace in signed-int32 scalar/byte domains, and saturates step_count. Adds allocation-free exact boundary/adjacent tests. Validation after rebase to current main: 143 focused tests passed; Ruff, strict mypy, root imports, and diff check passed.