### PR TITLE
fix(canonical-upgd): complete config and runtime resource contracts

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -52,7 +52,6 @@ Reference:
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -60,8 +59,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Int
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 UPGDMode = Literal["protecting", "non_protecting"]
 UPGDNormalization = Literal["global", "local"]
@@ -97,6 +99,30 @@ _RAW_GLOBAL_PROFILES = frozenset(
     }
 )
 _INT32_MAX = 2_147_483_647
+_UINT32_MAX = 4_294_967_295
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def _static_zero_scale(scale: float, value: Array) -> Array:
@@ -148,40 +174,48 @@ class CanonicalUPGDConfig:
     epsilon: float = 1e-8
 
     def __post_init__(self) -> None:
-        for name in (
-            "step_size",
-            "utility_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            if isinstance(getattr(self, name), bool):
-                raise ValueError(f"{name} must be numeric, not boolean")
-        if not math.isfinite(self.step_size) or self.step_size <= 0.0:
-            raise ValueError("step_size must be finite and positive")
-        if not math.isfinite(self.utility_decay) or not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be finite and in [0, 1)")
-        if not math.isfinite(self.noise_std) or self.noise_std < 0.0:
-            raise ValueError("noise_std must be finite and non-negative")
-        if not math.isfinite(self.weight_decay) or self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be finite and non-negative")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        # Host domain for decay is [0,1) exact; narrowed 1.0 is tolerated for
+        # continuity with existing lifetime-counter tests (e.g. 0.999999999
+        # rounds to 1.0 in float32 but remains <1.0 as a host ratio).
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar(
+            "noise_std", self.noise_std, lower=0.0
+        )
+        weight_decay = validated_float32_scalar(
+            "weight_decay", self.weight_decay, lower=0.0
+        )
+        epsilon = validated_float32_scalar(
+            "epsilon", self.epsilon, lower=0.0, positive=True
+        )
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "epsilon", epsilon)
         if self.mode not in {"protecting", "non_protecting"}:
-            raise ValueError("mode must be 'protecting' or 'non_protecting'")
+            raise ValueError("mode must be protecting or non_protecting")
         if self.profile not in _SOURCE_PROFILES | {"safe_extended"}:
             raise ValueError(
                 "profile must name a paper, official implementation, or safe_extended profile"
             )
         if self.profile == "safe_extended":
             if self.normalization not in {"global", "local"}:
-                raise ValueError("safe_extended requires normalization='global' or 'local'")
+                raise ValueError("safe_extended requires normalization=global or local")
         else:
             fixed_normalization = "global" if self.profile in _GLOBAL_PROFILES else "local"
             if self.normalization not in {None, fixed_normalization}:
-                raise ValueError(f"{self.profile} fixes normalization={fixed_normalization!r}")
+                raise ValueError(
+                    f"{self.profile} fixes normalization to {fixed_normalization}"
+                )
         if self.profile == "official_readme_global" and self.mode != "protecting":
             raise ValueError("official_readme_global only defines protecting UPGD")
-        if not math.isfinite(self.epsilon) or self.epsilon <= 0.0:
-            raise ValueError("epsilon must be finite and positive")
 
     @property
     def is_source_profile(self) -> bool:
@@ -248,7 +282,7 @@ class CanonicalUPGDConfig:
             raise ValueError("config fields do not match the CanonicalUPGD schema")
         type_name = payload.pop("type")
         if type_name != "CanonicalUPGD":
-            raise ValueError(f"expected CanonicalUPGD config, got {type_name!r}")
+            raise ValueError("expected CanonicalUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 
@@ -752,50 +786,32 @@ class AlbertaAdaUPGDConfig:
             raise ValueError(
                 "profile must be the explicit Alberta-derived AdaUPGD profile"
             )
-        for name in (
-            "step_size",
-            "utility_decay",
-            "second_moment_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be a real number, not boolean")
-            if not math.isfinite(float(value)):
-                raise ValueError(f"{name} must be finite")
-        if self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
-        if not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if not 0.0 <= self.second_moment_decay < 1.0:
-            raise ValueError("second_moment_decay must be in [0, 1)")
-        if self.noise_std < 0.0:
-            raise ValueError("noise_std must be non-negative")
-        if self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be non-negative")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        second_moment_decay = validated_float32_scalar(
+            "second_moment_decay", self.second_moment_decay, lower=0.0
+        )
+        if not 0.0 <= float(second_moment_decay) < 1.0:
+            raise ValueError("second_moment_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
+        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "second_moment_decay", second_moment_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "epsilon", epsilon)
         if self.mode not in {"protecting", "non_protecting"}:
-            raise ValueError("mode must be 'protecting' or 'non_protecting'")
+            raise ValueError("mode must be protecting or non_protecting")
         if self.normalization not in {"global", "local"}:
