### PR TITLE
fix(closed-loop): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="call-arg"
+# mypy: disable-error-code="call-arg,attr-defined"
 """Closed-loop micro-MDPs where actions affect observations.
 
 Every other stream in this package is open-loop: the observation sequence is
@@ -37,9 +37,10 @@ The state and config records are immutable chex dataclasses.
 from __future__ import annotations
 
 import itertools
+import operator
 from fractions import Fraction
 from numbers import Integral, Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -63,6 +64,8 @@ RIGHT_ACTION = 1
 _TWO_STATE_N = 2
 _TWO_STATE_ACTIONS = 2
 _INT32_MAX = 2**31 - 1
+_MAX_RIVERSWIM_PERSISTENT_BYTES = 64 * 1024 * 1024
+_MAX_EXACT_POLICY_STATES = 12
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_TINY_RATIO = _FLOAT32_TINY.as_integer_ratio()
 _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
@@ -81,6 +84,60 @@ _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
     np.float64,
     np.longdouble,
 )
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    """Canonicalize supported concrete integers without invoking hostile hooks."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _riverswim_persistent_resources(n_states: int) -> dict[str, int]:
+    """Return the exact resident NumPy+JAX array envelope before allocation."""
+    transition_scalars = 2 * n_states * n_states
+    reward_scalars = 2 * n_states
+    persistent_scalars = 2 * (transition_scalars + reward_scalars)
+    persistent_bytes = 4 * persistent_scalars
+    if persistent_scalars > _INT32_MAX:
+        raise ValueError("derived RiverSwim persistent scalars must fit signed int32")
+    if persistent_bytes > _MAX_RIVERSWIM_PERSISTENT_BYTES:
+        raise ValueError(
+            "derived RiverSwim persistent bytes exceed the 64 MiB micro-MDP budget"
+        )
+    return {
+        "transition_scalars": transition_scalars,
+        "reward_scalars": reward_scalars,
+        "persistent_scalars": persistent_scalars,
+        "persistent_bytes": persistent_bytes,
+    }
+
+
+def _saturating_step_count(step_count: Array) -> Array:
+    counter = jnp.asarray(step_count, dtype=jnp.int32)
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(counter, 0), maximum - 1) + 1
+
+
+def _validate_state_contract(
+    name: str, state: object, *, expected_type: type[object]
+) -> None:
+    """Validate the immutable public state's static JAX boundary contract."""
+    if type(state) is not expected_type:
+        raise TypeError(f"{name} must be an actual {expected_type.__name__}")
+    record = cast(Any, state)
+    for field_name in ("state_index", "step_count"):
+        value = jnp.asarray(getattr(record, field_name))
+        if value.shape != ():
+            raise ValueError(f"{name}.{field_name} must be scalar")
+        if value.dtype != jnp.dtype(jnp.int32):
+            raise TypeError(f"{name}.{field_name} must have dtype int32")
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -227,16 +284,12 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        if (
-            isinstance(config.phase_length, bool)
-            or not isinstance(config.phase_length, int)
-            or config.phase_length < 1
-            or config.phase_length > _INT32_MAX
-        ):
+        try:
+            phase_length = _require_int32("phase_length", config.phase_length, minimum=1)
+        except ValueError:
             raise ValueError(
-                "phase_length must be a positive integer in "
-                f"[1, {_INT32_MAX}], got {config.phase_length!r}"
-            )
+                f"phase_length must be a positive integer in [1, {_INT32_MAX}]"
+            ) from None
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -246,8 +299,9 @@ class SwitchingTwoStateMDP:
                 raise ValueError(f"{name} must contain only finite values, got {payoff.tolist()}")
             phase_payoffs.append(payoff)
         payoffs = np.stack(phase_payoffs)
+        config = cast(SwitchingTwoStateConfig, config.replace(phase_length=phase_length))
         self._config = config
-        self._phase_length = int(config.phase_length)
+        self._phase_length = phase_length
         self._payoffs_np = payoffs
         self._payoffs = jnp.asarray(payoffs)
 
@@ -284,6 +338,9 @@ class SwitchingTwoStateMDP:
     def phase_id(self, state: SwitchingTwoStateState) -> Array:
         """Return the active reward phase (``PHASE_A`` or ``PHASE_B``)."""
 
