### PR TITLE
fix(cumulant-discovery): preserve scalar and loader contracts

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -65,21 +66,14 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
+
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -90,6 +84,48 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+    preserve_nonzero: bool = False,
+) -> float:
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        positive=positive,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
+    if preserve_nonzero and numerator != 0 and np.float32(numerator / denominator) == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
+
+
+def _require_state_resources(raw_dim: int, n_candidates: int) -> None:
+    logical_scalars = 2 * raw_dim * n_candidates + 3 * n_candidates + 1
+    state_bytes = 4 * (2 * raw_dim * n_candidates + 3 * n_candidates) + 8
+    for name, value in (("state_scalars", logical_scalars), ("state_bytes", state_bytes)):
+        if value > _INT32_MAX:
+            raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
+
+
+def _read_mapping(value: object) -> dict[str, Any]:
+    if not issubclass(type(value), Mapping):
+        raise ValueError("config must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], value))
+    except Exception as error:
+        raise ValueError("config must be a readable mapping") from error
 
 
 # =============================================================================
@@ -168,12 +204,25 @@ class CumulantDiscovery:
         raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
         n_candidates = _require_int32("n_candidates", n_candidates, minimum=1)
         maturity_threshold = _require_int32("maturity_threshold", maturity_threshold, minimum=0)
-        if not 0.0 < decay_rate < 1.0:
-            raise ValueError(f"decay_rate must lie in (0, 1); got {decay_rate}")
-        if not 0.0 <= replacement_rate <= 1.0:
-            raise ValueError(f"replacement_rate must lie in [0, 1]; got {replacement_rate}")
-        if predictor_step_size <= 0:
-            raise ValueError(f"predictor_step_size must be positive; got {predictor_step_size}")
+        _require_state_resources(raw_dim, n_candidates)
+        decay_rate = _require_float32(
+            "decay_rate", decay_rate, positive=True, upper=1.0, upper_inclusive=False
+        )
+        replacement_rate = _require_float32(
+            "replacement_rate",
+            replacement_rate,
+            lower=0.0,
+            upper=1.0,
+            preserve_nonzero=True,
+        )
+        predictor_step_size = _require_float32(
+            "predictor_step_size", predictor_step_size, positive=True
+        )
+        gamma = _require_float32(
+            "gamma", gamma, lower=0.0, upper=1.0, preserve_nonzero=True
+        )
+        if type(enabled) is not bool:
+            raise ValueError("enabled must be an exact bool")
 
         self._raw_dim = raw_dim
         self._n_candidates = n_candidates
@@ -183,6 +232,50 @@ class CumulantDiscovery:
         self._predictor_step_size = predictor_step_size
         self._gamma = gamma
         self._enabled = enabled
+
+    def _require_state_contract(self, state: CumulantDiscoveryState) -> None:
+        if type(state) is not CumulantDiscoveryState:
+            raise ValueError("state must be a CumulantDiscoveryState")
+        matrix_shape = (self._n_candidates, self._raw_dim)
+        vector_shape = (self._n_candidates,)
+        for name in ("projections", "weights"):
+            leaf = getattr(state, name)
+            if leaf.shape != matrix_shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {matrix_shape} and dtype float32")
+        for name in ("biases", "utility"):
+            leaf = getattr(state, name)
+            if leaf.shape != vector_shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {vector_shape} and dtype float32")
+        if state.ages.shape != vector_shape or state.ages.dtype != jnp.int32:
+            raise ValueError(f"state.ages must have shape {vector_shape} and dtype int32")
+        self._require_key(state.key)
+
+    @staticmethod
+    def _require_key(key: object) -> Array:
+        try:
+            key_data = jr.key_data(cast(Any, key))
+        except Exception as error:
+            raise ValueError("key must be a Threefry JAX key") from error
+        if key_data.shape != (2,) or key_data.dtype != jnp.uint32:
+            raise ValueError("key must be a Threefry JAX key")
+        return cast(Array, key)
+
+    def _observation(self, name: str, value: object) -> Array:
+        observation = jnp.asarray(value, dtype=jnp.float32)
+        if observation.shape != (self._raw_dim,):
+            raise ValueError(f"{name} must have shape ({self._raw_dim},)")
+        return observation
+
+    @staticmethod
+    def _state_is_valid(state: CumulantDiscoveryState) -> Array:
+        return (
+            jnp.all(jnp.isfinite(state.projections))
+            & jnp.all(jnp.isfinite(state.weights))
+            & jnp.all(jnp.isfinite(state.biases))
+            & jnp.all(jnp.isfinite(state.utility))
+            & jnp.all(state.utility >= 0.0)
+            & jnp.all(state.ages >= 0)
+        )
 
     @property
     def n_candidates(self) -> int:
@@ -199,6 +292,7 @@ class CumulantDiscovery:
     def init(self, key: Array) -> CumulantDiscoveryState:
         """Initialize state with random projections, zero predictors,
         zero utility, zero ages."""
+        key = self._require_key(key)
         k_proj, k_state = jr.split(key)
         # Unit-norm random projections
         raw_proj = jr.normal(k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32)
@@ -224,6 +318,8 @@ class CumulantDiscovery:
         ``s_t`` to ``s_{t+1}`` should use ``c_{t+1}``, so callers feeding a
         Horde should normally pass the *next* observation here.
         """
+        self._require_state_contract(state)
+        observation = self._observation("observation", observation)
         return state.projections @ observation
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -255,6 +351,9 @@ class CumulantDiscovery:
         Returns:
             Updated discovery state
         """
+        self._require_state_contract(state)
+        observation = self._observation("observation", observation)
+        next_observation = self._observation("next_observation", next_observation)
         alpha = jnp.asarray(self._predictor_step_size, dtype=jnp.float32)
         gamma = jnp.asarray(self._gamma, dtype=jnp.float32)
         decay = jnp.asarray(self._decay_rate, dtype=jnp.float32)
@@ -276,7 +375,7 @@ class CumulantDiscovery:
             weights=proposed_weights,
             biases=proposed_biases,
             utility=proposed_utility,
-            ages=state.ages + 1,
+            ages=jnp.minimum(state.ages, _INT32_MAX - 1) + 1,
             key=state.key,
         )
         # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
