### PR TITLE
fix(world-model): preserve exact zero learning rates

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -28,7 +28,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.multi_head_learner import (
     AnyOptimizer,
     MultiHeadMLPLearner,
@@ -89,6 +92,20 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
+
+
+def _validated_step_size(name: str, value: object) -> float:
+    """Accept an exact zero freeze without silently underflowing learning to zero."""
+    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name, value, lower=0.0
+    )
+    # Values at or below half the smallest binary32 subnormal round to zero
+    # (the exact halfway case ties to the even zero significand).
+    if numerator > 0 and numerator * (1 << 150) <= denominator:
+        raise ValueError(f"{name} must remain positive once narrowed to float32 or be exact zero")
+    return stored
 
 
 def _validate_hidden_sizes(value: object) -> tuple[int, ...]:
@@ -279,7 +296,6 @@ class ActionConditionedWorldModelConfig:
         scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
             ("gamma", {"lower": 0.0, "upper": 1.0}),
             ("reward_scale", {"positive": True}),
-            ("step_size", {"positive": True}),
             ("sparsity", {"lower": 0.0, "upper": 1.0}),
             ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
             ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
@@ -291,6 +307,7 @@ class ActionConditionedWorldModelConfig:
         object.__setattr__(self, "n_actions", n_actions)
         object.__setattr__(self, "hidden_sizes", hidden_sizes)
         object.__setattr__(self, "observation_scale", observation_scale)
+        object.__setattr__(self, "step_size", _validated_step_size("step_size", self.step_size))
         for name, bounds in scalar_specs:
             object.__setattr__(
                 self,
@@ -1104,7 +1121,6 @@ class WorldModelConfig:
         for name in ("use_layer_norm", "predict_delta"):
             object.__setattr__(self, name, _require_bool(name, getattr(self, name)))
         scalar_specs: tuple[tuple[str, dict[str, Any]], ...] = (
-            ("step_size", {"positive": True}),
             ("sparsity", {"lower": 0.0, "upper": 1.0}),
             ("leaky_relu_slope", {"lower": 0.0, "upper": 1.0}),
             ("utility_decay", {"lower": 0.0, "upper": 1.0, "upper_inclusive": False}),
@@ -1113,6 +1129,7 @@ class WorldModelConfig:
         object.__setattr__(self, "n_actions", n_actions)
         object.__setattr__(self, "action_dim", action_dim)
         object.__setattr__(self, "hidden_sizes", hidden_sizes)
+        object.__setattr__(self, "step_size", _validated_step_size("step_size", self.step_size))
         for name, bounds in scalar_specs:
             object.__setattr__(
                 self,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -574,10 +574,18 @@ def test_config_canonicalizes_numpy_integer_family_and_complete_scalars() -> Non
     )
 
 
+def test_config_accepts_exact_zero_step_size_but_rejects_float32_underflow() -> None:
+    assert ActionConditionedWorldModelConfig(
+        observation_dim=2, n_actions=2, step_size=0.0
+    ).step_size == 0.0
+    with pytest.raises(ValueError, match="remain positive once narrowed.*or be exact zero"):
+        ActionConditionedWorldModelConfig(observation_dim=2, n_actions=2, step_size=1e-100)
+
+
 @pytest.mark.parametrize(
     "overrides",
     [
-        {"step_size": 0.0},
+        {"step_size": -0.01},
         {"sparsity": -0.1},
         {"sparsity": 1.1},
         {"leaky_relu_slope": -0.1},

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -347,7 +347,7 @@ def test_world_model_config_validates_all_public_fields_and_resources() -> None:
         {"n_actions": 2.5},
         {"action_dim": False},
         {"hidden_sizes": [4]},
-        {"step_size": 0.0},
+        {"step_size": -0.01},
         {"sparsity": float("nan")},
         {"leaky_relu_slope": 1.1},
         {"use_layer_norm": np.bool_(True)},
@@ -356,6 +356,10 @@ def test_world_model_config_validates_all_public_fields_and_resources() -> None:
     for overrides in invalid:
         with pytest.raises(ValueError):
             WorldModelConfig(**{"observation_dim": 2, **overrides})  # type: ignore[arg-type]
+
+    assert WorldModelConfig(observation_dim=2, step_size=0.0).step_size == 0.0
+    with pytest.raises(ValueError, match="remain positive once narrowed.*or be exact zero"):
+        WorldModelConfig(observation_dim=2, step_size=1e-100)
 
     with pytest.raises(ValueError, match="combined_direct_state_bytes"):
         WorldModelConfig(observation_dim=20_000, n_actions=2, hidden_sizes=())


### PR DESCRIPTION
Restores the established frozen-model endpoint for both one-step world-model configurations after the complete-config validator made `step_size` strictly positive. Step 8 and Step 9 facades already define zero as a legal endpoint, and Step 9 discount/control isolation relies on an exact zero learning rate.

The core now accepts exact zero while continuing to reject negative values and positive host values that would silently underflow to zero at the float32 sink. Both core config surfaces have direct regression coverage; the existing Step 8/Step 9 endpoint and differential-SARSA semantic tests exercise the downstream construction paths.

Validation:
- 358 focused world-model, Step 8, Step 9, and differential-SARSA tests passed
- Ruff passed on changed files
- strict mypy passed for `world_model.py`
- diff check clean

No benchmarks were run and no outputs were modified. This is L0 contract repair only and does not create or promote evidence.