### PR TITLE
fix(independent-horde): complete config, state, and resource contracts

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -35,12 +35,14 @@ for Learning Knowledge from Unsupervised Sensorimotor Interaction"
 """
 
 import functools
+import operator
 import time
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -69,6 +71,33 @@ from alberta_framework.core.update_safety import (
 # =============================================================================
 # Types
 # =============================================================================
+
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @chex.dataclass(frozen=True)
@@ -238,6 +267,13 @@ class IndependentDemonHorde:
                 ``REPLACING``). Applies independently inside every
                 demon's network.
         """
+        if type(hidden_sizes) is not tuple:
+            raise ValueError(
+                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
+            )
+        hidden_sizes = tuple(
+            _require_int32(f"hidden_sizes[{i}]", v, minimum=1) for i, v in enumerate(hidden_sizes)
+        )
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
@@ -276,16 +312,10 @@ class IndependentDemonHorde:
             "horde_spec": self._horde_spec.to_config(),
             "hidden_sizes": list(self._hidden_sizes),
             "optimizer": self._optimizer.to_config(),
-            "bounder": (
-                self._bounder.to_config() if self._bounder is not None else None
-            ),
-            "normalizer": (
-                self._normalizer.to_config() if self._normalizer is not None else None
-            ),
+            "bounder": (self._bounder.to_config() if self._bounder is not None else None),
+            "normalizer": (self._normalizer.to_config() if self._normalizer is not None else None),
             "head_optimizer": (
-                self._head_optimizer.to_config()
-                if self._head_optimizer is not None
-                else None
+                self._head_optimizer.to_config() if self._head_optimizer is not None else None
             ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
@@ -315,25 +345,15 @@ class IndependentDemonHorde:
         horde_spec = HordeSpec.from_config(config.pop("horde_spec"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)
-        bounder = (
-            bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
-        )
+        bounder = bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
         normalizer_cfg = config.pop("normalizer", None)
-        normalizer = (
-            normalizer_from_config(normalizer_cfg)
-            if normalizer_cfg is not None
-            else None
-        )
+        normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        )
+        head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
-            TraceMode(trace_mode_str)
-            if trace_mode_str is not None
-            else TraceMode.ACCUMULATING
+            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
         )
 
         return cls(
@@ -351,14 +371,13 @@ class IndependentDemonHorde:
     # Init
     # -------------------------------------------------------------------------
 
-    def _init_single_demon(
-        self, feature_dim: int, key: Array
-    ) -> MLPLearnerState:
+    def _init_single_demon(self, feature_dim: int, key: Array) -> MLPLearnerState:
         """Initialize one demon's ``MLPLearnerState``.
 
         Equivalent to the body of ``MLPLearner.init`` so that the same
         sparse-init / shape conventions apply.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         layer_sizes = [feature_dim, *self._hidden_sizes, 1]
 
         weights_list: list[Array] = []
@@ -405,9 +424,7 @@ class IndependentDemonHorde:
             uptime_s=0.0,
         )
 
-    def init(
-        self, feature_dim: int, key: Array
-    ) -> IndependentDemonHordeState:
+    def init(self, feature_dim: int, key: Array) -> IndependentDemonHordeState:
         """Initialize an :class:`IndependentDemonHordeState`.
 
         Args:
@@ -419,9 +436,7 @@ class IndependentDemonHorde:
             Initial state with one ``MLPLearnerState`` per demon.
         """
         keys = jax.random.split(key, self.n_demons)
-        demon_states = tuple(
-            self._init_single_demon(feature_dim, k) for k in keys
-        )
+        demon_states = tuple(self._init_single_demon(feature_dim, k) for k in keys)
         return IndependentDemonHordeState(
             demon_states=demon_states,
             step_count=jnp.array(0, dtype=jnp.int32),
@@ -433,18 +448,11 @@ class IndependentDemonHorde:
     # Per-demon predict / update (pure functions)
     # -------------------------------------------------------------------------
 
-    def _predict_single(
-        self, demon_state: MLPLearnerState, observation: Array
-    ) -> Array:
+    def _predict_single(self, demon_state: MLPLearnerState, observation: Array) -> Array:
         """Predict value for a single demon given its state and observation."""
         obs = observation
-        if (
-            self._normalizer is not None
-            and demon_state.normalizer_state is not None
-        ):
-            obs = self._normalizer.normalize_only(
-                demon_state.normalizer_state, observation
-            )
+        if self._normalizer is not None and demon_state.normalizer_state is not None:
+            obs = self._normalizer.normalize_only(demon_state.normalizer_state, observation)
         return _forward_mlp(
             demon_state.params.weights,
             demon_state.params.biases,
@@ -480,10 +488,7 @@ class IndependentDemonHorde:
         obs = observation
         new_normalizer_state = demon_state.normalizer_state
         normalizer_update_applied = jnp.asarray(True, dtype=jnp.bool_)
-        if (
-            self._normalizer is not None
-            and demon_state.normalizer_state is not None
-        ):
+        if self._normalizer is not None and demon_state.normalizer_state is not None:
             normalizer_result = self._normalizer.normalize_with_diagnostics(
                 demon_state.normalizer_state, observation
             )
@@ -504,9 +509,7 @@ class IndependentDemonHorde:
         )
         error = jnp.where(active, target - prediction_val, 0.0)
 
-        def pred_fn(
-            weights: tuple[Array, ...], biases: tuple[Array, ...]
-        ) -> Array:
+        def pred_fn(weights: tuple[Array, ...], biases: tuple[Array, ...]) -> Array:
             return _forward_mlp(weights, biases, obs, slope, ln)
 
         weight_grads, bias_grads = jax.grad(pred_fn, argnums=(0, 1))(
@@ -561,22 +564,17 @@ class IndependentDemonHorde:
         new_opt_states: list[Any] = []
         optimizer_updates_applied: list[Array] = []
         for j in range(n_trace_entries):
-            is_output = (
-                self._head_optimizer is not None
-                and j >= n_trace_entries - 2
-            )
+            is_output = self._head_optimizer is not None and j >= n_trace_entries - 2
             opt: AnyOptimizer = (
                 self._head_optimizer
                 if (is_output and self._head_optimizer is not None)
                 else self._optimizer
             )
-            step, new_opt, optimizer_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    opt,
-                    demon_state.optimizer_states[j],
-                    new_traces[j],
-                    error=error,
-                )
+            step, new_opt, optimizer_update_applied = _update_from_gradient_with_diagnostics(
+                opt,
+                demon_state.optimizer_states[j],
+                new_traces[j],
+                error=error,
             )
             all_steps.append(step)
             new_opt_states.append(new_opt)
@@ -599,12 +597,8 @@ class IndependentDemonHorde:
         new_weights: list[Array] = []
         new_biases: list[Array] = []
         for i in range(n_layers):
-            new_weights.append(
-                demon_state.params.weights[i] + error * all_steps[2 * i]
-            )
-            new_biases.append(
-                demon_state.params.biases[i] + error * all_steps[2 * i + 1]
-            )
+            new_weights.append(demon_state.params.weights[i] + error * all_steps[2 * i])
+            new_biases.append(demon_state.params.biases[i] + error * all_steps[2 * i + 1])
 
         new_params = MLPParams(
             weights=tuple(new_weights),
@@ -639,22 +633,16 @@ class IndependentDemonHorde:
         new_params = MLPParams(
             weights=tuple(
                 jnp.where(commit, new_w, old_w)
-                for new_w, old_w in zip(
-                    new_params.weights, demon_state.params.weights, strict=True
-                )
+                for new_w, old_w in zip(new_params.weights, demon_state.params.weights, strict=True)
             ),
             biases=tuple(
                 jnp.where(commit, new_b, old_b)
-                for new_b, old_b in zip(
-                    new_params.biases, demon_state.params.biases, strict=True
-                )
+                for new_b, old_b in zip(new_params.biases, demon_state.params.biases, strict=True)
             ),
         )
         masked_traces = tuple(
             jnp.where(commit, new_t, old_t)
-            for new_t, old_t in zip(
-                new_traces, demon_state.traces, strict=True
-            )
+            for new_t, old_t in zip(new_traces, demon_state.traces, strict=True)
         )
         masked_opt_states = tuple(
             jax.tree.map(
@@ -662,9 +650,7 @@ class IndependentDemonHorde:
                 new_opt,
                 old_opt,
             )
-            for new_opt, old_opt in zip(
-                new_opt_states, demon_state.optimizer_states, strict=True
-            )
+            for new_opt, old_opt in zip(new_opt_states, demon_state.optimizer_states, strict=True)
         )
         if (
             self._normalizer is not None
@@ -714,9 +700,7 @@ class IndependentDemonHorde:
     # -------------------------------------------------------------------------
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: IndependentDemonHordeState, observation: Array
-    ) -> Array:
+    def predict(self, state: IndependentDemonHordeState, observation: Array) -> Array:
         """Compute predictions from all demons.
 
         Args:
@@ -727,8 +711,7 @@ class IndependentDemonHorde:
             Array of shape ``(n_demons,)`` with one prediction per demon.
         """
         preds = [
-            self._predict_single(state.demon_states[i], observation)
-            for i in range(self.n_demons)
+            self._predict_single(state.demon_states[i], observation) for i in range(self.n_demons)
         ]
         return jnp.stack(preds)
 
@@ -767,12 +750,7 @@ class IndependentDemonHorde:
 
         # 1. Per-demon V(s') for bootstrapping (each demon uses its OWN net)
         next_preds = jnp.stack(
-            [
-                self._predict_single(
-                    state.demon_states[i], next_observation
-                )
-                for i in range(n_demons)
-            ]
+            [self._predict_single(state.demon_states[i], next_observation) for i in range(n_demons)]
         )
 
         # 2. TD targets: r + gamma * V(s'). gamma=0 must not multiply inf V(s').
@@ -804,10 +782,7 @@ class IndependentDemonHorde:
             )
         )
         active_mask = (
-            requested_mask
-            & jnp.isfinite(cumulants)
-            & jnp.isfinite(targets)
-            & global_inputs_valid
+            requested_mask & jnp.isfinite(cumulants) & jnp.isfinite(targets) & global_inputs_valid
         )
         safe_targets = jnp.where(active_mask, targets, 0.0)
 
@@ -951,11 +926,14 @@ def run_independent_horde_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (
-        per_demon_metrics,
-        td_errors,
-        head_updates_applied,
-        updates_applied,
+    (
+        final_state,
+        (
+            per_demon_metrics,
+            td_errors,
+            head_updates_applied,
+            updates_applied,
+        ),
     ) = jax.lax.scan(step_fn, state, (observations, cumulants, next_observations))
     elapsed = time.time() - t0
     final_state = final_state.replace(  # type: ignore[attr-defined]

--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -37,6 +37,7 @@ for Learning Knowledge from Unsupervised Sensorimotor Interaction"
 import functools
 import operator
 import time
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -46,6 +47,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.horde import HordeUpdateResult
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.learners import (
@@ -75,19 +77,10 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -98,6 +91,78 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32(
+    name: str,
+    value: object,
+    *,
+    lower: float | None = None,
+    upper: float | None = None,
+) -> float:
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    return validated_float32_scalar(name, value, lower=lower, upper=upper)
+
+
+def _read_mapping(name: str, value: object) -> dict[str, Any]:
+    if not issubclass(type(value), Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], value))
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+
+
+def _decode_tuple(name: str, value: object) -> tuple[Any, ...]:
+    if type(value) not in {list, tuple}:
+        raise ValueError(f"{name} must be an exact list or tuple")
+    return tuple(cast(list[Any] | tuple[Any, ...], value))
+
+
+def _require_direct_state_resources(
+    n_demons: int, hidden_sizes: tuple[int, ...], feature_dim: int
+) -> None:
+    """Bound arrays directly owned by the independent networks before allocation."""
+    layer_sizes = (feature_dim, *hidden_sizes, 1)
+    per_demon_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    n_layers = len(layer_sizes) - 1
+    direct_state_scalars = n_demons * (2 * per_demon_parameters + 2 * n_layers + 1) + 1
+    for name, value in (
+        ("per_demon_parameter_count", per_demon_parameters),
+        ("direct_state_scalars", direct_state_scalars),
+        ("direct_state_bytes", 4 * direct_state_scalars),
+    ):
+        if not 1 <= value <= _INT32_MAX:
+            raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
+
+
+def _require_loop_output_resources(num_steps: int, n_demons: int, n_seeds: int = 1) -> None:
+    logical_scalars = n_seeds * num_steps * (5 * n_demons + 1)
+    output_bytes = n_seeds * num_steps * (17 * n_demons + 1)
+    if logical_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
+        raise ValueError("derived learning-loop outputs exceed the signed-int32 budget")
+
+
+def _require_learning_arrays(
+    observations: object,
+    cumulants: object,
+    next_observations: object,
+    n_demons: int,
+) -> tuple[Array, Array, Array, int, int]:
+    obs = jnp.asarray(observations, dtype=jnp.float32)
+    cums = jnp.asarray(cumulants, dtype=jnp.float32)
+    next_obs = jnp.asarray(next_observations, dtype=jnp.float32)
+    if obs.ndim != 2 or obs.shape[0] < 1 or obs.shape[1] < 1:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    if next_obs.shape != obs.shape:
+        raise ValueError("next_observations must match observations shape")
+    if cums.shape != (obs.shape[0], n_demons):
+        raise ValueError("cumulants must have shape (num_steps, n_demons)")
+    return obs, cums, next_obs, obs.shape[0], obs.shape[1]
 
 
 @chex.dataclass(frozen=True)
@@ -267,13 +332,21 @@ class IndependentDemonHorde:
                 ``REPLACING``). Applies independently inside every
                 demon's network.
         """
+        if type(horde_spec) is not HordeSpec or not horde_spec.demons:
+            raise ValueError("horde_spec must be a nonempty HordeSpec")
         if type(hidden_sizes) is not tuple:
-            raise ValueError(
-                f"hidden_sizes must be an actual tuple, got {type(hidden_sizes).__name__}"
-            )
+            raise ValueError("hidden_sizes must be an exact tuple")
         hidden_sizes = tuple(
             _require_int32(f"hidden_sizes[{i}]", v, minimum=1) for i, v in enumerate(hidden_sizes)
         )
+        sparsity = _require_float32("sparsity", sparsity, lower=0.0, upper=1.0)
+        leaky_relu_slope = _require_float32(
+            "leaky_relu_slope", leaky_relu_slope, lower=0.0
+        )
+        if type(use_layer_norm) is not bool:
+            raise ValueError("use_layer_norm must be an exact bool")
+        if type(trace_mode) is not TraceMode:
+            raise ValueError("trace_mode must be a TraceMode")
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
@@ -324,7 +397,7 @@ class IndependentDemonHorde:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "IndependentDemonHorde":
+    def from_config(cls, config: Mapping[str, Any]) -> "IndependentDemonHorde":
         """Reconstruct learner from a config dict.
 
         Args:
@@ -339,7 +412,7 @@ class IndependentDemonHorde:
             optimizer_from_config,
         )
 
-        config = dict(config)
+        config = _read_mapping("config", config)
         config.pop("type", None)
 
         horde_spec = HordeSpec.from_config(config.pop("horde_spec"))
@@ -352,13 +425,20 @@ class IndependentDemonHorde:
         head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
 
         trace_mode_str = config.pop("trace_mode", None)
-        trace_mode = (
-            TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
-        )
+        if trace_mode_str is not None and type(trace_mode_str) is not str:
+            raise ValueError("trace_mode must be an exact string")
+        try:
+            trace_mode = (
+                TraceMode(trace_mode_str)
+                if trace_mode_str is not None
+                else TraceMode.ACCUMULATING
+            )
+        except (TypeError, ValueError) as error:
+            raise ValueError("trace_mode must name a supported mode") from error
 
         return cls(
             horde_spec=horde_spec,
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=_decode_tuple("hidden_sizes", config.pop("hidden_sizes")),
             optimizer=optimizer,
             bounder=bounder,
             normalizer=normalizer,
@@ -377,7 +457,6 @@ class IndependentDemonHorde:
         Equivalent to the body of ``MLPLearner.init`` so that the same
         sparse-init / shape conventions apply.
         """
-        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         layer_sizes = [feature_dim, *self._hidden_sizes, 1]
 
         weights_list: list[Array] = []
@@ -435,6 +514,8 @@ class IndependentDemonHorde:
         Returns:
             Initial state with one ``MLPLearnerState`` per demon.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_direct_state_resources(self.n_demons, self._hidden_sizes, feature_dim)
         keys = jax.random.split(key, self.n_demons)
         demon_states = tuple(self._init_single_demon(feature_dim, k) for k in keys)
         return IndependentDemonHordeState(
@@ -443,6 +524,65 @@ class IndependentDemonHorde:
             birth_timestamp=time.time(),
             uptime_s=0.0,
         )
+
+    def _feature_dim_from_state(self, state: IndependentDemonHordeState) -> int:
+        """Validate the static learner-owned state contract and return its input width."""
+        if type(state) is not IndependentDemonHordeState:
+            raise ValueError("state must be an IndependentDemonHordeState")
+        if type(state.demon_states) is not tuple or len(state.demon_states) != self.n_demons:
+            raise ValueError("state.demon_states must match the configured demons")
+        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
+            raise ValueError("state.step_count must be a scalar int32")
+        feature_dim: int | None = None
+        for demon_state in state.demon_states:
+            if (
+                type(demon_state) is not MLPLearnerState
+                or type(demon_state.params) is not MLPParams
+            ):
+                raise ValueError("every demon state must be an MLPLearnerState")
+            weights = demon_state.params.weights
+            biases = demon_state.params.biases
+            expected_layers = len(self._hidden_sizes) + 1
+            if (
+                type(weights) is not tuple
+                or type(biases) is not tuple
+                or len(weights) != expected_layers
+                or len(biases) != expected_layers
+            ):
+                raise ValueError("demon parameter topology must match hidden_sizes")
+            current_feature_dim = weights[0].shape[1] if weights[0].ndim == 2 else -1
+            if feature_dim is None:
+                feature_dim = current_feature_dim
+            if current_feature_dim != feature_dim:
+                raise ValueError("all demon states must share one feature dimension")
+            layer_sizes = (current_feature_dim, *self._hidden_sizes, 1)
+            parameter_shapes: list[tuple[int, ...]] = []
+            for index, (fan_in, fan_out) in enumerate(
+                zip(layer_sizes, layer_sizes[1:], strict=False)
+            ):
+                if weights[index].shape != (fan_out, fan_in) or weights[index].dtype != jnp.float32:
+                    raise ValueError("demon weight shapes and dtypes must match the configuration")
+                if biases[index].shape != (fan_out,) or biases[index].dtype != jnp.float32:
+                    raise ValueError("demon bias shapes and dtypes must match the configuration")
+                parameter_shapes.extend(((fan_out, fan_in), (fan_out,)))
+            if type(demon_state.traces) is not tuple or tuple(
+                trace.shape for trace in demon_state.traces
+            ) != tuple(parameter_shapes):
+                raise ValueError("demon traces must match every parameter shape")
+            if any(trace.dtype != jnp.float32 for trace in demon_state.traces):
+                raise ValueError("demon traces must use float32")
+            if demon_state.step_count.shape != () or demon_state.step_count.dtype != jnp.int32:
+                raise ValueError("demon step_count must be a scalar int32")
+        if feature_dim is None or feature_dim < 1:
+            raise ValueError("state feature dimension must be positive")
+        return feature_dim
+
+    @staticmethod
+    def _operand(name: str, value: object, shape: tuple[int, ...]) -> Array:
+        array = jnp.asarray(value, dtype=jnp.float32)
+        if array.shape != shape:
+            raise ValueError(f"{name} must have shape {shape}")
+        return array
 
     # -------------------------------------------------------------------------
     # Per-demon predict / update (pure functions)
@@ -670,7 +810,11 @@ class IndependentDemonHorde:
             optimizer_states=masked_opt_states,
             traces=masked_traces,
             normalizer_state=masked_normalizer_state,
-            step_count=demon_state.step_count + jnp.where(commit, 1, 0),
+            step_count=jnp.where(
+                commit,
+                jnp.minimum(demon_state.step_count, _INT32_MAX - 1) + 1,
+                demon_state.step_count,
+            ),
             birth_timestamp=demon_state.birth_timestamp,
             uptime_s=demon_state.uptime_s,
         )
