### PR TITLE
fix(off-policy-td): harden off-policy TD learners feature dimension initialization with strict integer validation

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -51,12 +51,14 @@ Reference:
 from __future__ import annotations
 
 import functools
+import operator
 import time
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
@@ -64,6 +66,32 @@ from alberta_framework.core.types import Observation
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -74,6 +102,7 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 def _zero_if_unused(scale: Array, value: Array) -> Array:
     """Sanitize leftover inf only in the finite-state check when unused."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+
 
 # =============================================================================
 # State / result types
@@ -284,6 +313,7 @@ class OffPolicyTDLinearLearner:
 
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -295,9 +325,7 @@ class OffPolicyTDLinearLearner:
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: OffPolicyTDState, observation: Observation
-    ) -> Float[Array, " 1"]:
+    def predict(self, state: OffPolicyTDState, observation: Observation) -> Float[Array, " 1"]:
         """Compute V(s) = w . phi(s) + b."""
         return jnp.atleast_1d(jnp.dot(state.weights, observation) + state.bias)
 
@@ -343,12 +371,10 @@ class OffPolicyTDLinearLearner:
         # the prior ratios are already represented in the stored trace.
         decay = gamma_s * lam
         new_e = _skip_zero_scale(
-            rho_clipped,
-            _skip_zero_scale(decay, state.eligibility_traces) + observation
+            rho_clipped, _skip_zero_scale(decay, state.eligibility_traces) + observation
         )
         new_e_b = _skip_zero_scale(
-            rho_clipped,
-            _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
+            rho_clipped, _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
         )
 
         # rho_clipped is already represented in the trace.
@@ -398,9 +424,7 @@ class OffPolicyTDLinearLearner:
                 update_applied, jnp.atleast_1d(v_t), jnp.zeros_like(jnp.atleast_1d(v_t))
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            rho_clipped=jnp.where(
-                update_applied, rho_clipped, jnp.zeros_like(rho_clipped)
-            ),
+            rho_clipped=jnp.where(update_applied, rho_clipped, jnp.zeros_like(rho_clipped)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
         )
@@ -472,6 +496,7 @@ class ETDLinearLearner:
 
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -527,17 +552,13 @@ class ETDLinearLearner:
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
         follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
-        emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(
-            1.0 - lam, follow_on
-        )
+        emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(1.0 - lam, follow_on)
 
         trace_decay = gamma_s * lam
         new_e = rho_s * (
             _skip_zero_scale(trace_decay, state.eligibility_traces) + emphasis * observation
         )
-        new_e_b = rho_s * (
-            _skip_zero_scale(trace_decay, state.bias_eligibility_trace) + emphasis
-        )
+        new_e_b = rho_s * (_skip_zero_scale(trace_decay, state.bias_eligibility_trace) + emphasis)
 
         proposed_state = ETDState(  # type: ignore[call-arg]
             weights=state.weights + alpha * td_error * new_e,
@@ -560,9 +581,7 @@ class ETDLinearLearner:
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
             eligibility_traces=_zero_if_unused(trace_decay, state.eligibility_traces),
-            bias_eligibility_trace=_zero_if_unused(
-                trace_decay, state.bias_eligibility_trace
-            ),
+            bias_eligibility_trace=_zero_if_unused(trace_decay, state.bias_eligibility_trace),
             follow_on_trace=_zero_if_unused(gamma_s, state.follow_on_trace),
         )
         update_applied = (
@@ -589,9 +608,7 @@ class ETDLinearLearner:
                 update_applied, jnp.atleast_1d(v_t), jnp.zeros_like(jnp.atleast_1d(v_t))
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            follow_on_trace=jnp.where(
-                update_applied, follow_on, jnp.zeros_like(follow_on)
-            ),
+            follow_on_trace=jnp.where(update_applied, follow_on, jnp.zeros_like(follow_on)),
             emphasis=jnp.where(update_applied, emphasis, jnp.zeros_like(emphasis)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
@@ -641,10 +658,7 @@ class GradientTDLinearLearner:
         if step_size <= 0.0:
             raise ValueError(f"step_size must be positive; got {step_size}")
         if secondary_step_size < 0.0:
-            raise ValueError(
-                "secondary_step_size must be non-negative; "
-                f"got {secondary_step_size}"
-            )
+            raise ValueError(f"secondary_step_size must be non-negative; got {secondary_step_size}")
         if not 0.0 <= trace_decay <= 1.0:
             raise ValueError(f"trace_decay must lie in [0, 1]; got {trace_decay}")
         if ratio_clip <= 0.0:
@@ -676,6 +690,7 @@ class GradientTDLinearLearner:
 
     def init(self, feature_dim: int) -> GradientTDState:
         """Initialize primary weights, secondary weights, and traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         augmented_dim = feature_dim + 1
         return GradientTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
