### PR TITLE
fix(off-policy): complete TD and nonlinear Horde contracts

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -11,12 +11,14 @@ correction terms that are still separate from this shared-trunk backend.
 from __future__ import annotations
 
 import functools
+import operator
 import time
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -37,6 +39,32 @@ from alberta_framework.core.types import HordeSpec, MLPParams, TraceMode
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -242,13 +270,10 @@ class OffPolicyHordeLearner:
         if ratio_clip <= 0.0:
             raise ValueError(f"ratio_clip must be positive; got {ratio_clip}")
         if trace_ratio_clip <= 0.0:
-            raise ValueError(
-                f"trace_ratio_clip must be positive; got {trace_ratio_clip}"
-            )
+            raise ValueError(f"trace_ratio_clip must be positive; got {trace_ratio_clip}")
         if min_behavior_probability <= 0.0:
             raise ValueError(
-                "min_behavior_probability must be positive; "
-                f"got {min_behavior_probability}"
+                f"min_behavior_probability must be positive; got {min_behavior_probability}"
             )
 
         self._horde_spec = horde_spec
@@ -320,7 +345,6 @@ class OffPolicyHordeLearner:
     def predict(self, state: MultiHeadMLPState, observation: Array) -> Array:
         """Predict all demon values for one observation."""
         return self._learner.predict(state, observation)  # type: ignore[no-any-return]
-
 
     def update(
         self,
@@ -452,10 +476,7 @@ class OffPolicyHordeLearner:
             & jnp.isfinite(discounts)
             & (discounts >= 0.0)
             & (discounts <= 1.0)
-            & (
-                zero_discount_mask
-                | (next_observation_valid & jnp.isfinite(next_predictions))
-            )
+            & (zero_discount_mask | (next_observation_valid & jnp.isfinite(next_predictions)))
             & jnp.isfinite(td_targets)
         )
         active_mask = head_inputs_valid & global_inputs_valid & source_state_finite
@@ -521,13 +542,9 @@ class OffPolicyHordeLearner:
             effective_error_i = safe_clipped_rhos[i] * masked_td_error_i
 
             predictions_list.append(pred_i)
-            td_errors_list.append(
-                jnp.where(active_mask[i], td_error_i, jnp.nan)
-            )
+            td_errors_list.append(jnp.where(active_mask[i], td_error_i, jnp.nan))
             masked_td_errors_list.append(masked_td_error_i)
-            cotangent = cotangent + effective_error_i * jnp.squeeze(
-                state.head_params.weights[i]
-            )
+            cotangent = cotangent + effective_error_i * jnp.squeeze(state.head_params.weights[i])
 
         predictions = jnp.stack(predictions_list)
         td_errors = jnp.stack(td_errors_list)
@@ -563,13 +580,11 @@ class OffPolicyHordeLearner:
             else:
                 new_w_trace = w_grad_i
             new_trunk_traces.append(new_w_trace)
-            w_step, new_w_opt, w_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._optimizer,
-                    state.trunk_optimizer_states[2 * i],
-                    new_w_trace,
-                    error=None,
-                )
+            w_step, new_w_opt, w_update_applied = _update_from_gradient_with_diagnostics(
+                self._optimizer,
+                state.trunk_optimizer_states[2 * i],
+                new_w_trace,
+                error=None,
             )
             trunk_steps.append(w_step)
             new_trunk_opt_states.append(new_w_opt)
@@ -582,13 +597,11 @@ class OffPolicyHordeLearner:
             else:
                 new_b_trace = b_grad_i
             new_trunk_traces.append(new_b_trace)
-            b_step, new_b_opt, b_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    self._optimizer,
-                    state.trunk_optimizer_states[2 * i + 1],
-                    new_b_trace,
-                    error=None,
-                )
+            b_step, new_b_opt, b_update_applied = _update_from_gradient_with_diagnostics(
+                self._optimizer,
+                state.trunk_optimizer_states[2 * i + 1],
+                new_b_trace,
+                error=None,
             )
             trunk_steps.append(b_step)
             new_trunk_opt_states.append(new_b_opt)
@@ -611,12 +624,8 @@ class OffPolicyHordeLearner:
         new_trunk_weights: list[Array] = []
         new_trunk_biases: list[Array] = []
         for i in range(n_trunk_layers):
-            new_trunk_weights.append(
-                state.trunk_params.weights[i] + trunk_steps[2 * i]
-            )
-            new_trunk_biases.append(
-                state.trunk_params.biases[i] + trunk_steps[2 * i + 1]
-            )
+            new_trunk_weights.append(state.trunk_params.weights[i] + trunk_steps[2 * i])
+            new_trunk_biases.append(state.trunk_params.biases[i] + trunk_steps[2 * i + 1])
 
         new_trunk_params = MLPParams(
             weights=tuple(new_trunk_weights),
@@ -664,21 +673,17 @@ class OffPolicyHordeLearner:
                 new_b_trace = _skip_zero_scale(head_gl, old_b_trace) + b_grad
 
             error_i = masked_td_errors[i]
-            w_step, new_w_opt, w_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    head_optimizer,
-                    old_w_opt,
-                    new_w_trace,
-                    error=error_i,
-                )
+            w_step, new_w_opt, w_update_applied = _update_from_gradient_with_diagnostics(
+                head_optimizer,
+                old_w_opt,
+                new_w_trace,
+                error=error_i,
             )
-            b_step, new_b_opt, b_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    head_optimizer,
-                    old_b_opt,
-                    new_b_trace,
-                    error=error_i,
-                )
+            b_step, new_b_opt, b_update_applied = _update_from_gradient_with_diagnostics(
+                head_optimizer,
+                old_b_opt,
+                new_b_trace,
+                error=error_i,
             )
             optimizer_updates_applied.extend((w_update_applied, b_update_applied))
 
@@ -803,9 +808,7 @@ class OffPolicyHordeLearner:
             jnp.zeros_like(predictions),
         )
         sanitized_next_predictions = jnp.where(
-            head_updates_applied
-            & zero_discount_mask
-            & ~jnp.isfinite(next_predictions),
+            head_updates_applied & zero_discount_mask & ~jnp.isfinite(next_predictions),
             jnp.zeros_like(next_predictions),
             next_predictions,
         )
@@ -823,16 +826,10 @@ class OffPolicyHordeLearner:
             state=committed_state,
             predictions=reported_predictions,
             next_predictions=reported_next_predictions,
