### PR TITLE
fix(option-duration): validate host dimensions

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import operator
 import time
 from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -44,6 +45,31 @@ REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
+    """Validate one actual host integer in the signed-int32 domain."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
 
 
 def _require_float32_real(
@@ -227,9 +253,7 @@ class OptionValueDurationLearner:
         config: OptionValueDurationConfig | None = None,
     ):
         """Create a fixed-capacity option predictor."""
-        if n_options < 1:
-            raise ValueError("n_options must be positive")
-        self._n_options = n_options
+        self._n_options = _require_int32("n_options", n_options)
         self._config = config or OptionValueDurationConfig()
 
     @property
@@ -256,23 +280,21 @@ class OptionValueDurationLearner:
         payload = dict(config)
         payload.pop("type", None)
         return cls(
-            n_options=int(payload["n_options"]),
+            n_options=payload["n_options"],
             config=OptionValueDurationConfig.from_config(payload["config"]),
         )
 
     def trainable_parameter_count(self, feature_dim: int) -> int:
         """Return the exact history-independent trainable parameter count."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        return self._n_options * N_HEADS * feature_dim
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
+        return self._n_options * N_HEADS * validated_feature_dim
 
     def init(self, feature_dim: int) -> OptionValueDurationState:
         """Initialize all heads to zero."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
         return OptionValueDurationState(
             weights=jnp.zeros(
-                (self._n_options, N_HEADS, feature_dim),
+                (self._n_options, N_HEADS, validated_feature_dim),
                 dtype=jnp.float32,
             ),
             option_update_counts=jnp.zeros((self._n_options,), dtype=jnp.int32),

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -57,6 +57,38 @@ def test_config_roundtrip_validation_and_fixed_parameter_count() -> None:
 
 
 @pytest.mark.parametrize(
+    "invalid",
+    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1, 2_147_483_648),
+)
+def test_learner_rejects_noncanonical_option_counts(invalid: object) -> None:
+    with pytest.raises(ValueError, match="n_options"):
+        OptionValueDurationLearner(invalid)  # type: ignore[arg-type]
+
+    payload = OptionValueDurationLearner(2).to_config()
+    payload["n_options"] = invalid
+    with pytest.raises(ValueError, match="n_options"):
+        OptionValueDurationLearner.from_config(payload)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1),
+)
+def test_learner_rejects_noncanonical_feature_dimensions(invalid: object) -> None:
+    learner = OptionValueDurationLearner(2)
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.trainable_parameter_count(invalid)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(invalid)  # type: ignore[arg-type]
+
+
+def test_learner_rejects_feature_dimensions_above_int32() -> None:
+    learner = OptionValueDurationLearner(2)
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.trainable_parameter_count(2_147_483_648)
+
+
+@pytest.mark.parametrize(
     "field",
     ("reward_step_size", "duration_step_size", "duration_floor"),
 )


### PR DESCRIPTION
Closes #858.

## What changed

`OptionValueDurationLearner` now applies the repository's strict host-integer contract to `n_options` and `feature_dim`:

- accepts only actual built-in or NumPy integer scalar types;
- rejects booleans, floats, numeric strings, `None`, and other coercible non-integers;
- canonicalizes accepted values through `operator.index`;
- bounds both dimensions to the positive signed-int32 domain `[1, 2147483647]`;
- passes raw `from_config()` payloads through the constructor instead of truncating them with `int(...)`;
- uses the validated canonical feature dimension for parameter counts and JAX array shapes.

Focused table-driven regressions cover direct construction, deserialization, parameter counting, initialization, and the int32 upper bound.

## Reproduction

Before the production change, the focused tests-first run produced **14 failures / 44 passes**. It demonstrated that booleans and floats were accepted as dimensions, oversized values were unbounded, serialized values were silently coerced, and malformed values escaped as incidental type errors.

## Verification

Base: `82ff5aff0402922937396836d976e86034d6037d`  
Exact head: `9bfa12c18092b871daec2ce83a931a11a70f86d0`

- tests-first focused suite: **14 failed / 44 passed**;
- focused suite after repair and after final rebase: **58 passed**;
- focused Ruff: **all checks passed**;
- full strict mypy: **no issues in 168 source files**;
- `git diff --check`: clean;
- exact-head factory proof: recorded green for `9bfa12c18`.

The repository fast lane currently stops during collection on an unrelated current-base contract mismatch: `tests/test_step12_production.py` constructs `SubtaskSpec(threshold=1.0e-50)`, while `options.py` now correctly rejects values that underflow to zero at the float32 sink. Neither file is touched here.

## Ownership and scientific integrity

A complete live scan immediately before publication covered all **11 open ASI PRs / 23 changed-file rows** and **2 open issues**, with zero overlap or matching claim on `alberta_framework/core/option_value_duration.py`, `tests/test_option_value_duration.py`, or this host-dimension boundary.

No `outputs/**` file, frozen protocol, benchmark threshold, seed, scientific claim, or registered evidence source changed. This patch is limited to one production file and one focused test file.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no shareable model trajectory artifact was generated; verification commands and exact-head proof are listed above

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Claude Code CLI Proxy
- Attribution status: self-reported

— [sol-option-duration-host-dimensions]
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code CLI Proxy","attribution":"self-reported"} -->
