### PR TITLE
fix(swift-td): complete initialization and state contracts

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -51,6 +51,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
@@ -66,6 +67,7 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 
 # Paper default for the step-size floor: eta_min = e^-15.
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -90,6 +92,13 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    if float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 _DEFAULT_ETA_MIN = math.exp(-15.0)
@@ -128,17 +137,27 @@ def _require_finite_config_float(
     if not any(actual_type is supported_type for supported_type in _SUPPORTED_CONFIG_REAL_TYPES):
         raise ValueError(message)
     try:
-        concrete = float(cast(Any, value))
-    except (OverflowError, TypeError, ValueError) as error:
+        concrete = validated_float32_scalar(
+            name,
+            value,
+            positive=not minimum_inclusive and minimum == 0.0,
+            lower=minimum if minimum_inclusive else None,
+            upper=maximum,
+        )
+    except Exception as error:
         raise ValueError(message) from error
-    minimum_valid = concrete >= minimum if minimum_inclusive else concrete > minimum
-    if (
-        not math.isfinite(concrete)
-        or not minimum_valid
-        or (maximum is not None and concrete > maximum)
-    ):
-        raise ValueError(message)
     return concrete
+
+
+def _require_positive_normal_config_float(
+    value: object, name: str, *, maximum: float | None = None
+) -> float:
+    if type(value) not in _SUPPORTED_CONFIG_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real scalar in its documented range")
+    try:
+        return validated_float32_scalar(name, value, lower=_FLOAT32_MIN_NORMAL, upper=maximum)
+    except Exception as error:
+        raise ValueError(f"{name} must be a finite real scalar in its documented range") from error
 
 
 @chex.dataclass(frozen=True)
@@ -248,11 +267,8 @@ class SwiftTD:
         Raises:
             ValueError: If a hyperparameter is outside its valid range
         """
-        self._initial_step_size = _require_finite_config_float(
-            initial_step_size,
-            "initial_step_size",
-            minimum=0.0,
-            minimum_inclusive=False,
+        self._initial_step_size = _require_positive_normal_config_float(
+            initial_step_size, "initial_step_size"
         )
         self._meta_step_size = _require_finite_config_float(
             meta_step_size,
@@ -267,25 +283,13 @@ class SwiftTD:
             minimum_inclusive=True,
             maximum=1.0,
         )
-        self._eta = _require_finite_config_float(
-            eta,
-            "eta",
-            minimum=0.0,
-            minimum_inclusive=False,
+        self._eta = _require_positive_normal_config_float(eta, "eta")
+        self._step_size_decay = _require_positive_normal_config_float(
+            step_size_decay, "step_size_decay", maximum=1.0
         )
-        self._step_size_decay = _require_finite_config_float(
-            step_size_decay,
-            "step_size_decay",
-            minimum=0.0,
-            minimum_inclusive=False,
-            maximum=1.0,
-        )
-        self._eta_min = _require_finite_config_float(
-            eta_min,
-            "eta_min",
-            minimum=0.0,
-            minimum_inclusive=False,
-        )
+        self._eta_min = _require_positive_normal_config_float(eta_min, "eta_min")
+        if self._eta_min > self._eta:
+            raise ValueError("eta_min must be <= eta")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -309,8 +313,12 @@ class SwiftTD:
         Returns:
             SwiftTD state with per-feature log step-sizes and zeroed traces
         """
-        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX - 1)
         aug_dim = feature_dim + 1
+        _require_float32_resource(
+            "SwiftTD state",
+            float32_scalars=8 * aug_dim + 5,
+        )
         # The dense reference implementation clips beta into
         # [ln(eta_min), ln(eta)] on every pass, including the (otherwise
         # trivial) very first one -- so step-sizes are capped BEFORE the
@@ -334,6 +342,66 @@ class SwiftTD:
             eta=jnp.array(self._eta, dtype=jnp.float32),
             eta_min=jnp.array(self._eta_min, dtype=jnp.float32),
             step_size_decay=jnp.array(self._step_size_decay, dtype=jnp.float32),