-            td_targets=_report_demon_values(
-                td_targets, requested_mask, head_updates_applied
-            ),
-            td_errors=_report_demon_values(
-                td_errors, requested_mask, head_updates_applied
-            ),
+            td_targets=_report_demon_values(td_targets, requested_mask, head_updates_applied),
+            td_errors=_report_demon_values(td_errors, requested_mask, head_updates_applied),
             rhos=jnp.where(head_updates_applied, rhos, jnp.zeros_like(rhos)),
-            clipped_rhos=_report_demon_values(
-                clipped_rhos, requested_mask, head_updates_applied
-            ),
+            clipped_rhos=_report_demon_values(clipped_rhos, requested_mask, head_updates_applied),
             trace_coefficients=_report_demon_values(
                 trace_coefficients, requested_mask, head_updates_applied
             ),
@@ -860,9 +857,7 @@ class OffPolicyHordeLearner:
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
             "use_layer_norm": self._use_layer_norm,
-            "head_optimizer": (
-                self._head_optimizer.to_config() if self._head_optimizer else None
-            ),
+            "head_optimizer": (self._head_optimizer.to_config() if self._head_optimizer else None),
             "trace_mode": self._trace_mode.value,
             "utility_decay": self._utility_decay,
             "ratio_clip": self._ratio_clip,
@@ -888,11 +883,7 @@ class OffPolicyHordeLearner:
         normalizer_cfg = config.pop("normalizer", None)
         normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg else None
         head_optimizer_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_optimizer_cfg)
-            if head_optimizer_cfg
-            else None
-        )
+        head_optimizer = optimizer_from_config(head_optimizer_cfg) if head_optimizer_cfg else None
         trace_mode = TraceMode(config.pop("trace_mode", TraceMode.ACCUMULATING.value))
 
         return cls(
@@ -925,8 +916,7 @@ class NonlinearSharedGTDHordeLearner:
         ratio_clip: float = 10.0,
         init_scale: float = 0.25,
     ) -> None:
-        if hidden_size <= 0:
-            raise ValueError("hidden_size must be positive")
+        hidden_size = _require_int32("hidden_size", hidden_size, minimum=1)
         if primary_step_size <= 0.0:
             raise ValueError("primary_step_size must be positive")
         if secondary_step_size <= 0.0:
@@ -954,6 +944,7 @@ class NonlinearSharedGTDHordeLearner:
 
     def init(self, feature_dim: int, key: Array) -> NonlinearSharedGTDHordeState:
         """Initialize primary and secondary weights."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trunk_key, head_key = jax.random.split(key)
         trunk_w = self._init_scale * jax.random.normal(
             trunk_key,
@@ -1025,9 +1016,7 @@ class NonlinearSharedGTDHordeLearner:
             & jnp.isfinite(discounts)
             & jnp.isfinite(td_targets)
         )
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
-            jnp.isfinite(next_observation)
-        )
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(next_observation))
         source_state_finite = _floating_tree_is_finite(state)
         effective_mask = active_mask & inputs_valid & source_state_finite
         safe_td_errors = jnp.where(active_mask, td_errors, 0.0)
@@ -1228,12 +1217,15 @@ def run_off_policy_horde_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (
-        per_demon_metrics,
-        td_errors,
-        clipped_rhos,
-        head_updates_applied,
-        updates_applied,
+    (
+        final_state,
+        (
+            per_demon_metrics,
+            td_errors,
+            clipped_rhos,
+            head_updates_applied,
+            updates_applied,
+        ),
     ) = jax.lax.scan(
         step_fn,
         state,

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import functools
 import operator
 import time
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -22,6 +23,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
 from alberta_framework.core.multi_head_learner import (
     AnyOptimizer,
@@ -56,6 +58,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_TRUSTED_REAL_TYPES = (
+    _ACTUAL_INT_TYPES | frozenset(np.dtype(code).type for code in ("e", "f", "d", "g")) | {float}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -65,6 +70,31 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in _TRUSTED_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
+
+
+def _preflight_nonlinear_state(*, n_demons: int, hidden_size: int, feature_dim: int) -> None:
+    hidden_features = hidden_size * feature_dim
+    demon_hidden_features = n_demons * hidden_features
+    demon_hidden = n_demons * hidden_size
+    float_scalars = (
+        hidden_features * (n_demons + 1) + hidden_size + 3 * demon_hidden + 2 * n_demons + 2
+    )
+    logical_scalars = float_scalars + 1
+    for name, value in (
+        ("trunk weight scalars", hidden_features),
+        ("secondary trunk weight scalars", demon_hidden_features),
+        ("demon-hidden scalars", demon_hidden),
+        ("persistent state scalars", logical_scalars),
+        ("persistent state bytes", 4 * logical_scalars),
+    ):
+        if not 1 <= value <= _INT32_MAX:
+            raise ValueError(f"derived nonlinear Horde {name} must fit signed int32")
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -916,21 +946,24 @@ class NonlinearSharedGTDHordeLearner:
         ratio_clip: float = 10.0,
         init_scale: float = 0.25,
     ) -> None:
+        if type(horde_spec) is not HordeSpec:
+            raise ValueError("horde_spec must be an exact HordeSpec")
+        if not horde_spec.demons:
+            raise ValueError("horde_spec must contain at least one demon")
         hidden_size = _require_int32("hidden_size", hidden_size, minimum=1)
-        if primary_step_size <= 0.0:
-            raise ValueError("primary_step_size must be positive")
-        if secondary_step_size <= 0.0:
-            raise ValueError("secondary_step_size must be positive")
-        if ratio_clip <= 0.0:
-            raise ValueError("ratio_clip must be positive")
-        if init_scale <= 0.0:
-            raise ValueError("init_scale must be positive")
         self._horde_spec = horde_spec
         self._hidden_size = hidden_size
-        self._primary_step_size = primary_step_size
-        self._secondary_step_size = secondary_step_size
-        self._ratio_clip = ratio_clip
-        self._init_scale = init_scale
+        self._primary_step_size = _require_float32(
+            "primary_step_size", primary_step_size, positive=True
+        )
+        self._secondary_step_size = _require_float32(
+            "secondary_step_size", secondary_step_size, positive=True
+        )
+        self._ratio_clip = _require_float32("ratio_clip", ratio_clip, positive=True)
+        self._init_scale = _require_float32("init_scale", init_scale, positive=True)
+        _preflight_nonlinear_state(
+            n_demons=len(horde_spec.demons), hidden_size=hidden_size, feature_dim=1
+        )
 
     @property
     def horde_spec(self) -> HordeSpec:
@@ -942,9 +975,90 @@ class NonlinearSharedGTDHordeLearner:
         """Number of demons."""
         return len(self._horde_spec.demons)
 
+    def to_config(self) -> dict[str, Any]:
+        """Serialize the complete nonlinear Horde construction."""
+        return {
+            "type": self.__class__.__name__,
+            "horde_spec": self._horde_spec.to_config(),
+            "hidden_size": self._hidden_size,
+            "primary_step_size": self._primary_step_size,
+            "secondary_step_size": self._secondary_step_size,
+            "ratio_clip": self._ratio_clip,
+            "init_scale": self._init_scale,
+        }
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> NonlinearSharedGTDHordeLearner:
+        """Reconstruct the exact serialized nonlinear Horde schema."""
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be an actual mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
+        expected = {
+            "type",
+            "horde_spec",
+            "hidden_size",
+            "primary_step_size",
+            "secondary_step_size",
+            "ratio_clip",
+            "init_scale",
+        }
+        if any(type(key) is not str for key in payload) or set(payload) != expected:
+            raise ValueError("config fields do not match the serialized schema")
+        marker = payload.pop("type")
+        if type(marker) is not str or marker != cls.__name__:
+            raise ValueError("config type differs")
+        raw_horde = payload.pop("horde_spec")
+        if type(raw_horde) is not dict or set(raw_horde) != {"demons"}:
+            raise ValueError("serialized horde_spec does not match its schema")
+        if type(raw_horde["demons"]) is not list:
+            raise ValueError("serialized horde_spec demons must be an exact list")
+        demon_fields = {
+            "name",
+            "demon_type",
+            "gamma",
+            "lamda",
+            "cumulant_index",
+            "terminal_reward",
+        }
+        for demon in raw_horde["demons"]:
+            if (
+                type(demon) is not dict
+                or any(type(key) is not str for key in demon)
+                or set(demon) != demon_fields
+            ):
+                raise ValueError("serialized demon does not match the exact schema")
+            if (
+                type(demon["name"]) is not str
+                or type(demon["demon_type"]) is not str
+                or type(demon["cumulant_index"]) is not int
+                or any(
+                    type(demon[name]) is not float for name in ("gamma", "lamda", "terminal_reward")
+                )
+            ):
+                raise ValueError("serialized demon scalar types must be exact JSON values")
+        if type(payload["hidden_size"]) is not int or any(
+            type(payload[name]) is not float
+            for name in (
+                "primary_step_size",
+                "secondary_step_size",
+                "ratio_clip",
+                "init_scale",
+            )
+        ):
+            raise ValueError("serialized scalar fields must be exact JSON numbers")
+        return cls(horde_spec=HordeSpec.from_config(raw_horde), **payload)
+
     def init(self, feature_dim: int, key: Array) -> NonlinearSharedGTDHordeState:
         """Initialize primary and secondary weights."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_nonlinear_state(
