### PR TITLE
fix(cumulant-discovery): complete configuration and resource contracts

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -54,14 +54,43 @@ Reference:
 from __future__ import annotations
 
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
 
 # =============================================================================
 # State
@@ -136,24 +165,15 @@ class CumulantDiscovery:
         gamma: float = 0.0,
         enabled: bool = True,
     ):
-        if raw_dim <= 0:
-            raise ValueError(f"raw_dim must be positive; got {raw_dim}")
-        if n_candidates <= 0:
-            raise ValueError(f"n_candidates must be positive; got {n_candidates}")
+        raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
+        n_candidates = _require_int32("n_candidates", n_candidates, minimum=1)
+        maturity_threshold = _require_int32("maturity_threshold", maturity_threshold, minimum=0)
         if not 0.0 < decay_rate < 1.0:
             raise ValueError(f"decay_rate must lie in (0, 1); got {decay_rate}")
         if not 0.0 <= replacement_rate <= 1.0:
-            raise ValueError(
-                f"replacement_rate must lie in [0, 1]; got {replacement_rate}"
-            )
-        if maturity_threshold < 0:
-            raise ValueError(
-                f"maturity_threshold must be non-negative; got {maturity_threshold}"
-            )
+            raise ValueError(f"replacement_rate must lie in [0, 1]; got {replacement_rate}")
         if predictor_step_size <= 0:
-            raise ValueError(
-                f"predictor_step_size must be positive; got {predictor_step_size}"
-            )
+            raise ValueError(f"predictor_step_size must be positive; got {predictor_step_size}")
 
         self._raw_dim = raw_dim
         self._n_candidates = n_candidates