+        )
+
+    @staticmethod
+    def _validate_state_static_contract(state: SwiftTDState) -> int:
+        """Return feature_dim after rejecting malformed adopted state metadata."""
+        if type(state) is not SwiftTDState:
+            raise TypeError("state must be a SwiftTDState")
+        vectors = (
+            ("state.log_step_sizes", state.log_step_sizes),
+            ("state.eligibility_traces", state.eligibility_traces),
+            ("state.z_bar_traces", state.z_bar_traces),
+            ("state.p_traces", state.p_traces),
+            ("state.h_traces", state.h_traces),
+            ("state.h_old_traces", state.h_old_traces),
+            ("state.h_temp_traces", state.h_temp_traces),
+            ("state.prev_weight_update", state.prev_weight_update),
+        )
+        try:
+            augmented_dim = int(state.log_step_sizes.shape[0])
+        except Exception as error:
+            raise TypeError("state.log_step_sizes must expose array metadata") from error
+        if augmented_dim < 2:
+            raise ValueError("state vector length must include a positive feature dimension")
+        _require_float32_resource("SwiftTD adopted state", float32_scalars=8 * augmented_dim + 5)
+        for name, value in vectors:
+            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+                raise TypeError(f"{name} must expose array shape and dtype metadata")
+            if tuple(value.shape) != (augmented_dim,):
+                raise ValueError(f"{name} must have shape ({augmented_dim},)")
+            if jnp.dtype(value.dtype) != jnp.dtype(jnp.float32):
+                raise TypeError(f"{name} must have dtype float32")
+        for name, value in (
+            ("state.meta_step_size", state.meta_step_size),
+            ("state.trace_decay", state.trace_decay),
+            ("state.eta", state.eta),
+            ("state.eta_min", state.eta_min),
+            ("state.step_size_decay", state.step_size_decay),
+        ):
+            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+                raise TypeError(f"{name} must expose array shape and dtype metadata")
+            if tuple(value.shape) != ():
+                raise ValueError(f"{name} must have scalar shape")
+            if jnp.dtype(value.dtype) != jnp.dtype(jnp.float32):
+                raise TypeError(f"{name} must have dtype float32")
+        return augmented_dim - 1
+
+    @staticmethod
+    def _state_is_valid(state: SwiftTDState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & (state.meta_step_size >= 0.0)
+            & (state.trace_decay >= 0.0)
+            & (state.trace_decay <= 1.0)
+            & (state.eta > 0.0)
+            & (state.eta_min > 0.0)
+            & (state.eta_min <= state.eta)
+            & (state.step_size_decay > 0.0)
+            & (state.step_size_decay <= 1.0)
+            & jnp.all(state.log_step_sizes >= jnp.log(state.eta_min))
+            & jnp.all(state.log_step_sizes <= jnp.log(state.eta))
         )
 
     def update(
@@ -369,6 +437,19 @@ class SwiftTD:
         Returns:
             SwiftTDUpdate with weight deltas and updated state
         """
+        feature_dim = self._validate_state_static_contract(state)
+        for name, value, shape in (
+            ("td_error", td_error, ()),
+            ("observation", observation, (feature_dim,)),
+            ("next_observation", next_observation, (feature_dim,)),
+            ("gamma", gamma, ()),
+        ):
+            if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+                raise TypeError(f"{name} must expose array shape and dtype metadata")
+            if tuple(value.shape) != shape:
+                raise ValueError(f"{name} must have shape {shape}")
+            if jnp.dtype(value.dtype) != jnp.dtype(jnp.float32):
+                raise TypeError(f"{name} must have dtype float32")
         # V(s') is already folded into td_error, but the public transition is
         # accepted only when every supplied component is finite.
         next_observation_finite = jnp.all(jnp.isfinite(next_observation))
@@ -391,7 +472,9 @@ class SwiftTD:
         trace_dot = jnp.dot(state.eligibility_traces, phi)
         z_ext = state.eligibility_traces + z_delta * (1.0 - trace_dot)
         p_ext = state.p_traces + state.h_old_traces * phi
-        z_bar_ext = state.z_bar_traces + z_delta * (1.0 - trace_dot - state.z_bar_traces * phi)
+        z_bar_ext = state.z_bar_traces + z_delta * (
+            1.0 - trace_dot - state.z_bar_traces * phi
+        )
         h_temp_ext = (
             state.h_traces
             - state.h_old_traces * phi * (z_ext - z_delta)
@@ -479,7 +562,7 @@ class SwiftTD:
             & jnp.isfinite(gamma_scalar)
         )
         update_applied = (
-            floating_tree_is_finite(state)
+            self._state_is_valid(state)
             & inputs_valid
             & jnp.all(jnp.isfinite(meta_delta))
             & jnp.all(jnp.isfinite(delta_w))

--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -42,7 +42,8 @@ A Fast and Robust Algorithm for Temporal Difference Learning." RLJ/RLC 2024.
 """
 
 import math
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -62,7 +63,35 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 
+
 # Paper default for the step-size floor: eta_min = e^-15.
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 _DEFAULT_ETA_MIN = math.exp(-15.0)
 
 _SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
@@ -280,6 +309,7 @@ class SwiftTD:
         Returns:
             SwiftTD state with per-feature log step-sizes and zeroed traces
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         aug_dim = feature_dim + 1
         # The dense reference implementation clips beta into
         # [ln(eta_min), ln(eta)] on every pass, including the (otherwise
@@ -361,9 +391,7 @@ class SwiftTD:
         trace_dot = jnp.dot(state.eligibility_traces, phi)
         z_ext = state.eligibility_traces + z_delta * (1.0 - trace_dot)
         p_ext = state.p_traces + state.h_old_traces * phi
-        z_bar_ext = state.z_bar_traces + z_delta * (
-            1.0 - trace_dot - state.z_bar_traces * phi
-        )
+        z_bar_ext = state.z_bar_traces + z_delta * (1.0 - trace_dot - state.z_bar_traces * phi)
         h_temp_ext = (
             state.h_traces
             - state.h_old_traces * phi * (z_ext - z_delta)

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -30,6 +30,7 @@ from alberta_framework.core import (
     optimizer_from_config,
 )
 from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.swift_td import _require_float32_resource
 from alberta_framework.streams.alberta_plan_step1 import XDistShiftStream
 
 # =============================================================================
@@ -69,14 +70,19 @@ class _RefSwiftTDNonSparse:
             self.delta_w[i] = delta * self.z[i] - self.z_delta[i] * self.v_delta
             self.w[i] += self.delta_w[i]
             self.beta[i] += (
-                self.meta_step_size / np.exp(self.beta[i]) * (delta - self.v_delta) * self.p[i]
+                self.meta_step_size
+                / np.exp(self.beta[i])
+                * (delta - self.v_delta)
+                * self.p[i]
             )
             if np.exp(self.beta[i]) > self.eta:
                 self.beta[i] = np.log(self.eta)
             if np.exp(self.beta[i]) < self.eta_min:
                 self.beta[i] = np.log(self.eta_min)
             self.h_old[i] = self.h[i]
-            self.h[i] = self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
+            self.h[i] = (
+                self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
+            )
             self.h_temp[i] = self.h[i]
             self.z_delta[i] = 0.0
             self.z[i] *= self.gamma * self.lam
@@ -129,7 +135,9 @@ class TestSwiftTDInit:
 
     def test_init_creates_correct_state(self):
         """Arrays get feature_dim + 1 entries (bias last), traces start at zero."""
-        optimizer = SwiftTD(initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1)
+        optimizer = SwiftTD(
+            initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1
+        )
         state = optimizer.init(feature_dim=10)
 
         chex.assert_shape(state.log_step_sizes, (11,))
@@ -265,7 +273,9 @@ class TestSwiftTDMatchesReference:
         for t in range(1, steps):
             obs = jnp.asarray(xs[t - 1], dtype=jnp.float32)
             nxt = jnp.asarray(xs[t], dtype=jnp.float32)
-            td_error = rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
+            td_error = (
+                rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
+            )
             upd = optimizer.update(state, td_error, obs, nxt, jnp.array(gamma))
             w = w + upd.weight_delta
             b = b + upd.bias_delta
@@ -369,7 +379,9 @@ class TestSwiftTDBehavior:
         )
         assert float(upd.metrics["decay_triggered"]) == 1.0
         expected = float(jnp.log(0.05) + jnp.log(0.99))  # phi_i^2 = 1 for all entries
-        chex.assert_trees_all_close(upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6)
+        chex.assert_trees_all_close(
+            upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6
+        )
 
         # tau = 0.02 * 3 = 0.06 < eta = 0.1 -> no decay, step-sizes unchanged.
         optimizer = SwiftTD(
@@ -392,7 +404,9 @@ class TestSwiftTDBehavior:
         obs = jnp.ones(3, dtype=jnp.float32)
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.0))
-        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7)
+        chex.assert_trees_all_close(
+            result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7
+        )
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.9))
         assert float(jnp.max(jnp.abs(result.new_state.eligibility_traces))) > 0.0
