### PR TITLE
fix(feature-discovery): harden fixed-budget feature learner integer parameters with strict validation

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -22,13 +22,15 @@ References:
 """
 
 import functools
+import operator
 import time
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
@@ -45,6 +47,32 @@ from alberta_framework.core.update_safety import (
     neutralize_array,
     select_transaction,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: float, value: Array) -> Array:
@@ -274,29 +302,27 @@ class FixedBudgetFeatureLearner:
                 ``(1.25, 1.0, 0.8)`` tighten or loosen promotion roughly
                 symmetrically on a log scale (``1.25 = 1 / 0.8``).
         """
-        if n_features < 1:
-            raise ValueError("n_features must be positive")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if candidate_count < 0:
-            raise ValueError("candidate_count must be non-negative")
+        n_features = _require_int32("n_features", n_features, minimum=1)
+        n_tasks = _require_int32("n_tasks", n_tasks, minimum=1)
+        candidate_count = _require_int32("candidate_count", candidate_count, minimum=0)
+        replacement_interval = _require_int32(
+            "replacement_interval", replacement_interval, minimum=0
+        )
+        min_feature_age = _require_int32("min_feature_age", min_feature_age, minimum=0)
+        candidate_min_age = _require_int32("candidate_min_age", candidate_min_age, minimum=0)
+        utility_top_k = _require_int32("utility_top_k", utility_top_k, minimum=1)
         utility_decay_config = utility_decay
         utility_decay = canonical_float32_ema_decay(
             "utility_decay",
             utility_decay,
         )
-        if replacement_interval < 0:
-            raise ValueError("replacement_interval must be non-negative")
         if not 0.0 <= promotion_blend <= 1.0:
             raise ValueError("promotion_blend must be in [0, 1]")
         if utility_aggregation not in {"mean", "max", "topk"}:
             raise ValueError("utility_aggregation must be 'mean', 'max', or 'topk'")
-        if utility_top_k < 1:
-            raise ValueError("utility_top_k must be positive")
         if utility_task_balancing not in {"none", "active", "active_inverse_frequency"}:
             raise ValueError(
-                "utility_task_balancing must be 'none', 'active', "
-                "or 'active_inverse_frequency'"
+                "utility_task_balancing must be 'none', 'active', or 'active_inverse_frequency'"
             )
         if not 0.0 <= task_activity_decay < 1.0:
             raise ValueError("task_activity_decay must be in [0, 1)")
@@ -305,9 +331,7 @@ class FixedBudgetFeatureLearner:
         if not 0.0 <= future_utility_trace_decay < 1.0:
             raise ValueError("future_utility_trace_decay must be in [0, 1)")
         if future_utility_trace_mode not in {"contribution", "marginal"}:
-            raise ValueError(
-                "future_utility_trace_mode must be 'contribution' or 'marginal'"
-            )
+            raise ValueError("future_utility_trace_mode must be 'contribution' or 'marginal'")
         if future_utility_normalization not in {
             "none",
             "age",
@@ -329,9 +353,7 @@ class FixedBudgetFeatureLearner:
                 utility_retention_decay,
             )
             if utility_retention_decay < utility_decay:
-                raise ValueError(
-                    "utility_retention_decay must be in [utility_decay, 1) when set"
-                )
+                raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
 
         mix = jnp.array(generator_mix, dtype=jnp.float32)
         if mix.shape != (3,):
@@ -350,15 +372,11 @@ class FixedBudgetFeatureLearner:
         if len(plasticity_replacement_multipliers) != 3:
             raise ValueError("plasticity_replacement_multipliers must have length 3")
         if len(plasticity_promotion_margin_multipliers) != 3:
-            raise ValueError(
-                "plasticity_promotion_margin_multipliers must have length 3"
-            )
+            raise ValueError("plasticity_promotion_margin_multipliers must have length 3")
         if any(v <= 0.0 for v in plasticity_replacement_multipliers):
             raise ValueError("plasticity_replacement_multipliers must be positive")
         if any(v <= 0.0 for v in plasticity_promotion_margin_multipliers):
-            raise ValueError(
-                "plasticity_promotion_margin_multipliers must be positive"
-            )
+            raise ValueError("plasticity_promotion_margin_multipliers must be positive")
 
         self._n_features = n_features
         self._n_tasks = n_tasks
@@ -395,9 +413,7 @@ class FixedBudgetFeatureLearner:
         self._resource_exploration = resource_exploration
         self._resource_advantage_clip = resource_advantage_clip
         self._plasticity_replacement_multipliers = plasticity_replacement_multipliers
-        self._plasticity_promotion_margin_multipliers = (
-            plasticity_promotion_margin_multipliers
-        )
+        self._plasticity_promotion_margin_multipliers = plasticity_promotion_margin_multipliers
 
     @property
     def n_features(self) -> int:
@@ -433,9 +449,7 @@ class FixedBudgetFeatureLearner:
             "future_utility_trace_decay": self._future_utility_trace_decay,
             "future_utility_trace_mode": self._future_utility_trace_mode,
             "future_utility_normalization": self._future_utility_normalization,
-            "future_utility_normalization_decay": (
-                self._future_utility_normalization_decay
-            ),
+            "future_utility_normalization_decay": (self._future_utility_normalization_decay),
             "future_utility_rare_task_power": self._future_utility_rare_task_power,
             "utility_retention_decay": self._utility_retention_decay_config,
             "init_scale": self._init_scale,
@@ -447,9 +461,7 @@ class FixedBudgetFeatureLearner:
             "resource_discount": self._resource_discount,
             "resource_exploration": self._resource_exploration,
             "resource_advantage_clip": self._resource_advantage_clip,