@@ -181,16 +201,12 @@ class CumulantDiscovery:
         zero utility, zero ages."""
         k_proj, k_state = jr.split(key)
         # Unit-norm random projections
-        raw_proj = jr.normal(
-            k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32
-        )
+        raw_proj = jr.normal(k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32)
         norms = jnp.linalg.norm(raw_proj, axis=1, keepdims=True) + 1e-8
         projections = raw_proj / norms
         return CumulantDiscoveryState(  # type: ignore[call-arg]
             projections=projections,
-            weights=jnp.zeros(
-                (self._n_candidates, self._raw_dim), dtype=jnp.float32
-            ),
+            weights=jnp.zeros((self._n_candidates, self._raw_dim), dtype=jnp.float32),
             biases=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             utility=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             ages=jnp.zeros(self._n_candidates, dtype=jnp.int32),
@@ -265,9 +281,7 @@ class CumulantDiscovery:
         )
         # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
         # alpha * nan * obs poisons every candidate. Hold the finite state.
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
-            jnp.isfinite(next_observation)
-        )
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(next_observation))
         proposed_finite = (
             jnp.all(jnp.isfinite(proposed_weights))
             & jnp.all(jnp.isfinite(proposed_biases))
@@ -308,9 +322,7 @@ class CumulantDiscovery:
         # Among mature candidates, find the one with lowest utility
         mature = state.ages >= self._maturity_threshold
         # Disqualify immature candidates by setting their utility to +inf
-        masked_utility = jnp.where(
-            mature, state.utility, jnp.full_like(state.utility, jnp.inf)
-        )
+        masked_utility = jnp.where(mature, state.utility, jnp.full_like(state.utility, jnp.inf))
         # If no candidates are mature, this index is arbitrary
         worst_idx = jnp.argmin(masked_utility)
         any_mature = jnp.any(mature)

--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -54,14 +54,69 @@ Reference:
 from __future__ import annotations
 
 import functools
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
+_INT32_MAX = 2**31 - 1
+_MAX_PERSISTENT_STATE_BYTES = 256 * 1024 * 1024
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
+
+
+def _require_float32(
+    name: str,
+    value: object,
+    *,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+    positive: bool = False,
+) -> float:
+    try:
+        return validated_float32_scalar(
+            name,
+            value,
+            lower=lower,
+            upper=upper,
+            upper_inclusive=upper_inclusive,
+            positive=positive,
+        )
+    except Exception as error:
+        raise ValueError(f"{name} is outside its finite float32 domain") from error
+
+
+def _persistent_resources(raw_dim: int, n_candidates: int) -> dict[str, int]:
+    """Exact retained-array budget, excluding compiler and transient buffers."""
+    persistent_scalars = 2 * n_candidates * raw_dim + 3 * n_candidates + 2
+    persistent_bytes = 4 * persistent_scalars
+    if persistent_scalars > _INT32_MAX:
+        raise ValueError("derived cumulant-discovery persistent scalars must fit signed int32")
+    if persistent_bytes > _MAX_PERSISTENT_STATE_BYTES:
+        raise ValueError("derived cumulant-discovery persistent state exceeds 256 MiB")
+    return {
+        "persistent_scalars": persistent_scalars,
+        "persistent_bytes": persistent_bytes,
+    }
 
 # =============================================================================
 # State
@@ -136,24 +191,29 @@ class CumulantDiscovery:
         gamma: float = 0.0,
         enabled: bool = True,
     ):
-        if raw_dim <= 0:
-            raise ValueError(f"raw_dim must be positive; got {raw_dim}")
-        if n_candidates <= 0:
-            raise ValueError(f"n_candidates must be positive; got {n_candidates}")
-        if not 0.0 < decay_rate < 1.0:
-            raise ValueError(f"decay_rate must lie in (0, 1); got {decay_rate}")
-        if not 0.0 <= replacement_rate <= 1.0:
-            raise ValueError(
-                f"replacement_rate must lie in [0, 1]; got {replacement_rate}"
-            )
-        if maturity_threshold < 0:
-            raise ValueError(
-                f"maturity_threshold must be non-negative; got {maturity_threshold}"
-            )
-        if predictor_step_size <= 0:
-            raise ValueError(
-                f"predictor_step_size must be positive; got {predictor_step_size}"
-            )
+        raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
+        n_candidates = _require_int32("n_candidates", n_candidates, minimum=1)
+        maturity_threshold = _require_int32(
+            "maturity_threshold", maturity_threshold, minimum=0
+        )
+        _persistent_resources(raw_dim, n_candidates)
+        decay_rate = _require_float32(
+            "decay_rate",
+            decay_rate,
+            positive=True,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        replacement_rate = _require_float32(
+            "replacement_rate", replacement_rate, lower=0.0, upper=1.0
+        )
+        predictor_step_size = _require_float32(
+            "predictor_step_size", predictor_step_size, positive=True
+        )
+        gamma = _require_float32("gamma", gamma, lower=0.0, upper=1.0)
+        if type(enabled) not in (bool, np.bool_):
+            raise ValueError("enabled must be a boolean")
+        enabled = bool(enabled)
 
         self._raw_dim = raw_dim
         self._n_candidates = n_candidates
@@ -175,6 +235,11 @@ class CumulantDiscovery:
     @property
     def enabled(self) -> bool:
         return self._enabled
+
+    @property
+    def persistent_resource_budget(self) -> dict[str, int]:
+        """Exact persistent JAX-array envelope."""
+        return _persistent_resources(self._raw_dim, self._n_candidates)
 
     def init(self, key: Array) -> CumulantDiscoveryState:
         """Initialize state with random projections, zero predictors,
@@ -260,7 +325,7 @@ class CumulantDiscovery:
             weights=proposed_weights,
             biases=proposed_biases,
             utility=proposed_utility,
-            ages=state.ages + 1,
+            ages=jnp.minimum(state.ages, jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)) + 1,
             key=state.key,
         )
         # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
@@ -373,6 +438,35 @@ class CumulantDiscovery:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> CumulantDiscovery:
         """Reconstruct from dict."""
+        if type(config) is not dict:
+            raise ValueError("cumulant-discovery config must be an exact dictionary")
         config = dict(config)
-        config.pop("type", None)
+        expected = {
+            "type",
+            "raw_dim",
+            "n_candidates",
+            "decay_rate",
+            "replacement_rate",
+            "maturity_threshold",
+            "predictor_step_size",
+            "gamma",
+            "enabled",
+        }
+        if set(config) != expected:
+            raise ValueError("cumulant-discovery config keys are not the exact schema")
+        if config.pop("type") != "CumulantDiscovery":
+            raise ValueError("cumulant-discovery config type is unsupported")
+        for name in ("raw_dim", "n_candidates", "maturity_threshold"):
+            if type(config[name]) is not int:
+                raise ValueError(f"serialized {name} must be an exact JSON integer")
+        for name in (
+            "decay_rate",
+            "replacement_rate",
+            "predictor_step_size",
+            "gamma",
+        ):
+            if type(config[name]) is not float:
+                raise ValueError(f"serialized {name} must be an exact JSON float")
+        if type(config["enabled"]) is not bool:
+            raise ValueError("serialized enabled must be an exact JSON boolean")
         return cls(**config)

