### PR TITLE
fix(resource-manager): complete exact resource-manager contracts

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -116,18 +116,31 @@ def _read_mapping(name: str, value: object) -> dict[str, Any]:
 
 
 def _require_manager_state_budget(name: str, n_contexts: int, n_choices: int) -> None:
-    """Preflight the three float32 matrices plus the int32 step counter."""
+    """Preflight persistent state and conservative update/select working sets."""
     state_scalars = 3 * n_contexts * n_choices + 1
-    state_bytes = 4 * state_scalars
-    if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
+    update_scalars = 3 * state_scalars + 40 * n_choices + 32
+    if (
+        state_scalars > _INT32_MAX
+        or 4 * state_scalars > _INT32_MAX
+        or update_scalars > _INT32_MAX
+        or 4 * update_scalars > _INT32_MAX
+    ):
         raise ValueError(f"{name} state exceeds the signed-int32 scalar/byte budget")
 
 
+def _require_array_metadata(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> None:
+    try:
+        actual_shape = tuple(value.shape)  # type: ignore[attr-defined]
+        actual_dtype = jnp.dtype(value.dtype)  # type: ignore[attr-defined]
+    except Exception as error:
+        raise ValueError(f"{name} must expose array shape and dtype metadata") from error
+    if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
+        raise ValueError(f"{name} has an invalid shape or dtype")
+
+
 def _require_vector(name: str, value: object, length: int, *, dtype: Any) -> Array:
-    array = jnp.asarray(value, dtype=dtype)
-    if array.shape != (length,):
-        raise ValueError(f"{name} must have shape ({length},)")
-    return array
+    _require_array_metadata(name, value, (length,), dtype)
+    return cast(Array, value)
 
 
 def _skip_zero_scale(scale: float, value: Array) -> Array:
@@ -402,7 +415,12 @@ class LearnedResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
         config = _read_mapping("config", config)
         config.pop("type", None)
-        return cls(**config)
+        try:
+            return cls(**config)
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized LearnedResourceManager is invalid") from error
 
     def init(self) -> LearnedResourceManagerState:
         """Create an initial uniform-allocation state."""
@@ -420,12 +438,9 @@ class LearnedResourceManager:
         shape = (self._n_contexts, self._n_actions)
         for name in ("log_weights", "loss_ema", "action_counts"):
             leaf = getattr(state, name)
-            if leaf.shape != shape or leaf.dtype != jnp.float32:
-                raise ValueError(f"state.{name} must have shape {shape} and dtype float32")
-        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
-            raise ValueError("state.step_count must be a scalar int32")
+            _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
+        _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def weights(
         self,
         state: LearnedResourceManagerState,
@@ -433,6 +448,14 @@ class LearnedResourceManager:
     ) -> Float[Array, " n_actions"]:
         """Return the current allocation for ``context_id``."""
         self._require_state_contract(state)
+        return cast(Array, self._weights_jit(state, context_id))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _weights_jit(
+        self,
+        state: LearnedResourceManagerState,
+        context_id: Array | int = 0,
+    ) -> Float[Array, " n_actions"]:
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -449,7 +472,6 @@ class LearnedResourceManager:
             jnp.full_like(weights, jnp.nan),
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
         state: LearnedResourceManagerState,
@@ -469,6 +491,24 @@ class LearnedResourceManager:
             :class:`LearnedResourceManagerUpdateResult`.
         """
         self._require_state_contract(state)
+        _require_vector("losses", losses, self._n_actions, dtype=jnp.float32)
+        if resource_costs is not None:
+            _require_vector(
+                "resource_costs", resource_costs, self._n_actions, dtype=jnp.float32
+            )
+        return cast(
+            LearnedResourceManagerUpdateResult,
+            self._update_jit(state, losses, context_id, resource_costs),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _update_jit(
+        self,
+        state: LearnedResourceManagerState,
+        losses: Float[Array, " n_actions"],
+        context_id: Array | int = 0,
+        resource_costs: Float[Array, " n_actions"] | None = None,
+    ) -> LearnedResourceManagerUpdateResult:
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -487,7 +527,7 @@ class LearnedResourceManager:
         valid_actions = finite_losses & costs_valid
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
-        weights = self.weights(state, context)
+        weights = self._weights_jit(state, context)
         finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
         masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
         baseline = jnp.sum(masked_weights * adjusted)
@@ -805,28 +845,33 @@ class GeneratorMetaResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
         config = _read_mapping("config", config)
         config.pop("type", None)
-        initial_preferences = config.pop("initial_preferences", None)
-        return cls(
-            policy_names=_decode_sequence("policy_names", config.pop("policy_names")),
-            op_ids=_decode_sequence("op_ids", config.pop("op_ids")),
-            parent_modes=_decode_sequence("parent_modes", config.pop("parent_modes")),
-            replacement_multipliers=_decode_sequence(
-                "replacement_multipliers", config.pop("replacement_multipliers")
-            ),
-            promotion_margin_multipliers=_decode_sequence(
-                "promotion_margin_multipliers", config.pop("promotion_margin_multipliers")
-            ),
-            candidate_min_age_multipliers=_decode_sequence(
-                "candidate_min_age_multipliers", config.pop("candidate_min_age_multipliers")
-            ),
-            imprint_scales=_decode_sequence("imprint_scales", config.pop("imprint_scales")),
-            initial_preferences=(
-                None
-                if initial_preferences is None
-                else _decode_sequence("initial_preferences", initial_preferences)
-            ),
-            **config,
-        )
+        try:
+            initial_preferences = config.pop("initial_preferences", None)
+            return cls(
+                policy_names=_decode_sequence("policy_names", config.pop("policy_names")),
+                op_ids=_decode_sequence("op_ids", config.pop("op_ids")),
+                parent_modes=_decode_sequence("parent_modes", config.pop("parent_modes")),
+                replacement_multipliers=_decode_sequence(
+                    "replacement_multipliers", config.pop("replacement_multipliers")
+                ),
+                promotion_margin_multipliers=_decode_sequence(
+                    "promotion_margin_multipliers", config.pop("promotion_margin_multipliers")
+                ),
+                candidate_min_age_multipliers=_decode_sequence(
+                    "candidate_min_age_multipliers", config.pop("candidate_min_age_multipliers")
+                ),
+                imprint_scales=_decode_sequence("imprint_scales", config.pop("imprint_scales")),
+                initial_preferences=(
+                    None
+                    if initial_preferences is None
+                    else _decode_sequence("initial_preferences", initial_preferences)
+                ),
+                **config,
+            )
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized GeneratorMetaResourceManager is invalid") from error
 
     def init(self) -> GeneratorMetaResourceManagerState:
         """Create an initial uniform-allocation state."""
@@ -849,12 +894,9 @@ class GeneratorMetaResourceManager:
         shape = (self._n_contexts, self.n_policies)
         for name in ("log_weights", "reward_ema", "action_counts"):
             leaf = getattr(state, name)
-            if leaf.shape != shape or leaf.dtype != jnp.float32:
-                raise ValueError(f"state.{name} must have shape {shape} and dtype float32")
-        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
-            raise ValueError("state.step_count must be a scalar int32")
+            _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
+        _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def weights(
         self,
         state: GeneratorMetaResourceManagerState,
@@ -862,6 +904,14 @@ class GeneratorMetaResourceManager:
     ) -> Float[Array, " n_policies"]:
         """Return the current policy allocation for ``context_id``."""
         self._require_state_contract(state)
+        return cast(Array, self._weights_jit(state, context_id))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _weights_jit(
+        self,
+        state: GeneratorMetaResourceManagerState,
+        context_id: Array | int = 0,
+    ) -> Float[Array, " n_policies"]:
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -878,7 +928,6 @@ class GeneratorMetaResourceManager:
             jnp.full_like(weights, jnp.nan),
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def select(
         self,
         state: GeneratorMetaResourceManagerState,
@@ -887,11 +936,20 @@ class GeneratorMetaResourceManager:
     ) -> GeneratorMetaResourceDecision:
         """Sample one policy and return the generator knobs it controls."""
         self._require_state_contract(state)
+        return cast(GeneratorMetaResourceDecision, self._select_jit(state, key, context_id))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _select_jit(
+        self,
+        state: GeneratorMetaResourceManagerState,
+        key: Array,
+        context_id: Array | int = 0,
+    ) -> GeneratorMetaResourceDecision:
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
         )
-        weights = self.weights(state, context)
+        weights = self._weights_jit(state, context)
         selection_valid = (
             context_valid & floating_tree_is_finite(state) & jnp.all(jnp.isfinite(weights))
         )
@@ -940,7 +998,6 @@ class GeneratorMetaResourceManager:
             valid=selection_valid,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
         state: GeneratorMetaResourceManagerState,
@@ -960,6 +1017,37 @@ class GeneratorMetaResourceManager:
         sparse and the experiment wants explicit exploration credit.
         """
         self._require_state_contract(state)
+        _require_vector("rewards", rewards, self.n_policies, dtype=jnp.float32)
+        if finite_mask is not None:
+            _require_vector("finite_mask", finite_mask, self.n_policies, dtype=jnp.bool_)
+        if resource_costs is not None:
+            _require_vector(
+                "resource_costs", resource_costs, self.n_policies, dtype=jnp.float32
+            )
+        return cast(
+            GeneratorMetaResourceUpdateResult,
+            self._update_jit(
+                state,
+                rewards,
+                context_id,
+                finite_mask,
+                resource_costs,
+                selected_action,
+                selected_probability,
+            ),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _update_jit(
+        self,
+        state: GeneratorMetaResourceManagerState,
+        rewards: Float[Array, " n_policies"],
+        context_id: Array | int = 0,
+        finite_mask: Array | None = None,
+        resource_costs: Float[Array, " n_policies"] | None = None,
+        selected_action: Array | int | None = None,
+        selected_probability: Array | float | None = None,
+    ) -> GeneratorMetaResourceUpdateResult:
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -982,7 +1070,7 @@ class GeneratorMetaResourceManager:
         finite = finite & costs_valid
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
-        weights = self.weights(state, context)
+        weights = self._weights_jit(state, context)
         finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
         masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
         baseline = jnp.sum(masked_weights * adjusted)

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import functools
 import math
 import operator
-import struct
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -41,6 +41,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     neutralize_array,
@@ -50,19 +51,10 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -73,6 +65,69 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _validated_float32(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+    preserve_nonzero: bool = False,
+) -> float:
+    """Validate one trusted concrete scalar in both host and float32 domains."""
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        positive=positive,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
+    narrowed = float(np.float32(numerator / denominator))
+    if preserve_nonzero and numerator != 0 and narrowed == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
+
+
+def _require_exact_tuple(name: str, value: object) -> tuple[Any, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be an exact tuple")
+    return value
+
+
+def _decode_sequence(name: str, value: object) -> tuple[Any, ...]:
+    if type(value) not in {list, tuple}:
+        raise ValueError(f"{name} must be an exact list or tuple")
+    return tuple(cast(list[Any] | tuple[Any, ...], value))
+
+
+def _read_mapping(name: str, value: object) -> dict[str, Any]:
+    if not issubclass(type(value), Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], value))
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+
+
+def _require_manager_state_budget(name: str, n_contexts: int, n_choices: int) -> None:
+    """Preflight the three float32 matrices plus the int32 step counter."""
+    state_scalars = 3 * n_contexts * n_choices + 1
+    state_bytes = 4 * state_scalars
+    if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
+        raise ValueError(f"{name} state exceeds the signed-int32 scalar/byte budget")
+
+
+def _require_vector(name: str, value: object, length: int, *, dtype: Any) -> Array:
+    array = jnp.asarray(value, dtype=dtype)
+    if array.shape != (length,):
+        raise ValueError(f"{name} must have shape ({length},)")
+    return array
 
 
 def _skip_zero_scale(scale: float, value: Array) -> Array:
@@ -104,16 +159,7 @@ def _mask_unused_history(
 
 def _validated_cost_weight(value: float) -> float:
     """Return a non-negative weight that stays finite and nonzero in float32."""
-    numeric = float(value)
-    if not math.isfinite(numeric) or numeric < 0.0:
-        raise ValueError("cost_weight must be finite and non-negative")
-    try:
-        float32_value = struct.unpack("!f", struct.pack("!f", numeric))[0]
-    except OverflowError as error:
-        raise ValueError("cost_weight must be float32-representable") from error
-    if not math.isfinite(float32_value) or (numeric > 0.0 and float32_value <= 0.0):
-        raise ValueError("cost_weight must be float32-representable")
-    return numeric
+    return _validated_float32("cost_weight", value, lower=0.0, preserve_nonzero=True)
 
 
 def _weighted_cost_terms(costs: Array, cost_weight: float) -> tuple[Array, Array]:
@@ -272,26 +318,40 @@ class LearnedResourceManager:
         """
         n_actions = _require_int32("n_actions", n_actions, minimum=1)
         n_contexts = _require_int32("n_contexts", n_contexts, minimum=1)
-        if learning_rate < 0.0:
-            raise ValueError("learning_rate must be non-negative")
-        if not 0.0 <= discount <= 1.0:
-            raise ValueError("discount must be in [0, 1]")
-        if not 0.0 <= exploration < 1.0:
-            raise ValueError("exploration must be in [0, 1)")
-        if not 0.0 <= loss_decay < 1.0:
-            raise ValueError("loss_decay must be in [0, 1)")
+        _require_manager_state_budget("LearnedResourceManager", n_contexts, n_actions)
+        learning_rate = _validated_float32(
+            "learning_rate", learning_rate, lower=0.0, preserve_nonzero=True
+        )
+        discount = _validated_float32(
+            "discount", discount, lower=0.0, upper=1.0, preserve_nonzero=True
+        )
+        exploration = _validated_float32(
+            "exploration",
+            exploration,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+            preserve_nonzero=True,
+        )
+        loss_decay = _validated_float32(
+            "loss_decay",
+            loss_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+            preserve_nonzero=True,
+        )
         validated_cost_weight = _validated_cost_weight(cost_weight)
-        if advantage_clip <= 0.0:
-            raise ValueError("advantage_clip must be positive")
+        advantage_clip = _validated_float32("advantage_clip", advantage_clip, positive=True)
 
         self._n_actions = int(n_actions)
         self._n_contexts = int(n_contexts)
-        self._learning_rate = float(learning_rate)
-        self._discount = float(discount)
-        self._exploration = float(exploration)
-        self._loss_decay = float(loss_decay)
+        self._learning_rate = learning_rate
+        self._discount = discount
+        self._exploration = exploration
+        self._loss_decay = loss_decay
         self._cost_weight = validated_cost_weight
-        self._advantage_clip = float(advantage_clip)
+        self._advantage_clip = advantage_clip
 
     @property
     def n_actions(self) -> int:
@@ -338,9 +398,9 @@ class LearnedResourceManager:
         )
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> LearnedResourceManager:
+    def from_config(cls, config: Mapping[str, Any]) -> LearnedResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
-        config = dict(config)
+        config = _read_mapping("config", config)
         config.pop("type", None)
         return cls(**config)
 
@@ -354,6 +414,17 @@ class LearnedResourceManager:
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
+    def _require_state_contract(self, state: LearnedResourceManagerState) -> None:
+        if type(state) is not LearnedResourceManagerState:
+            raise ValueError("state must be a LearnedResourceManagerState")
+        shape = (self._n_contexts, self._n_actions)
+        for name in ("log_weights", "loss_ema", "action_counts"):
+            leaf = getattr(state, name)
+            if leaf.shape != shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {shape} and dtype float32")
+        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
+            raise ValueError("state.step_count must be a scalar int32")
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def weights(
         self,
@@ -361,6 +432,7 @@ class LearnedResourceManager:
         context_id: Array | int = 0,
     ) -> Float[Array, " n_actions"]:
         """Return the current allocation for ``context_id``."""
+        self._require_state_contract(state)
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -396,17 +468,20 @@ class LearnedResourceManager:
         Returns:
             :class:`LearnedResourceManagerUpdateResult`.
         """
+        self._require_state_contract(state)
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
         )
-        losses = jnp.asarray(losses, dtype=jnp.float32)
+        losses = _require_vector("losses", losses, self._n_actions, dtype=jnp.float32)
         finite_losses = jnp.isfinite(losses)
         safe_losses = jnp.where(finite_losses, losses, 0.0)
         costs = (
             jnp.zeros_like(safe_losses)
             if resource_costs is None
-            else jnp.asarray(resource_costs, dtype=jnp.float32)
+            else _require_vector(
+                "resource_costs", resource_costs, self._n_actions, dtype=jnp.float32
+            )
         )
         cost_terms, costs_valid = _weighted_cost_terms(costs, self._cost_weight)
         valid_actions = finite_losses & costs_valid
@@ -444,7 +519,7 @@ class LearnedResourceManager:
             log_weights=new_log_weights,
             loss_ema=new_loss_ema,
             action_counts=new_counts,
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         checked_log_weights = _mask_unused_history(
             state.log_weights,
@@ -464,6 +539,7 @@ class LearnedResourceManager:
         )
         update_applied = (
             context_valid
+            & (state.step_count >= 0)
             & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))
