### PR TITLE
fix(working-memory): close allocation residuals

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -241,9 +241,6 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return number
 
 
-_UINT32_MAX: int = 4294967295
-
-
 def _require_float32_resource(
     name: str,
     *,
@@ -323,6 +320,13 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError(
             f"configuration feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
         )
+    for name, dimension in (
+        ("observation vector", observation_dim),
+        ("action vector", action_dim),
+        ("reward vector", reward_dim),
+        ("working-memory feature output", feature_dim),
+    ):
+        _require_float32_resource(name, vector_scalars=dimension)
     trace_scalars = (
         observation_dim * len(observation_decay_rates)
         + action_dim * len(action_decay_rates)
@@ -330,17 +334,11 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     )
     if trace_scalars > _INT32_MAX:
         raise ValueError("WorkingMemoryConfig dimensions must fit signed int32")
-    total_state_scalars = trace_scalars + 4
     _require_float32_resource(
         "WorkingMemoryConfig state",
         vector_scalars=trace_scalars,
         fixed_scalars=4,
     )
-    persistent_bytes = 4 * total_state_scalars
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
-    if persistent_bytes > _UINT32_MAX:
-        raise ValueError("working memory allocation exceeds uint32 byte accounting")
 
 
 def _empty_or_vector(value: Array, dim: int) -> Array:
@@ -756,8 +754,8 @@ def transform_working_memory_arrays(
             f"(got {_obs.shape[0]}, {_act.shape[0]}, {_rew.shape[0]})"
         )
     _require_sequence_resource(
-        "working memory transform outputs",
-        float32_scalars=int(steps) * cfg.feature_dim(),
+        "working memory transform outputs and default gate workspace",
+        float32_scalars=int(steps) * (cfg.feature_dim() + 1),
         bool_scalars=int(steps),
     )
     if state is None:

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -561,9 +561,10 @@ def test_config_rejects_derived_feature_dimension_above_int32() -> None:
         WorkingMemoryConfig(observation_dim=2**31 - 1)
 
 
-def test_config_accepts_exact_int32_max_derived_feature_dimension() -> None:
+def test_config_feature_byte_boundary_is_allocation_free() -> None:
+    last_valid = (2**31 - 1) // 4
     config = WorkingMemoryConfig(
-        observation_dim=2**31 - 1,
+        observation_dim=last_valid,
         action_dim=0,
         reward_dim=0,
         observation_decay_rates=(),
@@ -574,7 +575,19 @@ def test_config_accepts_exact_int32_max_derived_feature_dimension() -> None:
         include_traces=False,
     )
 
-    assert config.feature_dim() == 2**31 - 1
+    assert config.feature_dim() == last_valid
+    with pytest.raises(ValueError, match="feature output byte count"):
+        WorkingMemoryConfig(
+            observation_dim=last_valid,
+            action_dim=1,
+            reward_dim=0,
+            observation_decay_rates=(),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+            include_current_action=True,
+            include_current_reward=False,
+            include_traces=False,
+        )
 
 
 @pytest.mark.parametrize("method", ["features", "update_checked", "step"])

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -232,6 +232,7 @@ def test_working_state_preflight_bytes_without_allocation() -> None:
         observation_decay_rates=(0.5, 0.9, 0.99),
         action_decay_rates=(),
         reward_decay_rates=(),
+        include_current_observation=False,
     )
     assert cfg.observation_dim == last_legal
     with pytest.raises(ValueError, match="byte count"):
@@ -242,6 +243,7 @@ def test_working_state_preflight_bytes_without_allocation() -> None:
             observation_decay_rates=(0.5, 0.9, 0.99),
             action_decay_rates=(),
             reward_decay_rates=(),
+            include_current_observation=False,
         )
     # Non-minimal should also be allocation-free
     with pytest.raises(ValueError, match="byte count|scalar count|dimensions"):
@@ -260,6 +262,21 @@ def test_working_state_preflight_feature_dim_boundary() -> None:
         match="configuration feature_dim|byte count|scalar count|dimensions",
     ):
         _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)
+
+
+def test_unused_signal_vector_still_fits_public_zero_allocation() -> None:
+    with pytest.raises(ValueError, match="action vector byte count"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            action_dim=_INT32_MAX // 4 + 1,
+            reward_dim=0,
+            observation_decay_rates=(),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+            include_current_action=False,
+            include_current_reward=False,
+            include_traces=False,
+        )
 
 
 def test_working_serialized_schema_preserves_only_exact_list_tuple_compatibility() -> None:
@@ -384,7 +401,9 @@ def test_working_transform_preflights_output_bytes_without_allocation() -> None:
             include_traces=False,
         )
     )
-    first_overflow = _INT32_MAX // 5 + 1
+    # Returned float32 features, bool verdicts, and a default float32 gate
+    # workspace consume nine bytes per one-dimensional event.
+    first_overflow = _INT32_MAX // 9 + 1
     observations = jax.ShapeDtypeStruct((first_overflow, 1), jnp.float32)
     empty = jax.ShapeDtypeStruct((first_overflow, 0), jnp.float32)
     with pytest.raises(ValueError, match="byte count"):


### PR DESCRIPTION
Follow-up to merged #825 after exact comparison with superseded #826. #825 is the authoritative stronger integration; this applies only its missing allocation residuals: signed-int32 byte bounds for each public signal vector and feature output, removal of unreachable uint32 accounting after the stricter int32 byte gate, and batch accounting for the default float32 gate workspace in addition to returned features/verdicts. Allocation-free boundary tests cover feature, unused zero-vector, trace-state, and batch products. Validation: 152 focused tests, Ruff, strict mypy, and diff check pass.