### PR TITLE
fix(world-model): validate complete configurations and resources

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -139,6 +139,45 @@ def _serialized_sequence(name: str, value: object) -> tuple[Any, ...]:
     return tuple(cast(list[Any] | tuple[Any, ...], value))
 
 
+def _require_scan_resource(name: str, *, float32_scalars: int, bool_scalars: int) -> None:
+    if float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} scalar count must fit in signed int32")
+    if 4 * float32_scalars + bool_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} byte count must fit in signed int32")
+
+
+def _scan_array_metadata(name: str, value: object) -> tuple[int, ...]:
+    """Read shape and numeric dtype before any user-controlled array conversion."""
+    try:
+        raw_shape = object.__getattribute__(value, "shape")
+        raw_dtype = object.__getattribute__(value, "dtype")
+    except (AttributeError, TypeError):
+        raise ValueError(f"{name} must expose array shape and dtype metadata") from None
+    if type(raw_shape) is not tuple:
+        raise ValueError(f"{name} shape metadata must be an exact tuple")
+    shape = tuple(
+        _require_int32(f"{name} shape dimension", dimension, minimum=0)
+        for dimension in raw_shape
+    )
+    try:
+        dtype = np.dtype(raw_dtype)
+    except Exception:
+        raise ValueError(f"{name} dtype metadata must be readable") from None
+    if dtype.kind not in "biuf":
+        raise ValueError(f"{name} must have a real numeric dtype")
+    return shape
+
+
+def _require_scan_array(name: str, value: object, expected: tuple[int, ...]) -> None:
+    if _scan_array_metadata(name, value) != expected:
+        raise ValueError(f"{name} must have shape {expected}")
+
+
+def _saturating_increment(value: Array) -> Array:
+    one = jnp.asarray(1, dtype=jnp.int32)
+    return jnp.minimum(value, jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)) + one
+
+
 def _float32_operand(
     name: str,
     value: Array | float | int,
@@ -248,6 +287,12 @@ class ActionConditionedWorldModelConfig:
                 name,
                 validated_float32_scalar(name, getattr(self, name), **bounds),
             )
+        if (
+            observation_scale is not None
+            and max(observation_scale) * self.max_delta_scale
+            > float(np.finfo(np.float32).max)
+        ):
+            raise ValueError("observation_scale * max_delta_scale must remain finite")
 
         action_feature_dim = n_actions
         if self.include_action_interactions:
@@ -401,8 +446,23 @@ def _rollback_multi_head_result(
 
 def _action_world_model_state_is_valid(
     state: ActionConditionedWorldModelState,
+    observation_dim: int,
 ) -> Bool[Array, ""]:
     """Accept either the intentional empty-bound sentinels or finite learned bounds."""
+    direct_structure_valid = (
+        state.observation_min.shape == (observation_dim,)
+        and state.observation_max.shape == (observation_dim,)
+        and state.reward_min.shape == ()
+        and state.reward_max.shape == ()
+        and state.model_error_ema.shape == ()
+        and state.step_count.shape == ()
+        and state.observation_min.dtype == jnp.float32
+        and state.observation_max.dtype == jnp.float32
+        and state.reward_min.dtype == jnp.float32
+        and state.reward_max.dtype == jnp.float32
+        and state.model_error_ema.dtype == jnp.float32
+        and state.step_count.dtype == jnp.int32
+    )
     finite_bounds = (
         jnp.all(jnp.isfinite(state.observation_min))
         & jnp.all(jnp.isfinite(state.observation_max))
@@ -417,7 +477,8 @@ def _action_world_model_state_is_valid(
         & jnp.isneginf(state.reward_max)
     )
     return (
-        floating_tree_is_finite(state.learner_state)
+        direct_structure_valid
+        & floating_tree_is_finite(state.learner_state)
         & jnp.isfinite(state.model_error_ema)
         & (state.step_count >= 0)
         & (finite_bounds | empty_bounds)
@@ -813,7 +874,7 @@ class ActionConditionedWorldModel:
             reward_min=jnp.minimum(state.reward_min, safe_reward),
             reward_max=jnp.maximum(state.reward_max, safe_reward),
             model_error_ema=next_error_ema,
-            step_count=state.step_count + 1,
+            step_count=_saturating_increment(state.step_count),
         )
 
         diagnostics_finite = (
@@ -830,7 +891,7 @@ class ActionConditionedWorldModel:
         update_applied = (
             inputs_valid
             & learner_result.update_applied
-            & _action_world_model_state_is_valid(state)
+            & _action_world_model_state_is_valid(state, self._config.observation_dim)
             & floating_tree_is_finite(candidate_state)
             & diagnostics_finite
         )
@@ -885,12 +946,38 @@ def run_action_conditioned_world_model_learning_loop(
     discounts: Float[Array, " num_steps"] | None = None,
 ) -> ActionConditionedWorldModelLearningResult:
     """Run online one-step model learning over transition arrays."""
+    observation_dim = model.config.observation_dim
+    n_heads = observation_dim + 2
+    observation_shape = _scan_array_metadata("observations", observations)
+    if len(observation_shape) != 2 or observation_shape[1] != observation_dim:
+        raise ValueError(f"observations must have shape (num_steps, {observation_dim})")
+    num_steps = observation_shape[0]
+    _require_scan_array("actions", actions, (num_steps,))
+    _require_scan_array("rewards", rewards, (num_steps,))
+    _require_scan_array(
+        "next_observations", next_observations, (num_steps, observation_dim)
+    )
+    if discounts is not None:
+        _require_scan_array("discounts", discounts, (num_steps,))
+    _require_scan_resource(
+        "action-conditioned world-model learning result",
+        float32_scalars=(
+            2 * num_steps * observation_dim + 6 * num_steps + 6 * num_steps * n_heads
+        ),
+        bool_scalars=num_steps,
+    )
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    actions = jnp.asarray(actions, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     if discounts is None:
         discounts = jnp.full(
-            jnp.shape(rewards),
+            (num_steps,),
             jnp.asarray(model.config.gamma, dtype=jnp.float32),
             dtype=jnp.float32,
         )
+    else:
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
 
     def _scan_fn(
         carry: ActionConditionedWorldModelState,
@@ -1296,13 +1383,29 @@ class OneStepWorldModel:
         prediction_error = jnp.nanmean(learner_result.errors**2)
         candidate_state = WorldModelState(
             learner_state=learner_result.state,
-            step_count=state.step_count + 1,
+            step_count=_saturating_increment(state.step_count),
+        )
+        diagnostics_valid = (
+            jnp.all(jnp.isfinite(prediction.next_observation))
+            & jnp.isfinite(prediction.reward)
+            & jnp.all(jnp.isfinite(prediction.raw_predictions))
+            & jnp.all(~jnp.isinf(targets))
+            & jnp.all(~jnp.isinf(learner_result.errors))
+            & jnp.all(~jnp.isinf(learner_result.per_head_metrics))
+            & jnp.all(~jnp.isinf(next_observation_errors))
+            & ~jnp.isinf(reward_error)
+            & ~jnp.isinf(observation_mse)
+            & ~jnp.isinf(prediction_error)
         )
         update_applied = (
             action_valid
             & learner_result.update_applied
             & floating_tree_is_finite(state)
+            & (state.step_count.shape == ())
+            & (state.step_count.dtype == jnp.int32)
+            & (state.step_count >= 0)
             & floating_tree_is_finite(candidate_state)
+            & diagnostics_valid
         )
         new_state = select_transaction(update_applied, candidate_state, state)
         reported_learner_result = _rollback_multi_head_result(
@@ -1357,6 +1460,33 @@ def run_world_model_learning_loop(
     next_observations: Array,
 ) -> WorldModelLearningResult:
     """Run one-step world-model learning with ``jax.lax.scan``."""
+    observation_dim = model.config.observation_dim
+    n_heads = observation_dim + 1
+    observation_shape = _scan_array_metadata("observations", observations)
+    if len(observation_shape) != 2 or observation_shape[1] != observation_dim:
+        raise ValueError(f"observations must have shape (num_steps, {observation_dim})")
+    num_steps = observation_shape[0]
+    action_shape = (
+        (num_steps,)
+        if model.config.n_actions is not None
+        else (num_steps, model.config.action_dim)
+    )
+    _require_scan_array("actions", actions, action_shape)
+    _require_scan_array("rewards", rewards, (num_steps,))
+    _require_scan_array(
+        "next_observations", next_observations, (num_steps, observation_dim)
+    )
+    _require_scan_resource(
+        "world-model learning result",
+        float32_scalars=(
+            2 * num_steps * observation_dim + 2 * num_steps + 3 * num_steps * n_heads
+        ),
+        bool_scalars=num_steps,
+    )
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    actions = jnp.asarray(actions, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
 
     def step_fn(
         carry: WorldModelState,

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -16,11 +16,14 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Any, cast
+import operator
+from collections.abc import Mapping
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -44,6 +47,96 @@ from alberta_framework.core.update_safety import (
     safe_discrete_action,
     select_transaction,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a bool")
+    return value
+
+
+def _validate_hidden_sizes(value: object) -> tuple[int, ...]:
+    if type(value) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(
+        _require_int32(f"hidden_sizes[{index}]", width, minimum=1)
+        for index, width in enumerate(value)
+    )
+
+
+def _checked_product(name: str, left: int, right: int) -> int:
+    if left > _INT32_MAX // right:
+        raise ValueError(f"derived {name} must fit in signed int32")
+    return left * right
+
+
+def _validate_world_model_resources(
+    *,
+    observation_dim: int,
+    action_feature_dim: int,
+    hidden_sizes: tuple[int, ...],
+    n_heads: int,
+    outer_state_scalars: int,
+) -> None:
+    if observation_dim > _INT32_MAX - action_feature_dim:
+        raise ValueError("derived input_dim must fit in signed int32")
+    input_dim = observation_dim + action_feature_dim
+    layer_sizes = (input_dim, *hidden_sizes)
+    for index, (fan_in, fan_out) in enumerate(
+        zip(layer_sizes, layer_sizes[1:], strict=False)
+    ):
+        _checked_product(f"hidden_layer[{index}]_scalars", fan_in, fan_out)
+    head_input = hidden_sizes[-1] if hidden_sizes else input_dim
+    _checked_product("head_weight_scalars", n_heads, head_input)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    head_parameters = n_heads * (head_input + 1)
+    direct_scalars = (
+        2 * (trunk_parameters + head_parameters)
+        + sum(hidden_sizes)
+        + 3
+        + outer_state_scalars
+    )
+    for name, value in (
+        ("combined_direct_state_scalars", direct_scalars),
+        ("combined_direct_state_bytes", 4 * direct_scalars),
+    ):
+        if value > _INT32_MAX:
+            raise ValueError(f"derived {name} must fit in signed int32")
+
+
+def _serialized_sequence(name: str, value: object) -> tuple[Any, ...]:
+    if type(value) not in (list, tuple):
+        raise ValueError(f"serialized {name} must be an actual list or tuple")
+    return tuple(cast(list[Any] | tuple[Any, ...], value))
 
 
 def _float32_operand(
@@ -111,6 +204,69 @@ class ActionConditionedWorldModelConfig:
     max_delta_scale: float = 5.0
     include_action_interactions: bool = False
 
+    def __post_init__(self) -> None:
+        """Validate and canonicalize the complete static construction."""
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        n_actions = _require_int32("n_actions", self.n_actions, minimum=1)
+        hidden_sizes = _validate_hidden_sizes(self.hidden_sizes)
+        for name in ("predict_delta", "use_layer_norm", "include_action_interactions"):
+            object.__setattr__(self, name, _require_bool(name, getattr(self, name)))
+        if type(self.trace_mode) is not TraceMode:
+            raise ValueError("trace_mode must be a TraceMode")
+
+        observation_scale = self.observation_scale
+        if observation_scale is not None:
+            if type(observation_scale) is not tuple:
+                raise ValueError("observation_scale must be an actual tuple or None")
+            if len(observation_scale) != observation_dim:
+                raise ValueError("observation_scale length must equal observation_dim")
+            observation_scale = tuple(
+                validated_float32_scalar(
+                    f"observation_scale[{index}]", scale, positive=True
+                )
+                for index, scale in enumerate(observation_scale)
+            )
+
+        scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
+            ("gamma", {"lower": 0.0, "upper": 1.0}),
+            ("reward_scale", {"positive": True}),
+            ("step_size", {"positive": True}),
+            ("sparsity", {"lower": 0.0, "upper": 1.0}),
+            ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
+            ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+            ("error_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+            ("observation_clip_margin", {"lower": 0.0}),
+            ("max_delta_scale", {"positive": True}),
+        )
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_actions", n_actions)
+        object.__setattr__(self, "hidden_sizes", hidden_sizes)
+        object.__setattr__(self, "observation_scale", observation_scale)
+        for name, bounds in scalar_specs:
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), **bounds),
+            )
+
+        action_feature_dim = n_actions
+        if self.include_action_interactions:
+            interactions = _checked_product(
+                "action_interaction_scalars", observation_dim, n_actions
+            )
+            if action_feature_dim > _INT32_MAX - interactions:
+                raise ValueError("derived action_feature_dim must fit in signed int32")
+            action_feature_dim += interactions
+        if observation_dim > _INT32_MAX - 2:
+            raise ValueError("derived n_heads must fit in signed int32")
+        _validate_world_model_resources(
+            observation_dim=observation_dim,
+            action_feature_dim=action_feature_dim,
+            hidden_sizes=hidden_sizes,
+            n_heads=observation_dim + 2,
+            outer_state_scalars=2 * observation_dim + 4,
+        )
+
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
         payload = dataclasses.asdict(self)
@@ -122,15 +278,26 @@ class ActionConditionedWorldModelConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ActionConditionedWorldModelConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> ActionConditionedWorldModelConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be an actual mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
         payload.pop("type", None)
         if "hidden_sizes" in payload:
-            payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
+            payload["hidden_sizes"] = _serialized_sequence(
+                "hidden_sizes", payload["hidden_sizes"]
+            )
         if "observation_scale" in payload and payload["observation_scale"] is not None:
-            payload["observation_scale"] = tuple(payload["observation_scale"])
+            payload["observation_scale"] = _serialized_sequence(
+                "observation_scale", payload["observation_scale"]
+            )
         if "trace_mode" in payload:
+            if type(payload["trace_mode"]) is not str:
+                raise ValueError("serialized trace_mode must be an actual string")
             payload["trace_mode"] = TraceMode(payload["trace_mode"])
         return cls(**payload)
 
@@ -703,40 +870,9 @@ class ActionConditionedWorldModel:
         self, config: ActionConditionedWorldModelConfig
     ) -> ActionConditionedWorldModelConfig:
         """Fail closed on malformed configuration and return its canonical float32 form."""
-        if config.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if config.n_actions <= 0:
-            raise ValueError("n_actions must be positive")
-        if any(size <= 0 for size in config.hidden_sizes):
-            raise ValueError("hidden_sizes must contain only positive widths")
-        observation_scale = config.observation_scale
-        if observation_scale is not None:
-            if len(observation_scale) != config.observation_dim:
-                raise ValueError("observation_scale length must equal observation_dim")
-            observation_scale = tuple(
-                validated_float32_scalar("observation_scale values", scale, positive=True)
-                for scale in observation_scale
-            )
-        return dataclasses.replace(
-            config,
-            gamma=validated_float32_scalar("gamma", config.gamma, lower=0.0, upper=1.0),
-            observation_scale=observation_scale,
-            reward_scale=validated_float32_scalar(
-                "reward_scale", config.reward_scale, positive=True
-            ),
-            utility_decay=validated_float32_scalar(
-                "utility_decay", config.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
-            ),
-            error_decay=validated_float32_scalar(
-                "error_decay", config.error_decay, lower=0.0, upper=1.0, upper_inclusive=False
-            ),
-            observation_clip_margin=validated_float32_scalar(
-                "observation_clip_margin", config.observation_clip_margin, lower=0.0
-            ),
-            max_delta_scale=validated_float32_scalar(
-                "max_delta_scale", config.max_delta_scale, positive=True
-            ),
-        )
+        if type(config) is not ActionConditionedWorldModelConfig:
+            raise ValueError("config must be an ActionConditionedWorldModelConfig")
+        return config
 
 
 def run_action_conditioned_world_model_learning_loop(
@@ -852,6 +988,44 @@ class WorldModelConfig:
     predict_delta: bool = False
     utility_decay: float = 0.99
 
+    def __post_init__(self) -> None:
+        """Validate and canonicalize the complete static construction."""
+        observation_dim = _require_int32("observation_dim", self.observation_dim, minimum=1)
+        n_actions = (
+            _require_int32("n_actions", self.n_actions, minimum=1)
+            if self.n_actions is not None
+            else None
+        )
+        action_dim = _require_int32("action_dim", self.action_dim, minimum=1)
+        hidden_sizes = _validate_hidden_sizes(self.hidden_sizes)
+        for name in ("use_layer_norm", "predict_delta"):
+            object.__setattr__(self, name, _require_bool(name, getattr(self, name)))
+        scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
+            ("step_size", {"positive": True}),
+            ("sparsity", {"lower": 0.0, "upper": 1.0}),
+            ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
+            ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
+        )
+        object.__setattr__(self, "observation_dim", observation_dim)
+        object.__setattr__(self, "n_actions", n_actions)
+        object.__setattr__(self, "action_dim", action_dim)
+        object.__setattr__(self, "hidden_sizes", hidden_sizes)
+        for name, bounds in scalar_specs:
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), **bounds),
+            )
+        if observation_dim == _INT32_MAX:
+            raise ValueError("derived n_heads must fit in signed int32")
+        _validate_world_model_resources(
+            observation_dim=observation_dim,
+            action_feature_dim=n_actions if n_actions is not None else action_dim,
+            hidden_sizes=hidden_sizes,
+            n_heads=observation_dim + 1,
+            outer_state_scalars=1,
+        )
+
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
         payload = dataclasses.asdict(self)
@@ -860,12 +1034,19 @@ class WorldModelConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> WorldModelConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> WorldModelConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be an actual mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
         payload.pop("type", None)
         if "hidden_sizes" in payload:
-            payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
+            payload["hidden_sizes"] = _serialized_sequence(
+                "hidden_sizes", payload["hidden_sizes"]
+            )
         return cls(**payload)
 
 
@@ -1163,16 +1344,8 @@ class OneStepWorldModel:
         )
 
     def _validate_config(self, config: WorldModelConfig) -> None:
-        if config.observation_dim <= 0:
-            raise ValueError("observation_dim must be positive")
-        if config.n_actions is not None and config.n_actions <= 0:
-            raise ValueError("n_actions must be positive when provided")
-        if config.n_actions is None and config.action_dim <= 0:
-            raise ValueError("action_dim must be positive for vector actions")
-        if any(size <= 0 for size in config.hidden_sizes):
-            raise ValueError("hidden_sizes must contain only positive widths")
-        if not 0.0 <= config.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        if type(config) is not WorldModelConfig:
+            raise ValueError("config must be a WorldModelConfig")
 
 
 def run_world_model_learning_loop(

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -830,3 +830,97 @@ def test_diagnostics_reflect_true_decodes_not_guard_clips() -> None:
     assert float(far_result.next_observation_errors[0]) == pytest.approx(
         config.max_delta_scale, abs=1e-3
     )
+
+
+def test_action_world_model_rejects_decode_product_overflow() -> None:
+    with pytest.raises(ValueError, match=r"observation_scale \* max_delta_scale"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            observation_scale=(float(np.finfo(np.float32).max),),
+            max_delta_scale=2.0,
+        )
+
+
+def test_action_world_model_scan_preflights_complete_result_resources() -> None:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(observation_dim=1, n_actions=2, hidden_sizes=())
+    )
+    state = model.init(jr.key(0))
+    steps = 21_000_000
+    with pytest.raises(ValueError, match="byte count"):
+        run_action_conditioned_world_model_learning_loop(
+            model,
+            state,
+            jax.ShapeDtypeStruct((steps, 1), jnp.float32),
+            jax.ShapeDtypeStruct((steps,), jnp.int32),
+            jax.ShapeDtypeStruct((steps,), jnp.float32),
+            jax.ShapeDtypeStruct((steps, 1), jnp.float32),
+        )
+
+
+def test_action_world_model_outer_step_count_saturates() -> None:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    state = model.init(jr.key(0))
+    state = dataclasses.replace(
+        state,
+        observation_min=jnp.zeros((1,), dtype=jnp.float32),
+        observation_max=jnp.zeros((1,), dtype=jnp.float32),
+        reward_min=jnp.asarray(0.0, dtype=jnp.float32),
+        reward_max=jnp.asarray(0.0, dtype=jnp.float32),
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32),
+    )
+    result = model.update(
+        state,
+        jnp.asarray([0.0], dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([0.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_action_world_model_rolls_back_reduction_overflow() -> None:
+    observation_dim = 8
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=observation_dim,
+            n_actions=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+            observation_scale=(8.0e18,) * observation_dim,
+        )
+    )
+    state = model.init(jr.key(0))
+    heads = state.learner_state.head_params
+    biased_heads = dataclasses.replace(
+        heads,
+        biases=tuple(
+            jnp.ones_like(bias) if index < observation_dim else jnp.zeros_like(bias)
+            for index, bias in enumerate(heads.biases)
+        ),
+    )
+    state = dataclasses.replace(
+        state,
+        learner_state=dataclasses.replace(state.learner_state, head_params=biased_heads),
+    )
+    result = model.update(
+        state,
+        jnp.zeros((observation_dim,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.zeros((observation_dim,), dtype=jnp.float32),
+    )
+    assert not bool(result.update_applied)
+    assert float(result.observation_mse) == 0.0
+    assert int(result.state.step_count) == 0

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -419,11 +419,13 @@ def test_default_discounts_do_not_inherit_the_reward_dtype() -> None:
 )
 def test_config_rejects_non_finite_scalars(overrides: dict[str, object]) -> None:
     """A NaN scalar passes a bare `< 0` check and yields an all-rejected run scoring 0.0."""
-    config = ActionConditionedWorldModelConfig(
-        observation_dim=2, n_actions=2, hidden_sizes=(), **overrides  # type: ignore[arg-type]
-    )
     with pytest.raises(ValueError, match="finite"):
-        ActionConditionedWorldModel(config)
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            **overrides,  # type: ignore[arg-type]
+        )
 
 
 class _FloatSpoof:
@@ -474,13 +476,15 @@ def test_config_rejects_scalars_that_leave_the_float32_domain(
     overrides: dict[str, object], message: str
 ) -> None:
     """Host-finite values must also stay finite and in range once narrowed to float32."""
-    config = ActionConditionedWorldModelConfig(
-        observation_dim=2, n_actions=2, hidden_sizes=(), **overrides  # type: ignore[arg-type]
-    )
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         with pytest.raises(ValueError, match=message):
-            ActionConditionedWorldModel(config)
+            ActionConditionedWorldModelConfig(
+                observation_dim=2,
+                n_actions=2,
+                hidden_sizes=(),
+                **overrides,  # type: ignore[arg-type]
+            )
 
 
 def test_config_canonicalizes_real_scalars_and_preserves_builtin_floats() -> None:
@@ -535,6 +539,85 @@ def test_config_normalizes_real_comparison_hooks_and_conversion_failures() -> No
                 gamma=BrokenFraction(1, 2),
             )
         )
+
+
+@pytest.mark.parametrize("value", [True, 1.5, "2", object()])
+def test_config_rejects_non_integer_dimensions_without_repr(value: object) -> None:
+    with pytest.raises(ValueError, match="observation_dim"):
+        ActionConditionedWorldModelConfig(observation_dim=value, n_actions=2)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        ActionConditionedWorldModelConfig(observation_dim=2, n_actions=value)  # type: ignore[arg-type]
+
+
+def test_config_canonicalizes_numpy_integer_family_and_complete_scalars() -> None:
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=np.uint64(3),
+        n_actions=np.int8(2),
+        hidden_sizes=(np.uint16(4),),
+        step_size=np.float64(0.02),
+        sparsity=np.float32(0.5),
+        leaky_relu_slope=Fraction(1, 10),
+    )
+    assert type(config.observation_dim) is int
+    assert type(config.n_actions) is int
+    assert config.hidden_sizes == (4,)
+    assert all(type(value) is int for value in config.hidden_sizes)
+    assert all(
+        type(value) is float
+        for value in (config.step_size, config.sparsity, config.leaky_relu_slope)
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"step_size": 0.0},
+        {"sparsity": -0.1},
+        {"sparsity": 1.1},
+        {"leaky_relu_slope": -0.1},
+        {"leaky_relu_slope": 1.1},
+        {"predict_delta": np.bool_(True)},
+        {"use_layer_norm": 1},
+        {"include_action_interactions": "yes"},
+    ],
+)
+def test_config_rejects_invalid_complete_public_fields(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        ActionConditionedWorldModelConfig(
+            observation_dim=2, n_actions=2, **overrides  # type: ignore[arg-type]
+        )
+
+
+def test_config_preflights_derived_dimensions_and_state() -> None:
+    with pytest.raises(ValueError, match="action_interaction_scalars"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=50_000,
+            n_actions=50_000,
+            hidden_sizes=(),
+            include_action_interactions=True,
+        )
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=20_000,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+
+
+def test_config_serialization_preserves_list_and_tuple_compatibility() -> None:
+    payload = ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        hidden_sizes=(),
+        observation_scale=(1.0, 2.0),
+    ).to_config()
+    assert ActionConditionedWorldModelConfig.from_config(payload).hidden_sizes == ()
+    payload["hidden_sizes"] = (3,)
+    payload["observation_scale"] = (1.0, 2.0)
+    assert ActionConditionedWorldModelConfig.from_config(payload).hidden_sizes == (3,)
+    payload["hidden_sizes"] = range(2)
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        ActionConditionedWorldModelConfig.from_config(payload)
 
 
 @pytest.mark.parametrize("discount", [1.5, -0.5, 5.0])

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -367,3 +369,55 @@ def test_world_model_config_deserialization_preserves_sequence_compatibility() -
     payload["hidden_sizes"] = range(2)
     with pytest.raises(ValueError, match="actual list or tuple"):
         WorldModelConfig.from_config(payload)