-            "plasticity_replacement_multipliers": list(
-                self._plasticity_replacement_multipliers
-            ),
+            "plasticity_replacement_multipliers": list(self._plasticity_replacement_multipliers),
             "plasticity_promotion_margin_multipliers": list(
                 self._plasticity_promotion_margin_multipliers
             ),
@@ -520,12 +532,8 @@ class FixedBudgetFeatureLearner:
             ),
             utility_error_trace=jnp.zeros(self._n_tasks, dtype=jnp.float32),
             utility_feature_trace=jnp.zeros(self._n_features, dtype=jnp.float32),
-            utility_feature_energy_trace=jnp.zeros(
-                self._n_features, dtype=jnp.float32
-            ),
-            utility_signal_second_moment=jnp.zeros(
-                self._n_features, dtype=jnp.float32
-            ),
+            utility_feature_energy_trace=jnp.zeros(self._n_features, dtype=jnp.float32),
+            utility_signal_second_moment=jnp.zeros(self._n_features, dtype=jnp.float32),
             task_activity_ema=jnp.zeros(self._n_tasks, dtype=jnp.float32),
             ages=jnp.zeros(self._n_features, dtype=jnp.int32),
             candidate_weights=candidate_weights,
@@ -537,9 +545,7 @@ class FixedBudgetFeatureLearner:
             candidate_utility_contribution_trace=jnp.zeros(
                 (self._n_tasks, self._candidate_count), dtype=jnp.float32
             ),
-            candidate_utility_feature_trace=jnp.zeros(
-                self._candidate_count, dtype=jnp.float32
-            ),
+            candidate_utility_feature_trace=jnp.zeros(self._candidate_count, dtype=jnp.float32),
             candidate_utility_feature_energy_trace=jnp.zeros(
                 self._candidate_count, dtype=jnp.float32
             ),
@@ -549,19 +555,13 @@ class FixedBudgetFeatureLearner:
             candidate_ages=jnp.zeros(self._candidate_count, dtype=jnp.int32),
             feature_parent_a=jnp.full(self._n_features, -1, dtype=jnp.int32),
             feature_parent_b=jnp.full(self._n_features, -1, dtype=jnp.int32),
-            feature_generator=jnp.full(
-                self._n_features, GENERATOR_RANDOM, dtype=jnp.int32
-            ),
+            feature_generator=jnp.full(self._n_features, GENERATOR_RANDOM, dtype=jnp.int32),
             candidate_parent_a=jnp.full(self._candidate_count, -1, dtype=jnp.int32),
             candidate_parent_b=jnp.full(self._candidate_count, -1, dtype=jnp.int32),
-            candidate_generator=jnp.full(
-                self._candidate_count, GENERATOR_RANDOM, dtype=jnp.int32
-            ),
+            candidate_generator=jnp.full(self._candidate_count, GENERATOR_RANDOM, dtype=jnp.int32),
             generator_log_weights=(
                 jnp.log(jnp.asarray(self._generator_mix, dtype=jnp.float32) + 1e-8)
-                - jnp.mean(
-                    jnp.log(jnp.asarray(self._generator_mix, dtype=jnp.float32) + 1e-8)
-                )
+                - jnp.mean(jnp.log(jnp.asarray(self._generator_mix, dtype=jnp.float32) + 1e-8))
             ),
             generator_utility_ema=jnp.zeros(3, dtype=jnp.float32),
             plasticity_log_weights=jnp.zeros(3, dtype=jnp.float32),
@@ -584,10 +584,9 @@ class FixedBudgetFeatureLearner:
         active_mask: Array,
     ) -> Array:
         """Track active target heads for opt-in task-balanced utility."""
