### PR TITLE
fix(interaction-features): complete scalar and resource contracts

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -19,17 +19,19 @@ References:
 import dataclasses
 import functools
 import math
+import operator
 import struct
 import time
 from collections.abc import Mapping
 from numbers import Real
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray, UInt
 
@@ -47,6 +49,73 @@ from alberta_framework.core.future_utility import one_step_output_loss_reduction
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(
+    name: str,
+    value: object,
+    *,
+    minimum: int,
+    maximum: int = _INT32_MAX,
+) -> int:
+    """Return one exact built-in/NumPy integer inside the JAX int32 domain."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_resource(name: str, *, scalars: int, nbytes: int) -> None:
+    """Reject derived device resources before a JAX allocation is attempted."""
+    if scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if nbytes > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_state_resources(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> None:
+    """Preflight the exact persistent state constructed by ``init``."""
+    normalizer = int(scale_robust)
+    scalars = (
+        2 * n_tasks * n_features
+        + n_tasks * candidate_count
+        + (10 + normalizer) * n_features
+        + (9 + normalizer) * candidate_count
+        + (3 + normalizer) * n_tasks
+        + 7
+    )
+    nbytes = (
+        8 * n_tasks * n_features
+        + 4 * n_tasks * candidate_count
+        + (37 + 4 * normalizer) * n_features
+        + (33 + 4 * normalizer) * candidate_count
+        + (12 + 4 * normalizer) * n_tasks
+        + 32
+    )
+    _require_resource("interaction-feature state", scalars=scalars, nbytes=nbytes)
 
 CURATION_ACTIVE_INELIGIBLE_RANK = float.fromhex("0x1.fffffep+127")
 CURATION_CANDIDATE_INELIGIBLE_RANK = -CURATION_ACTIVE_INELIGIBLE_RANK
@@ -406,22 +475,69 @@ class FixedBudgetInteractionLearner:
         scale_normalizer_epsilon: float = 1e-6,
         task_utility_weights: tuple[float, ...] | None = None,
     ):
-        if n_features < 1:
-            raise ValueError("n_features must be positive")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if candidate_count < 0:
-            raise ValueError("candidate_count must be non-negative")
+        n_features = _require_int32("n_features", n_features, minimum=1)
+        n_tasks = _require_int32("n_tasks", n_tasks, minimum=1)
+        candidate_count = _require_int32("candidate_count", candidate_count, minimum=0)
+        replacement_interval = _require_int32(
+            "replacement_interval", replacement_interval, minimum=0
+        )
+        min_feature_age = _require_int32("min_feature_age", min_feature_age, minimum=0)
+        candidate_min_age = _require_int32("candidate_min_age", candidate_min_age, minimum=0)
+        utility_top_k = _require_int32("utility_top_k", utility_top_k, minimum=1)
+        if utility_retention_grace_steps is not None:
+            utility_retention_grace_steps = _require_int32(
+                "utility_retention_grace_steps",
+                utility_retention_grace_steps,
+                minimum=0,
+                maximum=_INT32_MAX - 1,
+            )
+        utility_evidence_confirmation_steps = _require_int32(
+            "utility_evidence_confirmation_steps",
+            utility_evidence_confirmation_steps,
+            minimum=0,
+            maximum=_INT32_MAX - 1,
+        )
+        if stale_retirement_interval is not None:
+            try:
+                stale_retirement_interval = _require_int32(
+                    "stale_retirement_interval", stale_retirement_interval, minimum=1
+                )
+            except ValueError as error:
+                raise ValueError(
+                    "stale_retirement_interval must be None or a positive int32-safe integer"
+                ) from error
+        candidate_promotion_confirmation_steps = _require_int32(
+            "candidate_promotion_confirmation_steps",
+            candidate_promotion_confirmation_steps,
+            minimum=1,
+            maximum=_INT32_MAX - 1,
+        )
+        candidate_reacquisition_confirmation_steps = _require_int32(
+            "candidate_reacquisition_confirmation_steps",
+            candidate_reacquisition_confirmation_steps,
+            minimum=1,
+            maximum=_INT32_MAX - 1,
+        )
+        for name, value in (
+            ("evidence_gated_active_output_memory", evidence_gated_active_output_memory),
+            ("independent_relevance_probe", independent_relevance_probe),
+            ("retire_stale_features", retire_stale_features),
+            ("refresh_candidates", refresh_candidates),
+            ("refresh_promoted_candidate", refresh_promoted_candidate),
+            ("include_squares", include_squares),
+            ("use_obgd", use_obgd),
+            ("scale_robust", scale_robust),
+        ):
+            if type(value) is not bool:
+                raise ValueError(f"{name} must be boolean")
+        _require_state_resources(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
         if not 0.0 <= utility_decay < 1.0:
             raise ValueError("utility_decay must be in [0, 1)")
-        if (
-            isinstance(replacement_interval, bool)
-            or not isinstance(replacement_interval, int)
-            or not 0 <= replacement_interval <= _INT32_MAX
-        ):
-            raise ValueError(
-                "replacement_interval must be an int32-safe non-negative integer"
-            )
         if (
             isinstance(promotion_margin, bool)
             or not isinstance(cast(object, promotion_margin), Real)
@@ -435,8 +551,6 @@ class FixedBudgetInteractionLearner:
             raise ValueError("candidate_strategy must be 'random' or 'all_pairs'")
         if utility_aggregation not in {"mean", "max", "topk"}:
             raise ValueError("utility_aggregation must be 'mean', 'max', or 'topk'")
-        if utility_top_k < 1:
-            raise ValueError("utility_top_k must be positive")
         if utility_task_balancing not in {"none", "active", "active_inverse_frequency"}:
             raise ValueError(
                 "utility_task_balancing must be 'none', 'active', or 'active_inverse_frequency'"
@@ -1111,8 +1225,17 @@ class FixedBudgetInteractionLearner:
 
     def init(self, feature_dim: int, key: Array) -> InteractionFeatureState:
         """Initialize active and candidate pair banks."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         if feature_dim < 2 and not self._include_squares:
             raise ValueError("feature_dim must be at least 2 when squares are disabled")