@@ -290,7 +389,7 @@ class CumulantDiscovery:
         return cast(
             CumulantDiscoveryState,
             jax.lax.cond(
-                inputs_valid & proposed_finite,
+                self._state_is_valid(state) & inputs_valid & proposed_finite,
                 lambda: proposed_state,
                 lambda: state,
             ),
@@ -311,6 +410,7 @@ class CumulantDiscovery:
         Replacement: re-sample the projection row, zero the predictor
         weights/bias, reset utility to 0 and age to 0.
         """
+        self._require_state_contract(state)
         if not self._enabled:
             return state
 
@@ -359,13 +459,18 @@ class CumulantDiscovery:
             state.ages,
         )
 
-        return CumulantDiscoveryState(  # type: ignore[call-arg]
+        candidate = CumulantDiscoveryState(  # type: ignore[call-arg]
             projections=new_projections,
             weights=new_weights,
             biases=new_biases,
             utility=new_utility,
             ages=new_ages,
             key=k_next,
+        )
+        commit = self._state_is_valid(state) & self._state_is_valid(candidate)
+        return cast(
+            CumulantDiscoveryState,
+            jax.lax.cond(commit, lambda: candidate, lambda: state),
         )
 
     def to_config(self) -> dict[str, Any]:
@@ -383,8 +488,8 @@ class CumulantDiscovery:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> CumulantDiscovery:
+    def from_config(cls, config: Mapping[str, Any]) -> CumulantDiscovery:
         """Reconstruct from dict."""
-        config = dict(config)
+        config = _read_mapping(config)
         config.pop("type", None)
         return cls(**config)

--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -54,14 +54,43 @@ Reference:
 from __future__ import annotations
 
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
 
 # =============================================================================
 # State
@@ -136,24 +165,15 @@ class CumulantDiscovery:
         gamma: float = 0.0,
         enabled: bool = True,
     ):
-        if raw_dim <= 0:
-            raise ValueError(f"raw_dim must be positive; got {raw_dim}")
-        if n_candidates <= 0:
-            raise ValueError(f"n_candidates must be positive; got {n_candidates}")
+        raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
+        n_candidates = _require_int32("n_candidates", n_candidates, minimum=1)
+        maturity_threshold = _require_int32("maturity_threshold", maturity_threshold, minimum=0)
         if not 0.0 < decay_rate < 1.0:
             raise ValueError(f"decay_rate must lie in (0, 1); got {decay_rate}")
         if not 0.0 <= replacement_rate <= 1.0:
-            raise ValueError(
-                f"replacement_rate must lie in [0, 1]; got {replacement_rate}"
-            )
-        if maturity_threshold < 0:
-            raise ValueError(
-                f"maturity_threshold must be non-negative; got {maturity_threshold}"
-            )
+            raise ValueError(f"replacement_rate must lie in [0, 1]; got {replacement_rate}")
         if predictor_step_size <= 0:
-            raise ValueError(
-                f"predictor_step_size must be positive; got {predictor_step_size}"
-            )
+            raise ValueError(f"predictor_step_size must be positive; got {predictor_step_size}")
 
         self._raw_dim = raw_dim
         self._n_candidates = n_candidates
@@ -181,16 +201,12 @@ class CumulantDiscovery:
         zero utility, zero ages."""
         k_proj, k_state = jr.split(key)
         # Unit-norm random projections
-        raw_proj = jr.normal(
-            k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32
-        )
+        raw_proj = jr.normal(k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32)
         norms = jnp.linalg.norm(raw_proj, axis=1, keepdims=True) + 1e-8
         projections = raw_proj / norms
         return CumulantDiscoveryState(  # type: ignore[call-arg]
             projections=projections,
-            weights=jnp.zeros(
-                (self._n_candidates, self._raw_dim), dtype=jnp.float32
-            ),
+            weights=jnp.zeros((self._n_candidates, self._raw_dim), dtype=jnp.float32),
             biases=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             utility=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             ages=jnp.zeros(self._n_candidates, dtype=jnp.int32),
@@ -265,9 +281,7 @@ class CumulantDiscovery:
         )
         # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
         # alpha * nan * obs poisons every candidate. Hold the finite state.
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
-            jnp.isfinite(next_observation)
-        )
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(next_observation))
         proposed_finite = (
             jnp.all(jnp.isfinite(proposed_weights))
             & jnp.all(jnp.isfinite(proposed_biases))
@@ -308,9 +322,7 @@ class CumulantDiscovery:
         # Among mature candidates, find the one with lowest utility
         mature = state.ages >= self._maturity_threshold
         # Disqualify immature candidates by setting their utility to +inf
-        masked_utility = jnp.where(
-            mature, state.utility, jnp.full_like(state.utility, jnp.inf)
-        )
+        masked_utility = jnp.where(mature, state.utility, jnp.full_like(state.utility, jnp.inf))
         # If no candidates are mature, this index is arbitrary
         worst_idx = jnp.argmin(masked_utility)
         any_mature = jnp.any(mature)

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -12,6 +14,7 @@ import pytest
 from alberta_framework.core.cumulant_discovery import (
     CumulantDiscovery,
     CumulantDiscoveryState,
+    _require_state_resources,
 )
 
 # =============================================================================
@@ -315,3 +318,86 @@ def test_cumulant_discovery_integer_validation() -> None:
     assert type(discovery._raw_dim) is int
     assert type(discovery._n_candidates) is int
     assert type(discovery._maturity_threshold) is int
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile hook executed")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("decay_rate", _HostileFloat(0.5)),
+        ("decay_rate", np.float64(1.0 - 1e-10)),
+        ("replacement_rate", np.float64(1e-100)),
+        ("predictor_step_size", 1e100),
+        ("gamma", np.float64(1e-100)),
+        ("gamma", -0.1),
+        ("enabled", np.bool_(True)),
+    ],
+)
+def test_cumulant_discovery_rejects_invalid_float32_and_static_config(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        CumulantDiscovery(raw_dim=2, **{field: value})  # type: ignore[arg-type]
+
+
+def test_cumulant_discovery_config_is_canonical_and_mapping_compatible() -> None:
+    discovery = CumulantDiscovery(
+        raw_dim=np.int16(2),
+        n_candidates=np.uint16(3),
+        decay_rate=np.float32(0.5),
+        replacement_rate=np.float64(0.25),
+        predictor_step_size=np.float16(0.125),
+        gamma=np.float32(0.75),
+    )
+    config = discovery.to_config()
+    clone = CumulantDiscovery.from_config(MappingProxyType(config))
+    assert clone.to_config() == config
+    for name in ("decay_rate", "replacement_rate", "predictor_step_size", "gamma"):
+        assert type(config[name]) is float
+
+
+def test_cumulant_discovery_preflights_state_before_allocation() -> None:
+    _require_state_resources(268_435_453, 1)
+    with pytest.raises(ValueError, match="state_bytes"):
+        _require_state_resources(268_435_454, 1)
+    with pytest.raises(ValueError, match="state_bytes"):
+        CumulantDiscovery(raw_dim=268_435_454, n_candidates=1)
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
+def test_cumulant_discovery_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -> None:
+    discovery = CumulantDiscovery(raw_dim=2, n_candidates=2)
+    state = discovery.init(jr.key(0))
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observation"):
+        discovery.cumulants(state, malformed)
+    with pytest.raises(ValueError, match="observation"):
+        discovery.step(state, malformed, jnp.zeros((2,), dtype=jnp.float32))
+
+
+def test_cumulant_discovery_state_contract_and_saturating_ages() -> None:
+    discovery = CumulantDiscovery(raw_dim=2, n_candidates=2, replacement_rate=1.0)
+    state = discovery.init(jr.key(0))
+    malformed = state.replace(weights=jnp.zeros((2,), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="state.weights"):
+        discovery.step(
+            malformed,
+            jnp.zeros((2,), dtype=jnp.float32),
+            jnp.zeros((2,), dtype=jnp.float32),
+        )
+
+    saturated = state.replace(ages=jnp.full((2,), 2**31 - 1, dtype=jnp.int32))
+    stepped = discovery.step(
+        saturated,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )
+    assert stepped.ages.tolist() == [2**31 - 1, 2**31 - 1]
+
+    invalid = state.replace(ages=jnp.asarray([-1, 0], dtype=jnp.int32))
+    replaced = discovery.maybe_replace(invalid)
+    chex.assert_trees_all_equal(replaced, invalid)

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -100,9 +100,7 @@ class TestStep:
             predictor_step_size=0.1,
             gamma=0.0,
         )
-        s0 = d.init(jr.key(0)).replace(
-            projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32)
-        )
+        s0 = d.init(jr.key(0)).replace(projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32))
         # If the current observation were used as the cumulant this would
         # produce non-zero utility. GVF/nexting convention uses c_{t+1}.
         s1 = d.step(s0, jnp.array([2.0, 0.0]), jnp.array([0.0, 0.0]))
