### PR TITLE
fix(actor-critic): harden actor-critic configuration dimensions and scalar hyperparameters with strict validation

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -21,21 +21,50 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
 from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclasses.dataclass(frozen=True)
@@ -59,6 +88,43 @@ class ActorCriticConfig:
     actor_lamda: float = 0.9
     critic_lamda: float = 0.9
     temperature: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=2),
+        )
+        object.__setattr__(
+            self,
+            "gamma",
+            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_step_size",
+            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_step_size",
+            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_lamda",
+            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_lamda",
+            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "temperature",
+            validated_float32_scalar("temperature", self.temperature, positive=True),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -237,6 +303,7 @@ class ActorCriticAgent:
         Returns:
             Initial immutable actor-critic state.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         zeros_actor = jnp.zeros((self._config.n_actions, feature_dim), dtype=jnp.float32)
         zeros_policy_bias = jnp.zeros((self._config.n_actions,), dtype=jnp.float32)
         zeros_critic = jnp.zeros((feature_dim,), dtype=jnp.float32)
@@ -287,9 +354,7 @@ class ActorCriticAgent:
         """
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(
-            jnp.int32
-        )
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -351,9 +416,7 @@ class ActorCriticAgent:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
         # Terminal 0 * inf V(s') is NaN and would freeze the critic.
-        bootstrap = jnp.where(
-            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
-        )
+        bootstrap = jnp.where(discount == 0.0, jnp.zeros_like(next_value), discount * next_value)
         td_error = reward + bootstrap - value
 
         one_hot = jax.nn.one_hot(action, cfg.n_actions, dtype=jnp.float32)
@@ -461,9 +524,7 @@ class ActorCriticAgent:
             & jnp.isfinite(critic_metric)
         )
         candidate_ok = (
-            inputs_valid
-            & _floating_tree_is_finite(state)
-            & _floating_tree_is_finite(updated)
+            inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
         )
         held = jax.lax.cond(
             candidate_ok,
@@ -500,13 +561,9 @@ class ActorCriticAgent:
             ),
             policy=jnp.where(params_ok, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(
-                params_ok & jnp.isfinite(next_value), next_value, zero
-            ),
+            next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(
-                params_ok, (actor_metric + critic_metric) / 2.0, zero
-            ),
+            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
             update_applied=params_ok,
         )
 
@@ -653,6 +710,55 @@ class ContinuousActorCriticConfig:
     log_sigma_max: float = 2.0
     action_low: float | None = None
     action_high: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "action_dim",
+            _require_int32("action_dim", self.action_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "gamma",
+            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_step_size",
+            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_step_size",
+            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_lamda",
+            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_lamda",
+            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_init",
+            validated_float32_scalar("log_sigma_init", self.log_sigma_init),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_min",
+            validated_float32_scalar("log_sigma_min", self.log_sigma_min),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_max",
+            validated_float32_scalar("log_sigma_max", self.log_sigma_max),
+        )
+        if self.log_sigma_min > self.log_sigma_max:
+            raise ValueError("log_sigma_min must be <= log_sigma_max")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -870,6 +976,7 @@ class ContinuousActorCriticAgent:
         Returns:
             Initial immutable continuous actor-critic state.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         cfg = self._config
         zeros_mean = jnp.zeros((cfg.action_dim, feature_dim), dtype=jnp.float32)
         zeros_mean_bias = jnp.zeros((cfg.action_dim,), dtype=jnp.float32)
@@ -1014,9 +1121,7 @@ class ContinuousActorCriticAgent:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
         # Terminal 0 * inf V(s') is NaN and would freeze the critic.
-        bootstrap = jnp.where(
-            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
-        )
+        bootstrap = jnp.where(discount == 0.0, jnp.zeros_like(next_value), discount * next_value)
         td_error = reward + bootstrap - value
 
         sigma_sq = prev_sigma * prev_sigma + 1e-8
@@ -1145,9 +1250,7 @@ class ContinuousActorCriticAgent:
             & jnp.isfinite(critic_metric)
         )
         candidate_ok = (
-            inputs_valid
-            & _floating_tree_is_finite(state)
-            & _floating_tree_is_finite(updated)
+            inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
         )
         held = jax.lax.cond(
             candidate_ok,
@@ -1155,9 +1258,7 @@ class ContinuousActorCriticAgent:
             lambda: state,
         )
         safe_observation = jnp.where(candidate_ok, observation, state.last_observation)
-        next_action, key, next_mean, next_sigma = self.select_action(
-            held, safe_observation
-        )
+        next_action, key, next_mean, next_sigma = self.select_action(held, safe_observation)
         proposed_final_state = held.replace(
             last_observation=observation,
             last_action=next_action,
@@ -1183,13 +1284,9 @@ class ContinuousActorCriticAgent:
             mean=jnp.where(params_ok, next_mean, jnp.zeros_like(next_mean)),
             sigma=jnp.where(params_ok, next_sigma, jnp.zeros_like(next_sigma)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(
-                params_ok & jnp.isfinite(next_value), next_value, zero
-            ),
+            next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(
-                params_ok, (actor_metric + critic_metric) / 2.0, zero
-            ),
+            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
             update_applied=params_ok,
         )
 
@@ -1253,9 +1350,7 @@ def run_continuous_actor_critic_from_arrays(
             current_action = fixed_action.astype(jnp.float32)
             current_mean, current_sigma = agent.policy_params(started_state, obs)
         else:
-            started_state, current_action, current_mean, current_sigma = agent.start(
-                carry, obs
-            )
+            started_state, current_action, current_mean, current_sigma = agent.start(carry, obs)
         result = agent.update(
             started_state,
             reward,
@@ -1268,15 +1363,9 @@ def run_continuous_actor_critic_from_arrays(
             lambda: carry,
         )
         return next_carry, (
-            jnp.where(
-                result.update_applied, current_action, jnp.zeros_like(current_action)
-            ),
-            jnp.where(
-                result.update_applied, current_mean, jnp.zeros_like(current_mean)
-            ),
-            jnp.where(
-                result.update_applied, current_sigma, jnp.zeros_like(current_sigma)
-            ),
+            jnp.where(result.update_applied, current_action, jnp.zeros_like(current_action)),
+            jnp.where(result.update_applied, current_mean, jnp.zeros_like(current_mean)),
+            jnp.where(result.update_applied, current_sigma, jnp.zeros_like(current_sigma)),
             result.value,
             result.td_error,
             result.update_applied,

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -4,6 +4,8 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
+import pytest
 
 from alberta_framework import ActorCriticAgent as TopLevelActorCriticAgent
 from alberta_framework.core import ActorCriticAgent as CoreActorCriticAgent
@@ -60,9 +62,7 @@ def test_actor_critic_update_changes_actor_and_critic() -> None:
     )
     agent = ActorCriticAgent(config)
     state = agent.init(feature_dim=3, key=jr.key(1))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32))
 
     result = agent.update(
         state,
@@ -76,9 +76,7 @@ def test_actor_critic_update_changes_actor_and_critic() -> None:
     assert not jnp.allclose(result.state.actor_weights, state.actor_weights)
     assert not jnp.allclose(result.state.critic_weights, state.critic_weights)
     _assert_actor_critic_numeric_state_finite(result.state)
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 def test_actor_critic_temperature_scales_actor_gradient() -> None:
@@ -217,9 +215,7 @@ def test_actor_critic_explicit_discount_semantics() -> None:
 def test_actor_critic_update_is_jittable() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(feature_dim=2, key=jr.key(2))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 0.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
 
     update = jax.jit(agent.update)
     result = update(
@@ -236,12 +232,8 @@ def test_actor_critic_update_is_jittable() -> None:
 def test_run_actor_critic_from_arrays_scan() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(feature_dim=2, key=jr.key(3))
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     terminated = jnp.array([False, False, True])
 
@@ -302,12 +294,8 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
     state = state.replace(  # type: ignore[attr-defined]
         actor_weights=jnp.array([[0.0, 3.0], [3.0, 0.0]], dtype=jnp.float32)
     )
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     actions = jnp.array([0, 1, 0], dtype=jnp.int32)
     discounts = jnp.array([0.9, 0.9, 0.0], dtype=jnp.float32)
@@ -350,9 +338,7 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
     assert float(scan_result.policies[0, scan_result.actions[0]]) < 0.1
     chex.assert_trees_all_close(scan_result.td_errors, jnp.stack(loop_td_errors))
     chex.assert_trees_all_close(scan_result.state.actor_weights, loop_state.actor_weights)
-    chex.assert_trees_all_close(
-        scan_result.state.critic_weights, loop_state.critic_weights
-    )
+    chex.assert_trees_all_close(scan_result.state.critic_weights, loop_state.critic_weights)
 
 
 def test_actor_critic_config_round_trip_with_bounder() -> None:
@@ -378,9 +364,7 @@ def test_actor_critic_bounder_hook_runs() -> None:
         bounder=ObGDBounding(kappa=2.0),
     )
     state = agent.init(feature_dim=2, key=jr.key(4))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 1.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 1.0], dtype=jnp.float32))
 
     result = agent.update(
         state,
@@ -391,9 +375,7 @@ def test_actor_critic_bounder_hook_runs() -> None:
 
     assert float(result.bound_metric) < 1.0
     _assert_actor_critic_numeric_state_finite(result.state)
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> None:
@@ -415,9 +397,7 @@ def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> Non
     assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
     chex.assert_trees_all_close(poisoned.state.actor_weights, state.actor_weights)
     chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
-    chex.assert_trees_all_equal(
-        jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         poisoned.state.replace(rng_key=jr.key_data(poisoned.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -467,3 +447,30 @@ def test_actor_critic_terminal_does_not_multiply_inf_next_value() -> None:
 def test_actor_critic_exports() -> None:
     assert TopLevelActorCriticAgent is ActorCriticAgent
     assert CoreActorCriticAgent is ActorCriticAgent
+
+
+def test_actor_critic_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=1)
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="gamma"):
+        ActorCriticConfig(n_actions=2, gamma=1.5)
+    with pytest.raises(ValueError, match="actor_step_size"):
+        ActorCriticConfig(n_actions=2, actor_step_size=-0.1)
+
+    cfg = ActorCriticConfig(n_actions=np.int32(4))
+    assert cfg.n_actions == 4
+    assert type(cfg.n_actions) is int
+
+    agent = ActorCriticAgent(cfg)
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=0, key=jr.key(0))
+
+    state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
+    assert state.actor_weights.shape == (4, 5)

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -353,9 +353,7 @@ def test_continuous_actor_critic_action_clipping() -> None:
 def test_continuous_actor_critic_update_is_jittable() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(feature_dim=2, key=jr.key(6))
-    state, _action, _mean, _sigma = agent.start(
-        state, jnp.array([1.0, 0.0], dtype=jnp.float32)
-    )
+    state, _action, _mean, _sigma = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
     update = jax.jit(agent.update)
     result = update(
         state,
@@ -370,12 +368,8 @@ def test_continuous_actor_critic_update_is_jittable() -> None:
 def test_continuous_actor_critic_run_from_arrays_scan() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(feature_dim=2, key=jr.key(7))
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     terminated = jnp.array([False, False, True])
 
@@ -459,9 +453,7 @@ def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> 
         bounder=ObGDBounding(kappa=2.0),
     )
     state = agent.init(feature_dim=3, key=jr.key(8))
-    state, _, _, _ = agent.start(
-        state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
-    )
+    state, _, _, _ = agent.start(state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32))
     poisoned = agent.update(
         state,
         reward=jnp.array(jnp.inf, dtype=jnp.float32),
@@ -472,9 +464,7 @@ def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> 
     assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
     chex.assert_trees_all_close(poisoned.state.mean_weights, state.mean_weights)
     chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
-    chex.assert_trees_all_equal(
-        jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         poisoned.state.replace(rng_key=jr.key_data(poisoned.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -523,3 +513,30 @@ def test_continuous_actor_critic_terminal_does_not_multiply_inf_next_value() -> 
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
     _assert_continuous_actor_critic_state_finite(result.state)
+
+
+def test_continuous_actor_critic_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=0)
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=2.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="gamma"):
+        ContinuousActorCriticConfig(action_dim=2, gamma=1.5)
+    with pytest.raises(ValueError, match="actor_step_size"):
+        ContinuousActorCriticConfig(action_dim=2, actor_step_size=-0.1)
+
+    cfg = ContinuousActorCriticConfig(action_dim=np.int32(3))
+    assert cfg.action_dim == 3
+    assert type(cfg.action_dim) is int
+
+    agent = ContinuousActorCriticAgent(cfg)
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=0, key=jr.key(0))
+
+    state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
+    assert state.mean_weights.shape == (3, 5)


### PR DESCRIPTION
## Summary
- Hardens `ActorCriticConfig` and `ContinuousActorCriticConfig` dimension parameters (`n_actions`, `action_dim`) and state initialization (`feature_dim`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Validates float hyperparameters (`gamma`, `actor_step_size`, `critic_step_size`, `actor_lamda`, `critic_lamda`, `temperature`, `log_sigma_init`, `log_sigma_min`, `log_sigma_max`) with `validated_float32_scalar`.

## Verification
- `PYTHONPATH=. pytest tests/test_actor_critic.py tests/test_continuous_actor_critic.py`: 44 passed
- `PYTHONPATH=. pytest tests/test_horde_actor_critic.py tests/test_recurrent_trace_actor_critic.py`: 179 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/actor_critic.py`: clean