+        _validate_state_contract(
+            "state", state, expected_type=SwitchingTwoStateState
+        )
         segment = jnp.floor_divide(state.step_count, self._phase_length)
         return jnp.mod(segment, 2).astype(jnp.int32)
 
@@ -298,6 +355,9 @@ class SwitchingTwoStateMDP:
     def observe(self, state: SwitchingTwoStateState) -> Float[Array, " feature_dim"]:
         """One-hot observation of the latent state."""
 
+        _validate_state_contract(
+            "state", state, expected_type=SwitchingTwoStateState
+        )
         return jax.nn.one_hot(state.state_index, _TWO_STATE_N, dtype=jnp.float32)
 
     def step(
@@ -319,12 +379,15 @@ class SwitchingTwoStateMDP:
         """
 
         del key  # deterministic dynamics
+        _validate_state_contract(
+            "state", state, expected_type=SwitchingTwoStateState
+        )
         action_index = jnp.clip(jnp.asarray(action, dtype=jnp.int32), 0, _TWO_STATE_ACTIONS - 1)
         phase = self.phase_id(state)
         reward = self._payoffs[phase, state.state_index, action_index]
         new_state = SwitchingTwoStateState(
             state_index=action_index,
-            step_count=state.step_count + jnp.array(1, dtype=jnp.int32),
+            step_count=_saturating_step_count(state.step_count),
         )
         return self.observe(new_state), reward, new_state
 
@@ -427,8 +490,11 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
-        if config.n_states < 2:
-            raise ValueError(f"n_states must be at least 2, got {config.n_states}")
+        n_states = _require_int32("n_states", config.n_states, minimum=2)
+        initial_state = _require_int32(
+            "initial_state", config.initial_state, minimum=0, maximum=n_states - 1
+        )
+        _riverswim_persistent_resources(n_states)
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,
@@ -466,20 +532,11 @@ class RiverSwimMDP:
                 "p_right_up + p_right_down must not exceed 1, got "
                 f"{config.p_right_up} + {config.p_right_down}"
             )
-        if not 0 <= config.initial_state < config.n_states:
-            raise ValueError(
-                f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
-            )
-        if isinstance(config.initial_state, bool) or not isinstance(
-            config.initial_state, Integral
-        ):
-            raise ValueError(
-                "initial_state must be an integer, got "
-                f"{config.initial_state!r}"
-            )
         config = cast(
             RiverSwimConfig,
             config.replace(
+                n_states=n_states,
+                initial_state=initial_state,
                 p_right_up=p_right_up,
                 p_right_down=p_right_down,
                 reward_left=reward_left,
@@ -487,7 +544,7 @@ class RiverSwimMDP:
             ),
         )
         self._config: RiverSwimConfig = config
-        self._n_states: int = int(config.n_states)
+        self._n_states: int = n_states
         self._transitions_np: np.ndarray = self._build_transitions(config)
         self._rewards_np: np.ndarray = self._build_rewards(config)
         self._transition_logits: Array = jnp.where(
@@ -561,6 +618,12 @@ class RiverSwimMDP:
 
         return self._rewards_np.copy()
 
+    @property
+    def persistent_resource_budget(self) -> dict[str, int]:
+        """Exact resident NumPy and JAX array accounting."""
+
+        return _riverswim_persistent_resources(self._n_states)
+
     def init(self, key: Array) -> RiverSwimState:
         """Create the initial state at ``config.initial_state``.
 
@@ -578,6 +641,7 @@ class RiverSwimMDP:
     def observe(self, state: RiverSwimState) -> Float[Array, " feature_dim"]:
         """One-hot observation of the latent state."""
 
+        _validate_state_contract("state", state, expected_type=RiverSwimState)
         return jax.nn.one_hot(state.state_index, self._n_states, dtype=jnp.float32)
 
     def step(
@@ -597,6 +661,7 @@ class RiverSwimMDP:
             Tuple of (observation of the new state, reward, new state).
         """
 
+        _validate_state_contract("state", state, expected_type=RiverSwimState)
         action_index = jnp.clip(jnp.asarray(action, dtype=jnp.int32), 0, 1)
         reward = self._rewards[state.state_index, action_index]
         next_index = jr.categorical(
@@ -604,7 +669,7 @@ class RiverSwimMDP:
         ).astype(jnp.int32)
         new_state = RiverSwimState(
             state_index=next_index,
-            step_count=state.step_count + jnp.array(1, dtype=jnp.int32),
+            step_count=_saturating_step_count(state.step_count),
         )
         return self.observe(new_state), reward, new_state
 
@@ -657,6 +722,11 @@ class RiverSwimMDP:
         return _stationary_average_reward(kernel, step_rewards)
 
     def _enumerate_optimal(self) -> tuple[tuple[int, ...], float]:
+        if self._n_states > _MAX_EXACT_POLICY_STATES:
+            raise ValueError(
+                "exact RiverSwim policy enumeration supports at most "
+                f"{_MAX_EXACT_POLICY_STATES} states"
+            )
         best_policy = (LEFT_ACTION,) * self._n_states
         best_gain = -np.inf
         for candidate in itertools.product((LEFT_ACTION, RIGHT_ACTION), repeat=self._n_states):

--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="call-arg,attr-defined"
+# mypy: disable-error-code="call-arg"
 """Closed-loop micro-MDPs where actions affect observations.
 
 Every other stream in this package is open-loop: the observation sequence is
@@ -81,32 +81,6 @@ _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
     np.float64,
     np.longdouble,
 )
-
-
-def _require_builtin_int(
-    value: object,
-    *,
-    name: str,
-    minimum: int,
-    maximum: int = _INT32_MAX,
-) -> int:
-    """Return a built-in int at or above ``minimum``; reject bool and numpy ints.
-
-    ``type(value) is not int`` is deliberate: ``isinstance(value, int)``
-    consults the overridable ``__class__`` attribute, so an object whose
-    ``__class__`` property returns ``int`` would pass an isinstance check
-    even though its true type never implements the integer protocol,
-    letting it reach downstream integer-only sinks (``range``, JAX array
-    construction) and raise an undocumented, unclean exception there
-    instead of the ``ValueError`` this contract promises.
-    """
-    if type(value) is not int:
-        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
-    if value < minimum:
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
-    if value > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
-    return value
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -253,7 +227,16 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        _require_builtin_int(config.phase_length, name="phase_length", minimum=1)
+        if (
+            isinstance(config.phase_length, bool)
+            or not isinstance(config.phase_length, int)
+            or config.phase_length < 1
+            or config.phase_length > _INT32_MAX
+        ):
+            raise ValueError(
+                "phase_length must be a positive integer in "
+                f"[1, {_INT32_MAX}], got {config.phase_length!r}"
+            )
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -444,7 +427,8 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
-        n_states = _require_builtin_int(config.n_states, name="n_states", minimum=2)
+        if config.n_states < 2:
+            raise ValueError(f"n_states must be at least 2, got {config.n_states}")
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,
@@ -482,12 +466,17 @@ class RiverSwimMDP:
                 "p_right_up + p_right_down must not exceed 1, got "
                 f"{config.p_right_up} + {config.p_right_down}"
             )
