### PR TITLE
fix(option-duration): preserve scalar and loader compatibility

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -29,6 +29,8 @@ import dataclasses
 import functools
 import operator
 import time
+from collections.abc import Mapping
+from fractions import Fraction
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -47,6 +49,9 @@ _INT32_MAX = 2_147_483_647
 _MAX_PERSISTENT_STATE_BYTES = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in "efdg")}
 )
 
 
@@ -67,16 +72,14 @@ def _require_float32_real(
     strictly_positive: bool,
 ) -> float:
     """Validate one host scalar in its exact domain and float32 sink."""
-    domain = "positive" if strictly_positive else "non-negative"
-    try:
-        stored, numerator, _ = validated_float32_scalar_with_ratio(
-            name,
-            value,
-            positive=strictly_positive,
-            lower=None if strictly_positive else 0.0,
-        )
-    except Exception as error:
-        raise ValueError(f"{name} must be finite and {domain}") from error
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    stored, numerator, _ = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        positive=strictly_positive,
+        lower=None if strictly_positive else 0.0,
+    )
     narrowed = float(np.float32(stored))
     if numerator != 0 and narrowed == 0.0:
         raise ValueError(f"{name} must not underflow to zero in float32")
@@ -160,28 +163,21 @@ class OptionValueDurationConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> OptionValueDurationConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> OptionValueDurationConfig:
         """Reconstruct a config from :meth:`to_config` output."""
-        if type(config) is not dict:
-            raise ValueError("option-duration config must be an exact dictionary")
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
         if any(type(key) is not str for key in payload):
-            raise ValueError("option-duration config keys must be exact strings")
-        expected = {
-            "type",
-            "reward_step_size",
-            "duration_step_size",
-            "duration_floor",
-        }
-        if set(payload) != expected:
-            raise ValueError("option-duration config keys are not the exact schema")
-        marker = payload.pop("type")
-        if type(marker) is not str or marker != "OptionValueDurationConfig":
-            raise ValueError("option-duration config type is unsupported")
-        for name, value in payload.items():
-            if type(value) is not float:
-                raise ValueError(f"serialized {name} must be an exact JSON float")
-        return cls(**payload)
+            raise ValueError("config keys must be strings")
+        payload.pop("type", None)
+        try:
+            return cls(**payload)
+        except TypeError as error:
+            raise ValueError("config has unsupported fields") from error
 
 
 @chex.dataclass(frozen=True)
@@ -289,26 +285,24 @@ class OptionValueDurationLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> OptionValueDurationLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> OptionValueDurationLearner:
         """Reconstruct a learner from :meth:`to_config` output."""
-        if type(config) is not dict:
-            raise ValueError("option-duration learner config must be an exact dictionary")
-        payload = dict(config)
+        if not issubclass(type(config), Mapping):
+            raise ValueError("config must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("config must be a readable mapping") from error
         if any(type(key) is not str for key in payload):
-            raise ValueError("option-duration learner config keys must be exact strings")
-        if set(payload) != {"type", "n_options", "config"}:
-            raise ValueError("option-duration learner config keys are not the exact schema")
-        marker = payload.pop("type")
-        if type(marker) is not str or marker != "OptionValueDurationLearner":
-            raise ValueError("option-duration learner config type is unsupported")
-        if type(payload["n_options"]) is not int:
-            raise ValueError("serialized n_options must be an exact JSON integer")
-        if type(payload["config"]) is not dict:
-            raise ValueError("serialized config must be an exact JSON object")
-        return cls(
-            n_options=payload["n_options"],
-            config=OptionValueDurationConfig.from_config(payload["config"]),
-        )
+            raise ValueError("config keys must be strings")
+        payload.pop("type", None)
+        try:
+            return cls(
+                n_options=payload["n_options"],
+                config=OptionValueDurationConfig.from_config(payload["config"]),
+            )
+        except (KeyError, TypeError) as error:
+            raise ValueError("config has missing or unsupported fields") from error
 
     def trainable_parameter_count(self, feature_dim: int) -> int:
         """Return the exact history-independent trainable parameter count."""

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -30,7 +30,6 @@ import functools
 import operator
 import time
 from collections.abc import Mapping
-from fractions import Fraction
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -50,11 +49,6 @@ _MAX_PERSISTENT_STATE_BYTES = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
 )
-_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
-    {float, Fraction, *(np.dtype(code).type for code in "efdg")}
-)
-
-
 def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
     """Canonicalize one concrete Python/NumPy integer without invoking hooks."""
     if type(value) not in _ACTUAL_INT_TYPES:
@@ -72,14 +66,16 @@ def _require_float32_real(
     strictly_positive: bool,
 ) -> float:
     """Validate one host scalar in its exact domain and float32 sink."""
-    if type(value) not in _ACTUAL_REAL_TYPES:
-        raise ValueError(f"{name} must be a finite real number")
-    stored, numerator, _ = validated_float32_scalar_with_ratio(
-        name,
-        value,
-        positive=strictly_positive,
-        lower=None if strictly_positive else 0.0,
-    )
+    domain = "positive" if strictly_positive else "non-negative"
+    try:
+        stored, numerator, _ = validated_float32_scalar_with_ratio(
+            name,
+            value,
+            positive=strictly_positive,
+            lower=None if strictly_positive else 0.0,
+        )
+    except Exception as error:
+        raise ValueError(f"{name} must be finite and {domain}") from error
     narrowed = float(np.float32(stored))
     if numerator != 0 and narrowed == 0.0:
         raise ValueError(f"{name} must not underflow to zero in float32")

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -8,6 +8,7 @@ import json
 import math
 from decimal import Decimal
 from fractions import Fraction
+from types import MappingProxyType
 
 import chex
 import jax
