### PR TITLE
fix(world-model): retain frozen zero-step endpoint

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -279,7 +279,7 @@ class ActionConditionedWorldModelConfig:
         scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
             ("gamma", {"lower": 0.0, "upper": 1.0}),
             ("reward_scale", {"positive": True}),
-            ("step_size", {"positive": True}),
+            ("step_size", {"lower": 0.0}),
             ("sparsity", {"lower": 0.0, "upper": 1.0}),
             ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
             ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
@@ -1104,7 +1104,7 @@ class WorldModelConfig:
         for name in ("use_layer_norm", "predict_delta"):
             object.__setattr__(self, name, _require_bool(name, getattr(self, name)))
         scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
-            ("step_size", {"positive": True}),
+            ("step_size", {"lower": 0.0}),
             ("sparsity", {"lower": 0.0, "upper": 1.0}),
             ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
             ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -577,7 +577,7 @@ def test_config_canonicalizes_numpy_integer_family_and_complete_scalars() -> Non
 @pytest.mark.parametrize(
     "overrides",
     [
-        {"step_size": 0.0},
+        {"step_size": -0.01},
         {"sparsity": -0.1},
         {"sparsity": 1.1},
         {"leaky_relu_slope": -0.1},
@@ -592,6 +592,16 @@ def test_config_rejects_invalid_complete_public_fields(overrides: dict[str, obje
         ActionConditionedWorldModelConfig(
             observation_dim=2, n_actions=2, **overrides  # type: ignore[arg-type]
         )
+
+
+def test_config_preserves_zero_step_size_for_frozen_models() -> None:
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        hidden_sizes=(),
+        step_size=0.0,
+    )
+    assert config.step_size == 0.0
 
 
 def test_config_preflights_derived_dimensions_and_state() -> None:

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -347,7 +347,7 @@ def test_world_model_config_validates_all_public_fields_and_resources() -> None:
         {"n_actions": 2.5},
         {"action_dim": False},
         {"hidden_sizes": [4]},
-        {"step_size": 0.0},
+        {"step_size": -0.01},
         {"sparsity": float("nan")},
         {"leaky_relu_slope": 1.1},
         {"use_layer_norm": np.bool_(True)},
@@ -359,6 +359,9 @@ def test_world_model_config_validates_all_public_fields_and_resources() -> None:
 
     with pytest.raises(ValueError, match="combined_direct_state_bytes"):
         WorldModelConfig(observation_dim=20_000, n_actions=2, hidden_sizes=())
+
+    frozen = WorldModelConfig(observation_dim=2, hidden_sizes=(), step_size=0.0)
+    assert frozen.step_size == 0.0
 
 
 def test_world_model_config_deserialization_preserves_sequence_compatibility() -> None:


### PR DESCRIPTION
Repairs the current-main contract regression exposed when #881 restored complete test collection. Step 9 intentionally permits `model_step_size == 0` to freeze model learning, but #837 made both nested core world-model configs reject that endpoint.

- restore nonnegative step-size validation in direct and action-conditioned world models
- retain rejection of negative values
- add explicit frozen-model endpoint coverage

Validation:
- exact three CI failures pass on the repaired contract
- 275 complete world-model / action-conditioned / Step 9 / discount tests pass
- Ruff and mypy pass
- diff check passes