### PR TITLE
fix(world-model-ensemble): validate scalar and resource contracts

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -39,17 +39,19 @@ import dataclasses
 import functools
 import hashlib
 import json
-import math
+import operator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -71,8 +73,94 @@ from alberta_framework.core.world_model import (
 WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA = "alberta.world_model_ensemble.v2"
 _WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA_V1 = "alberta.world_model_ensemble.v1"
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
 _REPLAY_KEY_FOLD_IN = 0x5245504C
 _V1_REPLAY_KEY_FOLD_IN = 0x50525632
+
+
+def _require_int32(
+    name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _configured_member_state_scalars(model: ActionConditionedWorldModelConfig) -> int:
+    input_dim = model.observation_dim + model.n_actions
+    if model.include_action_interactions:
+        input_dim += model.observation_dim * model.n_actions
+    n_heads = model.observation_dim + 2
+    layer_sizes = (input_dim, *model.hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    head_input = model.hidden_sizes[-1] if model.hidden_sizes else input_dim
+    head_parameters = n_heads * (head_input + 1)
+    optimizer_scalars = 2 * len(model.hidden_sizes) + 2 * n_heads
+    learner_scalars = (
+        2 * (trunk_parameters + head_parameters)
+        + optimizer_scalars
+        + sum(model.hidden_sizes)
+        + 5  # array counters plus two logical host timing leaves
+    )
+    return learner_scalars + 2 * model.observation_dim + 4
+
+
+def _validate_ensemble_resources(
+    model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> None:
+    target_dim = model.observation_dim + 2
+    member_scalars = _configured_member_state_scalars(model)
+    residual_scalars = ensemble_size * target_dim
+    # Members, residual matrix, signal estimator (9), two typed PRNG keys (4),
+    # two masks, two count vectors, and two event counters.
+    persistent_scalars = (
+        ensemble_size * member_scalars
+        + residual_scalars
+        + 9
+        + 4
+        + 4 * ensemble_size
+        + 2
+    )
+    persistent_bytes = (
+        4
+        * (
+            ensemble_size * member_scalars
+            + residual_scalars
+            + 9
+            + 4
+            + 2 * ensemble_size
+            + 2
+        )
+        + 2 * ensemble_size
+    )
+    for name, value in (
+        ("member_state_scalars", member_scalars),
+        ("residual_variance_scalars", residual_scalars),
+        ("persistent_state_scalars", persistent_scalars),
+        ("persistent_state_bytes", persistent_bytes),
+    ):
+        if value > _INT32_MAX:
+            raise ValueError(f"derived {name} must fit in signed int32")
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -127,43 +215,51 @@ class WorldModelEnsembleConfig:
     residual_variance_floor: float = 1.0e-6
 
     def __post_init__(self) -> None:
-        if (
-            isinstance(self.ensemble_size, bool)
-            or not isinstance(self.ensemble_size, int)
-            or self.ensemble_size < 2
-        ):
-            raise ValueError("ensemble_size must be an integer >= 2")
-        if (
-            not math.isfinite(self.bootstrap_probability)
-            or not 0.0 < self.bootstrap_probability < 1.0
-        ):
-            raise ValueError("bootstrap_probability must be finite and in (0, 1)")
-        if (
-            not math.isfinite(self.residual_variance_decay)
-            or not 0.0 <= self.residual_variance_decay < 1.0
-        ):
-            raise ValueError("residual_variance_decay must be finite and in [0, 1)")
-        if (
-            isinstance(self.residual_variance_warmup_steps, bool)
-            or not isinstance(self.residual_variance_warmup_steps, int)
-            or not 1 <= self.residual_variance_warmup_steps <= _INT32_MAX
-        ):
-            raise ValueError("residual_variance_warmup_steps must be an integer in [1, int32 max]")
-        if not math.isfinite(self.residual_variance_floor) or self.residual_variance_floor <= 0.0:
-            raise ValueError("residual_variance_floor must be positive and finite")
-        if self.signal_estimator.ensemble_size != self.ensemble_size:
+        if type(self.model) is not ActionConditionedWorldModelConfig:
+            raise ValueError("model must be an ActionConditionedWorldModelConfig")
+        if type(self.signal_estimator) is not LearningSignalEstimatorConfig:
+            raise ValueError("signal_estimator must be a LearningSignalEstimatorConfig")
+        ensemble_size = _require_int32(
+            "ensemble_size", self.ensemble_size, minimum=2, maximum=_INT32_MAX - 1
+        )
+        warmup = _require_int32(
+            "residual_variance_warmup_steps",
+            self.residual_variance_warmup_steps,
+            minimum=1,
+        )
+        bootstrap_probability = validated_float32_scalar(
+            "bootstrap_probability",
+            self.bootstrap_probability,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        residual_variance_decay = validated_float32_scalar(
+            "residual_variance_decay",
+            self.residual_variance_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        residual_variance_floor = validated_float32_scalar(
+            "residual_variance_floor", self.residual_variance_floor, positive=True
+        )
+        if self.signal_estimator.ensemble_size != ensemble_size:
             raise ValueError("signal_estimator.ensemble_size must match ensemble_size")
         expected_target_dim = self.model.observation_dim + 2
         if self.signal_estimator.target_dim != expected_target_dim:
             raise ValueError("signal_estimator.target_dim must equal model.observation_dim + 2")
-        if self.residual_variance_floor < self.signal_estimator.variance_floor:
+        if residual_variance_floor < self.signal_estimator.variance_floor:
             raise ValueError("residual_variance_floor must be >= signal_estimator.variance_floor")
-        if self.residual_variance_floor > self.signal_estimator.max_predicted_variance:
+        if residual_variance_floor > self.signal_estimator.max_predicted_variance:
             raise ValueError("residual_variance_floor exceeds the signal estimator variance bound")
 
-        # Reuse the model's complete constructor validation rather than
-        # maintaining a second, drifting copy here.
-        ActionConditionedWorldModel(self.model)
+        object.__setattr__(self, "ensemble_size", ensemble_size)
+        object.__setattr__(self, "residual_variance_warmup_steps", warmup)
+        object.__setattr__(self, "bootstrap_probability", bootstrap_probability)
+        object.__setattr__(self, "residual_variance_decay", residual_variance_decay)
+        object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
+        _validate_ensemble_resources(self.model, ensemble_size)
 
     @property
     def target_dim(self) -> int:
@@ -551,6 +647,8 @@ class WorldModelEnsemble:
     """Fixed-size bootstrap ensemble with causal typed learning signals."""
 
     def __init__(self, config: WorldModelEnsembleConfig):
+        if type(config) is not WorldModelEnsembleConfig:
+            raise ValueError("config must be a WorldModelEnsembleConfig")
         self._config = config
         self._model = ActionConditionedWorldModel(config.model)
         self._signals = LearningSignalEstimator(config.signal_estimator)
@@ -676,7 +774,11 @@ class WorldModelEnsemble:
             raise TypeError("bootstrap PRNG key storage must use uint32 words")
         bootstrap_words = int(bootstrap_key_data.size + replay_key_data.size)
         bootstrap_bytes = int(bootstrap_key_data.nbytes + replay_key_data.nbytes)
-        if persistent.uint32_scalars != bootstrap_words or bootstrap_bytes != 4 * bootstrap_words:
+        expected_uint32 = (
+            self._config.ensemble_size * member_account.uint32_scalars
+            + bootstrap_words
+        )
+        if persistent.uint32_scalars != expected_uint32 or bootstrap_bytes != 4 * bootstrap_words:
             raise ValueError("bootstrap PRNG key accounting does not match state")
 
         prediction = _logical_tree_accounting(self._zero_prediction())

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,8 @@ def _config(
     max_predicted_variance: float = 10_000.0,
     max_observed_loss: float = 10_000.0,
     residual_variance_warmup_steps: int = 1,
+    residual_variance_decay: float = 0.8,
+    residual_variance_floor: float = 1.0e-6,
 ) -> WorldModelEnsembleConfig:
     model = ActionConditionedWorldModelConfig(
         observation_dim=2,
@@ -79,9 +82,9 @@ def _config(
         signal_estimator=signals,
         ensemble_size=ensemble_size,
         bootstrap_probability=bootstrap_probability,
-        residual_variance_decay=0.8,
+        residual_variance_decay=residual_variance_decay,
         residual_variance_warmup_steps=residual_variance_warmup_steps,
-        residual_variance_floor=1.0e-6,
+        residual_variance_floor=residual_variance_floor,
     )
 
 
@@ -751,3 +754,110 @@ def test_checkpoint_rejects_invalid_state(tmp_path: Path) -> None:
             corrupt,
             tmp_path / "invalid",
         )
+
+
+def test_config_validates_numpy_integer_and_float32_scalar_families() -> None:
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=()
+    )
+    signals = LearningSignalEstimatorConfig(ensemble_size=3, target_dim=4)
+    config = WorldModelEnsembleConfig(
+        model=model,
+        signal_estimator=signals,
+        ensemble_size=np.uint16(3),
+        bootstrap_probability=np.float64(0.75),
+        residual_variance_decay=Fraction(3, 4),
+        residual_variance_warmup_steps=np.int64(2),
+        residual_variance_floor=np.float32(1.0e-5),
+    )
+    assert type(config.ensemble_size) is int
+    assert type(config.residual_variance_warmup_steps) is int
+    assert all(
+        type(value) is float
+        for value in (
+            config.bootstrap_probability,
+            config.residual_variance_decay,
+            config.residual_variance_floor,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"ensemble_size": True},
+        {"ensemble_size": 3.0},
+        {"residual_variance_warmup_steps": np.bool_(True)},
+        {"residual_variance_warmup_steps": 1.5},
+        {"bootstrap_probability": 1.0e-100},
+        {"bootstrap_probability": 1.0 - 1.0e-10},
+        {"residual_variance_decay": 1.0 - 1.0e-10},
+        {"residual_variance_floor": 1.0e100},
+    ],
+)
+def test_config_rejects_hostile_scalar_domains(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        _config(**overrides)  # type: ignore[arg-type]
+
+
+def test_config_preflights_aggregate_state_before_split_or_allocation() -> None:
+    ensemble_size = 20_000_000
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=()
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=ensemble_size,
+        target_dim=4,
+    )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        WorldModelEnsembleConfig(
+            model=model,
+            signal_estimator=signals,
+            ensemble_size=ensemble_size,
+        )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        ActionConditionedWorldModelConfig(
+            observation_dim=2, n_actions=2, hidden_sizes=()
+        ),
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(3,),
+            include_action_interactions=True,
+        ),
+    ],
+)
+def test_config_resource_formula_matches_initialized_tree(
+    model: ActionConditionedWorldModelConfig,
+) -> None:
+    signals = LearningSignalEstimatorConfig(ensemble_size=2, target_dim=4)
+    ensemble = WorldModelEnsemble(
+        WorldModelEnsembleConfig(
+            model=model,
+            signal_estimator=signals,
+            ensemble_size=2,
+        )
+    )
+    budget = ensemble.resource_budget()
+    assert budget.persistent_state_scalars == (
+        budget.persistent_float32_scalars
+        + budget.persistent_float64_scalars
+        + budget.persistent_int32_scalars
+        + budget.persistent_int64_scalars
+        + budget.persistent_uint32_scalars
+        + budget.persistent_bool_scalars
+    )
+    assert budget.persistent_state_bytes == (
+        4
+        * (
+            budget.persistent_float32_scalars
+            + budget.persistent_int32_scalars
+            + budget.persistent_uint32_scalars
+        )
+        + 8 * (budget.persistent_float64_scalars + budget.persistent_int64_scalars)
+        + budget.persistent_bool_scalars
+    )


### PR DESCRIPTION
Supersedes #814 while preserving Kayvan Zahiri's contribution with attribution and removing unrelated formatting churn.

The contributor's exact Python/NumPy integer-family and float32 scalar canonicalization is retained and completed. The replacement additionally validates exact nested config types, bounds `ensemble_size + 1` before `jax.random.split`, preflights member, residual-grid, aggregate persistent scalar, and mixed-dtype byte counts before allocation, and rejects host-valid values that underflow/round onto excluded float32 endpoints.

It also fixes a current-main resource-accounting regression exposed during review: multi-head member states now contain uint32 lifetime words, but `resource_budget()` still asserted that every persistent uint32 belonged to the two bootstrap keys. The accounting now separates member lifetime words from the two key streams while keeping the bootstrap-specific fields exact.

Compatibility is unchanged: the existing ensemble/config serialization envelopes and nested config decoders are preserved; this does not add broader exact-schema restrictions.

Validation:
- 49 of 51 ensemble + Prototype ensemble tests passed in the broad run; the only two failures were test-helper argument omissions, then fixed
- 21 config/resource tests passed after the fix and current-main rebase
- Ruff clean
- mypy clean on `world_model_ensemble.py`
- `git diff --check` clean

This is development-only L0 mechanism/resource hardening. It does not authorize compute, promote evidence, or alter a registered five-claim source inventory.

Co-authored-by: kzahiri1 <kzahiri@dons.usfca.edu>