-            raise ValueError("normalization must be 'global' or 'local'")
-        if self.epsilon <= 0.0:
-            raise ValueError("epsilon must be positive")
-        # Config constants participate in float32 arithmetic.  Reject silent
-        # overflow while preserving ordinary Python numeric spellings.
-        for name in (
-            "step_size",
-            "utility_decay",
-            "second_moment_decay",
-            "noise_std",
-            "weight_decay",
-            "epsilon",
-        ):
-            narrowed = jnp.asarray(getattr(self, name), dtype=jnp.float32)
-            if not bool(jnp.isfinite(narrowed)):
-                raise ValueError(f"{name} must be finite in float32")
-            if float(getattr(self, name)) != 0.0 and float(narrowed) == 0.0:
-                raise ValueError(f"{name} must not underflow in float32")
+            raise ValueError("normalization must be global or local")
 
     @property
     def official_reference_parity(self) -> bool:
@@ -851,7 +867,7 @@ class AlbertaAdaUPGDConfig:
             raise ValueError("config fields do not match the AlbertaAdaUPGD schema")
         type_name = payload.pop("type")
         if type_name != "AlbertaAdaUPGD":
-            raise ValueError(f"expected AlbertaAdaUPGD config, got {type_name!r}")
+            raise ValueError("expected AlbertaAdaUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 
@@ -1532,39 +1548,30 @@ class OfficialAdaUPGDConfig:
             raise ValueError("source_commit must match the pinned AdaptiveUPGD commit")
         if self.source_path != OFFICIAL_ADAUPGD_PATH:
             raise ValueError("source_path must match the pinned AdaptiveUPGD path")
-        for name in (
-            "step_size",
-            "weight_decay",
-            "utility_decay",
-            "noise_std",
-            "beta1",
-            "beta2",
-            "epsilon",
-        ):
-            value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be a real number, not boolean")
-            if not math.isfinite(float(value)):
-                raise ValueError(f"{name} must be finite")
-            narrowed = jnp.asarray(value, dtype=jnp.float32)
-            if not bool(jnp.isfinite(narrowed)):
-                raise ValueError(f"{name} must be finite in float32")
-            if float(value) != 0.0 and float(narrowed) == 0.0:
-                raise ValueError(f"{name} must not underflow in float32")
-        if self.step_size <= 0.0:
-            raise ValueError("step_size must be positive")
-        if self.weight_decay < 0.0:
-            raise ValueError("weight_decay must be non-negative")
-        if not 0.0 <= self.utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if self.noise_std < 0.0:
-            raise ValueError("noise_std must be non-negative")
-        if not 0.0 <= self.beta1 < 1.0:
-            raise ValueError("beta1 must be in [0, 1)")
-        if not 0.0 <= self.beta2 < 1.0:
-            raise ValueError("beta2 must be in [0, 1)")
-        if self.epsilon <= 0.0:
-            raise ValueError("epsilon must be positive")
+        step_size = validated_float32_scalar(
+            "step_size", self.step_size, lower=0.0, positive=True
+        )
+        weight_decay = validated_float32_scalar("weight_decay", self.weight_decay, lower=0.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay", self.utility_decay, lower=0.0
+        )
+        if not 0.0 <= float(utility_decay) < 1.0:
+            raise ValueError("utility_decay must be in [0.0, 1.0)")
+        noise_std = validated_float32_scalar("noise_std", self.noise_std, lower=0.0)
+        beta1 = validated_float32_scalar("beta1", self.beta1, lower=0.0)
+        if not 0.0 <= float(beta1) < 1.0:
+            raise ValueError("beta1 must be in [0.0, 1.0)")
+        beta2 = validated_float32_scalar("beta2", self.beta2, lower=0.0)
+        if not 0.0 <= float(beta2) < 1.0:
+            raise ValueError("beta2 must be in [0.0, 1.0)")
+        epsilon = validated_float32_scalar("epsilon", self.epsilon, lower=0.0, positive=True)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "weight_decay", weight_decay)
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(self, "noise_std", noise_std)
+        object.__setattr__(self, "beta1", beta1)
+        object.__setattr__(self, "beta2", beta2)
+        object.__setattr__(self, "epsilon", epsilon)
 
     @property
     def official_reference_parity(self) -> bool:
@@ -1619,7 +1626,7 @@ class OfficialAdaUPGDConfig:
             raise ValueError("config fields do not match the OfficialAdaUPGD schema")
         type_name = payload.pop("type")
         if type_name != "OfficialAdaUPGD":
-            raise ValueError(f"expected OfficialAdaUPGD config, got {type_name!r}")
+            raise ValueError("expected OfficialAdaUPGD config, got invalid value")
         return cls(**payload)  # type: ignore[arg-type]
 
 

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -52,8 +52,10 @@ Reference:
 
 from __future__ import annotations
 