--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -54,43 +54,14 @@ Reference:
 from __future__ import annotations
 
 import functools
-import operator
-from typing import Any, SupportsIndex, cast
+from typing import Any, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
-
-_INT32_MAX = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
-
-
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
-    return canonical
-
 
 # =============================================================================
 # State
@@ -165,15 +136,24 @@ class CumulantDiscovery:
         gamma: float = 0.0,
         enabled: bool = True,
     ):
-        raw_dim = _require_int32("raw_dim", raw_dim, minimum=1)
-        n_candidates = _require_int32("n_candidates", n_candidates, minimum=1)
-        maturity_threshold = _require_int32("maturity_threshold", maturity_threshold, minimum=0)
+        if raw_dim <= 0:
+            raise ValueError(f"raw_dim must be positive; got {raw_dim}")
+        if n_candidates <= 0:
+            raise ValueError(f"n_candidates must be positive; got {n_candidates}")
         if not 0.0 < decay_rate < 1.0:
             raise ValueError(f"decay_rate must lie in (0, 1); got {decay_rate}")
         if not 0.0 <= replacement_rate <= 1.0:
-            raise ValueError(f"replacement_rate must lie in [0, 1]; got {replacement_rate}")
+            raise ValueError(
+                f"replacement_rate must lie in [0, 1]; got {replacement_rate}"
+            )
+        if maturity_threshold < 0:
+            raise ValueError(
+                f"maturity_threshold must be non-negative; got {maturity_threshold}"
+            )
         if predictor_step_size <= 0:
-            raise ValueError(f"predictor_step_size must be positive; got {predictor_step_size}")
+            raise ValueError(
+                f"predictor_step_size must be positive; got {predictor_step_size}"
+            )
 
         self._raw_dim = raw_dim
         self._n_candidates = n_candidates
