### PR TITLE
fix(upgd-memory): complete combined learner contracts

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -14,8 +14,9 @@ rather than a route-selecting portfolio.
 from __future__ import annotations
 
 import functools
+import operator
 from dataclasses import asdict, dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
@@ -50,7 +51,23 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.uint16,
     np.uint32,
     np.uint64,
+    np.longlong,
+    np.ulonglong,
 )
+_UINT32_MAX: int = 4294967295
+
+
+def _require_float32_resource(
+    name: str,
+    *,
+    vector_scalars: int,
+    fixed_scalars: int = 0,
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def _require_real(name: str, value: object) -> float:
@@ -96,16 +113,16 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(int, value))
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive, got invalid value")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative, got invalid value")
+        raise ValueError(f"{name} must be >= {minimum}, got invalid value")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}, got invalid value")
     return number
 
 
@@ -295,7 +312,7 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     readout_mode = config.readout_mode
     if type(readout_mode) is not str:
         raise TypeError(
-            f"readout_mode must be an actual string, got {readout_mode!r}"
+            "readout_mode must be an actual string, got invalid value"
         )
     if readout_mode not in {"linear_mse", "softmax_ce"}:
         raise ValueError("readout_mode must be 'linear_mse' or 'softmax_ce'")
@@ -484,6 +501,22 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     object.__setattr__(
         config, "max_novelty_threshold", max_novelty_threshold
     )
+    if n_heads * slots_per_class > _INT32_MAX:
+        raise ValueError("UPGDMemoryConfig dimensions must fit signed int32")
+    if n_heads * slots_per_class * feature_dim > _INT32_MAX:
+        raise ValueError("UPGDMemoryConfig dimensions must fit signed int32")
+    total_means = n_heads * slots_per_class * feature_dim
+    fixed_state_scalars = 2 * n_heads * slots_per_class + 9
+    _require_float32_resource(
+        "UPGDMemoryConfig state",
+        vector_scalars=total_means,
+        fixed_scalars=fixed_state_scalars,
+    )
+    persistent_bytes = 4 * (total_means + fixed_state_scalars)
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("UPGDMemoryConfig state byte count must fit signed int32")
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("upgd memory allocation exceeds uint32 byte accounting")
 
 
 def _active_mse(prediction: Array, target: Array) -> Array:

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass
 from typing import Any, Literal, SupportsIndex, cast
 
 import chex