+import math
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import chex
 import jax
@@ -123,6 +125,83 @@ def _require_float32_resource(
         raise ValueError(f"{name} scalar count must fit signed int32")
     if 4 * total_scalars > _INT32_MAX:
         raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _read_exact_config(
+    name: str,
+    config: object,
+    expected: set[str],
+) -> dict[str, object]:
+    if not issubclass(type(config), Mapping):
+        raise ValueError(f"{name} config must be a mapping")
+    try:
+        payload = dict(cast(Mapping[str, object], config))
+    except Exception as error:
+        raise ValueError(f"{name} config must be a readable mapping") from error
+    if set(payload) != expected:
+        raise ValueError(f"config fields do not match the {name} schema")
+    return payload
+
+
+def _host_float_tree_contract(
+    name: str,
+    tree: Any,
+    *,
+    persistent_copies: int,
+    working_copies: int,
+) -> tuple[list[Array], jax.tree_util.PyTreeDef]:
+    """Validate array metadata and aggregate resources before JAX materialization."""
+    leaves, structure = _flatten_with_none(tree)
+    if not leaves or any(value is None for value in leaves):
+        raise ValueError(f"{name} must contain at least one array leaf")
+    arrays: list[Array] = []
+    scalar_count = 0
+    input_bytes = 0
+    for value in leaves:
+        try:
+            shape = tuple(value.shape)
+            dtype = np.dtype(value.dtype)
+        except Exception as error:
+            raise ValueError(f"every {name} leaf must expose array metadata") from error
+        if not np.issubdtype(dtype, np.floating):
+            raise ValueError(f"{name} leaves must have floating-point dtype")
+        if any(type(dimension) is not int or dimension < 0 for dimension in shape):
+            raise ValueError(f"every {name} leaf must have a valid concrete shape")
+        leaf_scalars = math.prod(shape)
+        if leaf_scalars > _INT32_MAX:
+            raise ValueError(f"{name} leaf scalar count must fit signed int32")
+        scalar_count += leaf_scalars
+        input_bytes += leaf_scalars * dtype.itemsize
+        arrays.append(cast(Array, value))
+    aggregate_scalars = (persistent_copies + working_copies) * scalar_count + 32
+    aggregate_bytes = (
+        input_bytes
+        + persistent_copies * input_bytes
+        + working_copies * input_bytes
+        + 4 * scalar_count
+        + 128
+    )
+    if aggregate_scalars > _INT32_MAX or aggregate_bytes > _INT32_MAX:
+        raise ValueError(f"{name} aggregate state/update resources exceed signed-int32 bounds")
+    return arrays, structure
+
+
+def _matching_array_leaf(
+    name: str,
+    value: object,
+    parameter: Array,
+    *,
+    dtype: Any | None = None,
+) -> Array:
+    try:
+        shape = tuple(value.shape)  # type: ignore[attr-defined]
+        actual_dtype = np.dtype(value.dtype)  # type: ignore[attr-defined]
+    except Exception as error:
+        raise ValueError(f"{name} must expose array shape and dtype metadata") from error
+    expected_dtype = np.dtype(parameter.dtype if dtype is None else dtype)
+    if shape != tuple(parameter.shape) or actual_dtype != expected_dtype:
+        raise ValueError(f"{name} must match its parameter shape and dtype")
+    return cast(Array, value)
 
 
 def _static_zero_scale(scale: float, value: Array) -> Array:
@@ -263,10 +342,9 @@ class CanonicalUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> CanonicalUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> CanonicalUPGDConfig:
         """Strictly reconstruct from the complete serialized schema."""
 
-        payload = dict(config)
         expected = {
             "type",
             "step_size",
@@ -278,12 +356,16 @@ class CanonicalUPGDConfig:
             "normalization",
             "epsilon",
         }
-        if set(payload) != expected:
-            raise ValueError("config fields do not match the CanonicalUPGD schema")
+        payload = _read_exact_config("CanonicalUPGD", config, expected)
         type_name = payload.pop("type")
         if type_name != "CanonicalUPGD":
             raise ValueError("expected CanonicalUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)  # type: ignore[arg-type]
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized CanonicalUPGD config is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -366,7 +448,7 @@ class CanonicalUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> CanonicalUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> CanonicalUPGD:
         """Reconstruct an optimizer from serialized configuration."""
 
         return cls(CanonicalUPGDConfig.from_config(config))
@@ -374,13 +456,9 @@ class CanonicalUPGD:
     def init(self, params: Any) -> CanonicalUPGDState:
         """Initialize signed-utility traces matching ``params``."""
 
-        leaves = jax.tree_util.tree_leaves(params)
-        if not leaves:
-            raise ValueError("params must contain at least one array leaf")
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("UPGD parameters must have floating-point dtype")
+        _host_float_tree_contract(
+            "params", params, persistent_copies=2, working_copies=20
+        )
 
         return CanonicalUPGDState(  # type: ignore[call-arg]
             utility_ema=jax.tree.map(jnp.zeros_like, params),
@@ -424,13 +502,37 @@ class CanonicalUPGD:
         branch excludes the numerical proposal from reverse-mode
         differentiation, preserving the same identity boundary there.
         """
-
-        param_leaves, structure = _flatten_with_none(params)
+        if type(state) is not CanonicalUPGDState:
+            raise ValueError("state must be a CanonicalUPGDState")
+        param_leaves, structure = _host_float_tree_contract(
+            "params", params, persistent_copies=2, working_copies=20
+        )
         grad_leaves, grad_structure = _flatten_with_none(gradients)
         utility_leaves, utility_structure = _flatten_with_none(state.utility_ema)
         age_leaves, age_structure = _flatten_with_none(state.utility_age)
         if not (structure == grad_structure == utility_structure == age_structure):
             raise ValueError("params, gradients, and UPGD state must share a PyTree structure")
+        for param, utility, age in zip(
+            param_leaves, utility_leaves, age_leaves, strict=True
+        ):
+            try:
+                utility_shape = tuple(utility.shape)
+                utility_dtype = np.dtype(utility.dtype)
+                age_shape = tuple(age.shape)
+                age_dtype = np.dtype(age.dtype)
+            except Exception as error:
+                raise ValueError("UPGD state leaves must expose array metadata") from error
+            if utility_shape != param.shape or utility_dtype != np.dtype(param.dtype):
+                raise ValueError("utility state leaves must match parameter shape and dtype")
+            if age_shape != param.shape or age_dtype != np.dtype(np.int32):
+                raise ValueError("utility ages must match parameter shape and use int32")
+        try:
+            step_shape = tuple(state.step.shape)
+            step_dtype = np.dtype(state.step.dtype)
+        except Exception as error:
+            raise ValueError("state.step must expose array metadata") from error
+        if step_shape != () or step_dtype != np.dtype(np.int32):
+            raise ValueError("state.step must be one scalar int32 array")
 
         if self._config.is_source_profile and mask is not None:
             raise ValueError("source profiles do not accept masks")
@@ -845,12 +947,9 @@ class AlbertaAdaUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> AlbertaAdaUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> AlbertaAdaUPGDConfig:
         """Strictly reconstruct the adaptive extension configuration."""
 
-        if type(config) is not dict:
-            raise TypeError("AlbertaAdaUPGD config must be an exact dict")
-        payload = dict(config)
         expected = {
             "type",
             "profile",
@@ -863,12 +962,16 @@ class AlbertaAdaUPGDConfig:
             "normalization",
             "epsilon",
         }
-        if set(payload) != expected:
-            raise ValueError("config fields do not match the AlbertaAdaUPGD schema")
+        payload = _read_exact_config("AlbertaAdaUPGD", config, expected)
         type_name = payload.pop("type")
         if type_name != "AlbertaAdaUPGD":
             raise ValueError("expected AlbertaAdaUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)  # type: ignore[arg-type]
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized AlbertaAdaUPGD config is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -986,23 +1089,16 @@ class AlbertaAdaUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> AlbertaAdaUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> AlbertaAdaUPGD:
         """Reconstruct the optimizer from its strict configuration."""
 
         return cls(AlbertaAdaUPGDConfig.from_config(config))
 
     @staticmethod
     def _parameter_contract(params: Any) -> tuple[list[Array], jax.tree_util.PyTreeDef]:
-        leaves, structure = _flatten_with_none(params)
-        if not leaves or any(value is None for value in leaves):
-            raise ValueError("params must contain at least one array leaf")
-        arrays: list[Array] = []
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("AlbertaAdaUPGD parameters must have floating-point dtype")
-            arrays.append(array)
-        return arrays, structure
+        return _host_float_tree_contract(
+            "AlbertaAdaUPGD params", params, persistent_copies=3, working_copies=30
+        )
 
     @staticmethod
     def _state_contract(
@@ -1015,8 +1111,8 @@ class AlbertaAdaUPGD:
         list[Array],
         jax.tree_util.PyTreeDef,
     ]:
-        if not isinstance(state, AlbertaAdaUPGDState):
-            raise TypeError("state must be an AlbertaAdaUPGDState")
+        if type(state) is not AlbertaAdaUPGDState:
+            raise ValueError("state must be an AlbertaAdaUPGDState")
         param_leaves, structure = AlbertaAdaUPGD._parameter_contract(params)
         utility_leaves, utility_structure = _flatten_with_none(state.utility_ema)
         age_leaves, age_structure = _flatten_with_none(state.utility_age)
@@ -1037,23 +1133,21 @@ class AlbertaAdaUPGD:
             moment_leaves,
             strict=True,
         ):
-            utility_array = jnp.asarray(utility)
-            age_array = jnp.asarray(age)
-            moment_array = jnp.asarray(moment)
-            if utility_array.shape != param.shape or moment_array.shape != param.shape:
-                raise ValueError("every adaptive state leaf must match its parameter shape")
-            if age_array.shape != param.shape:
-                raise ValueError("every utility-age leaf must match its parameter shape")
-            if utility_array.dtype != param.dtype or moment_array.dtype != param.dtype:
-                raise TypeError("utility and second-moment dtypes must match parameters")
-            if age_array.dtype != jnp.int32:
-                raise TypeError("utility-age leaves must have int32 dtype")
+            utility_array = _matching_array_leaf("utility state leaf", utility, param)
+            age_array = _matching_array_leaf(
+                "utility-age state leaf", age, param, dtype=np.int32
+            )
+            moment_array = _matching_array_leaf("second-moment state leaf", moment, param)
             utilities.append(utility_array)
             ages.append(age_array)
             moments.append(moment_array)
-        step = jnp.asarray(state.step)
-        if step.shape != () or step.dtype != jnp.int32:
-            raise TypeError("state.step must be one scalar int32 array")
+        try:
+            step_shape = tuple(state.step.shape)
+            step_dtype = np.dtype(state.step.dtype)
+        except Exception as error:
+            raise ValueError("state.step must expose array metadata") from error
+        if step_shape != () or step_dtype != np.dtype(np.int32):
+            raise ValueError("state.step must be one scalar int32 array")
         return param_leaves, utilities, ages, moments, structure
 
     def init(self, params: Any) -> AlbertaAdaUPGDState:
@@ -1603,12 +1697,9 @@ class OfficialAdaUPGDConfig:
         }
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> OfficialAdaUPGDConfig:
+    def from_config(cls, config: Mapping[str, object]) -> OfficialAdaUPGDConfig:
         """Strictly reconstruct the pinned official profile."""
 
-        if type(config) is not dict:
-            raise TypeError("OfficialAdaUPGD config must be an exact dict")
-        payload = dict(config)
         expected = {
             "type",
             "profile",
@@ -1622,12 +1713,16 @@ class OfficialAdaUPGDConfig:
             "beta2",
             "epsilon",
         }
-        if set(payload) != expected:
-            raise ValueError("config fields do not match the OfficialAdaUPGD schema")
+        payload = _read_exact_config("OfficialAdaUPGD", config, expected)
         type_name = payload.pop("type")
         if type_name != "OfficialAdaUPGD":
             raise ValueError("expected OfficialAdaUPGD config, got invalid value")
-        return cls(**payload)  # type: ignore[arg-type]
+        try:
+            return cls(**payload)  # type: ignore[arg-type]
+        except ValueError:
+            raise
+        except Exception as error:
+            raise ValueError("serialized OfficialAdaUPGD config is invalid") from error
 
 
 @chex.dataclass(frozen=True)
@@ -1712,23 +1807,16 @@ class OfficialAdaUPGD:
         return self._config.to_config()
 
     @classmethod
-    def from_config(cls, config: dict[str, object]) -> OfficialAdaUPGD:
+    def from_config(cls, config: Mapping[str, object]) -> OfficialAdaUPGD:
         """Reconstruct the transform from a strict source-bound config."""
 
         return cls(OfficialAdaUPGDConfig.from_config(config))
 
     @staticmethod
     def _parameter_contract(params: Any) -> tuple[list[Array], jax.tree_util.PyTreeDef]:
-        leaves, structure = _flatten_with_none(params)
-        if not leaves or any(value is None for value in leaves):
-            raise ValueError("params must contain at least one array leaf")
-        arrays: list[Array] = []
-        for value in leaves:
-            array = jnp.asarray(value)
-            if not jnp.issubdtype(array.dtype, jnp.floating):
-                raise ValueError("OfficialAdaUPGD parameters must have floating-point dtype")
-            arrays.append(array)
-        return arrays, structure
+        return _host_float_tree_contract(
+            "OfficialAdaUPGD params", params, persistent_copies=3, working_copies=30
+        )
 
     @staticmethod
     def _state_contract(
@@ -1741,8 +1829,8 @@ class OfficialAdaUPGD:
         list[Array],
         jax.tree_util.PyTreeDef,
     ]:
-        if not isinstance(state, OfficialAdaUPGDState):
-            raise TypeError("state must be an OfficialAdaUPGDState")
+        if type(state) is not OfficialAdaUPGDState:
+            raise ValueError("state must be an OfficialAdaUPGDState")
         param_leaves, structure = OfficialAdaUPGD._parameter_contract(params)
         utility_leaves, utility_structure = _flatten_with_none(state.utility_ema)
         first_leaves, first_structure = _flatten_with_none(state.first_moment)
@@ -1761,27 +1849,19 @@ class OfficialAdaUPGD:
             second_leaves,
             strict=True,
         ):
-            utility_array = jnp.asarray(utility)
-            first_array = jnp.asarray(first)
-            second_array = jnp.asarray(second)
-            if (
-                utility_array.shape != param.shape
-                or first_array.shape != param.shape
-                or second_array.shape != param.shape
-            ):
-                raise ValueError("every official AdaUPGD state leaf must match its parameter shape")
-            if (
-                utility_array.dtype != param.dtype
-                or first_array.dtype != param.dtype
-                or second_array.dtype != param.dtype
-            ):
-                raise TypeError("official AdaUPGD state dtypes must match parameters")
+            utility_array = _matching_array_leaf("utility state leaf", utility, param)
+            first_array = _matching_array_leaf("first-moment state leaf", first, param)
+            second_array = _matching_array_leaf("second-moment state leaf", second, param)
             utilities.append(utility_array)
             first_moments.append(first_array)
             second_moments.append(second_array)
-        step = jnp.asarray(state.step)
-        if step.shape != () or step.dtype != jnp.int32:
-            raise TypeError("state.step must be one scalar int32 array")
+        try:
+            step_shape = tuple(state.step.shape)
+            step_dtype = np.dtype(state.step.dtype)
+        except Exception as error:
+            raise ValueError("state.step must expose array metadata") from error
+        if step_shape != () or step_dtype != np.dtype(np.int32):
+            raise ValueError("state.step must be one scalar int32 array")
         return param_leaves, utilities, first_moments, second_moments, structure
 
     def init(self, params: Any) -> OfficialAdaUPGDState:

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
 from typing import Any
 
 import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.core.canonical_upgd import (
+    AlbertaAdaUPGD,
     AlbertaAdaUPGDConfig,
+    CanonicalUPGD,
     CanonicalUPGDConfig,
+    OfficialAdaUPGD,
     OfficialAdaUPGDConfig,
     _require_float32_resource,
 )
@@ -356,3 +362,55 @@ def test_resource_helper_allocation_free_boundaries() -> None:
     _require_float32_resource("test", vector_scalars=legal_scalars - 5, fixed_scalars=5)
     with pytest.raises(ValueError, match="byte count"):
         _require_float32_resource("test", vector_scalars=legal_scalars, fixed_scalars=1)
+
+
+def test_parameter_resources_are_preflighted_by_all_production_initializers() -> None:
+    class OversizedLeaf:
+        shape = (30_000_000,)
+        dtype = np.dtype(np.float32)
+
+        def __jax_array__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("JAX conversion must not run")
+
+    params = {"w": OversizedLeaf()}
+    for optimizer in (CanonicalUPGD(), AlbertaAdaUPGD(), OfficialAdaUPGD()):
+        with pytest.raises(ValueError, match="aggregate state/update resources"):
+            optimizer.init(params)
+
+
+def test_state_metadata_is_checked_without_conversion_or_hostile_repr() -> None:
+    class HostileLeaf:
+        @property
+        def shape(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("shape hook")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    params = {"w": jnp.ones(2, dtype=jnp.float32)}
+    gradients = {"w": jnp.ones(2, dtype=jnp.float32)}
+    optimizer = AlbertaAdaUPGD()
+    state = optimizer.init(params).replace(utility_ema={"w": HostileLeaf()})
+    with pytest.raises(ValueError, match="utility state leaf"):
+        optimizer.update(state, params, gradients, jr.key(0))
+
+
+def test_config_loaders_accept_mapping_and_normalize_unreadable_hooks() -> None:
+    config = CanonicalUPGDConfig().to_config()
+    assert CanonicalUPGDConfig.from_config(MappingProxyType(config)).to_config() == config
+
+    class HostileMapping(Mapping[str, object]):
+        def __iter__(self) -> Iterator[str]:
+            raise RuntimeError("mapping hook")
+
+        def __len__(self) -> int:
+            return len(config)
+
+        def __getitem__(self, key: str) -> object:
+            return config[key]
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+    with pytest.raises(ValueError, match="readable mapping"):
+        CanonicalUPGDConfig.from_config(HostileMapping())

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -1,0 +1,358 @@
+"""Focused validation for canonical UPGD configs — hostile-safe and float32."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.canonical_upgd import (
+    AlbertaAdaUPGDConfig,
+    CanonicalUPGDConfig,
+    OfficialAdaUPGDConfig,
+    _require_float32_resource,
+)
+
+_INT32_MAX = 2_147_483_647
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        type(self).calls += 1
+        raise RuntimeError("untrusted ratio hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _RaisingRepr:
+    def __float__(self) -> float:  # pragma: no cover
+        return 1.0
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _ClassSpoof:
+    @property
+    def __class__(self) -> type:
+        return float  # type: ignore[return-value]
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+def _canon(**overrides: Any) -> CanonicalUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "profile": "safe_extended",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    base.update(overrides)
+    return CanonicalUPGDConfig(**base)
+
+
+def _alberta(**overrides: Any) -> AlbertaAdaUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "second_moment_decay": 0.9,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    base.update(overrides)
+    return AlbertaAdaUPGDConfig(**base)
+
+
+def _official(**overrides: Any) -> OfficialAdaUPGDConfig:
+    base: dict[str, Any] = {
+        "step_size": 1e-5,
+        "weight_decay": 0.001,
+        "utility_decay": 0.999,
+        "noise_std": 0.001,
+        "beta1": 0.9,
+        "beta2": 0.999,
+        "epsilon": 1e-5,
+    }
+    base.update(overrides)
+    return OfficialAdaUPGDConfig(**base)
+
+
+def test_canonical_validators_accept_valid_values() -> None:
+    cfg = _canon()
+    assert cfg.step_size == pytest.approx(1e-3)
+    assert cfg.utility_decay == pytest.approx(0.5)
+    # float32 canonicalization check
+    assert jnp.isfinite(jnp.asarray(cfg.step_size, dtype=jnp.float32))
+
+
+def test_alberta_validators_accept_valid_values() -> None:
+    cfg = _alberta()
+    assert cfg.second_moment_decay == pytest.approx(0.9)
+    assert jnp.isfinite(jnp.asarray(cfg.epsilon, dtype=jnp.float32))
+
+
+def test_official_validators_accept_valid_values() -> None:
+    cfg = _official()
+    assert cfg.beta1 == pytest.approx(0.9)
+    assert jnp.isfinite(jnp.asarray(cfg.step_size, dtype=jnp.float32))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "utility_decay", "noise_std", "weight_decay", "epsilon"],
+)
+def test_canonical_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _canon(**{field: bad})
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "utility_decay", "second_moment_decay", "noise_std", "weight_decay", "epsilon"],
+)
+def test_alberta_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _alberta(**{field: bad})
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["step_size", "weight_decay", "utility_decay", "noise_std", "beta1", "beta2", "epsilon"],
+)
+def test_official_rejects_bool_and_spoof(field: str) -> None:
+    for bad in (True, np.bool_(True), _ClassSpoof()):
+        with pytest.raises((ValueError, TypeError), match="must be"):
+            _official(**{field: bad})
+
+
+def test_canonical_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _canon(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_alberta_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _alberta(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_official_hostile_ratio_is_caught_and_counts_once() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="must be a finite real"):
+        _official(step_size=_HostileFloat(1.0))
+    assert _HostileFloat.calls == 1
+
+
+def test_hostile_repr_is_not_executed_for_float_fields() -> None:
+    # validated_float32_scalar must not interpolate !r
+    for bad in (_RaisingRepr(),):
+        # Canonical uses validated helper which should not call __repr__
+        try:
+            _canon(step_size=bad)  # type: ignore
+        except ValueError:
+            pass
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("should have raised")
+        # if repr had been called, AssertionError from __repr__ would propagate
+
+
+def test_canonical_domain_rejects_invalid_ranges() -> None:
+    # step_size must be positive
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=-1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=float("inf"))
+    with pytest.raises(ValueError, match="must be"):
+        _canon(step_size=float("nan"))
+    # utility_decay must be in [0,1)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _canon(utility_decay=-0.1)
+    # epsilon must be positive
+    with pytest.raises(ValueError, match="must be"):
+        _canon(epsilon=0.0)
+    # noise_std must be >=0
+    with pytest.raises(ValueError, match="must be"):
+        _canon(noise_std=-0.1)
+
+
+def test_alberta_domain_rejects_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(second_moment_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(epsilon=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _alberta(noise_std=-1.0)
+
+
+def test_official_domain_rejects_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="must be"):
+        _official(step_size=0.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(utility_decay=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(beta1=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(beta2=1.0)
+    with pytest.raises(ValueError, match="must be"):
+        _official(epsilon=0.0)
+
+
+def test_float32_overflow_is_rejected() -> None:
+    # 1e40 is finite in host float64 but overflows float32 -> inf
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _canon(step_size=1e40)
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _alberta(step_size=1e40)
+    with pytest.raises(ValueError, match="must remain finite once narrowed"):
+        _official(step_size=1e40)
+
+
+def test_float32_underflow_is_rejected_for_positive() -> None:
+    # tiny positive that underflows float32 to 0.0 while host is non-zero
+    tiny = 1e-50  # way below float32 subnormal, rounds to 0.0
+    # only positive fields should reject underflow
+    with pytest.raises(ValueError, match="must remain"):
+        _canon(step_size=tiny)
+    with pytest.raises(ValueError, match="must remain"):
+        _canon(epsilon=tiny)
+
+
+def test_config_string_validators_reject_invalid_and_hostile_repr() -> None:
+    # mode must be protecting/non_protecting without !r
+    class BadRepr:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    with pytest.raises(ValueError, match="mode must be"):
+        _canon(mode="bad")  # type: ignore
+    # normalization
+    with pytest.raises(ValueError, match="normalization"):
+        _canon(normalization="bad")  # type: ignore
+    # profile
+    with pytest.raises(ValueError, match="profile must"):
+        _canon(profile="bad")  # type: ignore
+    # ensure hostile repr in mode string does not call repr
+    # mode string compare does not call repr
+    bad = BadRepr()
+    # pass bad object as mode; comparison calls __eq__, not __repr__
+    with pytest.raises(ValueError):
+        _canon(mode=bad)  # type: ignore
+
+
+def test_from_config_hostile_repr_not_executed() -> None:
+    # canonical from_config previously used !r for type_name
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "profile": "safe_extended",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    with pytest.raises(ValueError, match="expected CanonicalUPGD"):
+        CanonicalUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_alberta_from_config_hostile_repr_not_executed() -> None:
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "profile": "alberta_derived_first_order_adaptive_v1",
+        "step_size": 1e-3,
+        "utility_decay": 0.5,
+        "second_moment_decay": 0.9,
+        "noise_std": 1e-3,
+        "weight_decay": 0.0,
+        "mode": "protecting",
+        "normalization": "global",
+        "epsilon": 1e-8,
+    }
+    with pytest.raises(ValueError, match="expected AlbertaAdaUPGD"):
+        AlbertaAdaUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_official_from_config_hostile_repr_not_executed() -> None:
+    class HostileType:
+        def __repr__(self) -> str:
+            raise AssertionError("repr executed")
+
+    payload = {
+        "type": HostileType(),  # type: ignore
+        "profile": "official_rl_adaptive_upgd_b75e90a",
+        "source_commit": "b75e90ad4b09c28971ac9dbb902a8fd86709b28c",
+        "source_path": "core/run/rl/adaupgd.py",
+        "step_size": 1e-5,
+        "weight_decay": 0.001,
+        "utility_decay": 0.999,
+        "noise_std": 0.001,
+        "beta1": 0.9,
+        "beta2": 0.999,
+        "epsilon": 1e-5,
+    }
+    with pytest.raises(ValueError, match="expected OfficialAdaUPGD"):
+        OfficialAdaUPGDConfig.from_config(payload)  # type: ignore
+
+
+def test_canonical_normalization_fixed_by_profile() -> None:
+    # paper_global fixes normalization to global, passing local should fail
+    with pytest.raises(ValueError, match="fixes normalization"):
+        _canon(profile="paper_global", normalization="local")  # type: ignore
+    # official_experiment_local fixes to local
+    with pytest.raises(ValueError, match="fixes normalization"):
+        _canon(profile="official_experiment_local", normalization="global")  # type: ignore
+    # safe_extended allows explicit global/local
+    _canon(profile="safe_extended", normalization="global")
+    _canon(profile="safe_extended", normalization="local")
+
+
+def test_resource_helper_allocation_free_boundaries() -> None:
+    legal_scalars = _INT32_MAX // 4
+    # scalar count must fit signed int32
+    _require_float32_resource("test", vector_scalars=legal_scalars)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
+    # byte count must fit signed int32 (4*scalars)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=legal_scalars + 1)
+    # combined vector + fixed
+    _require_float32_resource("test", vector_scalars=legal_scalars - 5, fixed_scalars=5)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource("test", vector_scalars=legal_scalars, fixed_scalars=1)


### PR DESCRIPTION
Supersedes #851 while preserving its scalar-validation commit. Retains hostile-safe float32 canonicalization for CanonicalUPGD, AlbertaAdaUPGD, and OfficialAdaUPGD, then connects the formerly test-only resource work to production: every init/update validates concrete host leaf metadata before JAX materialization; aggregate parameter, persistent-state, result, and conservative worst-case working trees are bounded in signed-int32 scalar/byte domains; adaptive and official state leaves are exact shape/dtype matched without coercion; and complete Mapping schemas normalize unreadable hooks and constructor failures without hostile repr. Adds production oversized non-conversion, hostile state metadata, and Mapping regressions. Verification on rebased latest main: 133 full canonical/Ada tests passed; post-rebase 39 validation tests passed; Ruff clean; strict mypy 168 files clean; diff-check clean. No outputs or registered evidence source changed.