### PR TITLE
fix(optimizers): complete initializer resource contracts

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -13,11 +13,13 @@ References:
 - Elsayed et al. 2024, "Streaming Deep Reinforcement Learning Finally Works"
 """
 
+import operator
 from abc import ABC, abstractmethod
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -44,6 +46,40 @@ from alberta_framework.core.update_safety import (
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_shape(shape: object) -> tuple[int, ...]:
+    if type(shape) is not tuple:
+        raise ValueError("shape must be an actual tuple")
+    return tuple(_require_int32(f"shape[{i}]", s, minimum=1) for i, s in enumerate(shape))
+
 
 # =============================================================================
 # Bounder ABC
@@ -97,10 +133,7 @@ def _apply_obgd_bound(
     scale = 1.0 / jnp.maximum(kappa * delta_bar * total_step, 1.0)
     collapsed = scale == 0
     return (
-        tuple(
-            zero_if_collapsed_infinity(scale * step, step, collapsed)
-            for step in steps
-        ),
+        tuple(zero_if_collapsed_infinity(scale * step, step, collapsed) for step in steps),
         scale,
     )
 
@@ -218,9 +251,7 @@ class AdaptiveObGDBounding(Bounder):
         for s in bounded:
             sum_sq = sum_sq + jnp.sum(s**2)
             n_weights = n_weights + s.size
-        rms = jnp.sqrt(
-            sum_sq / jnp.maximum(n_weights.astype(jnp.float32), 1.0) + self._eps
-        )
+        rms = jnp.sqrt(sum_sq / jnp.maximum(n_weights.astype(jnp.float32), 1.0) + self._eps)
         rms_scale = jnp.maximum(rms, 1.0)
         adaptive = tuple(s / rms_scale for s in bounded)
         return adaptive, scale
@@ -291,9 +322,7 @@ class AGCBounding(Bounder):
             needs_clip = g_norm > max_norm
             clipped_step = jnp.where(needs_clip, step * scale, step)
             collapsed = needs_clip & (scale == 0)
-            clipped.append(
-                zero_if_collapsed_infinity(clipped_step, step, collapsed)
-            )
+            clipped.append(zero_if_collapsed_infinity(clipped_step, step, collapsed))
 
             total_units += needs_clip.size
             clipped_units = clipped_units + jnp.sum(needs_clip.astype(jnp.float32))
@@ -321,8 +350,7 @@ class OptimizerUpdate:
     weight_delta: Float[Array, " feature_dim"]
     bias_delta: Float[Array, ""]
     new_state: (
-        LMSState | IDBDState | AutostepState | AutostepGTDLambdaState | ObGDState
-        | IDBDParamState
+        LMSState | IDBDState | AutostepState | AutostepGTDLambdaState | ObGDState | IDBDParamState
     )
     metrics: dict[str, Array]
     update_applied: Bool[Array, ""]
@@ -345,8 +373,13 @@ class ParamOptimizerUpdate:
 
 class Optimizer[
     StateT: (
-        LMSState, IDBDState, AutostepState, AutostepGTDLambdaState, ObGDState,
-        AutostepParamState, IDBDParamState,
+        LMSState,
+        IDBDState,
+        AutostepState,
+        AutostepGTDLambdaState,
+        ObGDState,
+        AutostepParamState,
+        IDBDParamState,
     )
 ](ABC):
     """Base class for optimizers."""
@@ -474,9 +507,7 @@ class Optimizer[
 
         step, new_state = self.update_from_gradient(state, gradient, error=error)
         error_is_finite = (
-            jnp.asarray(True, dtype=jnp.bool_)
-            if error is None
-            else jnp.all(jnp.isfinite(error))
+            jnp.asarray(True, dtype=jnp.bool_) if error is None else jnp.all(jnp.isfinite(error))
         )
         update_applied = (
             floating_tree_is_finite(state)
@@ -525,6 +556,7 @@ class LMS(Optimizer[LMSState]):
         Returns:
             LMS state containing the step-size
         """
