### PR TITLE
fix(actor-critic): complete config and resource contracts

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -21,21 +21,50 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
+import operator
 from numbers import Real
-from typing import Any
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int
 
 from alberta_framework._float32 import round_real_to_float32
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
 
 
 @dataclasses.dataclass(frozen=True)
@@ -59,6 +88,43 @@ class ActorCriticConfig:
     actor_lamda: float = 0.9
     critic_lamda: float = 0.9
     temperature: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=2),
+        )
+        object.__setattr__(
+            self,
+            "gamma",
+            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_step_size",
+            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_step_size",
+            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_lamda",
+            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_lamda",
+            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "temperature",
+            validated_float32_scalar("temperature", self.temperature, positive=True),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -237,6 +303,7 @@ class ActorCriticAgent:
         Returns:
             Initial immutable actor-critic state.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         zeros_actor = jnp.zeros((self._config.n_actions, feature_dim), dtype=jnp.float32)
         zeros_policy_bias = jnp.zeros((self._config.n_actions,), dtype=jnp.float32)
         zeros_critic = jnp.zeros((feature_dim,), dtype=jnp.float32)
@@ -287,9 +354,7 @@ class ActorCriticAgent:
         """
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(
-            jnp.int32
-        )
+        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -351,9 +416,7 @@ class ActorCriticAgent:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
         # Terminal 0 * inf V(s') is NaN and would freeze the critic.
-        bootstrap = jnp.where(
-            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
-        )
+        bootstrap = jnp.where(discount == 0.0, jnp.zeros_like(next_value), discount * next_value)
         td_error = reward + bootstrap - value
 
         one_hot = jax.nn.one_hot(action, cfg.n_actions, dtype=jnp.float32)
@@ -461,9 +524,7 @@ class ActorCriticAgent:
             & jnp.isfinite(critic_metric)
         )
         candidate_ok = (
-            inputs_valid
-            & _floating_tree_is_finite(state)
-            & _floating_tree_is_finite(updated)
+            inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
         )
         held = jax.lax.cond(
             candidate_ok,
@@ -500,13 +561,9 @@ class ActorCriticAgent:
             ),
             policy=jnp.where(params_ok, next_policy, jnp.zeros_like(next_policy)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(
-                params_ok & jnp.isfinite(next_value), next_value, zero
-            ),
+            next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(
-                params_ok, (actor_metric + critic_metric) / 2.0, zero
-            ),
+            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
             update_applied=params_ok,
         )
 
@@ -653,6 +710,55 @@ class ContinuousActorCriticConfig:
     log_sigma_max: float = 2.0
     action_low: float | None = None
     action_high: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "action_dim",
+            _require_int32("action_dim", self.action_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "gamma",
+            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_step_size",
+            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_step_size",
+            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+        )
+        object.__setattr__(
+            self,
+            "actor_lamda",
+            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "critic_lamda",
+            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_init",
+            validated_float32_scalar("log_sigma_init", self.log_sigma_init),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_min",
+            validated_float32_scalar("log_sigma_min", self.log_sigma_min),
+        )
+        object.__setattr__(
+            self,
+            "log_sigma_max",
+            validated_float32_scalar("log_sigma_max", self.log_sigma_max),
+        )
+        if self.log_sigma_min > self.log_sigma_max:
+            raise ValueError("log_sigma_min must be <= log_sigma_max")
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -870,6 +976,7 @@ class ContinuousActorCriticAgent:
         Returns:
             Initial immutable continuous actor-critic state.
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         cfg = self._config
         zeros_mean = jnp.zeros((cfg.action_dim, feature_dim), dtype=jnp.float32)
         zeros_mean_bias = jnp.zeros((cfg.action_dim,), dtype=jnp.float32)
@@ -1014,9 +1121,7 @@ class ContinuousActorCriticAgent:
                 discount = jnp.where(terminated, 0.0, cfg.gamma)
         discount = jnp.asarray(discount, dtype=jnp.float32)
         # Terminal 0 * inf V(s') is NaN and would freeze the critic.
-        bootstrap = jnp.where(
-            discount == 0.0, jnp.zeros_like(next_value), discount * next_value
-        )
+        bootstrap = jnp.where(discount == 0.0, jnp.zeros_like(next_value), discount * next_value)
         td_error = reward + bootstrap - value
 
         sigma_sq = prev_sigma * prev_sigma + 1e-8
@@ -1145,9 +1250,7 @@ class ContinuousActorCriticAgent:
             & jnp.isfinite(critic_metric)
         )
         candidate_ok = (
-            inputs_valid
-            & _floating_tree_is_finite(state)
-            & _floating_tree_is_finite(updated)
+            inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
         )
         held = jax.lax.cond(
             candidate_ok,
@@ -1155,9 +1258,7 @@ class ContinuousActorCriticAgent:
             lambda: state,
         )
         safe_observation = jnp.where(candidate_ok, observation, state.last_observation)
-        next_action, key, next_mean, next_sigma = self.select_action(
-            held, safe_observation
-        )
+        next_action, key, next_mean, next_sigma = self.select_action(held, safe_observation)
         proposed_final_state = held.replace(
             last_observation=observation,
             last_action=next_action,
@@ -1183,13 +1284,9 @@ class ContinuousActorCriticAgent:
             mean=jnp.where(params_ok, next_mean, jnp.zeros_like(next_mean)),
             sigma=jnp.where(params_ok, next_sigma, jnp.zeros_like(next_sigma)),
             value=jnp.where(params_ok, value, zero),
-            next_value=jnp.where(
-                params_ok & jnp.isfinite(next_value), next_value, zero
-            ),
+            next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(
-                params_ok, (actor_metric + critic_metric) / 2.0, zero
-            ),
+            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
             update_applied=params_ok,
         )
 
@@ -1253,9 +1350,7 @@ def run_continuous_actor_critic_from_arrays(
             current_action = fixed_action.astype(jnp.float32)
             current_mean, current_sigma = agent.policy_params(started_state, obs)
         else:
-            started_state, current_action, current_mean, current_sigma = agent.start(
-                carry, obs
-            )
+            started_state, current_action, current_mean, current_sigma = agent.start(carry, obs)
         result = agent.update(
             started_state,
             reward,
@@ -1268,15 +1363,9 @@ def run_continuous_actor_critic_from_arrays(
             lambda: carry,
         )
         return next_carry, (
-            jnp.where(
-                result.update_applied, current_action, jnp.zeros_like(current_action)
-            ),
-            jnp.where(
-                result.update_applied, current_mean, jnp.zeros_like(current_mean)
-            ),
-            jnp.where(
-                result.update_applied, current_sigma, jnp.zeros_like(current_sigma)
-            ),
+            jnp.where(result.update_applied, current_action, jnp.zeros_like(current_action)),
+            jnp.where(result.update_applied, current_mean, jnp.zeros_like(current_mean)),
+            jnp.where(result.update_applied, current_sigma, jnp.zeros_like(current_sigma)),
             result.value,
             result.td_error,
             result.update_applied,

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -22,7 +22,8 @@ import dataclasses
 import functools
 import math
 import operator
-from numbers import Real
+from collections.abc import Mapping
+from fractions import Fraction
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -34,7 +35,7 @@ from jax import Array
 from jaxtyping import Bool, Float, Int
 
 from alberta_framework._float32 import round_real_to_float32
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
@@ -42,19 +43,10 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -65,6 +57,80 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_float32(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    preserve_nonzero: bool = False,
+) -> float:
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name, value, positive=positive, lower=lower, upper=upper
+    )
+    if preserve_nonzero and numerator != 0 and np.float32(numerator / denominator) == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
+
+
+def _read_mapping(name: str, value: object) -> dict[str, Any]:
+    if not issubclass(type(value), Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], value))
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+
+
+def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 5
+    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+    if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
+        raise ValueError("derived actor-critic state exceeds the signed-int32 budget")
+
+
+def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> None:
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 4
+    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+    if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
+        raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
+
+
+def _array(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> Array:
+    array = jnp.asarray(value, dtype=dtype)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    return array
+
+
+def _require_key(key: object) -> Array:
+    try:
+        data = jr.key_data(cast(Any, key))
+    except Exception as error:
+        raise ValueError("key must be a Threefry JAX key") from error
+    if data.shape != (2,) or data.dtype != jnp.uint32:
+        raise ValueError("key must be a Threefry JAX key")
+    return cast(Array, key)
+
+
+def _require_action_bound(name: str, value: object) -> float:
+    if type(value) not in _ACTUAL_REAL_TYPES | {Fraction}:
+        raise ValueError(f"{name} must be a finite real number")
+    try:
+        host = float(cast(Any, value))
+        narrowed = round_real_to_float32(cast(Any, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be finite when set") from error
+    if not math.isfinite(host):
+        raise ValueError(f"{name} must be finite when set")
+    if not math.isfinite(narrowed):
+        raise ValueError(f"{name} must remain finite once narrowed to float32")
+    return host if type(value) is float else narrowed
 
 
 @dataclasses.dataclass(frozen=True)
@@ -93,37 +159,47 @@ class ActorCriticConfig:
         object.__setattr__(
             self,
             "n_actions",
-            _require_int32("n_actions", self.n_actions, minimum=2),
+            _require_int32("n_actions", self.n_actions, minimum=1),
         )
         object.__setattr__(
             self,
             "gamma",
-            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+            _require_float32(
+                "gamma", self.gamma, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "actor_step_size",
-            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+            _require_float32(
+                "actor_step_size", self.actor_step_size, lower=0.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "critic_step_size",
-            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+            _require_float32(
+                "critic_step_size", self.critic_step_size, lower=0.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "actor_lamda",
-            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+            _require_float32(
+                "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "critic_lamda",
-            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+            _require_float32(
+                "critic_lamda", self.critic_lamda, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "temperature",
-            validated_float32_scalar("temperature", self.temperature, positive=True),
+            _require_float32("temperature", self.temperature, positive=True),
         )
 
     def to_config(self) -> dict[str, Any]:
@@ -139,9 +215,9 @@ class ActorCriticConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ActorCriticConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> ActorCriticConfig:
         """Reconstruct an ``ActorCriticConfig`` from a dictionary."""
-        return cls(**config)
+        return cls(**_read_mapping("config", config))
 
 
 @chex.dataclass(frozen=True)
@@ -258,10 +334,8 @@ class ActorCriticAgent:
                 ``Bounder`` ABC. When present, actor and critic proposed steps
                 are bounded independently using the TD error.
         """
-        if config.n_actions <= 0:
-            raise ValueError("n_actions must be positive")
-        if config.temperature <= 0:
-            raise ValueError("temperature must be positive")
+        if type(config) is not ActorCriticConfig:
+            raise ValueError("config must be an ActorCriticConfig")
         self._config = config
         self._bounder = bounder
 
@@ -284,9 +358,9 @@ class ActorCriticAgent:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ActorCriticAgent:
+    def from_config(cls, config: Mapping[str, Any]) -> ActorCriticAgent:
         """Reconstruct an ``ActorCriticAgent`` from a dictionary."""
-        config = dict(config)
+        config = _read_mapping("config", config)
         config.pop("type", None)
         ac_config = ActorCriticConfig.from_config(config.pop("config"))
         bounder_config = config.pop("bounder", None)
@@ -304,6 +378,8 @@ class ActorCriticAgent:
             Initial immutable actor-critic state.
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _require_discrete_state_resources(self._config.n_actions, feature_dim)
+        key = _require_key(key)
         zeros_actor = jnp.zeros((self._config.n_actions, feature_dim), dtype=jnp.float32)
         zeros_policy_bias = jnp.zeros((self._config.n_actions,), dtype=jnp.float32)
         zeros_critic = jnp.zeros((feature_dim,), dtype=jnp.float32)
@@ -322,6 +398,40 @@ class ActorCriticAgent:
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
+    def _feature_dim(self, state: ActorCriticState) -> int:
+        if type(state) is not ActorCriticState:
+            raise ValueError("state must be an ActorCriticState")
+        n_actions = self._config.n_actions
+        if state.actor_weights.ndim != 2 or state.actor_weights.shape[0] != n_actions:
+            raise ValueError("state.actor_weights must match n_actions and feature_dim")
+        feature_dim = state.actor_weights.shape[1]
+        matrix_shape = (n_actions, feature_dim)
+        for name in ("actor_weights", "actor_trace_weights"):
+            leaf = getattr(state, name)
+            if leaf.shape != matrix_shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {matrix_shape} and dtype float32")
+        for name in ("actor_bias", "actor_trace_bias"):
+            leaf = getattr(state, name)
+            if leaf.shape != (n_actions,) or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape ({n_actions},) and dtype float32")
+        for name in ("critic_weights", "critic_trace_weights", "last_observation"):
+            leaf = getattr(state, name)
+            if leaf.shape != (feature_dim,) or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape ({feature_dim},) and dtype float32")
+        for name in ("critic_bias", "critic_trace_bias"):
+            leaf = getattr(state, name)
+            if leaf.shape != () or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must be a scalar float32")
+        if state.last_action.shape != () or state.last_action.dtype != jnp.int32:
+            raise ValueError("state.last_action must be a scalar int32")
+        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
+            raise ValueError("state.step_count must be a scalar int32")
+        _require_key(state.rng_key)
+        return feature_dim
+
+    def _observation(self, state: ActorCriticState, value: object) -> Array:
+        return _array("observation", value, (self._feature_dim(state),), jnp.float32)
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def policy(
         self,
@@ -329,12 +439,14 @@ class ActorCriticAgent:
         observation: Array,
     ) -> Float[Array, " n_actions"]:
         """Compute softmax action probabilities for one observation."""
+        observation = self._observation(state, observation)
         logits = state.actor_weights @ observation + state.actor_bias
         return jax.nn.softmax(logits / self._config.temperature)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def value(self, state: ActorCriticState, observation: Array) -> Float[Array, ""]:
         """Compute the critic value estimate for one observation."""
+        observation = self._observation(state, observation)
         return jnp.dot(state.critic_weights, observation) + state.critic_bias
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -352,6 +464,7 @@ class ActorCriticAgent:
         Returns:
             Tuple ``(action, new_rng_key, probabilities)``.
         """
+        observation = self._observation(state, observation)
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
         action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
@@ -364,6 +477,7 @@ class ActorCriticAgent:
         observation: Array,
     ) -> tuple[ActorCriticState, Int[Array, ""], Float[Array, " n_actions"]]:
         """Select and store the first action for a new stream or episode."""
+        observation = self._observation(state, observation)
         action, key, probs = self.select_action(state, observation)
         new_state = state.replace(  # type: ignore[attr-defined]
             last_observation=observation,
@@ -402,6 +516,12 @@ class ActorCriticAgent:
         Returns:
             ``ActorCriticUpdateResult`` containing the updated state and metrics.
         """
+        observation = self._observation(state, observation)
+        reward = _array("reward", reward, (), jnp.float32)
+        if terminated is not None:
+            terminated = _array("terminated", terminated, (), jnp.bool_)
+        if discount is not None:
+            discount = _array("discount", discount, (), jnp.float32)
         cfg = self._config
         prev_obs = state.last_observation
         action = state.last_action
@@ -504,7 +624,7 @@ class ActorCriticAgent:
             actor_trace_bias=stored_actor_trace_bias,
             critic_trace_weights=stored_critic_trace_weights,
             critic_trace_bias=stored_critic_trace_bias,
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         # Reject the complete transition if its inputs or proposed persistent
         # state are non-finite. The result carries the rejection explicitly.
@@ -522,6 +642,7 @@ class ActorCriticAgent:
             & ((discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(actor_metric)
             & jnp.isfinite(critic_metric)
+            & (state.step_count >= 0)
         )
         candidate_ok = (
             inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
@@ -604,8 +725,31 @@ def run_actor_critic_from_arrays(
     Returns:
         ``ActorCriticArrayResult`` with final state and per-step metrics.
     """
+    feature_dim = agent._feature_dim(state)
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
+    if observations.ndim != 2 or observations.shape[0] < 1:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    num_steps = observations.shape[0]
+    if observations.shape[1] != feature_dim or next_observations.shape != observations.shape:
+        raise ValueError("observations and next_observations must match state feature_dim")
+    if rewards.shape != (num_steps,):
+        raise ValueError("rewards must have shape (num_steps,)")
+    output_scalars = num_steps * (agent.config.n_actions + 4)
+    output_bytes = num_steps * (4 * agent.config.n_actions + 13)
+    if output_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
+        raise ValueError("derived actor-critic scan outputs exceed the signed-int32 budget")
     if terminated is None and discounts is None:
         raise ValueError("terminated or discounts must be provided")
+    if terminated is not None:
+        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        if terminated.shape != (num_steps,):
+            raise ValueError("terminated must have shape (num_steps,)")
+    if discounts is not None:
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
+        if discounts.shape != (num_steps,):
+            raise ValueError("discounts must have shape (num_steps,)")
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
     if discounts is None:
@@ -614,6 +758,9 @@ def run_actor_critic_from_arrays(
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
         use_fixed_actions = False
     else:
+        actions = jnp.asarray(actions, dtype=jnp.int32)
+        if actions.shape != (num_steps,):
+            raise ValueError("actions must have shape (num_steps,)")
         use_fixed_actions = True
 
     def _scan_fn(
@@ -720,42 +867,52 @@ class ContinuousActorCriticConfig:
         object.__setattr__(
             self,
             "gamma",
-            validated_float32_scalar("gamma", self.gamma, lower=0.0, upper=1.0),
+            _require_float32(
+                "gamma", self.gamma, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "actor_step_size",
-            validated_float32_scalar("actor_step_size", self.actor_step_size, lower=0.0),
+            _require_float32(
+                "actor_step_size", self.actor_step_size, lower=0.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "critic_step_size",
-            validated_float32_scalar("critic_step_size", self.critic_step_size, lower=0.0),
+            _require_float32(
+                "critic_step_size", self.critic_step_size, lower=0.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "actor_lamda",
-            validated_float32_scalar("actor_lamda", self.actor_lamda, lower=0.0, upper=1.0),
+            _require_float32(
+                "actor_lamda", self.actor_lamda, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "critic_lamda",
-            validated_float32_scalar("critic_lamda", self.critic_lamda, lower=0.0, upper=1.0),
+            _require_float32(
+                "critic_lamda", self.critic_lamda, lower=0.0, upper=1.0, preserve_nonzero=True
+            ),
         )
         object.__setattr__(
             self,
             "log_sigma_init",
-            validated_float32_scalar("log_sigma_init", self.log_sigma_init),
+            _require_float32("log_sigma_init", self.log_sigma_init),
         )
         object.__setattr__(
             self,
             "log_sigma_min",
-            validated_float32_scalar("log_sigma_min", self.log_sigma_min),
+            _require_float32("log_sigma_min", self.log_sigma_min),
         )
         object.__setattr__(
             self,
             "log_sigma_max",
-            validated_float32_scalar("log_sigma_max", self.log_sigma_max),
+            _require_float32("log_sigma_max", self.log_sigma_max),
         )
         if self.log_sigma_min > self.log_sigma_max:
             raise ValueError("log_sigma_min must be <= log_sigma_max")
@@ -777,9 +934,9 @@ class ContinuousActorCriticConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ContinuousActorCriticConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> ContinuousActorCriticConfig:
         """Reconstruct a ``ContinuousActorCriticConfig`` from a dictionary."""
-        return cls(**config)
+        return cls(**_read_mapping("config", config))
 
 
 @chex.dataclass(frozen=True)
@@ -901,30 +1058,12 @@ class ContinuousActorCriticAgent:
                 ``Bounder`` ABC. When present, actor and critic proposed steps
                 are bounded independently using the TD error.
         """
-        if config.action_dim <= 0:
-            raise ValueError("action_dim must be positive")
-        if config.log_sigma_min > config.log_sigma_max:
-            raise ValueError("log_sigma_min must be <= log_sigma_max")
+        if type(config) is not ContinuousActorCriticConfig:
+            raise ValueError("config must be a ContinuousActorCriticConfig")
         canonical_bounds: dict[str, float | None] = {}
         for name in ("action_low", "action_high"):
             bound = getattr(config, name)
-            if bound is None:
-                canonical_bounds[name] = None
-                continue
-            actual_type = type(bound)
-            if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-                raise ValueError(f"{name} must be a finite real number when set")
-            if not math.isfinite(bound):
-                raise ValueError(f"{name} must be finite when set")
-            try:
-                narrowed = round_real_to_float32(bound)
-            except Exception as exc:
-                raise ValueError(f"{name} must be finite when set") from exc
-            if not math.isfinite(narrowed):
-                raise ValueError(f"{name} must remain finite once narrowed to float32")
-            # Only an actual built-in float is already the binary64 payload JAX will
-            # narrow exactly; ints and other reals store the validated binary32 value.
-            canonical_bounds[name] = bound if type(bound) is float else narrowed
+            canonical_bounds[name] = None if bound is None else _require_action_bound(name, bound)
         low = canonical_bounds["action_low"]
         high = canonical_bounds["action_high"]
         if low is not None and high is not None and low > high:
@@ -957,9 +1096,9 @@ class ContinuousActorCriticAgent:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> ContinuousActorCriticAgent:
+    def from_config(cls, config: Mapping[str, Any]) -> ContinuousActorCriticAgent:
         """Reconstruct a ``ContinuousActorCriticAgent`` from a dictionary."""
-        config = dict(config)
+        config = _read_mapping("config", config)
         config.pop("type", None)
         ac_config = ContinuousActorCriticConfig.from_config(config.pop("config"))
         bounder_config = config.pop("bounder", None)
@@ -978,6 +1117,8 @@ class ContinuousActorCriticAgent:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         cfg = self._config
+        _require_continuous_state_resources(cfg.action_dim, feature_dim)
+        key = _require_key(key)
         zeros_mean = jnp.zeros((cfg.action_dim, feature_dim), dtype=jnp.float32)
         zeros_mean_bias = jnp.zeros((cfg.action_dim,), dtype=jnp.float32)
         log_sigma = jnp.full(
@@ -1003,6 +1144,44 @@ class ContinuousActorCriticAgent:
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
+    def _feature_dim(self, state: ContinuousActorCriticState) -> int:
+        if type(state) is not ContinuousActorCriticState:
+            raise ValueError("state must be a ContinuousActorCriticState")
+        action_dim = self._config.action_dim
+        if state.mean_weights.ndim != 2 or state.mean_weights.shape[0] != action_dim:
+            raise ValueError("state.mean_weights must match action_dim and feature_dim")
+        feature_dim = state.mean_weights.shape[1]
+        matrix_shape = (action_dim, feature_dim)
+        for name in ("mean_weights", "mean_trace_weights"):
+            leaf = getattr(state, name)
+            if leaf.shape != matrix_shape or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape {matrix_shape} and dtype float32")
+        for name in (
+            "mean_bias",
+            "log_sigma",
+            "mean_trace_bias",
+            "log_sigma_trace",
+            "last_action",
+        ):
+            leaf = getattr(state, name)
+            if leaf.shape != (action_dim,) or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape ({action_dim},) and dtype float32")
+        for name in ("critic_weights", "critic_trace_weights", "last_observation"):
+            leaf = getattr(state, name)
+            if leaf.shape != (feature_dim,) or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must have shape ({feature_dim},) and dtype float32")
+        for name in ("critic_bias", "critic_trace_bias"):
+            leaf = getattr(state, name)
+            if leaf.shape != () or leaf.dtype != jnp.float32:
+                raise ValueError(f"state.{name} must be a scalar float32")
+        if state.step_count.shape != () or state.step_count.dtype != jnp.int32:
+            raise ValueError("state.step_count must be a scalar int32")
+        _require_key(state.rng_key)
+        return feature_dim
+
+    def _observation(self, state: ContinuousActorCriticState, value: object) -> Array:
+        return _array("observation", value, (self._feature_dim(state),), jnp.float32)
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def policy_params(
         self,
@@ -1010,6 +1189,7 @@ class ContinuousActorCriticAgent:
         observation: Array,
     ) -> tuple[Float[Array, " action_dim"], Float[Array, " action_dim"]]:
         """Compute Gaussian policy mean and standard deviation for one observation."""
+        observation = self._observation(state, observation)
         mean = state.mean_weights @ observation + state.mean_bias
         sigma = jnp.exp(state.log_sigma)
         return mean, sigma
@@ -1021,6 +1201,7 @@ class ContinuousActorCriticAgent:
         observation: Array,
     ) -> Float[Array, ""]:
         """Compute the critic value estimate for one observation."""
+        observation = self._observation(state, observation)
         return jnp.dot(state.critic_weights, observation) + state.critic_bias
 
     def _maybe_clip_action(self, action: Array) -> Array:
@@ -1052,6 +1233,7 @@ class ContinuousActorCriticAgent:
             Tuple ``(action, new_rng_key, mean, sigma)`` where ``action`` is
             optionally clipped to the configured action bounds.
         """
+        observation = self._observation(state, observation)
         key, sample_key = jr.split(state.rng_key)
         mean, sigma = self.policy_params(state, observation)
         noise = jr.normal(sample_key, shape=mean.shape, dtype=jnp.float32)
@@ -1071,6 +1253,7 @@ class ContinuousActorCriticAgent:
         Float[Array, " action_dim"],
     ]:
         """Select and store the first action for a new stream or episode."""
+        observation = self._observation(state, observation)
         action, key, mean, sigma = self.select_action(state, observation)
         new_state = state.replace(  # type: ignore[attr-defined]
             last_observation=observation,
@@ -1107,6 +1290,12 @@ class ContinuousActorCriticAgent:
         Returns:
             ``ContinuousActorCriticUpdateResult`` containing the updated state.
         """
+        observation = self._observation(state, observation)
+        reward = _array("reward", reward, (), jnp.float32)
+        if terminated is not None:
+            terminated = _array("terminated", terminated, (), jnp.bool_)
+        if discount is not None:
+            discount = _array("discount", discount, (), jnp.float32)
         cfg = self._config
         prev_obs = state.last_observation
         action = state.last_action
@@ -1233,7 +1422,7 @@ class ContinuousActorCriticAgent:
             log_sigma_trace=stored_log_sigma_trace,
             critic_trace_weights=stored_critic_trace_weights,
             critic_trace_bias=stored_critic_trace_bias,
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         inputs_valid = (
             jnp.isfinite(jnp.squeeze(reward))
@@ -1248,6 +1437,7 @@ class ContinuousActorCriticAgent:
             & ((discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(actor_metric)
             & jnp.isfinite(critic_metric)
+            & (state.step_count >= 0)
         )
         candidate_ok = (
             inputs_valid & _floating_tree_is_finite(state) & _floating_tree_is_finite(updated)
@@ -1321,17 +1511,45 @@ def run_continuous_actor_critic_from_arrays(
     Returns:
         ``ContinuousActorCriticArrayResult`` with final state and per-step metrics.
     """
+    feature_dim = agent._feature_dim(state)
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
+    if observations.ndim != 2 or observations.shape[0] < 1:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    num_steps = observations.shape[0]
+    if observations.shape[1] != feature_dim or next_observations.shape != observations.shape:
+        raise ValueError("observations and next_observations must match state feature_dim")
+    if rewards.shape != (num_steps,):
+        raise ValueError("rewards must have shape (num_steps,)")
+    action_dim = agent.config.action_dim
+    output_scalars = num_steps * (3 * action_dim + 3)
+    output_bytes = num_steps * (12 * action_dim + 9)
+    if output_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
+        raise ValueError(
+            "derived continuous actor-critic scan outputs exceed the signed-int32 budget"
+        )
     if terminated is None and discounts is None:
         raise ValueError("terminated or discounts must be provided")
+    if terminated is not None:
+        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        if terminated.shape != (num_steps,):
+            raise ValueError("terminated must have shape (num_steps,)")
+    if discounts is not None:
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
+        if discounts.shape != (num_steps,):
+            raise ValueError("discounts must have shape (num_steps,)")
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
     if discounts is None:
         discounts = jnp.where(terminated, 0.0, agent.config.gamma).astype(jnp.float32)
-    action_dim = agent.config.action_dim
     if actions is None:
         actions = jnp.zeros((rewards.shape[0], action_dim), dtype=jnp.float32)
         use_fixed_actions = False
     else:
+        actions = jnp.asarray(actions, dtype=jnp.float32)
+        if actions.shape != (num_steps, action_dim):
+            raise ValueError("actions must have shape (num_steps, action_dim)")
         use_fixed_actions = True
 
     def _scan_fn(

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -87,6 +87,15 @@ def _read_mapping(name: str, value: object) -> dict[str, Any]:
         raise ValueError(f"{name} must be a readable mapping") from error
 
 
+def _serialized_mapping(
+    name: str, value: object, *, fields: frozenset[str]
+) -> dict[str, Any]:
+    payload = _read_mapping(name, value)
+    if any(type(key) is not str for key in payload) or set(payload) != fields:
+        raise ValueError(f"{name} fields do not match the serialized schema")
+    return payload
+
+
 def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
     state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 5
     state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
@@ -102,20 +111,30 @@ def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> No
 
 
 def _array(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> Array:
-    array = jnp.asarray(value, dtype=dtype)
+    if shape == () and dtype == jnp.bool_ and type(value) is bool:
+        return jnp.asarray(value, dtype=dtype)
+    if shape == () and dtype == jnp.float32 and type(value) in _ACTUAL_REAL_TYPES:
+        return jnp.asarray(_require_float32(name, value), dtype=dtype)
+    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+        raise ValueError(f"{name} must expose trusted array metadata")
+    array = jnp.asarray(value)
     if array.shape != shape:
         raise ValueError(f"{name} must have shape {shape}")
+    if array.dtype != jnp.dtype(dtype):
+        raise ValueError(f"{name} must have dtype {jnp.dtype(dtype)}")
     return array
 
 
 def _require_key(key: object) -> Array:
+    if not isinstance(key, jax.Array):
+        raise ValueError("key must be a Threefry JAX key")
     try:
         data = jr.key_data(cast(Any, key))
     except Exception as error:
         raise ValueError("key must be a Threefry JAX key") from error
     if data.shape != (2,) or data.dtype != jnp.uint32:
         raise ValueError("key must be a Threefry JAX key")
-    return cast(Array, key)
+    return key
 
 
 def _require_action_bound(name: str, value: object) -> float:
@@ -217,7 +236,13 @@ class ActorCriticConfig:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> ActorCriticConfig:
         """Reconstruct an ``ActorCriticConfig`` from a dictionary."""
-        return cls(**_read_mapping("config", config))
+        fields = frozenset(field.name for field in dataclasses.fields(cls))
+        payload = _serialized_mapping("config", config, fields=fields)
+        if type(payload["n_actions"]) is not int or any(
+            type(payload[name]) is not float for name in fields - {"n_actions"}
+        ):
+            raise ValueError("serialized config scalars must be exact JSON numbers")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -336,6 +361,8 @@ class ActorCriticAgent:
         """
         if type(config) is not ActorCriticConfig:
             raise ValueError("config must be an ActorCriticConfig")
+        if bounder is not None and not isinstance(bounder, Bounder):
+            raise ValueError("bounder must be a Bounder or None")
         self._config = config
         self._bounder = bounder
 
@@ -360,10 +387,15 @@ class ActorCriticAgent:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> ActorCriticAgent:
         """Reconstruct an ``ActorCriticAgent`` from a dictionary."""
-        config = _read_mapping("config", config)
-        config.pop("type", None)
-        ac_config = ActorCriticConfig.from_config(config.pop("config"))
-        bounder_config = config.pop("bounder", None)
+        payload = _serialized_mapping(
+            "config", config, fields=frozenset({"type", "config", "bounder"})
+        )
+        if type(payload["type"]) is not str or payload.pop("type") != cls.__name__:
+            raise ValueError("config type differs")
+        ac_config = ActorCriticConfig.from_config(payload.pop("config"))
+        bounder_config = payload.pop("bounder")
+        if bounder_config is not None and not issubclass(type(bounder_config), Mapping):
+            raise ValueError("serialized bounder must be a mapping or None")
         bounder = bounder_from_config(bounder_config) if bounder_config else None
         return cls(config=ac_config, bounder=bounder)
 
@@ -916,6 +948,20 @@ class ContinuousActorCriticConfig:
         )
         if self.log_sigma_min > self.log_sigma_max:
             raise ValueError("log_sigma_min must be <= log_sigma_max")
+        action_low = (
+            None
+            if self.action_low is None
+            else _require_action_bound("action_low", self.action_low)
+        )
+        action_high = (
+            None
+            if self.action_high is None
+            else _require_action_bound("action_high", self.action_high)
+        )
+        if action_low is not None and action_high is not None and action_low > action_high:
+            raise ValueError("action_low must be <= action_high")
+        object.__setattr__(self, "action_low", action_low)
+        object.__setattr__(self, "action_high", action_high)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -936,7 +982,14 @@ class ContinuousActorCriticConfig:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> ContinuousActorCriticConfig:
         """Reconstruct a ``ContinuousActorCriticConfig`` from a dictionary."""
-        return cls(**_read_mapping("config", config))
+        fields = frozenset(field.name for field in dataclasses.fields(cls))
+        payload = _serialized_mapping("config", config, fields=fields)
+        if type(payload["action_dim"]) is not int or any(
+            payload[name] is not None and type(payload[name]) is not float
+            for name in fields - {"action_dim"}
+        ):
+            raise ValueError("serialized config scalars must be exact JSON numbers or None")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -1060,20 +1113,8 @@ class ContinuousActorCriticAgent:
         """
         if type(config) is not ContinuousActorCriticConfig:
             raise ValueError("config must be a ContinuousActorCriticConfig")
-        canonical_bounds: dict[str, float | None] = {}
-        for name in ("action_low", "action_high"):
-            bound = getattr(config, name)
-            canonical_bounds[name] = None if bound is None else _require_action_bound(name, bound)
-        low = canonical_bounds["action_low"]
-        high = canonical_bounds["action_high"]
-        if low is not None and high is not None and low > high:
-            raise ValueError("action_low must be <= action_high")
-        if (low, high) != (config.action_low, config.action_high) or any(
-            type(value) is not float
-            for value in (config.action_low, config.action_high)
-            if value is not None
-        ):
-            config = dataclasses.replace(config, action_low=low, action_high=high)
+        if bounder is not None and not isinstance(bounder, Bounder):
+            raise ValueError("bounder must be a Bounder or None")
         self._config = config
         self._bounder = bounder
 
@@ -1098,10 +1139,15 @@ class ContinuousActorCriticAgent:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> ContinuousActorCriticAgent:
         """Reconstruct a ``ContinuousActorCriticAgent`` from a dictionary."""
-        config = _read_mapping("config", config)
-        config.pop("type", None)
-        ac_config = ContinuousActorCriticConfig.from_config(config.pop("config"))
-        bounder_config = config.pop("bounder", None)
+        payload = _serialized_mapping(
+            "config", config, fields=frozenset({"type", "config", "bounder"})
+        )
+        if type(payload["type"]) is not str or payload.pop("type") != cls.__name__:
+            raise ValueError("config type differs")
+        ac_config = ContinuousActorCriticConfig.from_config(payload.pop("config"))
+        bounder_config = payload.pop("bounder")
+        if bounder_config is not None and not issubclass(type(bounder_config), Mapping):
+            raise ValueError("serialized bounder must be a mapping or None")
         bounder = bounder_from_config(bounder_config) if bounder_config else None
         return cls(config=ac_config, bounder=bounder)
 

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -4,6 +4,8 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
+import pytest
 
 from alberta_framework import ActorCriticAgent as TopLevelActorCriticAgent
 from alberta_framework.core import ActorCriticAgent as CoreActorCriticAgent
@@ -60,9 +62,7 @@ def test_actor_critic_update_changes_actor_and_critic() -> None:
     )
     agent = ActorCriticAgent(config)
     state = agent.init(feature_dim=3, key=jr.key(1))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32))
 
     result = agent.update(
         state,
@@ -76,9 +76,7 @@ def test_actor_critic_update_changes_actor_and_critic() -> None:
     assert not jnp.allclose(result.state.actor_weights, state.actor_weights)
     assert not jnp.allclose(result.state.critic_weights, state.critic_weights)
     _assert_actor_critic_numeric_state_finite(result.state)
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 def test_actor_critic_temperature_scales_actor_gradient() -> None:
@@ -217,9 +215,7 @@ def test_actor_critic_explicit_discount_semantics() -> None:
 def test_actor_critic_update_is_jittable() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(feature_dim=2, key=jr.key(2))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 0.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
 
     update = jax.jit(agent.update)
     result = update(
@@ -236,12 +232,8 @@ def test_actor_critic_update_is_jittable() -> None:
 def test_run_actor_critic_from_arrays_scan() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(feature_dim=2, key=jr.key(3))
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     terminated = jnp.array([False, False, True])
 
@@ -302,12 +294,8 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
     state = state.replace(  # type: ignore[attr-defined]
         actor_weights=jnp.array([[0.0, 3.0], [3.0, 0.0]], dtype=jnp.float32)
     )
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     actions = jnp.array([0, 1, 0], dtype=jnp.int32)
     discounts = jnp.array([0.9, 0.9, 0.0], dtype=jnp.float32)
@@ -350,9 +338,7 @@ def test_run_actor_critic_from_arrays_fixed_actions_matches_loop() -> None:
     assert float(scan_result.policies[0, scan_result.actions[0]]) < 0.1
     chex.assert_trees_all_close(scan_result.td_errors, jnp.stack(loop_td_errors))
     chex.assert_trees_all_close(scan_result.state.actor_weights, loop_state.actor_weights)
-    chex.assert_trees_all_close(
-        scan_result.state.critic_weights, loop_state.critic_weights
-    )
+    chex.assert_trees_all_close(scan_result.state.critic_weights, loop_state.critic_weights)
 
 
 def test_actor_critic_config_round_trip_with_bounder() -> None:
@@ -378,9 +364,7 @@ def test_actor_critic_bounder_hook_runs() -> None:
         bounder=ObGDBounding(kappa=2.0),
     )
     state = agent.init(feature_dim=2, key=jr.key(4))
-    state, _action, _policy = agent.start(
-        state, jnp.array([1.0, 1.0], dtype=jnp.float32)
-    )
+    state, _action, _policy = agent.start(state, jnp.array([1.0, 1.0], dtype=jnp.float32))
 
     result = agent.update(
         state,
@@ -391,9 +375,7 @@ def test_actor_critic_bounder_hook_runs() -> None:
 
     assert float(result.bound_metric) < 1.0
     _assert_actor_critic_numeric_state_finite(result.state)
-    chex.assert_tree_all_finite(
-        (result.policy, result.value, result.next_value, result.td_error)
-    )
+    chex.assert_tree_all_finite((result.policy, result.value, result.next_value, result.td_error))
 
 
 def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> None:
@@ -415,9 +397,7 @@ def test_actor_critic_infinite_reward_with_obgd_does_not_poison_weights() -> Non
     assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
     chex.assert_trees_all_close(poisoned.state.actor_weights, state.actor_weights)
     chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
-    chex.assert_trees_all_equal(
-        jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         poisoned.state.replace(rng_key=jr.key_data(poisoned.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -467,3 +447,30 @@ def test_actor_critic_terminal_does_not_multiply_inf_next_value() -> None:
 def test_actor_critic_exports() -> None:
     assert TopLevelActorCriticAgent is ActorCriticAgent
     assert CoreActorCriticAgent is ActorCriticAgent
+
+
+def test_actor_critic_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=1)
+    with pytest.raises(ValueError, match="n_actions"):
+        ActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="gamma"):
+        ActorCriticConfig(n_actions=2, gamma=1.5)
+    with pytest.raises(ValueError, match="actor_step_size"):
+        ActorCriticConfig(n_actions=2, actor_step_size=-0.1)
+
+    cfg = ActorCriticConfig(n_actions=np.int32(4))
+    assert cfg.n_actions == 4
+    assert type(cfg.n_actions) is int
+
+    agent = ActorCriticAgent(cfg)
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=0, key=jr.key(0))
+
+    state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
+    assert state.actor_weights.shape == (4, 5)

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -1,5 +1,7 @@
 """Tests for Step 4b actor-critic core."""
 
+from types import MappingProxyType
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -12,6 +14,7 @@ from alberta_framework.core import ActorCriticAgent as CoreActorCriticAgent
 from alberta_framework.core.actor_critic import (
     ActorCriticAgent,
     ActorCriticConfig,
+    _require_discrete_state_resources,
     run_actor_critic_from_arrays,
 )
 from alberta_framework.core.optimizers import ObGDBounding
@@ -452,8 +455,7 @@ def test_actor_critic_exports() -> None:
 def test_actor_critic_integer_and_scalar_validation() -> None:
     with pytest.raises(ValueError, match="n_actions"):
         ActorCriticConfig(n_actions=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_actions"):
-        ActorCriticConfig(n_actions=1)
+    assert ActorCriticConfig(n_actions=1).n_actions == 1
     with pytest.raises(ValueError, match="n_actions"):
         ActorCriticConfig(n_actions=2.5)  # type: ignore[arg-type]
 
@@ -474,3 +476,62 @@ def test_actor_critic_integer_and_scalar_validation() -> None:
 
     state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
     assert state.actor_weights.shape == (4, 5)
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile hook executed")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("gamma", _HostileFloat(0.5)),
+        ("gamma", np.float64(1e-100)),
+        ("actor_step_size", np.float64(1e-100)),
+        ("critic_lamda", 1e100),
+        ("temperature", True),
+    ],
+)
+def test_actor_critic_rejects_invalid_float32_config(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        ActorCriticConfig(n_actions=2, **{field: value})  # type: ignore[arg-type]
+
+
+def test_actor_critic_mapping_config_and_resource_boundary() -> None:
+    config = ActorCriticConfig(n_actions=np.uint16(2), gamma=np.float32(0.5)).to_config()
+    clone = ActorCriticConfig.from_config(MappingProxyType(config))
+    assert clone.to_config() == config
+    _require_discrete_state_resources(1, 107_374_180)
+    with pytest.raises(ValueError, match="state exceeds"):
+        _require_discrete_state_resources(1, 107_374_181)
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
+def test_actor_critic_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observation"):
+        agent.policy(state, malformed)
+    with pytest.raises(ValueError, match="observation"):
+        agent.update(state, jnp.asarray(0.0), malformed)
+
+
+def test_actor_critic_state_contract_and_counter_saturation() -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    malformed = state.replace(actor_weights=jnp.zeros((2,), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="actor_weights"):
+        agent.policy(malformed, jnp.zeros((2,), dtype=jnp.float32))
+    saturated = state.replace(
+        last_action=jnp.asarray(0, dtype=jnp.int32),
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32),
+    )
+    result = agent.update(
+        saturated,
+        jnp.asarray(0.0),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -507,6 +507,34 @@ def test_actor_critic_mapping_config_and_resource_boundary() -> None:
         _require_discrete_state_resources(1, 107_374_181)
 
 
+class _HostileArray:
+    def __jax_array__(self) -> jax.Array:
+        raise RuntimeError("hostile array hook executed")
+
+
+def test_actor_critic_serialized_schema_and_hostile_runtime_inputs_fail_closed() -> None:
+    config = ActorCriticConfig(n_actions=2).to_config()
+    with pytest.raises(ValueError, match="serialized schema"):
+        ActorCriticConfig.from_config({**config, "unknown": 1})
+    with pytest.raises(ValueError, match="exact JSON"):
+        ActorCriticConfig.from_config({**config, "n_actions": np.int32(2)})
+
+    payload = ActorCriticAgent(ActorCriticConfig(n_actions=2)).to_config()
+    with pytest.raises(ValueError, match="type differs"):
+        ActorCriticAgent.from_config({**payload, "type": "wrong"})
+    with pytest.raises(ValueError, match="serialized schema"):
+        ActorCriticAgent.from_config({**payload, "unknown": None})
+    with pytest.raises(ValueError, match="Bounder"):
+        ActorCriticAgent(ActorCriticConfig(n_actions=2), bounder=object())  # type: ignore[arg-type]
+
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    with pytest.raises(ValueError, match="Threefry"):
+        agent.init(2, _HostileArray())  # type: ignore[arg-type]
+    state = agent.init(2, jr.key(0))
+    with pytest.raises(ValueError, match="trusted array metadata"):
+        agent.policy.__wrapped__(agent, state, _HostileArray())  # type: ignore[attr-defined,arg-type]
+
+
 @pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
 def test_actor_critic_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -353,9 +353,7 @@ def test_continuous_actor_critic_action_clipping() -> None:
 def test_continuous_actor_critic_update_is_jittable() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(feature_dim=2, key=jr.key(6))
-    state, _action, _mean, _sigma = agent.start(
-        state, jnp.array([1.0, 0.0], dtype=jnp.float32)
-    )
+    state, _action, _mean, _sigma = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
     update = jax.jit(agent.update)
     result = update(
         state,
@@ -370,12 +368,8 @@ def test_continuous_actor_critic_update_is_jittable() -> None:
 def test_continuous_actor_critic_run_from_arrays_scan() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(feature_dim=2, key=jr.key(7))
-    observations = jnp.array(
-        [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32
-    )
-    next_observations = jnp.array(
-        [[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32
-    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0], [0.5, -0.5]], dtype=jnp.float32)
     rewards = jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
     terminated = jnp.array([False, False, True])
 
@@ -459,9 +453,7 @@ def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> 
         bounder=ObGDBounding(kappa=2.0),
     )
     state = agent.init(feature_dim=3, key=jr.key(8))
-    state, _, _, _ = agent.start(
-        state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32)
-    )
+    state, _, _, _ = agent.start(state, jnp.array([1.0, 0.0, -1.0], dtype=jnp.float32))
     poisoned = agent.update(
         state,
         reward=jnp.array(jnp.inf, dtype=jnp.float32),
@@ -472,9 +464,7 @@ def test_continuous_actor_critic_infinite_reward_with_obgd_does_not_poison() -> 
     assert bool(jnp.all(jnp.isfinite(poisoned.state.critic_weights)))
     chex.assert_trees_all_close(poisoned.state.mean_weights, state.mean_weights)
     chex.assert_trees_all_close(poisoned.state.critic_weights, state.critic_weights)
-    chex.assert_trees_all_equal(
-        jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key)
-    )
+    chex.assert_trees_all_equal(jr.key_data(poisoned.state.rng_key), jr.key_data(state.rng_key))
     chex.assert_trees_all_close(
         poisoned.state.replace(rng_key=jr.key_data(poisoned.state.rng_key)),
         state.replace(rng_key=jr.key_data(state.rng_key)),
@@ -523,3 +513,30 @@ def test_continuous_actor_critic_terminal_does_not_multiply_inf_next_value() -> 
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.td_error, jnp.array(3.0, dtype=jnp.float32))
     _assert_continuous_actor_critic_state_finite(result.state)
+
+
+def test_continuous_actor_critic_integer_and_scalar_validation() -> None:
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=0)
+    with pytest.raises(ValueError, match="action_dim"):
+        ContinuousActorCriticConfig(action_dim=2.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="gamma"):
+        ContinuousActorCriticConfig(action_dim=2, gamma=1.5)
+    with pytest.raises(ValueError, match="actor_step_size"):
+        ContinuousActorCriticConfig(action_dim=2, actor_step_size=-0.1)
+
+    cfg = ContinuousActorCriticConfig(action_dim=np.int32(3))
+    assert cfg.action_dim == 3
+    assert type(cfg.action_dim) is int
+
+    agent = ContinuousActorCriticAgent(cfg)
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        agent.init(feature_dim=0, key=jr.key(0))
+
+    state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
+    assert state.mean_weights.shape == (3, 5)

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from types import MappingProxyType
 
 import chex
 import jax
@@ -18,6 +19,7 @@ from alberta_framework.core import (
 from alberta_framework.core.actor_critic import (
     ContinuousActorCriticAgent,
     ContinuousActorCriticConfig,
+    _require_continuous_state_resources,
     run_continuous_actor_critic_from_arrays,
 )
 from alberta_framework.core.optimizers import ObGDBounding
@@ -319,7 +321,7 @@ def test_continuous_actor_critic_normalizes_conversion_hook_failures() -> None:
         def as_integer_ratio(self) -> tuple[int, int]:
             raise RuntimeError("conversion hook failed")
 
-    with pytest.raises(ValueError, match="action_low must be finite"):
+    with pytest.raises(ValueError, match="action_low must be"):
         ContinuousActorCriticAgent(
             ContinuousActorCriticConfig(
                 action_dim=1,
@@ -540,3 +542,67 @@ def test_continuous_actor_critic_integer_and_scalar_validation() -> None:
 
     state = agent.init(feature_dim=np.int32(5), key=jr.key(0))
     assert state.mean_weights.shape == (3, 5)
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:
+        raise RuntimeError("hostile hook executed")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("gamma", _HostileFloat(0.5)),
+        ("actor_step_size", np.float64(1e-100)),
+        ("log_sigma_init", 1e100),
+        ("log_sigma_min", True),
+        ("action_low", _HostileFloat(-1.0)),
+        ("action_high", np.float64(1e100)),
+    ],
+)
+def test_continuous_actor_critic_rejects_invalid_float32_config(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        config = ContinuousActorCriticConfig(action_dim=2, **{field: value})  # type: ignore[arg-type]
+        ContinuousActorCriticAgent(config)
+
+
+def test_continuous_actor_critic_mapping_config_and_resource_boundary() -> None:
+    config = ContinuousActorCriticConfig(
+        action_dim=np.uint16(2), action_low=np.float32(-1), action_high=np.float64(1)
+    ).to_config()
+    clone = ContinuousActorCriticConfig.from_config(MappingProxyType(config))
+    assert clone.to_config() == config
+    _require_continuous_state_resources(1, 107_374_180)
+    with pytest.raises(ValueError, match="state exceeds"):
+        _require_continuous_state_resources(1, 107_374_181)
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
+def test_continuous_actor_critic_rejects_wrong_observation_shapes(
+    shape: tuple[int, ...]
+) -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    malformed = jnp.zeros(shape, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observation"):
+        agent.policy_params(state, malformed)
+    with pytest.raises(ValueError, match="observation"):
+        agent.update(state, jnp.asarray(0.0), malformed)
+
+
+def test_continuous_actor_critic_state_contract_and_counter_saturation() -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    malformed = state.replace(mean_weights=jnp.zeros((2,), dtype=jnp.float32))
+    with pytest.raises(ValueError, match="mean_weights"):
+        agent.policy_params(malformed, jnp.zeros((2,), dtype=jnp.float32))
+    saturated = state.replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    result = agent.update(
+        saturated,
+        jnp.asarray(0.0),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -225,8 +225,8 @@ def test_continuous_actor_critic_rejects_inverted_or_nonfinite_action_bounds(
     low: float | None, high: float | None, message: str | None
 ) -> None:
     """low > high makes jnp.clip return high for every input: a constant-action policy."""
-    config = ContinuousActorCriticConfig(action_dim=2, action_low=low, action_high=high)
     if message is None:
+        config = ContinuousActorCriticConfig(action_dim=2, action_low=low, action_high=high)
         agent = ContinuousActorCriticAgent(config)
         state = agent.init(feature_dim=1, key=jr.key(2))
         _state, action, _mean, _sigma = agent.start(state, jnp.array([1.0], dtype=jnp.float32))
@@ -235,7 +235,7 @@ def test_continuous_actor_critic_rejects_inverted_or_nonfinite_action_bounds(
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         with pytest.raises(ValueError, match=message):
-            ContinuousActorCriticAgent(config)
+            ContinuousActorCriticConfig(action_dim=2, action_low=low, action_high=high)
 
 
 class _FloatSpoof:
@@ -266,9 +266,10 @@ class _FloatSpoof:
 
 @pytest.mark.parametrize("field", ["action_low", "action_high"])
 def test_continuous_actor_critic_rejects_bounds_that_only_spoof_float(field: str) -> None:
-    config = ContinuousActorCriticConfig(action_dim=1, **{field: _FloatSpoof()})  # type: ignore[arg-type]
     with pytest.raises(ValueError, match=f"{field} must be a finite real number"):
-        ContinuousActorCriticAgent(config)
+        ContinuousActorCriticConfig(  # type: ignore[arg-type]
+            action_dim=1, **{field: _FloatSpoof()}
+        )
 
 
 @pytest.mark.parametrize(
@@ -577,6 +578,31 @@ def test_continuous_actor_critic_mapping_config_and_resource_boundary() -> None:
     _require_continuous_state_resources(1, 107_374_180)
     with pytest.raises(ValueError, match="state exceeds"):
         _require_continuous_state_resources(1, 107_374_181)
+
+
+class _HostileArray:
+    def __jax_array__(self) -> jax.Array:
+        raise RuntimeError("hostile array hook executed")
+
+
+def test_continuous_actor_critic_schema_and_hostile_inputs_fail_closed() -> None:
+    config = ContinuousActorCriticConfig(action_dim=2).to_config()
+    with pytest.raises(ValueError, match="serialized schema"):
+        ContinuousActorCriticConfig.from_config({**config, "unknown": 1})
+    with pytest.raises(ValueError, match="exact JSON"):
+        ContinuousActorCriticConfig.from_config({**config, "action_dim": np.int32(2)})
+
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    payload = agent.to_config()
+    with pytest.raises(ValueError, match="type differs"):
+        ContinuousActorCriticAgent.from_config({**payload, "type": "wrong"})
+    with pytest.raises(ValueError, match="Bounder"):
+        ContinuousActorCriticAgent(agent.config, bounder=object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Threefry"):
+        agent.init(2, _HostileArray())  # type: ignore[arg-type]
+    state = agent.init(2, jr.key(0))
+    with pytest.raises(ValueError, match="trusted array metadata"):
+        agent.policy_params.__wrapped__(agent, state, _HostileArray())  # type: ignore[attr-defined,arg-type]
 
 
 @pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])


### PR DESCRIPTION
Supersedes #852 while preserving its contributor commit and attribution.\n\nCompletes the actor-critic boundary: exact Python/NumPy integer and binary32 scalar validation, canonical storage, legacy Mapping/list/tuple config compatibility, exact discrete and continuous state scalar/byte preflights, runtime feature dimensions, adopted-state/key/input/scan shape and dtype contracts, and saturating lifetime counters. It preserves the historically valid one-action discrete contract and keeps continuous action-bound validation at agent construction.\n\nValidation: 248 actor-critic/recurrent/horde tests passed before the latest-main rebase; 69 focused actor-critic tests passed after rebase; scoped Ruff, strict mypy, and diff-check pass. No outputs or registered evidence sources changed.