-        return (
-            _skip_zero_scale(self._task_activity_decay, old_activity)
-            + (1.0 - self._task_activity_decay) * active_mask.astype(jnp.float32)
-        )
+        return _skip_zero_scale(self._task_activity_decay, old_activity) + (
+            1.0 - self._task_activity_decay
+        ) * active_mask.astype(jnp.float32)
 
     def _output_utility_signal(
         self,
@@ -601,9 +600,7 @@ class FixedBudgetFeatureLearner:
         if self._utility_task_balancing != "none":
             active = active_mask.astype(jnp.float32)
             if self._utility_task_balancing == "active_inverse_frequency":
-                frequency_floor = jnp.array(
-                    1.0 - self._task_activity_decay, dtype=jnp.float32
-                )
+                frequency_floor = jnp.array(1.0 - self._task_activity_decay, dtype=jnp.float32)
                 task_weights = active / jnp.maximum(task_activity_ema, frequency_floor)
             else:
                 task_weights = active
@@ -642,9 +639,7 @@ class FixedBudgetFeatureLearner:
         if self._utility_task_balancing != "none":
             active = active_mask.astype(jnp.float32)
             if self._utility_task_balancing == "active_inverse_frequency":
-                frequency_floor = jnp.array(
-                    1.0 - self._task_activity_decay, dtype=jnp.float32
-                )
+                frequency_floor = jnp.array(1.0 - self._task_activity_decay, dtype=jnp.float32)
                 task_weights = active / jnp.maximum(task_activity_ema, frequency_floor)
             else:
                 task_weights = active
@@ -719,9 +714,7 @@ class FixedBudgetFeatureLearner:
             new_feature_trace = feature_trace
 
         if self._future_utility_rare_task_power > 0.0:
-            frequency_floor = jnp.array(
-                1.0 - self._task_activity_decay, dtype=jnp.float32
-            )
+            frequency_floor = jnp.array(1.0 - self._task_activity_decay, dtype=jnp.float32)
             rare_weights = jnp.power(
                 1.0 / jnp.maximum(task_activity_ema, frequency_floor),
                 self._future_utility_rare_task_power,
@@ -809,9 +802,8 @@ class FixedBudgetFeatureLearner:
         if self._resource_exploration > 0.0:
             uniform = jnp.full_like(weights, 1.0 / weights.shape[0])
             weights = (
-                (1.0 - self._resource_exploration) * weights
-                + self._resource_exploration * uniform
-            )
+                1.0 - self._resource_exploration
+            ) * weights + self._resource_exploration * uniform
         return weights
 
     def _resource_log_weight_update(
@@ -937,9 +929,7 @@ class FixedBudgetFeatureLearner:
         once Step 2 has found useful features, downstream predictors such as
         Horde/GVF learners can treat these values as given features.
         """
-        features, _ = self._features(
-            state.feature_weights, state.feature_biases, observation
-        )
+        features, _ = self._features(state.feature_weights, state.feature_biases, observation)
         return features
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -949,9 +939,7 @@ class FixedBudgetFeatureLearner:
         observation: Array,
     ) -> Array:
         """Concatenate raw observation with active constructed features."""
-        return jnp.concatenate(
-            [observation, self.constructed_features(state, observation)]
-        )
+        return jnp.concatenate([observation, self.constructed_features(state, observation)])
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: FeatureDiscoveryState, observation: Array) -> Array:
@@ -969,8 +957,7 @@ class FixedBudgetFeatureLearner:
         """Perform one temporally-uniform feature-discovery update."""
         previous_checked = state
         utility_history_discarded = self._utility_decay == 0.0 and (
-            self._utility_retention_decay is None
-            or self._utility_retention_decay == 0.0
+            self._utility_retention_decay is None or self._utility_retention_decay == 0.0
         )
         if utility_history_discarded:
             previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
@@ -989,21 +976,16 @@ class FixedBudgetFeatureLearner:
                 plasticity_signal_ema=jnp.zeros_like(state.plasticity_signal_ema),
             )
         source_state_finite = floating_tree_is_finite(previous_checked)
-        inputs_valid = (
-            jnp.all(jnp.isfinite(observation))
-            & jnp.all(jnp.isfinite(targets) | jnp.isnan(targets))
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
+            jnp.isfinite(targets) | jnp.isnan(targets)
         )
         active_mask = ~jnp.isnan(targets)
         safe_targets = jnp.where(active_mask, targets, 0.0)
         active_count = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
-        task_activity_ema = self._task_activity_update(
-            state.task_activity_ema, active_mask
-        )
+        task_activity_ema = self._task_activity_update(state.task_activity_ema, active_mask)
         generator_mix = jnp.asarray(self._generator_mix, dtype=jnp.float32)
         future_utility_ranking_mode = (
-            self._future_utility_normalization
-            if self._future_utility_mix > 0.0
-            else "none"
+            self._future_utility_normalization if self._future_utility_mix > 0.0 else "none"
         )
         plasticity_weights = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32)
         if self._learn_feature_resources:
@@ -1015,9 +997,7 @@ class FixedBudgetFeatureLearner:
                 self._plasticity_promotion_margin_multipliers,
                 dtype=jnp.float32,
             )
-            promotion_margin = promotion_margin * jnp.sum(
-                plasticity_weights * margin_multipliers
-            )
+            promotion_margin = promotion_margin * jnp.sum(plasticity_weights * margin_multipliers)
 
         features, feature_derivs = self._features(
             state.feature_weights, state.feature_biases, observation
@@ -1026,12 +1006,7 @@ class FixedBudgetFeatureLearner:
         errors = jnp.where(active_mask, safe_targets - predictions, 0.0)
         reported_errors = jnp.where(active_mask, errors, jnp.nan)
 
-        output_delta = (
-            self._step_size_output
-            * errors[:, None]
-            * features[None, :]
-            / active_count
-        )
+        output_delta = self._step_size_output * errors[:, None] * features[None, :] / active_count
         output_bias_delta = self._step_size_output * errors / active_count
 
         feature_credit = (errors @ state.output_weights) * feature_derivs / active_count
@@ -1046,9 +1021,7 @@ class FixedBudgetFeatureLearner:
             active_mask,
             task_activity_ema,
         )
-        current_utility_signal = 0.5 * output_utility_signal + 0.5 * jnp.abs(
-            feature_credit
-        )
+        current_utility_signal = 0.5 * output_utility_signal + 0.5 * jnp.abs(feature_credit)
         (
             utility_signal,
             utility_contribution_trace,
@@ -1068,19 +1041,14 @@ class FixedBudgetFeatureLearner:
             state.utility_feature_energy_trace,
         )
         utility_signal_second_moment = state.utility_signal_second_moment
-        if (
-            self._future_utility_mix > 0.0
-            and self._future_utility_normalization != "none"
-        ):
-            utility_signal, utility_signal_second_moment = (
-                normalize_future_utility_signal(
-                    utility_signal,
-                    state.ages,
-                    state.utility_signal_second_moment,
-                    self._future_utility_normalization_decay,
-                    self._utility_decay,
-                    self._future_utility_normalization,
-                )
+        if self._future_utility_mix > 0.0 and self._future_utility_normalization != "none":
+            utility_signal, utility_signal_second_moment = normalize_future_utility_signal(
+                utility_signal,
+                state.ages,
+                state.utility_signal_second_moment,
+                self._future_utility_normalization_decay,
+                self._utility_decay,
+                self._future_utility_normalization,
             )
         new_utilities = self._utility_update(
             state.utilities,
@@ -1091,16 +1059,10 @@ class FixedBudgetFeatureLearner:
         candidate_weight_delta = jnp.zeros_like(state.candidate_weights)
         candidate_bias_delta = jnp.zeros_like(state.candidate_biases)
         new_candidate_utilities = state.candidate_utilities
-        candidate_utility_contribution_trace = (
-            state.candidate_utility_contribution_trace
-        )
+        candidate_utility_contribution_trace = state.candidate_utility_contribution_trace
         candidate_utility_feature_trace = state.candidate_utility_feature_trace
-        candidate_utility_feature_energy_trace = (
-            state.candidate_utility_feature_energy_trace
-        )
-        candidate_utility_signal_second_moment = (
-            state.candidate_utility_signal_second_moment
-        )
+        candidate_utility_feature_energy_trace = state.candidate_utility_feature_energy_trace
+        candidate_utility_signal_second_moment = state.candidate_utility_signal_second_moment
         if self._candidate_count > 0:
             candidate_features, candidate_derivs = self._features(
                 state.candidate_weights, state.candidate_biases, observation
@@ -1112,12 +1074,10 @@ class FixedBudgetFeatureLearner:
                 / active_count
             )
             candidate_credit = (
-                errors @ state.candidate_output_weights
-            ) * candidate_derivs / active_count
+                (errors @ state.candidate_output_weights) * candidate_derivs / active_count
+            )
             candidate_weight_delta = (
-                self._step_size_feature
-                * candidate_credit[:, None]
-                * observation[None, :]
+                self._step_size_feature * candidate_credit[:, None] * observation[None, :]
             )
             candidate_bias_delta = self._step_size_feature * candidate_credit
             candidate_output_signal = self._output_utility_signal(
@@ -1126,9 +1086,7 @@ class FixedBudgetFeatureLearner:
                 active_mask,
                 task_activity_ema,
             )
-            candidate_signal = 0.5 * candidate_output_signal + 0.5 * jnp.abs(
-                candidate_credit
-            )
+            candidate_signal = 0.5 * candidate_output_signal + 0.5 * jnp.abs(candidate_credit)
             (
                 candidate_signal,
                 candidate_utility_contribution_trace,
@@ -1148,10 +1106,7 @@ class FixedBudgetFeatureLearner:
                 state.candidate_utility_feature_energy_trace,
             )
             del _candidate_error_trace
-            if (
-                self._future_utility_mix > 0.0
-                and self._future_utility_normalization != "none"
-            ):
+            if self._future_utility_mix > 0.0 and self._future_utility_normalization != "none":
                 candidate_signal, candidate_utility_signal_second_moment = (
                     normalize_future_utility_signal(
                         candidate_signal,
@@ -1195,9 +1150,7 @@ class FixedBudgetFeatureLearner:
         output_biases = state.output_biases + output_bias_delta
         candidate_weights = state.candidate_weights + candidate_weight_delta
         candidate_biases = state.candidate_biases + candidate_bias_delta
-        candidate_output_weights = (
-            state.candidate_output_weights + candidate_output_delta
-        )
+        candidate_output_weights = state.candidate_output_weights + candidate_output_delta
         ages = state.ages + 1
         candidate_ages = state.candidate_ages + 1
         ranking_utilities = bias_correct_future_utility(
@@ -1224,9 +1177,8 @@ class FixedBudgetFeatureLearner:
                 self._plasticity_replacement_multipliers,
                 dtype=jnp.float32,
             )
-            replacement_rate = (
-                jnp.sum(plasticity_weights * replacement_multipliers)
-                / float(self._replacement_interval)
+            replacement_rate = jnp.sum(plasticity_weights * replacement_multipliers) / float(
+                self._replacement_interval
             )
             replacement_accumulator = replacement_accumulator + replacement_rate
             should_try_replace = replacement_accumulator >= 1.0
@@ -1236,9 +1188,8 @@ class FixedBudgetFeatureLearner:
                 replacement_accumulator,
             )
         else:
-            should_try_replace = (
-                (self._replacement_interval > 0)
-                & (step_count % jnp.array(max(self._replacement_interval, 1)) == 0)
+            should_try_replace = (self._replacement_interval > 0) & (
+                step_count % jnp.array(max(self._replacement_interval, 1)) == 0
             )
 
         eligible_active = ages >= self._min_feature_age
@@ -1248,13 +1199,9 @@ class FixedBudgetFeatureLearner:
 
         if self._candidate_count > 0:
             eligible_candidates = candidate_ages >= self._candidate_min_age
-            candidate_scores = jnp.where(
-                eligible_candidates, ranking_candidate_utilities, -jnp.inf
-            )
+            candidate_scores = jnp.where(eligible_candidates, ranking_candidate_utilities, -jnp.inf)
             best_candidate = jnp.argmax(candidate_scores).astype(jnp.int32)
-            worst_candidate = jnp.argmin(ranking_candidate_utilities).astype(
-                jnp.int32
-            )
+            worst_candidate = jnp.argmin(ranking_candidate_utilities).astype(jnp.int32)
             has_candidate = jnp.any(eligible_candidates)
             should_promote = (
                 should_try_replace
@@ -1338,16 +1285,13 @@ class FixedBudgetFeatureLearner:
                 )
                 fw = fw.at[worst_active].set(cw[best_candidate])
                 fb = fb.at[worst_active].set(cb[best_candidate])
-                ow = ow.at[:, worst_active].set(
-                    self._promotion_blend * cow[:, best_candidate]
-                )
+                ow = ow.at[:, worst_active].set(self._promotion_blend * cow[:, best_candidate])
                 # Active age tracks this new lifecycle, so the raw EMA must
                 # restart with it.  Inheriting a mature candidate EMA at age
                 # zero would apply the warm-up correction twice.
                 promoted_utility = (
                     jnp.array(0.0, dtype=jnp.float32)
-                    if future_utility_ranking_mode
-                    in {"age", "uncertainty_age"}
+                    if future_utility_ranking_mode in {"age", "uncertainty_age"}
                     else cutil[best_candidate]
                 )
                 util = util.at[worst_active].set(promoted_utility)
@@ -1456,24 +1400,12 @@ class FixedBudgetFeatureLearner:
                 do_refresh = should_try_replace
                 cw = jax.lax.select(do_refresh, cw.at[worst_candidate].set(new_cw), cw)
                 cb = jax.lax.select(do_refresh, cb.at[worst_candidate].set(new_cb), cb)
-                cow = jax.lax.select(
-                    do_refresh, cow.at[:, worst_candidate].set(0.0), cow
-                )
-                cutil = jax.lax.select(
-                    do_refresh, cutil.at[worst_candidate].set(0.0), cutil
-                )
-                cage = jax.lax.select(
-                    do_refresh, cage.at[worst_candidate].set(0), cage
-                )
-                cpa = jax.lax.select(
-                    do_refresh, cpa.at[worst_candidate].set(new_pa), cpa
-                )
-                cpb = jax.lax.select(
-                    do_refresh, cpb.at[worst_candidate].set(new_pb), cpb
-                )
-                cg = jax.lax.select(
-                    do_refresh, cg.at[worst_candidate].set(new_gen), cg
-                )
+                cow = jax.lax.select(do_refresh, cow.at[:, worst_candidate].set(0.0), cow)
+                cutil = jax.lax.select(do_refresh, cutil.at[worst_candidate].set(0.0), cutil)
+                cage = jax.lax.select(do_refresh, cage.at[worst_candidate].set(0), cage)
+                cpa = jax.lax.select(do_refresh, cpa.at[worst_candidate].set(new_pa), cpa)
+                cpb = jax.lax.select(do_refresh, cpb.at[worst_candidate].set(new_pb), cpb)
+                cg = jax.lax.select(do_refresh, cg.at[worst_candidate].set(new_gen), cg)
                 return (
                     fw,
                     fb,
@@ -1528,13 +1460,9 @@ class FixedBudgetFeatureLearner:
                 candidate_parent_a,
                 candidate_parent_b,
                 candidate_generator,
-            ) = jax.lax.cond(
-                should_promote, promote_branch, refresh_candidate_branch, carry
-            )
+            ) = jax.lax.cond(should_promote, promote_branch, refresh_candidate_branch, carry)
             replaced_slot = jnp.where(should_promote, worst_active, replaced_slot)
-            promoted_candidate = jnp.where(
-                should_promote, best_candidate, promoted_candidate
-            )
+            promoted_candidate = jnp.where(should_promote, best_candidate, promoted_candidate)
         else:
 
             def replace_active_branch(
@@ -1641,27 +1569,20 @@ class FixedBudgetFeatureLearner:
             )
 
             if self._candidate_count > 0:
-                eligible_candidates_for_pressure = (
-                    candidate_ages >= self._candidate_min_age
-                )
+                eligible_candidates_for_pressure = candidate_ages >= self._candidate_min_age
                 candidate_pressure_scores = jnp.where(
                     eligible_candidates_for_pressure,
                     ranking_candidate_utilities,
                     -jnp.inf,
                 )
-                best_candidate_for_pressure = jnp.argmax(
-                    candidate_pressure_scores
-                ).astype(jnp.int32)
-                has_candidate_for_pressure = jnp.any(
-                    eligible_candidates_for_pressure
+                best_candidate_for_pressure = jnp.argmax(candidate_pressure_scores).astype(
+                    jnp.int32
                 )
+                has_candidate_for_pressure = jnp.any(eligible_candidates_for_pressure)
                 worst_active_utility = ranking_utilities[worst_active]
-                best_candidate_utility = ranking_candidate_utilities[
-                    best_candidate_for_pressure
-                ]
+                best_candidate_utility = ranking_candidate_utilities[best_candidate_for_pressure]
                 pressure_raw = (
-                    best_candidate_utility
-                    - promotion_margin * worst_active_utility
+                    best_candidate_utility - promotion_margin * worst_active_utility
                 ) / (jnp.abs(worst_active_utility) + 1e-6)
                 pressure = jnp.where(
                     has_active_slot & has_candidate_for_pressure,
@@ -1670,9 +1591,7 @@ class FixedBudgetFeatureLearner:
                 )
             else:
                 pressure = jnp.array(0.0, dtype=jnp.float32)
-            plasticity_scores = jnp.stack(
-                [-pressure, jnp.array(0.0, dtype=jnp.float32), pressure]
-            )
+            plasticity_scores = jnp.stack([-pressure, jnp.array(0.0, dtype=jnp.float32), pressure])
             plasticity_signal_ema = (
                 _skip_zero_scale(self._resource_discount, plasticity_signal_ema)
                 + (1.0 - self._resource_discount) * plasticity_scores
@@ -1688,9 +1607,7 @@ class FixedBudgetFeatureLearner:
         utility_contribution_trace = jnp.where(
             reset_active_traces[None, :], 0.0, utility_contribution_trace
         )
-        utility_feature_trace = jnp.where(
-            reset_active_traces, 0.0, utility_feature_trace
-        )
+        utility_feature_trace = jnp.where(reset_active_traces, 0.0, utility_feature_trace)
         utility_feature_energy_trace = jnp.where(
             reset_active_traces, 0.0, utility_feature_energy_trace
         )
@@ -1748,12 +1665,8 @@ class FixedBudgetFeatureLearner:
             candidate_utilities=new_candidate_utilities,
             candidate_utility_contribution_trace=candidate_utility_contribution_trace,
             candidate_utility_feature_trace=candidate_utility_feature_trace,
-            candidate_utility_feature_energy_trace=(
-                candidate_utility_feature_energy_trace
-            ),
-            candidate_utility_signal_second_moment=(
-                candidate_utility_signal_second_moment
-            ),
+            candidate_utility_feature_energy_trace=(candidate_utility_feature_energy_trace),
+            candidate_utility_signal_second_moment=(candidate_utility_signal_second_moment),
             candidate_ages=candidate_ages,
             feature_parent_a=feature_parent_a,
             feature_parent_b=feature_parent_b,
@@ -1835,9 +1748,7 @@ def run_feature_discovery_arrays(
         return result.state, (result.metrics, result.update_applied)
 
     t0 = time.time()
-    final_state, (metrics, updates_applied) = jax.lax.scan(
-        step_fn, state, (observations, targets)
-    )
+    final_state, (metrics, updates_applied) = jax.lax.scan(step_fn, state, (observations, targets))
     elapsed = time.time() - t0
     final_state = final_state.replace(uptime_s=final_state.uptime_s + elapsed)  # type: ignore[attr-defined]
     return FeatureDiscoveryLearningResult(

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -170,16 +170,12 @@ class TestInteractionFeatureDiscoveryStream:
         def tied_uniform(key, shape, dtype=jnp.float32, **kwargs):
             return jnp.zeros(shape, dtype=dtype)
 
-        monkeypatch.setattr(
-            "alberta_framework.streams.feature_discovery.jr.uniform", tied_uniform
-        )
+        monkeypatch.setattr("alberta_framework.streams.feature_discovery.jr.uniform", tied_uniform)
         state = stream.init(jr.key(0))
         assert int(jnp.count_nonzero(state.context_weights)) == 2
 
     @pytest.mark.parametrize("active_count", [0, -1, True, 1.0, np.int64(1)])
-    def test_active_pair_count_requires_positive_builtin_int(
-        self, active_count: object
-    ) -> None:
+    def test_active_pair_count_requires_positive_builtin_int(self, active_count: object) -> None:
         with pytest.raises(ValueError, match="positive built-in integer"):
             InteractionFeatureDiscoveryStream(
                 feature_dim=4,
@@ -219,8 +215,10 @@ class TestInteractionFeatureDiscoveryStream:
             assert np.unique(row).size == pair_count
         threshold = jnp.sort(scores, axis=-1)[..., 2:3]
         legacy_mask = scores <= threshold
-        expected = dense_weights * legacy_mask.astype(jnp.float32) / jnp.sqrt(
-            jnp.sum(legacy_mask, axis=-1, keepdims=True)
+        expected = (
+            dense_weights
+            * legacy_mask.astype(jnp.float32)
+            / jnp.sqrt(jnp.sum(legacy_mask, axis=-1, keepdims=True))
         )
 
         np.testing.assert_array_equal(
@@ -259,19 +257,13 @@ class TestInteractionFeatureDiscoveryStream:
             del key, kwargs
             return jnp.broadcast_to(jnp.asarray(scores, dtype=dtype), shape)
 
-        monkeypatch.setattr(
-            "alberta_framework.streams.feature_discovery.jr.normal", fixed_normal
-        )
-        monkeypatch.setattr(
-            "alberta_framework.streams.feature_discovery.jr.uniform", fixed_uniform
-        )
+        monkeypatch.setattr("alberta_framework.streams.feature_discovery.jr.normal", fixed_normal)
+        monkeypatch.setattr("alberta_framework.streams.feature_discovery.jr.uniform", fixed_uniform)
         init = jax.jit(stream.init) if compiled else stream.init
         state = init(jr.key(0))
 
         actual_mask = state.context_weights != 0.0
-        expected = jnp.broadcast_to(
-            jnp.asarray(expected_mask), state.context_weights.shape
-        )
+        expected = jnp.broadcast_to(jnp.asarray(expected_mask), state.context_weights.shape)
         chex.assert_trees_all_equal(actual_mask, expected)
 
         def body(carry, idx):
@@ -456,18 +448,10 @@ class TestFixedBudgetFeatureLearner:
             utilities=jnp.full((3,), jnp.inf, dtype=jnp.float32),
             candidate_utilities=jnp.full((2,), -jnp.inf, dtype=jnp.float32),
             task_activity_ema=jnp.array([jnp.inf, jnp.nan], dtype=jnp.float32),
-            generator_log_weights=jnp.array(
-                [jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32
-            ),
-            generator_utility_ema=jnp.array(
-                [jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32
-            ),
-            plasticity_log_weights=jnp.array(
-                [jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32
-            ),
-            plasticity_signal_ema=jnp.array(
-                [jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32
-            ),
+            generator_log_weights=jnp.array([jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32),
+            generator_utility_ema=jnp.array([jnp.inf, jnp.nan, -jnp.inf], dtype=jnp.float32),
+            plasticity_log_weights=jnp.array([jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32),
+            plasticity_signal_ema=jnp.array([jnp.nan, jnp.inf, -jnp.inf], dtype=jnp.float32),
             birth_timestamp=0.0,
         )
         recovered_weights = learner._resource_weights(state.generator_log_weights)
@@ -827,9 +811,7 @@ def test_curation_priority_override_has_exact_no_cadence_learning_parity() -> No
     assert not bool(full.curation_priority_override_applied)
     assert not bool(random.curation_priority_override_applied)
     assert not bool(jnp.array_equal(random.state.utilities, active_ranks))
-    assert not bool(
-        jnp.array_equal(random.state.candidate_utilities, candidate_ranks)
-    )
+    assert not bool(jnp.array_equal(random.state.candidate_utilities, candidate_ranks))
 
 
 def test_curation_priority_override_changes_only_forced_transaction_selection() -> None:
@@ -864,9 +846,7 @@ def test_curation_priority_override_changes_only_forced_transaction_selection() 
         active_ranks=active_ranks,
         candidate_ranks=candidate_ranks,
     )
-    random_override = full_override.replace(
-        enabled=jnp.asarray(True, dtype=jnp.bool_)
-    )
+    random_override = full_override.replace(enabled=jnp.asarray(True, dtype=jnp.bool_))
     observation = jnp.ones((4,), dtype=jnp.float32)
     target = jnp.zeros((1,), dtype=jnp.float32)
 
@@ -901,9 +881,7 @@ def test_curation_priority_override_changes_only_forced_transaction_selection() 
     assert int(random.promoted_candidate) == 1
     assert bool(random.curation_priority_override_applied)
     assert not bool(jnp.array_equal(random.state.utilities, active_ranks))
-    assert not bool(
-        jnp.array_equal(random.state.candidate_utilities, candidate_ranks)
-    )
+    assert not bool(jnp.array_equal(random.state.candidate_utilities, candidate_ranks))
 
 
 def test_curation_priority_override_controls_candidate_refresh_argmin() -> None:
@@ -946,9 +924,7 @@ def test_curation_priority_override_controls_candidate_refresh_argmin() -> None:
         state,
         observation,
         target,
-        curation_priority_override=ranks.replace(
-            enabled=jnp.asarray(True, dtype=jnp.bool_)
-        ),
+        curation_priority_override=ranks.replace(enabled=jnp.asarray(True, dtype=jnp.bool_)),
     )
 
     chex.assert_trees_all_equal(full.pre_curation_state, random.pre_curation_state)
@@ -1143,17 +1119,13 @@ def test_target_only_probe_is_invariant_to_durable_bank_and_learns_separate_bias
         candidate_second_moments=jnp.ones((1,), dtype=jnp.float32),
         target_second_moments=jnp.ones((1,), dtype=jnp.float32),
     )
-    changed_bank = base.replace(
-        output_weights=jnp.asarray(((2.0, -0.5),), dtype=jnp.float32)
-    )
+    changed_bank = base.replace(output_weights=jnp.asarray(((2.0, -0.5),), dtype=jnp.float32))
     observation = jnp.ones((3,), dtype=jnp.float32)
     target = jnp.ones((1,), dtype=jnp.float32)
     reference = learner.update(base, observation, target)
     changed = learner.update(changed_bank, observation, target)
     changed_probe = learner.update(
-        base.replace(
-            relevance_probe_weights=base.relevance_probe_weights.at[0, 0].set(9.0)
-        ),
+        base.replace(relevance_probe_weights=base.relevance_probe_weights.at[0, 0].set(9.0)),
         observation,
         target,
     )
@@ -1922,9 +1894,7 @@ class TestFixedBudgetInteractionLearner:
 
         assert not bool(wrong_sign.evidence_refreshed[0])
         assert not bool(wrong_sign.retention_evidence_refreshed[0])
-        assert float(wrong_sign.state.output_weights[0, 0]) == pytest.approx(
-            committed_weight
-        )
+        assert float(wrong_sign.state.output_weights[0, 0]) == pytest.approx(committed_weight)
         assert int(wrong_sign.state.utility_evidence_streak[0]) == 0
         assert int(wrong_sign.state.evidence_idle_steps[0]) == 1
 
@@ -2016,9 +1986,7 @@ class TestFixedBudgetInteractionLearner:
             feature_second_moments=jnp.ones((2,), dtype=jnp.float32),
             target_second_moments=jnp.ones((1,), dtype=jnp.float32),
         )
-        perturbed = base.replace(
-            output_weights=jnp.array([[10.0, -100.0]], dtype=jnp.float32)
-        )
+        perturbed = base.replace(output_weights=jnp.array([[10.0, -100.0]], dtype=jnp.float32))
         observation = jnp.ones((3,), dtype=jnp.float32)
         target = jnp.ones((1,), dtype=jnp.float32)
         external = jnp.ones((2,), dtype=jnp.bool_)
@@ -2034,13 +2002,10 @@ class TestFixedBudgetInteractionLearner:
             changed.relevance_probe_errors,
             jnp.asarray(((101.0, -9.0),), dtype=jnp.float32),
         )
-        assert not bool(
-            jnp.all(reference.relevance_probe_scores == changed.relevance_probe_scores)
-        )
+        assert not bool(jnp.all(reference.relevance_probe_scores == changed.relevance_probe_scores))
         assert not bool(
             jnp.all(
-                reference.state.relevance_probe_weights
-                == changed.state.relevance_probe_weights
+                reference.state.relevance_probe_weights == changed.state.relevance_probe_weights
             )
         )
 
@@ -2136,9 +2101,7 @@ class TestFixedBudgetInteractionLearner:
             candidate_second_moments=jnp.ones((1,), dtype=jnp.float32),
             target_second_moments=jnp.ones((1,), dtype=jnp.float32),
         )
-        perturbed = base.replace(
-            output_weights=jnp.array([[100.0]], dtype=jnp.float32)
-        )
+        perturbed = base.replace(output_weights=jnp.array([[100.0]], dtype=jnp.float32))
         observation = jnp.ones((3,), dtype=jnp.float32)
         target = jnp.ones((1,), dtype=jnp.float32)
         reference = learner.update(base, observation, target)
@@ -2157,15 +2120,11 @@ class TestFixedBudgetInteractionLearner:
         )
         assert not bool(
             jnp.all(
-                reference.state.relevance_probe_weights
-                == changed.state.relevance_probe_weights
+                reference.state.relevance_probe_weights == changed.state.relevance_probe_weights
             )
         )
         assert not bool(
-            jnp.all(
-                reference.candidate_promotion_signal
-                == changed.candidate_promotion_signal
-            )
+            jnp.all(reference.candidate_promotion_signal == changed.candidate_promotion_signal)
         )
         chex.assert_trees_all_equal(
             reference.state.output_weights,
@@ -2232,12 +2191,8 @@ class TestFixedBudgetInteractionLearner:
                 jnp.array([target_value], dtype=jnp.float32),
             )
             results.append(result)
-            assert int(result.candidate_promotion_evidence_streak_updated[0]) == (
-                expected_updated
-            )
-            assert int(result.state.candidate_promotion_evidence_streak[0]) == (
-                expected_post
-            )
+            assert int(result.candidate_promotion_evidence_streak_updated[0]) == (expected_updated)
+            assert int(result.state.candidate_promotion_evidence_streak[0]) == (expected_post)
             state = result.state
 
         assert bool(results[0].candidate_promotion_raw_evidence[0])
@@ -2250,11 +2205,7 @@ class TestFixedBudgetInteractionLearner:
         assert int(results[5].promoted_candidate) == 0
         assert bool(results[5].candidate_promotion_confirmed[0])
         assert float(results[5].candidate_promotion_signal[0]) > 0.1
-        assert int(
-            np.asarray(
-                results[5].state.candidate_output_weights[0, 0]
-            ).view(np.uint32)
-        ) == 0
+        assert int(np.asarray(results[5].state.candidate_output_weights[0, 0]).view(np.uint32)) == 0
 
     def test_reacquisition_confirmation_does_not_delay_first_acquisition(self) -> None:
         learner = FixedBudgetInteractionLearner(
@@ -2803,9 +2754,7 @@ class TestFixedBudgetInteractionLearner:
 
         assert int(retired.retired_slot) == 0
         assert int(np.asarray(retired.state.output_weights[0, 0]).view(np.uint32)) == 0
-        assert int(
-            np.asarray(retired.state.relevance_probe_weights[0, 0]).view(np.uint32)
-        ) == 0
+        assert int(np.asarray(retired.state.relevance_probe_weights[0, 0]).view(np.uint32)) == 0
 
     def test_relevance_probe_state_is_always_fixed_shape_and_accounted(self) -> None:
         disabled = FixedBudgetInteractionLearner(
@@ -3134,9 +3083,7 @@ class TestFeatureDiscoveryStreamsValidation:
             ({"noise_std": -0.01}, "noise_std"),
         ],
     )
-    def test_nonlinear_rejects_malformed_inputs(
-        self, kwargs: dict[str, Any], match: str
-    ) -> None:
+    def test_nonlinear_rejects_malformed_inputs(self, kwargs: dict[str, Any], match: str) -> None:
         base: dict[str, Any] = {"feature_dim": 8}
         base.update(kwargs)
         with pytest.raises(ValueError, match=match):
@@ -3216,9 +3163,7 @@ class TestFeatureDiscoveryStreamsValidation:
             ({"noise_std": -0.01}, "noise_std"),
         ],
     )
-    def test_interaction_rejects_malformed_inputs(
-        self, kwargs: dict[str, Any], match: str
-    ) -> None:
+    def test_interaction_rejects_malformed_inputs(self, kwargs: dict[str, Any], match: str) -> None:
         base: dict[str, Any] = {"feature_dim": 6}
         base.update(kwargs)
         with pytest.raises(ValueError, match=match):
@@ -3267,3 +3212,29 @@ class TestFeatureDiscoveryStreamsValidation:
             collect_feature_discovery_stream(stream, -1, key)
         with pytest.raises(TypeError, match="init"):
             collect_feature_discovery_stream(object(), 10, key)
+
+
+def test_fixed_budget_feature_learner_integer_validation() -> None:
+    with pytest.raises(ValueError, match="n_features"):
+        FixedBudgetFeatureLearner(n_features=True, n_tasks=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_features"):
+        FixedBudgetFeatureLearner(n_features=4.5, n_tasks=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_tasks"):
+        FixedBudgetFeatureLearner(n_features=4, n_tasks=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="candidate_count"):
+        FixedBudgetFeatureLearner(n_features=4, n_tasks=1, candidate_count=True)  # type: ignore[arg-type]
+
+    learner = FixedBudgetFeatureLearner(
+        n_features=np.int32(4),
+        n_tasks=np.int64(2),
+        candidate_count=np.int32(2),
+        replacement_interval=np.int32(50),
+        min_feature_age=np.int64(20),
+        candidate_min_age=np.int32(10),
+    )
+    assert learner.n_features == 4
+    assert learner.n_tasks == 2
+    assert learner._candidate_count == 2
+    assert type(learner._candidate_count) is int
+    assert type(learner.n_features) is int
+    assert type(learner.n_tasks) is int


### PR DESCRIPTION
## Summary
- Hardens `FixedBudgetFeatureLearner` integer parameters (`n_features`, `n_tasks`, `candidate_count`, `replacement_interval`, `min_feature_age`, `candidate_min_age`, `utility_top_k`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Canonicalizes integer attributes to Python `int` at construction time.

## Verification
- `PYTHONPATH=. pytest tests/test_feature_discovery.py`: 133 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/feature_discovery.py`: clean