### PR TITLE
fix(actor-critic): restore runtime sink guards

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -125,6 +125,12 @@ def _array(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> Arra
     return array
 
 
+def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
+    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+        raise ValueError(f"{name} must expose trusted array metadata")
+    return tuple(value.shape)
+
+
 def _require_key(key: object) -> Array:
     if not isinstance(key, jax.Array):
         raise ValueError("key must be a Threefry JAX key")
@@ -691,12 +697,14 @@ class ActorCriticAgent:
             last_action=next_action,
             rng_key=key,
         )
+        bound_metric = actor_metric / 2.0 + critic_metric / 2.0
         params_ok = (
             candidate_ok
             & _floating_tree_is_finite(proposed_final_state)
             & jnp.all(jnp.isfinite(next_policy))
             & (next_action >= 0)
             & (next_action < cfg.n_actions)
+            & jnp.isfinite(bound_metric)
         )
         new_state = jax.lax.cond(
             params_ok,
@@ -716,7 +724,7 @@ class ActorCriticAgent:
             value=jnp.where(params_ok, value, zero),
             next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
+            bound_metric=jnp.where(params_ok, bound_metric, zero),
             update_applied=params_ok,
         )
 
@@ -758,30 +766,34 @@ def run_actor_critic_from_arrays(
         ``ActorCriticArrayResult`` with final state and per-step metrics.
     """
     feature_dim = agent._feature_dim(state)
-    observations = jnp.asarray(observations, dtype=jnp.float32)
-    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
-    rewards = jnp.asarray(rewards, dtype=jnp.float32)
-    if observations.ndim != 2 or observations.shape[0] < 1:
+    observations_shape = _trusted_shape("observations", observations)
+    if len(observations_shape) != 2 or observations_shape[0] < 1:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
-    num_steps = observations.shape[0]
-    if observations.shape[1] != feature_dim or next_observations.shape != observations.shape:
+    num_steps = observations_shape[0]
+    expected_observations_shape = (num_steps, feature_dim)
+    if observations_shape != expected_observations_shape or _trusted_shape(
+        "next_observations", next_observations
+    ) != expected_observations_shape:
         raise ValueError("observations and next_observations must match state feature_dim")
-    if rewards.shape != (num_steps,):
+    if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
     output_scalars = num_steps * (agent.config.n_actions + 4)
     output_bytes = num_steps * (4 * agent.config.n_actions + 13)
     if output_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
         raise ValueError("derived actor-critic scan outputs exceed the signed-int32 budget")
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is None and discounts is None:
         raise ValueError("terminated or discounts must be provided")
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
-        if terminated.shape != (num_steps,):
+        if _trusted_shape("terminated", terminated) != (num_steps,):
             raise ValueError("terminated must have shape (num_steps,)")
+        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
     if discounts is not None:
-        discounts = jnp.asarray(discounts, dtype=jnp.float32)
-        if discounts.shape != (num_steps,):
+        if _trusted_shape("discounts", discounts) != (num_steps,):
             raise ValueError("discounts must have shape (num_steps,)")
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
     if discounts is None:
@@ -790,9 +802,9 @@ def run_actor_critic_from_arrays(
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
         use_fixed_actions = False
     else:
-        actions = jnp.asarray(actions, dtype=jnp.int32)
-        if actions.shape != (num_steps,):
+        if _trusted_shape("actions", actions) != (num_steps,):
             raise ValueError("actions must have shape (num_steps,)")
+        actions = jnp.asarray(actions, dtype=jnp.int32)
         use_fixed_actions = True
 
     def _scan_fn(
@@ -1500,12 +1512,14 @@ class ContinuousActorCriticAgent:
             last_action=next_action,
             rng_key=key,
         )
+        bound_metric = actor_metric / 2.0 + critic_metric / 2.0
         params_ok = (
             candidate_ok
             & _floating_tree_is_finite(proposed_final_state)
             & jnp.all(jnp.isfinite(next_action))
             & jnp.all(jnp.isfinite(next_mean))
             & jnp.all(jnp.isfinite(next_sigma))
+            & jnp.isfinite(bound_metric)
         )
         new_state = jax.lax.cond(
             params_ok,
@@ -1522,7 +1536,7 @@ class ContinuousActorCriticAgent:
             value=jnp.where(params_ok, value, zero),
             next_value=jnp.where(params_ok & jnp.isfinite(next_value), next_value, zero),
             td_error=jnp.where(params_ok, td_error, zero),
-            bound_metric=jnp.where(params_ok, (actor_metric + critic_metric) / 2.0, zero),
+            bound_metric=jnp.where(params_ok, bound_metric, zero),
             update_applied=params_ok,
         )
 
@@ -1558,15 +1572,16 @@ def run_continuous_actor_critic_from_arrays(
         ``ContinuousActorCriticArrayResult`` with final state and per-step metrics.
     """
     feature_dim = agent._feature_dim(state)
-    observations = jnp.asarray(observations, dtype=jnp.float32)
-    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
-    rewards = jnp.asarray(rewards, dtype=jnp.float32)
-    if observations.ndim != 2 or observations.shape[0] < 1:
+    observations_shape = _trusted_shape("observations", observations)
+    if len(observations_shape) != 2 or observations_shape[0] < 1:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
-    num_steps = observations.shape[0]
-    if observations.shape[1] != feature_dim or next_observations.shape != observations.shape:
+    num_steps = observations_shape[0]
+    expected_observations_shape = (num_steps, feature_dim)
+    if observations_shape != expected_observations_shape or _trusted_shape(
+        "next_observations", next_observations
+    ) != expected_observations_shape:
         raise ValueError("observations and next_observations must match state feature_dim")
-    if rewards.shape != (num_steps,):
+    if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
     action_dim = agent.config.action_dim
     output_scalars = num_steps * (3 * action_dim + 3)
@@ -1575,16 +1590,19 @@ def run_continuous_actor_critic_from_arrays(
         raise ValueError(
             "derived continuous actor-critic scan outputs exceed the signed-int32 budget"
         )
+    observations = jnp.asarray(observations, dtype=jnp.float32)
+    next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
+    rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is None and discounts is None:
         raise ValueError("terminated or discounts must be provided")
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
-        if terminated.shape != (num_steps,):
+        if _trusted_shape("terminated", terminated) != (num_steps,):
             raise ValueError("terminated must have shape (num_steps,)")
+        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
     if discounts is not None:
-        discounts = jnp.asarray(discounts, dtype=jnp.float32)
-        if discounts.shape != (num_steps,):
+        if _trusted_shape("discounts", discounts) != (num_steps,):
             raise ValueError("discounts must have shape (num_steps,)")
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
     if discounts is None:
@@ -1593,9 +1611,9 @@ def run_continuous_actor_critic_from_arrays(
         actions = jnp.zeros((rewards.shape[0], action_dim), dtype=jnp.float32)
         use_fixed_actions = False
     else:
-        actions = jnp.asarray(actions, dtype=jnp.float32)
-        if actions.shape != (num_steps, action_dim):
+        if _trusted_shape("actions", actions) != (num_steps, action_dim):
             raise ValueError("actions must have shape (num_steps, action_dim)")
+        actions = jnp.asarray(actions, dtype=jnp.float32)
         use_fixed_actions = True
 
     def _scan_fn(

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -1,0 +1,84 @@
+"""Regressions for actor-critic runtime sinks lost during integration."""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+from jax import Array
+
+from alberta_framework.core.actor_critic import (
+    ActorCriticAgent,
+    ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
+    run_actor_critic_from_arrays,
+    run_continuous_actor_critic_from_arrays,
+)
+from alberta_framework.core.optimizers import Bounder
+
+
+class _MaxMetricBounder(Bounder):
+    def to_config(self) -> dict[str, Any]:
+        return {"type": "test-only"}
+
+    def bound(
+        self,
+        steps: tuple[Array, ...],
+        error: Array,
+        params: tuple[Array, ...],
+    ) -> tuple[tuple[Array, ...], Array]:
+        del error, params
+        return steps, jnp.asarray(np.finfo(np.float32).max, dtype=jnp.float32)
+
+
+class _HostileArray:
+    @property
+    def shape(self) -> tuple[int, int]:
+        return (2**31 - 1, 2)
+
+    def __jax_array__(self) -> jax.Array:
+        raise AssertionError("conversion executed before trusted metadata rejection")
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_bound_metric_average_of_finite_extremes_remains_finite(continuous: bool) -> None:
+    if continuous:
+        agent = ContinuousActorCriticAgent(
+            ContinuousActorCriticConfig(action_dim=2), bounder=_MaxMetricBounder()
+        )
+        state = agent.init(2, jr.key(0))
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=2), bounder=_MaxMetricBounder())
+        state = agent.init(2, jr.key(0)).replace(  # type: ignore[attr-defined]
+            last_action=jnp.asarray(0, dtype=jnp.int32)
+        )
+    result = agent.update(  # type: ignore[union-attr]
+        state, jnp.asarray(0.0, dtype=jnp.float32), jnp.zeros((2,), dtype=jnp.float32)
+    )
+    assert bool(result.update_applied)
+    assert bool(jnp.isfinite(result.bound_metric))
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_scan_rejects_hostile_input_before_jax_conversion(continuous: bool) -> None:
+    if continuous:
+        agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+        state = agent.init(2, jr.key(0))
+        runner = run_continuous_actor_critic_from_arrays
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+        state = agent.init(2, jr.key(0))
+        runner = run_actor_critic_from_arrays
+    with pytest.raises(ValueError, match="trusted array metadata"):
+        runner(  # type: ignore[arg-type]
+            agent,
+            state,
+            _HostileArray(),
+            jnp.zeros((1,), dtype=jnp.float32),
+            None,
+            jnp.zeros((1, 2), dtype=jnp.float32),
+            discounts=jnp.zeros((1,), dtype=jnp.float32),
+        )


### PR DESCRIPTION
Corrective follow-up to merged #877. The final integration head lost two independently verified runtime guards: scan inputs again reached JAX conversion before trusted host metadata/resource checks, and two finite bounder metrics could overflow during their public average while the update remained marked applied. This restores host shape and complete scan-output preflights before conversion for both discrete and continuous runners, and computes the two-metric average by pre-scaling halves with a finite result gate. Four regressions cover both variants with hostile conversion hooks and max-float metrics. Verification: both actor-critic suites plus residuals, 75 passed; Ruff clean; targeted strict source mypy clean; diff-check clean. No API, serialized schema, output, or evidence changes.