@@ -710,6 +854,8 @@ class IndependentDemonHorde:
         Returns:
             Array of shape ``(n_demons,)`` with one prediction per demon.
         """
+        feature_dim = self._feature_dim_from_state(state)
+        observation = self._operand("observation", observation, (feature_dim,))
         preds = [
             self._predict_single(state.demon_states[i], observation) for i in range(self.n_demons)
         ]
@@ -744,7 +890,13 @@ class IndependentDemonHorde:
             :class:`HordeLearner`) but with ``state`` set to the new
             ``IndependentDemonHordeState``.
         """
+        feature_dim = self._feature_dim_from_state(state)
         n_demons = self.n_demons
+        observation = self._operand("observation", observation, (feature_dim,))
+        cumulants = self._operand("cumulants", cumulants, (n_demons,))
+        next_observation = self._operand(
+            "next_observation", next_observation, (feature_dim,)
+        )
         gammas = self._horde_spec.gammas
         lamdas = self._horde_spec.lamdas
 
@@ -775,6 +927,10 @@ class IndependentDemonHorde:
         global_inputs_valid = (
             jnp.all(jnp.isfinite(observation))
             & jnp.all(jnp.isfinite(next_observation))
+            & (state.step_count >= 0)
+            & jnp.all(
+                jnp.stack([demon_state.step_count >= 0 for demon_state in state.demon_states])
+            )
             & _floating_tree_is_finite(
                 state.replace(  # type: ignore[attr-defined]
                     demon_states=checked_demon_states
@@ -829,7 +985,7 @@ class IndependentDemonHorde:
         )
         proposed_state = IndependentDemonHordeState(
             demon_states=tuple(new_demon_states),
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -911,6 +1067,13 @@ def run_independent_horde_learning_loop(
         per-demon metrics, and TD errors over time.
     """
 
+    observations, cumulants, next_observations, num_steps, feature_dim = (
+        _require_learning_arrays(observations, cumulants, next_observations, horde.n_demons)
+    )
+    if horde._feature_dim_from_state(state) != feature_dim:
+        raise ValueError("state feature dimension must match observations")
+    _require_loop_output_resources(num_steps, horde.n_demons)
+
     def step_fn(
         carry: IndependentDemonHordeState,
         inputs: tuple[Array, Array, Array],
@@ -971,7 +1134,18 @@ def run_independent_horde_learning_loop_batched(
         ``BatchedIndependentDemonHordeResult`` with batched states,
         per-demon metrics, and TD errors.
     """
-    feature_dim = observations.shape[1]
+    observations, cumulants, next_observations, num_steps, feature_dim = (
+        _require_learning_arrays(observations, cumulants, next_observations, horde.n_demons)
+    )
+    keys = jnp.asarray(keys)
+    if (
+        keys.ndim not in {1, 2}
+        or keys.shape[0] < 1
+        or (keys.ndim == 2 and keys.shape[1] != 2)
+    ):
+        raise ValueError("keys must contain at least one JAX key")
+    n_seeds = keys.shape[0]
+    _require_loop_output_resources(num_steps, horde.n_demons, n_seeds)
 
     def single_run(
         key: Array,

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -21,8 +21,10 @@ These tests verify that:
 """
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -140,13 +142,9 @@ class TestIndependence:
         # Demon 1's parameters and traces must be byte-identical to before.
         d1_old = state.demon_states[1]
         d1_new = result.state.demon_states[1]  # type: ignore[attr-defined]
-        for w_old, w_new in zip(
-            d1_old.params.weights, d1_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d1_old.params.weights, d1_new.params.weights, strict=True):
             chex.assert_trees_all_close(w_old, w_new)
-        for b_old, b_new in zip(
-            d1_old.params.biases, d1_new.params.biases, strict=True
-        ):
+        for b_old, b_new in zip(d1_old.params.biases, d1_new.params.biases, strict=True):
             chex.assert_trees_all_close(b_old, b_new)
         for t_old, t_new in zip(d1_old.traces, d1_new.traces, strict=True):
             chex.assert_trees_all_close(t_old, t_new)
@@ -156,9 +154,7 @@ class TestIndependence:
         d0_new = result.state.demon_states[0]  # type: ignore[attr-defined]
         # At least one weight matrix should be different.
         any_changed = False
-        for w_old, w_new in zip(
-            d0_old.params.weights, d0_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d0_old.params.weights, d0_new.params.weights, strict=True):
             if not jnp.allclose(w_old, w_new):
                 any_changed = True
                 break
@@ -185,23 +181,17 @@ class TestObgdApplyFinite:
         obs = jnp.ones(3, dtype=jnp.float32)
         next_obs = jnp.zeros(3, dtype=jnp.float32)
 
-        poisoned = horde.update(
-            state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), next_obs
-        )
+        poisoned = horde.update(state, obs, jnp.array([jnp.inf, 1.0], dtype=jnp.float32), next_obs)
         d0_old = state.demon_states[0]
         d0_new = poisoned.state.demon_states[0]  # type: ignore[attr-defined]
-        for w_old, w_new in zip(
-            d0_old.params.weights, d0_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d0_old.params.weights, d0_new.params.weights, strict=True):
             assert bool(jnp.all(jnp.isfinite(w_new)))
             chex.assert_trees_all_close(w_old, w_new)
 
         d1_old = state.demon_states[1]
         d1_new = poisoned.state.demon_states[1]  # type: ignore[attr-defined]
         any_changed = False
-        for w_old, w_new in zip(
-            d1_old.params.weights, d1_new.params.weights, strict=True
-        ):
+        for w_old, w_new in zip(d1_old.params.weights, d1_new.params.weights, strict=True):
             assert bool(jnp.all(jnp.isfinite(w_new)))
             if not jnp.allclose(w_old, w_new):
                 any_changed = True
@@ -240,9 +230,7 @@ class TestZeroGammaBootstrap:
         state = horde.init(2, jr.key(0))
         ds = state.demon_states[0]
         ds = ds.replace(
-            params=ds.params.replace(
-                weights=(jnp.asarray([[huge, 0.0]], dtype=jnp.float32),)
-            )
+            params=ds.params.replace(weights=(jnp.asarray([[huge, 0.0]], dtype=jnp.float32),))
         )
         state = state.replace(demon_states=(ds,))
         obs = jnp.asarray([0.0, 1.0], dtype=jnp.float32)
@@ -386,9 +374,7 @@ class TestMatchesHordeLearnerWithGammaZero:
 
         observations = jr.normal(k2, (num_steps, feature_dim))
         cumulants = jr.normal(k3, (num_steps, n_demons))
-        next_observations = jnp.concatenate(
-            [observations[1:], observations[:1]], axis=0
-        )
+        next_observations = jnp.concatenate([observations[1:], observations[:1]], axis=0)
 
         ind_result = run_independent_horde_learning_loop(
             independent, ind_state, observations, cumulants, next_observations
@@ -401,9 +387,7 @@ class TestMatchesHordeLearnerWithGammaZero:
 
         # Final mean squared error over the last 20 steps for each demon.
         ind_final_se = jnp.nanmean(ind_result.per_demon_metrics[-20:, :, 0])
-        shared_final_se = jnp.nanmean(
-            shared_result.per_demon_metrics[-20:, :, 0]
-        )
+        shared_final_se = jnp.nanmean(shared_result.per_demon_metrics[-20:, :, 0])
 
         # Sanity check: same order of magnitude. We accept up to a 3x gap
         # because the architectures genuinely differ; the test catches
@@ -461,9 +445,7 @@ class TestTemporalDemonsFinite:
 
         observations = jr.normal(k2, (50, 5))
         cumulants = jr.normal(k3, (50, 2))
-        next_observations = jnp.concatenate(
-            [observations[1:], observations[:1]], axis=0
-        )
+        next_observations = jnp.concatenate([observations[1:], observations[:1]], axis=0)
 
         result = run_independent_horde_learning_loop(
             horde, state, observations, cumulants, next_observations
@@ -594,9 +576,7 @@ class TestScanLoopCorrectShape:
         )
 
         assert isinstance(result, IndependentDemonHordeLearningResult)
-        chex.assert_shape(
-            result.per_demon_metrics, (num_steps, n_demons, 3)
-        )
+        chex.assert_shape(result.per_demon_metrics, (num_steps, n_demons, 3))
         chex.assert_shape(result.td_errors, (num_steps, n_demons))
 
     def test_batched_loop_correct_shape(self) -> None:
@@ -623,9 +603,32 @@ class TestScanLoopCorrectShape:
             horde, observations, cumulants, next_observations, keys
         )
         assert isinstance(result, BatchedIndependentDemonHordeResult)
-        chex.assert_shape(
-            result.per_demon_metrics, (n_seeds, num_steps, n_demons, 3)
-        )
-        chex.assert_shape(
-            result.td_errors, (n_seeds, num_steps, n_demons)
-        )
+        chex.assert_shape(result.per_demon_metrics, (n_seeds, num_steps, n_demons, 3))
+        chex.assert_shape(result.td_errors, (n_seeds, num_steps, n_demons))
+
+
+def test_independent_demon_horde_integer_validation() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=(True, 32))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde(horde_spec=spec, hidden_sizes=(32, 0))
+
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=(np.int32(16), np.int64(8)))
+    assert horde._hidden_sizes == (16, 8)
+    assert type(horde._hidden_sizes[0]) is int
+    assert type(horde._hidden_sizes[1]) is int
+
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=True, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=4.5, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=0, key=key)
+
+    state = horde.init(feature_dim=np.int32(4), key=key)
+    assert len(state.demon_states) == 1

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -20,6 +20,8 @@ These tests verify that:
 - The scan-based learning loop returns correctly shaped arrays.
 """
 
+from types import MappingProxyType
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -39,6 +41,8 @@ from alberta_framework.core.independent_demon_horde import (
     IndependentDemonHorde,
     IndependentDemonHordeLearningResult,
     IndependentDemonHordeState,
+    _require_direct_state_resources,
+    _require_loop_output_resources,
     run_independent_horde_learning_loop,
     run_independent_horde_learning_loop_batched,
 )
@@ -632,3 +636,125 @@ def test_independent_demon_horde_integer_validation() -> None:
 
     state = horde.init(feature_dim=np.int32(4), key=key)
     assert len(state.demon_states) == 1
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile hook executed")
+
+
+class _SequenceSpoof:
+    @property
+    def __class__(self) -> type[list[object]]:
+        return list
+
+    def __iter__(self) -> object:
+        raise RuntimeError("hostile iterator executed")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sparsity", True),
+        ("sparsity", _HostileFloat(0.5)),
+        ("sparsity", np.float64(1.0 + 1e-10)),
+        ("leaky_relu_slope", 1e100),
+        ("leaky_relu_slope", -1.0),
+        ("use_layer_norm", np.bool_(True)),
+    ],
+)
+def test_independent_horde_rejects_invalid_static_config(field: str, value: object) -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    with pytest.raises(ValueError, match=field):
+        IndependentDemonHorde(horde_spec=spec, **{field: value})  # type: ignore[arg-type]
+
+
+def test_independent_horde_config_accepts_mapping_and_exact_list_or_tuple() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(
+        horde_spec=spec,
+        hidden_sizes=(np.int32(4),),
+        sparsity=np.float64(0.5),
+        leaky_relu_slope=np.float32(0.125),
+    )
+    config = horde.to_config()
+    clone = IndependentDemonHorde.from_config(MappingProxyType(config))
+    assert clone.to_config() == config
+    assert type(clone._sparsity) is float
+    assert type(clone._leaky_relu_slope) is float
+    config["hidden_sizes"] = _SequenceSpoof()
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        IndependentDemonHorde.from_config(config)
+
+
+def test_independent_horde_preflights_direct_state_before_allocation() -> None:
+    _require_direct_state_resources(1, (), 268_435_452)
+    with pytest.raises(ValueError, match="direct_state_bytes"):
+        _require_direct_state_resources(1, (), 268_435_453)
+
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=())
+    with pytest.raises(ValueError, match="direct_state_bytes"):
+        horde.init(268_435_453, jr.key(0))
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 3), (3, 1), (4,)])
+def test_independent_horde_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=())
+    state = horde.init(3, jr.key(0))
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observation"):
+        horde.predict(state, malformed)
+    with pytest.raises(ValueError, match="observation"):
+        horde.update(state, malformed, jnp.zeros((1,)), jnp.zeros((3,)))
+
+
+def test_independent_horde_state_contract_and_counters_saturate() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=())
+    state = horde.init(3, jr.key(0))
+    demon = state.demon_states[0]
+    malformed = state.replace(
+        demon_states=(
+            demon.replace(
+                params=demon.params.replace(
+                    weights=(jnp.zeros((1, 2), dtype=jnp.float32),)
+                )
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="demon traces"):
+        horde.predict(malformed, jnp.zeros((3,), dtype=jnp.float32))
+
+    saturated_demon = demon.replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    saturated = state.replace(
+        demon_states=(saturated_demon,),
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32),
+    )
+    result = horde.update(
+        saturated,
+        jnp.zeros((3,), dtype=jnp.float32),
+        jnp.ones((1,), dtype=jnp.float32),
+        jnp.zeros((3,), dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
+    assert int(result.state.demon_states[0].step_count) == 2**31 - 1
+
+
+def test_independent_horde_loop_preflights_shapes_and_output_budget() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=())
+    state = horde.init(3, jr.key(0))
+    with pytest.raises(ValueError, match="observations"):
+        run_independent_horde_learning_loop(
+            horde,
+            state,
+            jnp.zeros((3,), dtype=jnp.float32),
+            jnp.zeros((1, 1), dtype=jnp.float32),
+            jnp.zeros((1, 3), dtype=jnp.float32),
+        )
+    _require_loop_output_resources(119_304_647, 1)
+    with pytest.raises(ValueError, match="learning-loop outputs"):
+        _require_loop_output_resources(119_304_648, 1)


### PR DESCRIPTION
Supersedes #839 while preserving its contributor commit and integer validation.

Completes the boundary with full concrete Python/NumPy integer families, float32 sink validation for static scalars, exact tuple/direct and list-or-tuple serialized compatibility, Mapping support, nonempty Horde/type checks, allocation-free parameter/state/output resource preflights, public state/operand/learning-loop shape contracts, stable deserialization errors, and saturating nonnegative lifetime counters.

Validation after latest-main rebase:
- 29 independent-Horde tests passed
- prior broad independent/Horde/mixed run: 74/75 passed; its sole assertion-message mismatch was corrected, then the exact focused suite passed
- Ruff clean
- strict targeted mypy clean
- diff-check clean

No outputs or registered evidence sources are changed.