@@ -579,6 +655,21 @@ class GeneratorMetaResourceManager:
                 estimator; Auer et al. 2002).
             initial_preferences: Optional additive initial log-preferences.
         """
+        policy_names = _require_exact_tuple("policy_names", policy_names)
+        op_ids = _require_exact_tuple("op_ids", op_ids)
+        parent_modes = _require_exact_tuple("parent_modes", parent_modes)
+        replacement_multipliers = _require_exact_tuple(
+            "replacement_multipliers", replacement_multipliers
+        )
+        promotion_margin_multipliers = _require_exact_tuple(
+            "promotion_margin_multipliers", promotion_margin_multipliers
+        )
+        candidate_min_age_multipliers = _require_exact_tuple(
+            "candidate_min_age_multipliers", candidate_min_age_multipliers
+        )
+        imprint_scales = _require_exact_tuple("imprint_scales", imprint_scales)
+        if initial_preferences is not None:
+            initial_preferences = _require_exact_tuple("initial_preferences", initial_preferences)
         n_policies = len(policy_names)
         if n_policies < 1:
             raise ValueError("at least one generator policy is required")
@@ -593,55 +684,86 @@ class GeneratorMetaResourceManager:
         if lengths != {n_policies}:
             raise ValueError("all generator policy tuples must have the same length")
         n_contexts = _require_int32("n_contexts", n_contexts, minimum=1)
+        _require_manager_state_budget("GeneratorMetaResourceManager", n_contexts, n_policies)
+        if any(type(name) is not str for name in policy_names):
+            raise ValueError("policy_names elements must be exact strings")
         op_ids = tuple(_require_int32("op_ids element", op_id, minimum=0) for op_id in op_ids)
         parent_modes = tuple(
             _require_int32("parent_modes element", mode, minimum=0) for mode in parent_modes
         )
-        if learning_rate < 0.0:
-            raise ValueError("learning_rate must be non-negative")
-        if not 0.0 <= discount <= 1.0:
-            raise ValueError("discount must be in [0, 1]")
-        if not 0.0 <= exploration < 1.0:
-            raise ValueError("exploration must be in [0, 1)")
-        if not 0.0 <= reward_decay < 1.0:
-            raise ValueError("reward_decay must be in [0, 1)")
+        learning_rate = _validated_float32(
+            "learning_rate", learning_rate, lower=0.0, preserve_nonzero=True
+        )
+        discount = _validated_float32(
+            "discount", discount, lower=0.0, upper=1.0, preserve_nonzero=True
+        )
+        exploration = _validated_float32(
+            "exploration",
+            exploration,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+            preserve_nonzero=True,
+        )
+        reward_decay = _validated_float32(
+            "reward_decay",
+            reward_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+            preserve_nonzero=True,
+        )
         validated_cost_weight = _validated_cost_weight(cost_weight)
-        if advantage_clip <= 0.0:
-            raise ValueError("advantage_clip must be positive")
-        if update_rule not in {"hedge", "exp3"}:
+        advantage_clip = _validated_float32("advantage_clip", advantage_clip, positive=True)
+        if type(update_rule) is not str or update_rule not in {"hedge", "exp3"}:
             raise ValueError("update_rule must be 'hedge' or 'exp3'")
         if initial_preferences is not None and len(initial_preferences) != n_policies:
             raise ValueError("initial_preferences must match policy_names length")
-        if any(value <= 0.0 for value in replacement_multipliers):
-            raise ValueError("replacement_multipliers must be positive")
-        if any(value <= 0.0 for value in promotion_margin_multipliers):
-            raise ValueError("promotion_margin_multipliers must be positive")
-        if any(value <= 0.0 for value in candidate_min_age_multipliers):
-            raise ValueError("candidate_min_age_multipliers must be positive")
-        if any(value < 0.0 for value in imprint_scales):
-            raise ValueError("imprint_scales must be non-negative")
+        replacement_multipliers = tuple(
+            _validated_float32("replacement_multipliers element", value, positive=True)
+            for value in replacement_multipliers
+        )
+        promotion_margin_multipliers = tuple(
+            _validated_float32("promotion_margin_multipliers element", value, positive=True)
+            for value in promotion_margin_multipliers
+        )
+        candidate_min_age_multipliers = tuple(
+            _validated_float32("candidate_min_age_multipliers element", value, positive=True)
+            for value in candidate_min_age_multipliers
+        )
+        imprint_scales = tuple(
+            _validated_float32(
+                "imprint_scales element", value, lower=0.0, preserve_nonzero=True
+            )
+            for value in imprint_scales
+        )
+        if initial_preferences is not None:
+            initial_preferences = tuple(
+                _validated_float32("initial_preferences element", value)
+                for value in initial_preferences
+            )
+            if max(initial_preferences) - min(initial_preferences) > float(
+                np.finfo(np.float32).max
+            ):
+                raise ValueError("initial_preferences span must remain finite in float32")
 
-        self._policy_names = tuple(policy_names)
+        self._policy_names = policy_names
         self._op_ids = tuple(int(value) for value in op_ids)
         self._parent_modes = tuple(int(value) for value in parent_modes)
-        self._replacement_multipliers = tuple(float(value) for value in replacement_multipliers)
-        self._promotion_margin_multipliers = tuple(
-            float(value) for value in promotion_margin_multipliers
-        )
-        self._candidate_min_age_multipliers = tuple(
-            float(value) for value in candidate_min_age_multipliers
-        )
-        self._imprint_scales = tuple(float(value) for value in imprint_scales)
+        self._replacement_multipliers = replacement_multipliers
+        self._promotion_margin_multipliers = promotion_margin_multipliers
+        self._candidate_min_age_multipliers = candidate_min_age_multipliers
+        self._imprint_scales = imprint_scales
         self._n_contexts = int(n_contexts)
-        self._learning_rate = float(learning_rate)
-        self._discount = float(discount)
-        self._exploration = float(exploration)
-        self._reward_decay = float(reward_decay)
+        self._learning_rate = learning_rate
+        self._discount = discount
+        self._exploration = exploration
+        self._reward_decay = reward_decay
         self._cost_weight = validated_cost_weight
-        self._advantage_clip = float(advantage_clip)
+        self._advantage_clip = advantage_clip
         self._update_rule = update_rule
         self._initial_preferences = (
-            tuple(float(value) for value in initial_preferences)
+            initial_preferences
             if initial_preferences is not None
             else tuple(0.0 for _ in range(n_policies))
         )
@@ -679,21 +801,29 @@ class GeneratorMetaResourceManager:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> GeneratorMetaResourceManager:
+    def from_config(cls, config: Mapping[str, Any]) -> GeneratorMetaResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
-        config = dict(config)
+        config = _read_mapping("config", config)
         config.pop("type", None)
         initial_preferences = config.pop("initial_preferences", None)
         return cls(
-            policy_names=tuple(config.pop("policy_names")),
-            op_ids=tuple(config.pop("op_ids")),
-            parent_modes=tuple(config.pop("parent_modes")),
-            replacement_multipliers=tuple(config.pop("replacement_multipliers")),
-            promotion_margin_multipliers=tuple(config.pop("promotion_margin_multipliers")),
-            candidate_min_age_multipliers=tuple(config.pop("candidate_min_age_multipliers")),
-            imprint_scales=tuple(config.pop("imprint_scales")),
+            policy_names=_decode_sequence("policy_names", config.pop("policy_names")),
+            op_ids=_decode_sequence("op_ids", config.pop("op_ids")),
+            parent_modes=_decode_sequence("parent_modes", config.pop("parent_modes")),
+            replacement_multipliers=_decode_sequence(
+                "replacement_multipliers", config.pop("replacement_multipliers")
+            ),
+            promotion_margin_multipliers=_decode_sequence(
+                "promotion_margin_multipliers", config.pop("promotion_margin_multipliers")
+            ),
+            candidate_min_age_multipliers=_decode_sequence(
+                "candidate_min_age_multipliers", config.pop("candidate_min_age_multipliers")
+            ),
+            imprint_scales=_decode_sequence("imprint_scales", config.pop("imprint_scales")),
             initial_preferences=(
-                None if initial_preferences is None else tuple(initial_preferences)
+                None
+                if initial_preferences is None
+                else _decode_sequence("initial_preferences", initial_preferences)
             ),
             **config,
         )
@@ -702,7 +832,9 @@ class GeneratorMetaResourceManager:
         """Create an initial uniform-allocation state."""
         shape = (self._n_contexts, self.n_policies)
         initial = jnp.asarray(self._initial_preferences, dtype=jnp.float32)
-        initial = initial - jnp.mean(initial)
+        # Softmax is shift invariant; subtracting the maximum avoids an
+        # overflowing reduction when every legal preference is near FLT_MAX.
+        initial = initial - jnp.max(initial)
         log_weights = jnp.broadcast_to(initial, shape)
         return GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
             log_weights=log_weights,
@@ -711,6 +843,17 @@ class GeneratorMetaResourceManager:
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
+    def _require_state_contract(self, state: GeneratorMetaResourceManagerState) -> None:
+        if type(state) is not GeneratorMetaResourceManagerState:
+            raise ValueError("state must be a GeneratorMetaResourceManagerState")
+        shape = (self._n_contexts, self.n_policies)
+        for name in ("log_weights", "reward_ema", "action_counts"):
+            leaf = getattr(state, name)
+            if leaf.shape != shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {shape} and dtype float32")
+        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
+            raise ValueError("state.step_count must be a scalar int32")
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def weights(
         self,
@@ -718,6 +861,7 @@ class GeneratorMetaResourceManager:
         context_id: Array | int = 0,
     ) -> Float[Array, " n_policies"]:
         """Return the current policy allocation for ``context_id``."""
+        self._require_state_contract(state)
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -742,6 +886,7 @@ class GeneratorMetaResourceManager:
         context_id: Array | int = 0,
     ) -> GeneratorMetaResourceDecision:
         """Sample one policy and return the generator knobs it controls."""
+        self._require_state_contract(state)
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
@@ -814,19 +959,24 @@ class GeneratorMetaResourceManager:
         importance-weighted update.  This is useful when provenance rewards are
         sparse and the experiment wants explicit exploration credit.
         """
