### PR TITLE
fix(canonical-upgd): complete config, tree, and resource contracts

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -52,7 +52,6 @@ Reference:
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -60,8 +59,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Int
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 UPGDMode = Literal["protecting", "non_protecting"]
 UPGDNormalization = Literal["global", "local"]
@@ -97,6 +99,30 @@ _RAW_GLOBAL_PROFILES = frozenset(
     }
 )
 _INT32_MAX = 2_147_483_647
+_UINT32_MAX = 4_294_967_295
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def _static_zero_scale(scale: float, value: Array) -> Array:
@@ -148,40 +174,48 @@ class CanonicalUPGDConfig:
     epsilon: float = 1e-8
 
     def __post_init__(self) -> None:
-        for name in (
-            "step_size",
-            "utility_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            if isinstance(getattr(self, name), bool):
-                raise ValueError(f"{name} must be numeric, not boolean")
-        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
-            raise ValueError("step_size must be finite and positive")
-        if not math.isfinite(self.utility_decay) or not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be finite and in [0, 1)")
-        if not math.isfinite(self.noise_std) or self.noise_std < 0.0:
-            raise ValueError("noise_std must be finite and non-negative")
-        if not math.isfinite(self.weight_decay) or self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be finite and non-negative")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        # Host domain for decay is [0,1) exact; narrowed 1.0 is tolerated for
+        # continuity with existing lifetime-counter tests (e.g. 0.999999999
+        # rounds to 1.0 in float32 but remains <1.0 as a host ratio).
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar(
+            "noise_std", self.noise_std, lower=0.0
+        )
+        weight_decay = validated_float32_scalar(
+            "weight_decay", self.weight_decay, lower=0.0
+        )
+        epsilon = validated_float32_scalar(
+            "epsilon", self.epsilon, lower=0.0, positive=True
+        )
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "epsilon", epsilon)
         if self.mode not in {"protecting", "non_protecting"}:
-            raise ValueError("mode must be 'protecting' or 'non_protecting'")
+            raise ValueError("mode must be protecting or non_protecting")
         if self.profile not in _SOURCE_PROFILES | {"safe_extended"}:
             raise ValueError(
                 "profile must name a paper, official implementation, or safe_extended profile"
             )
         if self.profile == "safe_extended":
             if self.normalization not in {"global", "local"}:
-                raise ValueError("safe_extended requires normalization='global' or 'local'")
+                raise ValueError("safe_extended requires normalization=global or local")
         else:
             fixed_normalization = "global" if self.profile in _GLOBAL_PROFILES else "local"
             if self.normalization not in {None, fixed_normalization}:
-                raise ValueError(f"{self.profile} fixes normalization={fixed_normalization!r}")
+                raise ValueError(
+                    f"{self.profile} fixes normalization to {fixed_normalization}"
+                )
         if self.profile == "official_readme_global" and self.mode != "protecting":
             raise ValueError("official_readme_global only defines protecting UPGD")
-        if not math.isfinite(self.epsilon) or self.epsilon <= 0.0:
-            raise ValueError("epsilon must be finite and positive")
 
     @property
     def is_source_profile(self) -> bool:
@@ -248,7 +282,7 @@ class CanonicalUPGDConfig:
             raise ValueError("config fields do not match the CanonicalUPGD schema")
         type_name = payload.pop("type")
         if type_name != "CanonicalUPGD":
-            raise ValueError(f"expected CanonicalUPGD config, got {type_name!r}")
+            raise ValueError("expected CanonicalUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 
@@ -752,50 +786,32 @@ class AlbertaAdaUPGDConfig:
             raise ValueError(
                 "profile must be the explicit Alberta-derived AdaUPGD profile"
             )
-        for name in (
-            "step_size",
-            "utility_decay",
-            "second_moment_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be a real number, not boolean")
-            if not math.isfinite(float(value)):
-                raise ValueError(f"{name} must be finite")
-        if self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
-        if not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= self.second_moment_decay < 1.0:
-            raise ValueError("second_moment_decay must be in [0, 1)")
-        if self.noise_std < 0.0:
-            raise ValueError("noise_std must be non-negative")
-        if self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be non-negative")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        second_moment_decay = validated_float32_scalar(
+            "second_moment_decay", self.second_moment_decay, lower=0.0
+        )
+        if not 0.0 <= float(second_moment_decay) < 1.0:
+            raise ValueError("second_moment_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
+        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "second_moment_decay", second_moment_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "epsilon", epsilon)
         if self.mode not in {"protecting", "non_protecting"}:
-            raise ValueError("mode must be 'protecting' or 'non_protecting'")
+            raise ValueError("mode must be protecting or non_protecting")
         if self.normalization not in {"global", "local"}:
-            raise ValueError("normalization must be 'global' or 'local'")
-        if self.epsilon <= 0.0:
-            raise ValueError("epsilon must be positive")
-        # Config constants participate in float32 arithmetic.  Reject silent
-        # overflow while preserving ordinary Python numeric spellings.
-        for name in (
-            "step_size",
-            "utility_decay",
-            "second_moment_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            narrowed = jnp.asarray(getattr(self, name), dtype=jnp.float32)
-            if not bool(jnp.isfinite(narrowed)):
-                raise ValueError(f"{name} must be finite in float32")
-            if float(getattr(self, name)) != 0.0 and float(narrowed) == 0.0:
-                raise ValueError(f"{name} must not underflow in float32")
+            raise ValueError("normalization must be global or local")
 
     @property
     def official_reference_parity(self) -> bool:
@@ -851,7 +867,7 @@ class AlbertaAdaUPGDConfig:
             raise ValueError("config fields do not match the AlbertaAdaUPGD schema")
         type_name = payload.pop("type")
         if type_name != "AlbertaAdaUPGD":
-            raise ValueError(f"expected AlbertaAdaUPGD config, got {type_name!r}")
+            raise ValueError("expected AlbertaAdaUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 
@@ -1532,39 +1548,30 @@ class OfficialAdaUPGDConfig:
             raise ValueError("source_commit must match the pinned AdaptiveUPGD commit")
         if self.source_path != OFFICIAL_ADAUPGD_PATH:
             raise ValueError("source_path must match the pinned AdaptiveUPGD path")
-        for name in (
-            "step_size",
-            "weight_decay",
-            "utility_decay",
-            "noise_std",
-            "beta1",
-            "beta2",
-            "epsilon",
-        ):
-            value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be a real number, not boolean")
-            if not math.isfinite(float(value)):
-                raise ValueError(f"{name} must be finite")
-            narrowed = jnp.asarray(value, dtype=jnp.float32)
-            if not bool(jnp.isfinite(narrowed)):
-                raise ValueError(f"{name} must be finite in float32")
-            if float(value) != 0.0 and float(narrowed) == 0.0:
-                raise ValueError(f"{name} must not underflow in float32")
-        if self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
-        if self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be non-negative")
-        if not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if self.noise_std < 0.0:
-            raise ValueError("noise_std must be non-negative")
-        if not 0.0 <= self.beta1 < 1.0:
-            raise ValueError("beta1 must be in [0, 1)")
-        if not 0.0 <= self.beta2 < 1.0:
-            raise ValueError("beta2 must be in [0, 1)")
-        if self.epsilon <= 0.0:
-            raise ValueError("epsilon must be positive")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        beta1 = validated_float32_scalar("beta1", self.beta1, lower=0.0)
+        if not 0.0 <= float(beta1) < 1.0:
+            raise ValueError("beta1 must be in [0.0, 1.0)")
+        beta2 = validated_float32_scalar("beta2", self.beta2, lower=0.0)
+        if not 0.0 <= float(beta2) < 1.0:
+            raise ValueError("beta2 must be in [0.0, 1.0)")
+        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "beta1", beta1)
+        object.__setattr__(self, "beta2", beta2)
+        object.__setattr__(self, "epsilon", epsilon)
 
     @property
     def official_reference_parity(self) -> bool:
@@ -1619,7 +1626,7 @@ class OfficialAdaUPGDConfig:
             raise ValueError("config fields do not match the OfficialAdaUPGD schema")
         type_name = payload.pop("type")
         if type_name != "OfficialAdaUPGD":
-            raise ValueError(f"expected OfficialAdaUPGD config, got {type_name!r}")
+            raise ValueError("expected OfficialAdaUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -66,10 +66,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Int
 
-from alberta_framework.core._float32_scalars import (
-    validated_float32_scalar,
-    validated_float32_scalar_with_ratio,
-)
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 
 UPGDMode = Literal["protecting", "non_protecting"]
 UPGDNormalization = Literal["global", "local"]
@@ -117,6 +114,9 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.uint64,
     np.longlong,
     np.ulonglong,
+)
+_ACTUAL_REAL_TYPES = frozenset(
+    (*_ACTUAL_INT_TYPES, float, np.float16, np.float32, np.float64, np.longdouble)
 )
 
 
@@ -260,13 +260,28 @@ def _parameter_arrays(
     return arrays, structure, _ParameterResources(scalars=scalars, nbytes=nbytes)
 
 
-def _nonnegative_float32_scalar(name: str, value: object) -> float:
-    """Validate a nonnegative sink without silently erasing a nonzero value."""
+def _validated_float32_scalar(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+    lower: float | None = None,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> float:
+    """Validate an exact trusted scalar before any user-defined ratio hook."""
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
     stored, numerator, denominator = validated_float32_scalar_with_ratio(
-        name, value, lower=0.0
+        name,
+        value,
+        positive=positive,
+        lower=lower,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
     )
-    if numerator != 0 and abs(numerator) * (1 << 150) <= denominator:
-        raise ValueError(f"{name} must not underflow to zero once narrowed to float32")
+    if numerator != 0 and float(np.float32(numerator / denominator)) == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 
 
@@ -319,20 +334,21 @@ class CanonicalUPGDConfig:
     epsilon: float = 1e-8
 
     def __post_init__(self) -> None:
-        step_size = validated_float32_scalar(
+        step_size = _validated_float32_scalar(
             "step_size", self.step_size, lower=0.0, positive=True
         )
-        # Host domain for decay is [0,1) exact; narrowed 1.0 is tolerated for
-        # continuity with existing lifetime-counter tests (e.g. 0.999999999
-        # rounds to 1.0 in float32 but remains <1.0 as a host ratio).
-        utility_decay = _nonnegative_float32_scalar(
-            "utility_decay", self.utility_decay
+        utility_decay = _validated_float32_scalar(
+            "utility_decay",
+            self.utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
-        if not 0.0 <= float(utility_decay) < 1.0:
-            raise ValueError("utility_decay must be in [0.0, 1.0)")
-        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
-        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
-        epsilon = validated_float32_scalar(
+        noise_std = _validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        weight_decay = _validated_float32_scalar(
+            "weight_decay", self.weight_decay, lower=0.0
+        )
+        epsilon = _validated_float32_scalar(
             "epsilon", self.epsilon, lower=0.0, positive=True
         )
         object.__setattr__(self, "step_size", step_size)
@@ -992,22 +1008,26 @@ class AlbertaAdaUPGDConfig:
             raise ValueError(
                 "profile must be the explicit Alberta-derived AdaUPGD profile"
             )
-        step_size = validated_float32_scalar(
+        step_size = _validated_float32_scalar(
             "step_size", self.step_size, lower=0.0, positive=True
         )
-        utility_decay = _nonnegative_float32_scalar(
-            "utility_decay", self.utility_decay
+        utility_decay = _validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
         )
-        if not 0.0 <= float(utility_decay) < 1.0:
-            raise ValueError("utility_decay must be in [0.0, 1.0)")
-        second_moment_decay = _nonnegative_float32_scalar(
-            "second_moment_decay", self.second_moment_decay
+        second_moment_decay = _validated_float32_scalar(
+            "second_moment_decay",
+            self.second_moment_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
-        if not 0.0 <= float(second_moment_decay) < 1.0:
-            raise ValueError("second_moment_decay must be in [0.0, 1.0)")
-        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
-        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
-        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        noise_std = _validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        weight_decay = _validated_float32_scalar(
+            "weight_decay", self.weight_decay, lower=0.0
+        )
+        epsilon = _validated_float32_scalar(
+            "epsilon", self.epsilon, lower=0.0, positive=True
+        )
         object.__setattr__(self, "step_size", step_size)
         object.__setattr__(self, "utility_decay", utility_decay)
         object.__setattr__(self, "second_moment_decay", second_moment_decay)
@@ -1761,23 +1781,25 @@ class OfficialAdaUPGDConfig:
             raise ValueError("source_commit must match the pinned AdaptiveUPGD commit")
         if type(self.source_path) is not str or self.source_path != OFFICIAL_ADAUPGD_PATH:
             raise ValueError("source_path must match the pinned AdaptiveUPGD path")
-        step_size = validated_float32_scalar(
+        step_size = _validated_float32_scalar(
             "step_size", self.step_size, lower=0.0, positive=True
         )
-        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
-        utility_decay = _nonnegative_float32_scalar(
-            "utility_decay", self.utility_decay
+        weight_decay = _validated_float32_scalar(
+            "weight_decay", self.weight_decay, lower=0.0
         )
-        if not 0.0 <= float(utility_decay) < 1.0:
-            raise ValueError("utility_decay must be in [0.0, 1.0)")
-        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
-        beta1 = _nonnegative_float32_scalar("beta1", self.beta1)
-        if not 0.0 <= float(beta1) < 1.0:
-            raise ValueError("beta1 must be in [0.0, 1.0)")
-        beta2 = _nonnegative_float32_scalar("beta2", self.beta2)
-        if not 0.0 <= float(beta2) < 1.0:
-            raise ValueError("beta2 must be in [0.0, 1.0)")
-        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        utility_decay = _validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        noise_std = _validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        beta1 = _validated_float32_scalar(
+            "beta1", self.beta1, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        beta2 = _validated_float32_scalar(
+            "beta2", self.beta2, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        epsilon = _validated_float32_scalar(
+            "epsilon", self.epsilon, lower=0.0, positive=True
+        )
         object.__setattr__(self, "step_size", step_size)
         object.__setattr__(self, "weight_decay", weight_decay)
         object.__setattr__(self, "utility_decay", utility_decay)

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -235,6 +235,8 @@ def _parameter_arrays(
     owner: str,
     persistent_nbytes: Callable[[int, int], int],
     update_nbytes: Callable[[int, int], int],
+    working_scalars: Callable[[int], int],
+    working_nbytes: Callable[[int, int], int],
 ) -> tuple[list[Array], jax.tree_util.PyTreeDef, _ParameterResources]:
     leaves, structure = _flatten_with_none(params)
     if not leaves or any(value is None for value in leaves):
@@ -248,6 +250,8 @@ def _parameter_arrays(
         ("parameter_count", scalars),
         ("persistent_state_nbytes", persistent_nbytes(scalars, nbytes)),
         ("update_result_nbytes", update_nbytes(scalars, nbytes)),
+        ("working_set_scalars", working_scalars(scalars)),
+        ("working_set_nbytes", working_nbytes(scalars, nbytes)),
     ):
         if amount > _INT32_MAX:
             raise ValueError(f"derived {owner} {resource_name} must fit signed int32")
@@ -302,6 +306,16 @@ def _saturating_increment(value: Array, increment: Array | int = 1) -> Array:
         value + increment_array,
         maximum,
     )
+
+
+def _floating_leaves_are_finite(*trees: Any) -> Array:
+    valid = jnp.asarray(True, dtype=jnp.bool_)
+    for tree in trees:
+        for leaf in jax.tree.leaves(tree):
+            array = jnp.asarray(leaf)
+            if jnp.issubdtype(array.dtype, jnp.floating):
+                valid = valid & jnp.all(jnp.isfinite(array))
+    return valid
 
 
 @dataclass(frozen=True)
@@ -549,6 +563,8 @@ class CanonicalUPGD:
             persistent_nbytes=lambda scalars, nbytes: nbytes + 4 * scalars + 4,
             # params, state, three diagnostic trees, key, and six metrics.
             update_nbytes=lambda scalars, nbytes: 5 * nbytes + 4 * scalars + 33,
+            working_scalars=lambda scalars: 22 * scalars + 32,
+            working_nbytes=lambda scalars, nbytes: 23 * nbytes + 4 * scalars + 128,
         )
 
     @staticmethod
@@ -839,8 +855,9 @@ class CanonicalUPGD:
             new_param_leaves: list[Array] = []
             gate_leaves: list[Array] = []
             perturbation_leaves: list[Array] = []
-            gate_sum = jnp.array(0.0, dtype=jnp.float32)
-            utility_sum = jnp.array(0.0, dtype=jnp.float32)
+            mean_gate = jnp.array(0.0, dtype=jnp.float32)
+            mean_utility = jnp.array(0.0, dtype=jnp.float32)
+            count_floor = jnp.maximum(eligible_count, 1.0)
 
             for (
                 param,
@@ -888,22 +905,24 @@ class CanonicalUPGD:
                 candidate = decayed - direction_step * direction
                 updated = jnp.where(finite, candidate, param)
 
-                gate_sum = gate_sum + jnp.sum(gate.astype(jnp.float32))
-                utility_sum = utility_sum + jnp.sum(
+                mean_gate = mean_gate + jnp.sum(
+                    gate.astype(jnp.float32) / count_floor
+                )
+                mean_utility = mean_utility + jnp.sum(
                     jnp.where(active, jnp.abs(corrected), 0.0).astype(jnp.float32)
+                    / count_floor
                 )
 
                 new_param_leaves.append(updated)
                 gate_leaves.append(gate)
                 perturbation_leaves.append(perturbation)
 
-            count_floor = jnp.maximum(eligible_count, 1.0)
             proposed_state = CanonicalUPGDState(  # type: ignore[call-arg]
                 utility_ema=jax.tree_util.tree_unflatten(structure, new_utility_leaves),
                 utility_age=jax.tree_util.tree_unflatten(structure, new_age_leaves),
                 step=next_step,
             )
-            return CanonicalUPGDUpdate(  # type: ignore[call-arg]
+            proposed_result = CanonicalUPGDUpdate(  # type: ignore[call-arg]
                 params=jax.tree_util.tree_unflatten(structure, new_param_leaves),
                 state=proposed_state,
                 next_key=next_key,
@@ -916,12 +935,34 @@ class CanonicalUPGD:
                 ),
                 metrics={
                     "update_applied": jnp.asarray(True, dtype=jnp.bool_),
-                    "mean_scaled_utility": gate_sum / count_floor,
-                    "mean_absolute_utility": utility_sum / count_floor,
+                    "mean_scaled_utility": mean_gate,
+                    "mean_absolute_utility": mean_utility,
                     "global_maximum_utility": global_maximum,
                     "eligible_parameter_count": eligible_count,
                     "nonfinite_or_missing_count": nonfinite_count,
                 },
+            )
+            if self._config.profile != "safe_extended":
+                return proposed_result
+            finite_payload = _floating_leaves_are_finite(
+                proposed_result.params,
+                proposed_result.state,
+                proposed_result.scaled_utility,
+                proposed_result.corrected_utility,
+                proposed_result.perturbation,
+                mean_gate,
+                mean_utility,
+            )
+            if self._config.resolved_normalization == "global":
+                finite_payload = finite_payload & jnp.isfinite(global_maximum)
+            return cast(
+                CanonicalUPGDUpdate,
+                jax.lax.cond(
+                    finite_payload,
+                    lambda _: proposed_result,
+                    reject_update,
+                    operand=None,
+                ),
             )
 
         def reject_update(_: None) -> CanonicalUPGDUpdate:
@@ -1229,6 +1270,8 @@ class AlbertaAdaUPGD:
             persistent_nbytes=lambda scalars, nbytes: 2 * nbytes + 4 * scalars + 4,
             # params, state, four diagnostics, key/accepted, and ten metrics.
             update_nbytes=lambda scalars, nbytes: 7 * nbytes + 4 * scalars + 50,
+            working_scalars=lambda scalars: 33 * scalars + 32,
+            working_nbytes=lambda scalars, nbytes: 34 * nbytes + 4 * scalars + 128,
         )
         return arrays, structure
 
@@ -1631,12 +1674,50 @@ class AlbertaAdaUPGD:
             ),
             step=proposed_step,
         )
+        eligible_count = sum(
+            (
+                jnp.sum(eligible.astype(jnp.int32), dtype=jnp.int32)
+                for eligible in eligible_leaves
+            ),
+            start=jnp.asarray(0, dtype=jnp.int32),
+        )
+        count_floor = jnp.maximum(eligible_count.astype(jnp.float32), 1.0)
+        mean_gate = sum(
+            (
+                jnp.sum(gate.astype(jnp.float32) / count_floor)
+                for gate in gate_leaves
+            ),
+            start=jnp.asarray(0.0, dtype=jnp.float32),
+        )
+        mean_utility = sum(
+            (
+                jnp.sum(
+                    jnp.where(eligible, jnp.abs(corrected), 0.0).astype(jnp.float32)
+                    / count_floor
+                )
+                for corrected, eligible in zip(
+                    corrected_leaves, eligible_leaves, strict=True
+                )
+            ),
+            start=jnp.asarray(0.0, dtype=jnp.float32),
+        )
         candidate_is_valid = self.state_valid(proposed_state, proposed_params)
+        diagnostics_are_valid = _floating_leaves_are_finite(
+            corrected_leaves,
+            denominator_leaves,
+            gate_leaves,
+            perturbation_leaves,
+            mean_gate,
+            mean_utility,
+        )
+        if self._config.normalization == "global":
+            diagnostics_are_valid = diagnostics_are_valid & jnp.isfinite(global_maximum)
         accepted = (
             state_is_valid
             & capacity_available
             & input_is_valid
             & candidate_is_valid
+            & diagnostics_are_valid
         )
         committed_params = _adaupgd_select_tree(accepted, proposed_params, params)
         committed_state = _adaupgd_select_tree(accepted, proposed_state, state)
@@ -1667,30 +1748,7 @@ class AlbertaAdaUPGD:
             jax.tree_util.tree_unflatten(structure, perturbation_leaves),
             zero_tree,
         )
-        eligible_count = sum(
-            (
-                jnp.sum(eligible.astype(jnp.int32), dtype=jnp.int32)
-                for eligible in eligible_leaves
-            ),
-            start=jnp.asarray(0, dtype=jnp.int32),
-        )
         parameter_count = sum(param.size for param in param_leaves)
-        gate_sum = sum(
-            (jnp.sum(gate.astype(jnp.float32)) for gate in gate_leaves),
-            start=jnp.asarray(0.0, dtype=jnp.float32),
-        )
-        utility_sum = sum(
-            (
-                jnp.sum(jnp.where(eligible, jnp.abs(corrected), 0.0)).astype(
-                    jnp.float32
-                )
-                for corrected, eligible in zip(
-                    corrected_leaves, eligible_leaves, strict=True
-                )
-            ),
-            start=jnp.asarray(0.0, dtype=jnp.float32),
-        )
-        count_floor = jnp.maximum(eligible_count.astype(jnp.float32), 1.0)
         reported_global_maximum = jnp.where(
             accepted & (self._config.normalization == "global"),
             global_maximum,
@@ -1707,12 +1765,8 @@ class AlbertaAdaUPGD:
             perturbation=perturbation,
             metrics={
                 "accepted": accepted,
-                "mean_scaled_utility": jnp.where(
-                    accepted, gate_sum / count_floor, 0.0
-                ),
-                "mean_absolute_utility": jnp.where(
-                    accepted, utility_sum / count_floor, 0.0
-                ),
+                "mean_scaled_utility": jnp.where(accepted, mean_gate, 0.0),
+                "mean_absolute_utility": jnp.where(accepted, mean_utility, 0.0),
                 "global_maximum_utility": reported_global_maximum,
                 "eligible_parameter_count": eligible_count,
                 "parameter_count": jnp.asarray(parameter_count, dtype=jnp.int32),
@@ -1961,6 +2015,8 @@ class OfficialAdaUPGD:
             persistent_nbytes=lambda _scalars, nbytes: 3 * nbytes + 4,
             # params, state, five diagnostics, key, and three metrics.
             update_nbytes=lambda _scalars, nbytes: 9 * nbytes + 24,
+            working_scalars=lambda scalars: 33 * scalars + 32,
+            working_nbytes=lambda scalars, nbytes: 34 * nbytes + 4 * scalars + 128,
         )
         return arrays, structure
 
@@ -2119,7 +2175,7 @@ class OfficialAdaUPGD:
         split_keys = jr.split(checked_key, len(param_leaves) + 1)
         next_key = split_keys[0]
         noise_keys = split_keys[1:]
-        next_step = state.step + jnp.asarray(1, dtype=jnp.int32)
+        next_step = _saturating_increment(state.step)
         proposed_utility_leaves: list[Array] = []
         proposed_first_leaves: list[Array] = []
         proposed_second_leaves: list[Array] = []

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -52,8 +52,11 @@ Reference:
 
 from __future__ import annotations
 
+import math
+import operator
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
@@ -63,7 +66,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Int
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 
 UPGDMode = Literal["protecting", "non_protecting"]
 UPGDNormalization = Literal["global", "local"]
@@ -99,7 +105,6 @@ _RAW_GLOBAL_PROFILES = frozenset(
     }
 )
 _INT32_MAX = 2_147_483_647
-_UINT32_MAX = 4_294_967_295
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -115,14 +120,154 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
 )
 
 
-def _require_float32_resource(
-    name: str, *, vector_scalars: int, fixed_scalars: int = 0
-) -> None:
-    total_scalars = vector_scalars + fixed_scalars
-    if total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} byte count must fit signed int32")
+@dataclass(frozen=True)
+class _ParameterResources:
+    scalars: int
+    nbytes: int
+
+
+def _copy_config_mapping(name: str, config: object) -> dict[str, Any]:
+    """Copy a legacy-compatible mapping while normalizing hostile hooks."""
+    if not isinstance(config, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        payload = dict(config)
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+    if any(type(key) is not str for key in payload):
+        raise ValueError(f"{name} fields must be strings")
+    return cast(dict[str, Any], payload)
+
+
+def _array_metadata(name: str, value: object) -> tuple[tuple[int, ...], np.dtype[Any]]:
+    """Read bounded host shape/dtype metadata without invoking JAX conversion."""
+    if type(value) is float:
+        raw_shape: object = ()
+        raw_dtype: object = np.dtype(float)
+    else:
+        try:
+            raw_shape = getattr(value, "shape")
+            raw_dtype = getattr(value, "dtype")
+        except Exception as error:
+            raise ValueError(f"{name} must expose array shape and dtype metadata") from error
+    if type(raw_shape) is not tuple:
+        raise ValueError(f"{name} shape must be a tuple")
+    shape: list[int] = []
+    for dimension in raw_shape:
+        if type(dimension) not in _ACTUAL_INT_TYPES:
+            raise ValueError(f"{name} dimensions must be actual integers")
+        size = operator.index(cast(SupportsIndex, dimension))
+        if not 0 <= size <= _INT32_MAX:
+            raise ValueError(f"{name} dimensions must fit signed int32")
+        shape.append(size)
+    try:
+        dtype = np.dtype(
+            jax.dtypes.canonicalize_dtype(np.dtype(cast(Any, raw_dtype)))
+        )
+    except Exception as error:
+        raise ValueError(f"{name} must expose a supported array dtype") from error
+    return tuple(shape), dtype
+
+
+def _floating_parameter_metadata(
+    name: str, value: object
+) -> tuple[tuple[int, ...], np.dtype[Any]]:
+    shape, dtype = _array_metadata(name, value)
+    if not jnp.issubdtype(dtype, jnp.floating):
+        raise ValueError(f"{name} must have floating-point dtype")
+    return shape, dtype
+
+
+def _matching_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: np.dtype[Any],
+) -> Array:
+    actual_shape, actual_dtype = _array_metadata(name, value)
+    if actual_shape != shape:
+        raise ValueError(f"{name} must match its parameter shape")
+    if actual_dtype != dtype:
+        raise TypeError(f"{name} dtype must match its parameter dtype")
+    try:
+        return jnp.asarray(value)
+    except Exception as error:
+        raise ValueError(f"{name} could not be converted to a JAX array") from error
+
+
+def _coerced_numeric_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    actual_shape, actual_dtype = _array_metadata(name, value)
+    if actual_shape != shape:
+        raise ValueError(f"{name} must match its parameter shape")
+    if actual_dtype.kind not in {"i", "u", "f"}:
+        raise TypeError(f"{name} must have real numeric dtype")
+    try:
+        return jnp.asarray(value, dtype=dtype)
+    except Exception as error:
+        raise ValueError(f"{name} could not be converted to a JAX array") from error
+
+
+def _broadcast_bool_array(name: str, value: object, shape: tuple[int, ...]) -> Array:
+    actual_shape, actual_dtype = _array_metadata(name, value)
+    if actual_dtype != np.dtype(np.bool_):
+        raise TypeError(f"{name} must have boolean dtype")
+    try:
+        if np.broadcast_shapes(actual_shape, shape) != shape:
+            raise ValueError
+    except ValueError as error:
+        raise ValueError(f"{name} must broadcast to its parameter shape") from error
+    try:
+        return jnp.broadcast_to(jnp.asarray(value), shape)
+    except Exception as error:
+        raise ValueError(f"{name} could not be converted to a JAX array") from error
+
+
+def _parameter_arrays(
+    params: Any,
+    *,
+    owner: str,
+    persistent_nbytes: Callable[[int, int], int],
+    update_nbytes: Callable[[int, int], int],
+) -> tuple[list[Array], jax.tree_util.PyTreeDef, _ParameterResources]:
+    leaves, structure = _flatten_with_none(params)
+    if not leaves or any(value is None for value in leaves):
+        raise ValueError("params must contain at least one array leaf")
+    metadata = [
+        _floating_parameter_metadata(f"{owner} parameter", value) for value in leaves
+    ]
+    scalars = sum(math.prod(shape) for shape, _ in metadata)
+    nbytes = sum(math.prod(shape) * dtype.itemsize for shape, dtype in metadata)
+    for resource_name, amount in (
+        ("parameter_count", scalars),
+        ("persistent_state_nbytes", persistent_nbytes(scalars, nbytes)),
+        ("update_result_nbytes", update_nbytes(scalars, nbytes)),
+    ):
+        if amount > _INT32_MAX:
+            raise ValueError(f"derived {owner} {resource_name} must fit signed int32")
+    arrays: list[Array] = []
+    for value in leaves:
+        try:
+            arrays.append(jnp.asarray(value))
+        except Exception as error:
+            raise ValueError(f"{owner} parameter could not be converted to a JAX array") from error
+    return arrays, structure, _ParameterResources(scalars=scalars, nbytes=nbytes)
+
+
+def _nonnegative_float32_scalar(name: str, value: object) -> float:
+    """Validate a nonnegative sink without silently erasing a nonzero value."""
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name, value, lower=0.0
+    )
+    if numerator != 0 and abs(numerator) * (1 << 150) <= denominator:
+        raise ValueError(f"{name} must not underflow to zero once narrowed to float32")
+    return stored
 
 
 def _static_zero_scale(scale: float, value: Array) -> Array:
@@ -180,17 +325,13 @@ class CanonicalUPGDConfig:
         # Host domain for decay is [0,1) exact; narrowed 1.0 is tolerated for
         # continuity with existing lifetime-counter tests (e.g. 0.999999999
         # rounds to 1.0 in float32 but remains <1.0 as a host ratio).
-        utility_decay = validated_float32_scalar(
-            "utility_decay", self.utility_decay, lower=0.0
+        utility_decay = _nonnegative_float32_scalar(
+            "utility_decay", self.utility_decay
         )
         if not 0.0 <= float(utility_decay) < 1.0:
             raise ValueError("utility_decay must be in [0.0, 1.0)")
-        noise_std = validated_float32_scalar(
-            "noise_std", self.noise_std, lower=0.0
-        )
-        weight_decay = validated_float32_scalar(
-            "weight_decay", self.weight_decay, lower=0.0
-        )
+        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
+        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
         epsilon = validated_float32_scalar(
             "epsilon", self.epsilon, lower=0.0, positive=True
         )
@@ -199,18 +340,26 @@ class CanonicalUPGDConfig:
         object.__setattr__(self, "noise_std", noise_std)
         object.__setattr__(self, "weight_decay", weight_decay)
         object.__setattr__(self, "epsilon", epsilon)
-        if self.mode not in {"protecting", "non_protecting"}:
+        if type(self.mode) is not str or self.mode not in {"protecting", "non_protecting"}:
             raise ValueError("mode must be protecting or non_protecting")
-        if self.profile not in _SOURCE_PROFILES | {"safe_extended"}:
+        if type(self.profile) is not str or self.profile not in _SOURCE_PROFILES | {
+            "safe_extended"
+        }:
             raise ValueError(
                 "profile must name a paper, official implementation, or safe_extended profile"
             )
         if self.profile == "safe_extended":
-            if self.normalization not in {"global", "local"}:
+            if type(self.normalization) is not str or self.normalization not in {
+                "global",
+                "local",
+            }:
                 raise ValueError("safe_extended requires normalization=global or local")
         else:
             fixed_normalization = "global" if self.profile in _GLOBAL_PROFILES else "local"
-            if self.normalization not in {None, fixed_normalization}:
+            if self.normalization is not None and (
+                type(self.normalization) is not str
+                or self.normalization != fixed_normalization
+            ):
                 raise ValueError(
                     f"{self.profile} fixes normalization to {fixed_normalization}"
                 )
@@ -263,10 +412,10 @@ class CanonicalUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> CanonicalUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> CanonicalUPGDConfig:
         """Strictly reconstruct from the complete serialized schema."""
 
-        payload = dict(config)
+        payload = _copy_config_mapping("CanonicalUPGD config", config)
         expected = {
             "type",
             "step_size",
@@ -281,9 +430,12 @@ class CanonicalUPGDConfig:
         if set(payload) != expected:
             raise ValueError("config fields do not match the CanonicalUPGD schema")
         type_name = payload.pop("type")
-        if type_name != "CanonicalUPGD":
+        if type(type_name) is not str or type_name != "CanonicalUPGD":
             raise ValueError("expected CanonicalUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)
+        except Exception as error:
+            raise ValueError("CanonicalUPGD config values are invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -366,27 +518,76 @@ class CanonicalUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> CanonicalUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> CanonicalUPGD:
         """Reconstruct an optimizer from serialized configuration."""
 
         return cls(CanonicalUPGDConfig.from_config(config))
 
+    @staticmethod
+    def _parameter_contract(
+        params: Any,
+    ) -> tuple[list[Array], jax.tree_util.PyTreeDef, _ParameterResources]:
+        return _parameter_arrays(
+            params,
+            owner="CanonicalUPGD",
+            persistent_nbytes=lambda scalars, nbytes: nbytes + 4 * scalars + 4,
+            # params, state, three diagnostic trees, key, and six metrics.
+            update_nbytes=lambda scalars, nbytes: 5 * nbytes + 4 * scalars + 33,
+        )
+
+    @staticmethod
+    def _state_contract(
+        state: CanonicalUPGDState,
+        params: Any,
+    ) -> tuple[list[Array], list[Array], list[Array], jax.tree_util.PyTreeDef]:
+        if not isinstance(state, CanonicalUPGDState):
+            raise TypeError("state must be a CanonicalUPGDState")
+        param_leaves, structure, _ = CanonicalUPGD._parameter_contract(params)
+        utility_leaves, utility_structure = _flatten_with_none(state.utility_ema)
+        age_leaves, age_structure = _flatten_with_none(state.utility_age)
+        if not structure == utility_structure == age_structure:
+            raise ValueError("params and CanonicalUPGD state must share a PyTree structure")
+        utilities: list[Array] = []
+        ages: list[Array] = []
+        for param, utility, age in zip(
+            param_leaves, utility_leaves, age_leaves, strict=True
+        ):
+            param_dtype = np.dtype(param.dtype)
+            utilities.append(
+                _matching_array(
+                    "utility state leaf",
+                    utility,
+                    shape=param.shape,
+                    dtype=param_dtype,
+                )
+            )
+            ages.append(
+                _matching_array(
+                    "utility-age state leaf",
+                    age,
+                    shape=param.shape,
+                    dtype=np.dtype(np.int32),
+                )
+            )
+        _matching_array(
+            "state.step",
+            state.step,
+            shape=(),
+            dtype=np.dtype(np.int32),
+        )
+        return param_leaves, utilities, ages, structure
+
     def init(self, params: Any) -> CanonicalUPGDState:
         """Initialize signed-utility traces matching ``params``."""
 
-        leaves = jax.tree_util.tree_leaves(params)
-        if not leaves:
-            raise ValueError("params must contain at least one array leaf")
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("UPGD parameters must have floating-point dtype")
+        leaves, structure, _ = self._parameter_contract(params)
+        array_params = jax.tree_util.tree_unflatten(structure, leaves)
 
         return CanonicalUPGDState(  # type: ignore[call-arg]
-            utility_ema=jax.tree.map(jnp.zeros_like, params),
+            utility_ema=jax.tree.map(jnp.zeros_like, array_params),
             utility_age=jax.tree.map(
                 lambda value: jnp.zeros(value.shape, dtype=jnp.int32),
-                params,
+                array_params,
             ),
             step=jnp.array(0, dtype=jnp.int32),
         )
@@ -425,11 +626,13 @@ class CanonicalUPGD:
         differentiation, preserving the same identity boundary there.
         """
 
-        param_leaves, structure = _flatten_with_none(params)
+        param_leaves, utility_leaves, age_leaves, structure = self._state_contract(
+            state, params
+        )
+        params = jax.tree_util.tree_unflatten(structure, param_leaves)
+        key = _adaupgd_typed_threefry_key(key, name="key")
         grad_leaves, grad_structure = _flatten_with_none(gradients)
-        utility_leaves, utility_structure = _flatten_with_none(state.utility_ema)
-        age_leaves, age_structure = _flatten_with_none(state.utility_age)
-        if not (structure == grad_structure == utility_structure == age_structure):
+        if structure != grad_structure:
             raise ValueError("params, gradients, and UPGD state must share a PyTree structure")
 
         if self._config.is_source_profile and mask is not None:
@@ -471,14 +674,14 @@ class CanonicalUPGD:
             mask_leaves,
             strict=True,
         ):
-            eligible = jnp.broadcast_to(jnp.asarray(mask_leaf, dtype=jnp.bool_), param.shape)
+            eligible = _broadcast_bool_array("mask leaf", mask_leaf, param.shape)
             if gradient is None:
                 finite = jnp.zeros(param.shape, dtype=jnp.bool_)
                 clean_gradient = jnp.zeros_like(param)
             else:
-                gradient_array = jnp.asarray(gradient, dtype=param.dtype)
-                if gradient_array.shape != param.shape:
-                    raise ValueError("every gradient leaf must match its parameter shape")
+                gradient_array = _coerced_numeric_array(
+                    "gradient leaf", gradient, shape=param.shape, dtype=param.dtype
+                )
                 finite = jnp.isfinite(param) & jnp.isfinite(gradient_array)
                 clean_gradient = jnp.where(finite, gradient_array, 0.0)
 
@@ -650,9 +853,12 @@ class CanonicalUPGD:
                         * self._config.noise_std
                     )
                 else:
-                    sampled_noise = jnp.asarray(supplied_noise, dtype=param.dtype)
-                    if sampled_noise.shape != param.shape:
-                        raise ValueError("every noise leaf must match its parameter shape")
+                    sampled_noise = _coerced_numeric_array(
+                        "noise leaf",
+                        supplied_noise,
+                        shape=param.shape,
+                        dtype=param.dtype,
+                    )
                 finite_noise = jnp.where(jnp.isfinite(sampled_noise), sampled_noise, 0.0)
                 perturbation = jnp.where(active, finite_noise, 0.0)
 
@@ -782,25 +988,25 @@ class AlbertaAdaUPGDConfig:
     epsilon: float = 1e-8
 
     def __post_init__(self) -> None:
-        if self.profile != ALBERTA_ADAUPGD_PROFILE:
+        if type(self.profile) is not str or self.profile != ALBERTA_ADAUPGD_PROFILE:
             raise ValueError(
                 "profile must be the explicit Alberta-derived AdaUPGD profile"
             )
         step_size = validated_float32_scalar(
             "step_size", self.step_size, lower=0.0, positive=True
         )
-        utility_decay = validated_float32_scalar(
-            "utility_decay", self.utility_decay, lower=0.0
+        utility_decay = _nonnegative_float32_scalar(
+            "utility_decay", self.utility_decay
         )
         if not 0.0 <= float(utility_decay) < 1.0:
             raise ValueError("utility_decay must be in [0.0, 1.0)")
-        second_moment_decay = validated_float32_scalar(
-            "second_moment_decay", self.second_moment_decay, lower=0.0
+        second_moment_decay = _nonnegative_float32_scalar(
+            "second_moment_decay", self.second_moment_decay
         )
         if not 0.0 <= float(second_moment_decay) < 1.0:
             raise ValueError("second_moment_decay must be in [0.0, 1.0)")
-        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
-        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
+        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
+        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
         epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
         object.__setattr__(self, "step_size", step_size)
         object.__setattr__(self, "utility_decay", utility_decay)
@@ -808,9 +1014,12 @@ class AlbertaAdaUPGDConfig:
         object.__setattr__(self, "noise_std", noise_std)
         object.__setattr__(self, "weight_decay", weight_decay)
         object.__setattr__(self, "epsilon", epsilon)
-        if self.mode not in {"protecting", "non_protecting"}:
+        if type(self.mode) is not str or self.mode not in {"protecting", "non_protecting"}:
             raise ValueError("mode must be protecting or non_protecting")
-        if self.normalization not in {"global", "local"}:
+        if type(self.normalization) is not str or self.normalization not in {
+            "global",
+            "local",
+        }:
             raise ValueError("normalization must be global or local")
 
     @property
@@ -845,12 +1054,10 @@ class AlbertaAdaUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> AlbertaAdaUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> AlbertaAdaUPGDConfig:
         """Strictly reconstruct the adaptive extension configuration."""
 
-        if type(config) is not dict:
-            raise TypeError("AlbertaAdaUPGD config must be an exact dict")
-        payload = dict(config)
+        payload = _copy_config_mapping("AlbertaAdaUPGD config", config)
         expected = {
             "type",
             "profile",
@@ -866,9 +1073,12 @@ class AlbertaAdaUPGDConfig:
         if set(payload) != expected:
             raise ValueError("config fields do not match the AlbertaAdaUPGD schema")
         type_name = payload.pop("type")
-        if type_name != "AlbertaAdaUPGD":
+        if type(type_name) is not str or type_name != "AlbertaAdaUPGD":
             raise ValueError("expected AlbertaAdaUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)
+        except Exception as error:
+            raise ValueError("AlbertaAdaUPGD config values are invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -986,22 +1196,20 @@ class AlbertaAdaUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> AlbertaAdaUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> AlbertaAdaUPGD:
         """Reconstruct the optimizer from its strict configuration."""
 
         return cls(AlbertaAdaUPGDConfig.from_config(config))
 
     @staticmethod
     def _parameter_contract(params: Any) -> tuple[list[Array], jax.tree_util.PyTreeDef]:
-        leaves, structure = _flatten_with_none(params)
-        if not leaves or any(value is None for value in leaves):
-            raise ValueError("params must contain at least one array leaf")
-        arrays: list[Array] = []
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("AlbertaAdaUPGD parameters must have floating-point dtype")
-            arrays.append(array)
+        arrays, structure, _ = _parameter_arrays(
+            params,
+            owner="AlbertaAdaUPGD",
+            persistent_nbytes=lambda scalars, nbytes: 2 * nbytes + 4 * scalars + 4,
+            # params, state, four diagnostics, key/accepted, and ten metrics.
+            update_nbytes=lambda scalars, nbytes: 7 * nbytes + 4 * scalars + 50,
+        )
         return arrays, structure
 
     @staticmethod
@@ -1037,36 +1245,37 @@ class AlbertaAdaUPGD:
             moment_leaves,
             strict=True,
         ):
-            utility_array = jnp.asarray(utility)
-            age_array = jnp.asarray(age)
-            moment_array = jnp.asarray(moment)
-            if utility_array.shape != param.shape or moment_array.shape != param.shape:
-                raise ValueError("every adaptive state leaf must match its parameter shape")
-            if age_array.shape != param.shape:
-                raise ValueError("every utility-age leaf must match its parameter shape")
-            if utility_array.dtype != param.dtype or moment_array.dtype != param.dtype:
-                raise TypeError("utility and second-moment dtypes must match parameters")
-            if age_array.dtype != jnp.int32:
-                raise TypeError("utility-age leaves must have int32 dtype")
+            param_dtype = np.dtype(param.dtype)
+            utility_array = _matching_array(
+                "utility state leaf", utility, shape=param.shape, dtype=param_dtype
+            )
+            age_array = _matching_array(
+                "utility-age state leaf",
+                age,
+                shape=param.shape,
+                dtype=np.dtype(np.int32),
+            )
+            moment_array = _matching_array(
+                "second-moment state leaf", moment, shape=param.shape, dtype=param_dtype
+            )
             utilities.append(utility_array)
             ages.append(age_array)
             moments.append(moment_array)
-        step = jnp.asarray(state.step)
-        if step.shape != () or step.dtype != jnp.int32:
-            raise TypeError("state.step must be one scalar int32 array")
+        _matching_array("state.step", state.step, shape=(), dtype=np.dtype(np.int32))
         return param_leaves, utilities, ages, moments, structure
 
     def init(self, params: Any) -> AlbertaAdaUPGDState:
         """Initialize utility and adaptive second-moment traces."""
 
-        self._parameter_contract(params)
+        leaves, structure = self._parameter_contract(params)
+        array_params = jax.tree_util.tree_unflatten(structure, leaves)
         return AlbertaAdaUPGDState(  # type: ignore[call-arg]
-            utility_ema=jax.tree.map(jnp.zeros_like, params),
+            utility_ema=jax.tree.map(jnp.zeros_like, array_params),
             utility_age=jax.tree.map(
-                lambda value: jnp.zeros(jnp.asarray(value).shape, dtype=jnp.int32),
-                params,
+                lambda value: jnp.zeros(value.shape, dtype=jnp.int32),
+                array_params,
             ),
-            gradient_second_moment=jax.tree.map(jnp.zeros_like, params),
+            gradient_second_moment=jax.tree.map(jnp.zeros_like, array_params),
             step=jnp.asarray(0, dtype=jnp.int32),
         )
 
@@ -1133,7 +1342,6 @@ class AlbertaAdaUPGD:
         splitting/commit contract as sampled noise.
         """
 
-        checked_key = _adaupgd_typed_threefry_key(key, name="key")
         (
             param_leaves,
             utility_leaves,
@@ -1141,6 +1349,8 @@ class AlbertaAdaUPGD:
             moment_leaves,
             structure,
         ) = self._state_contract(state, params)
+        params = jax.tree_util.tree_unflatten(structure, param_leaves)
+        checked_key = _adaupgd_typed_threefry_key(key, name="key")
         grad_leaves, grad_structure = _flatten_with_none(gradients)
         if grad_structure != structure:
             raise ValueError("params, gradients, and state must share a PyTree structure")
@@ -1153,14 +1363,9 @@ class AlbertaAdaUPGD:
                 raise ValueError("mask must share the parameter PyTree structure")
         eligible_leaves: list[Array] = []
         for param, mask_leaf in zip(param_leaves, mask_leaves, strict=True):
-            mask_array = jnp.asarray(mask_leaf)
-            if mask_array.dtype != jnp.bool_:
-                raise TypeError("every mask leaf must have boolean dtype")
-            try:
-                eligible = jnp.broadcast_to(mask_array, param.shape)
-            except ValueError as exc:
-                raise ValueError("every mask leaf must broadcast to its parameter shape") from exc
-            eligible_leaves.append(eligible)
+            eligible_leaves.append(
+                _broadcast_bool_array("mask leaf", mask_leaf, param.shape)
+            )
 
         if noise is None:
             supplied_noise_leaves: list[Any] = [None] * len(param_leaves)
@@ -1235,15 +1440,17 @@ class AlbertaAdaUPGD:
             if gradient is None:
                 clean_gradient = jnp.zeros_like(param)
                 gradient_finite = jnp.zeros(param.shape, dtype=jnp.bool_)
-                missing_gradient_leaf_count = missing_gradient_leaf_count + 1
+                missing_gradient_leaf_count = missing_gradient_leaf_count + jnp.asarray(
+                    1, dtype=jnp.int32
+                )
             else:
-                gradient_array = jnp.asarray(gradient, dtype=param.dtype)
-                if gradient_array.shape != param.shape:
-                    raise ValueError("every gradient leaf must match its parameter shape")
+                gradient_array = _coerced_numeric_array(
+                    "gradient leaf", gradient, shape=param.shape, dtype=param.dtype
+                )
                 gradient_finite = jnp.isfinite(gradient_array)
                 clean_gradient = jnp.where(gradient_finite, gradient_array, 0.0)
             nonfinite_gradient_count = nonfinite_gradient_count + jnp.sum(
-                (~gradient_finite).astype(jnp.int32)
+                (~gradient_finite).astype(jnp.int32), dtype=jnp.int32
             )
             input_is_valid = input_is_valid & jnp.all(gradient_finite)
             clean_gradients.append(clean_gradient)
@@ -1254,12 +1461,15 @@ class AlbertaAdaUPGD:
                     * self._config.noise_std
                 )
             else:
-                sampled_noise = jnp.asarray(supplied_noise, dtype=param.dtype)
-                if sampled_noise.shape != param.shape:
-                    raise ValueError("every noise leaf must match its parameter shape")
+                sampled_noise = _coerced_numeric_array(
+                    "noise leaf",
+                    supplied_noise,
+                    shape=param.shape,
+                    dtype=param.dtype,
+                )
             noise_finite = jnp.isfinite(sampled_noise)
             nonfinite_noise_count = nonfinite_noise_count + jnp.sum(
-                (~noise_finite).astype(jnp.int32)
+                (~noise_finite).astype(jnp.int32), dtype=jnp.int32
             )
             input_is_valid = input_is_valid & jnp.all(noise_finite)
             sampled_noise_leaves.append(jnp.where(noise_finite, sampled_noise, 0.0))
@@ -1438,7 +1648,10 @@ class AlbertaAdaUPGD:
             zero_tree,
         )
         eligible_count = sum(
-            (jnp.sum(eligible.astype(jnp.int32)) for eligible in eligible_leaves),
+            (
+                jnp.sum(eligible.astype(jnp.int32), dtype=jnp.int32)
+                for eligible in eligible_leaves
+            ),
             start=jnp.asarray(0, dtype=jnp.int32),
         )
         parameter_count = sum(param.size for param in param_leaves)
@@ -1542,26 +1755,26 @@ class OfficialAdaUPGDConfig:
     epsilon: float = 1e-5
 
     def __post_init__(self) -> None:
-        if self.profile != OFFICIAL_ADAUPGD_PROFILE:
+        if type(self.profile) is not str or self.profile != OFFICIAL_ADAUPGD_PROFILE:
             raise ValueError("profile must name the pinned official RL AdaptiveUPGD")
-        if self.source_commit != OFFICIAL_ADAUPGD_COMMIT:
+        if type(self.source_commit) is not str or self.source_commit != OFFICIAL_ADAUPGD_COMMIT:
             raise ValueError("source_commit must match the pinned AdaptiveUPGD commit")
-        if self.source_path != OFFICIAL_ADAUPGD_PATH:
+        if type(self.source_path) is not str or self.source_path != OFFICIAL_ADAUPGD_PATH:
             raise ValueError("source_path must match the pinned AdaptiveUPGD path")
         step_size = validated_float32_scalar(
             "step_size", self.step_size, lower=0.0, positive=True
         )
-        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
-        utility_decay = validated_float32_scalar(
-            "utility_decay", self.utility_decay, lower=0.0
+        weight_decay = _nonnegative_float32_scalar("weight_decay", self.weight_decay)
+        utility_decay = _nonnegative_float32_scalar(
+            "utility_decay", self.utility_decay
         )
         if not 0.0 <= float(utility_decay) < 1.0:
             raise ValueError("utility_decay must be in [0.0, 1.0)")
-        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
-        beta1 = validated_float32_scalar("beta1", self.beta1, lower=0.0)
+        noise_std = _nonnegative_float32_scalar("noise_std", self.noise_std)
+        beta1 = _nonnegative_float32_scalar("beta1", self.beta1)
         if not 0.0 <= float(beta1) < 1.0:
             raise ValueError("beta1 must be in [0.0, 1.0)")
-        beta2 = validated_float32_scalar("beta2", self.beta2, lower=0.0)
+        beta2 = _nonnegative_float32_scalar("beta2", self.beta2)
         if not 0.0 <= float(beta2) < 1.0:
             raise ValueError("beta2 must be in [0.0, 1.0)")
         epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
@@ -1603,12 +1816,10 @@ class OfficialAdaUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> OfficialAdaUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> OfficialAdaUPGDConfig:
         """Strictly reconstruct the pinned official profile."""
 
-        if type(config) is not dict:
-            raise TypeError("OfficialAdaUPGD config must be an exact dict")
-        payload = dict(config)
+        payload = _copy_config_mapping("OfficialAdaUPGD config", config)
         expected = {
             "type",
             "profile",
@@ -1625,9 +1836,12 @@ class OfficialAdaUPGDConfig:
         if set(payload) != expected:
             raise ValueError("config fields do not match the OfficialAdaUPGD schema")
         type_name = payload.pop("type")
-        if type_name != "OfficialAdaUPGD":
+        if type(type_name) is not str or type_name != "OfficialAdaUPGD":
             raise ValueError("expected OfficialAdaUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)
+        except Exception as error:
+            raise ValueError("OfficialAdaUPGD config values are invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -1712,22 +1926,20 @@ class OfficialAdaUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> OfficialAdaUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> OfficialAdaUPGD:
         """Reconstruct the transform from a strict source-bound config."""
 
         return cls(OfficialAdaUPGDConfig.from_config(config))
 
     @staticmethod
     def _parameter_contract(params: Any) -> tuple[list[Array], jax.tree_util.PyTreeDef]:
-        leaves, structure = _flatten_with_none(params)
-        if not leaves or any(value is None for value in leaves):
-            raise ValueError("params must contain at least one array leaf")
-        arrays: list[Array] = []
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("OfficialAdaUPGD parameters must have floating-point dtype")
-            arrays.append(array)
+        arrays, structure, _ = _parameter_arrays(
+            params,
+            owner="OfficialAdaUPGD",
+            persistent_nbytes=lambda _scalars, nbytes: 3 * nbytes + 4,
+            # params, state, five diagnostics, key, and three metrics.
+            update_nbytes=lambda _scalars, nbytes: 9 * nbytes + 24,
+        )
         return arrays, structure
 
     @staticmethod
@@ -1761,37 +1973,31 @@ class OfficialAdaUPGD:
             second_leaves,
             strict=True,
         ):
-            utility_array = jnp.asarray(utility)
-            first_array = jnp.asarray(first)
-            second_array = jnp.asarray(second)
-            if (
-                utility_array.shape != param.shape
-                or first_array.shape != param.shape
-                or second_array.shape != param.shape
-            ):
-                raise ValueError("every official AdaUPGD state leaf must match its parameter shape")
-            if (
-                utility_array.dtype != param.dtype
-                or first_array.dtype != param.dtype
-                or second_array.dtype != param.dtype
-            ):
-                raise TypeError("official AdaUPGD state dtypes must match parameters")
+            param_dtype = np.dtype(param.dtype)
+            utility_array = _matching_array(
+                "utility state leaf", utility, shape=param.shape, dtype=param_dtype
+            )
+            first_array = _matching_array(
+                "first-moment state leaf", first, shape=param.shape, dtype=param_dtype
+            )
+            second_array = _matching_array(
+                "second-moment state leaf", second, shape=param.shape, dtype=param_dtype
+            )
             utilities.append(utility_array)
             first_moments.append(first_array)
             second_moments.append(second_array)
-        step = jnp.asarray(state.step)
-        if step.shape != () or step.dtype != jnp.int32:
-            raise TypeError("state.step must be one scalar int32 array")
+        _matching_array("state.step", state.step, shape=(), dtype=np.dtype(np.int32))
         return param_leaves, utilities, first_moments, second_moments, structure
 
     def init(self, params: Any) -> OfficialAdaUPGDState:
         """Initialize the three source-defined moment PyTrees."""
 
-        self._parameter_contract(params)
+        leaves, structure = self._parameter_contract(params)
+        array_params = jax.tree_util.tree_unflatten(structure, leaves)
         return OfficialAdaUPGDState(  # type: ignore[call-arg]
-            utility_ema=jax.tree.map(jnp.zeros_like, params),
-            first_moment=jax.tree.map(jnp.zeros_like, params),
-            second_moment=jax.tree.map(jnp.zeros_like, params),
+            utility_ema=jax.tree.map(jnp.zeros_like, array_params),
+            first_moment=jax.tree.map(jnp.zeros_like, array_params),
+            second_moment=jax.tree.map(jnp.zeros_like, array_params),
             step=jnp.asarray(0, dtype=jnp.int32),
         )
 
@@ -1856,7 +2062,6 @@ class OfficialAdaUPGD:
         JAX port of the source's implicit PyTorch generator.
         """
 
-        checked_key = _adaupgd_typed_threefry_key(key, name="key")
         if mask is not None:
             raise ValueError("the official AdaptiveUPGD profile does not accept masks")
         (
@@ -1866,6 +2071,8 @@ class OfficialAdaUPGD:
             second_leaves,
             structure,
         ) = self._state_contract(state, params)
+        params = jax.tree_util.tree_unflatten(structure, param_leaves)
+        checked_key = _adaupgd_typed_threefry_key(key, name="key")
         grad_leaves, grad_structure = _flatten_with_none(gradients)
         if grad_structure != structure:
             raise ValueError("params, gradients, and state must share a PyTree structure")
@@ -1882,9 +2089,9 @@ class OfficialAdaUPGD:
 
         gradient_arrays: list[Array] = []
         for param, gradient in zip(param_leaves, grad_leaves, strict=True):
-            gradient_array = jnp.asarray(gradient, dtype=param.dtype)
-            if gradient_array.shape != param.shape:
-                raise ValueError("every gradient leaf must match its parameter shape")
+            gradient_array = _coerced_numeric_array(
+                "gradient leaf", gradient, shape=param.shape, dtype=param.dtype
+            )
             gradient_arrays.append(gradient_array)
 
         split_keys = jr.split(checked_key, len(param_leaves) + 1)
@@ -1962,9 +2169,12 @@ class OfficialAdaUPGD:
                     * self._config.noise_std
                 )
             else:
-                perturbation = jnp.asarray(supplied_noise, dtype=param.dtype)
-                if perturbation.shape != param.shape:
-                    raise ValueError("every noise leaf must match its parameter shape")
+                perturbation = _coerced_numeric_array(
+                    "noise leaf",
+                    supplied_noise,
+                    shape=param.shape,
+                    dtype=param.dtype,
+                )
             gate = jax.nn.sigmoid(
                 corrected_utility / raw_global_maximum.astype(param.dtype)
             )

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -280,7 +280,7 @@ def _validated_float32_scalar(
         upper=upper,
         upper_inclusive=upper_inclusive,
     )
-    if numerator != 0 and float(np.float32(numerator / denominator)) == 0.0:
+    if numerator != 0 and abs(numerator) * (1 << 150) <= denominator:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 

--- a/tests/test_canonical_upgd.py
+++ b/tests/test_canonical_upgd.py
@@ -16,6 +16,17 @@ from alberta_framework.core.canonical_upgd import (
 from alberta_framework.core.checkpoints import load_checkpoint, save_checkpoint
 
 
+def _legacy_sink_decay_config(**overrides: object) -> CanonicalUPGDConfig:
+    """Build the formerly accepted decay sink for defensive update-path tests."""
+
+    config = CanonicalUPGDConfig(utility_decay=0.9, **overrides)  # type: ignore[arg-type]
+    # Construction now rejects this value because it narrows to float32 1.0.
+    # Simulate an already-loaded legacy/corrupt in-memory config so the atomic
+    # refusal branch remains covered without reopening the public sink.
+    object.__setattr__(config, "utility_decay", 0.999999999)
+    return config
+
+
 def test_config_validation_and_roundtrip() -> None:
     config = CanonicalUPGDConfig(
         step_size=0.02,
@@ -314,9 +325,8 @@ def test_lifetime_counter_capacity_rejects_the_complete_update(
         params = {"w": jnp.array([2.0], dtype=jnp.float64)}
         gradients = {"w": jnp.array([-0.5], dtype=jnp.float64)}
         optimizer = CanonicalUPGD(
-            CanonicalUPGDConfig(
+            _legacy_sink_decay_config(
                 step_size=0.1,
-                utility_decay=0.999999999,
                 noise_std=0.0,
                 profile=profile,  # type: ignore[arg-type]
                 normalization=normalization,  # type: ignore[arg-type]
@@ -364,7 +374,7 @@ def test_final_representable_lifetime_update_is_consumed_before_capacity(
     with jax.enable_x64():
         params = {"w": jnp.array([2.0], dtype=jnp.float64)}
         gradients = {"w": jnp.array([-0.5], dtype=jnp.float64)}
-        decay = 0.999999999
+        decay = float(jnp.nextafter(jnp.float32(1.0), jnp.float32(0.0)))
         optimizer = CanonicalUPGD(
             CanonicalUPGDConfig(
                 step_size=0.1,
@@ -446,7 +456,7 @@ def test_safe_profile_global_saturation_does_not_consume_inactive_clock() -> Non
         optimizer = CanonicalUPGD(
             CanonicalUPGDConfig(
                 step_size=0.1,
-                utility_decay=0.999999999,
+                utility_decay=float(jnp.nextafter(jnp.float32(1.0), jnp.float32(0.0))),
                 noise_std=0.0,
                 profile="safe_extended",
                 normalization="global",
@@ -492,9 +502,8 @@ def test_safe_profile_exhausted_active_clock_rejects_available_peer_atomically(
             "exhausted": jnp.array([-0.5], dtype=jnp.float64),
         }
         optimizer = CanonicalUPGD(
-            CanonicalUPGDConfig(
+            _legacy_sink_decay_config(
                 step_size=0.1,
-                utility_decay=0.999999999,
                 noise_std=0.0,
                 mode=mode,  # type: ignore[arg-type]
                 profile="safe_extended",
@@ -551,9 +560,8 @@ def test_lifetime_refusal_is_reverse_mode_atomic_when_proposal_is_nonfinite(
             utility = jnp.array([jnp.finfo(jnp.float64).max], dtype=jnp.float64)
         params = {"w": param}
         optimizer = CanonicalUPGD(
-            CanonicalUPGDConfig(
+            _legacy_sink_decay_config(
                 step_size=0.1,
-                utility_decay=0.999999999,
                 noise_std=0.0,
                 mode=mode,  # type: ignore[arg-type]
                 profile=profile,  # type: ignore[arg-type]

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 from typing import Any
 
+import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -117,6 +118,14 @@ def _official(**overrides: Any) -> OfficialAdaUPGDConfig:
     }
     base.update(overrides)
     return OfficialAdaUPGDConfig(**base)
+
+
+def _floating_result_is_finite(result: object) -> bool:
+    return all(
+        bool(jnp.all(jnp.isfinite(leaf)))
+        for leaf in jax.tree.leaves(result)
+        if jnp.issubdtype(jnp.asarray(leaf).dtype, jnp.floating)
+    )
 
 
 def test_canonical_validators_accept_valid_values() -> None:
@@ -395,12 +404,12 @@ def test_canonical_normalization_fixed_by_profile() -> None:
 @pytest.mark.parametrize(
     ("optimizer", "bytes_per_scalar", "fixed_bytes"),
     [
-        (CanonicalUPGD(), 24, 33),
-        (AlbertaAdaUPGD(), 32, 50),
-        (OfficialAdaUPGD(), 36, 24),
+        (CanonicalUPGD(), 96, 128),
+        (AlbertaAdaUPGD(), 140, 128),
+        (OfficialAdaUPGD(), 140, 128),
     ],
 )
-def test_production_init_preflights_complete_update_result_before_conversion(
+def test_production_init_preflights_complete_working_set_before_conversion(
     optimizer: object, bytes_per_scalar: int, fixed_bytes: int
 ) -> None:
     last_legal = (_INT32_MAX - fixed_bytes) // bytes_per_scalar
@@ -410,7 +419,7 @@ def test_production_init_preflights_complete_update_result_before_conversion(
     assert legal.conversion_calls == 1
 
     oversized = _MetadataOnlyArray(last_legal + 1)
-    with pytest.raises(ValueError, match="derived .* update_result_nbytes"):
+    with pytest.raises(ValueError, match="derived .* working_set_nbytes"):
         optimizer.init({"w": oversized})  # type: ignore[attr-defined]
     assert oversized.conversion_calls == 0
 
@@ -494,3 +503,62 @@ def test_hostile_string_hooks_are_not_invoked() -> None:
         _alberta(profile=hostile)
     with pytest.raises(ValueError, match="profile"):
         _official(profile=hostile)
+
+
+def test_safe_canonical_operation_overflow_rolls_back_atomically() -> None:
+    maximum = np.finfo(np.float32).max
+    params = {"w": jnp.asarray([maximum], dtype=jnp.float32)}
+    gradients = {"w": jnp.asarray([-maximum], dtype=jnp.float32)}
+    noise = {"w": jnp.zeros((1,), dtype=jnp.float32)}
+    optimizer = CanonicalUPGD(
+        CanonicalUPGDConfig(
+            utility_decay=0.0,
+            noise_std=0.0,
+            profile="safe_extended",
+            normalization="global",
+        )
+    )
+    state = optimizer.init(params)
+    key = jr.key(11)
+    result = optimizer.update(state, params, gradients, key, noise=noise)
+    assert not bool(result.metrics["update_applied"])
+    chex.assert_trees_all_equal(result.params, params)
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(jr.key_data(result.next_key), jr.key_data(key))
+    assert _floating_result_is_finite(result)
+
+
+def test_alberta_float64_metric_narrowing_overflow_rolls_back() -> None:
+    with jax.enable_x64():
+        maximum32 = float(np.finfo(np.float32).max)
+        params = {"w": jnp.asarray([maximum32 * 2.0], dtype=jnp.float64)}
+        gradients = {"w": jnp.asarray([-1.0], dtype=jnp.float64)}
+        noise = {"w": jnp.zeros((1,), dtype=jnp.float64)}
+        optimizer = AlbertaAdaUPGD(
+            AlbertaAdaUPGDConfig(
+                utility_decay=0.0,
+                second_moment_decay=0.0,
+                noise_std=0.0,
+                normalization="global",
+            )
+        )
+        state = optimizer.init(params)
+        key = jr.key(12)
+        result = optimizer.update(state, params, gradients, key, noise=noise)
+        assert not bool(result.accepted)
+        chex.assert_trees_all_equal(result.params, params)
+        chex.assert_trees_all_equal(result.state, state)
+        chex.assert_trees_all_equal(jr.key_data(result.next_key), jr.key_data(key))
+        assert _floating_result_is_finite(result)
+
+
+def test_official_counter_saturates_without_changing_source_equations() -> None:
+    params = {"w": jnp.ones((1,), dtype=jnp.float32)}
+    gradients = {"w": jnp.ones((1,), dtype=jnp.float32)}
+    noise = {"w": jnp.zeros((1,), dtype=jnp.float32)}
+    optimizer = OfficialAdaUPGD()
+    state = optimizer.init(params).replace(  # type: ignore[attr-defined]
+        step=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    result = optimizer.update(state, params, gradients, jr.key(13), noise=noise)
+    assert int(result.state.step) == _INT32_MAX

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -169,25 +169,25 @@ def test_official_rejects_bool_and_spoof(field: str) -> None:
             _official(**{field: bad})
 
 
-def test_canonical_hostile_ratio_is_caught_and_counts_once() -> None:
+def test_canonical_hostile_ratio_is_rejected_without_executing_hook() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be a finite real"):
         _canon(step_size=_HostileFloat(1.0))
-    assert _HostileFloat.calls == 1
+    assert _HostileFloat.calls == 0
 
 
-def test_alberta_hostile_ratio_is_caught_and_counts_once() -> None:
+def test_alberta_hostile_ratio_is_rejected_without_executing_hook() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be a finite real"):
         _alberta(step_size=_HostileFloat(1.0))
-    assert _HostileFloat.calls == 1
+    assert _HostileFloat.calls == 0
 
 
-def test_official_hostile_ratio_is_caught_and_counts_once() -> None:
+def test_official_hostile_ratio_is_rejected_without_executing_hook() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be a finite real"):
         _official(step_size=_HostileFloat(1.0))
-    assert _HostileFloat.calls == 1
+    assert _HostileFloat.calls == 0
 
 
 def test_hostile_repr_is_not_executed_for_float_fields() -> None:
@@ -220,6 +220,8 @@ def test_canonical_domain_rejects_invalid_ranges() -> None:
         _canon(utility_decay=1.0)
     with pytest.raises(ValueError, match="must be"):
         _canon(utility_decay=-0.1)
+    with pytest.raises(ValueError, match="remain in"):
+        _canon(utility_decay=0.999999999)
     # epsilon must be positive
     with pytest.raises(ValueError, match="must be"):
         _canon(epsilon=0.0)
@@ -287,7 +289,7 @@ def test_float32_underflow_is_rejected_for_positive() -> None:
 def test_nonnegative_nonzero_scalars_cannot_silently_underflow(
     factory: Any, field: str
 ) -> None:
-    with pytest.raises(ValueError, match="must not underflow"):
+    with pytest.raises(ValueError, match="remain nonzero"):
         factory(**{field: 1e-50})
     assert getattr(factory(**{field: 0.0}), field) == 0.0
 

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -1,0 +1,358 @@
+"""Focused validation for canonical UPGD configs — hostile-safe and float32."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.canonical_upgd import (
+    AlbertaAdaUPGDConfig,
+    CanonicalUPGDConfig,
+    OfficialAdaUPGDConfig,
+    _require_float32_resource,
+)
+
+_INT32_MAX = 2_147_483_647
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        type(self).calls += 1
+        raise RuntimeError("untrusted ratio hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _RaisingRepr:
+    def __float__(self) -> float:  # pragma: no cover
+        return 1.0
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _ClassSpoof:
+    @property
+    def __class__(self) -> type:
+        return float  # type: ignore[return-value]
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+def _canon(**overrides: Any) -> CanonicalUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "profile": "safe_extended",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    base.update(overrides)
+    return CanonicalUPGDConfig(**base)
+
+
+def _alberta(**overrides: Any) -> AlbertaAdaUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "second_moment_decay": 0.9,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    base.update(overrides)
+    return AlbertaAdaUPGDConfig(**base)
+
+
+def _official(**overrides: Any) -> OfficialAdaUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-5,
+        "weight_decay": 0.001,
+        "utility_decay": 0.999,
+        "noise_std": 0.001,
+        "beta1": 0.9,
+        "beta2": 0.999,
+        "epsilon": 1e-5,
+    }
+    base.update(overrides)
+    return OfficialAdaUPGDConfig(**base)
+
+
+def test_canonical_validators_accept_valid_values() -> None:
+    cfg = _canon()
+    assert cfg.step_size == pytest.approx(1e-3)
+    assert cfg.utility_decay == pytest.approx(0.5)
+    # float32 canonicalization check
+    assert jnp.isfinite(jnp.asarray(cfg.step_size, dtype=jnp.float32))
+
+
+def test_alberta_validators_accept_valid_values() -> None:
+    cfg = _alberta()
+    assert cfg.second_moment_decay == pytest.approx(0.9)
+    assert jnp.isfinite(jnp.asarray(cfg.epsilon, dtype=jnp.float32))
+
+
+def test_official_validators_accept_valid_values() -> None:
+    cfg = _official()
+    assert cfg.beta1 == pytest.approx(0.9)
+    assert jnp.isfinite(jnp.asarray(cfg.step_size, dtype=jnp.float32))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "utility_decay", "noise_std", "weight_decay", "epsilon"],
+)
+def test_canonical_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _canon(**{field: bad})
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "utility_decay", "second_moment_decay", "noise_std", "weight_decay", "epsilon"],
+)
+def test_alberta_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _alberta(**{field: bad})
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "weight_decay", "utility_decay", "noise_std", "beta1", "beta2", "epsilon"],
+)
+def test_official_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _official(**{field: bad})
+
+
+def test_canonical_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _canon(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_alberta_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _alberta(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_official_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _official(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_hostile_repr_is_not_executed_for_float_fields() -> None:
+    # validated_float32_scalar must not interpolate !r
+    for bad in (_RaisingRepr(),):
+        # Canonical uses validated helper which should not call __repr__
+        try:
+            _canon(step_size=bad)  # type: ignore
+        except ValueError:
+            pass
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("should have raised")
+        # if repr had been called, AssertionError from __repr__ would propagate
+
+
+def test_canonical_domain_rejects_invalid_ranges() -> None:
+    # step_size must be positive
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=-1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=float("inf"))
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=float("nan"))
+    # utility_decay must be in [0,1)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(utility_decay=-0.1)
+    # epsilon must be positive
+    with pytest.raises(ValueError, match="must be"):
+        _canon(epsilon=0.0)
+    # noise_std must be >=0
+    with pytest.raises(ValueError, match="must be"):
+        _canon(noise_std=-0.1)
+
+
+def test_alberta_domain_rejects_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(second_moment_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(epsilon=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(noise_std=-1.0)
+
+
+def test_official_domain_rejects_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _official(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(beta1=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(beta2=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(epsilon=0.0)
+
+
+def test_float32_overflow_is_rejected() -> None:
+    # 1e40 is finite in host float64 but overflows float32 -> inf
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _canon(step_size=1e40)
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _alberta(step_size=1e40)
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _official(step_size=1e40)
+
+
+def test_float32_underflow_is_rejected_for_positive() -> None:
+    # tiny positive that underflows float32 to 0.0 while host is non-zero
+    tiny = 1e-50  # way below float32 subnormal, rounds to 0.0
+    # only positive fields should reject underflow
+    with pytest.raises(ValueError, match="must remain"):
+        _canon(step_size=tiny)
+    with pytest.raises(ValueError, match="must remain"):
+        _canon(epsilon=tiny)
+
+
+def test_config_string_validators_reject_invalid_and_hostile_repr() -> None:
+    # mode must be protecting/non_protecting without !r
+    class BadRepr:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="mode must be"):
+        _canon(mode="bad")  # type: ignore
+    # normalization
+    with pytest.raises(ValueError, match="normalization"):
+        _canon(normalization="bad")  # type: ignore
+    # profile
+    with pytest.raises(ValueError, match="profile must"):
+        _canon(profile="bad")  # type: ignore
+    # ensure hostile repr in mode string does not call repr
+    # mode string compare does not call repr
+    bad = BadRepr()
+    # pass bad object as mode; comparison calls __eq__, not __repr__
+    with pytest.raises(ValueError):
+        _canon(mode=bad)  # type: ignore
+
+
+def test_from_config_hostile_repr_not_executed() -> None:
+    # canonical from_config previously used !r for type_name
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "profile": "safe_extended",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    with pytest.raises(ValueError, match="expected CanonicalUPGD"):
+        CanonicalUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_alberta_from_config_hostile_repr_not_executed() -> None:
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "profile": "alberta_derived_first_order_adaptive_v1",
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "second_moment_decay": 0.9,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    with pytest.raises(ValueError, match="expected AlbertaAdaUPGD"):
+        AlbertaAdaUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_official_from_config_hostile_repr_not_executed() -> None:
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "profile": "official_rl_adaptive_upgd_b75e90a",
+        "source_commit": "b75e90ad4b09c28971ac9dbb902a8fd86709b28c",
+        "source_path": "core/run/rl/adaupgd.py",
+        "step_size": 1e-5,
+        "weight_decay": 0.001,
+        "utility_decay": 0.999,
+        "noise_std": 0.001,
+        "beta1": 0.9,
+        "beta2": 0.999,
+        "epsilon": 1e-5,
+    }
+    with pytest.raises(ValueError, match="expected OfficialAdaUPGD"):
+        OfficialAdaUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_canonical_normalization_fixed_by_profile() -> None:
+    # paper_global fixes normalization to global, passing local should fail
+    with pytest.raises(ValueError, match="fixes normalization"):
+        _canon(profile="paper_global", normalization="local")  # type: ignore
+    # official_experiment_local fixes to local
+    with pytest.raises(ValueError, match="fixes normalization"):
+        _canon(profile="official_experiment_local", normalization="global")  # type: ignore
+    # safe_extended allows explicit global/local
+    _canon(profile="safe_extended", normalization="global")
+    _canon(profile="safe_extended", normalization="local")
+
+
+def test_resource_helper_allocation_free_boundaries() -> None:
+    legal_scalars = _INT32_MAX // 4
+    # scalar count must fit signed int32
+    _require_float32_resource("test", vector_scalars=legal_scalars)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
+    # byte count must fit signed int32 (4*scalars)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=legal_scalars + 1)
+    # combined vector + fixed
+    _require_float32_resource("test", vector_scalars=legal_scalars - 5, fixed_scalars=5)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource("test", vector_scalars=legal_scalars, fixed_scalars=1)

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
 from typing import Any
 
+import jax
 import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.core.canonical_upgd import (
+    AlbertaAdaUPGD,
     AlbertaAdaUPGDConfig,
+    CanonicalUPGD,
     CanonicalUPGDConfig,
+    OfficialAdaUPGD,
     OfficialAdaUPGDConfig,
-    _require_float32_resource,
 )
 
 _INT32_MAX = 2_147_483_647
@@ -44,6 +50,29 @@ class _ClassSpoof:
 
     def __repr__(self) -> str:  # pragma: no cover
         raise AssertionError("repr executed")
+
+
+class _MetadataOnlyArray:
+    dtype = np.dtype(np.float32)
+
+    def __init__(self, size: int):
+        self.shape = (size,)
+        self.conversion_calls = 0
+
+    def __jax_array__(self) -> jax.Array:
+        self.conversion_calls += 1
+        raise RuntimeError("conversion must not run before resource preflight")
+
+
+class _UnreadableMapping(Mapping[str, object]):
+    def __getitem__(self, key: str) -> object:
+        raise RuntimeError("hostile mapping hook")
+
+    def __iter__(self) -> Iterator[str]:
+        raise RuntimeError("hostile mapping hook")
+
+    def __len__(self) -> int:
+        return 1
 
 
 def _canon(**overrides: Any) -> CanonicalUPGDConfig:
@@ -245,6 +274,24 @@ def test_float32_underflow_is_rejected_for_positive() -> None:
         _canon(epsilon=tiny)
 
 
+@pytest.mark.parametrize(
+    ("factory", "field"),
+    [
+        (_canon, "utility_decay"),
+        (_canon, "noise_std"),
+        (_canon, "weight_decay"),
+        (_alberta, "second_moment_decay"),
+        (_official, "beta1"),
+    ],
+)
+def test_nonnegative_nonzero_scalars_cannot_silently_underflow(
+    factory: Any, field: str
+) -> None:
+    with pytest.raises(ValueError, match="must not underflow"):
+        factory(**{field: 1e-50})
+    assert getattr(factory(**{field: 0.0}), field) == 0.0
+
+
 def test_config_string_validators_reject_invalid_and_hostile_repr() -> None:
     # mode must be protecting/non_protecting without !r
     class BadRepr:
@@ -343,16 +390,105 @@ def test_canonical_normalization_fixed_by_profile() -> None:
     _canon(profile="safe_extended", normalization="local")
 
 
-def test_resource_helper_allocation_free_boundaries() -> None:
-    legal_scalars = _INT32_MAX // 4
-    # scalar count must fit signed int32
-    _require_float32_resource("test", vector_scalars=legal_scalars)
-    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
-    # byte count must fit signed int32 (4*scalars)
-    with pytest.raises(ValueError, match="byte count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=legal_scalars + 1)
-    # combined vector + fixed
-    _require_float32_resource("test", vector_scalars=legal_scalars - 5, fixed_scalars=5)
-    with pytest.raises(ValueError, match="byte count"):
-        _require_float32_resource("test", vector_scalars=legal_scalars, fixed_scalars=1)
+@pytest.mark.parametrize(
+    ("optimizer", "bytes_per_scalar", "fixed_bytes"),
+    [
+        (CanonicalUPGD(), 24, 33),
+        (AlbertaAdaUPGD(), 32, 50),
+        (OfficialAdaUPGD(), 36, 24),
+    ],
+)
+def test_production_init_preflights_complete_update_result_before_conversion(
+    optimizer: object, bytes_per_scalar: int, fixed_bytes: int
+) -> None:
+    last_legal = (_INT32_MAX - fixed_bytes) // bytes_per_scalar
+    legal = _MetadataOnlyArray(last_legal)
+    with pytest.raises(ValueError, match="could not be converted"):
+        optimizer.init({"w": legal})  # type: ignore[attr-defined]
+    assert legal.conversion_calls == 1
+
+    oversized = _MetadataOnlyArray(last_legal + 1)
+    with pytest.raises(ValueError, match="derived .* update_result_nbytes"):
+        optimizer.init({"w": oversized})  # type: ignore[attr-defined]
+    assert oversized.conversion_calls == 0
+
+
+def _tree_nbytes(tree: object) -> int:
+    return sum(int(leaf.size) * int(leaf.dtype.itemsize) for leaf in jax.tree.leaves(tree))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.float32, jnp.float64])
+def test_resource_formulas_match_initialized_state_and_update_results(dtype: Any) -> None:
+    with jax.enable_x64():
+        params = {"w": jnp.ones((2, 3), dtype=dtype)}
+        gradients = jax.tree.map(jnp.ones_like, params)
+        noise = jax.tree.map(jnp.zeros_like, params)
+        parameter_nbytes = _tree_nbytes(params)
+        cases = [
+            (
+                CanonicalUPGD(),
+                parameter_nbytes + 4 * 6 + 4,
+                5 * parameter_nbytes + 4 * 6 + 33,
+            ),
+            (
+                AlbertaAdaUPGD(),
+                2 * parameter_nbytes + 4 * 6 + 4,
+                7 * parameter_nbytes + 4 * 6 + 50,
+            ),
+            (
+                OfficialAdaUPGD(),
+                3 * parameter_nbytes + 4,
+                9 * parameter_nbytes + 24,
+            ),
+        ]
+        for optimizer, expected_state, expected_update in cases:
+            state = optimizer.init(params)
+            result = optimizer.update(
+                state, params, gradients, jr.key(0), noise=noise
+            )
+            assert _tree_nbytes(state) == expected_state
+            assert _tree_nbytes(result) == expected_update
+
+
+@pytest.mark.parametrize("optimizer", [CanonicalUPGD(), AlbertaAdaUPGD(), OfficialAdaUPGD()])
+def test_python_float_parameter_leaf_compatibility(optimizer: object) -> None:
+    params = {"w": 1.0}
+    state = optimizer.init(params)  # type: ignore[attr-defined]
+    result = optimizer.update(  # type: ignore[attr-defined]
+        state, params, {"w": 0.5}, jr.key(4), noise={"w": 0.0}
+    )
+    assert jnp.asarray(result.params["w"]).shape == ()
+
+
+@pytest.mark.parametrize(
+    "config_type",
+    [CanonicalUPGDConfig, AlbertaAdaUPGDConfig, OfficialAdaUPGDConfig],
+)
+def test_from_config_preserves_mapping_compatibility_and_normalizes_hooks(
+    config_type: type[object],
+) -> None:
+    original = config_type()  # type: ignore[call-arg]
+    payload = original.to_config()  # type: ignore[attr-defined]
+    assert config_type.from_config(MappingProxyType(payload)) == original  # type: ignore[attr-defined]
+    with pytest.raises(ValueError, match="readable mapping"):
+        config_type.from_config(_UnreadableMapping())  # type: ignore[attr-defined]
+
+
+def test_hostile_string_hooks_are_not_invoked() -> None:
+    class HostileString:
+        def __hash__(self) -> int:
+            raise AssertionError("hash executed")
+
+        def __eq__(self, other: object) -> bool:
+            raise AssertionError("equality executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    hostile = HostileString()
+    with pytest.raises(ValueError, match="mode"):
+        _canon(mode=hostile)
+    with pytest.raises(ValueError, match="profile"):
+        _alberta(profile=hostile)
+    with pytest.raises(ValueError, match="profile"):
+        _official(profile=hostile)


### PR DESCRIPTION
Supersedes #851 while preserving byt61 original commit/authorship. Completes exact host+float32 config gates (including rejecting near-one decay that narrows to 1.0 and nonzero underflow), refuses arbitrary Real subclasses before ratio hooks, preserves exact Mapping schemas, and preflights complete parameter/state/update resources and metadata before conversion. Validation: 147 focused tests plus 53 validation rerun; Ruff and full mypy clean. No benchmark or output changes.