### PR TITLE
fix(associative-memory): restore exact serialized schemas

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -15,7 +15,7 @@ import functools
 import math
 import operator
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from numbers import Real
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -285,13 +285,37 @@ class AssociativeMemoryConfig:
     def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
         payload = _read_mapping("AssociativeMemoryConfig payload", config)
-        payload.pop("type", None)
-        try:
-            return cls(**payload)
-        except ValueError:
-            raise
-        except Exception as error:
-            raise ValueError("serialized AssociativeMemoryConfig is invalid") from error
+        if payload.pop("type", None) != "AssociativeMemoryConfig":
+            raise ValueError("AssociativeMemoryConfig type is invalid")
+        if set(payload) != {field.name for field in fields(cls)}:
+            raise ValueError("AssociativeMemoryConfig fields do not match its schema")
+        integer_fields = {
+            "vocab_size",
+            "block_size",
+            "suffix_length",
+            "max_features",
+            "min_effective_budget",
+        }
+        boolean_fields = {
+            "normalize_by_weight",
+            "adaptive_feature_family",
+            "adaptive_window",
+            "adaptive_budget",
+        }
+        string_fields = {"feature_family"}
+        for name, value in payload.items():
+            if name in integer_fields and type(value) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+            if name in boolean_fields and type(value) is not bool:
+                raise ValueError(f"serialized {name} must be a JSON boolean")
+            if name in string_fields and type(value) is not str:
+                raise ValueError(f"serialized {name} must be a JSON string")
+            if (
+                name not in integer_fields | boolean_fields | string_fields
+                and type(value) is not float
+            ):
+                raise ValueError(f"serialized {name} must be a JSON number")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -607,7 +631,11 @@ class AssociativeMemoryLearner:
     def from_config(cls, config: Mapping[str, Any]) -> AssociativeMemoryLearner:
         """Reconstruct from :meth:`to_config` output."""
         payload = _read_mapping("AssociativeMemoryLearner payload", config)
-        inner = payload.get("config")
+        if set(payload) != {"type", "config"}:
+            raise ValueError("AssociativeMemoryLearner fields do not match its schema")
+        if payload["type"] != "AssociativeMemoryLearner":
+            raise ValueError("AssociativeMemoryLearner type is invalid")
+        inner = payload["config"]
         if not issubclass(type(inner), Mapping):
             raise ValueError("AssociativeMemoryLearner config must be a mapping")
         return cls(AssociativeMemoryConfig.from_config(cast(Mapping[str, Any], inner)))

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -239,23 +239,33 @@ def test_associative_pair_descriptors_preflight_before_learner_construction() ->
         )
 
 
-def test_associative_serialization_preserves_historical_compatibility() -> None:
+def test_associative_serialized_schema_is_exact_and_mapping_compatible() -> None:
     config = _base_cfg()
     payload = config.to_config()
-    payload["type"] = "historical-marker"
-    payload["vocab_size"] = np.int32(config.vocab_size)
     restored = AssociativeMemoryConfig.from_config(MappingProxyType(payload))
     assert restored == config
-    partial = AssociativeMemoryConfig.from_config(
-        {"vocab_size": 4, "block_size": 8, "suffix_length": 2, "max_features": 4}
-    )
-    assert partial == config
     learner_payload = AssociativeMemoryLearner(config).to_config()
-    learner_payload["type"] = "historical-marker"
-    learner_payload["metadata"] = 1
     assert AssociativeMemoryLearner.from_config(learner_payload).config == config
-    with pytest.raises(ValueError, match="serialized AssociativeMemoryConfig"):
-        AssociativeMemoryConfig.from_config({**config.to_config(), "unknown": 1})
+
+    for mutation, match in (
+        ({"type": "historical-marker"}, "type"),
+        ({"vocab_size": np.int32(config.vocab_size)}, "vocab_size"),
+        ({"retention": np.float32(config.retention)}, "retention"),
+        ({"normalize_by_weight": np.bool_(True)}, "normalize_by_weight"),
+        ({"unknown": 1}, "fields"),
+    ):
+        invalid = dict(payload)
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            AssociativeMemoryConfig.from_config(invalid)
+    partial = {"vocab_size": 4, "block_size": 8, "suffix_length": 2, "max_features": 4}
+    with pytest.raises(ValueError, match="type"):
+        AssociativeMemoryConfig.from_config(partial)
+
+    with pytest.raises(ValueError, match="type"):
+        AssociativeMemoryLearner.from_config({**learner_payload, "type": "historical-marker"})
+    with pytest.raises(ValueError, match="fields"):
+        AssociativeMemoryLearner.from_config({**learner_payload, "metadata": 1})
 
 
 def test_associative_public_contracts_and_counters() -> None:


### PR DESCRIPTION
Post-merge corrective for #848. Its otherwise deeper resource/public-operation repair accidentally removed the exact config and learner serialization gates previously present in #846. Restore exact discriminators, full field sets, built-in JSON scalar types, and nested learner schema while retaining Mapping compatibility and all #848 derived-resource/state fixes.

Validation: 178 associative tests passed after the corrected assertion (177 passed plus one stale compatibility expectation identified, then the focused corrected test passed); Ruff and strict mypy passed. No benchmarks or outputs.