+        _require_int32("feature_dim", feature_dim, minimum=1)
         return LMSState(step_size=jnp.array(self._step_size, dtype=jnp.float32))
 
     def init_for_shape(self, shape: tuple[int, ...]) -> LMSState:
@@ -533,6 +565,7 @@ class LMS(Optimizer[LMSState]):
         LMS state is shape-independent (single scalar), so this returns
         the same state regardless of shape.
         """
+        _require_shape(shape)
         return LMSState(step_size=jnp.array(self._step_size, dtype=jnp.float32))
 
     def update_from_gradient(
@@ -558,9 +591,7 @@ class LMS(Optimizer[LMSState]):
 
         step = state.step_size * gradient
         error_is_finite = (
-            jnp.asarray(True, dtype=jnp.bool_)
-            if error is None
-            else jnp.all(jnp.isfinite(error))
+            jnp.asarray(True, dtype=jnp.bool_) if error is None else jnp.all(jnp.isfinite(error))
         )
         update_applied = (
             floating_tree_is_finite(state)
@@ -691,6 +722,7 @@ class IDBD(Optimizer[IDBDState]):
         Returns:
             IDBD state with per-weight step-sizes and traces
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return IDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -710,10 +742,9 @@ class IDBD(Optimizer[IDBDState]):
         Returns:
             IDBDParamState with arrays matching the given shape
         """
