### PR TITLE
fix(independent-demon-horde): harden independent demon horde hidden sizes and feature dimension with strict integer validation

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -35,12 +35,14 @@ for Learning Knowledge from Unsupervised Sensorimotor Interaction"
 """
 
 import functools
+import operator
 import time
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -69,6 +71,33 @@ from alberta_framework.core.update_safety import (
 # =============================================================================
 # Types
 # =============================================================================
+
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @chex.dataclass(frozen=True)
@@ -238,6 +267,13 @@ class IndependentDemonHorde:
                 ``REPLACING``). Applies independently inside every
                 demon's network.
         """
+        if type(hidden_sizes) is not tuple:
+            raise ValueError(
+                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
+            )
+        hidden_sizes = tuple(
+            _require_int32(f"hidden_sizes[{i}]", v, minimum=1) for i, v in enumerate(hidden_sizes)
+        )
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
@@ -276,16 +312,10 @@ class IndependentDemonHorde:
             "horde_spec": self._horde_spec.to_config(),
             "hidden_sizes": list(self._hidden_sizes),
             "optimizer": self._optimizer.to_config(),
-            "bounder": (
-                self._bounder.to_config() if self._bounder is not None else None
-            ),
-            "normalizer": (
-                self._normalizer.to_config() if self._normalizer is not None else None
-            ),
+            "bounder": (self._bounder.to_config() if self._bounder is not None else None),
+            "normalizer": (self._normalizer.to_config() if self._normalizer is not None else None),
             "head_optimizer": (
-                self._head_optimizer.to_config()
-                if self._head_optimizer is not None
-                else None
+                self._head_optimizer.to_config() if self._head_optimizer is not None else None
             ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
@@ -315,25 +345,15 @@ class IndependentDemonHorde:
         horde_spec = HordeSpec.from_config(config.pop("horde_spec"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)
-        bounder = (
-            bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
-        )
+        bounder = bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
         normalizer_cfg = config.pop("normalizer", None)
-        normalizer = (
-            normalizer_from_config(normalizer_cfg)
-            if normalizer_cfg is not None
-            else None
-        )
+        normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        )
+        head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
-            TraceMode(trace_mode_str)
-            if trace_mode_str is not None
-            else TraceMode.ACCUMULATING
+            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
         )
 
         return cls(
@@ -351,14 +371,13 @@ class IndependentDemonHorde:
     # Init
     # -------------------------------------------------------------------------
 
-    def _init_single_demon(
-        self, feature_dim: int, key: Array
-    ) -> MLPLearnerState:
+    def _init_single_demon(self, feature_dim: int, key: Array) -> MLPLearnerState:
         """Initialize one demon's ``MLPLearnerState``.
 
         Equivalent to the body of ``MLPLearner.init`` so that the same
         sparse-init / shape conventions apply.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         layer_sizes = [feature_dim, *self._hidden_sizes, 1]
 
         weights_list: list[Array] = []
@@ -405,9 +424,7 @@ class IndependentDemonHorde:
             uptime_s=0.0,
         )
 
-    def init(
-        self, feature_dim: int, key: Array
-    ) -> IndependentDemonHordeState:
+    def init(self, feature_dim: int, key: Array) -> IndependentDemonHordeState:
         """Initialize an :class:`IndependentDemonHordeState`.
 
         Args:
@@ -419,9 +436,7 @@ class IndependentDemonHorde:
             Initial state with one ``MLPLearnerState`` per demon.
         """
         keys = jax.random.split(key, self.n_demons)
-        demon_states = tuple(
-            self._init_single_demon(feature_dim, k) for k in keys
-        )
+        demon_states = tuple(self._init_single_demon(feature_dim, k) for k in keys)
         return IndependentDemonHordeState(
             demon_states=demon_states,
             step_count=jnp.array(0, dtype=jnp.int32),
@@ -433,18 +448,11 @@ class IndependentDemonHorde:
     # Per-demon predict / update (pure functions)
     # -------------------------------------------------------------------------
 
-    def _predict_single(
-        self, demon_state: MLPLearnerState, observation: Array
-    ) -> Array:
+    def _predict_single(self, demon_state: MLPLearnerState, observation: Array) -> Array:
         """Predict value for a single demon given its state and observation."""
         obs = observation
-        if (
-            self._normalizer is not None
-            and demon_state.normalizer_state is not None
-        ):
-            obs = self._normalizer.normalize_only(
-                demon_state.normalizer_state, observation
-            )
+        if self._normalizer is not None and demon_state.normalizer_state is not None:
+            obs = self._normalizer.normalize_only(demon_state.normalizer_state, observation)
         return _forward_mlp(
             demon_state.params.weights,
             demon_state.params.biases,
@@ -480,10 +488,7 @@ class IndependentDemonHorde:
         obs = observation
         new_normalizer_state = demon_state.normalizer_state
         normalizer_update_applied = jnp.asarray(True, dtype=jnp.bool_)
-        if (
-            self._normalizer is not None
-            and demon_state.normalizer_state is not None
-        ):
+        if self._normalizer is not None and demon_state.normalizer_state is not None:
             normalizer_result = self._normalizer.normalize_with_diagnostics(
                 demon_state.normalizer_state, observation
             )
@@ -504,9 +509,7 @@ class IndependentDemonHorde:
         )
         error = jnp.where(active, target - prediction_val, 0.0)
 
-        def pred_fn(
-            weights: tuple[Array, ...], biases: tuple[Array, ...]
-        ) -> Array:
+        def pred_fn(weights: tuple[Array, ...], biases: tuple[Array, ...]) -> Array:
             return _forward_mlp(weights, biases, obs, slope, ln)
 
         weight_grads, bias_grads = jax.grad(pred_fn, argnums=(0, 1))(
@@ -561,22 +564,17 @@ class IndependentDemonHorde:
         new_opt_states: list[Any] = []
         optimizer_updates_applied: list[Array] = []
         for j in range(n_trace_entries):
-            is_output = (
-                self._head_optimizer is not None
-                and j >= n_trace_entries - 2
-            )
+            is_output = self._head_optimizer is not None and j >= n_trace_entries - 2
             opt: AnyOptimizer = (
                 self._head_optimizer
                 if (is_output and self._head_optimizer is not None)
                 else self._optimizer
             )
-            step, new_opt, optimizer_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    opt,
-                    demon_state.optimizer_states[j],
-                    new_traces[j],
-                    error=error,
-                )
+            step, new_opt, optimizer_update_applied = _update_from_gradient_with_diagnostics(
+                opt,
+                demon_state.optimizer_states[j],
+                new_traces[j],
+                error=error,
             )
             all_steps.append(step)
             new_opt_states.append(new_opt)
@@ -599,12 +597,8 @@ class IndependentDemonHorde:
         new_weights: list[Array] = []
         new_biases: list[Array] = []
         for i in range(n_layers):
-            new_weights.append(
-                demon_state.params.weights[i] + error * all_steps[2 * i]
-            )
-            new_biases.append(
-                demon_state.params.biases[i] + error * all_steps[2 * i + 1]
-            )
+            new_weights.append(demon_state.params.weights[i] + error * all_steps[2 * i])
+            new_biases.append(demon_state.params.biases[i] + error * all_steps[2 * i + 1])
 
         new_params = MLPParams(
             weights=tuple(new_weights),
@@ -639,22 +633,16 @@ class IndependentDemonHorde:
         new_params = MLPParams(
             weights=tuple(
                 jnp.where(commit, new_w, old_w)
-                for new_w, old_w in zip(
-                    new_params.weights, demon_state.params.weights, strict=True
-                )
+                for new_w, old_w in zip(new_params.weights, demon_state.params.weights, strict=True)
             ),
             biases=tuple(
                 jnp.where(commit, new_b, old_b)
-                for new_b, old_b in zip(
-                    new_params.biases, demon_state.params.biases, strict=True
-                )
+                for new_b, old_b in zip(new_params.biases, demon_state.params.biases, strict=True)
             ),
         )
         masked_traces = tuple(
             jnp.where(commit, new_t, old_t)
-            for new_t, old_t in zip(
-                new_traces, demon_state.traces, strict=True
-            )
+            for new_t, old_t in zip(new_traces, demon_state.traces, strict=True)
         )
         masked_opt_states = tuple(
             jax.tree.map(
@@ -662,9 +650,7 @@ class IndependentDemonHorde:
                 new_opt,
                 old_opt,
             )
-            for new_opt, old_opt in zip(
-                new_opt_states, demon_state.optimizer_states, strict=True
-            )
+            for new_opt, old_opt in zip(new_opt_states, demon_state.optimizer_states, strict=True)
         )
         if (
             self._normalizer is not None
@@ -714,9 +700,7 @@ class IndependentDemonHorde:
     # -------------------------------------------------------------------------
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: IndependentDemonHordeState, observation: Array
-    ) -> Array:
+    def predict(self, state: IndependentDemonHordeState, observation: Array) -> Array:
         """Compute predictions from all demons.
 
         Args:
@@ -727,8 +711,7 @@ class IndependentDemonHorde:
             Array of shape ``(n_demons,)`` with one prediction per demon.
         """
         preds = [
-            self._predict_single(state.demon_states[i], observation)
-            for i in range(self.n_demons)
+            self._predict_single(state.demon_states[i], observation) for i in range(self.n_demons)
         ]
         return jnp.stack(preds)
 
@@ -767,12 +750,7 @@ class IndependentDemonHorde:
 
         # 1. Per-demon V(s') for bootstrapping (each demon uses its OWN net)
         next_preds = jnp.stack(
-            [
-                self._predict_single(
-                    state.demon_states[i], next_observation
-                )
-                for i in range(n_demons)
-            ]
+            [self._predict_single(state.demon_states[i], next_observation) for i in range(n_demons)]
         )
 
         # 2. TD targets: r + gamma * V(s'). gamma=0 must not multiply inf V(s').
@@ -804,10 +782,7 @@ class IndependentDemonHorde:
             )
         )
         active_mask = (
-            requested_mask
-            & jnp.isfinite(cumulants)
-            & jnp.isfinite(targets)
-            & global_inputs_valid
+            requested_mask & jnp.isfinite(cumulants) & jnp.isfinite(targets) & global_inputs_valid
         )
         safe_targets = jnp.where(active_mask, targets, 0.0)
 
@@ -951,11 +926,14 @@ def run_independent_horde_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (
-        per_demon_metrics,
-        td_errors,
-        head_updates_applied,
-        updates_applied,
+    (
+        final_state,
+        (
+            per_demon_metrics,
+            td_errors,
+            head_updates_applied,
+            updates_applied,
+        ),
     ) = jax.lax.scan(step_fn, state, (observations, cumulants, next_observations))
     elapsed = time.time() - t0
     final_state = final_state.replace(  # type: ignore[attr-defined]

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -21,8 +21,10 @@ These tests verify that:
 """
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -140,13 +142,9 @@ class TestIndependence:
         # Demon 1's parameters and traces must be byte-identical to before.
         d1_old = state.demon_states[1]
         d1_new = result.state.demon_states[1]  # type: ignore[attr-defined]
-        for w_old, w_new in zip(
-            d1_old.params.weights, d1_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d1_old.params.weights, d1_new.params.weights, strict=True):
             chex.assert_trees_all_close(w_old, w_new)
-        for b_old, b_new in zip(
-            d1_old.params.biases, d1_new.params.biases, strict=True
-        ):
+        for b_old, b_new in zip(d1_old.params.biases, d1_new.params.biases, strict=True):
             chex.assert_trees_all_close(b_old, b_new)
         for t_old, t_new in zip(d1_old.traces, d1_new.traces, strict=True):
             chex.assert_trees_all_close(t_old, t_new)
@@ -156,9 +154,7 @@ class TestIndependence:
         d0_new = result.state.demon_states[0]  # type: ignore[attr-defined]
         # At least one weight matrix should be different.
         any_changed = False
-        for w_old, w_new in zip(
-            d0_old.params.weights, d0_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d0_old.params.weights, d0_new.params.weights, strict=True):
             if not jnp.allclose(w_old, w_new):
                 any_changed = True
                 break
@@ -185,23 +181,17 @@ class TestObgdApplyFinite:
         obs = jnp.ones(3, dtype=jnp.float32)
         next_obs = jnp.zeros(3, dtype=jnp.float32)
 
-        poisoned = horde.update(
-            state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), next_obs
-        )
+        poisoned = horde.update(state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), next_obs)
         d0_old = state.demon_states[0]
         d0_new = poisoned.state.demon_states[0]  # type: ignore[attr-defined]