+
+
+def test_world_model_scan_preflights_metadata_and_complete_result_resources() -> None:
+    model = OneStepWorldModel(WorldModelConfig(observation_dim=1, hidden_sizes=()))
+    state = model.init(jr.key(0))
+    with pytest.raises(ValueError, match="rewards must have shape"):
+        run_world_model_learning_loop(
+            model,
+            state,
+            jnp.zeros((2, 1), dtype=jnp.float32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2, 1), dtype=jnp.float32),
+            jnp.zeros((2, 1), dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="real numeric dtype"):
+        run_world_model_learning_loop(
+            model,
+            state,
+            jnp.zeros((2, 1), dtype=jnp.float32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.complex64),
+            jnp.zeros((2, 1), dtype=jnp.float32),
+        )
+
+    steps = 60_000_000
+    with pytest.raises(ValueError, match="byte count"):
+        run_world_model_learning_loop(
+            model,
+            state,
+            jax.ShapeDtypeStruct((steps, 1), jnp.float32),
+            jax.ShapeDtypeStruct((steps,), jnp.int32),
+            jax.ShapeDtypeStruct((steps,), jnp.float32),
+            jax.ShapeDtypeStruct((steps, 1), jnp.float32),
+        )
+
+
+def test_world_model_outer_step_count_saturates() -> None:
+    model = OneStepWorldModel(
+        WorldModelConfig(observation_dim=1, n_actions=2, hidden_sizes=(), sparsity=0.0)
+    )
+    state = dataclasses.replace(
+        model.init(jr.key(0)), step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32)
+    )
+    result = model.update(
+        state,
+        jnp.asarray([0.0], dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([0.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -6,6 +6,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.core.world_model import (
@@ -323,3 +324,46 @@ def test_world_model_learns_action_conditional_deterministic_transition() -> Non
     assert float(last_mse) < float(first_mse)
     assert float(pred_a1.reward - pred_a0.reward) > 0.25
     assert float(pred_a1.next_observation[0] - pred_a0.next_observation[0]) > 0.5
+
+
+def test_world_model_config_validates_all_public_fields_and_resources() -> None:
+    config = WorldModelConfig(
+        observation_dim=np.int32(3),
+        n_actions=np.uint8(2),
+        action_dim=np.int64(1),
+        hidden_sizes=(np.uint16(4),),
+        step_size=np.float64(0.02),
+    )
+    assert type(config.observation_dim) is int
+    assert type(config.n_actions) is int
+    assert type(config.action_dim) is int
+    assert config.hidden_sizes == (4,)
+    assert type(config.step_size) is float
+
+    invalid = (
+        {"observation_dim": True},
+        {"n_actions": 2.5},
+        {"action_dim": False},
+        {"hidden_sizes": [4]},
+        {"step_size": 0.0},
+        {"sparsity": float("nan")},
+        {"leaky_relu_slope": 1.1},
+        {"use_layer_norm": np.bool_(True)},
+        {"predict_delta": 1},
+    )
+    for overrides in invalid:
+        with pytest.raises(ValueError):
+            WorldModelConfig(**{"observation_dim": 2, **overrides})  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        WorldModelConfig(observation_dim=20_000, n_actions=2, hidden_sizes=())
+
+
+def test_world_model_config_deserialization_preserves_sequence_compatibility() -> None:
+    payload = WorldModelConfig(observation_dim=2, hidden_sizes=()).to_config()
+    assert WorldModelConfig.from_config(payload).hidden_sizes == ()
+    payload["hidden_sizes"] = (3,)
+    assert WorldModelConfig.from_config(payload).hidden_sizes == (3,)
+    payload["hidden_sizes"] = range(2)
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        WorldModelConfig.from_config(payload)


### PR DESCRIPTION
Supersedes #810 while preserving Kayvan Zahiri's validation contribution and removing unrelated formatting churn.

This replacement validates both public one-step world-model config dataclasses at construction time: exact trusted Python/NumPy integer families, exact booleans/enums/containers, every float32-consumed scalar in both its host and narrowed domains, and canonicalized stored values. It also preflights action interactions, input/head/layer shapes, and the complete direct learner+wrapper state lower bound before JAX allocation.

Compatibility is retained at the serialized boundary: mappings remain accepted, both historical tuple sequences and canonical JSON lists decode, optional/legacy fields remain permissive, and no exact-field/type-discriminator schema tightening is introduced. Hostile sequence/mapping conversion failures are normalized without formatting attacker-controlled objects.

Validation:
- 243 world-model, dreaming, latent-model, ensemble, and Prototype ensemble tests passed
- 81 focused tests passed again after rebasing current main
- Ruff clean on changed files
- mypy clean on `world_model.py`
- `git diff --check` clean

This is L0 mechanism hardening only. `world_model.py` appears in a historical slowly-changing regression source snapshot, so this source change invalidates that snapshot's byte identity if it is replay-checked; it does not alter any registered five-claim evidence source inventory or authorize/promote evidence.

Co-authored-by: kzahiri1 <kzahiri@dons.usfca.edu>
