### PR TITLE
fix(associative-memory): complete derived contracts

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 import functools
 import math
 import operator
-from dataclasses import asdict, dataclass
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, fields
 from numbers import Real
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -34,7 +35,6 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX: int = 2**31 - 1
-_UINT32_MAX: int = 4294967295
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -50,16 +50,18 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
 )
 
 
-def _require_float32_resource(
+def _require_resource(
     name: str,
     *,
-    vector_scalars: int,
-    fixed_scalars: int = 0,
+    float32_scalars: int = 0,
+    int32_scalars: int = 0,
+    bool_scalars: int = 0,
 ) -> None:
-    total_scalars = vector_scalars + fixed_scalars
+    total_scalars = float32_scalars + int32_scalars + bool_scalars
     if total_scalars > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
+    total_bytes = 4 * (float32_scalars + int32_scalars) + bool_scalars
+    if total_bytes > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
@@ -236,10 +238,44 @@ class AssociativeMemoryConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> AssociativeMemoryConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
-        payload.pop("type", None)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("AssociativeMemoryConfig payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("AssociativeMemoryConfig mapping could not be read") from error
+        if payload.pop("type", None) != "AssociativeMemoryConfig":
+            raise ValueError("AssociativeMemoryConfig type is invalid")
+        if set(payload) != {field.name for field in fields(cls)}:
+            raise ValueError("AssociativeMemoryConfig fields do not match its schema")
+        integer_fields = {
+            "vocab_size",
+            "block_size",
+            "suffix_length",
+            "max_features",
+            "min_effective_budget",
+        }
+        boolean_fields = {
+            "normalize_by_weight",
+            "adaptive_feature_family",
+            "adaptive_window",
+            "adaptive_budget",
+        }
+        string_fields = {"feature_family"}
+        for name, value in payload.items():
+            if name in integer_fields and type(value) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+            if name in boolean_fields and type(value) is not bool:
+                raise ValueError(f"serialized {name} must be a JSON boolean")
+            if name in string_fields and type(value) is not str:
+                raise ValueError(f"serialized {name} must be a JSON string")
+            if (
+                name not in integer_fields | boolean_fields | string_fields
+                and type(value) is not float
+            ):
+                raise ValueError(f"serialized {name} must be a JSON number")
         return cls(**payload)
 
 
@@ -387,16 +423,32 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     fixed_state_scalars = (
         8 * max_features + vocab_size + suffix_length + 5
     )
-    _require_float32_resource(
+    _require_resource(
         "AssociativeMemoryConfig state",
-        vector_scalars=total_values_scalars,
-        fixed_scalars=fixed_state_scalars,
+        float32_scalars=total_values_scalars + fixed_state_scalars,
     )
-    persistent_bytes = 4 * (total_values_scalars + fixed_state_scalars)
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("AssociativeMemoryConfig state byte count must fit signed int32")
-    if persistent_bytes > _UINT32_MAX:
-        raise ValueError("associative memory allocation exceeds uint32 byte accounting")
+    pair_count = suffix_length * (suffix_length - 1) // 2
+    active_count = block_size + pair_count
+    # These arrays are constructed eagerly, including from Python pair-index lists.
+    _require_resource(
+        "AssociativeMemoryLearner static indices",
+        int32_scalars=5 * pair_count + 2 * block_size + suffix_length - 1,
+    )
+    # The vectorized lookup materializes the five-wide equality tensor and its
+    # reduction.  Prediction then gathers one vocabulary row per active feature.
+    _require_resource(
+        "AssociativeMemoryLearner lookup workspace",
+        bool_scalars=6 * active_count * max_features,
+    )
+    _require_resource(
+        "AssociativeMemoryLearner gathered rows",
+        float32_scalars=active_count * vocab_size,
+    )
+    if config.adaptive_window and feature_family != "position_token":
+        _require_resource(
+            "AssociativeMemoryLearner adaptive-window workspace",
+            float32_scalars=pair_count * (suffix_length - 1),
+        )
 
 
 def _softmax(logits: Array) -> Array:
@@ -493,10 +545,59 @@ class AssociativeMemoryLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> AssociativeMemoryLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryLearner:
         """Reconstruct from :meth:`to_config` output."""
-        return cls(
-            AssociativeMemoryConfig.from_config(cast(dict[str, Any], config["config"]))
+        if not issubclass(type(config), Mapping):
+            raise ValueError("AssociativeMemoryLearner payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("AssociativeMemoryLearner mapping could not be read") from error
+        if set(payload) != {"type", "config"}:
+            raise ValueError("AssociativeMemoryLearner fields do not match its schema")
+        if payload["type"] != "AssociativeMemoryLearner":
+            raise ValueError("AssociativeMemoryLearner type is invalid")
+        inner = payload["config"]
+        if not issubclass(type(inner), Mapping):
+            raise ValueError("AssociativeMemoryLearner config must be a mapping")
+        return cls(AssociativeMemoryConfig.from_config(cast(Mapping[str, Any], inner)))
+
+    def _validate_state_static_contract(self, state: AssociativeMemoryState) -> None:
+        """Reject malformed adopted state before traced computation."""
+        if type(state) is not AssociativeMemoryState:
+            raise TypeError("state must be an AssociativeMemoryState")
+        c = self._config
+        expected = (
+            ("state.keys", state.keys, (c.max_features, KEY_WIDTH), jnp.int32),
+            ("state.values", state.values, (c.max_features, c.vocab_size), jnp.float32),
+            ("state.utility", state.utility, (c.max_features,), jnp.float32),
+            ("state.counts", state.counts, (c.max_features,), jnp.float32),
+            ("state.last_update", state.last_update, (c.max_features,), jnp.int32),
+            ("state.prior", state.prior, (c.vocab_size,), jnp.float32),
+            ("state.family_logits", state.family_logits, (FAMILY_COUNT,), jnp.float32),
+            ("state.window_logits", state.window_logits, (c.suffix_length - 1,), jnp.float32),
+            ("state.budget_logit", state.budget_logit, (), jnp.float32),
+            ("state.allocations", state.allocations, (), jnp.int32),
+            ("state.replacements", state.replacements, (), jnp.int32),
+            ("state.step_count", state.step_count, (), jnp.int32),
+        )
+        for name, value, shape, dtype in expected:
+            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+                raise TypeError(f"{name} must expose array shape and dtype metadata")
+            if tuple(value.shape) != shape:
+                raise ValueError(f"{name} must have shape {shape}; got {tuple(value.shape)}")
+            if jnp.dtype(value.dtype) != jnp.dtype(dtype):
+                raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
+
+    @staticmethod
+    def _state_is_valid(state: AssociativeMemoryState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & jnp.all(state.counts >= 0.0)
+            & jnp.all(state.last_update >= 0)
+            & (state.allocations >= 0)
+            & (state.replacements >= 0)
+            & (state.step_count >= 0)
         )
 
     def init(self) -> AssociativeMemoryState:
@@ -530,7 +631,13 @@ class AssociativeMemoryLearner:
     ) -> tuple[Int[Array, "max_active key_width"], Int[Array, " max_active"]]:
         """Return fixed-shape active feature keys and a 0/1 mask."""
         c = self._config
-        tokens = jnp.asarray(context, dtype=jnp.int32)
+        if not hasattr(context, "shape") or not hasattr(context, "dtype"):
+            raise TypeError("context must expose array shape and dtype metadata")
+        if tuple(context.shape) != (c.block_size,):
+            raise ValueError(f"context must have shape ({c.block_size},); got {context.shape}")
+        if jnp.dtype(context.dtype) != jnp.dtype(jnp.int32):
+            raise TypeError("context must have dtype int32")
+        tokens = jnp.asarray(context)
         token_positions = jnp.arange(c.block_size, dtype=jnp.int32)
         token_keys = jnp.stack(
             [
@@ -650,6 +757,7 @@ class AssociativeMemoryLearner:
         context: Int[Array, " block_size"],
     ) -> AssociativeMemoryPrediction:
         """Predict label probabilities before any write."""
+        self._validate_state_static_contract(state)
         keys, mask = self.feature_keys(context)
         found, indices = self._lookup(state, keys, mask)
         row_values = state.values[indices]
@@ -821,6 +929,7 @@ class AssociativeMemoryLearner:
         label: Int[Array, ""],
     ) -> AssociativeMemoryUpdateResult:
         """Predict, then update active associative rows."""
+        self._validate_state_static_contract(state)
         safe_label, label_valid = self._prepare_label(label)
         return cast(
             AssociativeMemoryUpdateResult,
@@ -910,12 +1019,22 @@ class AssociativeMemoryLearner:
             new_row = old_row * self._config.retention
             new_row = new_row.at[label].add(self._config.write_lr)
             active_bool = active > 0
-            allocations = carry.allocations + (
+            allocation_increment = (
                 active_bool & (~found_scalar) & used_empty
             ).astype(jnp.int32)
-            replacements = carry.replacements + (
+            replacement_increment = (
                 active_bool & (~found_scalar) & (~used_empty)
             ).astype(jnp.int32)
+            allocations = jnp.where(
+                allocation_increment > 0,
+                jnp.minimum(carry.allocations, jnp.asarray(_INT32_MAX - 1, jnp.int32)) + 1,
+                carry.allocations,
+            )
+            replacements = jnp.where(
+                replacement_increment > 0,
+                jnp.minimum(carry.replacements, jnp.asarray(_INT32_MAX - 1, jnp.int32)) + 1,
+                carry.replacements,
+            )
             next_carry = carry.replace(  # type: ignore[attr-defined]
                 keys=jnp.where(
                     active_bool,
@@ -958,7 +1077,9 @@ class AssociativeMemoryLearner:
         next_state = self._update_window_scope(next_state, state, prediction, label, loss)
         next_state = self._update_budget_scope(next_state, state, prediction, loss)
         next_state = next_state.replace(  # type: ignore[attr-defined]
-            step_count=state.step_count + 1
+            step_count=(
+                jnp.minimum(state.step_count, jnp.asarray(_INT32_MAX - 1, jnp.int32)) + 1
+            )
         )
         active_count = jnp.sum(prediction.feature_mask.astype(jnp.float32))
         occupied_count = jnp.sum((next_state.counts > 0.0).astype(jnp.float32))
@@ -981,7 +1102,7 @@ class AssociativeMemoryLearner:
         )
         update_applied = (
             label_valid
-            & floating_tree_is_finite(state)
+            & self._state_is_valid(state)
             & floating_tree_is_finite(prediction)
             & jnp.isfinite(loss)
             & floating_tree_is_finite(next_state)
@@ -1003,6 +1124,30 @@ def run_associative_memory_arrays(
     labels: Int[Array, " steps"],
 ) -> AssociativeMemoryLearningResult:
     """Run a scan-compatible online associative learner over arrays."""
+    if type(learner) is not AssociativeMemoryLearner:
+        raise TypeError("learner must be an AssociativeMemoryLearner")
+    learner._validate_state_static_contract(state)
+    if not hasattr(contexts, "shape") or not hasattr(contexts, "dtype"):
+        raise TypeError("contexts must expose array shape and dtype metadata")
+    if not hasattr(labels, "shape") or not hasattr(labels, "dtype"):
+        raise TypeError("labels must expose array shape and dtype metadata")
+    expected_context_tail = (learner.config.block_size,)
+    if len(contexts.shape) != 2 or tuple(contexts.shape[1:]) != expected_context_tail:
+        raise ValueError(
+            f"contexts must have shape (steps, {learner.config.block_size}); got {contexts.shape}"
+        )
+    steps = int(contexts.shape[0])
+    if tuple(labels.shape) != (steps,):
+        raise ValueError(f"labels must have shape ({steps},); got {labels.shape}")
+    if jnp.dtype(contexts.dtype) != jnp.dtype(jnp.int32):
+        raise TypeError("contexts must have dtype int32")
+    if not jnp.issubdtype(labels.dtype, jnp.integer):
+        raise TypeError("labels must have an integer dtype")
+    _require_resource(
+        "associative memory batch outputs",
+        float32_scalars=steps * (learner.config.vocab_size + 8),
+        bool_scalars=steps,
+    )
 
     def step_fn(
         carry: AssociativeMemoryState,

--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import functools
 import math
+import operator
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
-from typing import Any, Literal, cast
+from numbers import Real
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
@@ -33,20 +34,47 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX: int = 2**31 - 1
+_UINT32_MAX: int = 4294967295
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
     """Return the original real, exact ratio, and finite binary32 rounding."""
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
+        raise ValueError(f"{name} must be a real number")
     real = cast(Real, value)
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    except Exception:
+        raise ValueError(f"{name} must narrow to a finite float32") from None
     if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+        raise ValueError(f"{name} must narrow to a finite float32")
     return real, numerator, denominator, narrowed
 
 
@@ -76,7 +104,7 @@ def _require_unit_interval(name: str, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in [0, 1], got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
@@ -90,21 +118,21 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
         or narrowed <= 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in (0, 1], got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be non-negative, got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
+        raise ValueError(f"{name} must be positive, got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
@@ -115,18 +143,17 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
-        raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive, got invalid value")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative, got invalid value")
+        raise ValueError(f"{name} must be >= {minimum}, got invalid value")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}, got invalid value")
     return number
 
 
@@ -286,15 +313,13 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     )
     feature_family = config.feature_family
     if type(feature_family) is not str:
-        raise ValueError(
-            f"feature_family must be an actual string, got {feature_family!r}"
-        )
+        raise ValueError("feature_family must be an actual string")
     if feature_family not in {
         "position_token",
         "suffix_pair",
         "token_suffix_pair",
     }:
-        raise ValueError(f"unknown feature_family: {feature_family!r}")
+        raise ValueError("unknown feature_family")
     canonical_feature_family = str(feature_family)
     max_features = _require_int(
         "max_features", config.max_features, minimum=1, maximum=_INT32_MAX
@@ -310,7 +335,7 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     logit_scale = _require_positive_real("logit_scale", config.logit_scale)
     if type(config.normalize_by_weight) is not bool:
         raise ValueError(
-            f"normalize_by_weight must be a bool, got {config.normalize_by_weight!r}"
+            "normalize_by_weight must be a bool"
         )
     for name in (
         "adaptive_feature_family",
@@ -319,7 +344,7 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     ):
         val = getattr(config, name)
         if type(val) is not bool:
-            raise ValueError(f"{name} must be a boolean, got {val!r}")
+            raise ValueError(f"{name} must be a boolean")
         object.__setattr__(config, name, bool(val))
     scope_lr = _require_nonnegative_real("scope_lr", config.scope_lr)
     budget_lr = _require_nonnegative_real("budget_lr", config.budget_lr)
@@ -354,6 +379,24 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     object.__setattr__(config, "initial_budget_fraction", initial_budget_fraction)
     object.__setattr__(config, "min_effective_budget", min_effective_budget)
     object.__setattr__(config, "scope_logit_clip", scope_logit_clip)
+    if max_features * vocab_size > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
+    if max_features * block_size > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
+    total_values_scalars = max_features * vocab_size
+    fixed_state_scalars = (
+        8 * max_features + vocab_size + suffix_length + 5
+    )
+    _require_float32_resource(
+        "AssociativeMemoryConfig state",
+        vector_scalars=total_values_scalars,
+        fixed_scalars=fixed_state_scalars,
+    )
+    persistent_bytes = 4 * (total_values_scalars + fixed_state_scalars)
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("associative memory allocation exceeds uint32 byte accounting")
 
 
 def _softmax(logits: Array) -> Array:

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.core.associative_memory import AssociativeMemoryConfig
+from alberta_framework.core.associative_memory import (
+    AssociativeMemoryConfig,
+    AssociativeMemoryLearner,
+    _require_resource,
+    run_associative_memory_arrays,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -218,3 +224,117 @@ def test_associative_float_validators_accept_valid_values() -> None:
     )
     assert cfg.write_lr == 1.0
     assert cfg.retention == 0.9
+
+
+def test_associative_static_pair_indices_preflight_before_python_lists() -> None:
+    with pytest.raises(ValueError, match="static indices.*scalar count"):
+        _base_cfg(block_size=50_000, suffix_length=50_000, max_features=1)
+
+
+def test_associative_lookup_and_gather_products_are_preflighted() -> None:
+    with pytest.raises(ValueError, match="lookup workspace.*scalar count"):
+        _base_cfg(block_size=1_000, suffix_length=2, max_features=400_000)
+    with pytest.raises(ValueError, match="gathered rows.*byte count"):
+        _base_cfg(
+            vocab_size=1_000_000,
+            block_size=1_000,
+            suffix_length=2,
+            max_features=1,
+        )
+
+
+def test_associative_adaptive_window_product_is_conditional() -> None:
+    # Other exact products fit; the pair-by-window matrix alone exceeds the bound.
+    _base_cfg(block_size=1_050, suffix_length=1_050, max_features=1)
+    with pytest.raises(ValueError, match="adaptive-window workspace.*byte count"):
+        _base_cfg(
+            block_size=1_050,
+            suffix_length=1_050,
+            max_features=1,
+            adaptive_window=True,
+        )
+
+
+def test_associative_resource_endpoint_is_exact_and_allocation_free() -> None:
+    _require_resource("endpoint", float32_scalars=_INT32_MAX // 4)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_resource("endpoint", float32_scalars=_INT32_MAX // 4 + 1)
+    with pytest.raises(ValueError, match="scalar count"):
+        _require_resource("endpoint", bool_scalars=_INT32_MAX + 1)
+
+
+def test_associative_serialized_schema_is_exact() -> None:
+    learner = AssociativeMemoryLearner(_base_cfg())
+    config_payload = learner.config.to_config()
+    learner_payload = learner.to_config()
+    assert AssociativeMemoryConfig.from_config(config_payload) == learner.config
+    assert AssociativeMemoryLearner.from_config(learner_payload).config == learner.config
+
+    for payload in (
+        {**config_payload, "extra": 1},
+        {key: value for key, value in config_payload.items() if key != "vocab_size"},
+        {**config_payload, "type": "Wrong"},
+        {**config_payload, "vocab_size": np.int32(4)},
+    ):
+        with pytest.raises(ValueError):
+            AssociativeMemoryConfig.from_config(payload)
+    with pytest.raises(ValueError):
+        AssociativeMemoryLearner.from_config({**learner_payload, "extra": 1})
+
+
+def test_associative_public_shapes_and_dtypes_fail_before_tracing() -> None:
+    learner = AssociativeMemoryLearner(_base_cfg())
+    state = learner.init()
+    with pytest.raises(ValueError, match="context must have shape"):
+        learner.predict(state, jnp.zeros((7,), dtype=jnp.int32))
+    with pytest.raises(TypeError, match="context must have dtype int32"):
+        learner.predict(state, jnp.zeros((8,), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="state.values must have shape"):
+        learner.predict(
+            state.replace(values=jnp.zeros((4, 3), dtype=jnp.float32)),
+            jnp.zeros((8,), dtype=jnp.int32),
+        )
+    with pytest.raises(ValueError, match="labels must have shape"):
+        run_associative_memory_arrays(
+            learner,
+            state,
+            jnp.zeros((2, 8), dtype=jnp.int32),
+            jnp.zeros((1,), dtype=jnp.int32),
+        )
+
+
+def test_associative_counters_saturate_without_wrapping() -> None:
+    learner = AssociativeMemoryLearner(
+        _base_cfg(
+            block_size=2,
+            suffix_length=2,
+            max_features=1,
+            feature_family="position_token",
+        )
+    )
+    state = learner.init().replace(
+        allocations=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+        replacements=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    result = learner.update(
+        state,
+        jnp.asarray([0, 1], dtype=jnp.int32),
+        jnp.asarray(1, dtype=jnp.int32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.allocations) == _INT32_MAX
+    assert int(result.state.replacements) == _INT32_MAX
+    assert int(result.state.step_count) == _INT32_MAX
+
+
+def test_associative_invalid_adopted_counter_rolls_back_transaction() -> None:
+    learner = AssociativeMemoryLearner(_base_cfg())
+    state = learner.init().replace(step_count=jnp.asarray(-1, dtype=jnp.int32))
+    result = learner.update(
+        state,
+        jnp.zeros((8,), dtype=jnp.int32),
+        jnp.asarray(1, dtype=jnp.int32),
+    )
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == -1

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -1,0 +1,220 @@
+"""Validation hardening for associative memory (int/float bounds + resources)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.associative_memory import AssociativeMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides: object) -> AssociativeMemoryConfig:
+    base: dict[str, object] = {
+        "vocab_size": 4,
+        "block_size": 8,
+        "suffix_length": 2,
+        "max_features": 4,
+    }
+    base.update(overrides)
+    return AssociativeMemoryConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+        lambda v: _base_cfg(suffix_length=v),
+        lambda v: _base_cfg(max_features=v),
+        lambda v: _base_cfg(min_effective_budget=v),
+    ],
+)
+def test_associative_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+    ],
+)
+def test_associative_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_associative_int_validators_canonicalize_numpy_scalars(
+    np_type: type,
+) -> None:
+    cfg = AssociativeMemoryConfig(
+        vocab_size=np_type(8),
+        block_size=np_type(8),
+        suffix_length=np_type(2),
+        max_features=np_type(16),
+        min_effective_budget=np_type(1),
+    )
+    assert cfg.vocab_size == 8
+    assert type(cfg.vocab_size) is int
+    assert type(cfg.block_size) is int
+    assert type(cfg.max_features) is int
+    assert type(cfg.min_effective_budget) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+        lambda v: _base_cfg(max_features=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1],
+)
+def test_associative_int_validators_reject_non_integer_and_out_of_range(
+    ctor,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+def test_associative_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("write_lr", float("nan")),
+        ("write_lr", float("inf")),
+        ("write_lr", 0.0),
+        ("write_lr", -1.0),
+        ("write_lr", HostileFloat(0.5)),
+        ("retention", -0.1),
+        ("retention", 1.5),
+        ("retention", ClassSpoof()),  # type: ignore[arg-type]
+        ("utility_decay", -0.1),
+        ("utility_decay", 1.5),
+        ("min_weight", 0.0),
+        ("max_weight", 0.0),
+        ("logit_scale", 0.0),
+        ("scope_lr", -0.1),
+        ("budget_lr", -0.1),
+        ("initial_budget_fraction", 0.0),
+        ("initial_budget_fraction", 1.5),
+        ("scope_logit_clip", 0.0),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_associative_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="write_lr"):
+        _base_cfg(write_lr=HostileFloat(1.0))  # type: ignore[arg-type]
+    assert HostileFloat.calls == 1
+
+
+def test_associative_dimensions_preflight_without_allocation() -> None:
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=_INT32_MAX, max_features=2, block_size=_INT32_MAX)
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=50000, max_features=50000, block_size=8)
+
+
+def test_associative_state_preflight_bytes_without_allocation() -> None:
+    # Simplified total = max_features*vocab + 8*max_features + vocab + suffix +5
+    # With vocab=2,suffix=2 -> total=10*max+9, persistent=40*max+36
+    last_legal = (2**31 - 1 - 36) // 40
+    _base_cfg(
+        vocab_size=2,
+        block_size=2,
+        suffix_length=2,
+        max_features=last_legal,
+    )
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        _base_cfg(
+            vocab_size=2,
+            block_size=2,
+            suffix_length=2,
+            max_features=last_legal + 1,
+        )
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=5000, block_size=8, suffix_length=2, max_features=500_000)
+
+
+def test_associative_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(
+        write_lr=1.0,
+        retention=0.9,
+        utility_decay=0.99,
+        min_weight=0.1,
+        max_weight=2.0,
+        logit_scale=1.0,
+        scope_lr=0.05,
+        budget_lr=0.05,
+        initial_budget_fraction=0.5,
+        scope_logit_clip=8.0,
+    )
+    assert cfg.write_lr == 1.0
+    assert cfg.retention == 0.9


### PR DESCRIPTION
Preserves and rebases the contributor work from #828, then closes the remaining public contracts.

- preflights persistent state, quadratic suffix indices, lookup/gather/adaptive-window work, and batch outputs with exact signed-int32 scalar/byte accounting
- validates exact serialized config/learner envelopes and static state/context/batch shapes and dtypes before tracing
- validates adopted counter domains transactionally and saturates all int32 lifetime counters
- adds allocation-free endpoint/adjacent/product tests plus schema, hostile-state, public-shape, and saturation coverage

Validation: 182 focused tests passed; scoped Ruff, mypy, root import, and diff check passed.

Supersedes #828. Contributor commit and co-authorship are retained.