@@ -411,7 +425,9 @@ class TestSwiftTDBehavior:
         )
         assert bool(result.update_applied)
         assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
-        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7)
+        chex.assert_trees_all_close(
+            result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7
+        )
 
     def test_zero_gamma_does_not_disguise_consumed_inf_trace_state(self) -> None:
         optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.0)
@@ -504,7 +520,9 @@ def _run_swift_seed(initial_step_size, key):
         (w, b, opt_state), s_state = carry
         ts, s_new = stream.step(s_state, idx)
         td_error = jnp.squeeze(ts.target) - (jnp.dot(w, ts.observation) + b)
-        upd = optimizer.update(opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0))
+        upd = optimizer.update(
+            opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0)
+        )
         new_carry = ((w + upd.weight_delta, b + upd.bias_delta, upd.new_state), s_new)
         return new_carry, td_error**2
 
@@ -543,7 +561,8 @@ class TestSwiftTDLearningQuality:
         swift_mean = float(jnp.mean(finals))
         best_fixed = _best_fixed_lms_mean()
         assert swift_mean < best_fixed, (
-            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed step-size {best_fixed:.4f}"
+            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed "
+            f"step-size {best_fixed:.4f}"
         )
         # Sanity: close to the stream's noise floor (0.1^2), far from divergence.
         assert swift_mean < 0.05
