### PR TITLE
fix(associative-memory): complete derived resource contracts

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import functools
 import math
 import operator
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from numbers import Real
 from typing import Any, Literal, SupportsIndex, cast
@@ -61,6 +62,51 @@ def _require_float32_resource(
         raise ValueError(f"{name} scalar count must fit signed int32")
     if 4 * total_scalars > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_sequence_resource(name: str, *, scalars: int, bools: int = 0) -> None:
+    if scalars + bools > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * scalars + bools > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _read_mapping(name: str, value: object) -> dict[str, Any]:
+    if not issubclass(type(value), Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], value))
+    except Exception as error:
+        raise ValueError(f"{name} mapping could not be read") from error
+
+
+def _require_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> None:
+    try:
+        actual_shape = tuple(value.shape)  # type: ignore[attr-defined]
+        actual_dtype = jnp.dtype(value.dtype)  # type: ignore[attr-defined]
+    except Exception as error:
+        raise TypeError(f"{name} must expose array shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} has an invalid shape")
+    if actual_dtype != jnp.dtype(dtype):
+        raise TypeError(f"{name} has an invalid dtype")
+
+
+def _saturating_increment(value: Array) -> Array:
+    return jnp.minimum(value, jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)) + jnp.asarray(
+        1, dtype=jnp.int32
+    )
+
+
+def _saturating_add_bool(value: Array, increment: Array) -> Array:
+    room = value < jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return value + (increment & room).astype(jnp.int32)
 
 
 def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
@@ -236,11 +282,16 @@ class AssociativeMemoryConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> AssociativeMemoryConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
+        payload = _read_mapping("AssociativeMemoryConfig payload", config)
         payload.pop("type", None)
-        return cls(**payload)
+        try:
+            return cls(**payload)
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized AssociativeMemoryConfig is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -299,6 +350,39 @@ class AssociativeMemoryLearningResult:
     predictions: Float[Array, "steps vocab_size"]
     metrics: Float[Array, "steps 8"]
     updates_applied: Bool[Array, " steps"]
+
+
+def _associative_resource_counts(
+    *, vocab_size: int, block_size: int, suffix_length: int, max_features: int
+) -> tuple[int, int, int, int, int]:
+    pair_count = suffix_length * (suffix_length - 1) // 2
+    active = block_size + pair_count
+    windows = suffix_length - 1
+    persistent = max_features * vocab_size + 8 * max_features + vocab_size + suffix_length + 5
+    descriptors = 5 * pair_count + 2 * block_size + suffix_length - 1
+    window_matrix = pair_count * windows
+    query = (
+        persistent
+        + block_size
+        + 16 * active
+        + active * max_features
+        + max_features
+        + active * vocab_size
+        + window_matrix
+        + 4 * vocab_size
+        + 5 * windows
+        + 32
+    )
+    update = (
+        query
+        + 2 * persistent
+        + active * vocab_size
+        + 10 * active
+        + 5 * vocab_size
+        + 5 * windows
+        + 64
+    )
+    return pair_count, active, descriptors, query, update
 
 
 def _validate_config(config: AssociativeMemoryConfig) -> None:
@@ -383,6 +467,24 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
         raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
     if max_features * block_size > _INT32_MAX:
         raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