@@ -132,9 +130,7 @@ class TestStep:
         chex.assert_trees_all_close(recovered.ages, state.ages + 1)
 
     def test_predictor_reduces_td_error(self) -> None:
-        d = CumulantDiscovery(
-            raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0
-        )
+        d = CumulantDiscovery(raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0)
         s0 = d.init(jr.key(2))
         # Repeatedly present the same observation: predictor should
         # learn to predict the cumulant exactly, so the TD error / utility
@@ -293,3 +289,29 @@ class TestConfig:
         assert restored.raw_dim == 8
         assert restored.n_candidates == 12
         assert restored.enabled is True
+
+
+def test_cumulant_discovery_integer_validation() -> None:
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=True, n_candidates=8)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=4.5, n_candidates=8)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=0, n_candidates=8)
+
+    with pytest.raises(ValueError, match="n_candidates"):
+        CumulantDiscovery(raw_dim=4, n_candidates=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="maturity_threshold"):
+        CumulantDiscovery(raw_dim=4, n_candidates=8, maturity_threshold=True)  # type: ignore[arg-type]
+
+    discovery = CumulantDiscovery(
+        raw_dim=np.int32(4),
+        n_candidates=np.int64(8),
+        maturity_threshold=np.int32(50),
+    )
+    assert discovery._raw_dim == 4
+    assert discovery._n_candidates == 8
+    assert discovery._maturity_threshold == 50
+    assert type(discovery._raw_dim) is int
+    assert type(discovery._n_candidates) is int
+    assert type(discovery._maturity_threshold) is int


### PR DESCRIPTION
Narrow residual after merged #860 and #865. Keeps their exact 256 MiB resource preflight, typed Threefry key, state/input shape+dtypes, transactional nonfinite handling, saturation, and contributor work. Adds only the remaining contracts: concrete host real types without hostile subclass hooks; exact-nonzero float32 underflow rejection for zero-legal replacement_rate/gamma; and the historical unversioned Mapping/partial-default/type-marker loader behavior instead of a breaking exact-schema change.\n\nVerification: 51 full cumulant-discovery tests passed; scoped Ruff, strict mypy, and diff-check passed.