@@ -572,3 +591,136 @@ def test_swift_td_integer_validation() -> None:
 
     state = swift.init(feature_dim=np.int32(4))
     assert state.log_step_sizes.shape == (5,)
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    ],
+)
+def test_swift_td_accepts_full_numpy_integer_family(integer_type: type) -> None:
+    assert SwiftTD().init(integer_type(2)).log_step_sizes.shape == (3,)
+
+
+def test_swift_td_rejects_hostile_integer_subclasses_without_hooks() -> None:
+    class HostileInt(int):
+        def __index__(self) -> int:  # pragma: no cover
+            raise AssertionError("conversion hook executed")
+
+        def __repr__(self) -> str:  # pragma: no cover
+            raise AssertionError("repr hook executed")
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        SwiftTD().init(HostileInt(2))
+
+
+def test_swift_td_state_resource_endpoint_and_adjacent_are_allocation_free() -> None:
+    scalar_budget = (2**31 - 1) // 4
+    _require_float32_resource("endpoint", float32_scalars=scalar_budget)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource("endpoint", float32_scalars=scalar_budget + 1)
+
+    last_feature_dim = ((scalar_budget - 5) // 8) - 1
+    with pytest.raises(ValueError, match="SwiftTD state byte count"):
+        SwiftTD().init(last_feature_dim + 1)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("initial_step_size", 1e100),
+        ("initial_step_size", 1e-100),
+        ("eta", 1e100),
+        ("eta_min", 1e-100),
+        ("step_size_decay", 1e-100),
+    ],
+)
+def test_swift_td_rejects_float32_overflow_and_underflow(
+    field: str, value: float
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        SwiftTD(**{field: value})
+
+
+def test_swift_td_rejects_inverted_eta_interval() -> None:
+    with pytest.raises(ValueError, match="eta_min must be <= eta"):
+        SwiftTD(eta=0.01, eta_min=0.02)
+
+
+def test_swift_td_validates_adopted_state_static_contract() -> None:
+    optimizer = SwiftTD(initial_step_size=0.01)
+    state = optimizer.init(3)
+    obs = jnp.ones((3,), dtype=jnp.float32)
+    scalar = jnp.asarray(0.5, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="eligibility_traces must have shape"):
+        optimizer.update(
+            state.replace(eligibility_traces=jnp.zeros((3,), dtype=jnp.float32)),
+            scalar,
+            obs,
+            obs,
+            scalar,
+        )
+    with pytest.raises(TypeError, match="log_step_sizes must have dtype float32"):
+        optimizer.update(
+            state.replace(log_step_sizes=jnp.zeros((4,), dtype=jnp.int32)),
+            scalar,
+            obs,
+            obs,
+            scalar,
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "replacement", "match"),
+    [
+        ("td_error", jnp.ones((1,), dtype=jnp.float32), "td_error must have shape"),
+        ("observation", jnp.ones((2,), dtype=jnp.float32), "observation must have shape"),
+        (
+            "next_observation",
+            jnp.ones((2,), dtype=jnp.float32),
+            "next_observation must have shape",
+        ),
+        ("gamma", jnp.ones((1,), dtype=jnp.float32), "gamma must have shape"),
+        ("observation", jnp.ones((3,), dtype=jnp.int32), "observation must have dtype"),
+    ],
+)
+def test_swift_td_public_input_metadata_fails_before_tracing(
+    name: str, replacement: jax.Array, match: str
+) -> None:
+    optimizer = SwiftTD(initial_step_size=0.01)
+    state = optimizer.init(3)
+    values = {
+        "td_error": jnp.asarray(1.0, dtype=jnp.float32),
+        "observation": jnp.ones((3,), dtype=jnp.float32),
+        "next_observation": jnp.ones((3,), dtype=jnp.float32),
+        "gamma": jnp.asarray(0.9, dtype=jnp.float32),
+    }
+    values[name] = replacement
+    with pytest.raises((TypeError, ValueError), match=match):
+        jax.jit(optimizer.update)(state, **values)
+
+
+def test_swift_td_invalid_adopted_scalar_domain_rolls_back() -> None:
+    optimizer = SwiftTD(initial_step_size=0.01)
+    state = optimizer.init(3).replace(eta_min=jnp.asarray(0.2, dtype=jnp.float32))
+    obs = jnp.ones((3,), dtype=jnp.float32)
+    result = optimizer.update(
+        state,
+        jnp.asarray(1.0, dtype=jnp.float32),
+        obs,
+        obs,
+        jnp.asarray(0.9, dtype=jnp.float32),
+    )
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.new_state, state)

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -69,19 +69,14 @@ class _RefSwiftTDNonSparse:
             self.delta_w[i] = delta * self.z[i] - self.z_delta[i] * self.v_delta
             self.w[i] += self.delta_w[i]
             self.beta[i] += (
-                self.meta_step_size
-                / np.exp(self.beta[i])
-                * (delta - self.v_delta)
-                * self.p[i]
+                self.meta_step_size / np.exp(self.beta[i]) * (delta - self.v_delta) * self.p[i]
             )
             if np.exp(self.beta[i]) > self.eta:
                 self.beta[i] = np.log(self.eta)
             if np.exp(self.beta[i]) < self.eta_min:
                 self.beta[i] = np.log(self.eta_min)
             self.h_old[i] = self.h[i]