@@ -461,7 +462,7 @@ def test_option_duration_rejects_hostile_integer_subclasses(field: str) -> None:
             learner.init(HostileInt(3))
 
 
-def test_option_duration_float_hook_runs_once_and_normalizes_failures() -> None:
+def test_option_duration_float_subclasses_never_run_hooks() -> None:
     class CountingFloat(float):
         def __new__(cls):
             instance = super().__new__(cls, 0.25)
@@ -473,9 +474,9 @@ def test_option_duration_float_hook_runs_once_and_normalizes_failures() -> None:
             return (1, 4)
 
     value = CountingFloat()
-    config = OptionValueDurationConfig(reward_step_size=value)
-    assert value.calls == 1
-    assert type(config.reward_step_size) is float
+    with pytest.raises(ValueError, match="reward_step_size"):
+        OptionValueDurationConfig(reward_step_size=value)
+    assert value.calls == 0
 
     class ExplodingFloat(float):
         def as_integer_ratio(self) -> tuple[int, int]:
@@ -493,7 +494,7 @@ def test_option_duration_rejects_builtin_float32_underflow() -> None:
         OptionValueDurationConfig(reward_step_size=1.0e-50)
 
 
-def test_option_duration_config_schemas_and_record_type_are_exact() -> None:
+def test_option_duration_config_preserves_historical_loader_forms() -> None:
     class ConfigSubclass(OptionValueDurationConfig):
         pass
 
@@ -502,19 +503,12 @@ def test_option_duration_config_schemas_and_record_type_are_exact() -> None:
 
     learner_payload = OptionValueDurationLearner(2).to_config()
     learner_payload["n_options"] = np.int32(2)
-    with pytest.raises(ValueError, match="exact JSON integer"):
-        OptionValueDurationLearner.from_config(learner_payload)
+    restored = OptionValueDurationLearner.from_config(MappingProxyType(learner_payload))
+    assert restored.n_options == 2
 
-    config_payload = OptionValueDurationConfig().to_config()
-    config_payload["type"] = "AnotherConfig"
-    with pytest.raises(ValueError, match="type is unsupported"):
-        OptionValueDurationConfig.from_config(config_payload)
-
-    class PayloadSubclass(dict):
-        pass
-
-    with pytest.raises(ValueError, match="exact dictionary"):
-        OptionValueDurationLearner.from_config(PayloadSubclass())
+    config_payload = {"type": "historical-marker", "reward_step_size": np.float32(0.25)}
+    config = OptionValueDurationConfig.from_config(MappingProxyType(config_payload))
+    assert config.reward_step_size == 0.25
 
 
 def test_option_duration_resource_formula_matches_materialized_state() -> None:

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -6,6 +6,7 @@ that Alberta Plan Step 5 is complete.
 
 import json
 import math
+from collections.abc import Iterator, Mapping
 from decimal import Decimal
 from fractions import Fraction
 from types import MappingProxyType
@@ -462,7 +463,7 @@ def test_option_duration_rejects_hostile_integer_subclasses(field: str) -> None:
             learner.init(HostileInt(3))
 
 
-def test_option_duration_float_subclasses_never_run_hooks() -> None:
+def test_option_duration_float_hook_runs_once_and_normalizes_failures() -> None:
     class CountingFloat(float):
         def __new__(cls):
             instance = super().__new__(cls, 0.25)
@@ -474,9 +475,9 @@ def test_option_duration_float_subclasses_never_run_hooks() -> None:
             return (1, 4)
 
     value = CountingFloat()
-    with pytest.raises(ValueError, match="reward_step_size"):
-        OptionValueDurationConfig(reward_step_size=value)
-    assert value.calls == 0
+    config = OptionValueDurationConfig(reward_step_size=value)
+    assert value.calls == 1
+    assert type(config.reward_step_size) is float
 
     class ExplodingFloat(float):
         def as_integer_ratio(self) -> tuple[int, int]:
@@ -509,6 +510,30 @@ def test_option_duration_config_preserves_historical_loader_forms() -> None:
     config_payload = {"type": "historical-marker", "reward_step_size": np.float32(0.25)}
     config = OptionValueDurationConfig.from_config(MappingProxyType(config_payload))
     assert config.reward_step_size == 0.25
+    assert config.duration_step_size == 0.1
+
+    learner_payload["type"] = "historical-learner-marker"
+    assert OptionValueDurationLearner.from_config(learner_payload).n_options == 2
+
+
+def test_option_duration_loaders_normalize_hostile_mapping_failures_without_repr() -> None:
+    class HostileMapping(Mapping[str, object]):
+        def __getitem__(self, key: str) -> object:
+            raise RuntimeError("hostile mapping")
+
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError("hostile mapping")
+
+        def __len__(self) -> int:
+            raise RuntimeError("hostile mapping")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match="readable mapping"):
+        OptionValueDurationConfig.from_config(HostileMapping())
+    with pytest.raises(ValueError, match="readable mapping"):
+        OptionValueDurationLearner.from_config(HostileMapping())
 
 
 def test_option_duration_resource_formula_matches_materialized_state() -> None:


### PR DESCRIPTION
Narrow corrective follow-up after merged #874. Keeps its contributor-preserving exact resource preflight, runtime state/input contracts, array runner, and saturating counters.

This restores the historical unversioned Mapping/partial/type-marker loader behavior, while retaining the established scalar contract: legitimate Real implementations receive exactly one guarded `as_integer_ratio` call, ordinary exceptions normalize to ValueError, hostile repr is never executed, and exact nonzero float32 underflow remains rejected. Hostile Mapping failures are also normalized.

Verification: 63 full option-duration tests passed; scoped Ruff, strict mypy, and diff-check passed. No outputs or registered evidence sources changed.