+            n_demons=self.n_demons,
+            hidden_size=self._hidden_size,
+            feature_dim=feature_dim,
+        )
         trunk_key, head_key = jax.random.split(key)
         trunk_w = self._init_scale * jax.random.normal(
             trunk_key,
@@ -1148,7 +1262,7 @@ class NonlinearSharedGTDHordeLearner:
             secondary_trunk_b=jnp.stack(new_secondary_trunk_b),
             secondary_head_w=jnp.stack(new_secondary_head_w),
             secondary_head_b=jnp.stack(new_secondary_head_b),
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
         candidate_state_finite = _floating_tree_is_finite(proposed_state)
         update_applied = (

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -51,12 +51,14 @@ Reference:
 from __future__ import annotations
 
 import functools
+import operator
 import time
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
@@ -64,6 +66,32 @@ from alberta_framework.core.types import Observation
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -74,6 +102,7 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 def _zero_if_unused(scale: Array, value: Array) -> Array:
     """Sanitize leftover inf only in the finite-state check when unused."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), value)
+
 
 # =============================================================================
 # State / result types
@@ -284,6 +313,7 @@ class OffPolicyTDLinearLearner:
 
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -295,9 +325,7 @@ class OffPolicyTDLinearLearner:
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: OffPolicyTDState, observation: Observation
-    ) -> Float[Array, " 1"]:
+    def predict(self, state: OffPolicyTDState, observation: Observation) -> Float[Array, " 1"]:
         """Compute V(s) = w . phi(s) + b."""
         return jnp.atleast_1d(jnp.dot(state.weights, observation) + state.bias)
 
@@ -343,12 +371,10 @@ class OffPolicyTDLinearLearner:
         # the prior ratios are already represented in the stored trace.
         decay = gamma_s * lam
         new_e = _skip_zero_scale(
-            rho_clipped,
-            _skip_zero_scale(decay, state.eligibility_traces) + observation
+            rho_clipped, _skip_zero_scale(decay, state.eligibility_traces) + observation
         )
         new_e_b = _skip_zero_scale(
-            rho_clipped,
-            _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
+            rho_clipped, _skip_zero_scale(decay, state.bias_eligibility_trace) + 1.0
         )
 
         # rho_clipped is already represented in the trace.
@@ -398,9 +424,7 @@ class OffPolicyTDLinearLearner:
                 update_applied, jnp.atleast_1d(v_t), jnp.zeros_like(jnp.atleast_1d(v_t))
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            rho_clipped=jnp.where(
-                update_applied, rho_clipped, jnp.zeros_like(rho_clipped)
-            ),
+            rho_clipped=jnp.where(update_applied, rho_clipped, jnp.zeros_like(rho_clipped)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
         )
@@ -472,6 +496,7 @@ class ETDLinearLearner:
 
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -527,17 +552,13 @@ class ETDLinearLearner:
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
         follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
-        emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(
-            1.0 - lam, follow_on
-        )
+        emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(1.0 - lam, follow_on)
 
         trace_decay = gamma_s * lam
         new_e = rho_s * (
             _skip_zero_scale(trace_decay, state.eligibility_traces) + emphasis * observation
         )
-        new_e_b = rho_s * (
-            _skip_zero_scale(trace_decay, state.bias_eligibility_trace) + emphasis
-        )
+        new_e_b = rho_s * (_skip_zero_scale(trace_decay, state.bias_eligibility_trace) + emphasis)
 
         proposed_state = ETDState(  # type: ignore[call-arg]
             weights=state.weights + alpha * td_error * new_e,
@@ -560,9 +581,7 @@ class ETDLinearLearner:
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
             eligibility_traces=_zero_if_unused(trace_decay, state.eligibility_traces),
-            bias_eligibility_trace=_zero_if_unused(
-                trace_decay, state.bias_eligibility_trace
-            ),
+            bias_eligibility_trace=_zero_if_unused(trace_decay, state.bias_eligibility_trace),
             follow_on_trace=_zero_if_unused(gamma_s, state.follow_on_trace),
         )
         update_applied = (
@@ -589,9 +608,7 @@ class ETDLinearLearner:
                 update_applied, jnp.atleast_1d(v_t), jnp.zeros_like(jnp.atleast_1d(v_t))
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            follow_on_trace=jnp.where(
-                update_applied, follow_on, jnp.zeros_like(follow_on)
-            ),
+            follow_on_trace=jnp.where(update_applied, follow_on, jnp.zeros_like(follow_on)),
             emphasis=jnp.where(update_applied, emphasis, jnp.zeros_like(emphasis)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
@@ -641,10 +658,7 @@ class GradientTDLinearLearner:
         if step_size <= 0.0:
             raise ValueError(f"step_size must be positive; got {step_size}")
         if secondary_step_size < 0.0:
-            raise ValueError(
-                "secondary_step_size must be non-negative; "
-                f"got {secondary_step_size}"
-            )
+            raise ValueError(f"secondary_step_size must be non-negative; got {secondary_step_size}")
         if not 0.0 <= trace_decay <= 1.0:
             raise ValueError(f"trace_decay must lie in [0, 1]; got {trace_decay}")
         if ratio_clip <= 0.0:
@@ -676,6 +690,7 @@ class GradientTDLinearLearner:
 
     def init(self, feature_dim: int) -> GradientTDState:
         """Initialize primary weights, secondary weights, and traces."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         augmented_dim = feature_dim + 1
         return GradientTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
@@ -697,9 +712,7 @@ class GradientTDLinearLearner:
         )
 
     @functools.partial(jax.jit, static_argnums=(0,))
-    def predict(
-        self, state: GradientTDState, observation: Observation
-    ) -> Float[Array, " 1"]:
+    def predict(self, state: GradientTDState, observation: Observation) -> Float[Array, " 1"]:
         """Compute ``theta^T phi`` with an appended bias feature."""
         return jnp.atleast_1d(jnp.dot(state.weights, self._augment(observation)))
 
@@ -729,19 +742,13 @@ class GradientTDLinearLearner:
         next_prediction = jnp.dot(state.weights, next_phi)
         td_error = reward_s + _skip_zero_scale(gamma_s, next_prediction) - prediction
 
-        traces = rho_clipped * (
-            phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces)
-        )
+        traces = rho_clipped * (phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces))
         secondary_dot_trace = jnp.dot(state.secondary_weights, traces)
         secondary_dot_phi = jnp.dot(state.secondary_weights, phi)
 
         correction_coefficient = gamma_s * (1.0 - lam)