+        self._require_state_contract(state)
         context, context_valid = safe_discrete_action(
             context_id,
             self._n_contexts,
         )
-        rewards = jnp.asarray(rewards, dtype=jnp.float32)
+        rewards = _require_vector("rewards", rewards, self.n_policies, dtype=jnp.float32)
         finite = jnp.isfinite(rewards)
         if finite_mask is not None:
-            finite = finite & jnp.asarray(finite_mask, dtype=jnp.bool_)
+            finite = finite & _require_vector(
+                "finite_mask", finite_mask, self.n_policies, dtype=jnp.bool_
+            )
         safe_rewards = jnp.where(finite, rewards, 0.0)
         costs = (
             jnp.zeros_like(safe_rewards)
             if resource_costs is None
-            else jnp.asarray(resource_costs, dtype=jnp.float32)
+            else _require_vector(
+                "resource_costs", resource_costs, self.n_policies, dtype=jnp.float32
+            )
         )
         cost_terms, costs_valid = _weighted_cost_terms(costs, self._cost_weight)
         finite = finite & costs_valid
@@ -849,6 +999,8 @@ class GeneratorMetaResourceManager:
                 if selected_probability is None
                 else jnp.asarray(selected_probability, dtype=jnp.float32)
             )
+            if raw_probability.shape != ():
+                raise ValueError("selected_probability must be scalar")
             probability_valid = (
                 jnp.all(jnp.isfinite(raw_probability))
                 & jnp.all(raw_probability > 0.0)
@@ -893,7 +1045,7 @@ class GeneratorMetaResourceManager:
             log_weights=new_log_weights,
             reward_ema=new_reward_ema,
             action_counts=new_counts,
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         checked_log_weights = _mask_unused_history(
             state.log_weights,
@@ -914,6 +1066,7 @@ class GeneratorMetaResourceManager:
         update_applied = (
             context_valid
             & selection_input_valid
+            & (state.step_count >= 0)
             & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -101,9 +101,9 @@ def _require_exact_tuple(name: str, value: object) -> tuple[Any, ...]:
 
 
 def _decode_sequence(name: str, value: object) -> tuple[Any, ...]:
-    if type(value) not in {list, tuple}:
-        raise ValueError(f"{name} must be an exact list or tuple")
-    return tuple(cast(list[Any] | tuple[Any, ...], value))
+    if type(value) is not list:
+        raise ValueError(f"serialized {name} must be an exact JSON list")
+    return tuple(value)
 
 
 def _read_mapping(name: str, value: object) -> dict[str, Any]:
@@ -113,6 +113,28 @@ def _read_mapping(name: str, value: object) -> dict[str, Any]:
         return dict(cast(Mapping[str, Any], value))
     except Exception as error:
         raise ValueError(f"{name} must be a readable mapping") from error
+
+
+def _require_serialized_fields(
+    payload: Mapping[str, Any],
+    *,
+    owner: str,
+    expected: set[str],
+    integer_fields: tuple[str, ...] = (),
+    float_fields: tuple[str, ...] = (),
+    string_fields: tuple[str, ...] = (),
+) -> None:
+    if set(payload) != expected:
+        raise ValueError(f"serialized {owner} config fields do not match its schema")
+    for name in integer_fields:
+        if type(payload[name]) is not int:
+            raise ValueError(f"serialized {name} must be a JSON integer")
+    for name in float_fields:
+        if type(payload[name]) is not float:
+            raise ValueError(f"serialized {name} must be a JSON number")
+    for name in string_fields:
+        if type(payload[name]) is not str:
+            raise ValueError(f"serialized {name} must be a JSON string")
 
 
 def _require_manager_state_budget(name: str, n_contexts: int, n_choices: int) -> None:
@@ -414,7 +436,31 @@ class LearnedResourceManager:
     def from_config(cls, config: Mapping[str, Any]) -> LearnedResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
         config = _read_mapping("config", config)
-        config.pop("type", None)
+        if config.pop("type", None) != "LearnedResourceManager":
+            raise ValueError("serialized LearnedResourceManager type is invalid")
+        _require_serialized_fields(
+            config,
+            owner="LearnedResourceManager",
+            expected={
+                "n_actions",
+                "n_contexts",
+                "learning_rate",
+                "discount",
+                "exploration",
+                "loss_decay",
+                "cost_weight",
+                "advantage_clip",
+            },
+            integer_fields=("n_actions", "n_contexts"),
+            float_fields=(
+                "learning_rate",
+                "discount",
+                "exploration",
+                "loss_decay",
+                "cost_weight",
+                "advantage_clip",
+            ),
+        )
         try:
             return cls(**config)
         except ValueError:
@@ -844,28 +890,76 @@ class GeneratorMetaResourceManager:
     def from_config(cls, config: Mapping[str, Any]) -> GeneratorMetaResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
         config = _read_mapping("config", config)
-        config.pop("type", None)
+        if config.pop("type", None) != "GeneratorMetaResourceManager":
+            raise ValueError("serialized GeneratorMetaResourceManager type is invalid")
+        _require_serialized_fields(
+            config,
+            owner="GeneratorMetaResourceManager",
+            expected={
+                "policy_names",
+                "op_ids",
+                "parent_modes",
+                "replacement_multipliers",
+                "promotion_margin_multipliers",
+                "candidate_min_age_multipliers",
+                "imprint_scales",
+                "n_contexts",
+                "learning_rate",
+                "discount",
+                "exploration",
+                "reward_decay",
+                "cost_weight",
+                "advantage_clip",
+                "update_rule",
+                "initial_preferences",
+            },
+            integer_fields=("n_contexts",),
+            float_fields=(
+                "learning_rate",
+                "discount",
+                "exploration",
+                "reward_decay",
+                "cost_weight",
+                "advantage_clip",
+            ),
+            string_fields=("update_rule",),
+        )
         try:
-            initial_preferences = config.pop("initial_preferences", None)
+            initial_preferences = config.pop("initial_preferences")
+            decoded_policy_names = _decode_sequence("policy_names", config.pop("policy_names"))
+            decoded_op_ids = _decode_sequence("op_ids", config.pop("op_ids"))
+            decoded_parent_modes = _decode_sequence("parent_modes", config.pop("parent_modes"))
+            if any(type(value) is not str for value in decoded_policy_names):
+                raise ValueError("serialized policy_names elements must be JSON strings")
+            if any(type(value) is not int for value in (*decoded_op_ids, *decoded_parent_modes)):
+                raise ValueError("serialized policy ids and modes must be JSON integers")
+            float_sequences: dict[str, tuple[Any, ...]] = {}
+            for name in (
+                "replacement_multipliers",
+                "promotion_margin_multipliers",
+                "candidate_min_age_multipliers",
+                "imprint_scales",
+            ):
+                values = _decode_sequence(name, config.pop(name))
+                if any(type(value) is not float for value in values):
+                    raise ValueError(f"serialized {name} elements must be JSON numbers")
+                float_sequences[name] = values
+            decoded_initial = _decode_sequence("initial_preferences", initial_preferences)
+            if any(type(value) is not float for value in decoded_initial):
+                raise ValueError("serialized initial_preferences elements must be JSON numbers")
             return cls(
-                policy_names=_decode_sequence("policy_names", config.pop("policy_names")),
-                op_ids=_decode_sequence("op_ids", config.pop("op_ids")),
-                parent_modes=_decode_sequence("parent_modes", config.pop("parent_modes")),
-                replacement_multipliers=_decode_sequence(
-                    "replacement_multipliers", config.pop("replacement_multipliers")
-                ),
-                promotion_margin_multipliers=_decode_sequence(
-                    "promotion_margin_multipliers", config.pop("promotion_margin_multipliers")
-                ),
-                candidate_min_age_multipliers=_decode_sequence(
-                    "candidate_min_age_multipliers", config.pop("candidate_min_age_multipliers")
-                ),
-                imprint_scales=_decode_sequence("imprint_scales", config.pop("imprint_scales")),
-                initial_preferences=(
-                    None
-                    if initial_preferences is None
-                    else _decode_sequence("initial_preferences", initial_preferences)
-                ),
+                policy_names=decoded_policy_names,
+                op_ids=decoded_op_ids,
+                parent_modes=decoded_parent_modes,
+                replacement_multipliers=float_sequences["replacement_multipliers"],
+                promotion_margin_multipliers=float_sequences[
+                    "promotion_margin_multipliers"
+                ],
+                candidate_min_age_multipliers=float_sequences[
+                    "candidate_min_age_multipliers"
+                ],
+                imprint_scales=float_sequences["imprint_scales"],
+                initial_preferences=decoded_initial,
                 **config,
             )
         except ValueError:

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -29,13 +29,15 @@ from __future__ import annotations
 
 import functools
 import math
+import operator
 import struct
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -45,6 +47,32 @@ from alberta_framework.core.update_safety import (
     safe_discrete_action,
     select_transaction,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: float, value: Array) -> Array:
@@ -93,11 +121,7 @@ def _weighted_cost_terms(costs: Array, cost_weight: float) -> tuple[Array, Array
     weight = jnp.asarray(cost_weight, dtype=jnp.float32)
     weighted = weight * costs
     used = weight != 0.0
-    valid = (~used) | (
-        jnp.isfinite(costs)
-        & (costs >= 0.0)
-        & jnp.isfinite(weighted)
-    )
+    valid = (~used) | (jnp.isfinite(costs) & (costs >= 0.0) & jnp.isfinite(weighted))
     terms = jnp.where(used & valid, weighted, jnp.zeros_like(weighted))
     return terms, valid
 
@@ -157,10 +181,7 @@ def finite_candidate_hedge_regret_bound(
         return 0.0
     if learning_rate == 0.0:
         return math.inf
-    return (
-        math.log(n_actions) / learning_rate
-        + learning_rate * horizon * loss_bound**2 / 8.0
-    )
+    return math.log(n_actions) / learning_rate + learning_rate * horizon * loss_bound**2 / 8.0
 
 
 @chex.dataclass(frozen=True)
@@ -249,10 +270,8 @@ class LearnedResourceManager:
         Raises:
             ValueError: If any hyperparameter is outside its valid range.
         """
-        if n_actions < 1:
-            raise ValueError("n_actions must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
+        n_actions = _require_int32("n_actions", n_actions, minimum=1)
+        n_contexts = _require_int32("n_contexts", n_contexts, minimum=1)
         if learning_rate < 0.0:
             raise ValueError("learning_rate must be non-negative")
         if not 0.0 <= discount <= 1.0:
@@ -394,9 +413,7 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self.weights(state, context)
-        finite_weight_sum = jnp.maximum(
-            jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12
-        )
+        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
         masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
@@ -408,8 +425,7 @@ class LearnedResourceManager:
 
         old_context_logits = state.log_weights[context]
         new_context_logits = (
-            _skip_zero_scale(self._discount, old_context_logits)
-            + self._learning_rate * advantages
+            _skip_zero_scale(self._discount, old_context_logits) + self._learning_rate * advantages
         )
         # Remove an arbitrary additive constant for numerical stability.
         new_context_logits = new_context_logits - jnp.mean(new_context_logits)
@@ -418,8 +434,7 @@ class LearnedResourceManager:
         old_ema = state.loss_ema[context]
         new_ema = jnp.where(
             valid_actions,
-            _skip_zero_scale(self._loss_decay, old_ema)
-            + (1.0 - self._loss_decay) * adjusted,
+            _skip_zero_scale(self._loss_decay, old_ema) + (1.0 - self._loss_decay) * adjusted,
             old_ema,
         )
         new_loss_ema = state.loss_ema.at[context].set(new_ema)
@@ -577,8 +592,11 @@ class GeneratorMetaResourceManager:
         }
         if lengths != {n_policies}:
             raise ValueError("all generator policy tuples must have the same length")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
+        n_contexts = _require_int32("n_contexts", n_contexts, minimum=1)
+        op_ids = tuple(_require_int32("op_ids element", op_id, minimum=0) for op_id in op_ids)
+        parent_modes = tuple(
+            _require_int32("parent_modes element", mode, minimum=0) for mode in parent_modes
+        )
         if learning_rate < 0.0:
             raise ValueError("learning_rate must be non-negative")
         if not 0.0 <= discount <= 1.0:
@@ -646,12 +664,8 @@ class GeneratorMetaResourceManager:
             "op_ids": list(self._op_ids),
             "parent_modes": list(self._parent_modes),
             "replacement_multipliers": list(self._replacement_multipliers),
-            "promotion_margin_multipliers": list(
-                self._promotion_margin_multipliers
-            ),
-            "candidate_min_age_multipliers": list(
-                self._candidate_min_age_multipliers
-            ),
+            "promotion_margin_multipliers": list(self._promotion_margin_multipliers),
+            "candidate_min_age_multipliers": list(self._candidate_min_age_multipliers),
             "imprint_scales": list(self._imprint_scales),
             "n_contexts": self._n_contexts,
             "learning_rate": self._learning_rate,
@@ -665,9 +679,7 @@ class GeneratorMetaResourceManager:
         }
 
     @classmethod
-    def from_config(
-        cls, config: dict[str, Any]
-    ) -> GeneratorMetaResourceManager:
+    def from_config(cls, config: dict[str, Any]) -> GeneratorMetaResourceManager:
         """Reconstruct a manager from :meth:`to_config` output."""
         config = dict(config)
         config.pop("type", None)
@@ -677,12 +689,8 @@ class GeneratorMetaResourceManager:
             op_ids=tuple(config.pop("op_ids")),
             parent_modes=tuple(config.pop("parent_modes")),
             replacement_multipliers=tuple(config.pop("replacement_multipliers")),
-            promotion_margin_multipliers=tuple(
-                config.pop("promotion_margin_multipliers")
-            ),
-            candidate_min_age_multipliers=tuple(
-                config.pop("candidate_min_age_multipliers")
-            ),
+            promotion_margin_multipliers=tuple(config.pop("promotion_margin_multipliers")),
+            candidate_min_age_multipliers=tuple(config.pop("candidate_min_age_multipliers")),
             imprint_scales=tuple(config.pop("imprint_scales")),
             initial_preferences=(
                 None if initial_preferences is None else tuple(initial_preferences)
@@ -740,9 +748,7 @@ class GeneratorMetaResourceManager:
         )
         weights = self.weights(state, context)
         selection_valid = (
-            context_valid
-            & floating_tree_is_finite(state)
-            & jnp.all(jnp.isfinite(weights))
+            context_valid & floating_tree_is_finite(state) & jnp.all(jnp.isfinite(weights))
         )
         action = jr.categorical(key, jnp.log(weights + 1e-8)).astype(jnp.int32)
         op_ids = jnp.asarray(self._op_ids, dtype=jnp.int32)
@@ -848,9 +854,7 @@ class GeneratorMetaResourceManager:
                 & jnp.all(raw_probability > 0.0)
                 & jnp.all(raw_probability <= 1.0)
             )
-            probability = jnp.maximum(
-                jnp.where(probability_valid, raw_probability, 1.0), 1e-6
-            )
+            probability = jnp.maximum(jnp.where(probability_valid, raw_probability, 1.0), 1e-6)
             selection_input_valid = action_valid & probability_valid
             selected_finite = finite[action] & selection_input_valid
             reward_hat = jnp.where(
@@ -871,8 +875,7 @@ class GeneratorMetaResourceManager:
 
         old_context_logits = state.log_weights[context]
         new_context_logits = (
-            _skip_zero_scale(self._discount, old_context_logits)
-            + self._learning_rate * advantages
+            _skip_zero_scale(self._discount, old_context_logits) + self._learning_rate * advantages
         )
         new_context_logits = new_context_logits - jnp.mean(new_context_logits)
         new_log_weights = state.log_weights.at[context].set(new_context_logits)
@@ -880,8 +883,7 @@ class GeneratorMetaResourceManager:
         old_ema = state.reward_ema[context]
         new_ema = jnp.where(
             finite,
-            _skip_zero_scale(self._reward_decay, old_ema)
-            + (1.0 - self._reward_decay) * adjusted,
+            _skip_zero_scale(self._reward_decay, old_ema) + (1.0 - self._reward_decay) * adjusted,
             old_ema,
         )
         new_reward_ema = state.reward_ema.at[context].set(new_ema)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -715,3 +715,34 @@ def test_resource_manager_loader_failures_are_normalized() -> None:
     del payload["policy_names"]
     with pytest.raises(ValueError, match="serialized GeneratorMetaResourceManager"):
         GeneratorMetaResourceManager.from_config(payload)
+
+
+def test_resource_manager_serialized_schemas_are_exact() -> None:
+    learned_payload = LearnedResourceManager(n_actions=2).to_config()
+    learned_clone = LearnedResourceManager.from_config(MappingProxyType(learned_payload))
+    assert learned_clone.to_config() == learned_payload
+    for mutation, match in (
+        ({"type": "Other"}, "type"),
+        ({"n_actions": np.int32(2)}, "n_actions"),
+        ({"learning_rate": np.float32(0.1)}, "learning_rate"),
+        ({"extra": 1}, "fields"),
+    ):
+        invalid = dict(learned_payload)
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            LearnedResourceManager.from_config(invalid)
+
+    generator_payload = _minimal_generator_manager().to_config()
+    for mutation, match in (
+        ({"type": "Other"}, "type"),
+        ({"n_contexts": np.int32(1)}, "n_contexts"),
+        ({"policy_names": ("p1", "p2")}, "policy_names"),
+        ({"op_ids": [np.int32(0), 1]}, "policy ids"),
+        ({"replacement_multipliers": [1, 1.0]}, "replacement_multipliers"),
+        ({"initial_preferences": [0, 0.0]}, "initial_preferences"),
+        ({"extra": 1}, "fields"),
+    ):
+        invalid = dict(generator_payload)
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            GeneratorMetaResourceManager.from_config(invalid)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -125,9 +125,7 @@ class TestLearnedResourceManager:
             jax.nn.softmax(finite_state.log_weights[0]),
         )
 
-        state = finite_state.replace(
-            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
-        )
+        state = finite_state.replace(log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32))
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
         assert not bool(jnp.isfinite(raw))
         assert manager.weights(state).tolist() == pytest.approx([0.5, 0.5])
@@ -139,9 +137,7 @@ class TestLearnedResourceManager:
 
     def test_nonzero_discount_rejects_nonfinite_logits(self) -> None:
         manager = LearnedResourceManager(n_actions=2, discount=0.5)
-        state = manager.init().replace(
-            log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32)
-        )
+        state = manager.init().replace(log_weights=jnp.full((1, 2), jnp.inf, dtype=jnp.float32))
 
         assert not bool(jnp.all(jnp.isfinite(manager.weights(state))))
         result = manager.update(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
@@ -151,9 +147,7 @@ class TestLearnedResourceManager:
 
     def test_zero_loss_decay_recovers_observed_nonfinite_ema(self) -> None:
         manager = LearnedResourceManager(n_actions=2, loss_decay=0.0)
-        state = manager.init().replace(
-            loss_ema=jnp.asarray([[jnp.inf, 7.0]], dtype=jnp.float32)
-        )
+        state = manager.init().replace(loss_ema=jnp.asarray([[jnp.inf, 7.0]], dtype=jnp.float32))
 
         result = manager.update(state, jnp.asarray([0.1, jnp.nan], dtype=jnp.float32))
 
@@ -162,9 +156,7 @@ class TestLearnedResourceManager:
 
     def test_zero_loss_decay_rejects_poisoned_ema_in_ignored_slot(self) -> None:
         manager = LearnedResourceManager(n_actions=2, loss_decay=0.0)
-        state = manager.init().replace(
-            loss_ema=jnp.asarray([[0.0, jnp.inf]], dtype=jnp.float32)
-        )
+        state = manager.init().replace(loss_ema=jnp.asarray([[0.0, jnp.inf]], dtype=jnp.float32))
 
         result = manager.update(state, jnp.asarray([0.1, jnp.nan], dtype=jnp.float32))
 
@@ -173,9 +165,7 @@ class TestLearnedResourceManager:
 
     def test_nonzero_loss_decay_rejects_consumed_nonfinite_ema(self) -> None:
         manager = LearnedResourceManager(n_actions=2, loss_decay=0.5)
-        state = manager.init().replace(
-            loss_ema=jnp.asarray([[jnp.inf, 0.0]], dtype=jnp.float32)
-        )
+        state = manager.init().replace(loss_ema=jnp.asarray([[jnp.inf, 0.0]], dtype=jnp.float32))
 
         result = manager.update(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
 
@@ -498,3 +488,47 @@ class TestGeneratorMetaResourceManager:
 
         assert jnp.all(jnp.isfinite(result.metrics))
         assert jnp.all(jnp.isfinite(result.state.generator_resource_state.log_weights))
+
+
+def test_learned_resource_manager_integer_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        LearnedResourceManager(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        LearnedResourceManager(n_actions=3.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_contexts"):
+        LearnedResourceManager(n_actions=3, n_contexts=True)  # type: ignore[arg-type]
+
+    rm = LearnedResourceManager(n_actions=np.int32(4), n_contexts=np.int64(2))
+    assert rm.n_actions == 4
+    assert rm.n_contexts == 2
+    assert type(rm.n_actions) is int
+    assert type(rm.n_contexts) is int
+
+
+def test_generator_meta_resource_manager_integer_validation() -> None:
+    with pytest.raises(ValueError, match="n_contexts"):
+        GeneratorMetaResourceManager(
+            policy_names=("p1",),
+            op_ids=(0,),
+            parent_modes=(0,),
+            replacement_multipliers=(1.0,),
+            promotion_margin_multipliers=(1.0,),
+            candidate_min_age_multipliers=(1.0,),
+            imprint_scales=(1.0,),
+            n_contexts=True,  # type: ignore[arg-type]
+        )
+
+    mgr = GeneratorMetaResourceManager(
+        policy_names=("p1",),
+        op_ids=(np.int32(1),),
+        parent_modes=(np.int64(0),),
+        replacement_multipliers=(1.0,),
+        promotion_margin_multipliers=(1.0,),
+        candidate_min_age_multipliers=(1.0,),
+        imprint_scales=(1.0,),
+        n_contexts=np.int32(2),
+    )
+    assert mgr.n_contexts == 2
+    assert mgr._op_ids == (1,)
+    assert type(mgr._op_ids[0]) is int
+    assert type(mgr.n_contexts) is int

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from types import MappingProxyType
 
 import chex
 import jax
@@ -532,3 +533,136 @@ def test_generator_meta_resource_manager_integer_validation() -> None:
     assert mgr._op_ids == (1,)
     assert type(mgr._op_ids[0]) is int
     assert type(mgr.n_contexts) is int
+
+
+class _FloatSubclass(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile hook executed")
+
+
+class _TupleSpoof:
+    @property
+    def __class__(self) -> type[tuple[object, ...]]:
+        return tuple
+
+    def __iter__(self) -> object:
+        raise RuntimeError("hostile iterator executed")
+
+
+def _minimal_generator_manager(**overrides: object) -> GeneratorMetaResourceManager:
+    kwargs: dict[str, object] = {
+        "policy_names": ("p1", "p2"),
+        "op_ids": (0, 1),
+        "parent_modes": (0, 1),
+        "replacement_multipliers": (1.0, 1.0),
+        "promotion_margin_multipliers": (1.0, 1.0),
+        "candidate_min_age_multipliers": (1.0, 1.0),
+        "imprint_scales": (0.0, 1.0),
+    }
+    kwargs.update(overrides)
+    return GeneratorMetaResourceManager(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("learning_rate", _FloatSubclass(0.5)),
+        ("discount", 1e100),
+        ("discount", np.float64(1e-100)),
+        ("exploration", np.float64(1e-100)),
+        ("exploration", np.float64(1.0 - 1e-10)),
+        ("loss_decay", np.float64(1.0 - 1e-10)),
+        ("cost_weight", np.float64(1e-100)),
+        ("advantage_clip", True),
+    ],
+)
+def test_learned_resource_manager_rejects_invalid_float32_config(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        LearnedResourceManager(n_actions=2, **{field: value})  # type: ignore[arg-type]
+
+
+def test_resource_manager_float32_config_is_canonical_and_json_safe() -> None:
+    manager = LearnedResourceManager(
+        n_actions=np.int16(2),
+        learning_rate=np.float32(0.5),
+        discount=np.float64(0.75),
+        exploration=np.float16(0.125),
+        loss_decay=np.float32(0.5),
+        cost_weight=np.float64(0.25),
+        advantage_clip=np.float32(2.0),
+    )
+    config = manager.to_config()
+    assert all(type(config[name]) is float for name in (
+        "learning_rate", "discount", "exploration", "loss_decay", "cost_weight",
+        "advantage_clip",
+    ))
+
+
+def test_resource_manager_preflights_complete_state_before_allocation() -> None:
+    # 3 float32 matrices plus one int32 counter must fit a signed-int32 byte count.
+    LearnedResourceManager(n_actions=178_956_970)
+    with pytest.raises(ValueError, match="state exceeds"):
+        LearnedResourceManager(n_actions=178_956_971)
+    with pytest.raises(ValueError, match="state exceeds"):
+        _minimal_generator_manager(n_contexts=89_478_486)
+
+
+def test_generator_config_rejects_hostile_sequences_and_accepts_mapping_proxy() -> None:
+    with pytest.raises(ValueError, match="policy_names"):
+        _minimal_generator_manager(policy_names=_TupleSpoof())
+
+    config = _minimal_generator_manager().to_config()
+    clone = GeneratorMetaResourceManager.from_config(MappingProxyType(config))
+    assert clone.to_config() == config
+    config["op_ids"] = range(2)
+    with pytest.raises(ValueError, match="op_ids"):
+        GeneratorMetaResourceManager.from_config(config)
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
+def test_resource_manager_updates_reject_wrong_vector_shapes_under_jit(
+    shape: tuple[int, ...]
+) -> None:
+    learned = LearnedResourceManager(n_actions=2)
+    generator = _minimal_generator_manager()
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="losses"):
+        learned.update(learned.init(), malformed)
+    with pytest.raises(ValueError, match="rewards"):
+        generator.update(generator.init(), malformed)
+
+
+def test_generator_float_sequences_are_validated_at_float32_sink() -> None:
+    with pytest.raises(ValueError, match="replacement_multipliers"):
+        _minimal_generator_manager(replacement_multipliers=(1.0, 1e100))
+    with pytest.raises(ValueError, match="initial_preferences"):
+        _minimal_generator_manager(initial_preferences=(0.0, _FloatSubclass(1.0)))
+    with pytest.raises(ValueError, match="initial_preferences span"):
+        _minimal_generator_manager(initial_preferences=(-3e38, 3e38))
+    manager = _minimal_generator_manager(
+        replacement_multipliers=(np.float32(0.5), np.float64(2.0)),
+        initial_preferences=(np.float32(-0.5), np.float64(0.5)),
+    )
+    config = manager.to_config()
+    assert all(type(value) is float for value in config["replacement_multipliers"])
+    assert all(type(value) is float for value in config["initial_preferences"])
+
+
+def test_resource_manager_state_contract_and_counter_saturation() -> None:
+    learned = LearnedResourceManager(n_actions=2)
+    state = learned.init()
+    malformed = state.replace(log_weights=jnp.zeros((2,), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="state.log_weights"):
+        learned.weights(malformed)
+
+    saturated = state.replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    result = learned.update(saturated, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
+
+    invalid = state.replace(step_count=jnp.asarray(-1, dtype=jnp.int32))
+    result = learned.update(invalid, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, invalid)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -601,12 +601,16 @@ def test_resource_manager_float32_config_is_canonical_and_json_safe() -> None:
 
 
 def test_resource_manager_preflights_complete_state_before_allocation() -> None:
-    # 3 float32 matrices plus one int32 counter must fit a signed-int32 byte count.
-    LearnedResourceManager(n_actions=178_956_970)
+    # Conservative update/select working set is 49*n_actions+35 for one context.
+    last_legal = ((2**31 - 1) // 4 - 35) // 49
+    LearnedResourceManager(n_actions=last_legal)
     with pytest.raises(ValueError, match="state exceeds"):
-        LearnedResourceManager(n_actions=178_956_971)
+        LearnedResourceManager(n_actions=last_legal + 1)
+    # Multiple contexts are covered by the same aggregate formula.
+    generator_last = ((2**31 - 1) // 4 - 115) // 18
+    _minimal_generator_manager(n_contexts=generator_last)
     with pytest.raises(ValueError, match="state exceeds"):
-        _minimal_generator_manager(n_contexts=89_478_486)
+        _minimal_generator_manager(n_contexts=generator_last + 1)
 
 
 def test_generator_config_rejects_hostile_sequences_and_accepts_mapping_proxy() -> None:
@@ -666,3 +670,48 @@ def test_resource_manager_state_contract_and_counter_saturation() -> None:
     result = learned.update(invalid, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
     assert not bool(result.update_applied)
     chex.assert_trees_all_equal(result.state, invalid)
+
+
+def test_resource_manager_host_preflight_and_hostile_state_metadata() -> None:
+    learned = LearnedResourceManager(n_actions=2)
+    generator = _minimal_generator_manager()
+
+    class HostVector:
+        shape = (2,)
+        dtype = np.dtype(np.float64)
+
+        def __jax_array__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("conversion must not run")
+
+    with pytest.raises(ValueError, match="losses"):
+        learned.update(learned.init(), HostVector())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="rewards"):
+        generator.update(generator.init(), HostVector())  # type: ignore[arg-type]
+
+    class HostileLeaf:
+        @property
+        def shape(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("shape hook")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook must not run")
+
+    malformed = learned.init().replace(log_weights=HostileLeaf())
+    with pytest.raises(ValueError, match="state.log_weights"):
+        learned.weights(malformed)
+
+    malformed_generator = generator.init().replace(log_weights=HostileLeaf())
+    with pytest.raises(ValueError, match="state.log_weights"):
+        generator.select(malformed_generator, jr.key(0))
+
+
+def test_resource_manager_loader_failures_are_normalized() -> None:
+    learned = LearnedResourceManager(n_actions=2)
+    with pytest.raises(ValueError, match="serialized LearnedResourceManager"):
+        LearnedResourceManager.from_config({**learned.to_config(), "unknown": 1})
+
+    generator = _minimal_generator_manager()
+    payload = generator.to_config()
+    del payload["policy_names"]
+    with pytest.raises(ValueError, match="serialized GeneratorMetaResourceManager"):
+        GeneratorMetaResourceManager.from_config(payload)


### PR DESCRIPTION
Supersedes #840 while preserving all three commits, including Kayvan’s original author commit.

The #840 implementation correctly covers integer/float32 sinks, derived persistent and operation workspaces, runtime shapes/state, counter saturation, and hostile metadata. This successor adds the remaining exact serialized-schema gates: exact discriminator and field set, built-in JSON scalar types, exact emitted list containers/elements, while retaining Mapping compatibility and normalized hostile mapping failures.

Validation:
- 47 resource-manager tests passed
- 52 compositional consumer tests passed
- Ruff passed
- strict mypy passed

No benchmarks or outputs were run or modified.