@@ -697,9 +712,7 @@ class GradientTDLinearLearner:
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: GradientTDState, observation: Observation
-    ) -> Float[Array, " 1"]:
+    def predict(self, state: GradientTDState, observation: Observation) -> Float[Array, " 1"]:
         """Compute ``theta^T phi`` with an appended bias feature."""
         return jnp.atleast_1d(jnp.dot(state.weights, self._augment(observation)))
 
@@ -729,19 +742,13 @@ class GradientTDLinearLearner:
         next_prediction = jnp.dot(state.weights, next_phi)
         td_error = reward_s + _skip_zero_scale(gamma_s, next_prediction) - prediction
 
-        traces = rho_clipped * (
-            phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces)
-        )
+        traces = rho_clipped * (phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces))
         secondary_dot_trace = jnp.dot(state.secondary_weights, traces)
         secondary_dot_phi = jnp.dot(state.secondary_weights, phi)
 
         correction_coefficient = gamma_s * (1.0 - lam)
-        scaled_secondary_trace = _skip_zero_scale(
-            correction_coefficient, secondary_dot_trace
-        )
-        bootstrap_correction = _skip_zero_scale(
-            scaled_secondary_trace, next_phi
-        )
+        scaled_secondary_trace = _skip_zero_scale(correction_coefficient, secondary_dot_trace)
+        bootstrap_correction = _skip_zero_scale(scaled_secondary_trace, next_phi)
         primary_step = alpha * (td_error * traces - bootstrap_correction)
         secondary_step = beta * (td_error * traces - secondary_dot_phi * phi)
 