-        scaled_secondary_trace = _skip_zero_scale(
-            correction_coefficient, secondary_dot_trace
-        )
-        bootstrap_correction = _skip_zero_scale(
-            scaled_secondary_trace, next_phi
-        )
+        scaled_secondary_trace = _skip_zero_scale(correction_coefficient, secondary_dot_trace)
+        bootstrap_correction = _skip_zero_scale(scaled_secondary_trace, next_phi)
         primary_step = alpha * (td_error * traces - bootstrap_correction)
         secondary_step = beta * (td_error * traces - secondary_dot_phi * phi)
 
@@ -761,9 +768,7 @@ class GradientTDLinearLearner:
             & jnp.isfinite(rho_s)
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
-            eligibility_traces=_zero_if_unused(
-                gamma_s * lam, state.eligibility_traces
-            ),
+            eligibility_traces=_zero_if_unused(gamma_s * lam, state.eligibility_traces),
         )
         update_applied = (
             inputs_valid
@@ -794,9 +799,7 @@ class GradientTDLinearLearner:
                 jnp.zeros_like(jnp.atleast_1d(prediction)),
             ),
             td_error=jnp.where(update_applied, td_error, jnp.zeros_like(td_error)),
-            rho_clipped=jnp.where(
-                update_applied, rho_clipped, jnp.zeros_like(rho_clipped)
-            ),
+            rho_clipped=jnp.where(update_applied, rho_clipped, jnp.zeros_like(rho_clipped)),
             metrics=jnp.where(update_applied, metrics, jnp.zeros_like(metrics)),
             update_applied=update_applied,
         )
