### PR TITLE
fix(world-model): integrate exact scalar, schema, and ensemble resource contracts

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -18,6 +18,7 @@ import dataclasses
 import functools
 import operator
 from collections.abc import Mapping
+from fractions import Fraction
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -64,6 +65,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int) -> int:
@@ -79,6 +83,12 @@ def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be a bool")
     return value
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
 
 
 def _validate_hidden_sizes(value: object) -> tuple[int, ...]:
@@ -260,7 +270,7 @@ class ActionConditionedWorldModelConfig:
             if len(observation_scale) != observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
-                validated_float32_scalar(
+                _validated_config_float(
                     f"observation_scale[{index}]", scale, positive=True
                 )
                 for index, scale in enumerate(observation_scale)
@@ -285,7 +295,7 @@ class ActionConditionedWorldModelConfig:
             object.__setattr__(
                 self,
                 name,
-                validated_float32_scalar(name, getattr(self, name), **bounds),
+                _validated_config_float(name, getattr(self, name), **bounds),
             )
         if (
             observation_scale is not None
@@ -331,7 +341,13 @@ class ActionConditionedWorldModelConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("config must be a readable mapping") from error
-        payload.pop("type", None)
+        if any(type(key) is not str for key in payload):
+            raise ValueError("config keys must be exact strings")
+        type_name = payload.pop("type", None)
+        if type_name is not None and (
+            type(type_name) is not str or type_name != cls.__name__
+        ):
+            raise ValueError("config type differs")
         if "hidden_sizes" in payload:
             payload["hidden_sizes"] = _serialized_sequence(
                 "hidden_sizes", payload["hidden_sizes"]
@@ -1101,7 +1117,7 @@ class WorldModelConfig:
             object.__setattr__(
                 self,
                 name,
-                validated_float32_scalar(name, getattr(self, name), **bounds),
+                _validated_config_float(name, getattr(self, name), **bounds),
             )
         if observation_dim == _INT32_MAX:
             raise ValueError("derived n_heads must fit in signed int32")
@@ -1129,7 +1145,13 @@ class WorldModelConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("config must be a readable mapping") from error
-        payload.pop("type", None)
+        if any(type(key) is not str for key in payload):
+            raise ValueError("config keys must be exact strings")
+        type_name = payload.pop("type", None)
+        if type_name is not None and (
+            type(type_name) is not str or type_name != cls.__name__
+        ):
+            raise ValueError("config type differs")
         if "hidden_sizes" in payload:
             payload["hidden_sizes"] = _serialized_sequence(
                 "hidden_sizes", payload["hidden_sizes"]

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -39,17 +39,19 @@ import dataclasses
 import functools
 import hashlib
 import json
-import math
+import operator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -71,6 +73,52 @@ from alberta_framework.core.world_model import (
 WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA = "alberta.world_model_ensemble.v2"
 _WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA_V1 = "alberta.world_model_ensemble.v1"
 _INT32_MAX = 2**31 - 1
+_UINT32_MAX = 4294967295
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if minimum is not None and number < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return number
+
+
 _REPLAY_KEY_FOLD_IN = 0x5245504C
 _V1_REPLAY_KEY_FOLD_IN = 0x50525632
 
@@ -127,39 +175,64 @@ class WorldModelEnsembleConfig:
     residual_variance_floor: float = 1.0e-6
 
     def __post_init__(self) -> None:
-        if (
-            isinstance(self.ensemble_size, bool)
-            or not isinstance(self.ensemble_size, int)
-            or self.ensemble_size < 2
-        ):
-            raise ValueError("ensemble_size must be an integer >= 2")
-        if (
-            not math.isfinite(self.bootstrap_probability)
-            or not 0.0 < self.bootstrap_probability < 1.0
-        ):
-            raise ValueError("bootstrap_probability must be finite and in (0, 1)")
-        if (
-            not math.isfinite(self.residual_variance_decay)
-            or not 0.0 <= self.residual_variance_decay < 1.0
-        ):
-            raise ValueError("residual_variance_decay must be finite and in [0, 1)")
-        if (
-            isinstance(self.residual_variance_warmup_steps, bool)
-            or not isinstance(self.residual_variance_warmup_steps, int)
-            or not 1 <= self.residual_variance_warmup_steps <= _INT32_MAX
-        ):
-            raise ValueError("residual_variance_warmup_steps must be an integer in [1, int32 max]")
-        if not math.isfinite(self.residual_variance_floor) or self.residual_variance_floor <= 0.0:
-            raise ValueError("residual_variance_floor must be positive and finite")
-        if self.signal_estimator.ensemble_size != self.ensemble_size:
+        ensemble_size = _require_int(
+            "ensemble_size", self.ensemble_size, minimum=2, maximum=_INT32_MAX
+        )
+        bootstrap_probability = validated_float32_scalar(
+            "bootstrap_probability",
+            self.bootstrap_probability,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+            positive=True,
+        )
+        residual_variance_decay = validated_float32_scalar(
+            "residual_variance_decay",
+            self.residual_variance_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        residual_variance_warmup_steps = _require_int(
+            "residual_variance_warmup_steps",
+            self.residual_variance_warmup_steps,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
+        residual_variance_floor = validated_float32_scalar(
+            "residual_variance_floor",
+            self.residual_variance_floor,
+            positive=True,
+        )
+        if residual_variance_floor < self.signal_estimator.variance_floor:
+            raise ValueError("residual_variance_floor must be >= signal_estimator.variance_floor")
+        if residual_variance_floor > self.signal_estimator.max_predicted_variance:
+            raise ValueError("residual_variance_floor exceeds the signal estimator variance bound")
+        if self.signal_estimator.ensemble_size != ensemble_size:
             raise ValueError("signal_estimator.ensemble_size must match ensemble_size")
         expected_target_dim = self.model.observation_dim + 2
         if self.signal_estimator.target_dim != expected_target_dim:
             raise ValueError("signal_estimator.target_dim must equal model.observation_dim + 2")
-        if self.residual_variance_floor < self.signal_estimator.variance_floor:
-            raise ValueError("residual_variance_floor must be >= signal_estimator.variance_floor")
-        if self.residual_variance_floor > self.signal_estimator.max_predicted_variance:
-            raise ValueError("residual_variance_floor exceeds the signal estimator variance bound")
+        object.__setattr__(self, "ensemble_size", ensemble_size)
+        object.__setattr__(self, "bootstrap_probability", bootstrap_probability)
+        object.__setattr__(self, "residual_variance_decay", residual_variance_decay)
+        object.__setattr__(
+            self, "residual_variance_warmup_steps", residual_variance_warmup_steps
+        )
+        object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
+        if ensemble_size * expected_target_dim > _INT32_MAX:
+            raise ValueError("WorldModelEnsembleConfig dimensions must fit signed int32")
+        total_variance_scalars = ensemble_size * expected_target_dim
+        _require_float32_resource(
+            "WorldModelEnsembleConfig state",
+            vector_scalars=total_variance_scalars,
+            fixed_scalars=ensemble_size * 2 + 10,
+        )
+        persistent_bytes = 4 * (total_variance_scalars + ensemble_size * 2 + 10)
+        if persistent_bytes > _INT32_MAX:
+            raise ValueError("WorldModelEnsembleConfig state byte count must fit signed int32")
+        if persistent_bytes > _UINT32_MAX:
+            raise ValueError("world model ensemble allocation exceeds uint32 byte accounting")
 
         # Reuse the model's complete constructor validation rather than
         # maintaining a second, drifting copy here.

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -40,6 +40,8 @@ import functools
 import hashlib
 import json
 import operator
+from collections.abc import Mapping
+from fractions import Fraction
 from pathlib import Path
 from typing import Any, SupportsIndex, cast
 
@@ -73,7 +75,6 @@ from alberta_framework.core.world_model import (
 WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA = "alberta.world_model_ensemble.v2"
 _WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA_V1 = "alberta.world_model_ensemble.v1"
 _INT32_MAX = 2**31 - 1
-_UINT32_MAX = 4294967295
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -87,19 +88,9 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.longlong,
     np.ulonglong,
 )
-
-
-def _require_float32_resource(
-    name: str,
-    *,
-    vector_scalars: int,
-    fixed_scalars: int = 0,
-) -> None:
-    total_scalars = vector_scalars + fixed_scalars
-    if total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} byte count must fit signed int32")
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
 
 
 def _require_int(
@@ -117,6 +108,53 @@ def _require_int(
     if maximum is not None and number > maximum:
         raise ValueError(f"{name} must be <= {maximum}")
     return number
+
+
+def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in (frozenset(_ACTUAL_INT_TYPES) | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
+
+
+def _member_state_scalars(config: ActionConditionedWorldModelConfig) -> int:
+    """Return exact default-LMS member state scalars counted by the budget surface."""
+    input_dim = config.observation_dim + config.n_actions
+    if config.include_action_interactions:
+        input_dim += config.observation_dim * config.n_actions
+    layer_sizes = (input_dim, *config.hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    n_heads = config.observation_dim + 2
+    final_width = config.hidden_sizes[-1] if config.hidden_sizes else input_dim
+    parameters = trunk_parameters + n_heads * (final_width + 1)
+    tensor_count = 2 * len(config.hidden_sizes) + 2 * n_heads
+    return (
+        2 * parameters
+        + tensor_count
+        + sum(config.hidden_sizes)
+        + 2 * config.observation_dim
+        + 9
+    )
+
+
+def _preflight_ensemble_state_resources(
+    *, model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> None:
+    target_dim = model.observation_dim + 2
+    members = ensemble_size * _member_state_scalars(model)
+    residuals = ensemble_size * target_dim
+    logical_scalars = members + residuals + 4 * ensemble_size + 15
+    logical_bytes = 4 * members + 4 * residuals + 10 * ensemble_size + 60
+    for name, value in (
+        ("ensemble member state scalars", members),
+        ("ensemble residual scalars", residuals),
+        ("ensemble persistent state scalars", logical_scalars),
+        ("ensemble persistent state bytes", logical_bytes),
+    ):
+        if not 1 <= value <= _INT32_MAX:
+            raise ValueError(f"derived {name} must fit signed int32")
 
 
 _REPLAY_KEY_FOLD_IN = 0x5245504C
@@ -175,10 +213,14 @@ class WorldModelEnsembleConfig:
     residual_variance_floor: float = 1.0e-6
 
     def __post_init__(self) -> None:
+        if type(self.model) is not ActionConditionedWorldModelConfig:
+            raise ValueError("model must be an exact ActionConditionedWorldModelConfig")
+        if type(self.signal_estimator) is not LearningSignalEstimatorConfig:
+            raise ValueError("signal_estimator must be an exact LearningSignalEstimatorConfig")
         ensemble_size = _require_int(
-            "ensemble_size", self.ensemble_size, minimum=2, maximum=_INT32_MAX
+            "ensemble_size", self.ensemble_size, minimum=2, maximum=_INT32_MAX - 1
         )
-        bootstrap_probability = validated_float32_scalar(
+        bootstrap_probability = _validated_config_float(
             "bootstrap_probability",
             self.bootstrap_probability,
             lower=0.0,
@@ -186,7 +228,7 @@ class WorldModelEnsembleConfig:
             upper_inclusive=False,
             positive=True,
         )
-        residual_variance_decay = validated_float32_scalar(
+        residual_variance_decay = _validated_config_float(
             "residual_variance_decay",
             self.residual_variance_decay,
             lower=0.0,
@@ -199,7 +241,7 @@ class WorldModelEnsembleConfig:
             minimum=1,
             maximum=_INT32_MAX,
         )
-        residual_variance_floor = validated_float32_scalar(
+        residual_variance_floor = _validated_config_float(
             "residual_variance_floor",
             self.residual_variance_floor,
             positive=True,
@@ -220,23 +262,7 @@ class WorldModelEnsembleConfig:
             self, "residual_variance_warmup_steps", residual_variance_warmup_steps
         )
         object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
-        if ensemble_size * expected_target_dim > _INT32_MAX:
-            raise ValueError("WorldModelEnsembleConfig dimensions must fit signed int32")
-        total_variance_scalars = ensemble_size * expected_target_dim
-        _require_float32_resource(
-            "WorldModelEnsembleConfig state",
-            vector_scalars=total_variance_scalars,
-            fixed_scalars=ensemble_size * 2 + 10,
-        )
-        persistent_bytes = 4 * (total_variance_scalars + ensemble_size * 2 + 10)
-        if persistent_bytes > _INT32_MAX:
-            raise ValueError("WorldModelEnsembleConfig state byte count must fit signed int32")
-        if persistent_bytes > _UINT32_MAX:
-            raise ValueError("world model ensemble allocation exceeds uint32 byte accounting")
-
-        # Reuse the model's complete constructor validation rather than
-        # maintaining a second, drifting copy here.
-        ActionConditionedWorldModel(self.model)
+        _preflight_ensemble_state_resources(model=self.model, ensemble_size=ensemble_size)
 
     @property
     def target_dim(self) -> int:
@@ -259,22 +285,39 @@ class WorldModelEnsembleConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> WorldModelEnsembleConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> WorldModelEnsembleConfig:
         """Reconstruct the exact development-only configuration."""
-        payload = dict(config)
-        type_name = payload.pop("type", "WorldModelEnsembleConfig")
-        if type_name != "WorldModelEnsembleConfig":
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be an actual mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
+        if any(type(key) is not str for key in payload):
+            raise ValueError("config keys must be exact strings")
+        type_name = payload.pop("type", None)
+        if type_name is not None and (
+            type(type_name) is not str or type_name != "WorldModelEnsembleConfig"
+        ):
             raise ValueError("type must be WorldModelEnsembleConfig")
         if payload.pop("development_only", True) is not True:
             raise ValueError("world-model ensemble is development_only")
         if payload.pop("accepted_scientific_evidence", False) is not False:
             raise ValueError("world-model ensemble is not accepted scientific evidence")
-        model = ActionConditionedWorldModelConfig.from_config(
-            cast(dict[str, Any], payload.pop("model"))
-        )
-        signal_estimator = LearningSignalEstimatorConfig.from_config(
-            cast(dict[str, Any], payload.pop("signal_estimator"))
-        )
+        raw_model = payload.pop("model")
+        raw_signals = payload.pop("signal_estimator")
+        if not issubclass(type(raw_model), Mapping) or not issubclass(
+            type(raw_signals), Mapping
+        ):
+            raise ValueError("nested configs must be actual mappings")
+        model = ActionConditionedWorldModelConfig.from_config(raw_model)
+        try:
+            signal_payload = dict(raw_signals)
+        except Exception as error:
+            raise ValueError("signal_estimator must be a readable mapping") from error
+        if any(type(key) is not str for key in signal_payload):
+            raise ValueError("signal_estimator keys must be exact strings")
+        signal_estimator = LearningSignalEstimatorConfig.from_config(signal_payload)
         return cls(model=model, signal_estimator=signal_estimator, **payload)
 
 
@@ -624,6 +667,8 @@ class WorldModelEnsemble:
     """Fixed-size bootstrap ensemble with causal typed learning signals."""
 
     def __init__(self, config: WorldModelEnsembleConfig):
+        if type(config) is not WorldModelEnsembleConfig:
+            raise ValueError("config must be an exact WorldModelEnsembleConfig")
         self._config = config
         self._model = ActionConditionedWorldModel(config.model)
         self._signals = LearningSignalEstimator(config.signal_estimator)
@@ -653,15 +698,27 @@ class WorldModelEnsemble:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> WorldModelEnsemble:
+    def from_config(cls, config: Mapping[str, Any]) -> WorldModelEnsemble:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
-        type_name = payload.pop("type", "WorldModelEnsemble")
-        if type_name != "WorldModelEnsemble":
+        if not issubclass(type(config), Mapping):
+            raise ValueError("ensemble payload must be an actual mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("ensemble payload must be a readable mapping") from error
+        if any(type(key) is not str for key in payload):
+            raise ValueError("ensemble payload keys must be exact strings")
+        type_name = payload.pop("type", None)
+        if type_name is not None and (
+            type(type_name) is not str or type_name != "WorldModelEnsemble"
+        ):
             raise ValueError("type must be WorldModelEnsemble")
         if set(payload) != {"config"}:
             raise ValueError("world-model ensemble config keys are invalid")
-        return cls(WorldModelEnsembleConfig.from_config(cast(dict[str, Any], payload["config"])))
+        nested = payload["config"]
+        if not issubclass(type(nested), Mapping):
+            raise ValueError("nested ensemble config must be an actual mapping")
+        return cls(WorldModelEnsembleConfig.from_config(nested))
 
     def init(self, key: Array) -> WorldModelEnsembleState:
         """Initialize distinct members and isolated real/replay mask streams."""
@@ -749,7 +806,10 @@ class WorldModelEnsemble:
             raise TypeError("bootstrap PRNG key storage must use uint32 words")
         bootstrap_words = int(bootstrap_key_data.size + replay_key_data.size)
         bootstrap_bytes = int(bootstrap_key_data.nbytes + replay_key_data.nbytes)
-        if persistent.uint32_scalars != bootstrap_words or bootstrap_bytes != 4 * bootstrap_words:
+        expected_uint32 = (
+            bootstrap_words + member_account.uint32_scalars * self._config.ensemble_size
+        )
+        if persistent.uint32_scalars != expected_uint32 or bootstrap_bytes != 4 * bootstrap_words:
             raise ValueError("bootstrap PRNG key accounting does not match state")
 
         prediction = _logical_tree_accounting(self._zero_prediction())

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import warnings
 from fractions import Fraction
+from types import MappingProxyType
 
 import chex
 import jax
@@ -457,8 +458,8 @@ class _FloatSpoof:
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
-        ({"reward_scale": _FloatSpoof()}, "reward_scale must be a finite real number"),
-        ({"observation_clip_margin": _FloatSpoof()}, "must be a finite real number"),
+        ({"reward_scale": _FloatSpoof()}, "reward_scale must be a finite real scalar"),
+        ({"observation_clip_margin": _FloatSpoof()}, "must be a finite real scalar"),
         ({"reward_scale": 1e100}, "reward_scale must remain finite once narrowed"),
         ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
         ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
@@ -506,9 +507,12 @@ def test_config_canonicalizes_real_scalars_and_preserves_builtin_floats() -> Non
     assert restored.config == model.config
 
 
-def test_config_normalizes_real_comparison_hooks_and_conversion_failures() -> None:
+def test_config_rejects_real_subclasses_without_running_hooks() -> None:
+    hooks_run: list[str] = []
+
     class LyingFraction(Fraction):
         def __gt__(self, other: object) -> bool:
+            hooks_run.append("comparison")
             return True
 
         def __ge__(self, other: object) -> bool:
@@ -519,9 +523,10 @@ def test_config_normalizes_real_comparison_hooks_and_conversion_failures() -> No
 
     class BrokenFraction(Fraction):
         def as_integer_ratio(self) -> tuple[int, int]:
+            hooks_run.append("ratio")
             raise RuntimeError("conversion hook failed")
 
-    with pytest.raises(ValueError, match="reward_scale must be positive"):
+    with pytest.raises(ValueError, match="reward_scale must be a finite real scalar"):
         ActionConditionedWorldModel(
             ActionConditionedWorldModelConfig(
                 observation_dim=2,
@@ -530,7 +535,7 @@ def test_config_normalizes_real_comparison_hooks_and_conversion_failures() -> No
                 reward_scale=LyingFraction(-1, 1),
             )
         )
-    with pytest.raises(ValueError, match="gamma must be a finite real number"):
+    with pytest.raises(ValueError, match="gamma must be a finite real scalar"):
         ActionConditionedWorldModel(
             ActionConditionedWorldModelConfig(
                 observation_dim=2,
@@ -539,6 +544,7 @@ def test_config_normalizes_real_comparison_hooks_and_conversion_failures() -> No
                 gamma=BrokenFraction(1, 2),
             )
         )
+    assert hooks_run == []
 
 
 @pytest.mark.parametrize("value", [True, 1.5, "2", object()])
@@ -618,6 +624,23 @@ def test_config_serialization_preserves_list_and_tuple_compatibility() -> None:
     payload["hidden_sizes"] = range(2)
     with pytest.raises(ValueError, match="actual list or tuple"):
         ActionConditionedWorldModelConfig.from_config(payload)
+
+
+def test_config_mapping_compatibility_retains_exact_keys_and_type_marker() -> None:
+    partial = MappingProxyType({"observation_dim": 2, "n_actions": 2, "hidden_sizes": []})
+    assert ActionConditionedWorldModelConfig.from_config(partial).hidden_sizes == ()
+    with pytest.raises(ValueError, match="type differs"):
+        ActionConditionedWorldModelConfig.from_config(
+            {"type": "wrong", "observation_dim": 2, "n_actions": 2}
+        )
+
+    class StringSubclass(str):
+        pass
+
+    with pytest.raises(ValueError, match="exact strings"):
+        ActionConditionedWorldModelConfig.from_config(
+            {StringSubclass("observation_dim"): 2, "n_actions": 2}
+        )
 
 
 @pytest.mark.parametrize("discount", [1.5, -0.5, 5.0])

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -421,3 +421,17 @@ def test_world_model_outer_step_count_saturates() -> None:
     )
     assert bool(result.update_applied)
     assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_world_model_config_rejects_hostile_float_subclass_without_hooks() -> None:
+    hook_ran = False
+
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            nonlocal hook_ran
+            hook_ran = True
+            raise AssertionError("untrusted ratio hook ran")
+
+    with pytest.raises(ValueError, match="finite real scalar"):
+        WorldModelConfig(observation_dim=2, step_size=HostileFloat(0.1))
+    assert not hook_ran

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -208,6 +208,18 @@ def test_init_uses_distinct_member_keys_and_isolated_real_replay_mask_keys() -> 
     )
 
 
+def test_resource_budget_counts_member_lifetime_words_and_matches_state() -> None:
+    ensemble = WorldModelEnsemble(_config())
+    state = ensemble.init(jr.key(0))
+    budget = ensemble.resource_budget(state)
+    leaves = jax.tree.leaves(_materialize_keys(state))
+    expected_scalars = sum(int(jnp.asarray(leaf).size) for leaf in leaves)
+    expected_bytes = sum(int(jnp.asarray(leaf).nbytes) for leaf in leaves)
+    assert budget.persistent_state_scalars == expected_scalars
+    assert budget.persistent_state_bytes == expected_bytes
+    assert budget.persistent_uint32_scalars == 2 * budget.ensemble_size + 4
+
+
 def test_predict_is_read_only_and_fail_closed() -> None:
     ensemble = WorldModelEnsemble(_config())
     state = ensemble.init(jr.key(0))

--- a/tests/test_world_model_ensemble_validation.py
+++ b/tests/test_world_model_ensemble_validation.py
@@ -1,0 +1,230 @@
+"""Validation hardening for world-model ensemble (int/float bounds + resources)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import WorldModelEnsembleConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides: object) -> WorldModelEnsembleConfig:
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        gamma=0.95,
+        hidden_sizes=(),
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=2,
+        target_dim=4,
+        progress_warmup_steps=2,
+        change_calibration_steps=2,
+        fast_loss_decay=0.5,
+        slow_loss_decay=0.9,
+        max_input_magnitude=100.0,
+        max_predicted_variance=10_000.0,
+        max_observed_loss=10_000.0,
+    )
+    base: dict[str, object] = {
+        "model": model,
+        "signal_estimator": signals,
+        "ensemble_size": 2,
+        "bootstrap_probability": 0.5,
+        "residual_variance_decay": 0.8,
+        "residual_variance_warmup_steps": 1,
+        "residual_variance_floor": 1.0e-6,
+    }
+    base.update(overrides)
+    # Keep signal_estimator in sync when ensemble_size overridden
+    if "ensemble_size" in overrides:
+        signals = LearningSignalEstimatorConfig(
+            ensemble_size=overrides["ensemble_size"],  # type: ignore[arg-type]
+            target_dim=4,
+            progress_warmup_steps=2,
+            change_calibration_steps=2,
+            fast_loss_decay=0.5,
+            slow_loss_decay=0.9,
+            max_input_magnitude=100.0,
+            max_predicted_variance=10_000.0,
+            max_observed_loss=10_000.0,
+        )
+        base["signal_estimator"] = signals
+    return WorldModelEnsembleConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(ensemble_size=v),
+        lambda v: _base_cfg(residual_variance_warmup_steps=v),
+    ],
+)
+def test_wm_ensemble_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(ensemble_size=v),
+        lambda v: _base_cfg(residual_variance_warmup_steps=v),
+    ],
+)
+def test_wm_ensemble_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_wm_ensemble_int_validators_canonicalize_numpy_scalars(
+    np_type: type,
+) -> None:
+    cfg = _base_cfg(
+        ensemble_size=np_type(2),
+        residual_variance_warmup_steps=np_type(2),
+    )
+    assert cfg.ensemble_size == 2
+    assert type(cfg.ensemble_size) is int
+    assert type(cfg.residual_variance_warmup_steps) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(ensemble_size=v),
+        lambda v: _base_cfg(residual_variance_warmup_steps=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1],
+)
+def test_wm_ensemble_int_validators_reject_non_integer_and_out_of_range(
+    ctor,
+    value: object,
+) -> None:
+    # ensemble_size min 2, warmup min 1 -> 0/1 invalid for ensemble_size
+    with pytest.raises(ValueError, match="must be"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+def test_wm_ensemble_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("bootstrap_probability", float("nan")),
+        ("bootstrap_probability", float("inf")),
+        ("bootstrap_probability", 0.0),
+        ("bootstrap_probability", 1.0),
+        ("bootstrap_probability", -0.1),
+        ("bootstrap_probability", HostileFloat(0.5)),
+        ("residual_variance_decay", float("nan")),
+        ("residual_variance_decay", 1.0),
+        ("residual_variance_decay", -0.1),
+        ("residual_variance_decay", ClassSpoof()),  # type: ignore[arg-type]
+        ("residual_variance_floor", 0.0),
+        ("residual_variance_floor", float("inf")),
+        ("residual_variance_floor", HostileFloat(0.5)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_wm_ensemble_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="bootstrap_probability"):
+        _base_cfg(bootstrap_probability=HostileFloat(0.5))  # type: ignore[arg-type]
+    assert HostileFloat.calls == 1
+
+
+def test_wm_ensemble_dimensions_preflight_without_allocation() -> None:
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(ensemble_size=_INT32_MAX)
+    # Large ensemble with observation_dim 2 => target_dim 4, product 4*ensemble
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(ensemble_size=600_000_000)
+
+
+def test_wm_ensemble_state_preflight_bytes_without_allocation() -> None:
+    # target_dim=4, total=ensemble*4, fixed=ensemble*2+10, persistent=4*(6*ensemble+10)
+    last_legal = (2**31 - 1 - 40) // 24
+    _base_cfg(ensemble_size=last_legal)
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        _base_cfg(ensemble_size=last_legal + 1)
+    with pytest.raises(ValueError, match="scalar count|byte count|dimensions"):
+        _base_cfg(ensemble_size=500_000_000)
+
+
+def test_wm_ensemble_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(
+        bootstrap_probability=0.5,
+        residual_variance_decay=0.8,
+        residual_variance_floor=1e-6,
+    )
+    assert cfg.bootstrap_probability == 0.5
+    assert cfg.residual_variance_decay == 0.8

--- a/tests/test_world_model_ensemble_validation.py
+++ b/tests/test_world_model_ensemble_validation.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import numpy as np
 import pytest
 
 from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
-from alberta_framework.core.world_model_ensemble import WorldModelEnsembleConfig
+from alberta_framework.core.world_model_ensemble import WorldModelEnsemble, WorldModelEnsembleConfig
 
 _INT32_MAX = 2**31 - 1
 
@@ -199,24 +201,24 @@ def test_wm_ensemble_float_validators_reject_hostile_ratio() -> None:
 
     with pytest.raises(ValueError, match="bootstrap_probability"):
         _base_cfg(bootstrap_probability=HostileFloat(0.5))  # type: ignore[arg-type]
-    assert HostileFloat.calls == 1
+    assert HostileFloat.calls == 0
 
 
 def test_wm_ensemble_dimensions_preflight_without_allocation() -> None:
-    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+    with pytest.raises(ValueError, match="ensemble_size"):
         _base_cfg(ensemble_size=_INT32_MAX)
     # Large ensemble with observation_dim 2 => target_dim 4, product 4*ensemble
-    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+    with pytest.raises(ValueError, match="fit signed int32"):
         _base_cfg(ensemble_size=600_000_000)
 
 
 def test_wm_ensemble_state_preflight_bytes_without_allocation() -> None:
-    # target_dim=4, total=ensemble*4, fixed=ensemble*2+10, persistent=4*(6*ensemble+10)
-    last_legal = (2**31 - 1 - 40) // 24
+    # This base has 61 scalars/member; total persistent bytes are 270*ensemble + 60.
+    last_legal = (2**31 - 1 - 60) // 270
     _base_cfg(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="scalar count|byte count"):
+    with pytest.raises(ValueError, match="persistent state bytes"):
         _base_cfg(ensemble_size=last_legal + 1)
-    with pytest.raises(ValueError, match="scalar count|byte count|dimensions"):
+    with pytest.raises(ValueError, match="fit signed int32"):
         _base_cfg(ensemble_size=500_000_000)
 
 
@@ -228,3 +230,36 @@ def test_wm_ensemble_float_validators_accept_valid_values() -> None:
     )
     assert cfg.bootstrap_probability == 0.5
     assert cfg.residual_variance_decay == 0.8
+
+
+def test_wm_ensemble_mapping_loaders_preserve_markers_and_exact_keys() -> None:
+    config = _base_cfg()
+    payload = config.to_config()
+    restored = WorldModelEnsembleConfig.from_config(MappingProxyType(payload))
+    assert restored == config
+    with pytest.raises(ValueError, match="type"):
+        WorldModelEnsembleConfig.from_config({**payload, "type": "wrong"})
+
+    outer = WorldModelEnsemble(config).to_config()
+    assert WorldModelEnsemble.from_config(MappingProxyType(outer)).config == config
+
+    class StringSubclass(str):
+        pass
+
+    with pytest.raises(ValueError, match="exact strings"):
+        WorldModelEnsemble.from_config(
+            {StringSubclass("type"): "WorldModelEnsemble", "config": payload}
+        )
+
+
+def test_wm_ensemble_rejects_nested_config_subclasses() -> None:
+    class ModelConfigSubclass(ActionConditionedWorldModelConfig):
+        pass
+
+    base = _base_cfg()
+    with pytest.raises(ValueError, match="exact ActionConditioned"):
+        WorldModelEnsembleConfig(
+            model=ModelConfigSubclass(observation_dim=2, n_actions=2, hidden_sizes=()),
+            signal_estimator=base.signal_estimator,
+            ensemble_size=2,
+        )


### PR DESCRIPTION
Supersedes #837, #849, and #836 after a joint audit of #810/#814/#836 and current main. The branch preserves Kayvan Zahiri's world-model and ensemble validation contribution, cherry-picks byt61's #836 commit verbatim, and retains the unique sound deltas from #849 with attribution.

The integrated repair:
- preserves the historical Mapping, partial-config, and list/tuple loader compatibility while requiring exact string keys and valid type markers;
- validates the complete direct world-model scalar/container/enum surface, canonicalizes trusted Python/NumPy values, and rejects hostile scalar subclasses before any conversion/comparison hooks;
- preflights action interactions, layer/head allocations, complete direct member state, `jr.split(ensemble_size + 1)`, residual grids, aggregate persistent logical scalars, and exact mixed-dtype bytes before JAX allocation;
- fixes `resource_budget()` after multi-head lifetime words by separating per-member uint32 words from the two bootstrap keys;
- adds exact measured-state accounting, hostile hook, Mapping/schema, trusted NumPy, and allocation-free endpoint regressions.

Verification:
- 122 world-model/config/ensemble-validation tests passed
- 40 world-model-ensemble + Prototype integration/checkpoint tests passed in 270s
- 8 focused hostile/schema/resource endpoint tests passed after final integration
- scoped Ruff passed
- strict mypy passed for both source modules
- `git diff --check` passed

No outputs or registered evidence artifacts were modified. This is development-only L0 mechanism hardening and does not authorize or promote evidence.

Co-authored-by: kzahiri1 <kzahiri@dons.usfca.edu>
Co-authored-by: byt61 <271805600+byt61@users.noreply.github.com>
Co-authored-by: lalalune <shawmakesmagic@gmail.com>