+        if self._candidate_strategy == "all_pairs" and self._candidate_count > 0:
+            diagonal = 1 if self._include_squares else -1
+            pair_count = feature_dim * (feature_dim + diagonal) // 2
+            _require_resource(
+                "all-pairs candidate construction",
+                scalars=2 * pair_count,
+                nbytes=8 * pair_count,
+            )
 
         key, k_active, k_candidate = jr.split(key, 3)
         feature_left, feature_right = self._random_pairs(k_active, self._n_features, feature_dim)

--- a/tests/test_interaction_feature_validation.py
+++ b/tests/test_interaction_feature_validation.py
@@ -1,0 +1,160 @@
+"""Focused scalar and allocation preflights for interaction features."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.interaction_features import FixedBudgetInteractionLearner
+
+_INT32_MAX = 2**31 - 1
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover - exact-type rejection must win
+        raise AssertionError("integer hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover - errors must not interpolate values
+        raise AssertionError("repr executed")
+
+
+class _ClassSpoof:
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:
+        return int
+
+    def __repr__(self) -> str:  # pragma: no cover - errors must not interpolate values
+        raise AssertionError("repr executed")
+
+
+def _construct(**overrides: Any) -> FixedBudgetInteractionLearner:
+    values: dict[str, Any] = {"n_features": 4, "n_tasks": 2, "candidate_count": 2}
+    values.update(overrides)
+    return FixedBudgetInteractionLearner(**values)
+
+
+@pytest.mark.parametrize(
+    ("field", "valid"),
+    [
+        ("n_features", 4),
+        ("n_tasks", 2),
+        ("candidate_count", 2),
+        ("replacement_interval", 0),
+        ("min_feature_age", 0),
+        ("candidate_min_age", 0),
+        ("utility_top_k", 1),
+        ("utility_retention_grace_steps", 0),
+        ("utility_evidence_confirmation_steps", 0),
+        ("stale_retirement_interval", 1),
+        ("candidate_promotion_confirmation_steps", 1),
+        ("candidate_reacquisition_confirmation_steps", 1),
+    ],
+)
+def test_integer_fields_reject_spoofs_without_hooks(field: str, valid: int) -> None:
+    valid_overrides: dict[str, Any] = {field: np.int64(valid)}
+    if field == "utility_retention_grace_steps":
+        valid_overrides["utility_evidence_threshold"] = 0.1
+    assert _construct(**valid_overrides).to_config()[field] == valid
+    assert type(_construct(**valid_overrides).to_config()[field]) is int
+    for invalid in (True, np.bool_(True), float(valid), _HostileInt(valid), _ClassSpoof()):
+        with pytest.raises(ValueError, match=field):
+            _construct(**{field: invalid})
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    [
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ],
+)
+def test_full_numpy_integer_family_canonicalizes(integer_type: Callable[[int], Any]) -> None:
+    learner = _construct(
+        n_features=integer_type(4),
+        n_tasks=integer_type(2),
+        candidate_count=integer_type(2),
+        replacement_interval=integer_type(0),
+        min_feature_age=integer_type(0),
+        candidate_min_age=integer_type(0),
+        utility_top_k=integer_type(1),
+    )
+    payload = learner.to_config()
+    for field in (
+        "n_features",
+        "n_tasks",
+        "candidate_count",
+        "replacement_interval",
+        "min_feature_age",
+        "candidate_min_age",
+        "utility_top_k",
+    ):
+        assert type(payload[field]) is int
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "evidence_gated_active_output_memory",
+        "independent_relevance_probe",
+        "retire_stale_features",
+        "refresh_candidates",
+        "refresh_promoted_candidate",
+        "include_squares",
+        "use_obgd",
+        "scale_robust",
+    ],
+)
+def test_boolean_fields_require_exact_bool(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _construct(**{field: np.bool_(False)})
+
+
+def test_persistent_state_resources_are_preflighted_without_allocation() -> None:
+    # With one task, no candidates, and no normalizers, state bytes are 45F + 44.
+    last_legal = (_INT32_MAX - 44) // 45
+    legal = _construct(n_features=last_legal, n_tasks=1, candidate_count=0)
+    assert legal.n_features == last_legal
+    with pytest.raises(ValueError, match="state byte count"):
+        _construct(n_features=last_legal + 1, n_tasks=1, candidate_count=0)
+    with pytest.raises(ValueError, match="state (scalar|byte) count"):
+        _construct(n_features=50_000, n_tasks=50_000, candidate_count=1)
+
+
+def test_all_pairs_resources_and_feature_dim_are_checked_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    learner = _construct(
+        n_features=1,
+        n_tasks=1,
+        candidate_count=1,
+        candidate_strategy="all_pairs",
+    )
+    max_pairs = _INT32_MAX // 8
+    last_legal_dim = (1 + math.isqrt(1 + 8 * max_pairs)) // 2
+
+    def tiny_candidates(*_args: object) -> tuple[jnp.ndarray, jnp.ndarray]:
+        zero = jnp.zeros((1,), dtype=jnp.int32)
+        return zero, zero
+
+    monkeypatch.setattr(learner, "_candidate_pairs", tiny_candidates)
+    state = learner.init(last_legal_dim, jr.key(0))
+    assert state.candidate_left.shape == (1,)
+    with pytest.raises(ValueError, match="all-pairs candidate construction byte count"):
+        learner.init(last_legal_dim + 1, jr.key(0))
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(True, jr.key(0))


### PR DESCRIPTION
Supersedes #820 while preserving its contributor credit and exact-integer direction. The original rejects several malformed integers, but leaves every tasks×features/tasks×candidates aggregate, total persistent state, runtime feature_dim, and exhaustive all-pairs construction unchecked before JAX/host allocation, and carries broad whole-file formatting churn.\n\nThis focused successor:\n- canonicalizes the full exact built-in/NumPy integer family and rejects bools, subclasses, class spoofs, and hostile hooks without repr;\n- preserves established int32-minus-one confirmation endpoints and existing retirement error compatibility;\n- requires exact booleans for configuration gates;\n- preflights the exact complete state scalar/byte formula, including optional normalizers and mixed bool/int/float leaves;\n- validates runtime feature_dim and the quadratic all-pairs construction before enumeration/device allocation;\n- pins allocation-free legal/overflow boundaries and serialization canonicalization.\n\nValidation: 197 interaction/feature-discovery tests passed; focused post-rebase set 65 passed; Ruff, targeted strict mypy, and diff-check passed.\n\nEvidence note: interaction_features.py is registered by the recurring/scale-robust claims. Current main already reports those artifacts invalid from source-hash drift; this correctness repair does not alter artifacts, rerun evidence, or promote any claim.\n\nCo-authored-by: Kayvan Zahiri <kzahiri@dons.usfca.edu>