@@ -848,12 +851,10 @@ def run_gradient_td_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (predictions, td_errors, rho_clipped, metrics, updates_applied) = (
-        jax.lax.scan(
+    final_state, (predictions, td_errors, rho_clipped, metrics, updates_applied) = jax.lax.scan(
         step_fn,
         state,
         (observations, rewards, next_observations, gammas, rhos),
-        )
     )
     elapsed = time.time() - t0
     final_state = final_state.replace(  # type: ignore[attr-defined]

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import functools
 import operator
 import time
+from collections.abc import Mapping
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -62,6 +63,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.types import Observation
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
@@ -83,6 +85,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_TRUSTED_REAL_TYPES = (
+    _ACTUAL_INT_TYPES | frozenset(np.dtype(code).type for code in ("e", "f", "d", "g")) | {float}
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -92,6 +97,52 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32(name: str, value: object, **bounds: Any) -> float:
+    if type(value) not in _TRUSTED_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real scalar")
+    return validated_float32_scalar(name, value, **bounds)
+
+
+def _require_positive_clip(name: str, value: object) -> float:
+    if type(value) not in _TRUSTED_REAL_TYPES:
+        raise ValueError(f"{name} must be a positive real scalar")
+    concrete = float(cast(Any, value))
+    if concrete == float("inf"):
+        return concrete
+    return validated_float32_scalar(name, value, positive=True)
+
+
+def _require_state_resources(name: str, *, scalars: int, bytes_: int) -> None:
+    if scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} state scalars must fit signed int32")
+    if bytes_ > _INT32_MAX:
+        raise ValueError(f"derived {name} state bytes must fit signed int32")
+
+
+def _serialized_payload(
+    config: Mapping[str, Any], *, type_name: str, fields: frozenset[str]
+) -> dict[str, Any]:
+    if not issubclass(type(config), Mapping):
+        raise ValueError("config must be an actual mapping")
+    try:
+        payload = dict(config)
+    except Exception as error:
+        raise ValueError("config must be a readable mapping") from error
+    if any(type(key) is not str for key in payload) or set(payload) != fields | {"type"}:
+        raise ValueError("config fields do not match the serialized schema")
+    marker = payload.pop("type")
+    if type(marker) is not str or marker != type_name:
+        raise ValueError("config type differs")
+    if any(type(value) not in (int, float) for value in payload.values()):
+        raise ValueError("serialized scalar fields must be exact JSON numbers")
+    return payload
+
+
+def _saturating_increment(value: Array) -> Array:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(value, 0), maximum - 1) + 1
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -286,15 +337,9 @@ class OffPolicyTDLinearLearner:
             retrace_clip: Maximum allowed importance ratio (default 1.0;
                 pass float("inf") to disable clipping).
         """
-        if step_size <= 0:
-            raise ValueError(f"step_size must be positive; got {step_size}")
-        if not 0.0 <= trace_decay <= 1.0:
-            raise ValueError(f"trace_decay must lie in [0, 1]; got {trace_decay}")
-        if retrace_clip <= 0:
-            raise ValueError(f"retrace_clip must be positive; got {retrace_clip}")
-        self._step_size = step_size
-        self._trace_decay = trace_decay
-        self._retrace_clip = retrace_clip
+        self._step_size = _require_float32("step_size", step_size, positive=True)
+        self._trace_decay = _require_float32("trace_decay", trace_decay, lower=0.0, upper=1.0)
+        self._retrace_clip = _require_positive_clip("retrace_clip", retrace_clip)
 
     @property
     def step_size(self) -> float:
@@ -314,6 +359,9 @@ class OffPolicyTDLinearLearner:
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_state_resources(
+            "OffPolicyTD", scalars=2 * feature_dim + 5, bytes_=8 * feature_dim + 20
+        )
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -384,7 +432,7 @@ class OffPolicyTDLinearLearner:
             bias=state.bias + scaled_update * new_e_b,
             eligibility_traces=new_e,
             bias_eligibility_trace=new_e_b,
-            step_count=state.step_count + 1,
+            step_count=_saturating_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -439,11 +487,15 @@ class OffPolicyTDLinearLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> OffPolicyTDLinearLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> OffPolicyTDLinearLearner:
         """Reconstruct from dict."""
-        config = dict(config)
-        config.pop("type", None)
-        return cls(**config)
+        return cls(
+            **_serialized_payload(
+                config,
+                type_name=cls.__name__,
+                fields=frozenset({"step_size", "trace_decay", "retrace_clip"}),
+            )
+        )
 
 
 class ETDLinearLearner:
@@ -477,12 +529,8 @@ class ETDLinearLearner:
             step_size: Learning rate alpha (scalar)
             trace_decay: Eligibility trace decay lambda in [0, 1]
         """
-        if step_size <= 0:
-            raise ValueError(f"step_size must be positive; got {step_size}")
-        if not 0.0 <= trace_decay <= 1.0:
-            raise ValueError(f"trace_decay must lie in [0, 1]; got {trace_decay}")
-        self._step_size = step_size
-        self._trace_decay = trace_decay
+        self._step_size = _require_float32("step_size", step_size, positive=True)
+        self._trace_decay = _require_float32("trace_decay", trace_decay, lower=0.0, upper=1.0)
 
     @property
     def step_size(self) -> float:
@@ -497,6 +545,7 @@ class ETDLinearLearner:
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_state_resources("ETD", scalars=2 * feature_dim + 7, bytes_=8 * feature_dim + 28)
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -567,7 +616,7 @@ class ETDLinearLearner:
             bias_eligibility_trace=new_e_b,
             follow_on_trace=follow_on,
             emphasis=emphasis,
-            step_count=state.step_count + 1,
+            step_count=_saturating_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -623,11 +672,15 @@ class ETDLinearLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ETDLinearLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> ETDLinearLearner:
         """Reconstruct from dict."""
-        config = dict(config)
-        config.pop("type", None)
-        return cls(**config)
+        return cls(
+            **_serialized_payload(
+                config,
+                type_name=cls.__name__,
+                fields=frozenset({"step_size", "trace_decay"}),
+            )
+        )
 
 
 class GradientTDLinearLearner:
@@ -655,18 +708,12 @@ class GradientTDLinearLearner:
         ratio_clip: float = 10.0,
     ):
         """Initialize the learner."""
-        if step_size <= 0.0:
-            raise ValueError(f"step_size must be positive; got {step_size}")
-        if secondary_step_size < 0.0:
-            raise ValueError(f"secondary_step_size must be non-negative; got {secondary_step_size}")
-        if not 0.0 <= trace_decay <= 1.0:
-            raise ValueError(f"trace_decay must lie in [0, 1]; got {trace_decay}")
-        if ratio_clip <= 0.0:
-            raise ValueError(f"ratio_clip must be positive; got {ratio_clip}")
-        self._step_size = step_size
-        self._secondary_step_size = secondary_step_size
-        self._trace_decay = trace_decay
-        self._ratio_clip = ratio_clip
+        self._step_size = _require_float32("step_size", step_size, positive=True)
+        self._secondary_step_size = _require_float32(
+            "secondary_step_size", secondary_step_size, lower=0.0
+        )
+        self._trace_decay = _require_float32("trace_decay", trace_decay, lower=0.0, upper=1.0)
+        self._ratio_clip = _require_positive_clip("ratio_clip", ratio_clip)
 
     @property
     def step_size(self) -> float:
@@ -690,8 +737,11 @@ class GradientTDLinearLearner:
 
     def init(self, feature_dim: int) -> GradientTDState:
         """Initialize primary weights, secondary weights, and traces."""
-        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX - 1)
         augmented_dim = feature_dim + 1
+        _require_state_resources(
+            "GradientTD", scalars=3 * augmented_dim + 3, bytes_=12 * augmented_dim + 12
+        )
         return GradientTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
             secondary_weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
