### PR TITLE
fix(world-model-ensemble): stabilize aggregate operations

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -156,6 +156,30 @@ def _preflight_ensemble_state_resources(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
 
+    update_float32_scalars = (
+        2 * ensemble_size * target_dim
+        + 3 * target_dim
+        + ensemble_size * model.observation_dim
+        + 2 * model.observation_dim
+        + 3 * ensemble_size
+        + 13
+    )
+    update_bool_scalars = 2 * ensemble_size + 20
+    update_scalars = logical_scalars + update_float32_scalars + update_bool_scalars
+    update_bytes = logical_bytes + 4 * update_float32_scalars + update_bool_scalars
+    for name, value in (
+        ("ensemble update-result scalars", update_scalars),
+        ("ensemble update-result bytes", update_bytes),
+    ):
+        if not 1 <= value <= _INT32_MAX:
+            raise ValueError(f"derived {name} must fit signed int32")
+
+
+def _safe_mean(values: Array, *, axis: int | None = None) -> Array:
+    """Compute a float32 mean without first forming an overflowing sum."""
+    divisor = values.size if axis is None else values.shape[axis]
+    return jnp.sum(values / jnp.asarray(divisor, dtype=values.dtype), axis=axis)
+
 
 _REPLAY_KEY_FOLD_IN = 0x5245504C
 _V1_REPLAY_KEY_FOLD_IN = 0x50525632
@@ -1068,25 +1092,39 @@ class WorldModelEnsemble:
         )
         rewards = jnp.stack([prediction.reward for prediction in predictions])
         discounts = jnp.stack([prediction.discount for prediction in predictions])
