### PR TITLE
fix(feature-discovery): close sink and schema residuals

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -88,7 +88,7 @@ def _saturating_int32_increment(value: Array) -> Array:
 def validated_float32_scalar(name: str, value: object, **domain: Any) -> float:
     """Validate a float32 sink and reject exact nonzero values that collapse to zero."""
     stored, numerator, _ = validated_float32_scalar_with_ratio(name, value, **domain)
-    if numerator != 0 and stored == 0.0:
+    if numerator != 0 and float(np.float32(stored)) == 0.0:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 
@@ -337,11 +337,11 @@ class FixedBudgetFeatureLearner:
         step_size_feature = validated_float32_scalar(
             "step_size_feature", step_size_feature, lower=0.0
         )
-        utility_decay_config = utility_decay
         utility_decay = canonical_float32_ema_decay(
             "utility_decay",
             utility_decay,
         )
+        utility_decay_config = utility_decay
         promotion_margin = validated_float32_scalar(
             "promotion_margin", promotion_margin, positive=True
         )
@@ -404,7 +404,6 @@ class FixedBudgetFeatureLearner:
         future_utility_rare_task_power = validated_float32_scalar(
             "future_utility_rare_task_power", future_utility_rare_task_power, lower=0.0
         )
-        utility_retention_decay_config = utility_retention_decay
         if utility_retention_decay is not None:
             utility_retention_decay = canonical_float32_ema_decay(
                 "utility_retention_decay",
@@ -412,6 +411,7 @@ class FixedBudgetFeatureLearner:
             )
             if utility_retention_decay < utility_decay:
                 raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
+        utility_retention_decay_config = utility_retention_decay
 
         if type(generator_mix) is not tuple or len(generator_mix) != 3:
             raise ValueError("generator_mix must have three entries")
@@ -596,7 +596,11 @@ class FixedBudgetFeatureLearner:
             raise ValueError("config must be a readable mapping") from error
         if any(type(key) is not str for key in config):
             raise ValueError("config keys must be strings")
-        config.pop("type", None)
+        marker = config.pop("type", None)
+        if marker is not None and (
+            type(marker) is not str or marker != "FixedBudgetFeatureLearner"
+        ):
+            raise ValueError("config type is unsupported")
         # replace_fraction was serialized by older versions but never read by
         # the update path; drop it so old configs keep loading.
         config.pop("replace_fraction", None)

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -3330,6 +3330,8 @@ def test_fixed_budget_float32_sink_rejects_exact_nonzero_underflow() -> None:
     tiny = np.nextafter(np.longdouble(0), np.longdouble(1))
     with pytest.raises(ValueError, match="step_size_output must remain nonzero"):
         FixedBudgetFeatureLearner(n_features=2, n_tasks=1, step_size_output=tiny)
+    with pytest.raises(ValueError, match="step_size_output must remain nonzero"):
+        FixedBudgetFeatureLearner(n_features=2, n_tasks=1, step_size_output=1.0e-50)
     learner = FixedBudgetFeatureLearner(n_features=2, n_tasks=1, step_size_output=-0.0)
     assert learner.to_config()["step_size_output"] == 0.0
 
@@ -3343,6 +3345,23 @@ def test_fixed_budget_from_config_preserves_historical_forms_and_round_trip() ->
     malformed["n_features"] = np.int64(3)
     compatible = FixedBudgetFeatureLearner.from_config(malformed)
     assert compatible.n_features == 3
+
+    wrong_marker = learner.to_config()
+    wrong_marker["type"] = "AnotherLearner"
+    with pytest.raises(ValueError, match="type is unsupported"):
+        FixedBudgetFeatureLearner.from_config(wrong_marker)
+
+
+def test_fixed_budget_to_config_canonicalizes_numpy_decay_scalars() -> None:
+    learner = FixedBudgetFeatureLearner(
+        n_features=2,
+        n_tasks=1,
+        utility_decay=np.float64(0.9),
+        utility_retention_decay=np.float64(0.95),
+    )
+
+    assert type(learner.to_config()["utility_decay"]) is float
+    assert type(learner.to_config()["utility_retention_decay"]) is float
 
 
 def test_fixed_budget_init_preflights_aggregate_allocation(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Narrow post-merge audit correction for #855.

- checks the actual float32 narrowing for exact-nonzero underflow, including built-in `float` values preserved by the shared validator
- canonicalizes utility decay and retention decay in serialized configs
- rejects an incorrect serialized learner type marker while retaining missing-marker historical compatibility

Verification: focused regression tests, scoped Ruff, strict mypy, diff-check. No benchmark or output modification.