### PR TITLE
fix(actor-critic): validate bounder runtime results

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -131,6 +131,33 @@ def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
     return tuple(value.shape)
 
 
+def _validated_bounder_result(
+    name: str,
+    result: object,
+    templates: tuple[Array, ...],
+) -> tuple[tuple[Array, ...], Array]:
+    """Validate one third-party bounder result before using it in state arithmetic."""
+    if type(result) is not tuple or len(result) != 2:
+        raise ValueError(f"{name} bounder result must be a (steps, metric) tuple")
+    steps, metric = result
+    if type(steps) is not tuple or len(steps) != len(templates):
+        raise ValueError(f"{name} bounder steps must match the parameter tree")
+    for step, template in zip(steps, templates, strict=True):
+        if (
+            not isinstance(step, jax.Array)
+            or tuple(step.shape) != tuple(template.shape)
+            or step.dtype != template.dtype
+        ):
+            raise ValueError(f"{name} bounder steps must match parameter shapes and dtypes")
+    if (
+        not isinstance(metric, jax.Array)
+        or tuple(metric.shape) != ()
+        or metric.dtype != jnp.float32
+    ):
+        raise ValueError(f"{name} bounder metric must be a scalar float32 JAX array")
+    return steps, metric
+
+
 def _require_key(key: object) -> Array:
     if not isinstance(key, jax.Array):
         raise ValueError("key must be a Threefry JAX key")
@@ -627,15 +654,23 @@ class ActorCriticAgent:
         actor_metric = jnp.array(1.0, dtype=jnp.float32)
         critic_metric = jnp.array(1.0, dtype=jnp.float32)
         if self._bounder is not None:
-            actor_steps, actor_metric = self._bounder.bound(
+            actor_steps, actor_metric = _validated_bounder_result(
+                "actor",
+                self._bounder.bound(
+                    actor_steps,
+                    td_error,
+                    (state.actor_weights, state.actor_bias),
+                ),
                 actor_steps,
-                td_error,
-                (state.actor_weights, state.actor_bias),
             )
-            critic_steps, critic_metric = self._bounder.bound(
+            critic_steps, critic_metric = _validated_bounder_result(
+                "critic",
+                self._bounder.bound(
+                    critic_steps,
+                    td_error,
+                    (state.critic_weights, state.critic_bias),
+                ),
                 critic_steps,
-                td_error,
-                (state.critic_weights, state.critic_bias),
             )
         actor_steps = tuple(td_error * step for step in actor_steps)
         critic_steps = tuple(td_error * step for step in critic_steps)
@@ -1435,15 +1470,23 @@ class ContinuousActorCriticAgent:
         actor_metric = jnp.array(1.0, dtype=jnp.float32)
         critic_metric = jnp.array(1.0, dtype=jnp.float32)
         if self._bounder is not None:
-            actor_steps, actor_metric = self._bounder.bound(
+            actor_steps, actor_metric = _validated_bounder_result(
+                "actor",
+                self._bounder.bound(
+                    actor_steps,
+                    td_error,
+                    (state.mean_weights, state.mean_bias, state.log_sigma),
+                ),
                 actor_steps,
-                td_error,
-                (state.mean_weights, state.mean_bias, state.log_sigma),
             )
-            critic_steps, critic_metric = self._bounder.bound(
+            critic_steps, critic_metric = _validated_bounder_result(
+                "critic",
+                self._bounder.bound(
+                    critic_steps,
+                    td_error,
+                    (state.critic_weights, state.critic_bias),
+                ),
                 critic_steps,
-                td_error,
-                (state.critic_weights, state.critic_bias),
             )
         actor_steps = tuple(td_error * step for step in actor_steps)
         critic_steps = tuple(td_error * step for step in critic_steps)

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -43,6 +43,20 @@ class _HostileArray:
         raise AssertionError("conversion executed before trusted metadata rejection")
 
 
+class _MalformedBounder(Bounder):
+    def to_config(self) -> dict[str, Any]:
+        return {"type": "test-only"}
+
+    def bound(
+        self,
+        steps: tuple[Array, ...],
+        error: Array,
+        params: tuple[Array, ...],
+    ) -> tuple[tuple[Array, ...], Array]:
+        del error, params
+        return (steps[0][None, ...], *steps[1:]), jnp.ones((1,), dtype=jnp.float32)
+
+
 @pytest.mark.parametrize("continuous", [False, True])
 def test_bound_metric_average_of_finite_extremes_remains_finite(continuous: bool) -> None:
     if continuous:
@@ -60,6 +74,26 @@ def test_bound_metric_average_of_finite_extremes_remains_finite(continuous: bool
     )
     assert bool(result.update_applied)
     assert bool(jnp.isfinite(result.bound_metric))
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_bounder_result_must_match_parameter_tree_and_scalar_metric(continuous: bool) -> None:
+    if continuous:
+        agent = ContinuousActorCriticAgent(
+            ContinuousActorCriticConfig(action_dim=2), bounder=_MalformedBounder()
+        )
+        state = agent.init(2, jr.key(0))
+    else:
+        agent = ActorCriticAgent(
+            ActorCriticConfig(n_actions=2), bounder=_MalformedBounder()
+        )
+        state = agent.init(2, jr.key(0)).replace(  # type: ignore[attr-defined]
+            last_action=jnp.asarray(0, dtype=jnp.int32)
+        )
+    with pytest.raises(ValueError, match="bounder steps"):
+        agent.update(  # type: ignore[union-attr]
+            state, jnp.asarray(0.0, dtype=jnp.float32), jnp.zeros((2,), dtype=jnp.float32)
+        )
 
 
 @pytest.mark.parametrize("continuous", [False, True])


### PR DESCRIPTION
Post-merge corrective to #888. The actor-critic constructors now require a Bounder, but update still trusted arbitrary bounder return containers, step shapes/dtypes, and metric rank/dtype. A malformed third-party bounder could therefore broadcast a step into a malformed persistent state or turn the scalar commit predicate into a runtime error. Validate both actor and critic bounder results against their parameter templates before state arithmetic in discrete and continuous agents. Preserves #888 scan preflight and stable metric averaging. Regression coverage exercises both variants. Verification: 77 focused tests passed; scoped Ruff and strict mypy passed; diff-check clean. No outputs or evidence sources changed.