+    pair_count, active_features, descriptor_scalars, query_scalars, update_scalars = (
+        _associative_resource_counts(
+            vocab_size=vocab_size,
+            block_size=block_size,
+            suffix_length=suffix_length,
+            max_features=max_features,
+        )
+    )
+    for name, count in (
+        ("pair count", pair_count),
+        ("active feature count", active_features),
+        ("feature-key count", 5 * active_features),
+        ("lookup match count", active_features * max_features),
+        ("row-value count", active_features * vocab_size),
+        ("window-scope count", pair_count * (suffix_length - 1)),
+    ):
+        if count > _INT32_MAX:
+            raise ValueError(f"AssociativeMemoryConfig {name} must fit signed int32")
     total_values_scalars = max_features * vocab_size
     fixed_state_scalars = (
         8 * max_features + vocab_size + suffix_length + 5
@@ -397,6 +499,15 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
         raise ValueError("AssociativeMemoryConfig state byte count must fit signed int32")
     if persistent_bytes > _UINT32_MAX:
         raise ValueError("associative memory allocation exceeds uint32 byte accounting")
+    _require_float32_resource(
+        "AssociativeMemoryConfig descriptors", vector_scalars=descriptor_scalars
+    )
+    _require_float32_resource(
+        "AssociativeMemoryConfig query", vector_scalars=query_scalars
+    )
+    _require_float32_resource(
+        "AssociativeMemoryConfig update", vector_scalars=update_scalars
+    )
 
 
 def _softmax(logits: Array) -> Array:
@@ -493,10 +604,53 @@ class AssociativeMemoryLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> AssociativeMemoryLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryLearner:
         """Reconstruct from :meth:`to_config` output."""
-        return cls(
-            AssociativeMemoryConfig.from_config(cast(dict[str, Any], config["config"]))
+        payload = _read_mapping("AssociativeMemoryLearner payload", config)
+        inner = payload.get("config")
+        if not issubclass(type(inner), Mapping):
+            raise ValueError("AssociativeMemoryLearner config must be a mapping")
+        return cls(AssociativeMemoryConfig.from_config(cast(Mapping[str, Any], inner)))
+
+    def _validate_state_static_contract(self, state: AssociativeMemoryState) -> None:
+        if type(state) is not AssociativeMemoryState:
+            raise TypeError("state must be an AssociativeMemoryState")
+        c = self._config
+        expected = (
+            ("state.keys", state.keys, (c.max_features, KEY_WIDTH), jnp.int32),
+            ("state.values", state.values, (c.max_features, c.vocab_size), jnp.float32),
+            ("state.utility", state.utility, (c.max_features,), jnp.float32),
+            ("state.counts", state.counts, (c.max_features,), jnp.float32),
+            ("state.last_update", state.last_update, (c.max_features,), jnp.int32),
+            ("state.prior", state.prior, (c.vocab_size,), jnp.float32),
+            ("state.family_logits", state.family_logits, (FAMILY_COUNT,), jnp.float32),
+            ("state.window_logits", state.window_logits, (c.suffix_length - 1,), jnp.float32),
+            ("state.budget_logit", state.budget_logit, (), jnp.float32),
+            ("state.allocations", state.allocations, (), jnp.int32),
+            ("state.replacements", state.replacements, (), jnp.int32),
+            ("state.step_count", state.step_count, (), jnp.int32),
+        )
+        for name, value, shape, dtype in expected:
+            _require_array(name, value, shape=shape, dtype=dtype)
+
+    @staticmethod
+    def _state_is_valid(state: AssociativeMemoryState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & jnp.all(state.counts >= 0.0)
+            & jnp.all(state.last_update >= 0)
+            & (state.allocations >= 0)
+            & (state.replacements >= 0)
+            & (state.step_count >= 0)
+            & jnp.all(state.last_update <= state.step_count)
+        )
+
+    def _validate_context_static_contract(self, context: object) -> None:
+        _require_array(
+            "context",
+            context,
+            shape=(self._config.block_size,),
+            dtype=jnp.int32,
         )
 
     def init(self) -> AssociativeMemoryState:
@@ -523,14 +677,21 @@ class AssociativeMemoryLearner:
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def feature_keys(
         self,
         context: Int[Array, " block_size"],
     ) -> tuple[Int[Array, "max_active key_width"], Int[Array, " max_active"]]:
         """Return fixed-shape active feature keys and a 0/1 mask."""
+        self._validate_context_static_contract(context)
+        return cast(tuple[Array, Array], self._feature_keys_jit(context))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _feature_keys_jit(
+        self,
+        context: Int[Array, " block_size"],
+    ) -> tuple[Int[Array, "max_active key_width"], Int[Array, " max_active"]]:
         c = self._config
-        tokens = jnp.asarray(context, dtype=jnp.int32)
+        tokens = jnp.asarray(context)
         token_positions = jnp.arange(c.block_size, dtype=jnp.int32)
         token_keys = jnp.stack(
             [
@@ -643,14 +804,23 @@ class AssociativeMemoryLearner:
         uniform_loss = jnp.log(jnp.asarray(self._config.vocab_size, dtype=jnp.float32))
         return jnp.where(total_weight > 0.0, loss, uniform_loss)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def predict(
         self,
         state: AssociativeMemoryState,
         context: Int[Array, " block_size"],
     ) -> AssociativeMemoryPrediction:
         """Predict label probabilities before any write."""
-        keys, mask = self.feature_keys(context)
+        self._validate_state_static_contract(state)
+        self._validate_context_static_contract(context)
+        return cast(AssociativeMemoryPrediction, self._predict_jit(state, context))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _predict_jit(
+        self,
+        state: AssociativeMemoryState,
+        context: Int[Array, " block_size"],
+    ) -> AssociativeMemoryPrediction:
+        keys, mask = self._feature_keys_jit(context)
         found, indices = self._lookup(state, keys, mask)
         row_values = state.values[indices]
         row_utility = state.utility[indices]
@@ -821,6 +991,8 @@ class AssociativeMemoryLearner:
         label: Int[Array, ""],
     ) -> AssociativeMemoryUpdateResult:
         """Predict, then update active associative rows."""
+        self._validate_state_static_contract(state)
+        self._validate_context_static_contract(context)
         safe_label, label_valid = self._prepare_label(label)
         return cast(
             AssociativeMemoryUpdateResult,
@@ -866,7 +1038,7 @@ class AssociativeMemoryLearner:
         label_valid: Bool[Array, ""],
     ) -> AssociativeMemoryUpdateResult:
         """Execute one already-domain-checked associative transaction."""
-        prediction = self.predict(state, context)
+        prediction = self._predict_jit(state, context)
         loss = _cross_entropy_from_logits(prediction.logits, label)
         accuracy = (jnp.argmax(prediction.logits) == label).astype(jnp.float32)
         next_state = state.replace(  # type: ignore[attr-defined]
@@ -910,12 +1082,14 @@ class AssociativeMemoryLearner:
             new_row = old_row * self._config.retention
             new_row = new_row.at[label].add(self._config.write_lr)
             active_bool = active > 0
-            allocations = carry.allocations + (
-                active_bool & (~found_scalar) & used_empty
-            ).astype(jnp.int32)
-            replacements = carry.replacements + (
-                active_bool & (~found_scalar) & (~used_empty)
-            ).astype(jnp.int32)
+            allocations = _saturating_add_bool(
+                carry.allocations,
+                active_bool & (~found_scalar) & used_empty,
+            )
+            replacements = _saturating_add_bool(
+                carry.replacements,
+                active_bool & (~found_scalar) & (~used_empty),
+            )
             next_carry = carry.replace(  # type: ignore[attr-defined]
                 keys=jnp.where(
                     active_bool,
@@ -958,7 +1132,7 @@ class AssociativeMemoryLearner:
         next_state = self._update_window_scope(next_state, state, prediction, label, loss)
         next_state = self._update_budget_scope(next_state, state, prediction, loss)
         next_state = next_state.replace(  # type: ignore[attr-defined]
-            step_count=state.step_count + 1
+            step_count=_saturating_increment(state.step_count)
         )
         active_count = jnp.sum(prediction.feature_mask.astype(jnp.float32))
         occupied_count = jnp.sum((next_state.counts > 0.0).astype(jnp.float32))
@@ -981,7 +1155,7 @@ class AssociativeMemoryLearner:
         )
         update_applied = (
             label_valid
-            & floating_tree_is_finite(state)
+            & self._state_is_valid(state)
             & floating_tree_is_finite(prediction)
             & jnp.isfinite(loss)
             & floating_tree_is_finite(next_state)
@@ -1003,6 +1177,42 @@ def run_associative_memory_arrays(
     labels: Int[Array, " steps"],
 ) -> AssociativeMemoryLearningResult:
     """Run a scan-compatible online associative learner over arrays."""
+    if type(learner) is not AssociativeMemoryLearner:
+        raise TypeError("learner must be an AssociativeMemoryLearner")
+    learner._validate_state_static_contract(state)
+    c = learner.config
+    try:
+        context_shape = tuple(contexts.shape)
+        label_shape = tuple(labels.shape)
+    except Exception as error:
+        raise TypeError("contexts and labels must expose array metadata") from error
+    if len(context_shape) != 2 or context_shape[1] != c.block_size:
+        raise ValueError("contexts have an invalid shape")
+    steps = context_shape[0]
+    if type(steps) is not int or steps < 0:
+        raise ValueError("associative memory step count must be a non-negative integer")
+    if label_shape != (steps,):
+        raise ValueError("labels have an invalid shape")
+    _require_array("contexts", contexts, shape=(steps, c.block_size), dtype=jnp.int32)
+    _require_array("labels", labels, shape=(steps,), dtype=jnp.int32)
+    _, _, _, query_scalars, update_scalars = _associative_resource_counts(
+        vocab_size=c.vocab_size,
+        block_size=c.block_size,
+        suffix_length=c.suffix_length,
+        max_features=c.max_features,
+    )
+    _require_sequence_resource(
+        "associative memory scan outputs",
+        scalars=steps * (c.vocab_size + 8),
+        bools=steps,
+    )
+    _require_sequence_resource(
+        "associative memory scan aggregate",
+        scalars=steps * (c.block_size + 1 + c.vocab_size + 8)
+        + query_scalars
+        + update_scalars,
+        bools=steps,
+    )
 
     def step_fn(
         carry: AssociativeMemoryState,

--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import functools
 import math
+import operator
 from dataclasses import asdict, dataclass
-from numbers import Integral, Real
-from typing import Any, Literal, cast
+from numbers import Real
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
@@ -33,20 +34,47 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX: int = 2**31 - 1
+_UINT32_MAX: int = 4294967295
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
     """Return the original real, exact ratio, and finite binary32 rounding."""
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
+        raise ValueError(f"{name} must be a real number")
     real = cast(Real, value)
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
-    except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+    except Exception:
+        raise ValueError(f"{name} must narrow to a finite float32") from None
     if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+        raise ValueError(f"{name} must narrow to a finite float32")
     return real, numerator, denominator, narrowed
 
 
@@ -76,7 +104,7 @@ def _require_unit_interval(name: str, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in [0, 1], got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
@@ -90,21 +118,21 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
         or narrowed <= 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in (0, 1], got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be non-negative, got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
+        raise ValueError(f"{name} must be positive, got invalid value")
     return canonical_float32_storage(real, narrowed)
 
 
@@ -115,18 +143,17 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
-        raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive, got invalid value")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative, got invalid value")
+        raise ValueError(f"{name} must be >= {minimum}, got invalid value")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}, got invalid value")
     return number
 
 
@@ -286,15 +313,13 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     )
     feature_family = config.feature_family
     if type(feature_family) is not str:
-        raise ValueError(
-            f"feature_family must be an actual string, got {feature_family!r}"
-        )
+        raise ValueError("feature_family must be an actual string")
     if feature_family not in {
         "position_token",
         "suffix_pair",
         "token_suffix_pair",
     }:
-        raise ValueError(f"unknown feature_family: {feature_family!r}")
+        raise ValueError("unknown feature_family")
     canonical_feature_family = str(feature_family)
     max_features = _require_int(
         "max_features", config.max_features, minimum=1, maximum=_INT32_MAX
@@ -310,7 +335,7 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     logit_scale = _require_positive_real("logit_scale", config.logit_scale)
     if type(config.normalize_by_weight) is not bool:
         raise ValueError(
-            f"normalize_by_weight must be a bool, got {config.normalize_by_weight!r}"
+            "normalize_by_weight must be a bool"
         )
     for name in (
         "adaptive_feature_family",
@@ -319,7 +344,7 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     ):
         val = getattr(config, name)
         if type(val) is not bool:
-            raise ValueError(f"{name} must be a boolean, got {val!r}")
+            raise ValueError(f"{name} must be a boolean")
         object.__setattr__(config, name, bool(val))
     scope_lr = _require_nonnegative_real("scope_lr", config.scope_lr)
     budget_lr = _require_nonnegative_real("budget_lr", config.budget_lr)
@@ -354,6 +379,24 @@ def _validate_config(config: AssociativeMemoryConfig) -> None:
     object.__setattr__(config, "initial_budget_fraction", initial_budget_fraction)
     object.__setattr__(config, "min_effective_budget", min_effective_budget)
     object.__setattr__(config, "scope_logit_clip", scope_logit_clip)
+    if max_features * vocab_size > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
+    if max_features * block_size > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig dimensions must fit signed int32")
+    total_values_scalars = max_features * vocab_size
+    fixed_state_scalars = (
+        8 * max_features + vocab_size + suffix_length + 5
+    )
+    _require_float32_resource(
+        "AssociativeMemoryConfig state",
+        vector_scalars=total_values_scalars,
+        fixed_scalars=fixed_state_scalars,
+    )
+    persistent_bytes = 4 * (total_values_scalars + fixed_state_scalars)
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("AssociativeMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("associative memory allocation exceeds uint32 byte accounting")
 
 
 def _softmax(logits: Array) -> Array:

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import dataclasses
+from types import MappingProxyType
+
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.core.associative_memory import AssociativeMemoryConfig
+from alberta_framework.core.associative_memory import (
+    AssociativeMemoryConfig,
+    AssociativeMemoryLearner,
+    run_associative_memory_arrays,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -183,9 +191,8 @@ def test_associative_dimensions_preflight_without_allocation() -> None:
 
 
 def test_associative_state_preflight_bytes_without_allocation() -> None:
-    # Simplified total = max_features*vocab + 8*max_features + vocab + suffix +5
-    # With vocab=2,suffix=2 -> total=10*max+9, persistent=40*max+36
-    last_legal = (2**31 - 1 - 36) // 40
+    # With vocab=block=suffix=2, the conservative update bound is 34*max+244.
+    last_legal = (_INT32_MAX // 4 - 244) // 34
     _base_cfg(
         vocab_size=2,
         block_size=2,
@@ -218,3 +225,84 @@ def test_associative_float_validators_accept_valid_values() -> None:
     )
     assert cfg.write_lr == 1.0
     assert cfg.retention == 0.9
+
+
+def test_associative_pair_descriptors_preflight_before_learner_construction() -> None:
+    with pytest.raises(
+        ValueError, match="pair count|active feature|feature-key|descriptor|query"
+    ):
+        AssociativeMemoryConfig(
+            vocab_size=2,
+            block_size=50_000,
+            suffix_length=50_000,
+            max_features=1,
+        )
+
+
+def test_associative_serialization_preserves_historical_compatibility() -> None:
+    config = _base_cfg()
+    payload = config.to_config()
+    payload["type"] = "historical-marker"
+    payload["vocab_size"] = np.int32(config.vocab_size)
+    restored = AssociativeMemoryConfig.from_config(MappingProxyType(payload))
+    assert restored == config
+    partial = AssociativeMemoryConfig.from_config(
+        {"vocab_size": 4, "block_size": 8, "suffix_length": 2, "max_features": 4}
+    )
+    assert partial == config
+    learner_payload = AssociativeMemoryLearner(config).to_config()
+    learner_payload["type"] = "historical-marker"
+    learner_payload["metadata"] = 1
+    assert AssociativeMemoryLearner.from_config(learner_payload).config == config
+    with pytest.raises(ValueError, match="serialized AssociativeMemoryConfig"):
+        AssociativeMemoryConfig.from_config({**config.to_config(), "unknown": 1})
+
+
+def test_associative_public_contracts_and_counters() -> None:
+    learner = AssociativeMemoryLearner(_base_cfg())
+    state = learner.init()
+    context = jnp.zeros((8,), dtype=jnp.int32)
+    label = jnp.asarray(1, dtype=jnp.int32)
+    with pytest.raises(ValueError, match="context"):
+        learner.predict(state, jnp.zeros((1, 8), dtype=jnp.int32))
+    with pytest.raises(TypeError, match="context"):
+        learner.predict(state, jnp.zeros((8,), dtype=jnp.int16))
+    malformed = dataclasses.replace(
+        state, values=jnp.zeros((4, 4), dtype=jnp.float16)
+    )
+    with pytest.raises(TypeError, match="state.values"):
+        learner.update(malformed, context, label)
+
+    maximum = dataclasses.replace(
+        state,
+        allocations=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+        replacements=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    result = learner.update(maximum, context, label)
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.allocations) == _INT32_MAX
+    assert int(result.state.replacements) == _INT32_MAX
+
+
+def test_associative_scan_preflight_precedes_conversion() -> None:
+    learner = AssociativeMemoryLearner(_base_cfg())
+    first_overflow = _INT32_MAX // (4 * (learner.config.vocab_size + 9)) + 1
+
+    class HostArray:
+        dtype = np.dtype(np.int32)
+
+        def __init__(self, shape: tuple[int, ...]):
+            self.shape = shape
+
+        def __jax_array__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("conversion must not run")
+
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        run_associative_memory_arrays(
+            learner,
+            learner.init(),
+            HostArray((first_overflow, 8)),  # type: ignore[arg-type]
+            HostArray((first_overflow,)),  # type: ignore[arg-type]
+        )

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -1,0 +1,220 @@
+"""Validation hardening for associative memory (int/float bounds + resources)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.associative_memory import AssociativeMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides: object) -> AssociativeMemoryConfig:
+    base: dict[str, object] = {
+        "vocab_size": 4,
+        "block_size": 8,
+        "suffix_length": 2,
+        "max_features": 4,
+    }
+    base.update(overrides)
+    return AssociativeMemoryConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+        lambda v: _base_cfg(suffix_length=v),
+        lambda v: _base_cfg(max_features=v),
+        lambda v: _base_cfg(min_effective_budget=v),
+    ],
+)
+def test_associative_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+    ],
+)
+def test_associative_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_associative_int_validators_canonicalize_numpy_scalars(
+    np_type: type,
+) -> None:
+    cfg = AssociativeMemoryConfig(
+        vocab_size=np_type(8),
+        block_size=np_type(8),
+        suffix_length=np_type(2),
+        max_features=np_type(16),
+        min_effective_budget=np_type(1),
+    )
+    assert cfg.vocab_size == 8
+    assert type(cfg.vocab_size) is int
+    assert type(cfg.block_size) is int
+    assert type(cfg.max_features) is int
+    assert type(cfg.min_effective_budget) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(vocab_size=v),
+        lambda v: _base_cfg(block_size=v),
+        lambda v: _base_cfg(max_features=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1],
+)
+def test_associative_int_validators_reject_non_integer_and_out_of_range(
+    ctor,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+def test_associative_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("write_lr", float("nan")),
+        ("write_lr", float("inf")),
+        ("write_lr", 0.0),
+        ("write_lr", -1.0),
+        ("write_lr", HostileFloat(0.5)),
+        ("retention", -0.1),
+        ("retention", 1.5),
+        ("retention", ClassSpoof()),  # type: ignore[arg-type]
+        ("utility_decay", -0.1),
+        ("utility_decay", 1.5),
+        ("min_weight", 0.0),
+        ("max_weight", 0.0),
+        ("logit_scale", 0.0),
+        ("scope_lr", -0.1),
+        ("budget_lr", -0.1),
+        ("initial_budget_fraction", 0.0),
+        ("initial_budget_fraction", 1.5),
+        ("scope_logit_clip", 0.0),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_associative_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="write_lr"):
+        _base_cfg(write_lr=HostileFloat(1.0))  # type: ignore[arg-type]
+    assert HostileFloat.calls == 1
+
+
+def test_associative_dimensions_preflight_without_allocation() -> None:
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=_INT32_MAX, max_features=2, block_size=_INT32_MAX)
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=50000, max_features=50000, block_size=8)
+
+
+def test_associative_state_preflight_bytes_without_allocation() -> None:
+    # Simplified total = max_features*vocab + 8*max_features + vocab + suffix +5
+    # With vocab=2,suffix=2 -> total=10*max+9, persistent=40*max+36
+    last_legal = (2**31 - 1 - 36) // 40
+    _base_cfg(
+        vocab_size=2,
+        block_size=2,
+        suffix_length=2,
+        max_features=last_legal,
+    )
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        _base_cfg(
+            vocab_size=2,
+            block_size=2,
+            suffix_length=2,
+            max_features=last_legal + 1,
+        )
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(vocab_size=5000, block_size=8, suffix_length=2, max_features=500_000)
+
+
+def test_associative_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(
+        write_lr=1.0,
+        retention=0.9,
+        utility_decay=0.99,
+        min_weight=0.1,
+        max_weight=2.0,
+        logit_scale=1.0,
+        scope_lr=0.05,
+        budget_lr=0.05,
+        initial_budget_fraction=0.5,
+        scope_logit_clip=8.0,
+    )
+    assert cfg.write_lr == 1.0
+    assert cfg.retention == 0.9


### PR DESCRIPTION
Supersedes #828 while preserving byt61's contributor commit and authorship. The original persistent-state arithmetic is retained, and this successor closes the derived constructor/runtime gaps.\n\n- preflights quadratic suffix pairs, active feature/key descriptors, lookup match matrix, gathered row values, adaptive-window matrix, and conservative query/update logical working sets before constructor list/JAX allocations\n- exact public state/context shape+dtypes, runtime state invariants, and atomic invalid-state updates\n- saturating step/allocation/replacement counters\n- host metadata and exact aggregate input/output/working-set scan bounds before JAX scan conversion\n- hostile-safe Mapping loaders that preserve historical optional markers/defaulted fields/NumPy scalar constructors and outer learner metadata\n- preserves arbitrary int32 context-key compatibility (vocab_size bounds labels/values; existing consumers use larger context token ids)\n\nVerification at 8a51cb3 on current main:\n- 178 associative-memory tests passed\n- Ruff passed\n- full strict mypy passed (168 source files)\n- git diff --check passed\n\nNo registered evidence source or output is changed.