-        _require_builtin_int(
-            config.initial_state,
-            name="initial_state",
-            minimum=0,
-            maximum=n_states - 1,
-        )
+        if not 0 <= config.initial_state < config.n_states:
+            raise ValueError(
+                f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
+            )
+        if isinstance(config.initial_state, bool) or not isinstance(
+            config.initial_state, Integral
+        ):
+            raise ValueError(
+                "initial_state must be an integer, got "
+                f"{config.initial_state!r}"
+            )
         config = cast(
             RiverSwimConfig,
             config.replace(
@@ -498,7 +487,7 @@ class RiverSwimMDP:
             ),
         )
         self._config: RiverSwimConfig = config
-        self._n_states: int = n_states
+        self._n_states: int = int(config.n_states)
         self._transitions_np: np.ndarray = self._build_transitions(config)
         self._rewards_np: np.ndarray = self._build_rewards(config)
         self._transition_logits: Array = jnp.where(

--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="call-arg"
+# mypy: disable-error-code="call-arg,attr-defined"
 """Closed-loop micro-MDPs where actions affect observations.
 
 Every other stream in this package is open-loop: the observation sequence is
@@ -81,6 +81,32 @@ _SUPPORTED_NUMPY_REWARD_TYPES: tuple[type[object], ...] = (
     np.float64,
     np.longdouble,
 )
+
+
+def _require_builtin_int(
+    value: object,
+    *,
+    name: str,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
+    """Return a built-in int at or above ``minimum``; reject bool and numpy ints.
+
+    ``type(value) is not int`` is deliberate: ``isinstance(value, int)``
+    consults the overridable ``__class__`` attribute, so an object whose
+    ``__class__`` property returns ``int`` would pass an isinstance check
+    even though its true type never implements the integer protocol,
+    letting it reach downstream integer-only sinks (``range``, JAX array
+    construction) and raise an undocumented, unclean exception there
+    instead of the ``ValueError`` this contract promises.
+    """
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+    if value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+    return value
 
 
 def _normalized_finite_float32_reward(name: str, value: object) -> float:
@@ -227,16 +253,7 @@ class SwitchingTwoStateMDP:
 
     def __init__(self, config: SwitchingTwoStateConfig | None = None) -> None:
         config = SwitchingTwoStateConfig() if config is None else config
-        if (
-            isinstance(config.phase_length, bool)
-            or not isinstance(config.phase_length, int)
-            or config.phase_length < 1
-            or config.phase_length > _INT32_MAX
-        ):
-            raise ValueError(
-                "phase_length must be a positive integer in "
-                f"[1, {_INT32_MAX}], got {config.phase_length!r}"
-            )
+        _require_builtin_int(config.phase_length, name="phase_length", minimum=1)
         phase_payoffs = []
         for name in ("payoffs_a", "payoffs_b"):
             payoff = np.asarray(getattr(config, name), dtype=np.float32)
@@ -427,8 +444,7 @@ class RiverSwimMDP:
 
     def __init__(self, config: RiverSwimConfig | None = None) -> None:
         config = RiverSwimConfig() if config is None else config
-        if config.n_states < 2:
-            raise ValueError(f"n_states must be at least 2, got {config.n_states}")
+        n_states = _require_builtin_int(config.n_states, name="n_states", minimum=2)
         up_numerator, up_denominator = _exact_real_ratio(
             "p_right_up",
             config.p_right_up,
@@ -466,17 +482,12 @@ class RiverSwimMDP:
                 "p_right_up + p_right_down must not exceed 1, got "
                 f"{config.p_right_up} + {config.p_right_down}"
             )
-        if not 0 <= config.initial_state < config.n_states:
-            raise ValueError(
-                f"initial_state must lie in [0, {config.n_states}), got {config.initial_state}"
-            )
-        if isinstance(config.initial_state, bool) or not isinstance(
-            config.initial_state, Integral
-        ):
-            raise ValueError(
-                "initial_state must be an integer, got "
-                f"{config.initial_state!r}"
-            )
+        _require_builtin_int(
+            config.initial_state,
+            name="initial_state",
+            minimum=0,
+            maximum=n_states - 1,
+        )
         config = cast(
             RiverSwimConfig,
             config.replace(
@@ -487,7 +498,7 @@ class RiverSwimMDP:
             ),
         )
         self._config: RiverSwimConfig = config
-        self._n_states: int = int(config.n_states)
+        self._n_states: int = n_states
         self._transitions_np: np.ndarray = self._build_transitions(config)
         self._rewards_np: np.ndarray = self._build_rewards(config)
         self._transition_logits: Array = jnp.where(

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -148,12 +148,35 @@ class TestSwitchingTwoStateDynamics:
     @pytest.mark.parametrize("phase_length", _INVALID_PHASE_LENGTHS)
     def test_invalid_phase_length_raises(self, phase_length):
         """Schedule divisors must be built-in positive JAX-int32 integers."""
-        with pytest.raises(
-            ValueError,
-            match=rf"phase_length must be a positive integer in \[1, {_INT32_MAX}\]",
-        ):
+        with pytest.raises(ValueError, match=r"phase_length must be"):
             SwitchingTwoStateMDP(
                 SwitchingTwoStateConfig(phase_length=phase_length)  # type: ignore[arg-type]
+            )
+
+    def test_phase_length_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        ``isinstance(value, int)`` consults the overridable ``__class__``
+        property, so a non-int object could previously spoof the isinstance
+        check and reach ``int(config.phase_length)`` unvalidated, raising an
+        undocumented ``TypeError`` from deep inside JAX construction instead
+        of the clean ``ValueError`` this constructor promises.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __lt__(self, other: object) -> bool:
+                return False
+
+            def __gt__(self, other: object) -> bool:
+                return False
+
+        with pytest.raises(ValueError, match=r"phase_length must be a built-in integer"):
+            SwitchingTwoStateMDP(
+                SwitchingTwoStateConfig(phase_length=_SpoofedInt())  # type: ignore[arg-type]
             )
 
     def test_int32_max_phase_length_runs_first_eager_and_jit_query(self):
@@ -376,8 +399,42 @@ class TestRiverSwim:
     @pytest.mark.parametrize("initial_state", [1.5, True, 2.0])
     def test_non_integer_initial_state_raises(self, initial_state):
         """initial_state must be a canonical integer in range."""
-        with pytest.raises(ValueError, match="initial_state must be an integer"):
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
             RiverSwimMDP(RiverSwimConfig(initial_state=initial_state))  # type: ignore[arg-type]
+
+    def test_initial_state_class_spoofed_int_raises(self):
+        """A ``__class__`` override that fakes ``int`` must still be rejected.
+
+        Previously ``isinstance(config.initial_state, Integral)`` consulted
+        the overridable ``__class__`` property, so this object would pass
+        validation and reach ``jnp.array(self._config.initial_state, ...)``
+        inside :meth:`RiverSwimMDP.init` unvalidated.
+        """
+
+        class _SpoofedInt:
+            @property
+            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
+                return int
+
+            def __ge__(self, other: object) -> bool:
+                return True
+
+            def __lt__(self, other: object) -> bool:
+                return True
+
+        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(initial_state=_SpoofedInt()))  # type: ignore[arg-type]
+
+    def test_non_integer_n_states_raises(self):
+        """n_states must be a canonical built-in integer, not merely numeric.
+
+        Previously ``n_states`` had no type check at all: a float such as
+        ``6.5`` passed the ``config.n_states < 2`` comparison and then raised
+        an undocumented ``TypeError`` from ``range(n)`` deep inside
+        ``_build_transitions`` instead of a clean ``ValueError``.
+        """
+        with pytest.raises(ValueError, match="n_states must be a built-in integer"):
+            RiverSwimMDP(RiverSwimConfig(n_states=6.5))  # type: ignore[arg-type]
 
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -20,6 +20,11 @@ from alberta_framework.streams import (
     SwitchingTwoStateConfig,
     SwitchingTwoStateMDP,
 )
+from alberta_framework.streams.closed_loop import (
+    RiverSwimState,
+    SwitchingTwoStateState,
+    _riverswim_persistent_resources,
+)
 
 _INT32_MAX = 2**31 - 1
 _INVALID_PHASE_LENGTHS = (0, -1, False, True, 1.5, None, 2**31, 10**100)
@@ -589,3 +594,116 @@ class TestRiverSwim:
                     p_right_down=p_right_down,
                 )
             )
+
+
+@pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_closed_loop_integer_configs_accept_and_canonicalize_numpy_families(code: str) -> None:
+    integer_type = np.dtype(code).type
+    switching = SwitchingTwoStateMDP(
+        SwitchingTwoStateConfig(phase_length=integer_type(3))
+    )
+    river = RiverSwimMDP(
+        RiverSwimConfig(n_states=integer_type(4), initial_state=integer_type(1))
+    )
+    assert type(switching.config.phase_length) is int
+    assert type(river.config.n_states) is int
+    assert type(river.config.initial_state) is int
+
+
+def test_closed_loop_integer_rejection_never_invokes_hostile_hooks() -> None:
+    class HostileInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("untrusted index hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self) -> type:  # type: ignore[override]
+            return int
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    for config in (
+        SwitchingTwoStateConfig(phase_length=HostileInt(2)),
+        SwitchingTwoStateConfig(phase_length=ClassSpoof()),  # type: ignore[arg-type]
+    ):
+        with pytest.raises(ValueError, match="phase_length"):
+            SwitchingTwoStateMDP(config)
+    with pytest.raises(ValueError, match="n_states"):
+        RiverSwimMDP(RiverSwimConfig(n_states=ClassSpoof()))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="initial_state"):
+        RiverSwimMDP(RiverSwimConfig(initial_state=HostileInt(0)))
+
+
+def test_riverswim_resource_formula_matches_resident_arrays() -> None:
+    env = RiverSwimMDP(RiverSwimConfig(n_states=5))
+    actual_bytes = (
+        env._transitions_np.nbytes
+        + env._rewards_np.nbytes
+        + env._transition_logits.nbytes
+        + env._rewards.nbytes
+    )
+    assert env.persistent_resource_budget == _riverswim_persistent_resources(5)
+    assert env.persistent_resource_budget["persistent_bytes"] == actual_bytes
+
+
+def test_riverswim_resource_limit_fails_before_numpy_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _riverswim_persistent_resources(2047)["persistent_bytes"] <= 64 * 1024 * 1024
+    monkeypatch.setattr(
+        np,
+        "zeros",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("allocation started")),
+    )
+    with pytest.raises(ValueError, match="64 MiB"):
+        RiverSwimMDP(RiverSwimConfig(n_states=2048))
+
+
+def test_riverswim_exact_policy_api_has_separate_practical_bound() -> None:
+    env = RiverSwimMDP(RiverSwimConfig(n_states=13))
+    with pytest.raises(ValueError, match="at most 12"):
+        env.optimal_policy()
+    with pytest.raises(ValueError, match="at most 12"):
+        env.optimal_average_reward()
+
+
+def test_closed_loop_step_counts_saturate_eager_and_outer_jit() -> None:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    switching = SwitchingTwoStateMDP()
+    switching_state = SwitchingTwoStateState(
+        state_index=jnp.asarray(0, dtype=jnp.int32), step_count=maximum
+    )
+    switched = jax.jit(lambda state: switching.step(state, jnp.asarray(1), jr.key(0))[2])(
+        switching_state
+    )
+    assert int(switched.step_count) == _INT32_MAX
+
+    river = RiverSwimMDP()
+    river_state = RiverSwimState(
+        state_index=jnp.asarray(0, dtype=jnp.int32), step_count=maximum
+    )
+    advanced = river.step(river_state, jnp.asarray(0), jr.key(1))[2]
+    assert int(advanced.step_count) == _INT32_MAX
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        RiverSwimState(
+            state_index=jnp.zeros((1,), dtype=jnp.int32),
+            step_count=jnp.asarray(0, dtype=jnp.int32),
+        ),
+        RiverSwimState(
+            state_index=jnp.asarray(0, dtype=jnp.int16),
+            step_count=jnp.asarray(0, dtype=jnp.int32),
+        ),
+    ),
+)
+def test_riverswim_rejects_invalid_static_state_contract(state: RiverSwimState) -> None:
+    env = RiverSwimMDP()
+    with pytest.raises((TypeError, ValueError), match="state.state_index"):
+        env.step(state, jnp.asarray(0), jr.key(0))

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -148,35 +148,12 @@ class TestSwitchingTwoStateDynamics:
     @pytest.mark.parametrize("phase_length", _INVALID_PHASE_LENGTHS)
     def test_invalid_phase_length_raises(self, phase_length):
         """Schedule divisors must be built-in positive JAX-int32 integers."""
-        with pytest.raises(ValueError, match=r"phase_length must be"):
+        with pytest.raises(
+            ValueError,
+            match=rf"phase_length must be a positive integer in \[1, {_INT32_MAX}\]",
+        ):
             SwitchingTwoStateMDP(
                 SwitchingTwoStateConfig(phase_length=phase_length)  # type: ignore[arg-type]
-            )
-
-    def test_phase_length_class_spoofed_int_raises(self):
-        """A ``__class__`` override that fakes ``int`` must still be rejected.
-
-        ``isinstance(value, int)`` consults the overridable ``__class__``
-        property, so a non-int object could previously spoof the isinstance
-        check and reach ``int(config.phase_length)`` unvalidated, raising an
-        undocumented ``TypeError`` from deep inside JAX construction instead
-        of the clean ``ValueError`` this constructor promises.
-        """
-
-        class _SpoofedInt:
-            @property
-            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
-                return int
-
-            def __lt__(self, other: object) -> bool:
-                return False
-
-            def __gt__(self, other: object) -> bool:
-                return False
-
-        with pytest.raises(ValueError, match=r"phase_length must be a built-in integer"):
-            SwitchingTwoStateMDP(
-                SwitchingTwoStateConfig(phase_length=_SpoofedInt())  # type: ignore[arg-type]
             )
 
     def test_int32_max_phase_length_runs_first_eager_and_jit_query(self):
@@ -399,42 +376,8 @@ class TestRiverSwim:
     @pytest.mark.parametrize("initial_state", [1.5, True, 2.0])
     def test_non_integer_initial_state_raises(self, initial_state):
         """initial_state must be a canonical integer in range."""
-        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
+        with pytest.raises(ValueError, match="initial_state must be an integer"):
             RiverSwimMDP(RiverSwimConfig(initial_state=initial_state))  # type: ignore[arg-type]
-
-    def test_initial_state_class_spoofed_int_raises(self):
-        """A ``__class__`` override that fakes ``int`` must still be rejected.
-
-        Previously ``isinstance(config.initial_state, Integral)`` consulted
-        the overridable ``__class__`` property, so this object would pass
-        validation and reach ``jnp.array(self._config.initial_state, ...)``
-        inside :meth:`RiverSwimMDP.init` unvalidated.
-        """
-
-        class _SpoofedInt:
-            @property
-            def __class__(self) -> type:  # noqa: A003 - deliberate spoof target
-                return int
-
-            def __ge__(self, other: object) -> bool:
-                return True
-
-            def __lt__(self, other: object) -> bool:
-                return True
-
-        with pytest.raises(ValueError, match="initial_state must be a built-in integer"):
-            RiverSwimMDP(RiverSwimConfig(initial_state=_SpoofedInt()))  # type: ignore[arg-type]
-
-    def test_non_integer_n_states_raises(self):
-        """n_states must be a canonical built-in integer, not merely numeric.
-
-        Previously ``n_states`` had no type check at all: a float such as
-        ``6.5`` passed the ``config.n_states < 2`` comparison and then raised
-        an undocumented ``TypeError`` from ``range(n)`` deep inside
-        ``_build_transitions`` instead of a clean ``ValueError``.
-        """
-        with pytest.raises(ValueError, match="n_states must be a built-in integer"):
-            RiverSwimMDP(RiverSwimConfig(n_states=6.5))  # type: ignore[arg-type]
 
     def test_transition_tensor_structure(self):
         """Kernels are row-stochastic with drift folded at the boundaries."""


### PR DESCRIPTION
Clean contributor-preserving successor to #803 and #817.

## Repairs
- accepts and canonicalizes the full supported concrete NumPy integer family for `phase_length`, `n_states`, and `initial_state` with `operator.index`, while rejecting bools, subclasses, class spoofs, and hostile repr/index hooks;
- preflights the exact duplicated NumPy+JAX RiverSwim transition/reward resident envelope before allocation, with a 64 MiB micro-MDP cap and allocation-free adjacent 2047/2048 boundary tests;
- independently gates exhaustive `2 ** n_states` optimal-policy enumeration at 12 states before iteration;
- canonicalizes stored configs, saturates both environment step counters at signed-int32 max, and validates public state scalar shapes/dtypes under eager and outer-JIT execution;
- verifies the resource formula against actual resident NumPy/JAX bytes.

## Verification
- 99 complete closed-loop tests passed
- 21 control/prototype downstream tests passed
- 2 selected continual-IA downstream tests passed
- 31 post-final-rebase adversarial/resource tests passed
- scoped Ruff, strict mypy, and diff-check passed

## Evidence impact
`alberta_framework/streams/closed_loop.py` is a registered source for the historical `continual_intelligence_amplification` evidence artifact and is also hashed by its artifact module. This source correction therefore intentionally changes that historical source identity; no pinned output was edited or promoted, and the existing rejection is not converted into evidence.