### PR TITLE
fix(cumulant-discovery): preserve scalar and loader contracts

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import functools
 import operator
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -65,12 +66,15 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 
 _INT32_MAX = 2**31 - 1
 _MAX_PERSISTENT_STATE_BYTES = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -91,18 +95,21 @@ def _require_float32(
     upper: float | None = None,
     upper_inclusive: bool = True,
     positive: bool = False,
+    preserve_nonzero: bool = False,
 ) -> float:
-    try:
-        return validated_float32_scalar(
-            name,
-            value,
-            lower=lower,
-            upper=upper,
-            upper_inclusive=upper_inclusive,
-            positive=positive,
-        )
-    except Exception as error:
-        raise ValueError(f"{name} is outside its finite float32 domain") from error
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    stored, numerator, _ = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+        positive=positive,
+    )
+    if preserve_nonzero and numerator != 0 and stored == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
 
 
 def _persistent_resources(raw_dim: int, n_candidates: int) -> dict[str, int]:
@@ -205,12 +212,18 @@ class CumulantDiscovery:
             upper_inclusive=False,
         )
         replacement_rate = _require_float32(
-            "replacement_rate", replacement_rate, lower=0.0, upper=1.0
+            "replacement_rate",
+            replacement_rate,
+            lower=0.0,
+            upper=1.0,
+            preserve_nonzero=True,
         )
         predictor_step_size = _require_float32(
             "predictor_step_size", predictor_step_size, positive=True
         )
-        gamma = _require_float32("gamma", gamma, lower=0.0, upper=1.0)
+        gamma = _require_float32(
+            "gamma", gamma, lower=0.0, upper=1.0, preserve_nonzero=True
+        )
         if type(enabled) is not bool:
             raise ValueError("enabled must be an exact boolean")
 
@@ -514,37 +527,18 @@ class CumulantDiscovery:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> CumulantDiscovery:
+    def from_config(cls, config: Mapping[str, Any]) -> CumulantDiscovery:
         """Reconstruct from dict."""
-        if type(config) is not dict:
-            raise ValueError("cumulant-discovery config must be an exact dictionary")
-        config = dict(config)
-        expected = {
-            "type",
-            "raw_dim",
-            "n_candidates",
-            "decay_rate",
-            "replacement_rate",
-            "maturity_threshold",
-            "predictor_step_size",
-            "gamma",
-            "enabled",
-        }
-        if set(config) != expected:
-            raise ValueError("cumulant-discovery config keys are not the exact schema")
-        if config.pop("type") != "CumulantDiscovery":
-            raise ValueError("cumulant-discovery config type is unsupported")
-        for name in ("raw_dim", "n_candidates", "maturity_threshold"):
-            if type(config[name]) is not int:
-                raise ValueError(f"serialized {name} must be an exact JSON integer")
-        for name in (
-            "decay_rate",
-            "replacement_rate",
-            "predictor_step_size",
-            "gamma",
-        ):
-            if type(config[name]) is not float:
-                raise ValueError(f"serialized {name} must be an exact JSON float")
-        if type(config["enabled"]) is not bool:
-            raise ValueError("serialized enabled must be an exact JSON boolean")
-        return cls(**config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
+        if any(type(key) is not str for key in payload):
+            raise ValueError("config keys must be strings")
+        payload.pop("type", None)
+        try:
+            return cls(**payload)
+        except TypeError as error:
+            raise ValueError("config has missing or unsupported fields") from error

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -339,7 +341,7 @@ def test_cumulant_discovery_rejects_hostile_integer_subclasses(field: str) -> No
 @pytest.mark.parametrize(
     "field", ["decay_rate", "replacement_rate", "predictor_step_size", "gamma"]
 )
-def test_cumulant_discovery_float_hook_runs_once(field: str) -> None:
+def test_cumulant_discovery_rejects_float_subclasses_without_hooks(field: str) -> None:
     class CountingFloat(float):
         def __new__(cls):
             instance = super().__new__(cls, 0.5)
@@ -351,10 +353,9 @@ def test_cumulant_discovery_float_hook_runs_once(field: str) -> None:
             return (1, 2)
 
     value = CountingFloat()
-    discovery = CumulantDiscovery(raw_dim=4, **{field: value})
-
-    assert value.calls == 1
-    assert type(getattr(discovery, f"_{field}")) is float
+    with pytest.raises(ValueError, match=field):
+        CumulantDiscovery(raw_dim=4, **{field: value})
+    assert value.calls == 0
 
 
 def test_cumulant_discovery_hostile_float_failure_never_formats_repr() -> None:
@@ -367,6 +368,13 @@ def test_cumulant_discovery_hostile_float_failure_never_formats_repr() -> None:
 
     with pytest.raises(ValueError, match="decay_rate"):
         CumulantDiscovery(raw_dim=4, decay_rate=ExplodingFloat(0.5))
+
+
+@pytest.mark.parametrize("field", ["replacement_rate", "gamma"])
+def test_cumulant_discovery_rejects_exact_nonzero_float32_underflow(field: str) -> None:
+    tiny = np.nextafter(np.longdouble(0), np.longdouble(1))
+    with pytest.raises(ValueError, match="remain nonzero"):
+        CumulantDiscovery(raw_dim=4, **{field: tiny})
 
 
 def test_cumulant_discovery_resource_formula_matches_state() -> None:
@@ -385,22 +393,13 @@ def test_cumulant_discovery_resource_boundary_is_allocation_free() -> None:
         CumulantDiscovery(raw_dim=last_valid_dim + 1, n_candidates=1)
 
 
-def test_cumulant_discovery_config_schema_is_exact_json() -> None:
+def test_cumulant_discovery_config_preserves_historical_mapping_forms() -> None:
     config = CumulantDiscovery(raw_dim=4).to_config()
     config["raw_dim"] = np.int32(4)
-    with pytest.raises(ValueError, match="exact JSON integer"):
-        CumulantDiscovery.from_config(config)
-
-    config = CumulantDiscovery(raw_dim=4).to_config()
-    config["unknown"] = 1
-    with pytest.raises(ValueError, match="exact schema"):
-        CumulantDiscovery.from_config(config)
-
-    class ConfigSubclass(dict):
-        pass
-
-    with pytest.raises(ValueError, match="exact dictionary"):
-        CumulantDiscovery.from_config(ConfigSubclass())
+    assert CumulantDiscovery.from_config(MappingProxyType(config)).raw_dim == 4
+    partial = {"type": "historical-marker", "raw_dim": 4}
+    restored = CumulantDiscovery.from_config(partial)
+    assert restored.n_candidates == 16
 
 
 def test_cumulant_discovery_age_saturates_at_int32_max() -> None:


### PR DESCRIPTION
Narrow residual after merged #860 and #865. Keeps their exact 256 MiB resource preflight, typed Threefry key, state/input shape+dtypes, transactional nonfinite handling, saturation, and contributor work. Adds only the remaining contracts: concrete host real types without hostile subclass hooks; exact-nonzero float32 underflow rejection for zero-legal replacement_rate/gamma; and the historical unversioned Mapping/partial-default/type-marker loader behavior instead of a breaking exact-schema change.\n\nVerification: 51 full cumulant-discovery tests passed; scoped Ruff, strict mypy, and diff-check passed.