-        per_head_epistemic = jnp.var(raw, axis=0)
+        mean_raw = _safe_mean(raw, axis=0)
+        mean_next_observation = _safe_mean(next_observations, axis=0)
+        mean_reward = _safe_mean(rewards)
+        mean_discount = _safe_mean(discounts)
+        per_head_epistemic = _safe_mean(jnp.square(raw - mean_raw[None, :]), axis=0)
+        epistemic_disagreement = _safe_mean(per_head_epistemic)
+        aggregates_finite = (
+            jnp.all(jnp.isfinite(mean_raw))
+            & jnp.all(jnp.isfinite(mean_next_observation))
+            & jnp.isfinite(mean_reward)
+            & jnp.isfinite(mean_discount)
+            & jnp.all(jnp.isfinite(per_head_epistemic))
+            & jnp.isfinite(epistemic_disagreement)
+        )
         finite = (
             jnp.all(jnp.isfinite(raw))
             & jnp.all(jnp.isfinite(next_observations))
             & jnp.all(jnp.isfinite(rewards))
             & jnp.all(jnp.isfinite(discounts))
             & jnp.all(jnp.abs(raw) <= self._config.signal_estimator.max_input_magnitude)
+            & aggregates_finite
         )
         return WorldModelEnsemblePrediction(
             member_raw_predictions=raw,
-            mean_raw_prediction=jnp.mean(raw, axis=0),
+            mean_raw_prediction=mean_raw,
             member_next_observations=next_observations,
-            mean_next_observation=jnp.mean(next_observations, axis=0),
+            mean_next_observation=mean_next_observation,
             member_rewards=rewards,
-            mean_reward=jnp.mean(rewards),
+            mean_reward=mean_reward,
             member_discounts=discounts,
-            mean_discount=jnp.mean(discounts),
+            mean_discount=mean_discount,
             per_head_epistemic_variance=per_head_epistemic,
-            epistemic_disagreement=jnp.mean(per_head_epistemic),
+            epistemic_disagreement=epistemic_disagreement,
             residual_variances=state.residual_variances,
             residual_proxy_ready=(state.event_count >= self._config.residual_variance_warmup_steps),
             valid=finite,
@@ -1117,10 +1155,15 @@ class WorldModelEnsemble:
 
         def do_predict(_: None) -> WorldModelEnsemblePrediction:
             result = self._predict_unchecked(state, obs, act)
-            return dataclasses.replace(
-                result,
-                valid=result.valid & valid,
-            )  # type: ignore[type-var]
+            result_valid = result.valid & valid
+            return cast(
+                WorldModelEnsemblePrediction,
+                jax.lax.cond(
+                    result_valid,
+                    lambda: dataclasses.replace(cast(Any, result), valid=result_valid),
+                    self._zero_prediction,
+                ),
+            )
 
         return cast(
             WorldModelEnsemblePrediction,
@@ -1314,8 +1357,8 @@ class WorldModelEnsemble:
             targets = self._model.targets(obs, rew, disc, next_obs)
             residuals = prediction.member_raw_predictions - targets[None, :]
             squared_residuals = jnp.square(residuals)
-            member_losses = jnp.mean(squared_residuals, axis=1)
-            observed_loss = jnp.mean(member_losses)
+            member_losses = _safe_mean(squared_residuals, axis=1)
+            observed_loss = _safe_mean(member_losses)
             signal_cfg = self._config.signal_estimator
             predictions_valid = (
                 prediction.valid
@@ -1494,7 +1537,7 @@ class WorldModelEnsemble:
                     act,
                 )
                 residual = preupdate_prediction.member_raw_predictions - stopped_targets[None, :]
-                return 0.5 * jnp.mean(jnp.square(residual)), preupdate_prediction
+                return 0.5 * _safe_mean(jnp.square(residual)), preupdate_prediction
 
             (
                 (representation_objective, prediction),
@@ -1502,8 +1545,8 @@ class WorldModelEnsemble:
             ) = jax.value_and_grad(representation_loss, has_aux=True)(obs)
             residuals = prediction.member_raw_predictions - stopped_targets[None, :]
             squared_residuals = jnp.square(residuals)
-            member_losses = jnp.mean(squared_residuals, axis=1)
-            observed_loss = jnp.mean(member_losses)
+            member_losses = _safe_mean(squared_residuals, axis=1)
+            observed_loss = _safe_mean(member_losses)
             signal_cfg = self._config.signal_estimator
             predictions_valid = (
                 prediction.valid
@@ -1645,7 +1688,10 @@ class WorldModelEnsemble:
             )
             return WorldModelEnsembleUpdateResult(
                 state=next_state,
-                prediction=prediction,
+                prediction=cast(
+                    WorldModelEnsemblePrediction,
+                    jax.lax.cond(applied, lambda: prediction, self._zero_prediction),
+                ),
                 signals=reported_signals,
                 targets=jnp.where(applied, targets, zero_target),
                 observed_loss=jnp.where(applied, observed_loss, 0.0),

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -763,3 +763,120 @@ def test_checkpoint_rejects_invalid_state(tmp_path: Path) -> None:
             corrupt,
             tmp_path / "invalid",
         )
+
+
+def test_config_preflights_complete_update_result_at_exact_boundary() -> None:
+    # Linear 2-observation/2-action fixture: 324 * ensemble_size + 196 bytes.
+    last_legal = (2**31 - 1 - 196) // 324
+    _config(ensemble_size=last_legal)
+    with pytest.raises(ValueError, match="update-result bytes"):
+        _config(ensemble_size=last_legal + 1)
+
+
+def test_prediction_reductions_remain_finite_at_full_float32_member_means() -> None:
+    ensemble = WorldModelEnsemble(_config(ensemble_size=2))
+    state = ensemble.init(jr.key(0))
+    maximum = jnp.asarray(np.finfo(np.float32).max, dtype=jnp.float32)
+    members = tuple(
+        dataclasses.replace(
+            member,
+            observation_min=jnp.full((2,), maximum, dtype=jnp.float32),
+            observation_max=jnp.full((2,), maximum, dtype=jnp.float32),
+            reward_min=maximum,
+            reward_max=maximum,
+            step_count=jnp.asarray(1, dtype=jnp.int32),
+        )
+        for member in state.member_states
+    )
+    prediction = ensemble._predict_unchecked(  # noqa: SLF001
+        dataclasses.replace(state, member_states=members),
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    assert bool(prediction.valid)
+    assert bool(jnp.all(jnp.isfinite(prediction.mean_next_observation)))
+    assert bool(jnp.isfinite(prediction.mean_reward))
+    np.testing.assert_array_equal(
+        np.asarray(prediction.mean_next_observation),
+        np.full((2,), np.finfo(np.float32).max, dtype=np.float32),
+    )
+
+
+def test_prediction_variance_reduction_scales_before_sum() -> None:
+    magnitude = 8.0e18
+    ensemble_size = 8
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, hidden_sizes=(), sparsity=0.0
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=ensemble_size,
+        target_dim=4,
+        max_input_magnitude=magnitude,
+    )
+    ensemble = WorldModelEnsemble(
+        WorldModelEnsembleConfig(
+            model=model,
+            signal_estimator=signals,
+            ensemble_size=ensemble_size,
+        )
+    )
+    state = ensemble.init(jr.key(0))
+    members = []
+    for index, member in enumerate(state.member_states):
+        heads = member.learner_state.head_params
+        signed = magnitude if index % 2 == 0 else -magnitude
+        members.append(
+            dataclasses.replace(
+                member,
+                learner_state=dataclasses.replace(
+                    member.learner_state,
+                    head_params=dataclasses.replace(
+                        heads,
+                        weights=tuple(jnp.zeros_like(weight) for weight in heads.weights),
+                        biases=tuple(jnp.full_like(bias, signed) for bias in heads.biases),
+                    ),
+                ),
+            )
+        )
+    prediction = ensemble._predict_unchecked(  # noqa: SLF001
+        dataclasses.replace(state, member_states=tuple(members)),
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    assert bool(prediction.valid)
+    assert bool(jnp.all(jnp.isfinite(prediction.per_head_epistemic_variance)))
+    assert bool(jnp.isfinite(prediction.epistemic_disagreement))
+
+
+def test_public_prediction_neutralizes_nonfinite_aggregate_variance() -> None:
+    ensemble = WorldModelEnsemble(_config(ensemble_size=2))
+    state = ensemble.init(jr.key(0))
+    maximum = np.finfo(np.float32).max
+    members = []
+    for index, member in enumerate(state.member_states):
+        heads = member.learner_state.head_params
+        signed = maximum if index == 0 else -maximum
+        members.append(
+            dataclasses.replace(
+                member,
+                learner_state=dataclasses.replace(
+                    member.learner_state,
+                    head_params=dataclasses.replace(
+                        heads,
+                        weights=tuple(jnp.zeros_like(weight) for weight in heads.weights),
+                        biases=tuple(jnp.full_like(bias, signed) for bias in heads.biases),
+                    ),
+                ),
+            )
+        )
+    prediction = ensemble.predict(
+        dataclasses.replace(state, member_states=tuple(members)),
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    assert not bool(prediction.valid)
+    chex.assert_tree_all_finite(prediction)
+    np.testing.assert_array_equal(
+        np.asarray(prediction.member_raw_predictions),
+        np.zeros((2, 4), dtype=np.float32),
+    )


### PR DESCRIPTION
Narrow corrective follow-up to merged #856 (and superseded #849/#836).\n\nThe merged configuration/resource repair did not cover runtime reduction sinks: ordinary float32 `mean`/`var` reductions could overflow their intermediate sums even when every member value was finite, aggregate outputs were omitted from `prediction.valid`, the ordinary update returned an invalid/non-finite prediction on rollback, and the preflight stopped at persistent state instead of the largest public update result.\n\nThis follow-up scales before every ensemble/loss reduction, forms variance from the stable mean, includes every aggregate diagnostic in validity, neutralizes invalid public/update predictions, and preflights the exact complete update-result scalar/byte formula before any member allocation.\n\nVerification on merged #856/main:\n- 4 new allocation-free/full-float32/variance/neutralization regressions passed\n- Ruff clean on changed files\n- strict targeted mypy clean\n- diff-check clean\n\nDevelopment-only mechanism hardening; no outputs/evidence artifacts changed.