-        for w_old, w_new in zip(
-            d0_old.params.weights, d0_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d0_old.params.weights, d0_new.params.weights, strict=True):
             assert bool(jnp.all(jnp.isfinite(w_new)))
             chex.assert_trees_all_close(w_old, w_new)
 
         d1_old = state.demon_states[1]
         d1_new = poisoned.state.demon_states[1]  # type: ignore[attr-defined]
         any_changed = False
-        for w_old, w_new in zip(
-            d1_old.params.weights, d1_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d1_old.params.weights, d1_new.params.weights, strict=True):
             assert bool(jnp.all(jnp.isfinite(w_new)))
             if not jnp.allclose(w_old, w_new):
                 any_changed = True
@@ -240,9 +230,7 @@ class TestZeroGammaBootstrap:
         state = horde.init(2, jr.key(0))
         ds = state.demon_states[0]
         ds = ds.replace(
-            params=ds.params.replace(
-                weights=(jnp.asarray([[huge, 0.0]], dtype=jnp.float32),)
-            )
+            params=ds.params.replace(weights=(jnp.asarray([[huge, 0.0]], dtype=jnp.float32),))
         )
         state = state.replace(demon_states=(ds,))
         obs = jnp.asarray([0.0, 1.0], dtype=jnp.float32)