+        shape = _require_shape(shape)
         return IDBDParamState(
-            log_step_sizes=jnp.full(
-                shape, jnp.log(self._initial_step_size), dtype=jnp.float32
-            ),
+            log_step_sizes=jnp.full(shape, jnp.log(self._initial_step_size), dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
             meta_step_size=jnp.array(self._meta_step_size, dtype=jnp.float32),
         )
@@ -825,9 +856,7 @@ class IDBD(Optimizer[IDBDState]):
             meta_step_size=beta,
         )
         error_is_finite = (
-            jnp.asarray(True, dtype=jnp.bool_)
-            if error is None
-            else jnp.all(jnp.isfinite(error))
+            jnp.asarray(True, dtype=jnp.bool_) if error is None else jnp.all(jnp.isfinite(error))
         )
         unused_traces = (beta == 0.0) & (decay == 0.0)
         previous_checked = state.replace(  # type: ignore[attr-defined]
@@ -1034,6 +1063,7 @@ class Autostep(Optimizer[AutostepState]):
         Returns:
             Autostep state with per-weight step-sizes, traces, and normalizers
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return AutostepState(
             step_sizes=jnp.full(feature_dim, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -1054,6 +1084,7 @@ class Autostep(Optimizer[AutostepState]):
         Returns:
             AutostepParamState with arrays matching the given shape
         """
+        shape = _require_shape(shape)
         return AutostepParamState(
             step_sizes=jnp.full(shape, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1160,9 +1191,7 @@ class Autostep(Optimizer[AutostepState]):
             trace_candidate = decayed_traces + new_step_sizes * error_scalar * z
         else:
             trace_candidate = decayed_traces + new_step_sizes * z
-        new_traces = jnp.where(
-            jnp.isfinite(trace_candidate), trace_candidate, state.traces
-        )
+        new_traces = jnp.where(jnp.isfinite(trace_candidate), trace_candidate, state.traces)
 
         candidate_state = AutostepParamState(
             step_sizes=new_step_sizes,
@@ -1172,9 +1201,7 @@ class Autostep(Optimizer[AutostepState]):
             tau=tau,
         )
         error_is_finite = (
-            jnp.asarray(True, dtype=jnp.bool_)
-            if error is None
-            else jnp.all(jnp.isfinite(error))
+            jnp.asarray(True, dtype=jnp.bool_) if error is None else jnp.all(jnp.isfinite(error))
         )
         unused_traces = (mu == 0.0) & (trace_decay == 0.0)
         previous_checked = state.replace(  # type: ignore[attr-defined]
@@ -1267,9 +1294,7 @@ class Autostep(Optimizer[AutostepState]):
         bias_v_update = state.bias_normalizer + (1.0 / tau) * state.bias_step_size * (
             abs_bias_meta_gradient - state.bias_normalizer
         )
-        bias_normalizer_candidate = jnp.maximum(
-            abs_bias_meta_gradient, bias_v_update
-        )
+        bias_normalizer_candidate = jnp.maximum(abs_bias_meta_gradient, bias_v_update)
         valid_bias_meta_update = jnp.logical_and(
             jnp.isfinite(bias_meta_gradient),
             jnp.isfinite(bias_normalizer_candidate),
@@ -1309,18 +1334,14 @@ class Autostep(Optimizer[AutostepState]):
         # Trace update: h_i = h_i*(1 - α_i*x_i²) + α_i*δ*x_i
         trace_decay = 1.0 - new_step_sizes * x_sq
         trace_candidate = (
-            _skip_zero_scale(trace_decay, state.traces)
-            + new_step_sizes * error_scalar * x
+            _skip_zero_scale(trace_decay, state.traces) + new_step_sizes * error_scalar * x
         )
-        new_traces = jnp.where(
-            jnp.isfinite(trace_candidate), trace_candidate, state.traces
-        )
+        new_traces = jnp.where(jnp.isfinite(trace_candidate), trace_candidate, state.traces)
 
         # Bias trace: h_bias = h_bias*(1 - α_bias) + α_bias*δ
         bias_trace_decay = 1.0 - new_bias_step_size
         bias_trace_candidate = (
-            _skip_zero_scale(bias_trace_decay, state.bias_trace)
-            + new_bias_step_size * error_scalar
+            _skip_zero_scale(bias_trace_decay, state.bias_trace) + new_bias_step_size * error_scalar
         )
         new_bias_trace = jnp.where(
             jnp.isfinite(bias_trace_candidate),
@@ -1449,12 +1470,8 @@ class AutostepGTDLambda(Optimizer[AutostepGTDLambdaState]):
         observation: Array,
     ) -> OptimizerUpdate:
         """Compute one supervised-limit Autostep-for-GTD(lambda) update."""
-        eligibility = (
-            _skip_zero_scale(state.trace_decay, state.eligibility_traces) + observation
-        )
-        bias_eligibility = (
-            _skip_zero_scale(state.trace_decay, state.bias_eligibility_trace) + 1.0
-        )
+        eligibility = _skip_zero_scale(state.trace_decay, state.eligibility_traces) + observation
+        bias_eligibility = _skip_zero_scale(state.trace_decay, state.bias_eligibility_trace) + 1.0
         base_state = AutostepState(
             step_sizes=state.step_sizes,
             traces=state.traces,

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -15,6 +15,7 @@ References:
 
 import operator
 from abc import ABC, abstractmethod
+from math import prod
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -79,6 +80,17 @@ def _require_shape(shape: object) -> tuple[int, ...]:
     if type(shape) is not tuple:
         raise ValueError("shape must be an actual tuple")
     return tuple(_require_int32(f"shape[{i}]", s, minimum=1) for i, s in enumerate(shape))
+
+
+def _require_float32_state(name: str, scalar_count: int) -> None:
+    if scalar_count > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * scalar_count > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _shape_size(shape: tuple[int, ...]) -> int:
+    return prod(shape, start=1)
 
 
 # =============================================================================
@@ -723,6 +735,7 @@ class IDBD(Optimizer[IDBDState]):
             IDBD state with per-weight step-sizes and traces
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("IDBD state", 2 * feature_dim + 3)
         return IDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -743,6 +756,7 @@ class IDBD(Optimizer[IDBDState]):
             IDBDParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
+        _require_float32_state("IDBD parameter state", 2 * _shape_size(shape) + 1)
         return IDBDParamState(
             log_step_sizes=jnp.full(shape, jnp.log(self._initial_step_size), dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1064,6 +1078,7 @@ class Autostep(Optimizer[AutostepState]):
             Autostep state with per-weight step-sizes, traces, and normalizers
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("Autostep state", 3 * feature_dim + 5)
         return AutostepState(
             step_sizes=jnp.full(feature_dim, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -1085,6 +1100,7 @@ class Autostep(Optimizer[AutostepState]):
             AutostepParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
+        _require_float32_state("Autostep parameter state", 3 * _shape_size(shape) + 2)
         return AutostepParamState(
             step_sizes=jnp.full(shape, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1448,6 +1464,8 @@ class AutostepGTDLambda(Optimizer[AutostepGTDLambdaState]):
 
     def init(self, feature_dim: int) -> AutostepGTDLambdaState:
         """Initialize optimizer state."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("AutostepGTDLambda state", 4 * feature_dim + 7)
         base_state = self._base.init(feature_dim)
         return AutostepGTDLambdaState(
             step_sizes=base_state.step_sizes,
@@ -1591,6 +1609,8 @@ class ObGD(Optimizer[ObGDState]):
         Returns:
             ObGD state with eligibility traces
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("ObGD state", feature_dim + 5)
         return ObGDState(
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
             kappa=jnp.array(self._kappa, dtype=jnp.float32),
@@ -1818,6 +1838,8 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
         Returns:
             TD-IDBD state with per-weight step-sizes, traces, and h traces
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("TDIDBD state", 3 * feature_dim + 5)
         return TDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -2030,6 +2052,8 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         Returns:
             AutoTDIDBD state with per-weight step-sizes, traces, h traces, and normalizers
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 7)
         return AutoTDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -2,6 +2,7 @@
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -121,15 +122,11 @@ class TestIDBD:
         state = optimizer.init(feature_dim=2)
         observation = jnp.ones(2, dtype=jnp.float32)
 
-        poisoned = optimizer.update(
-            state, jnp.array(jnp.inf, dtype=jnp.float32), observation
-        )
+        poisoned = optimizer.update(state, jnp.array(jnp.inf, dtype=jnp.float32), observation)
         assert bool(jnp.all(jnp.isfinite(poisoned.new_state.log_step_sizes)))
         assert bool(jnp.isfinite(poisoned.new_state.bias_step_size))
         # Skipped adaptation keeps the previous (clipped) log step-sizes.
-        chex.assert_trees_all_close(
-            poisoned.new_state.log_step_sizes, state.log_step_sizes
-        )
+        chex.assert_trees_all_close(poisoned.new_state.log_step_sizes, state.log_step_sizes)
 
         recovered = optimizer.update(
             poisoned.new_state, jnp.array(1.0, dtype=jnp.float32), observation
@@ -163,13 +160,9 @@ class TestIDBD:
         state = optimizer.init(feature_dim=2)
         observation = jnp.array([1e20, 1.0], dtype=jnp.float32)
 
-        result = optimizer.update(
-            state, jnp.array(1e20, dtype=jnp.float32), observation
-        )
+        result = optimizer.update(state, jnp.array(1e20, dtype=jnp.float32), observation)
         assert bool(jnp.all(jnp.isfinite(result.new_state.log_step_sizes)))
-        chex.assert_trees_all_close(
-            result.new_state.log_step_sizes, state.log_step_sizes
-        )
+        chex.assert_trees_all_close(result.new_state.log_step_sizes, state.log_step_sizes)
 
     def test_finite_gradients_still_adapt_after_guard(self):
         """The non-finite guard must not change ordinary adaptation."""
@@ -180,11 +173,7 @@ class TestIDBD:
         first = optimizer.update(state, jnp.array(1.0), observation)
         second = optimizer.update(first.new_state, jnp.array(1.0), observation)
         # Correlated errors on the same feature raise the log step-sizes.
-        assert bool(
-            jnp.all(
-                second.new_state.log_step_sizes > state.log_step_sizes
-            )
-        )
+        assert bool(jnp.all(second.new_state.log_step_sizes > state.log_step_sizes))
 
 
 class TestAutostep:
@@ -289,9 +278,10 @@ class TestAutostep:
         result = optimizer.update(state, error, large_observation)
 
         # After M normalization: sum(alpha_i * x_i^2) + alpha_bias <= 1.0
-        effective = jnp.sum(
-            result.new_state.step_sizes * large_observation**2
-        ) + result.new_state.bias_step_size
+        effective = (
+            jnp.sum(result.new_state.step_sizes * large_observation**2)
+            + result.new_state.bias_step_size
+        )
         assert float(effective) <= 1.0 + 1e-6
 
     def test_normalizer_tracks_meta_gradient_not_primary(self):
@@ -486,9 +476,7 @@ class TestAutostepGTDLambda:
             result = optimizer.update(state, jnp.array(1.0), sample_observation)
             chex.assert_shape(result.weight_delta, sample_observation.shape)
             chex.assert_shape(result.new_state.step_sizes, sample_observation.shape)
-            chex.assert_shape(
-                result.new_state.eligibility_traces, sample_observation.shape
-            )
+            chex.assert_shape(result.new_state.eligibility_traces, sample_observation.shape)
             chex.assert_tree_all_finite(result.weight_delta)
             chex.assert_tree_all_finite(result.bias_delta)
             chex.assert_tree_all_finite(result.new_state)
@@ -563,9 +551,7 @@ class TestAutostepGTDLambda:
             chex.assert_trees_all_close(
                 res_g.weight_delta, res_a.weight_delta, atol=1e-5, rtol=1e-5
             )
-            chex.assert_trees_all_close(
-                res_g.bias_delta, res_a.bias_delta, atol=1e-5
-            )
+            chex.assert_trees_all_close(res_g.bias_delta, res_a.bias_delta, atol=1e-5)
             chex.assert_trees_all_close(
                 res_g.new_state.step_sizes,
                 res_a.new_state.step_sizes,
@@ -603,22 +589,16 @@ class TestAutostepGTDLambda:
 
     def test_eligibility_trace_accumulates_with_lambda(self):
         """With trace_decay > 0 the eligibility trace should accumulate."""
-        optimizer = AutostepGTDLambda(
-            initial_step_size=0.01, meta_step_size=0.01, trace_decay=0.5
-        )
+        optimizer = AutostepGTDLambda(initial_step_size=0.01, meta_step_size=0.01, trace_decay=0.5)
         state = optimizer.init(feature_dim=3)
         observation = jnp.array([1.0, 0.5, -0.25], dtype=jnp.float32)
 
         result1 = optimizer.update(state, jnp.array(1.0), observation)
-        chex.assert_trees_all_close(
-            result1.new_state.eligibility_traces, observation, atol=1e-6
-        )
+        chex.assert_trees_all_close(result1.new_state.eligibility_traces, observation, atol=1e-6)
 
         result2 = optimizer.update(result1.new_state, jnp.array(1.0), observation)
         expected = 0.5 * observation + observation
-        chex.assert_trees_all_close(
-            result2.new_state.eligibility_traces, expected, atol=1e-6
-        )
+        chex.assert_trees_all_close(result2.new_state.eligibility_traces, expected, atol=1e-6)
 
 
 class TestObGD:
@@ -815,9 +795,7 @@ class TestIDBDParamState:
 
         chex.assert_shape(state.log_step_sizes, (32, 10))
         chex.assert_shape(state.traces, (32, 10))
-        chex.assert_trees_all_close(
-            jnp.exp(state.log_step_sizes), jnp.full((32, 10), 0.01)
-        )
+        chex.assert_trees_all_close(jnp.exp(state.log_step_sizes), jnp.full((32, 10), 0.01))
         chex.assert_trees_all_close(state.traces, jnp.zeros((32, 10)))
         assert state.meta_step_size == pytest.approx(0.001)
 
@@ -828,9 +806,7 @@ class TestIDBDParamState:
 
         chex.assert_shape(state.log_step_sizes, (16,))
         chex.assert_shape(state.traces, (16,))
-        chex.assert_trees_all_close(
-            jnp.exp(state.log_step_sizes), jnp.full(16, 0.05)
-        )
+        chex.assert_trees_all_close(jnp.exp(state.log_step_sizes), jnp.full(16, 0.05))
 
     def test_update_from_gradient_shapes(self):
         """update_from_gradient should return correct shapes and finite values."""
@@ -859,9 +835,7 @@ class TestIDBDParamState:
         state = optimizer.init_for_shape((4, 3))
 
         gradient = jnp.full((4, 3), jnp.inf, dtype=jnp.float32)
-        step, poisoned = optimizer.update_from_gradient(
-            state, gradient, error=jnp.array(1.0)
-        )
+        step, poisoned = optimizer.update_from_gradient(state, gradient, error=jnp.array(1.0))
         del step
         assert bool(jnp.all(jnp.isfinite(poisoned.log_step_sizes)))
         chex.assert_trees_all_close(poisoned.log_step_sizes, state.log_step_sizes)
@@ -921,9 +895,7 @@ class TestIDBDParamState:
 
     def test_loss_grads_mode(self):
         """loss_grads h_decay_mode should produce finite results."""
-        optimizer = IDBD(
-            initial_step_size=0.01, meta_step_size=0.01, h_decay_mode="loss_grads"
-        )
+        optimizer = IDBD(initial_step_size=0.01, meta_step_size=0.01, h_decay_mode="loss_grads")
         state = optimizer.init_for_shape((8, 4))
 
         gradient = jnp.ones((8, 4)) * 0.1
@@ -954,9 +926,7 @@ class TestIDBDParamState:
         def single_update(s, g, e):
             return optimizer.update_from_gradient(s, g, error=e)
 
-        batched_step, batched_new_state = jax.vmap(single_update)(
-            batched_state, gradient, error
-        )
+        batched_step, batched_new_state = jax.vmap(single_update)(batched_state, gradient, error)
 
         chex.assert_shape(batched_step, (3, 8, 4))
         chex.assert_tree_all_finite(batched_step)
@@ -1036,3 +1006,37 @@ class TestSupportedForMLP:
             step, _ = optimizer.update_from_gradient(state, jnp.ones((2, 3)))
             assert optimizer.supported_for_mlp()
             assert step.shape == (2, 3)
+
+
+def test_optimizers_init_integer_and_shape_validation() -> None:
+    lms = LMS(step_size=0.01)
+    idbd = IDBD(initial_step_size=0.01)
+    autostep = Autostep(initial_step_size=0.01)
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        lms.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        idbd.init(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        autostep.init(feature_dim=0)
+
+    with pytest.raises(ValueError, match="shape"):
+        lms.init_for_shape(shape=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="shape"):
+        idbd.init_for_shape(shape=(True, 4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="shape"):
+        autostep.init_for_shape(shape=(4, 0))
+
+    s_lms = lms.init(feature_dim=np.int32(4))
+    s_idbd = idbd.init(feature_dim=np.int64(4))
+    s_auto = autostep.init(feature_dim=np.int32(4))
+    assert float(s_lms.step_size) == pytest.approx(0.01)
+    assert s_idbd.traces.shape == (4,)
+    assert s_auto.traces.shape == (4,)
+
+    s_lms_p = lms.init_for_shape(shape=(np.int32(4), np.int64(8)))
+    s_idbd_p = idbd.init_for_shape(shape=(np.int32(4), np.int64(8)))
+    s_auto_p = autostep.init_for_shape(shape=(np.int32(4), np.int64(8)))
+    assert float(s_lms_p.step_size) == pytest.approx(0.01)
+    assert s_idbd_p.traces.shape == (4, 8)
+    assert s_auto_p.traces.shape == (4, 8)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,6 +1,7 @@
 """Tests for LMS, IDBD, Autostep, and ObGD optimizers."""
 
 import chex
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -14,6 +15,9 @@ from alberta_framework import (
     ObGD,
     optimizer_from_config,
 )
+from alberta_framework.core.optimizers import TDIDBD, AutoTDIDBD
+
+_INT32_MAX = 2**31 - 1
 
 
 class TestLMS:
@@ -1040,3 +1044,80 @@ def test_optimizers_init_integer_and_shape_validation() -> None:
     assert float(s_lms_p.step_size) == pytest.approx(0.01)
     assert s_idbd_p.traces.shape == (4, 8)
     assert s_auto_p.traces.shape == (4, 8)
+
+
+@pytest.mark.parametrize(
+    ("optimizer", "array_field"),
+    [
+        (AutostepGTDLambda(), "step_sizes"),
+        (ObGD(), "traces"),
+        (TDIDBD(), "log_step_sizes"),
+        (AutoTDIDBD(), "log_step_sizes"),
+    ],
+)
+def test_all_vector_optimizer_initializers_reject_hostile_dimensions(
+    optimizer: object,
+    array_field: str,
+) -> None:
+    class HostileInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("index hook executed")
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        optimizer.init(HostileInt(4))  # type: ignore[attr-defined]
+    state = optimizer.init(np.int64(4))  # type: ignore[attr-defined]
+    assert getattr(state, array_field).shape == (4,)
+
+
+def test_optimizer_state_allocations_are_preflighted_at_exact_byte_bounds() -> None:
+    float32_scalar_limit = _INT32_MAX // 4
+    idbd_last = (float32_scalar_limit - 3) // 2
+    with pytest.raises(ValueError, match="IDBD state byte count"):
+        IDBD().init(idbd_last + 1)
+
+    autostep_last = (float32_scalar_limit - 5) // 3
+    with pytest.raises(ValueError, match="Autostep state byte count"):
+        Autostep().init(autostep_last + 1)
+
+    gtd_last = (float32_scalar_limit - 7) // 4
+    with pytest.raises(ValueError, match="AutostepGTDLambda state byte count"):
+        AutostepGTDLambda().init(gtd_last + 1)
+
+    obgd_last = float32_scalar_limit - 5
+    with pytest.raises(ValueError, match="ObGD state byte count"):
+        ObGD().init(obgd_last + 1)
+
+    td_last = (float32_scalar_limit - 5) // 3
+    with pytest.raises(ValueError, match="TDIDBD state byte count"):
+        TDIDBD().init(td_last + 1)
+
+    auto_td_last = (float32_scalar_limit - 7) // 4
+    with pytest.raises(ValueError, match="AutoTDIDBD state byte count"):
+        AutoTDIDBD().init(auto_td_last + 1)
+
+
+def test_optimizer_parameter_shape_products_are_preflighted_without_allocation() -> None:
+    with pytest.raises(ValueError, match="IDBD parameter state (scalar|byte) count"):
+        IDBD().init_for_shape((50_000, 50_000))
+    with pytest.raises(ValueError, match="Autostep parameter state (scalar|byte) count"):
+        Autostep().init_for_shape((50_000, 50_000))
+
+
+@pytest.mark.parametrize(
+    ("optimizer", "expected_scalars"),
+    [
+        (IDBD(), 2 * 4 + 3),
+        (Autostep(), 3 * 4 + 5),
+        (AutostepGTDLambda(), 4 * 4 + 7),
+        (ObGD(), 4 + 5),
+        (TDIDBD(), 3 * 4 + 5),
+        (AutoTDIDBD(), 4 * 4 + 7),
+    ],
+)
+def test_optimizer_vector_state_resource_formulas_are_exact(
+    optimizer: object,
+    expected_scalars: int,
+) -> None:
+    state = optimizer.init(4)  # type: ignore[attr-defined]
+    assert sum(int(leaf.size) for leaf in jax.tree.leaves(state)) == expected_scalars
+    assert sum(int(leaf.nbytes) for leaf in jax.tree.leaves(state)) == 4 * expected_scalars


### PR DESCRIPTION
Supersedes #834 while preserving its contributor commit and authorship.

Extends exact integer/shape validation to every vector optimizer initializer (AutostepGTDLambda, ObGD, TDIDBD, AutoTDIDBD in addition to LMS/IDBD/Autostep) and preflights exact persistent float32 scalar/byte counts plus arbitrary-shape products before JAX allocation. Includes hostile integer and exact boundary/formula regressions.

Validation:
- 156 focused optimizer/TD/nonfinite tests passed
- Ruff passed
- strict mypy passed

No benchmarks or outputs were run or modified.