### PR TITLE
fix(option-duration): complete configuration and resource contracts

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import operator
 import time
 from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -44,6 +45,31 @@ REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
 _INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
+    """Validate one actual host integer in the signed-int32 domain."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
 
 
 def _require_float32_real(
@@ -227,9 +253,7 @@ class OptionValueDurationLearner:
         config: OptionValueDurationConfig | None = None,
     ):
         """Create a fixed-capacity option predictor."""
-        if n_options < 1:
-            raise ValueError("n_options must be positive")
-        self._n_options = n_options
+        self._n_options = _require_int32("n_options", n_options)
         self._config = config or OptionValueDurationConfig()
 
     @property
@@ -256,23 +280,21 @@ class OptionValueDurationLearner:
         payload = dict(config)
         payload.pop("type", None)
         return cls(
-            n_options=int(payload["n_options"]),
+            n_options=payload["n_options"],
             config=OptionValueDurationConfig.from_config(payload["config"]),
         )
 
     def trainable_parameter_count(self, feature_dim: int) -> int:
         """Return the exact history-independent trainable parameter count."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        return self._n_options * N_HEADS * feature_dim
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
+        return self._n_options * N_HEADS * validated_feature_dim
 
     def init(self, feature_dim: int) -> OptionValueDurationState:
         """Initialize all heads to zero."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
         return OptionValueDurationState(
             weights=jnp.zeros(
-                (self._n_options, N_HEADS, feature_dim),
+                (self._n_options, N_HEADS, validated_feature_dim),
                 dtype=jnp.float32,
             ),
             option_update_counts=jnp.zeros((self._n_options,), dtype=jnp.int32),

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -27,10 +27,9 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-import operator
 import time
 from numbers import Real
-from typing import Any, SupportsIndex, cast
+from typing import Any
 
 import chex
 import jax
@@ -45,31 +44,6 @@ REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
 _INT32_MAX = 2_147_483_647
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
-
-
-def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
-    """Validate one actual host integer in the signed-int32 domain."""
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
-    canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= _INT32_MAX:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
-    return canonical
 
 
 def _require_float32_real(
@@ -253,7 +227,9 @@ class OptionValueDurationLearner:
         config: OptionValueDurationConfig | None = None,
     ):
         """Create a fixed-capacity option predictor."""
-        self._n_options = _require_int32("n_options", n_options)
+        if n_options < 1:
+            raise ValueError("n_options must be positive")
+        self._n_options = n_options
         self._config = config or OptionValueDurationConfig()
 
     @property
@@ -280,21 +256,23 @@ class OptionValueDurationLearner:
         payload = dict(config)
         payload.pop("type", None)
         return cls(
-            n_options=payload["n_options"],
+            n_options=int(payload["n_options"]),
             config=OptionValueDurationConfig.from_config(payload["config"]),
         )
 
     def trainable_parameter_count(self, feature_dim: int) -> int:
         """Return the exact history-independent trainable parameter count."""
-        validated_feature_dim = _require_int32("feature_dim", feature_dim)
-        return self._n_options * N_HEADS * validated_feature_dim
+        if feature_dim < 1:
+            raise ValueError("feature_dim must be positive")
+        return self._n_options * N_HEADS * feature_dim
 
     def init(self, feature_dim: int) -> OptionValueDurationState:
         """Initialize all heads to zero."""
-        validated_feature_dim = _require_int32("feature_dim", feature_dim)
+        if feature_dim < 1:
+            raise ValueError("feature_dim must be positive")
         return OptionValueDurationState(
             weights=jnp.zeros(
-                (self._n_options, N_HEADS, validated_feature_dim),
+                (self._n_options, N_HEADS, feature_dim),
                 dtype=jnp.float32,
             ),
             option_update_counts=jnp.zeros((self._n_options,), dtype=jnp.int32),

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -27,9 +27,9 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import operator
 import time
-from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
@@ -38,12 +38,26 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 
 REWARD_HEAD = 0
 DURATION_HEAD = 1
 N_HEADS = 2
 _INT32_MAX = 2_147_483_647
+_MAX_PERSISTENT_STATE_BYTES = 256 * 1024 * 1024
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
+    """Canonicalize one concrete Python/NumPy integer without invoking hooks."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
+    return canonical
 
 
 def _require_float32_real(
@@ -54,31 +68,35 @@ def _require_float32_real(
 ) -> float:
     """Validate one host scalar in its exact domain and float32 sink."""
     domain = "positive" if strictly_positive else "non-negative"
-    preserve_builtin_payload = type(value) is int or type(value) is float
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
-        raise ValueError(f"{name} must be finite and {domain}")
     try:
-        if strictly_positive:
-            if value <= 0:
-                raise ValueError
-        elif value < 0:
-            raise ValueError
-        narrowed = round_real_to_float32(value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+        stored, numerator, _ = validated_float32_scalar_with_ratio(
+            name,
+            value,
+            positive=strictly_positive,
+            lower=None if strictly_positive else 0.0,
+        )
+    except Exception as error:
         raise ValueError(f"{name} must be finite and {domain}") from error
-    if not bool(np.isfinite(narrowed)):
-        raise ValueError(f"{name} must narrow to a finite float32")
-    if value != 0 and narrowed == 0.0:
+    narrowed = float(np.float32(stored))
+    if numerator != 0 and narrowed == 0.0:
         raise ValueError(f"{name} must not underflow to zero in float32")
+    return stored
 
-    # Preserve already-valid built-in payloads for serialization compatibility.
-    # Non-built-in Real scalars are canonicalized to the exact execution value.
-    if not preserve_builtin_payload:
-        return narrowed
-    number = float(value)
-    with np.errstate(invalid="ignore", over="ignore", under="ignore"):
-        renarrowed = float(np.float32(number))
-    return number if narrowed == renarrowed else narrowed
+
+def _state_resources(n_options: int, feature_dim: int) -> dict[str, int]:
+    """Exact persistent array envelope, excluding Python/compiled/transient data."""
+    trainable_parameters = n_options * N_HEADS * feature_dim
+    persistent_scalars = trainable_parameters + n_options + 1
+    persistent_bytes = 4 * persistent_scalars
+    if trainable_parameters > _INT32_MAX or persistent_scalars > _INT32_MAX:
+        raise ValueError("derived option-duration persistent scalars must fit signed int32")
+    if persistent_bytes > _MAX_PERSISTENT_STATE_BYTES:
+        raise ValueError("derived option-duration persistent state exceeds 256 MiB")
+    return {
+        "trainable_parameters": trainable_parameters,
+        "persistent_scalars": persistent_scalars,
+        "persistent_bytes": persistent_bytes,
+    }
 
 
 def _saturating_increment(value: Array) -> Array:
@@ -144,8 +162,25 @@ class OptionValueDurationConfig:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> OptionValueDurationConfig:
         """Reconstruct a config from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("option-duration config must be an exact dictionary")
         payload = dict(config)
-        payload.pop("type", None)
+        if any(type(key) is not str for key in payload):
+            raise ValueError("option-duration config keys must be exact strings")
+        expected = {
+            "type",
+            "reward_step_size",
+            "duration_step_size",
+            "duration_floor",
+        }
+        if set(payload) != expected:
+            raise ValueError("option-duration config keys are not the exact schema")
+        marker = payload.pop("type")
+        if type(marker) is not str or marker != "OptionValueDurationConfig":
+            raise ValueError("option-duration config type is unsupported")
+        for name, value in payload.items():
+            if type(value) is not float:
+                raise ValueError(f"serialized {name} must be an exact JSON float")
         return cls(**payload)
 
 
@@ -227,10 +262,13 @@ class OptionValueDurationLearner:
         config: OptionValueDurationConfig | None = None,
     ):
         """Create a fixed-capacity option predictor."""
-        if n_options < 1:
-            raise ValueError("n_options must be positive")
-        self._n_options = n_options
-        self._config = config or OptionValueDurationConfig()
+        self._n_options = _require_int32("n_options", n_options)
+        _state_resources(self._n_options, 1)
+        if config is None:
+            config = OptionValueDurationConfig()
+        if type(config) is not OptionValueDurationConfig:
+            raise ValueError("config must be an actual OptionValueDurationConfig")
+        self._config = config
 
     @property
     def n_options(self) -> int:
@@ -253,23 +291,41 @@ class OptionValueDurationLearner:
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> OptionValueDurationLearner:
         """Reconstruct a learner from :meth:`to_config` output."""
+        if type(config) is not dict:
+            raise ValueError("option-duration learner config must be an exact dictionary")
         payload = dict(config)
-        payload.pop("type", None)
+        if any(type(key) is not str for key in payload):
+            raise ValueError("option-duration learner config keys must be exact strings")
+        if set(payload) != {"type", "n_options", "config"}:
+            raise ValueError("option-duration learner config keys are not the exact schema")
+        marker = payload.pop("type")
+        if type(marker) is not str or marker != "OptionValueDurationLearner":
+            raise ValueError("option-duration learner config type is unsupported")
+        if type(payload["n_options"]) is not int:
+            raise ValueError("serialized n_options must be an exact JSON integer")
+        if type(payload["config"]) is not dict:
+            raise ValueError("serialized config must be an exact JSON object")
         return cls(
-            n_options=int(payload["n_options"]),
+            n_options=payload["n_options"],
             config=OptionValueDurationConfig.from_config(payload["config"]),
         )
 
     def trainable_parameter_count(self, feature_dim: int) -> int:
         """Return the exact history-independent trainable parameter count."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        return self._n_options * N_HEADS * feature_dim
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
+        return _state_resources(self._n_options, validated_feature_dim)[
+            "trainable_parameters"
+        ]
+
+    def persistent_resource_budget(self, feature_dim: int) -> dict[str, int]:
+        """Return the exact retained-array budget before initialization."""
+        validated_feature_dim = _require_int32("feature_dim", feature_dim)
+        return _state_resources(self._n_options, validated_feature_dim)
 
     def init(self, feature_dim: int) -> OptionValueDurationState:
         """Initialize all heads to zero."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        feature_dim = _require_int32("feature_dim", feature_dim)
+        _state_resources(self._n_options, feature_dim)
         return OptionValueDurationState(
             weights=jnp.zeros(
                 (self._n_options, N_HEADS, feature_dim),
@@ -281,6 +337,64 @@ class OptionValueDurationLearner:
             uptime_s=0.0,
         )
 
+    def _require_state_contract(
+        self, state: object
+    ) -> tuple[OptionValueDurationState, int]:
+        if type(state) is not OptionValueDurationState:
+            raise ValueError("state must be an actual OptionValueDurationState")
+        canonical = state
+        try:
+            weights_ndim = canonical.weights.ndim
+            weights_shape = canonical.weights.shape
+            weights_dtype = canonical.weights.dtype
+            counts_shape = canonical.option_update_counts.shape
+            counts_dtype = canonical.option_update_counts.dtype
+            step_shape = canonical.step_count.shape
+            step_dtype = canonical.step_count.dtype
+        except Exception as error:
+            raise ValueError("state arrays must expose readable shape and dtype") from error
+        if weights_ndim != 3:
+            raise ValueError("state.weights must be rank 3")
+        feature_dim = weights_shape[2]
+        if (
+            weights_shape != (self._n_options, N_HEADS, feature_dim)
+            or weights_dtype != jnp.float32
+        ):
+            raise ValueError("state.weights has an incompatible shape or dtype")
+        if (
+            counts_shape != (self._n_options,)
+            or counts_dtype != jnp.int32
+        ):
+            raise ValueError("state.option_update_counts has an incompatible shape or dtype")
+        if step_shape != () or step_dtype != jnp.int32:
+            raise ValueError("state.step_count must be scalar int32")
+        _state_resources(self._n_options, feature_dim)
+        return canonical, feature_dim
+
+    @staticmethod
+    def _require_array(
+        name: str,
+        value: object,
+        *,
+        shape: tuple[int, ...],
+        dtype: Any,
+    ) -> Array:
+        try:
+            array = jnp.asarray(value)
+        except Exception as error:
+            raise ValueError(f"{name} must be a readable array") from error
+        if array.shape != shape or array.dtype != dtype:
+            raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
+        return array
+
+    @staticmethod
+    def _state_values_valid(state: OptionValueDurationState) -> Array:
+        return (
+            jnp.all(jnp.isfinite(state.weights))
+            & jnp.all(state.option_update_counts >= 0)
+            & (state.step_count >= 0)
+        )
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict_heads(
         self,
@@ -288,8 +402,15 @@ class OptionValueDurationLearner:
         observation: Array,
     ) -> Float[Array, "n_options 2"]:
         """Return raw ``[reward, duration]`` head predictions for all options."""
-        observation = jnp.asarray(observation, dtype=jnp.float32)
-        return jnp.einsum("ohf,f->oh", state.weights, observation)
+        state, feature_dim = self._require_state_contract(state)
+        observation = self._require_array(
+            "observation",
+            observation,
+            shape=(feature_dim,),
+            dtype=jnp.float32,
+        )
+        heads = jnp.einsum("ohf,f->oh", state.weights, observation)
+        return jnp.where(self._state_values_valid(state), heads, jnp.zeros_like(heads))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(
@@ -329,13 +450,28 @@ class OptionValueDurationLearner:
         responsible for supplying a scalar discount in ``[0, 1]`` and for
         setting it to zero when the option terminates.
         """
-        observation = jnp.asarray(observation, dtype=jnp.float32)
-        next_observation = jnp.asarray(next_observation, dtype=jnp.float32)
-        option_index = jnp.asarray(option_index, dtype=jnp.int32)
+        state, feature_dim = self._require_state_contract(state)
+        observation = self._require_array(
+            "observation", observation, shape=(feature_dim,), dtype=jnp.float32
+        )
+        next_observation = self._require_array(
+            "next_observation",
+            next_observation,
+            shape=(feature_dim,),
+            dtype=jnp.float32,
+        )
+        option_index = self._require_array(
+            "option_index", option_index, shape=(), dtype=jnp.int32
+        )
         option_index_valid = (option_index >= 0) & (option_index < self._n_options)
         safe_option_index = jnp.clip(option_index, 0, self._n_options - 1)
-        reward = jnp.squeeze(jnp.asarray(reward, dtype=jnp.float32))
-        continuation_discount = jnp.squeeze(jnp.asarray(continuation_discount, dtype=jnp.float32))
+        reward = self._require_array("reward", reward, shape=(), dtype=jnp.float32)
+        continuation_discount = self._require_array(
+            "continuation_discount",
+            continuation_discount,
+            shape=(),
+            dtype=jnp.float32,
+        )
 
         option_weights = state.weights[safe_option_index]
         predictions = option_weights @ observation
@@ -361,7 +497,7 @@ class OptionValueDurationLearner:
         proposed_option_weights = (
             option_weights + step_sizes[:, None] * td_errors[:, None] * observation[None, :]
         )
-        source_finite = jnp.all(jnp.isfinite(state.weights))
+        source_valid = self._state_values_valid(state)
         next_needed = continuation_discount != 0.0
         shared_inputs_valid = (
             jnp.all(jnp.isfinite(observation))
@@ -370,7 +506,7 @@ class OptionValueDurationLearner:
             & (continuation_discount >= 0.0)
             & (continuation_discount <= 1.0)
             & option_index_valid
-            & source_finite
+            & source_valid
         )
         head_inputs_valid = jnp.stack(
             (
@@ -434,6 +570,36 @@ def run_option_value_duration_from_arrays(
     continuation_discounts: Float[Array, " num_steps"],
 ) -> OptionValueDurationArrayResult:
     """Scan online TD(0) updates over primitive option transitions."""
+    if type(learner) is not OptionValueDurationLearner:
+        raise ValueError("learner must be an actual OptionValueDurationLearner")
+    state, feature_dim = learner._require_state_contract(state)
+    try:
+        observations = jnp.asarray(observations)
+    except Exception as error:
+        raise ValueError("observations must be a readable float32 matrix") from error
+    if observations.ndim != 2 or observations.shape[1] != feature_dim:
+        raise ValueError("observations have an incompatible shape")
+    if observations.dtype != jnp.float32:
+        raise ValueError("observations must have dtype float32")
+    num_steps = observations.shape[0]
+    next_observations = learner._require_array(
+        "next_observations",
+        next_observations,
+        shape=(num_steps, feature_dim),
+        dtype=jnp.float32,
+    )
+    option_indices = learner._require_array(
+        "option_indices", option_indices, shape=(num_steps,), dtype=jnp.int32
+    )
+    rewards = learner._require_array(
+        "rewards", rewards, shape=(num_steps,), dtype=jnp.float32
+    )
+    continuation_discounts = learner._require_array(
+        "continuation_discounts",
+        continuation_discounts,
+        shape=(num_steps,),
+        dtype=jnp.float32,
+    )
     start = time.time()
 
     def _scan_fn(

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -57,6 +57,38 @@ def test_config_roundtrip_validation_and_fixed_parameter_count() -> None:
 
 
 @pytest.mark.parametrize(
+    "invalid",
+    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1, 2_147_483_648),
+)
+def test_learner_rejects_noncanonical_option_counts(invalid: object) -> None:
+    with pytest.raises(ValueError, match="n_options"):
+        OptionValueDurationLearner(invalid)  # type: ignore[arg-type]
+
+    payload = OptionValueDurationLearner(2).to_config()
+    payload["n_options"] = invalid
+    with pytest.raises(ValueError, match="n_options"):
+        OptionValueDurationLearner.from_config(payload)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1),
+)
+def test_learner_rejects_noncanonical_feature_dimensions(invalid: object) -> None:
+    learner = OptionValueDurationLearner(2)
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.trainable_parameter_count(invalid)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(invalid)  # type: ignore[arg-type]
+
+
+def test_learner_rejects_feature_dimensions_above_int32() -> None:
+    learner = OptionValueDurationLearner(2)
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.trainable_parameter_count(2_147_483_648)
+
+
+@pytest.mark.parametrize(
     "field",
     ("reward_step_size", "duration_step_size", "duration_floor"),
 )

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -57,38 +57,6 @@ def test_config_roundtrip_validation_and_fixed_parameter_count() -> None:
 
 
 @pytest.mark.parametrize(
-    "invalid",
-    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1, 2_147_483_648),
-)
-def test_learner_rejects_noncanonical_option_counts(invalid: object) -> None:
-    with pytest.raises(ValueError, match="n_options"):
-        OptionValueDurationLearner(invalid)  # type: ignore[arg-type]
-
-    payload = OptionValueDurationLearner(2).to_config()
-    payload["n_options"] = invalid
-    with pytest.raises(ValueError, match="n_options"):
-        OptionValueDurationLearner.from_config(payload)
-
-
-@pytest.mark.parametrize(
-    "invalid",
-    (True, np.bool_(True), 1.5, np.float64(2.0), "2", None, -1),
-)
-def test_learner_rejects_noncanonical_feature_dimensions(invalid: object) -> None:
-    learner = OptionValueDurationLearner(2)
-    with pytest.raises(ValueError, match="feature_dim"):
-        learner.trainable_parameter_count(invalid)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_dim"):
-        learner.init(invalid)  # type: ignore[arg-type]
-
-
-def test_learner_rejects_feature_dimensions_above_int32() -> None:
-    learner = OptionValueDurationLearner(2)
-    with pytest.raises(ValueError, match="feature_dim"):
-        learner.trainable_parameter_count(2_147_483_648)
-
-
-@pytest.mark.parametrize(
     "field",
     ("reward_step_size", "duration_step_size", "duration_floor"),
 )

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -19,6 +19,7 @@ from alberta_framework.core.option_value_duration import (
     DURATION_HEAD,
     OptionValueDurationConfig,
     OptionValueDurationLearner,
+    run_option_value_duration_from_arrays,
 )
 
 pytestmark = pytest.mark.unit
@@ -417,3 +418,208 @@ def test_infinite_reward_on_zero_feature_does_not_poison_duration_head() -> None
     chex.assert_tree_all_finite(recovered.state.weights[0, DURATION_HEAD])
     assert bool(recovered.update_applied)
     assert bool(jnp.all(recovered.head_updates_applied))
+
+
+@pytest.mark.parametrize(
+    "integer_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.longlong,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.ulonglong,
+    ],
+)
+def test_option_duration_canonicalizes_numpy_integer_family(integer_type) -> None:
+    learner = OptionValueDurationLearner(integer_type(2))
+
+    assert type(learner.n_options) is int
+    assert learner.trainable_parameter_count(integer_type(3)) == 12
+    assert learner.init(integer_type(3)).weights.shape == (2, 2, 3)
+
+
+@pytest.mark.parametrize("field", ["n_options", "feature_dim"])
+def test_option_duration_rejects_hostile_integer_subclasses(field: str) -> None:
+    class HostileInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("untrusted index hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    if field == "n_options":
+        with pytest.raises(ValueError, match=field):
+            OptionValueDurationLearner(HostileInt(2))
+    else:
+        learner = OptionValueDurationLearner(2)
+        with pytest.raises(ValueError, match=field):
+            learner.init(HostileInt(3))
+
+
+def test_option_duration_float_hook_runs_once_and_normalizes_failures() -> None:
+    class CountingFloat(float):
+        def __new__(cls):
+            instance = super().__new__(cls, 0.25)
+            instance.calls = 0
+            return instance
+
+        def as_integer_ratio(self) -> tuple[int, int]:
+            self.calls += 1
+            return (1, 4)
+
+    value = CountingFloat()
+    config = OptionValueDurationConfig(reward_step_size=value)
+    assert value.calls == 1
+    assert type(config.reward_step_size) is float
+
+    class ExplodingFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("hostile ratio")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match="reward_step_size"):
+        OptionValueDurationConfig(reward_step_size=ExplodingFloat(0.25))
+
+
+def test_option_duration_rejects_builtin_float32_underflow() -> None:
+    with pytest.raises(ValueError, match="reward_step_size"):
+        OptionValueDurationConfig(reward_step_size=1.0e-50)
+
+
+def test_option_duration_config_schemas_and_record_type_are_exact() -> None:
+    class ConfigSubclass(OptionValueDurationConfig):
+        pass
+
+    with pytest.raises(ValueError, match="actual OptionValueDurationConfig"):
+        OptionValueDurationLearner(2, ConfigSubclass())
+
+    learner_payload = OptionValueDurationLearner(2).to_config()
+    learner_payload["n_options"] = np.int32(2)
+    with pytest.raises(ValueError, match="exact JSON integer"):
+        OptionValueDurationLearner.from_config(learner_payload)
+
+    config_payload = OptionValueDurationConfig().to_config()
+    config_payload["type"] = "AnotherConfig"
+    with pytest.raises(ValueError, match="type is unsupported"):
+        OptionValueDurationConfig.from_config(config_payload)
+
+    class PayloadSubclass(dict):
+        pass
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        OptionValueDurationLearner.from_config(PayloadSubclass())
+
+
+def test_option_duration_resource_formula_matches_materialized_state() -> None:
+    learner = OptionValueDurationLearner(3)
+    state = learner.init(5)
+    actual_bytes = sum(
+        int(leaf.nbytes)
+        for leaf in jax.tree_util.tree_leaves(state)
+        if hasattr(leaf, "nbytes")
+    )
+
+    assert learner.persistent_resource_budget(5) == {
+        "trainable_parameters": 30,
+        "persistent_scalars": 34,
+        "persistent_bytes": actual_bytes,
+    }
+
+
+def test_option_duration_resource_limit_precedes_allocation(monkeypatch) -> None:
+    learner = OptionValueDurationLearner(1)
+    last_valid = ((256 * 1024 * 1024 // 4) - 2) // 2
+    assert learner.persistent_resource_budget(last_valid)["persistent_bytes"] <= 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        jnp,
+        "zeros",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("allocation began before resource preflight")
+        ),
+    )
+    with pytest.raises(ValueError, match="256 MiB"):
+        learner.init(last_valid + 1)
+
+    last_valid_options = ((256 * 1024 * 1024 // 4) - 1) // 3
+    OptionValueDurationLearner(last_valid_options)
+    with pytest.raises(ValueError, match="256 MiB"):
+        OptionValueDurationLearner(last_valid_options + 1)
+
+
+def test_option_duration_runtime_shape_dtype_and_state_contracts() -> None:
+    learner = OptionValueDurationLearner(2)
+    state = learner.init(3)
+    malformed = state.replace(weights=jnp.zeros((2, 3), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="state.weights"):
+        learner.predict(malformed, jnp.ones(3, dtype=jnp.float32))
+
+    with pytest.raises(ValueError, match="observation"):
+        learner.predict(state, jnp.ones((1, 3), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="dtype"):
+        learner.predict(state, jnp.ones(3, dtype=jnp.int32))
+    with pytest.raises(ValueError, match="option_index"):
+        learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+    class HostileArray:
+        @property
+        def ndim(self):
+            raise RuntimeError("hostile shape")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    hostile_state = state.replace(weights=HostileArray())
+    with pytest.raises(ValueError, match="readable shape and dtype"):
+        learner._require_state_contract(hostile_state)
+
+
+def test_option_duration_invalid_dynamic_state_is_held_atomically() -> None:
+    learner = OptionValueDurationLearner(1)
+    state = learner.init(1).replace(
+        option_update_counts=jnp.asarray([-1], dtype=jnp.int32)
+    )
+    result = learner.update(
+        state,
+        jnp.ones(1, dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+    )
+
+    chex.assert_trees_all_equal(result.state.weights, state.weights)
+    chex.assert_trees_all_equal(
+        result.state.option_update_counts, state.option_update_counts
+    )
+    chex.assert_trees_all_equal(result.state.step_count, state.step_count)
+    assert not bool(result.update_applied)
+
+
+def test_option_duration_array_runner_requires_exact_shapes() -> None:
+    learner = OptionValueDurationLearner(1)
+    state = learner.init(2)
+    with pytest.raises(ValueError, match="option_indices"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            jnp.ones((2, 2), dtype=jnp.float32),
+            jnp.zeros((2, 1), dtype=jnp.int32),
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.ones((2, 2), dtype=jnp.float32),
+            jnp.zeros((2,), dtype=jnp.float32),
+        )


### PR DESCRIPTION
Contributor-preserving replacement for #861; closes #858.

Retains ss251’s concrete Python/NumPy integer canonicalization and raw loader pass-through, then completes the boundary:
- one guarded exact-ratio call for each float32 scalar, with ordinary failures normalized and exact nonzero underflow rejected;
- exact config record and JSON schemas, including markers, nested object, floats, and integer fields;
- exact persistent formula `4 * (2*n_options*feature_dim + n_options + 1)` with signed-int32 accounting and a 256 MiB preflight before allocation;
- state, vector, and scalar shape/dtype contracts under eager/JIT use; dynamic invalid state is held atomically;
- array-runner shape/dtype validation and existing saturating counters retained.

Verification: 62 focused tests, scoped Ruff, strict mypy, diff-check. No benchmark or output artifact was touched.