-            self.h[i] = (
-                self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
-            )
+            self.h[i] = self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
             self.h_temp[i] = self.h[i]
             self.z_delta[i] = 0.0
             self.z[i] *= self.gamma * self.lam
@@ -134,9 +129,7 @@ class TestSwiftTDInit:
 
     def test_init_creates_correct_state(self):
         """Arrays get feature_dim + 1 entries (bias last), traces start at zero."""
-        optimizer = SwiftTD(
-            initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1
-        )
+        optimizer = SwiftTD(initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1)
         state = optimizer.init(feature_dim=10)
 
         chex.assert_shape(state.log_step_sizes, (11,))
@@ -272,9 +265,7 @@ class TestSwiftTDMatchesReference:
         for t in range(1, steps):
             obs = jnp.asarray(xs[t - 1], dtype=jnp.float32)
             nxt = jnp.asarray(xs[t], dtype=jnp.float32)
-            td_error = (
-                rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
-            )
+            td_error = rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
             upd = optimizer.update(state, td_error, obs, nxt, jnp.array(gamma))
             w = w + upd.weight_delta
             b = b + upd.bias_delta
@@ -378,9 +369,7 @@ class TestSwiftTDBehavior:
         )
         assert float(upd.metrics["decay_triggered"]) == 1.0
         expected = float(jnp.log(0.05) + jnp.log(0.99))  # phi_i^2 = 1 for all entries