@@ -386,9 +374,7 @@ class TestMatchesHordeLearnerWithGammaZero:
 
         observations = jr.normal(k2, (num_steps, feature_dim))
         cumulants = jr.normal(k3, (num_steps, n_demons))
-        next_observations = jnp.concatenate(
-            [observations[1:], observations[:1]], axis=0
-        )
+        next_observations = jnp.concatenate([observations[1:], observations[:1]], axis=0)
 
         ind_result = run_independent_horde_learning_loop(
             independent, ind_state, observations, cumulants, next_observations
@@ -401,9 +387,7 @@ class TestMatchesHordeLearnerWithGammaZero:
 
         # Final mean squared error over the last 20 steps for each demon.
         ind_final_se = jnp.nanmean(ind_result.per_demon_metrics[-20:, :, 0])
-        shared_final_se = jnp.nanmean(
-            shared_result.per_demon_metrics[-20:, :, 0]
-        )
+        shared_final_se = jnp.nanmean(shared_result.per_demon_metrics[-20:, :, 0])
 
         # Sanity check: same order of magnitude. We accept up to a 3x gap
         # because the architectures genuinely differ; the test catches
@@ -461,9 +445,7 @@ class TestTemporalDemonsFinite:
 
         observations = jr.normal(k2, (50, 5))
         cumulants = jr.normal(k3, (50, 2))
-        next_observations = jnp.concatenate(
-            [observations[1:], observations[:1]], axis=0
-        )
+        next_observations = jnp.concatenate([observations[1:], observations[:1]], axis=0)
 
         result = run_independent_horde_learning_loop(
             horde, state, observations, cumulants, next_observations
@@ -594,9 +576,7 @@ class TestScanLoopCorrectShape:
         )
 
         assert isinstance(result, IndependentDemonHordeLearningResult)
-        chex.assert_shape(
-            result.per_demon_metrics, (num_steps, n_demons, 3)
-        )
+        chex.assert_shape(result.per_demon_metrics, (num_steps, n_demons, 3))
         chex.assert_shape(result.td_errors, (num_steps, n_demons))
 
     def test_batched_loop_correct_shape(self) -> None:
@@ -623,9 +603,32 @@ class TestScanLoopCorrectShape:
             horde, observations, cumulants, next_observations, keys
         )
         assert isinstance(result, BatchedIndependentDemonHordeResult)