@@ -761,9 +768,7 @@ class GradientTDLinearLearner:
             & jnp.isfinite(rho_s)
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
-            eligibility_traces=_zero_if_unused(
-                gamma_s * lam, state.eligibility_traces
-            ),
+            eligibility_traces=_zero_if_unused(gamma_s * lam, state.eligibility_traces),
         )
         update_applied = (
             inputs_valid
@@ -794,9 +799,7 @@ class GradientTDLinearLearner:
                 jnp.zeros_like(jnp.atleast_1d(prediction)),
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            rho_clipped=jnp.where(
-                update_applied, rho_clipped, jnp.zeros_like(rho_clipped)
-            ),
+            rho_clipped=jnp.where(update_applied, rho_clipped, jnp.zeros_like(rho_clipped)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
         )
@@ -848,12 +851,10 @@ def run_gradient_td_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (predictions, td_errors, rho_clipped, metrics, updates_applied) = (
-        jax.lax.scan(
+    final_state, (predictions, td_errors, rho_clipped, metrics, updates_applied) = jax.lax.scan(
         step_fn,
         state,
         (observations, rewards, next_observations, gammas, rhos),
-        )
     )
     elapsed = time.time() - t0
     final_state = final_state.replace(  # type: ignore[attr-defined]

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -58,15 +58,11 @@ class TestOnPolicyEquivalence:
         alpha = 0.1
         n_steps = 30
 
-        learner = OffPolicyTDLinearLearner(
-            step_size=alpha, trace_decay=0.0, retrace_clip=10.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=alpha, trace_decay=0.0, retrace_clip=10.0)
         state = learner.init(feature_dim)
 
         rng = np.random.default_rng(0)
-        observations = jnp.asarray(
-            rng.normal(size=(n_steps, feature_dim)).astype(np.float32)
-        )
+        observations = jnp.asarray(rng.normal(size=(n_steps, feature_dim)).astype(np.float32))
         rewards = jnp.asarray(rng.normal(size=n_steps).astype(np.float32))
 
         for t in range(n_steps):
@@ -190,9 +186,7 @@ class TestETDLambda:
         n_steps = 40
 
         rng = np.random.default_rng(123)
-        observations = jnp.asarray(
-            rng.normal(size=(n_steps, feature_dim)).astype(np.float32)
-        )
+        observations = jnp.asarray(rng.normal(size=(n_steps, feature_dim)).astype(np.float32))
         rewards = jnp.asarray(rng.normal(size=n_steps).astype(np.float32))
 
         etd = ETDLinearLearner(step_size=alpha, trace_decay=0.0)
@@ -504,9 +498,7 @@ class TestOffPolicyConvergence:
         # rho(action=1) = 1 / 0.5 = 2
         # rho(action=0) = 0 / 0.5 = 0  (the trajectory contributes nothing)
 
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.05, trace_decay=0.0, retrace_clip=2.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.05, trace_decay=0.0, retrace_clip=2.0)
         state = learner.init(n_states)
 
         rng = np.random.default_rng(42)
@@ -536,16 +528,12 @@ class TestOffPolicyConvergence:
         # Target V per state
         v_true = np.ones(n_states, dtype=np.float32)
         rmse = float(np.sqrt(np.mean((v_estimated - v_true) ** 2)))
-        assert rmse < 0.20, (
-            f"Off-policy TD did not converge: V_est={v_estimated}, RMSE={rmse}"
-        )
+        assert rmse < 0.20, f"Off-policy TD did not converge: V_est={v_estimated}, RMSE={rmse}"
 
     def test_naive_is_finite_with_clipping(self) -> None:
         """Even with a high IS-ratio target/behavior mismatch, clipping at
         c=1 should keep weights finite over many steps."""
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.01, trace_decay=0.7, retrace_clip=1.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.01, trace_decay=0.7, retrace_clip=1.0)
         state = learner.init(5)
 
         rng = np.random.default_rng(7)
@@ -555,9 +543,7 @@ class TestOffPolicyConvergence:
             r = jnp.float32(rng.normal())
             # Wildly varying rho
             rho = jnp.float32(rng.uniform(0.0, 50.0))
-            res = learner.update(
-                state, phi, r, phi_next, jnp.float32(0.95), rho
-            )
+            res = learner.update(state, phi, r, phi_next, jnp.float32(0.95), rho)
             state = res.state
 
         chex.assert_tree_all_finite(state.weights)
@@ -596,9 +582,7 @@ class TestJit:
 
 class TestConfig:
     def test_roundtrip(self) -> None:
-        original = OffPolicyTDLinearLearner(
-            step_size=0.07, trace_decay=0.6, retrace_clip=2.5
-        )
+        original = OffPolicyTDLinearLearner(step_size=0.07, trace_decay=0.6, retrace_clip=2.5)
         config = original.to_config()
         assert config["type"] == "OffPolicyTDLinearLearner"
         restored = OffPolicyTDLinearLearner.from_config(config)
@@ -621,9 +605,7 @@ class TestBairdStyle:
     """
 
     def test_no_divergence_with_clip(self) -> None:
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.01, trace_decay=0.5, retrace_clip=1.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.01, trace_decay=0.5, retrace_clip=1.0)
         state = learner.init(4)
 
         rng = np.random.default_rng(11)
@@ -633,9 +615,7 @@ class TestBairdStyle:
             r = jnp.float32(rng.normal())
             # Heavy-tailed rho but mostly modest values
             rho = jnp.float32(rng.exponential(1.0))
-            res = learner.update(
-                state, phi, r, phi_next, jnp.float32(0.9), rho
-            )
+            res = learner.update(state, phi, r, phi_next, jnp.float32(0.9), rho)
             state = res.state
 
         chex.assert_tree_all_finite(state.weights)
@@ -701,9 +681,7 @@ class TestInfiniteRewardDoesNotPoisonWeights:
             state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, gamma, rho
         )
         chex.assert_trees_all_close(poisoned.state.weights, state.weights)
-        chex.assert_trees_all_close(
-            poisoned.state.secondary_weights, state.secondary_weights
-        )
+        chex.assert_trees_all_close(poisoned.state.secondary_weights, state.secondary_weights)
         assert not bool(poisoned.update_applied)
         assert float(poisoned.td_error) == 0.0
 
@@ -861,3 +839,25 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         )
         assert bool(result.update_applied)
         chex.assert_tree_all_finite(result.state.eligibility_traces)
+
+
+def test_off_policy_td_learners_integer_validation() -> None:
+    optd = OffPolicyTDLinearLearner()
+    etd = ETDLinearLearner()
+    gtd = GradientTDLinearLearner()
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        optd.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        etd.init(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        gtd.init(feature_dim=0)
+
+    s_optd = optd.init(feature_dim=np.int32(4))
+    s_etd = etd.init(feature_dim=np.int64(4))
+    s_gtd = gtd.init(feature_dim=np.int32(4))
+
+    assert s_optd.weights.shape == (4,)
+    assert s_etd.weights.shape == (4,)
+    assert s_gtd.weights.shape == (5,)
+    assert s_gtd.secondary_weights.shape == (5,)


### PR DESCRIPTION
## Summary
- Hardens `OffPolicyTDLinearLearner`, `ETDLinearLearner`, and `GradientTDLinearLearner` state initialization (`feature_dim`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.

## Verification
- `PYTHONPATH=. pytest tests/test_off_policy_td.py`: 33 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/off_policy_td.py`: clean