@@ -42,6 +42,9 @@ from alberta_framework.core.update_safety import (
 from alberta_framework.core.upgd import UPGDLearner, UPGDState
 
 _INT32_MAX: int = 2**31 - 1
+_UINT32_MAX: int = 2**32 - 1
+_MAX_PERSISTENT_STATE_BYTES: int = 256 * 1024 * 1024
+_FLOAT32_MIN_NORMAL: float = float(np.finfo(np.float32).tiny)
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -119,6 +122,24 @@ def _require_array(
         raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
 
 
+def _require_typed_key(name: str, value: object) -> Array:
+    """Require one scalar typed Threefry key without accepting legacy words."""
+    try:
+        implementation = str(jr.key_impl(value))  # type: ignore[arg-type]
+        words = jr.key_data(value)  # type: ignore[arg-type]
+        shape = tuple(getattr(value, "shape"))
+    except Exception as error:
+        raise TypeError(f"{name} must be a typed scalar threefry2x32 key") from error
+    if (
+        shape != ()
+        or implementation != "threefry2x32"
+        or words.shape != (2,)
+        or words.dtype != jnp.uint32
+    ):
+        raise TypeError(f"{name} must be a typed scalar threefry2x32 key")
+    return cast(Array, value)
+
+
 def _require_real(name: str, value: object) -> float:
     return validated_float32_scalar(name, value)
 
@@ -152,6 +173,10 @@ def _require_nonnegative_real(name: str, value: object) -> float:
 
 def _require_positive_real(name: str, value: object) -> float:
     return validated_float32_scalar(name, value, positive=True)
+
+
+def _require_positive_normal_real(name: str, value: object) -> float:
+    return validated_float32_scalar(name, value, lower=_FLOAT32_MIN_NORMAL)
 
 
 def _require_int(
@@ -297,50 +322,27 @@ class UPGDMemoryConfig:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> UPGDMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        return cls._from_serialized(config, require_type=True)
+        return cls._from_serialized(config)
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> UPGDMemoryConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        return cls._from_serialized(data, require_type=False)
+        return cls._from_serialized(data)
 
     @classmethod
-    def _from_serialized(
-        cls, data: Mapping[str, Any], *, require_type: bool
-    ) -> UPGDMemoryConfig:
+    def _from_serialized(cls, data: Mapping[str, Any]) -> UPGDMemoryConfig:
         if not issubclass(type(data), Mapping):
             raise ValueError("UPGDMemoryConfig payload must be a mapping")
         try:
             payload = dict(data)
         except Exception as error:
             raise ValueError("UPGDMemoryConfig mapping could not be read") from error
-        marker = payload.pop("type", None)
-        if require_type and marker != "UPGDMemoryConfig":
-            raise ValueError("UPGDMemoryConfig type is invalid")
-        if not require_type and marker is not None:
-            raise ValueError("UPGDMemoryConfig dictionary must not contain a type marker")
-        if set(payload) != {field.name for field in fields(cls)}:
-            raise ValueError("UPGDMemoryConfig fields do not match its schema")
-        integer_fields = {
-            "feature_dim",
-            "n_heads",
-            "slots_per_class",
-            "upgd_head_loss_pressure_warmup_steps",
-            "upgd_head_repetition_warmup_steps",
-        }
-        for name in integer_fields:
-            if type(payload[name]) is not int:
-                raise ValueError(f"serialized {name} must be a JSON integer")
-        hidden = payload["hidden_sizes"]
-        if type(hidden) is not list or any(type(item) is not int for item in hidden):
-            raise ValueError("serialized hidden_sizes must be a list of JSON integers")
-        payload["hidden_sizes"] = tuple(hidden)
-        if type(payload["readout_mode"]) is not str:
-            raise ValueError("serialized readout_mode must be a JSON string")
-        for name, value in payload.items():
-            if name not in integer_fields | {"hidden_sizes", "readout_mode"}:
-                if type(value) is not float:
-                    raise ValueError(f"serialized {name} must be a JSON number")
+        payload.pop("type", None)
+        if "hidden_sizes" in payload:
+            hidden = payload["hidden_sizes"]
+            if type(hidden) not in {list, tuple}:
+                raise ValueError("hidden_sizes must be a list or tuple")
+            payload["hidden_sizes"] = tuple(hidden)
         return cls(**payload)
 
 
@@ -451,10 +453,10 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     memory_update_rate = _require_half_open_unit_interval(
         "memory_update_rate", config.memory_update_rate
     )
-    initial_novelty_threshold = _require_positive_real(
+    initial_novelty_threshold = _require_positive_normal_real(
         "initial_novelty_threshold", config.initial_novelty_threshold
     )
-    memory_bandwidth = _require_positive_real(
+    memory_bandwidth = _require_positive_normal_real(
         "memory_bandwidth", config.memory_bandwidth
     )
     initial_memory_logit = _require_real(
@@ -484,10 +486,10 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     target_allocation_rate = _require_unit_interval(
         "target_allocation_rate", config.target_allocation_rate
     )
-    min_novelty_threshold = _require_positive_real(
+    min_novelty_threshold = _require_positive_normal_real(
         "min_novelty_threshold", config.min_novelty_threshold
     )
-    max_novelty_threshold = _require_positive_real(
+    max_novelty_threshold = _require_positive_normal_real(
         "max_novelty_threshold", config.max_novelty_threshold
     )
     if min_novelty_threshold > max_novelty_threshold:
@@ -597,6 +599,11 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
         int32_scalars=int32_scalars,
         uint32_scalars=uint32_scalars,
     )
+    persistent_bytes = 4 * (float32_scalars + int32_scalars + uint32_scalars)
+    if persistent_bytes > _UINT32_MAX:
+        raise ValueError("UPGDMemoryConfig combined state bytes must fit unsigned int32")
+    if persistent_bytes > _MAX_PERSISTENT_STATE_BYTES:
+        raise ValueError("UPGDMemoryConfig persistent state exceeds 256 MiB")
 
 
 def _active_mse(prediction: Array, target: Array) -> Array:
@@ -694,11 +701,7 @@ class UPGDMemoryLearner:
             payload = dict(config)
         except Exception as error:
             raise ValueError("UPGDMemoryLearner mapping could not be read") from error
-        if set(payload) != {"type", "config"}:
-            raise ValueError("UPGDMemoryLearner fields do not match its schema")
-        if payload["type"] != "UPGDMemoryLearner":
-            raise ValueError("UPGDMemoryLearner type is invalid")
-        inner = payload["config"]
+        inner = payload.get("config")
         if not issubclass(type(inner), Mapping):
             raise ValueError("UPGDMemoryLearner config must be a mapping")
         return cls(UPGDMemoryConfig.from_config(cast(Mapping[str, Any], inner)))
@@ -815,14 +818,7 @@ class UPGDMemoryLearner:
         ):
             _require_array(f"state.upgd_state.{name}", getattr(upgd, name), (), jnp.float32)
         _require_array("state.upgd_state.step_count", upgd.step_count, (), jnp.int32)
-        if not (
-            hasattr(upgd.key, "shape")
-            and tuple(upgd.key.shape) == ()
-            and jax.dtypes.issubdtype(  # type: ignore[attr-defined]
-                upgd.key.dtype, jax.dtypes.prng_key
-            )
-        ):
-            raise TypeError("state.upgd_state.key must be a scalar typed JAX PRNG key")
+        _require_typed_key("state.upgd_state.key", upgd.key)
         for name in (
             "memory_logit",
             "novelty_log_threshold",
@@ -846,14 +842,7 @@ class UPGDMemoryLearner:
         """Initialize both components and adaptive blend state."""
         if key is None:
             key = jr.key(0)
-        if not (
-            hasattr(key, "shape")
-            and tuple(key.shape) == ()
-            and jax.dtypes.issubdtype(  # type: ignore[attr-defined]
-                key.dtype, jax.dtypes.prng_key
-            )
-        ):
-            raise TypeError("key must be a scalar typed JAX PRNG key")
+        key = _require_typed_key("key", key)
         cfg = self._config
         raw_upgd_state = self._upgd.init(cfg.feature_dim, key)
         upgd_state = raw_upgd_state.replace(  # type: ignore[attr-defined]
@@ -1132,7 +1121,9 @@ def run_upgd_memory_arrays(
         raise ValueError(
             f"observations must have shape (steps, {learner.config.feature_dim})"
         )
-    steps = int(observations.shape[0])
+    steps = observations.shape[0]
+    if type(steps) is not int or steps < 0:
+        raise ValueError("UPGD memory step count must be a non-negative integer")
     if tuple(targets.shape) != (steps, learner.config.n_heads):
         raise ValueError(f"targets must have shape ({steps}, {learner.config.n_heads})")
     if jnp.dtype(observations.dtype) != jnp.dtype(jnp.float32):
@@ -1144,6 +1135,21 @@ def run_upgd_memory_arrays(
         float32_scalars=steps * (learner.config.n_heads + 10),
         bool_scalars=steps,
     )
+    float32_scalars, int32_scalars, uint32_scalars = _combined_state_resource_counts(
+        learner.config.feature_dim,
+        learner.config.n_heads,
+        learner.config.hidden_sizes,
+        learner.config.slots_per_class,
+    )
+    working_set_bytes = (
+        4 * (float32_scalars + int32_scalars + uint32_scalars)
+        + steps
+        * (4 * (learner.config.feature_dim + 2 * learner.config.n_heads + 10) + 1)
+    )
+    if working_set_bytes > _UINT32_MAX:
+        raise ValueError("UPGD memory scan working set must fit unsigned int32")
+    if working_set_bytes > _MAX_PERSISTENT_STATE_BYTES:
+        raise ValueError("UPGD memory scan working set exceeds 256 MiB")
 
     def step_fn(
         carry: UPGDMemoryState,

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -58,6 +58,7 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.longlong,
     np.ulonglong,
 )
+_MIN_LOG_ROUNDTRIP_FLOAT32 = 2.0 * float(np.finfo(np.float32).tiny)
 
 
 def _require_resource(
@@ -181,6 +182,15 @@ def _require_positive_real(name: str, value: object) -> float:
 
 def _require_positive_normal_real(name: str, value: object) -> float:
     return validated_float32_scalar(name, value, lower=_FLOAT32_MIN_NORMAL)
+
+
+def _require_positive_log_real(name: str, value: object) -> float:
+    canonical = validated_float32_scalar(name, value, positive=True)
+    if canonical < _MIN_LOG_ROUNDTRIP_FLOAT32:
+        raise ValueError(
+            f"{name} must be at least the float32 log/exp round-trip endpoint"
+        )
+    return canonical
 
 
 def _require_int(
@@ -459,7 +469,7 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     memory_update_rate = _require_half_open_unit_interval(
         "memory_update_rate", config.memory_update_rate
     )
-    initial_novelty_threshold = _require_positive_normal_real(
+    initial_novelty_threshold = _require_positive_log_real(
         "initial_novelty_threshold", config.initial_novelty_threshold
     )
     memory_bandwidth = _require_positive_normal_real(
@@ -492,10 +502,10 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     target_allocation_rate = _require_unit_interval(
         "target_allocation_rate", config.target_allocation_rate
     )
-    min_novelty_threshold = _require_positive_normal_real(
+    min_novelty_threshold = _require_positive_log_real(
         "min_novelty_threshold", config.min_novelty_threshold
     )
-    max_novelty_threshold = _require_positive_normal_real(
+    max_novelty_threshold = _require_positive_log_real(
         "max_novelty_threshold", config.max_novelty_threshold
     )
     if min_novelty_threshold > max_novelty_threshold:
@@ -1151,28 +1161,36 @@ def run_upgd_memory_arrays(
         raise ValueError(
             f"observations must have shape (steps, {learner.config.feature_dim})"
         )
-    steps = observation_shape[0]
-    if type(steps) is not int or steps < 0:
-        raise ValueError("UPGD memory step count must be a non-negative integer")
+    steps = _require_int("steps", observation_shape[0], minimum=0, maximum=_INT32_MAX)
     if target_shape != (steps, learner.config.n_heads):
         raise ValueError(f"targets must have shape ({steps}, {learner.config.n_heads})")
     if observation_dtype != jnp.dtype(jnp.float32):
         raise TypeError("observations must have dtype float32")
     if target_dtype != jnp.dtype(jnp.float32):
         raise TypeError("targets must have dtype float32")
-    _require_resource(
-        "UPGD memory batch outputs",
-        float32_scalars=steps * (learner.config.n_heads + 10),
-        bool_scalars=steps,
-    )
-    float32_scalars, int32_scalars, uint32_scalars = _combined_state_resource_counts(
+    state_float32, state_int32, state_uint32 = _combined_state_resource_counts(
         learner.config.feature_dim,
         learner.config.n_heads,
         learner.config.hidden_sizes,
         learner.config.slots_per_class,
     )
+    _require_resource(
+        "UPGD memory batch aggregate",
+        float32_scalars=(
+            steps
+            * (
+                learner.config.feature_dim
+                + 2 * learner.config.n_heads
+                + 10
+            )
+            + 2 * state_float32
+        ),
+        int32_scalars=2 * state_int32,
+        uint32_scalars=2 * state_uint32,
+        bool_scalars=steps,
+    )
     working_set_bytes = (
-        4 * (float32_scalars + int32_scalars + uint32_scalars)
+        8 * (state_float32 + state_int32 + state_uint32)
         + steps
         * (4 * (learner.config.feature_dim + 2 * learner.config.n_heads + 10) + 1)
     )
@@ -1186,7 +1204,7 @@ def run_upgd_memory_arrays(
         batch: tuple[Array, Array],
     ) -> tuple[UPGDMemoryState, tuple[Array, Array, Array]]:
         observation, target = batch
-        result = learner.update(carry, observation, target)
+        result = learner._update_jitted(carry, observation, target)  # noqa: SLF001
         return result.state, (
             result.predictions,
             result.metrics,

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -114,12 +114,16 @@ def _combined_state_resource_counts(
 def _require_array(
     name: str, value: object, shape: tuple[int, ...], dtype: Any
 ) -> None:
-    if not hasattr(value, "shape") or not hasattr(value, "dtype"):
-        raise TypeError(f"{name} must expose array shape and dtype metadata")
-    if tuple(value.shape) != shape:
+    try:
+        actual_shape = tuple(getattr(value, "shape"))
+        actual_dtype = jnp.dtype(getattr(value, "dtype"))
+        expected_dtype = jnp.dtype(dtype)
+    except Exception as error:
+        raise TypeError(f"{name} must expose valid array shape and dtype metadata") from error
+    if actual_shape != shape:
         raise ValueError(f"{name} must have shape {shape}")
-    if jnp.dtype(value.dtype) != jnp.dtype(dtype):
-        raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
+    if actual_dtype != expected_dtype:
+        raise TypeError(f"{name} must have dtype {expected_dtype}")
 
 
 def _require_typed_key(name: str, value: object) -> Array:
@@ -337,7 +341,9 @@ class UPGDMemoryConfig:
             payload = dict(data)
         except Exception as error:
             raise ValueError("UPGDMemoryConfig mapping could not be read") from error
-        payload.pop("type", None)
+        marker = payload.pop("type", None)
+        if marker is not None and type(marker) is not str:
+            raise ValueError("UPGDMemoryConfig type marker must be an actual string")
         if "hidden_sizes" in payload:
             hidden = payload["hidden_sizes"]
             if type(hidden) not in {list, tuple}:
@@ -701,6 +707,9 @@ class UPGDMemoryLearner:
             payload = dict(config)
         except Exception as error:
             raise ValueError("UPGDMemoryLearner mapping could not be read") from error
+        marker = payload.get("type")
+        if marker is not None and type(marker) is not str:
+            raise ValueError("UPGDMemoryLearner type marker must be an actual string")
         inner = payload.get("config")
         if not issubclass(type(inner), Mapping):
             raise ValueError("UPGDMemoryLearner config must be a mapping")
@@ -921,7 +930,6 @@ class UPGDMemoryLearner:
             prediction = _normalize_simplex(prediction)
         return prediction, gate
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def predict(
         self,
         state: UPGDMemoryState,
@@ -930,6 +938,14 @@ class UPGDMemoryLearner:
         """Predict with the current learned UPGD-memory blend."""
         self._validate_state_static_contract(state)
         _require_array("observation", observation, (self._config.feature_dim,), jnp.float32)
+        return cast(Array, self._predict_jitted(state, observation))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _predict_jitted(
+        self,
+        state: UPGDMemoryState,
+        observation: Float[Array, " feature_dim"],
+    ) -> Float[Array, " n_heads"]:
         upgd_prediction = self._upgd.predict(state.upgd_state, observation)
         memory_prediction = self._memory.predict(state.memory_state, observation)
         prediction, _gate = self._blend_predictions(
@@ -940,7 +956,6 @@ class UPGDMemoryLearner:
         )
         return prediction
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
         state: UPGDMemoryState,
@@ -951,6 +966,15 @@ class UPGDMemoryLearner:
         self._validate_state_static_contract(state)
         _require_array("observation", observation, (self._config.feature_dim,), jnp.float32)
         _require_array("target", target, (self._config.n_heads,), jnp.float32)
+        return cast(UPGDMemoryUpdateResult, self._update_jitted(state, observation, target))
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _update_jitted(
+        self,
+        state: UPGDMemoryState,
+        observation: Float[Array, " feature_dim"],
+        target: Float[Array, " n_heads"],
+    ) -> UPGDMemoryUpdateResult:
         observation_arr = jnp.asarray(observation)
         target_arr = jnp.asarray(target)
         observation_valid = jnp.all(jnp.isfinite(observation_arr))
@@ -1111,24 +1135,30 @@ def run_upgd_memory_arrays(
     if type(learner) is not UPGDMemoryLearner:
         raise TypeError("learner must be a UPGDMemoryLearner")
     learner._validate_state_static_contract(state)  # noqa: SLF001
-    if not hasattr(observations, "shape") or not hasattr(observations, "dtype"):
-        raise TypeError("observations must expose array shape and dtype metadata")
-    if not hasattr(targets, "shape") or not hasattr(targets, "dtype"):
-        raise TypeError("targets must expose array shape and dtype metadata")
-    if len(observations.shape) != 2 or tuple(observations.shape[1:]) != (
+    try:
+        observation_shape = tuple(getattr(observations, "shape"))
+        observation_dtype = jnp.dtype(getattr(observations, "dtype"))
+    except Exception as error:
+        raise TypeError("observations must expose valid array metadata") from error
+    try:
+        target_shape = tuple(getattr(targets, "shape"))
+        target_dtype = jnp.dtype(getattr(targets, "dtype"))
+    except Exception as error:
+        raise TypeError("targets must expose valid array metadata") from error
+    if len(observation_shape) != 2 or observation_shape[1:] != (
         learner.config.feature_dim,
     ):
         raise ValueError(
             f"observations must have shape (steps, {learner.config.feature_dim})"
         )
-    steps = observations.shape[0]
+    steps = observation_shape[0]
     if type(steps) is not int or steps < 0:
         raise ValueError("UPGD memory step count must be a non-negative integer")
-    if tuple(targets.shape) != (steps, learner.config.n_heads):
+    if target_shape != (steps, learner.config.n_heads):
         raise ValueError(f"targets must have shape ({steps}, {learner.config.n_heads})")
-    if jnp.dtype(observations.dtype) != jnp.dtype(jnp.float32):
+    if observation_dtype != jnp.dtype(jnp.float32):
         raise TypeError("observations must have dtype float32")
-    if jnp.dtype(targets.dtype) != jnp.dtype(jnp.float32):
+    if target_dtype != jnp.dtype(jnp.float32):
         raise TypeError("targets must have dtype float32")
     _require_resource(
         "UPGD memory batch outputs",

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import functools
 import operator
-from dataclasses import asdict, dataclass
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, fields
 from typing import Any, Literal, SupportsIndex, cast
 
 import chex
@@ -54,20 +55,68 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.longlong,
     np.ulonglong,
 )
-_UINT32_MAX: int = 4294967295
 
 
-def _require_float32_resource(
+def _require_resource(
     name: str,
     *,
-    vector_scalars: int,
-    fixed_scalars: int = 0,
+    float32_scalars: int = 0,
+    int32_scalars: int = 0,
+    uint32_scalars: int = 0,
+    bool_scalars: int = 0,
 ) -> None:
-    total_scalars = vector_scalars + fixed_scalars
+    total_scalars = float32_scalars + int32_scalars + uint32_scalars + bool_scalars
     if total_scalars > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
+    total_bytes = 4 * (float32_scalars + int32_scalars + uint32_scalars) + bool_scalars
+    if total_bytes > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _combined_state_resource_counts(
+    feature_dim: int,
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    slots_per_class: int,
+) -> tuple[int, int, int]:
+    """Return exact serialized float32, int32, and uint32 state leaf counts."""
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_weights = sum(
+        layer_sizes[index] * layer_sizes[index + 1]
+        for index in range(len(layer_sizes) - 1)
+    )
+    trunk_biases = sum(hidden_sizes)
+    head_input_dim = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_weights = n_heads * head_input_dim
+    slots = n_heads * slots_per_class
+    # UPGD serializes ordinary and fast head leaves separately, even though
+    # initialization aliases their arrays. It also stores utilities, the
+    # label adapter, targets, nine control scalars, and two telemetry scalars.
+    upgd_float32 = (
+        2 * trunk_weights
+        + trunk_biases
+        + 2 * head_weights
+        + 3 * n_heads
+        + n_heads * n_heads
+        + 11
+    )
+    # Prototype means/counts plus the six wrapper EMA/logit scalars.
+    memory_and_wrapper_float32 = slots * feature_dim + slots + 6
+    # Prototype last-update words and three component/wrapper step counters.
+    int32_scalars = slots + 3
+    # One typed Threefry key has two underlying uint32 words.
+    return upgd_float32 + memory_and_wrapper_float32, int32_scalars, 2
+
+
+def _require_array(
+    name: str, value: object, shape: tuple[int, ...], dtype: Any
+) -> None:
+    if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+        raise TypeError(f"{name} must expose array shape and dtype metadata")
+    if tuple(value.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if jnp.dtype(value.dtype) != jnp.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
 
 
 def _require_real(name: str, value: object) -> float:
@@ -246,18 +295,53 @@ class UPGDMemoryConfig:
         return payload
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> UPGDMemoryConfig:
+    def from_config(cls, config: Mapping[str, Any]) -> UPGDMemoryConfig:
         """Reconstruct from :meth:`to_config` output."""
-        payload = dict(config)
-        payload.pop("type", None)
-        if "hidden_sizes" in payload:
-            payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
-        return cls(**payload)
+        return cls._from_serialized(config, require_type=True)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> UPGDMemoryConfig:
+    def from_dict(cls, data: Mapping[str, Any]) -> UPGDMemoryConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        return cls.from_config(data)
+        return cls._from_serialized(data, require_type=False)
+
+    @classmethod
+    def _from_serialized(
+        cls, data: Mapping[str, Any], *, require_type: bool
+    ) -> UPGDMemoryConfig:
+        if not issubclass(type(data), Mapping):
+            raise ValueError("UPGDMemoryConfig payload must be a mapping")
+        try:
+            payload = dict(data)
+        except Exception as error:
+            raise ValueError("UPGDMemoryConfig mapping could not be read") from error
+        marker = payload.pop("type", None)
+        if require_type and marker != "UPGDMemoryConfig":
+            raise ValueError("UPGDMemoryConfig type is invalid")
+        if not require_type and marker is not None:
+            raise ValueError("UPGDMemoryConfig dictionary must not contain a type marker")
+        if set(payload) != {field.name for field in fields(cls)}:
+            raise ValueError("UPGDMemoryConfig fields do not match its schema")
+        integer_fields = {
+            "feature_dim",
+            "n_heads",
+            "slots_per_class",
+            "upgd_head_loss_pressure_warmup_steps",
+            "upgd_head_repetition_warmup_steps",
+        }
+        for name in integer_fields:
+            if type(payload[name]) is not int:
+                raise ValueError(f"serialized {name} must be a JSON integer")
+        hidden = payload["hidden_sizes"]
+        if type(hidden) is not list or any(type(item) is not int for item in hidden):
+            raise ValueError("serialized hidden_sizes must be a list of JSON integers")
+        payload["hidden_sizes"] = tuple(hidden)
+        if type(payload["readout_mode"]) is not str:
+            raise ValueError("serialized readout_mode must be a JSON string")
+        for name, value in payload.items():
+            if name not in integer_fields | {"hidden_sizes", "readout_mode"}:
+                if type(value) is not float:
+                    raise ValueError(f"serialized {name} must be a JSON number")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -501,22 +585,18 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     object.__setattr__(
         config, "max_novelty_threshold", max_novelty_threshold
     )
-    if n_heads * slots_per_class > _INT32_MAX:
-        raise ValueError("UPGDMemoryConfig dimensions must fit signed int32")
-    if n_heads * slots_per_class * feature_dim > _INT32_MAX:
-        raise ValueError("UPGDMemoryConfig dimensions must fit signed int32")
-    total_means = n_heads * slots_per_class * feature_dim
-    fixed_state_scalars = 2 * n_heads * slots_per_class + 9
-    _require_float32_resource(
-        "UPGDMemoryConfig state",
-        vector_scalars=total_means,
-        fixed_scalars=fixed_state_scalars,
+    float32_scalars, int32_scalars, uint32_scalars = _combined_state_resource_counts(
+        feature_dim,
+        n_heads,
+        canonical_hidden,
+        slots_per_class,
     )
-    persistent_bytes = 4 * (total_means + fixed_state_scalars)
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("UPGDMemoryConfig state byte count must fit signed int32")
-    if persistent_bytes > _UINT32_MAX:
-        raise ValueError("upgd memory allocation exceeds uint32 byte accounting")
+    _require_resource(
+        "UPGDMemoryConfig combined state",
+        float32_scalars=float32_scalars,
+        int32_scalars=int32_scalars,
+        uint32_scalars=uint32_scalars,
+    )
 
 
 def _active_mse(prediction: Array, target: Array) -> Array:
@@ -606,17 +686,182 @@ class UPGDMemoryLearner:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> UPGDMemoryLearner:
+    def from_config(cls, config: Mapping[str, Any]) -> UPGDMemoryLearner:
         """Reconstruct from :meth:`to_config` output."""
-        return cls(UPGDMemoryConfig.from_config(dict(config["config"])))
+        if not issubclass(type(config), Mapping):
+            raise ValueError("UPGDMemoryLearner payload must be a mapping")
+        try:
+            payload = dict(config)
+        except Exception as error:
+            raise ValueError("UPGDMemoryLearner mapping could not be read") from error
+        if set(payload) != {"type", "config"}:
+            raise ValueError("UPGDMemoryLearner fields do not match its schema")
+        if payload["type"] != "UPGDMemoryLearner":
+            raise ValueError("UPGDMemoryLearner type is invalid")
+        inner = payload["config"]
+        if not issubclass(type(inner), Mapping):
+            raise ValueError("UPGDMemoryLearner config must be a mapping")
+        return cls(UPGDMemoryConfig.from_config(cast(Mapping[str, Any], inner)))
+
+    def _validate_state_static_contract(self, state: UPGDMemoryState) -> None:
+        """Reject malformed combined state before any traced computation."""
+        if type(state) is not UPGDMemoryState:
+            raise TypeError("state must be a UPGDMemoryState")
+        if type(state.upgd_state) is not UPGDState:
+            raise TypeError("state.upgd_state must be a UPGDState")
+        self._memory._validate_state_static_contract(state.memory_state)  # noqa: SLF001
+        cfg = self._config
+        upgd = state.upgd_state
+        layer_sizes = (cfg.feature_dim, *cfg.hidden_sizes)
+        if (
+            type(upgd.trunk_params.weights) is not tuple
+            or type(upgd.trunk_params.biases) is not tuple
+        ):
+            raise TypeError("UPGD trunk parameters must use tuple containers")
+        if len(upgd.trunk_params.weights) != len(cfg.hidden_sizes):
+            raise ValueError("UPGD trunk layer count is invalid")
+        if type(upgd.utilities) is not tuple or len(upgd.utilities) != len(cfg.hidden_sizes):
+            raise ValueError("UPGD utility layer count is invalid")
+        for index in range(len(cfg.hidden_sizes)):
+            shape = (layer_sizes[index + 1], layer_sizes[index])
+            _require_array(
+                f"state.upgd_state.trunk_params.weights[{index}]",
+                upgd.trunk_params.weights[index],
+                shape,
+                jnp.float32,
+            )
+            _require_array(
+                f"state.upgd_state.trunk_params.biases[{index}]",
+                upgd.trunk_params.biases[index],
+                (layer_sizes[index + 1],),
+                jnp.float32,
+            )
+            _require_array(
+                f"state.upgd_state.utilities[{index}]",
+                upgd.utilities[index],
+                shape,
+                jnp.float32,
+            )
+        head_input = cfg.hidden_sizes[-1] if cfg.hidden_sizes else cfg.feature_dim
+        for label, params in (
+            ("head_params", upgd.head_params),
+            ("readout_fast_head_params", upgd.readout_fast_head_params),
+        ):
+            if type(params.weights) is not tuple or type(params.biases) is not tuple:
+                raise TypeError(f"UPGD {label} must use tuple containers")
+            if len(params.weights) != cfg.n_heads or len(params.biases) != cfg.n_heads:
+                raise ValueError(f"UPGD {label} count is invalid")
+            for index in range(cfg.n_heads):
+                _require_array(
+                    f"state.upgd_state.{label}.weights[{index}]",
+                    params.weights[index],
+                    (1, head_input),
+                    jnp.float32,
+                )
+                _require_array(
+                    f"state.upgd_state.{label}.biases[{index}]",
+                    params.biases[index],
+                    (1,),
+                    jnp.float32,
+                )
+        _require_array(
+            "state.upgd_state.readout_label_adapter",
+            upgd.readout_label_adapter,
+            (cfg.n_heads, cfg.n_heads),
+            jnp.float32,
+        )
+        for name in (
+            "unit_utilities",
+            "unit_long_utilities",
+            "unit_gradient_emas",
+            "unit_ages",
+            "previous_trunk_weight_grads",
+            "previous_trunk_bias_grads",
+            "previous_head_weight_grads",
+            "previous_head_bias_grads",
+        ):
+            if getattr(upgd, name) != ():
+                raise ValueError(f"state.upgd_state.{name} must be empty")
+        _require_array(
+            "state.upgd_state.unit_replacement_counts",
+            upgd.unit_replacement_counts,
+            (0,),
+            jnp.float32,
+        )
+        _require_array(
+            "state.upgd_state.unit_replacement_accumulators",
+            upgd.unit_replacement_accumulators,
+            (0,),
+            jnp.float32,
+        )
+        _require_array(
+            "state.upgd_state.previous_targets",
+            upgd.previous_targets,
+            (cfg.n_heads,),
+            jnp.float32,
+        )
+        for name in (
+            "loss_fast_ema",
+            "loss_slow_ema",
+            "target_repeat_ema",
+            "target_simplex_ema",
+            "meta_trunk_log_scale",
+            "meta_head_weight_log_scale",
+            "meta_head_bias_log_scale",
+            "meta_repetition_log_scale",
+            "adaptive_kappa_log_scale",
+            "birth_timestamp",
+            "uptime_s",
+        ):
+            _require_array(f"state.upgd_state.{name}", getattr(upgd, name), (), jnp.float32)
+        _require_array("state.upgd_state.step_count", upgd.step_count, (), jnp.int32)
+        if not (
+            hasattr(upgd.key, "shape")
+            and tuple(upgd.key.shape) == ()
+            and jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+                upgd.key.dtype, jax.dtypes.prng_key
+            )
+        ):
+            raise TypeError("state.upgd_state.key must be a scalar typed JAX PRNG key")
+        for name in (
+            "memory_logit",
+            "novelty_log_threshold",
+            "upgd_loss_ema",
+            "memory_loss_ema",
+            "blended_loss_ema",
+            "allocation_ema",
+        ):
+            _require_array(f"state.{name}", getattr(state, name), (), jnp.float32)
+        _require_array("state.step_count", state.step_count, (), jnp.int32)
+
+    def _state_is_valid(self, state: UPGDMemoryState) -> Bool[Array, ""]:
+        return (
+            floating_tree_is_finite(state)
+            & (state.step_count >= 0)
+            & (state.upgd_state.step_count >= 0)
+            & self._memory._state_is_valid(state.memory_state)  # noqa: SLF001
+        )
 
     def init(self, key: Array | None = None) -> UPGDMemoryState:
         """Initialize both components and adaptive blend state."""
         if key is None:
             key = jr.key(0)
+        if not (
+            hasattr(key, "shape")
+            and tuple(key.shape) == ()
+            and jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+                key.dtype, jax.dtypes.prng_key
+            )
+        ):
+            raise TypeError("key must be a scalar typed JAX PRNG key")
         cfg = self._config
+        raw_upgd_state = self._upgd.init(cfg.feature_dim, key)
+        upgd_state = raw_upgd_state.replace(  # type: ignore[attr-defined]
+            birth_timestamp=jnp.asarray(raw_upgd_state.birth_timestamp, dtype=jnp.float32),
+            uptime_s=jnp.asarray(0.0, dtype=jnp.float32),
+        )
         return UPGDMemoryState(
-            upgd_state=self._upgd.init(cfg.feature_dim, key),
+            upgd_state=upgd_state,
             memory_state=self._memory.init(),
             memory_logit=jnp.asarray(cfg.initial_memory_logit, dtype=jnp.float32),
             novelty_log_threshold=jnp.log(
@@ -694,6 +939,8 @@ class UPGDMemoryLearner:
         observation: Float[Array, " feature_dim"],
     ) -> Float[Array, " n_heads"]:
         """Predict with the current learned UPGD-memory blend."""
+        self._validate_state_static_contract(state)
+        _require_array("observation", observation, (self._config.feature_dim,), jnp.float32)
         upgd_prediction = self._upgd.predict(state.upgd_state, observation)
         memory_prediction = self._memory.predict(state.memory_state, observation)
         prediction, _gate = self._blend_predictions(
@@ -712,8 +959,11 @@ class UPGDMemoryLearner:
         target: Float[Array, " n_heads"],
     ) -> UPGDMemoryUpdateResult:
         """Update UPGD, memory, blend reliability, and novelty threshold."""
-        observation_arr = jnp.asarray(observation, dtype=jnp.float32)
-        target_arr = jnp.asarray(target, dtype=jnp.float32)
+        self._validate_state_static_contract(state)
+        _require_array("observation", observation, (self._config.feature_dim,), jnp.float32)
+        _require_array("target", target, (self._config.n_heads,), jnp.float32)
+        observation_arr = jnp.asarray(observation)
+        target_arr = jnp.asarray(target)
         observation_valid = jnp.all(jnp.isfinite(observation_arr))
         target_valid = jnp.all(~jnp.isinf(target_arr))
         safe_observation = jnp.where(
@@ -757,6 +1007,15 @@ class UPGDMemoryLearner:
         upgd_result = self._upgd.update(
             state.upgd_state, safe_observation, safe_update_target
         )
+        safe_upgd_state = upgd_result.state.replace(
+            step_count=(
+                jnp.minimum(
+                    state.upgd_state.step_count,
+                    jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32),
+                )
+                + 1
+            )
+        )
         memory_result = self._memory.update_with_novelty_threshold(
             state.memory_state,
             safe_observation,
@@ -783,7 +1042,7 @@ class UPGDMemoryLearner:
         )
 
         candidate_state = UPGDMemoryState(
-            upgd_state=upgd_result.state,
+            upgd_state=safe_upgd_state,
             memory_state=memory_result.state,
             memory_logit=next_memory_logit,
             novelty_log_threshold=next_log_threshold,
@@ -796,7 +1055,13 @@ class UPGDMemoryLearner:
                 + one_minus_decay * blended_loss
             ),
             allocation_ema=next_allocation_ema,
-            step_count=state.step_count + 1,
+            step_count=(
+                jnp.minimum(
+                    state.step_count,
+                    jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32),
+                )
+                + 1
+            ),
         )
         metrics = jnp.asarray(
             [
@@ -827,7 +1092,7 @@ class UPGDMemoryLearner:
             observation_valid
             & target_valid
             & memory_result.update_applied
-            & floating_tree_is_finite(checked_state)
+            & self._state_is_valid(checked_state)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(prediction))
             & jnp.all(jnp.isfinite(errors))
@@ -854,6 +1119,31 @@ def run_upgd_memory_arrays(
     novelty_threshold, allocation_ema, active_prototypes, upgd_conf,
     memory_conf``.
     """
+    if type(learner) is not UPGDMemoryLearner:
+        raise TypeError("learner must be a UPGDMemoryLearner")
+    learner._validate_state_static_contract(state)  # noqa: SLF001
+    if not hasattr(observations, "shape") or not hasattr(observations, "dtype"):
+        raise TypeError("observations must expose array shape and dtype metadata")
+    if not hasattr(targets, "shape") or not hasattr(targets, "dtype"):
+        raise TypeError("targets must expose array shape and dtype metadata")
+    if len(observations.shape) != 2 or tuple(observations.shape[1:]) != (
+        learner.config.feature_dim,
+    ):
+        raise ValueError(
+            f"observations must have shape (steps, {learner.config.feature_dim})"
+        )
+    steps = int(observations.shape[0])
+    if tuple(targets.shape) != (steps, learner.config.n_heads):
+        raise ValueError(f"targets must have shape ({steps}, {learner.config.n_heads})")
+    if jnp.dtype(observations.dtype) != jnp.dtype(jnp.float32):
+        raise TypeError("observations must have dtype float32")
+    if jnp.dtype(targets.dtype) != jnp.dtype(jnp.float32):
+        raise TypeError("targets must have dtype float32")
+    _require_resource(
+        "UPGD memory batch outputs",
+        float32_scalars=steps * (learner.config.n_heads + 10),
+        bool_scalars=steps,
+    )
 
     def step_fn(
         carry: UPGDMemoryState,

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -233,21 +233,27 @@ def test_upgd_memory_float_validators_accept_valid_values() -> None:
     "field",
     [
         "initial_novelty_threshold",
-        "memory_bandwidth",
         "min_novelty_threshold",
         "max_novelty_threshold",
     ],
 )
-def test_upgd_memory_log_division_fields_require_positive_normal_float32(field: str) -> None:
-    minimum = np.finfo(np.float32).tiny
+def test_upgd_memory_log_fields_require_positive_float32_round_trip(field: str) -> None:
+    minimum = np.float32(2.0) * np.finfo(np.float32).tiny
     overrides = {field: minimum}
     if field == "max_novelty_threshold":
         overrides["min_novelty_threshold"] = minimum
     assert getattr(_base_cfg(**overrides), field) == float(minimum)
     with pytest.raises(ValueError, match=field):
-        _base_cfg(**{field: np.nextafter(np.float32(minimum), np.float32(0.0))})
+        _base_cfg(**{field: np.nextafter(minimum, np.float32(0.0))})
     with pytest.raises(ValueError, match=field):
         _base_cfg(**{field: np.longdouble("1e-500")})
+
+
+def test_upgd_memory_division_field_requires_positive_normal_float32() -> None:
+    minimum = np.finfo(np.float32).tiny
+    assert _base_cfg(memory_bandwidth=minimum).memory_bandwidth == float(minimum)
+    with pytest.raises(ValueError, match="memory_bandwidth"):
+        _base_cfg(memory_bandwidth=np.nextafter(minimum, np.float32(0.0)))
 
 
 def test_upgd_memory_combined_state_count_includes_all_components() -> None:
@@ -380,6 +386,63 @@ def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
             state,
             _RaisingMetadata(),  # type: ignore[arg-type]
             jnp.ones((1, 2), dtype=jnp.float32),
+        )
+
+    class HostileLeaf:
+        @property
+        def shape(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("shape hook")
+
+        def __jax_array__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("JAX conversion must not run")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    malformed = state.replace(memory_logit=HostileLeaf())
+    with pytest.raises(TypeError, match="state.memory_logit"):
+        learner.predict(malformed, jnp.ones((4,), dtype=jnp.float32))
+
+
+def test_upgd_memory_log_and_division_positive_endpoints() -> None:
+    minimum_normal = float(np.finfo(np.float32).tiny)
+    log_endpoint = 2.0 * minimum_normal
+    cfg = _base_cfg(
+        initial_novelty_threshold=log_endpoint,
+        min_novelty_threshold=log_endpoint,
+        memory_bandwidth=minimum_normal,
+    )
+    state = UPGDMemoryLearner(cfg).init()
+    assert bool(jnp.exp(state.novelty_log_threshold) > 0.0)
+    assert cfg.memory_bandwidth == minimum_normal
+
+    adjacent = float(np.nextafter(np.float32(log_endpoint), np.float32(0.0)))
+    with pytest.raises(ValueError, match="log/exp round-trip endpoint"):
+        _base_cfg(initial_novelty_threshold=adjacent)
+    with pytest.raises(ValueError, match="memory_bandwidth"):
+        _base_cfg(memory_bandwidth=float(np.nextafter(np.float32(minimum_normal), 0.0)))
+
+
+def test_upgd_memory_batch_aggregate_preflight_precedes_jax_conversion() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init()
+
+    class OversizedBatch:
+        dtype = np.dtype(np.float32)
+
+        def __init__(self, shape: tuple[int, ...]) -> None:
+            self.shape = shape
+
+        def __jax_array__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("JAX conversion must not run")
+
+    steps = 100_000_000
+    with pytest.raises(ValueError, match="batch aggregate"):
+        run_upgd_memory_arrays(
+            learner,
+            state,
+            OversizedBatch((steps, 4)),  # type: ignore[arg-type]
+            OversizedBatch((steps, 2)),  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.core.upgd_memory import UPGDMemoryConfig
+from alberta_framework.core.upgd_memory import (
+    UPGDMemoryConfig,
+    UPGDMemoryLearner,
+    _combined_state_resource_counts,
+    _require_resource,
+    run_upgd_memory_arrays,
+)
 
 _INT32_MAX = 2**31 - 1
 
@@ -184,10 +192,9 @@ def test_upgd_memory_dimensions_preflight_without_allocation() -> None:
 
 
 def test_upgd_memory_state_preflight_bytes_without_allocation() -> None:
-    # total_means = n_heads*slots*feature_dim, fixed=2*n_heads*slots+9
-    # With n_heads=2, slots var, feature_dim=2 -> total_state=8*slots+9
-    # persistent=32slots+36 -> last_legal=(INT32-36)//32
-    last_legal = (2**31 - 1 - 36) // 32
+    # For F=2,D=2,H=(4,), each slot/class adds 8 four-byte state leaves.
+    # The exact UPGD + wrapper + PRNG/counter fixed state is 68 leaves.
+    last_legal = (2**31 - 1 - 4 * 68) // 32
     _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal)
     with pytest.raises(ValueError, match="scalar count|byte count"):
         _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal + 1)
@@ -206,3 +213,113 @@ def test_upgd_memory_float_validators_accept_valid_values() -> None:
     )
     assert cfg.upgd_step_size == 0.03
     assert cfg.memory_update_rate == 0.3
+
+
+def test_upgd_memory_combined_state_count_includes_all_components() -> None:
+    # F=2,D=2,H=(4,),slots/class=3: 63+6*3 floats, 3+2*3 ints, two key words.
+    assert _combined_state_resource_counts(2, 2, (4,), 3) == (81, 9, 2)
+    with pytest.raises(ValueError, match="combined state.*(scalar|byte) count"):
+        _base_cfg(feature_dim=50_000, hidden_sizes=(50_000,), slots_per_class=1)
+
+
+def test_upgd_memory_resource_endpoint_is_exact_and_allocation_free() -> None:
+    scalar_budget = _INT32_MAX // 4
+    _require_resource("endpoint", float32_scalars=scalar_budget)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_resource("endpoint", float32_scalars=scalar_budget + 1)
+    with pytest.raises(ValueError, match="scalar count"):
+        _require_resource("endpoint", bool_scalars=_INT32_MAX + 1)
+
+
+def test_upgd_memory_serialized_envelopes_are_exact() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    config_payload = learner.config.to_config()
+    learner_payload = learner.to_config()
+    assert UPGDMemoryConfig.from_config(config_payload) == learner.config
+    assert UPGDMemoryLearner.from_config(learner_payload).config == learner.config
+
+    for payload in (
+        {**config_payload, "extra": 1},
+        {key: value for key, value in config_payload.items() if key != "feature_dim"},
+        {**config_payload, "type": "Wrong"},
+        {**config_payload, "feature_dim": np.int32(4)},
+    ):
+        with pytest.raises(ValueError):
+            UPGDMemoryConfig.from_config(payload)
+    with pytest.raises(ValueError):
+        UPGDMemoryLearner.from_config({**learner_payload, "extra": 1})
+
+
+def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init(jax.random.key(0))
+    observation = jnp.ones((4,), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="state.memory_logit must have shape"):
+        learner.predict(
+            state.replace(memory_logit=jnp.zeros((1,), dtype=jnp.float32)),
+            observation,
+        )
+    malformed_upgd = state.upgd_state.replace(  # type: ignore[attr-defined]
+        utilities=(jnp.zeros((4, 3), dtype=jnp.float32),)
+    )
+    with pytest.raises(ValueError, match=r"utilities\[0\].*shape"):
+        learner.predict(state.replace(upgd_state=malformed_upgd), observation)
+
+
+def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init(jax.random.key(0))
+    with pytest.raises(ValueError, match="observation must have shape"):
+        learner.predict(state, jnp.ones((3,), dtype=jnp.float32))
+    with pytest.raises(TypeError, match="observation must have dtype"):
+        learner.predict(state, jnp.ones((4,), dtype=jnp.int32))
+    with pytest.raises(ValueError, match="target must have shape"):
+        learner.update(
+            state,
+            jnp.ones((4,), dtype=jnp.float32),
+            jnp.ones((3,), dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="targets must have shape"):
+        run_upgd_memory_arrays(
+            learner,
+            state,
+            jnp.ones((2, 4), dtype=jnp.float32),
+            jnp.ones((1, 2), dtype=jnp.float32),
+        )
+
+
+def test_upgd_memory_all_lifetime_counters_saturate() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    initial = learner.init(jax.random.key(0))
+    state = initial.replace(
+        upgd_state=initial.upgd_state.replace(  # type: ignore[attr-defined]
+            step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+        ),
+        memory_state=initial.memory_state.replace(  # type: ignore[attr-defined]
+            step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+        ),
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    result = learner.update(
+        state,
+        jnp.ones((4,), dtype=jnp.float32),
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.upgd_state.step_count) == _INT32_MAX
+    assert int(result.state.memory_state.step_count) == _INT32_MAX
+
+
+def test_upgd_memory_negative_adopted_counter_rolls_back() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init(jax.random.key(0)).replace(
+        step_count=jnp.asarray(-1, dtype=jnp.int32)
+    )
+    result = learner.update(
+        state,
+        jnp.ones((4,), dtype=jnp.float32),
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == -1

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -1,0 +1,208 @@
+"""Validation hardening for UPGD memory (int/float bounds + resources)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.upgd_memory import UPGDMemoryConfig
+
+_INT32_MAX = 2**31 - 1
+
+
+class _LyingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        return 2
+
+    def __index__(self) -> int:  # pragma: no cover
+        return 2
+
+
+class _RaisingIntSubclass(int):
+    def __int__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover
+        raise RuntimeError("conversion hook must not run")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _base_cfg(**overrides: object) -> UPGDMemoryConfig:
+    base: dict[str, object] = {
+        "feature_dim": 4,
+        "n_heads": 2,
+        "hidden_sizes": (4,),
+    }
+    base.update(overrides)
+    return UPGDMemoryConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(feature_dim=v),
+        lambda v: _base_cfg(n_heads=v),
+        lambda v: _base_cfg(slots_per_class=v),
+        lambda v: _base_cfg(upgd_head_loss_pressure_warmup_steps=v),
+        lambda v: _base_cfg(upgd_head_repetition_warmup_steps=v),
+    ],
+)
+def test_upgd_memory_int_validators_reject_hostile_subclass_without_running_hook(
+    ctor,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_LyingIntSubclass(4))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        ctor(_RaisingIntSubclass(4))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(feature_dim=v),
+        lambda v: _base_cfg(n_heads=v),
+    ],
+)
+def test_upgd_memory_int_validators_do_not_run_repr_hook(ctor) -> None:
+    with pytest.raises(ValueError):
+        ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_upgd_memory_int_validators_canonicalize_numpy_scalars(
+    np_type: type,
+) -> None:
+    cfg = UPGDMemoryConfig(
+        feature_dim=np_type(4),
+        n_heads=np_type(2),
+        hidden_sizes=(np_type(4),),  # type: ignore[arg-type]
+        slots_per_class=np_type(4),
+        upgd_head_loss_pressure_warmup_steps=np_type(1),
+        upgd_head_repetition_warmup_steps=np_type(1),
+    )
+    assert cfg.feature_dim == 4
+    assert type(cfg.feature_dim) is int
+    assert type(cfg.n_heads) is int
+    assert type(cfg.slots_per_class) is int
+
+
+@pytest.mark.parametrize(
+    "ctor",
+    [
+        lambda v: _base_cfg(feature_dim=v),
+        lambda v: _base_cfg(n_heads=v),
+        lambda v: _base_cfg(slots_per_class=v),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [True, np.bool_(True), 4.0, np.float64(4.0), "4", None, 0, -1, _INT32_MAX + 1],
+)
+def test_upgd_memory_int_validators_reject_non_integer_and_out_of_range(
+    ctor,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be"):
+        ctor(value)  # type: ignore[arg-type]
+
+
+def test_upgd_memory_float_validators_reject_nonfinite_and_hostile() -> None:
+    class HostileFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            raise RuntimeError("untrusted ratio hook executed")
+
+    class ClassSpoof:
+        @property
+        def __class__(self):  # type: ignore[no-untyped-def]
+            return float
+
+        def __float__(self) -> float:  # pragma: no cover
+            return 0.1
+
+    for field, bad in [
+        ("upgd_step_size", float("nan")),
+        ("upgd_step_size", float("inf")),
+        ("upgd_step_size", 0.0),
+        ("upgd_step_size", -1.0),
+        ("upgd_step_size", HostileFloat(0.5)),
+        ("memory_update_rate", -0.1),
+        ("memory_update_rate", 1.5),
+        ("memory_update_rate", ClassSpoof()),  # type: ignore[arg-type]
+        ("memory_bandwidth", 0.0),
+        ("memory_bandwidth", float("nan")),
+        ("initial_novelty_threshold", 0.0),
+        ("reliability_decay", -0.1),
+        ("reliability_decay", 1.0),
+        ("target_trace_blend_scale", -0.1),
+        ("target_trace_blend_scale", 1.5),
+        ("novelty_adaptation_rate", -0.1),
+        ("target_allocation_rate", -0.1),
+        ("target_allocation_rate", 1.5),
+        ("min_novelty_threshold", 0.0),
+        ("max_novelty_threshold", 0.0),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _base_cfg(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_upgd_memory_float_validators_reject_hostile_ratio() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("ratio hook")
+
+    with pytest.raises(ValueError, match="upgd_step_size"):
+        _base_cfg(upgd_step_size=HostileFloat(1.0))  # type: ignore[arg-type]
+    assert HostileFloat.calls == 1
+
+
+def test_upgd_memory_dimensions_preflight_without_allocation() -> None:
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(feature_dim=_INT32_MAX, n_heads=2, slots_per_class=2)
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(feature_dim=50000, n_heads=50000, slots_per_class=50000)
+
+
+def test_upgd_memory_state_preflight_bytes_without_allocation() -> None:
+    # total_means = n_heads*slots*feature_dim, fixed=2*n_heads*slots+9
+    # With n_heads=2, slots var, feature_dim=2 -> total_state=8*slots+9
+    # persistent=32slots+36 -> last_legal=(INT32-36)//32
+    last_legal = (2**31 - 1 - 36) // 32
+    _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal)
+    with pytest.raises(ValueError, match="scalar count|byte count"):
+        _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal + 1)
+    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+        _base_cfg(feature_dim=5000, n_heads=100, slots_per_class=500_000)
+
+
+def test_upgd_memory_float_validators_accept_valid_values() -> None:
+    cfg = _base_cfg(
+        upgd_step_size=0.03,
+        memory_update_rate=0.3,
+        memory_bandwidth=0.01,
+        reliability_decay=0.98,
+        target_trace_blend_scale=0.8,
+        target_allocation_rate=0.18,
+    )
+    assert cfg.upgd_step_size == 0.03
+    assert cfg.memory_update_rate == 0.3

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -42,6 +42,21 @@ class _RaisingRepr:
         raise RuntimeError("repr hook must not run")
 
 
+class _RaisingMetadata:
+    @property
+    def shape(self):  # type: ignore[no-untyped-def]
+        raise RuntimeError("shape hook must not escape")
+
+    @property
+    def dtype(self):  # type: ignore[no-untyped-def]
+        raise RuntimeError("dtype hook must not escape")
+
+
+class _RaisingEquality:
+    def __eq__(self, other: object) -> bool:  # pragma: no cover
+        raise RuntimeError("equality hook must not run")
+
+
 def _base_cfg(**overrides: object) -> UPGDMemoryConfig:
     base: dict[str, object] = {
         "feature_dim": 4,
@@ -290,6 +305,32 @@ def test_upgd_memory_historical_mapping_envelopes_are_safe_and_compatible() -> N
         UPGDMemoryConfig.from_config(
             {"feature_dim": 4, "n_heads": 2, "hidden_sizes": "4"}
         )
+    with pytest.raises(ValueError, match="type marker"):
+        UPGDMemoryConfig.from_config(
+            {"type": _RaisingEquality(), "feature_dim": 4, "n_heads": 2}
+        )
+    with pytest.raises(ValueError, match="type marker"):
+        UPGDMemoryLearner.from_config(
+            {"type": _RaisingEquality(), "config": config_payload}
+        )
+
+
+@pytest.mark.parametrize("implementation", ["rbg", "unsafe_rbg"])
+def test_upgd_memory_requires_exact_threefry_key_resource_contract(
+    implementation: str,
+) -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    incompatible = jax.random.key(0, impl=implementation)
+    with pytest.raises(TypeError, match="threefry2x32"):
+        learner.init(incompatible)
+    state = learner.init(jax.random.key(0))
+    with pytest.raises(TypeError, match="threefry2x32"):
+        learner.predict(
+            state.replace(
+                upgd_state=state.upgd_state.replace(key=incompatible)  # type: ignore[attr-defined]
+            ),
+            jnp.ones((4,), dtype=jnp.float32),
+        )
 
 
 def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
@@ -306,6 +347,11 @@ def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
     )
     with pytest.raises(ValueError, match=r"utilities\[0\].*shape"):
         learner.predict(state.replace(upgd_state=malformed_upgd), observation)
+    with pytest.raises(TypeError, match="valid array shape and dtype metadata"):
+        learner.predict(
+            state.replace(memory_logit=_RaisingMetadata()),  # type: ignore[arg-type]
+            observation,
+        )
 
 
 def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
@@ -326,6 +372,13 @@ def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
             learner,
             state,
             jnp.ones((2, 4), dtype=jnp.float32),
+            jnp.ones((1, 2), dtype=jnp.float32),
+        )
+    with pytest.raises(TypeError, match="observations must expose valid array metadata"):
+        run_upgd_memory_arrays(
+            learner,
+            state,
+            _RaisingMetadata(),  # type: ignore[arg-type]
             jnp.ones((1, 2), dtype=jnp.float32),
         )
 

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -192,13 +195,9 @@ def test_upgd_memory_dimensions_preflight_without_allocation() -> None:
 
 
 def test_upgd_memory_state_preflight_bytes_without_allocation() -> None:
-    # For F=2,D=2,H=(4,), each slot/class adds 8 four-byte state leaves.
-    # The exact UPGD + wrapper + PRNG/counter fixed state is 68 leaves.
-    last_legal = (2**31 - 1 - 4 * 68) // 32
-    _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal)
-    with pytest.raises(ValueError, match="scalar count|byte count"):
-        _base_cfg(feature_dim=2, n_heads=2, slots_per_class=last_legal + 1)
-    with pytest.raises(ValueError, match="dimensions must fit signed|scalar count|byte count"):
+    with pytest.raises(ValueError, match="persistent state"):
+        _base_cfg(feature_dim=2, n_heads=2, slots_per_class=20_000_000)
+    with pytest.raises(ValueError, match="dimensions|scalar|byte|persistent"):
         _base_cfg(feature_dim=5000, n_heads=100, slots_per_class=500_000)
 
 
@@ -215,11 +214,41 @@ def test_upgd_memory_float_validators_accept_valid_values() -> None:
     assert cfg.memory_update_rate == 0.3
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "initial_novelty_threshold",
+        "memory_bandwidth",
+        "min_novelty_threshold",
+        "max_novelty_threshold",
+    ],
+)
+def test_upgd_memory_log_division_fields_require_positive_normal_float32(field: str) -> None:
+    minimum = np.finfo(np.float32).tiny
+    overrides = {field: minimum}
+    if field == "max_novelty_threshold":
+        overrides["min_novelty_threshold"] = minimum
+    assert getattr(_base_cfg(**overrides), field) == float(minimum)
+    with pytest.raises(ValueError, match=field):
+        _base_cfg(**{field: np.nextafter(np.float32(minimum), np.float32(0.0))})
+    with pytest.raises(ValueError, match=field):
+        _base_cfg(**{field: np.longdouble("1e-500")})
+
+
 def test_upgd_memory_combined_state_count_includes_all_components() -> None:
     # F=2,D=2,H=(4,),slots/class=3: 63+6*3 floats, 3+2*3 ints, two key words.
     assert _combined_state_resource_counts(2, 2, (4,), 3) == (81, 9, 2)
     with pytest.raises(ValueError, match="combined state.*(scalar|byte) count"):
         _base_cfg(feature_dim=50_000, hidden_sizes=(50_000,), slots_per_class=1)
+
+
+def test_upgd_memory_combined_resource_formula_matches_materialized_state() -> None:
+    for hidden_sizes in ((), (4,), (3, 5)):
+        learner = UPGDMemoryLearner(_base_cfg(hidden_sizes=hidden_sizes, slots_per_class=3))
+        state = learner.init(jax.random.key(1))
+        measured_bytes = sum(int(leaf.nbytes) for leaf in jax.tree_util.tree_leaves(state))
+        counts = _combined_state_resource_counts(4, 2, hidden_sizes, 3)
+        assert measured_bytes == 4 * sum(counts)
 
 
 def test_upgd_memory_resource_endpoint_is_exact_and_allocation_free() -> None:
@@ -231,23 +260,36 @@ def test_upgd_memory_resource_endpoint_is_exact_and_allocation_free() -> None:
         _require_resource("endpoint", bool_scalars=_INT32_MAX + 1)
 
 
-def test_upgd_memory_serialized_envelopes_are_exact() -> None:
+def test_upgd_memory_historical_mapping_envelopes_are_safe_and_compatible() -> None:
     learner = UPGDMemoryLearner(_base_cfg())
     config_payload = learner.config.to_config()
     learner_payload = learner.to_config()
-    assert UPGDMemoryConfig.from_config(config_payload) == learner.config
-    assert UPGDMemoryLearner.from_config(learner_payload).config == learner.config
+    assert UPGDMemoryConfig.from_config(MappingProxyType(config_payload)) == learner.config
+    assert UPGDMemoryLearner.from_config(MappingProxyType(learner_payload)).config == learner.config
+    partial = UPGDMemoryConfig.from_config(
+        MappingProxyType({"type": "historical", "feature_dim": 4, "n_heads": 2})
+    )
+    assert partial.hidden_sizes == (64,)
+    assert UPGDMemoryConfig.from_config(
+        {"feature_dim": np.int32(4), "n_heads": np.int32(2), "hidden_sizes": ()}
+    ).feature_dim == 4
 
-    for payload in (
-        {**config_payload, "extra": 1},
-        {key: value for key, value in config_payload.items() if key != "feature_dim"},
-        {**config_payload, "type": "Wrong"},
-        {**config_payload, "feature_dim": np.int32(4)},
-    ):
-        with pytest.raises(ValueError):
-            UPGDMemoryConfig.from_config(payload)
-    with pytest.raises(ValueError):
-        UPGDMemoryLearner.from_config({**learner_payload, "extra": 1})
+    class HostileMapping(Mapping):
+        def __getitem__(self, key):  # type: ignore[no-untyped-def]
+            raise RuntimeError("hostile mapping hook")
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("hostile mapping hook")
+
+        def __len__(self) -> int:
+            return 2
+
+    with pytest.raises(ValueError, match="could not be read"):
+        UPGDMemoryConfig.from_config(HostileMapping())
+    with pytest.raises(ValueError, match="list or tuple"):
+        UPGDMemoryConfig.from_config(
+            {"feature_dim": 4, "n_heads": 2, "hidden_sizes": "4"}
+        )
 
 
 def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
@@ -288,6 +330,27 @@ def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
         )
 
 
+def test_upgd_memory_scan_preflights_aggregate_working_set_without_allocation() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init(jax.random.key(0))
+
+    class HugeObservations:
+        shape = (10_000_000, 4)
+        dtype = jnp.float32
+
+    class HugeTargets:
+        shape = (10_000_000, 2)
+        dtype = jnp.float32
+
+    with pytest.raises(ValueError, match="working set"):
+        run_upgd_memory_arrays(
+            learner,
+            state,
+            HugeObservations(),  # type: ignore[arg-type]
+            HugeTargets(),  # type: ignore[arg-type]
+        )
+
+
 def test_upgd_memory_all_lifetime_counters_saturate() -> None:
     learner = UPGDMemoryLearner(_base_cfg())
     initial = learner.init(jax.random.key(0))
@@ -323,3 +386,21 @@ def test_upgd_memory_negative_adopted_counter_rolls_back() -> None:
     )
     assert not bool(result.update_applied)
     assert int(result.state.step_count) == -1
+
+
+def test_upgd_memory_finite_operation_overflow_rolls_back_atomically() -> None:
+    learner = UPGDMemoryLearner(_base_cfg())
+    state = learner.init(jax.random.key(7))
+    result = learner.update(
+        state,
+        jnp.zeros((4,), dtype=jnp.float32),
+        jnp.asarray([np.finfo(np.float32).max, 0.0], dtype=jnp.float32),
+    )
+    assert not bool(result.update_applied)
+    assert jax.tree_util.tree_all(
+        jax.tree_util.tree_map(
+            lambda left, right: jnp.array_equal(left, right),
+            result.state,
+            state,
+        )
+    )


### PR DESCRIPTION
Supersedes #833 while preserving byt61 original commit/authorship. Completes exact hostile-safe scalar/container/Mapping schemas; full nested UPGD + PrototypeMemory + wrapper scalar/byte accounting; 256 MiB persistent/scan bounds; positive-normal log/division sinks; typed Threefry and static state/input metadata gates; and counter/transaction safety. Validation: 209 focused tests; Ruff and full mypy clean. No benchmark or output changes.