-        chex.assert_trees_all_close(
-            upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6
-        )
+        chex.assert_trees_all_close(upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6)
 
         # tau = 0.02 * 3 = 0.06 < eta = 0.1 -> no decay, step-sizes unchanged.
         optimizer = SwiftTD(
@@ -403,9 +392,7 @@ class TestSwiftTDBehavior:
         obs = jnp.ones(3, dtype=jnp.float32)
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.0))
-        chex.assert_trees_all_close(
-            result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7
-        )
+        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7)
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.9))
         assert float(jnp.max(jnp.abs(result.new_state.eligibility_traces))) > 0.0
@@ -424,9 +411,7 @@ class TestSwiftTDBehavior:
         )
         assert bool(result.update_applied)
         assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
-        chex.assert_trees_all_close(
-            result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7
-        )
+        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7)
 
     def test_zero_gamma_does_not_disguise_consumed_inf_trace_state(self) -> None:
         optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.0)
@@ -519,9 +504,7 @@ def _run_swift_seed(initial_step_size, key):
         (w, b, opt_state), s_state = carry
         ts, s_new = stream.step(s_state, idx)
         td_error = jnp.squeeze(ts.target) - (jnp.dot(w, ts.observation) + b)
-        upd = optimizer.update(
-            opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0)
-        )
+        upd = optimizer.update(opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0))
         new_carry = ((w + upd.weight_delta, b + upd.bias_delta, upd.new_state), s_new)
         return new_carry, td_error**2
 
@@ -560,8 +543,7 @@ class TestSwiftTDLearningQuality:
         swift_mean = float(jnp.mean(finals))
         best_fixed = _best_fixed_lms_mean()
         assert swift_mean < best_fixed, (
-            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed "
-            f"step-size {best_fixed:.4f}"
+            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed step-size {best_fixed:.4f}"
         )
         # Sanity: close to the stream's noise floor (0.1^2), far from divergence.
         assert swift_mean < 0.05
@@ -576,3 +558,17 @@ class TestSwiftTDLearningQuality:
         swift_mean = float(jnp.mean(finals))
         assert swift_mean < _best_fixed_lms_mean()
         assert swift_mean < 0.05
+
+
+def test_swift_td_integer_validation() -> None:
+    swift = SwiftTD(initial_step_size=0.01)
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        swift.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        swift.init(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        swift.init(feature_dim=0)
+
+    state = swift.init(feature_dim=np.int32(4))
+    assert state.log_step_sizes.shape == (5,)


### PR DESCRIPTION
Preserves and rebases the contributor work from #845, then closes the remaining SwiftTD contracts.

- validates the complete NumPy/Python integer family and prevents augmented-dimension overflow
- preflights the exact eight-vector-plus-five-scalar float32 state allocation before JAX allocation
- validates every float32-consumed hyperparameter in host and narrowed domains, including normal positive sinks and eta_min <= eta
- validates adopted state shapes, dtypes, and scalar/log-step-size domains before tracing
- requires exact scalar/vector input metadata and keeps invalid adopted states transactional
- adds hostile subclass, overflow/underflow, endpoint/adjacent, state/input, JIT, and rollback tests

Validation: 138 focused tests passed; scoped Ruff, mypy, root import, and diff check passed.

Supersedes #845. Contributor commit and co-authorship are retained.