-        chex.assert_shape(
-            result.per_demon_metrics, (n_seeds, num_steps, n_demons, 3)
-        )
-        chex.assert_shape(
-            result.td_errors, (n_seeds, num_steps, n_demons)
-        )
+        chex.assert_shape(result.per_demon_metrics, (n_seeds, num_steps, n_demons, 3))
+        chex.assert_shape(result.td_errors, (n_seeds, num_steps, n_demons))
+
+
+def test_independent_demon_horde_integer_validation() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=(True, 32))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=(32, 0))
+
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=(np.int32(16), np.int64(8)))
+    assert horde._hidden_sizes == (16, 8)
+    assert type(horde._hidden_sizes[0]) is int
+    assert type(horde._hidden_sizes[1]) is int
+
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=True, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=4.5, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=0, key=key)
+
+    state = horde.init(feature_dim=np.int32(4), key=key)
+    assert len(state.demon_states) == 1


### PR DESCRIPTION
## Summary
- Hardens `IndependentDemonHorde` constructor parameters (`hidden_sizes`) and state initialization (`feature_dim`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Validates tuple structure strictly and ensures valid layer dimensions at initialization.

## Verification
- `PYTHONPATH=. pytest tests/test_independent_demon_horde.py tests/test_horde.py tests/test_mixed_horde.py`: 61 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/independent_demon_horde.py`: clean