@@ -201,12 +181,16 @@ class CumulantDiscovery:
         zero utility, zero ages."""
         k_proj, k_state = jr.split(key)
         # Unit-norm random projections
-        raw_proj = jr.normal(k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32)
+        raw_proj = jr.normal(
+            k_proj, (self._n_candidates, self._raw_dim), dtype=jnp.float32
+        )
         norms = jnp.linalg.norm(raw_proj, axis=1, keepdims=True) + 1e-8
         projections = raw_proj / norms
         return CumulantDiscoveryState(  # type: ignore[call-arg]
             projections=projections,
-            weights=jnp.zeros((self._n_candidates, self._raw_dim), dtype=jnp.float32),
+            weights=jnp.zeros(
+                (self._n_candidates, self._raw_dim), dtype=jnp.float32
+            ),
             biases=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             utility=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             ages=jnp.zeros(self._n_candidates, dtype=jnp.int32),
@@ -281,7 +265,9 @@ class CumulantDiscovery:
         )
         # Inf next obs makes 0 @ inf = NaN in V(s') at zero init, then
         # alpha * nan * obs poisons every candidate. Hold the finite state.
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(next_observation))
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
+            jnp.isfinite(next_observation)
+        )
         proposed_finite = (
             jnp.all(jnp.isfinite(proposed_weights))
             & jnp.all(jnp.isfinite(proposed_biases))
@@ -322,7 +308,9 @@ class CumulantDiscovery:
         # Among mature candidates, find the one with lowest utility
         mature = state.ages >= self._maturity_threshold
         # Disqualify immature candidates by setting their utility to +inf
-        masked_utility = jnp.where(mature, state.utility, jnp.full_like(state.utility, jnp.inf))
+        masked_utility = jnp.where(
+            mature, state.utility, jnp.full_like(state.utility, jnp.inf)
+        )
         # If no candidates are mature, this index is arbitrary
         worst_idx = jnp.argmin(masked_utility)
         any_mature = jnp.any(mature)

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -100,9 +100,7 @@ class TestStep:
             predictor_step_size=0.1,
             gamma=0.0,
         )
-        s0 = d.init(jr.key(0)).replace(
-            projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32)
-        )
+        s0 = d.init(jr.key(0)).replace(projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32))
         # If the current observation were used as the cumulant this would
         # produce non-zero utility. GVF/nexting convention uses c_{t+1}.
         s1 = d.step(s0, jnp.array([2.0, 0.0]), jnp.array([0.0, 0.0]))
@@ -132,9 +130,7 @@ class TestStep:
         chex.assert_trees_all_close(recovered.ages, state.ages + 1)
 
     def test_predictor_reduces_td_error(self) -> None:
-        d = CumulantDiscovery(
-            raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0
-        )
+        d = CumulantDiscovery(raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0)
         s0 = d.init(jr.key(2))
         # Repeatedly present the same observation: predictor should
         # learn to predict the cumulant exactly, so the TD error / utility
@@ -293,3 +289,29 @@ class TestConfig:
         assert restored.raw_dim == 8
         assert restored.n_candidates == 12
         assert restored.enabled is True
+
+
+def test_cumulant_discovery_integer_validation() -> None:
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=True, n_candidates=8)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=4.5, n_candidates=8)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="raw_dim"):
+        CumulantDiscovery(raw_dim=0, n_candidates=8)
+
+    with pytest.raises(ValueError, match="n_candidates"):
+        CumulantDiscovery(raw_dim=4, n_candidates=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="maturity_threshold"):
+        CumulantDiscovery(raw_dim=4, n_candidates=8, maturity_threshold=True)  # type: ignore[arg-type]
+
+    discovery = CumulantDiscovery(
+        raw_dim=np.int32(4),
+        n_candidates=np.int64(8),
+        maturity_threshold=np.int32(50),
+    )
+    assert discovery._raw_dim == 4
+    assert discovery._n_candidates == 8
+    assert discovery._maturity_threshold == 50
+    assert type(discovery._raw_dim) is int
+    assert type(discovery._n_candidates) is int
+    assert type(discovery._maturity_threshold) is int

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -100,7 +100,9 @@ class TestStep:
             predictor_step_size=0.1,
             gamma=0.0,
         )
-        s0 = d.init(jr.key(0)).replace(projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32))
+        s0 = d.init(jr.key(0)).replace(
+            projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32)
+        )
         # If the current observation were used as the cumulant this would
         # produce non-zero utility. GVF/nexting convention uses c_{t+1}.
         s1 = d.step(s0, jnp.array([2.0, 0.0]), jnp.array([0.0, 0.0]))
@@ -130,7 +132,9 @@ class TestStep:
         chex.assert_trees_all_close(recovered.ages, state.ages + 1)
 
     def test_predictor_reduces_td_error(self) -> None:
-        d = CumulantDiscovery(raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0)
+        d = CumulantDiscovery(
+            raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0
+        )
         s0 = d.init(jr.key(2))
         # Repeatedly present the same observation: predictor should
         # learn to predict the cumulant exactly, so the TD error / utility
@@ -289,29 +293,3 @@ class TestConfig:
         assert restored.raw_dim == 8
         assert restored.n_candidates == 12
         assert restored.enabled is True
-
-
-def test_cumulant_discovery_integer_validation() -> None:
-    with pytest.raises(ValueError, match="raw_dim"):
-        CumulantDiscovery(raw_dim=True, n_candidates=8)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="raw_dim"):
-        CumulantDiscovery(raw_dim=4.5, n_candidates=8)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="raw_dim"):
-        CumulantDiscovery(raw_dim=0, n_candidates=8)
-
-    with pytest.raises(ValueError, match="n_candidates"):
-        CumulantDiscovery(raw_dim=4, n_candidates=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="maturity_threshold"):
-        CumulantDiscovery(raw_dim=4, n_candidates=8, maturity_threshold=True)  # type: ignore[arg-type]
-
-    discovery = CumulantDiscovery(
-        raw_dim=np.int32(4),
-        n_candidates=np.int64(8),
-        maturity_threshold=np.int32(50),
-    )
-    assert discovery._raw_dim == 4
-    assert discovery._n_candidates == 8
-    assert discovery._maturity_threshold == 50
-    assert type(discovery._raw_dim) is int
-    assert type(discovery._n_candidates) is int
-    assert type(discovery._maturity_threshold) is int

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -293,3 +293,121 @@ class TestConfig:
         assert restored.raw_dim == 8
         assert restored.n_candidates == 12
         assert restored.enabled is True
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.longlong,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.ulonglong,
+    ],
+)
+def test_cumulant_discovery_canonicalizes_numpy_integer_family(integer_type) -> None:
+    discovery = CumulantDiscovery(
+        raw_dim=integer_type(4),
+        n_candidates=integer_type(3),
+        maturity_threshold=integer_type(2),
+    )
+
+    assert type(discovery.raw_dim) is int
+    assert type(discovery.n_candidates) is int
+    assert type(discovery._maturity_threshold) is int
+
+
+@pytest.mark.parametrize("field", ["raw_dim", "n_candidates", "maturity_threshold"])
+def test_cumulant_discovery_rejects_hostile_integer_subclasses(field: str) -> None:
+    class HostileInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("untrusted index hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    kwargs = {"raw_dim": 4, "n_candidates": 3, field: HostileInt(2)}
+    with pytest.raises(ValueError, match=field):
+        CumulantDiscovery(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "field", ["decay_rate", "replacement_rate", "predictor_step_size", "gamma"]
+)
+def test_cumulant_discovery_float_hook_runs_once(field: str) -> None:
+    class CountingFloat(float):
+        def __new__(cls):
+            instance = super().__new__(cls, 0.5)
+            instance.calls = 0
+            return instance
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            self.calls += 1
+            return (1, 2)
+
+    value = CountingFloat()
+    discovery = CumulantDiscovery(raw_dim=4, **{field: value})
+
+    assert value.calls == 1
+    assert type(getattr(discovery, f"_{field}")) is float
+
+
+def test_cumulant_discovery_hostile_float_failure_never_formats_repr() -> None:
+    class ExplodingFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("hostile ratio")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match="decay_rate"):
+        CumulantDiscovery(raw_dim=4, decay_rate=ExplodingFloat(0.5))
+
+
+def test_cumulant_discovery_resource_formula_matches_state() -> None:
+    discovery = CumulantDiscovery(raw_dim=5, n_candidates=3)
+    state = discovery.init(jr.key(0))
+    actual_bytes = sum(int(leaf.nbytes) for leaf in jax.tree_util.tree_leaves(state))
+
+    assert discovery.persistent_resource_budget["persistent_bytes"] == actual_bytes
+
+
+def test_cumulant_discovery_resource_boundary_is_allocation_free() -> None:
+    last_valid_dim = ((256 * 1024 * 1024 // 4) - 5) // 2
+    discovery = CumulantDiscovery(raw_dim=last_valid_dim, n_candidates=1)
+    assert discovery.persistent_resource_budget["persistent_bytes"] <= 256 * 1024 * 1024
+    with pytest.raises(ValueError, match="256 MiB"):
+        CumulantDiscovery(raw_dim=last_valid_dim + 1, n_candidates=1)
+
+
+def test_cumulant_discovery_config_schema_is_exact_json() -> None:
+    config = CumulantDiscovery(raw_dim=4).to_config()
+    config["raw_dim"] = np.int32(4)
+    with pytest.raises(ValueError, match="exact JSON integer"):
+        CumulantDiscovery.from_config(config)
+
+    config = CumulantDiscovery(raw_dim=4).to_config()
+    config["unknown"] = 1
+    with pytest.raises(ValueError, match="exact schema"):
+        CumulantDiscovery.from_config(config)
+
+    class ConfigSubclass(dict):
+        pass
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        CumulantDiscovery.from_config(ConfigSubclass())
+
+
+def test_cumulant_discovery_age_saturates_at_int32_max() -> None:
+    discovery = CumulantDiscovery(raw_dim=2, n_candidates=1)
+    state = discovery.init(jr.key(0)).replace(
+        ages=jnp.asarray([2**31 - 1], dtype=jnp.int32)
+    )
+    advanced = discovery.step(state, jnp.ones(2), jnp.ones(2))
+
+    assert int(advanced.ages[0]) == 2**31 - 1


### PR DESCRIPTION
Contributor-preserving replacement for #847.

Retains its full concrete NumPy integer canonicalization and adds exact one-call float32 scalar domains, strict boolean and JSON config schemas, hostile-hook/repr safety, a measured exact persistent-state formula with a 256 MiB allocation-free preflight, and saturating int32 ages. The retained formula is `4 * (2*n_candidates*raw_dim + 3*n_candidates + 2)` bytes and explicitly excludes compiler/transient buffers.

Verification: 41 focused tests, scoped Ruff, strict mypy, diff-check. No benchmark or output modification.