@@ -756,7 +806,7 @@ class GradientTDLinearLearner:
             weights=state.weights + primary_step,
             secondary_weights=state.secondary_weights + secondary_step,
             eligibility_traces=traces,
-            step_count=state.step_count + 1,
+            step_count=_saturating_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -815,11 +865,15 @@ class GradientTDLinearLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> GradientTDLinearLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> GradientTDLinearLearner:
         """Reconstruct from dict."""
-        config = dict(config)
-        config.pop("type", None)
-        return cls(**config)
+        return cls(
+            **_serialized_payload(
+                config,
+                type_name=cls.__name__,
+                fields=frozenset({"step_size", "secondary_step_size", "trace_decay", "ratio_clip"}),
+            )
+        )
 
 
 def run_gradient_td_learning_loop(

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -145,9 +145,7 @@ def test_infinite_cumulant_with_obgd_does_not_poison_head() -> None:
     assert bool(jnp.all(jnp.isfinite(poisoned.state.head_params.weights[0])))
     chex.assert_trees_all_close(poisoned.state.head_params.weights[0], before_w0)
     assert bool(jnp.all(jnp.isfinite(poisoned.state.head_params.weights[1])))
-    assert float(
-        jnp.linalg.norm(poisoned.state.head_params.weights[1] - before_w1)
-    ) > 0.0
+    assert float(jnp.linalg.norm(poisoned.state.head_params.weights[1] - before_w1)) > 0.0
     assert int(poisoned.state.step_count) == int(state.step_count) + 1
     assert bool(poisoned.update_applied)
     chex.assert_trees_all_equal(
@@ -197,9 +195,10 @@ def test_zero_discount_ignores_nonfinite_next_observation_under_jit() -> None:
     chex.assert_trees_all_close(result.next_predictions, jnp.zeros(1))
     chex.assert_tree_all_finite(result.state)
     assert int(result.state.step_count) == int(state.step_count) + 1
-    assert float(
-        jnp.linalg.norm(result.state.head_params.weights[0] - state.head_params.weights[0])
-    ) > 0.0
+    assert (
+        float(jnp.linalg.norm(result.state.head_params.weights[0] - state.head_params.weights[0]))
+        > 0.0
+    )
 
 
 def test_nonzero_discount_rejects_nonfinite_next_then_recovers_under_jit() -> None:
@@ -272,9 +271,10 @@ def test_mixed_discounts_isolate_nonfinite_next_to_consuming_head() -> None:
     )
     chex.assert_trees_all_close(result.td_targets, jnp.array([1.25, 0.0]))
     chex.assert_trees_all_close(result.next_predictions, jnp.zeros(2))
-    assert float(
-        jnp.linalg.norm(result.state.head_params.weights[0] - state.head_params.weights[0])
-    ) > 0.0
+    assert (
+        float(jnp.linalg.norm(result.state.head_params.weights[0] - state.head_params.weights[0]))
+        > 0.0
+    )
     chex.assert_trees_all_close(
         result.state.head_params.weights[1],
         state.head_params.weights[1],
@@ -304,9 +304,7 @@ def test_terminal_lifetime_counter_rejects_entire_update_under_jit() -> None:
     )
     state = learner.init(2, jax.random.key(17)).replace(
         step_count=jnp.asarray(jnp.iinfo(jnp.int32).max, dtype=jnp.int32),
-        step_words=jnp.full(
-            (2,), jnp.iinfo(jnp.uint32).max, dtype=jnp.uint32
-        ),
+        step_words=jnp.full((2,), jnp.iinfo(jnp.uint32).max, dtype=jnp.uint32),
     )
 
     rejected = learner.update_with_ratios(
@@ -319,9 +317,7 @@ def test_terminal_lifetime_counter_rejects_entire_update_under_jit() -> None:
 
     assert not bool(rejected.update_applied)
     chex.assert_trees_all_close(rejected.state, state)
-    chex.assert_trees_all_equal(
-        rejected.head_updates_applied, jnp.array([False])
-    )
+    chex.assert_trees_all_equal(rejected.head_updates_applied, jnp.array([False]))
     chex.assert_trees_all_close(rejected.predictions, jnp.zeros(1))
     chex.assert_trees_all_close(rejected.td_errors, jnp.zeros(1))
     chex.assert_trees_all_close(rejected.per_demon_metrics, jnp.zeros((1, 6)))
@@ -355,9 +351,7 @@ def test_invalid_lifetime_counter_rejects_then_repaired_state_recovers() -> None
     recovered = learner.update_with_ratios(initial, *inputs)
     assert bool(recovered.update_applied)
     assert int(recovered.state.step_count) == 1
-    chex.assert_trees_all_equal(
-        recovered.state.step_words, jnp.array([0, 1], dtype=jnp.uint32)
-    )
+    chex.assert_trees_all_equal(recovered.state.step_words, jnp.array([0, 1], dtype=jnp.uint32))
 
 
 def test_probability_api_matches_explicit_ratios() -> None:
@@ -437,9 +431,7 @@ def test_off_policy_positive_control_learns_target_action_value() -> None:
     observations = jnp.ones((240, 1), dtype=jnp.float32)
     next_observations = jnp.ones((240, 1), dtype=jnp.float32)
     cumulants = jnp.asarray((actions == 1).astype(np.float32)).reshape(-1, 1)
-    target_rhos = jnp.asarray(
-        np.where(actions == 1, 2.0, 0.0).astype(np.float32)
-    ).reshape(-1, 1)
+    target_rhos = jnp.asarray(np.where(actions == 1, 2.0, 0.0).astype(np.float32)).reshape(-1, 1)
     no_is_rhos = jnp.ones((240, 1), dtype=jnp.float32)
 
     learner = OffPolicyHordeLearner(
@@ -537,9 +529,7 @@ def test_nonlinear_shared_gtd_horde_two_state_positive_control() -> None:
 
     def step(carry, xs):  # type: ignore[no-untyped-def]
         obs, cums, next_obs, rho, discount = xs
-        update = learner.update_with_ratios_and_discounts(
-            carry, obs, cums, next_obs, rho, discount
-        )
+        update = learner.update_with_ratios_and_discounts(carry, obs, cums, next_obs, rho, discount)
         return update.state, update
 
     initial = learner.init(2, jax.random.key(9))
@@ -548,9 +538,7 @@ def test_nonlinear_shared_gtd_horde_two_state_positive_control() -> None:
         initial,
         (observations, cumulants, next_observations, rhos_jnp, discounts),
     )
-    predictions = jax.vmap(lambda x: learner.predict(final_state, x))(
-        jnp.eye(2, dtype=jnp.float32)
-    )
+    predictions = jax.vmap(lambda x: learner.predict(final_state, x))(jnp.eye(2, dtype=jnp.float32))
     target = jnp.array([[5.0, 4.0], [4.0, 5.0]], dtype=jnp.float32)
 
     assert float(jnp.mean(jnp.abs(predictions - target))) < 0.8
@@ -641,3 +629,29 @@ def test_replacing_zero_grad_does_not_multiply_inf_trunk_trace() -> None:
     assert bool(result.update_applied)
     for trace in result.state.trunk_traces:
         chex.assert_tree_all_finite(trace)
+
+
+def test_nonlinear_shared_gtd_horde_integer_validation() -> None:
+    spec = _spec()
+
+    with pytest.raises(ValueError, match="hidden_size"):
+        NonlinearSharedGTDHordeLearner(horde_spec=spec, hidden_size=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_size"):
+        NonlinearSharedGTDHordeLearner(horde_spec=spec, hidden_size=16.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_size"):
+        NonlinearSharedGTDHordeLearner(horde_spec=spec, hidden_size=0)
+
+    learner = NonlinearSharedGTDHordeLearner(horde_spec=spec, hidden_size=np.int32(16))
+    assert learner._hidden_size == 16
+    assert type(learner._hidden_size) is int
+
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(feature_dim=True, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(feature_dim=4.5, key=key)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(feature_dim=0, key=key)
+
+    state = learner.init(feature_dim=np.int32(4), key=key)
+    assert state.trunk_w.shape == (16, 4)

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -655,3 +655,53 @@ def test_nonlinear_shared_gtd_horde_integer_validation() -> None:
 
     state = learner.init(feature_dim=np.int32(4), key=key)
     assert state.trunk_w.shape == (16, 4)
+
+
+def test_nonlinear_shared_gtd_horde_complete_scalar_and_schema_contract() -> None:
+    calls = 0
+
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile hook ran")
+
+    with pytest.raises(ValueError, match="finite real scalar"):
+        NonlinearSharedGTDHordeLearner(_spec(), primary_step_size=HostileFloat(0.1))
+    assert calls == 0
+
+    learner = NonlinearSharedGTDHordeLearner(
+        _spec(),
+        hidden_size=np.uint16(4),
+        primary_step_size=np.float64(0.01),
+    )
+    config = learner.to_config()
+    restored = NonlinearSharedGTDHordeLearner.from_config(config)
+    assert restored.to_config() == config
+    with pytest.raises(ValueError, match="schema"):
+        NonlinearSharedGTDHordeLearner.from_config({**config, "unknown": 1})
+    with pytest.raises(ValueError, match="type"):
+        NonlinearSharedGTDHordeLearner.from_config({**config, "type": "wrong"})
+
+
+def test_nonlinear_shared_gtd_horde_preflights_aggregate_state_bytes() -> None:
+    learner = NonlinearSharedGTDHordeLearner(_spec(), hidden_size=16)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        learner.init(20_000_000, jax.random.key(0))
+
+
+def test_nonlinear_shared_gtd_horde_outer_counter_saturates() -> None:
+    learner = NonlinearSharedGTDHordeLearner(_spec(gammas=(0.0,)), hidden_size=2)
+    state = learner.init(2, jax.random.key(0)).replace(
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32)
+    )
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+        jnp.zeros(1, dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -58,15 +58,11 @@ class TestOnPolicyEquivalence:
         alpha = 0.1
         n_steps = 30
 
-        learner = OffPolicyTDLinearLearner(
-            step_size=alpha, trace_decay=0.0, retrace_clip=10.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=alpha, trace_decay=0.0, retrace_clip=10.0)
         state = learner.init(feature_dim)
 
         rng = np.random.default_rng(0)
-        observations = jnp.asarray(
-            rng.normal(size=(n_steps, feature_dim)).astype(np.float32)
-        )
+        observations = jnp.asarray(rng.normal(size=(n_steps, feature_dim)).astype(np.float32))
         rewards = jnp.asarray(rng.normal(size=n_steps).astype(np.float32))
 
         for t in range(n_steps):
@@ -190,9 +186,7 @@ class TestETDLambda:
         n_steps = 40
 
         rng = np.random.default_rng(123)
-        observations = jnp.asarray(
-            rng.normal(size=(n_steps, feature_dim)).astype(np.float32)
-        )
+        observations = jnp.asarray(rng.normal(size=(n_steps, feature_dim)).astype(np.float32))
         rewards = jnp.asarray(rng.normal(size=n_steps).astype(np.float32))
 
         etd = ETDLinearLearner(step_size=alpha, trace_decay=0.0)
@@ -504,9 +498,7 @@ class TestOffPolicyConvergence:
         # rho(action=1) = 1 / 0.5 = 2
         # rho(action=0) = 0 / 0.5 = 0  (the trajectory contributes nothing)
 
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.05, trace_decay=0.0, retrace_clip=2.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.05, trace_decay=0.0, retrace_clip=2.0)
         state = learner.init(n_states)
 
         rng = np.random.default_rng(42)
@@ -536,16 +528,12 @@ class TestOffPolicyConvergence:
         # Target V per state
         v_true = np.ones(n_states, dtype=np.float32)
         rmse = float(np.sqrt(np.mean((v_estimated - v_true) ** 2)))
-        assert rmse < 0.20, (
-            f"Off-policy TD did not converge: V_est={v_estimated}, RMSE={rmse}"
-        )
+        assert rmse < 0.20, f"Off-policy TD did not converge: V_est={v_estimated}, RMSE={rmse}"
 
     def test_naive_is_finite_with_clipping(self) -> None:
         """Even with a high IS-ratio target/behavior mismatch, clipping at
         c=1 should keep weights finite over many steps."""
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.01, trace_decay=0.7, retrace_clip=1.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.01, trace_decay=0.7, retrace_clip=1.0)
         state = learner.init(5)
 
         rng = np.random.default_rng(7)
@@ -555,9 +543,7 @@ class TestOffPolicyConvergence:
             r = jnp.float32(rng.normal())
             # Wildly varying rho
             rho = jnp.float32(rng.uniform(0.0, 50.0))
-            res = learner.update(
-                state, phi, r, phi_next, jnp.float32(0.95), rho
-            )
+            res = learner.update(state, phi, r, phi_next, jnp.float32(0.95), rho)
             state = res.state
 
         chex.assert_tree_all_finite(state.weights)
@@ -596,9 +582,7 @@ class TestJit:
 
 class TestConfig:
     def test_roundtrip(self) -> None:
-        original = OffPolicyTDLinearLearner(
-            step_size=0.07, trace_decay=0.6, retrace_clip=2.5
-        )
+        original = OffPolicyTDLinearLearner(step_size=0.07, trace_decay=0.6, retrace_clip=2.5)
         config = original.to_config()
         assert config["type"] == "OffPolicyTDLinearLearner"
         restored = OffPolicyTDLinearLearner.from_config(config)
@@ -621,9 +605,7 @@ class TestBairdStyle:
     """
 
     def test_no_divergence_with_clip(self) -> None:
-        learner = OffPolicyTDLinearLearner(
-            step_size=0.01, trace_decay=0.5, retrace_clip=1.0
-        )
+        learner = OffPolicyTDLinearLearner(step_size=0.01, trace_decay=0.5, retrace_clip=1.0)
         state = learner.init(4)
 
         rng = np.random.default_rng(11)
@@ -633,9 +615,7 @@ class TestBairdStyle:
             r = jnp.float32(rng.normal())
             # Heavy-tailed rho but mostly modest values
             rho = jnp.float32(rng.exponential(1.0))
-            res = learner.update(
-                state, phi, r, phi_next, jnp.float32(0.9), rho
-            )
+            res = learner.update(state, phi, r, phi_next, jnp.float32(0.9), rho)
             state = res.state
 
         chex.assert_tree_all_finite(state.weights)
@@ -701,9 +681,7 @@ class TestInfiniteRewardDoesNotPoisonWeights:
             state, obs, jnp.array(jnp.inf, dtype=jnp.float32), nxt, gamma, rho
         )
         chex.assert_trees_all_close(poisoned.state.weights, state.weights)
-        chex.assert_trees_all_close(
-            poisoned.state.secondary_weights, state.secondary_weights
-        )
+        chex.assert_trees_all_close(poisoned.state.secondary_weights, state.secondary_weights)
         assert not bool(poisoned.update_applied)
         assert float(poisoned.td_error) == 0.0
 
@@ -861,3 +839,25 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         )
         assert bool(result.update_applied)
         chex.assert_tree_all_finite(result.state.eligibility_traces)
+
+
+def test_off_policy_td_learners_integer_validation() -> None:
+    optd = OffPolicyTDLinearLearner()
+    etd = ETDLinearLearner()
+    gtd = GradientTDLinearLearner()
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        optd.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        etd.init(feature_dim=4.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        gtd.init(feature_dim=0)
+
+    s_optd = optd.init(feature_dim=np.int32(4))
+    s_etd = etd.init(feature_dim=np.int64(4))
+    s_gtd = gtd.init(feature_dim=np.int32(4))
+
+    assert s_optd.weights.shape == (4,)
+    assert s_etd.weights.shape == (4,)
+    assert s_gtd.weights.shape == (5,)
+    assert s_gtd.secondary_weights.shape == (5,)

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -861,3 +861,46 @@ def test_off_policy_td_learners_integer_validation() -> None:
     assert s_etd.weights.shape == (4,)
     assert s_gtd.weights.shape == (5,)
     assert s_gtd.secondary_weights.shape == (5,)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [OffPolicyTDLinearLearner, ETDLinearLearner, GradientTDLinearLearner],
+)
+def test_off_policy_td_configs_reject_hostile_scalars_without_hooks(factory: type) -> None:
+    calls = 0
+
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile hook ran")
+
+    with pytest.raises(ValueError, match="finite real scalar"):
+        factory(step_size=HostileFloat(0.1))
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "learner",
+    [OffPolicyTDLinearLearner(), ETDLinearLearner(), GradientTDLinearLearner()],
+)
+def test_off_policy_td_serialized_schema_is_exact(learner: object) -> None:
+    config = learner.to_config()  # type: ignore[attr-defined]
+    assert type(learner).from_config(config).to_config() == config
+    with pytest.raises(ValueError, match="schema"):
+        type(learner).from_config({**config, "unknown": 1})
+    with pytest.raises(ValueError, match="type"):
+        type(learner).from_config({**config, "type": "wrong"})
+    scalar = next(name for name in config if name != "type")
+    with pytest.raises(ValueError, match="exact JSON"):
+        type(learner).from_config({**config, scalar: np.float32(config[scalar])})
+
+
+def test_off_policy_td_preflights_complete_state_bytes_before_allocation() -> None:
+    with pytest.raises(ValueError, match="state bytes"):
+        OffPolicyTDLinearLearner().init((2**31 - 1) // 8)
+    with pytest.raises(ValueError, match="state bytes"):
+        ETDLinearLearner().init((2**31 - 1) // 8)
+    with pytest.raises(ValueError, match="state bytes"):
+        GradientTDLinearLearner().init((2**31 - 1) // 12)


### PR DESCRIPTION
Supersedes #841 and #844 while preserving both Kayvan Zahiri contributor commits/authorship and integrating their integer validation onto current main.

The replacement removes the old-base-only limitation and completes the affected public boundaries:
- exact trusted Python/NumPy integer and float32 scalar validation, canonical storage, float32 underflow/overflow/endpoints, and hostile-subclass rejection before hooks;
- all three linear off-policy TD constructors, feature/augmented dimensions, exact aggregate state scalar/byte preflights, exact Mapping serialization schemas, and saturating lifetime counters;
- exact HordeSpec/hidden/scalar contracts for nonlinear shared GTD Horde, all primary/secondary tensor-product and aggregate byte preflights before key split/allocation, exact nested serialization schema, and saturating outer counter;
- regressions for full NumPy families, hostile scalar hooks, schemas, derived allocation rejection, canonical roundtrips, and counter endpoints.

Verification after current-main rebase:
- 62 focused off-policy TD + off-policy Horde tests passed
- 54 broader rho/Horde/mixed-Horde tests passed
- scoped Ruff passed
- strict mypy passed for both source modules
- `git diff --check` passed

No outputs or evidence artifacts were modified.

Co-authored-by: kzahiri1 <kzahiri@dons.usfca.edu>
