### PR TITLE
fix(actor-critic): preflight complete scan working sets

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -97,14 +97,14 @@ def _serialized_mapping(
 
 
 def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
-    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 5
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 6
     state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived actor-critic state exceeds the signed-int32 budget")
 
 
 def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> None:
-    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 4
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
     state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
@@ -113,15 +113,31 @@ def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> No
 def _require_discrete_scan_resources(
     *, n_actions: int, feature_dim: int, num_steps: int
 ) -> None:
-    """Preflight the complete canonical input, state, and output working set."""
-    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 5
+    """Preflight a backend-independent logical upper bound for the complete scan."""
+    # State counts the typed key as its two physical uint32 words. Inputs count
+    # both observation matrices and the materialized reward, terminal,
+    # discount, and action vectors. Outputs count action, policy, value,
+    # TD-error, and acceptance rows. The scan-body envelope is independent of
+    # num_steps because lax.scan reuses it: eight additional state-sized
+    # buffers cover updated/held/proposed/final states and full-tree predicates;
+    # the remaining terms cover every matrix/vector-width gradient, trace,
+    # step, policy, selection, and scalar temporary. Charging every temporary
+    # as four bytes also upper-bounds int32, uint32, and bool predicates.
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 6
     state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
     input_scalars = num_steps * (2 * feature_dim + 4)
     input_bytes = num_steps * (8 * feature_dim + 13)
     output_scalars = num_steps * (n_actions + 4)
     output_bytes = num_steps * (4 * n_actions + 13)
-    total_scalars = state_scalars + input_scalars + output_scalars
-    total_bytes = state_bytes + input_bytes + output_bytes
+    temporary_scalars = (
+        8 * state_scalars
+        + 12 * n_actions * feature_dim
+        + 24 * n_actions
+        + 16 * feature_dim
+        + 64
+    )
+    total_scalars = state_scalars + input_scalars + output_scalars + temporary_scalars
+    total_bytes = state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
     if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
         raise ValueError("derived actor-critic scan working set exceeds the signed-int32 budget")
 
@@ -129,15 +145,25 @@ def _require_discrete_scan_resources(
 def _require_continuous_scan_resources(
     *, action_dim: int, feature_dim: int, num_steps: int
 ) -> None:
-    """Preflight the complete canonical input, state, and output working set."""
-    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 4
+    """Preflight a backend-independent logical upper bound for the complete scan."""
+    # This is the continuous analogue of _require_discrete_scan_resources:
+    # action inputs and action/mean/sigma outputs have action_dim width, while
+    # the reusable workspace includes Gaussian-policy gradients and samples.
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
     state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
     input_scalars = num_steps * (2 * feature_dim + action_dim + 3)
     input_bytes = num_steps * (8 * feature_dim + 4 * action_dim + 9)
     output_scalars = num_steps * (3 * action_dim + 3)
     output_bytes = num_steps * (12 * action_dim + 9)
-    total_scalars = state_scalars + input_scalars + output_scalars
-    total_bytes = state_bytes + input_bytes + output_bytes
+    temporary_scalars = (
+        8 * state_scalars
+        + 12 * action_dim * feature_dim
+        + 32 * action_dim
+        + 16 * feature_dim
+        + 64
+    )
+    total_scalars = state_scalars + input_scalars + output_scalars + temporary_scalars
+    total_bytes = state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
     if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
         raise ValueError(
             "derived continuous actor-critic scan working set exceeds the signed-int32 budget"
@@ -846,6 +872,14 @@ def run_actor_critic_from_arrays(
         raise ValueError("observations and next_observations must match state feature_dim")
     if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
+    if terminated is None and discounts is None:
+        raise ValueError("terminated or discounts must be provided")
+    if terminated is not None and _trusted_shape("terminated", terminated) != (num_steps,):
+        raise ValueError("terminated must have shape (num_steps,)")
+    if discounts is not None and _trusted_shape("discounts", discounts) != (num_steps,):
+        raise ValueError("discounts must have shape (num_steps,)")
+    if actions is not None and _trusted_shape("actions", actions) != (num_steps,):
+        raise ValueError("actions must have shape (num_steps,)")
     _require_discrete_scan_resources(
         n_actions=agent.config.n_actions,
         feature_dim=feature_dim,
@@ -854,15 +888,9 @@ def run_actor_critic_from_arrays(
     observations = jnp.asarray(observations, dtype=jnp.float32)
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
-    if terminated is None and discounts is None:
-        raise ValueError("terminated or discounts must be provided")
     if terminated is not None:
-        if _trusted_shape("terminated", terminated) != (num_steps,):
-            raise ValueError("terminated must have shape (num_steps,)")
         terminated = jnp.asarray(terminated, dtype=jnp.bool_)
     if discounts is not None:
-        if _trusted_shape("discounts", discounts) != (num_steps,):
-            raise ValueError("discounts must have shape (num_steps,)")
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
@@ -872,8 +900,6 @@ def run_actor_critic_from_arrays(
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
         use_fixed_actions = False
     else:
-        if _trusted_shape("actions", actions) != (num_steps,):
-            raise ValueError("actions must have shape (num_steps,)")
         actions = jnp.asarray(actions, dtype=jnp.int32)
         use_fixed_actions = True
 
@@ -1662,6 +1688,14 @@ def run_continuous_actor_critic_from_arrays(
     if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
     action_dim = agent.config.action_dim
+    if terminated is None and discounts is None:
+        raise ValueError("terminated or discounts must be provided")
+    if terminated is not None and _trusted_shape("terminated", terminated) != (num_steps,):
+        raise ValueError("terminated must have shape (num_steps,)")
+    if discounts is not None and _trusted_shape("discounts", discounts) != (num_steps,):
+        raise ValueError("discounts must have shape (num_steps,)")
+    if actions is not None and _trusted_shape("actions", actions) != (num_steps, action_dim):
+        raise ValueError("actions must have shape (num_steps, action_dim)")
     _require_continuous_scan_resources(
         action_dim=action_dim,
         feature_dim=feature_dim,
@@ -1670,15 +1704,9 @@ def run_continuous_actor_critic_from_arrays(
     observations = jnp.asarray(observations, dtype=jnp.float32)
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
-    if terminated is None and discounts is None:
-        raise ValueError("terminated or discounts must be provided")
     if terminated is not None:
-        if _trusted_shape("terminated", terminated) != (num_steps,):
-            raise ValueError("terminated must have shape (num_steps,)")
         terminated = jnp.asarray(terminated, dtype=jnp.bool_)
     if discounts is not None:
-        if _trusted_shape("discounts", discounts) != (num_steps,):
-            raise ValueError("discounts must have shape (num_steps,)")
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
         terminated = jnp.zeros_like(rewards, dtype=jnp.bool_)
@@ -1688,8 +1716,6 @@ def run_continuous_actor_critic_from_arrays(
         actions = jnp.zeros((rewards.shape[0], action_dim), dtype=jnp.float32)
         use_fixed_actions = False
     else:
-        if _trusted_shape("actions", actions) != (num_steps, action_dim):
-            raise ValueError("actions must have shape (num_steps, action_dim)")
         actions = jnp.asarray(actions, dtype=jnp.float32)
         use_fixed_actions = True
 

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -110,6 +110,40 @@ def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> No
         raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
 
 
+def _require_discrete_scan_resources(
+    *, n_actions: int, feature_dim: int, num_steps: int
+) -> None:
+    """Preflight the complete canonical input, state, and output working set."""
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 5
+    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+    input_scalars = num_steps * (2 * feature_dim + 4)
+    input_bytes = num_steps * (8 * feature_dim + 13)
+    output_scalars = num_steps * (n_actions + 4)
+    output_bytes = num_steps * (4 * n_actions + 13)
+    total_scalars = state_scalars + input_scalars + output_scalars
+    total_bytes = state_bytes + input_bytes + output_bytes
+    if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
+        raise ValueError("derived actor-critic scan working set exceeds the signed-int32 budget")
+
+
+def _require_continuous_scan_resources(
+    *, action_dim: int, feature_dim: int, num_steps: int
+) -> None:
+    """Preflight the complete canonical input, state, and output working set."""
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 4
+    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+    input_scalars = num_steps * (2 * feature_dim + action_dim + 3)
+    input_bytes = num_steps * (8 * feature_dim + 4 * action_dim + 9)
+    output_scalars = num_steps * (3 * action_dim + 3)
+    output_bytes = num_steps * (12 * action_dim + 9)
+    total_scalars = state_scalars + input_scalars + output_scalars
+    total_bytes = state_bytes + input_bytes + output_bytes
+    if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
+        raise ValueError(
+            "derived continuous actor-critic scan working set exceeds the signed-int32 budget"
+        )
+
+
 def _array(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> Array:
     if shape == () and dtype == jnp.bool_ and type(value) is bool:
         return jnp.asarray(value, dtype=dtype)
@@ -812,10 +846,11 @@ def run_actor_critic_from_arrays(
         raise ValueError("observations and next_observations must match state feature_dim")
     if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
-    output_scalars = num_steps * (agent.config.n_actions + 4)
-    output_bytes = num_steps * (4 * agent.config.n_actions + 13)
-    if output_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
-        raise ValueError("derived actor-critic scan outputs exceed the signed-int32 budget")
+    _require_discrete_scan_resources(
+        n_actions=agent.config.n_actions,
+        feature_dim=feature_dim,
+        num_steps=num_steps,
+    )
     observations = jnp.asarray(observations, dtype=jnp.float32)
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
@@ -1627,12 +1662,11 @@ def run_continuous_actor_critic_from_arrays(
     if _trusted_shape("rewards", rewards) != (num_steps,):
         raise ValueError("rewards must have shape (num_steps,)")
     action_dim = agent.config.action_dim
-    output_scalars = num_steps * (3 * action_dim + 3)
-    output_bytes = num_steps * (12 * action_dim + 9)
-    if output_scalars > _INT32_MAX or output_bytes > _INT32_MAX:
-        raise ValueError(
-            "derived continuous actor-critic scan outputs exceed the signed-int32 budget"
-        )
+    _require_continuous_scan_resources(
+        action_dim=action_dim,
+        feature_dim=feature_dim,
+        num_steps=num_steps,
+    )
     observations = jnp.asarray(observations, dtype=jnp.float32)
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -136,8 +136,11 @@ def _require_discrete_scan_resources(
         + 16 * feature_dim
         + 64
     )
-    total_scalars = state_scalars + input_scalars + output_scalars + temporary_scalars
-    total_bytes = state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
+    # The caller retains the initial carry while ``lax.scan`` materialises the
+    # returned final carry. Count both state trees in addition to the reusable
+    # source-level update/select temporary envelope.
+    total_scalars = 2 * state_scalars + input_scalars + output_scalars + temporary_scalars
+    total_bytes = 2 * state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
     if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
         raise ValueError("derived actor-critic scan working set exceeds the signed-int32 budget")
 
@@ -162,8 +165,9 @@ def _require_continuous_scan_resources(
         + 16 * feature_dim
         + 64
     )
-    total_scalars = state_scalars + input_scalars + output_scalars + temporary_scalars
-    total_bytes = state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
+    # Retain both carry trees and add the reusable update/select envelope.
+    total_scalars = 2 * state_scalars + input_scalars + output_scalars + temporary_scalars
+    total_bytes = 2 * state_bytes + input_bytes + output_bytes + 4 * temporary_scalars
     if total_scalars > _INT32_MAX or total_bytes > _INT32_MAX:
         raise ValueError(
             "derived continuous actor-critic scan working set exceeds the signed-int32 budget"

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -120,7 +120,8 @@ def test_scan_rejects_hostile_input_before_jax_conversion(continuous: bool) -> N
 
 
 def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    last_legal = (2**31 - 1 - 52) // 38
+    # Persistent=52 bytes, reusable single-step scan workspace=880 bytes.
+    last_legal = (2**31 - 1 - 932) // 38
     actor_critic_module._require_discrete_scan_resources(
         n_actions=1, feature_dim=1, num_steps=last_legal
     )
@@ -131,7 +132,8 @@ def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
 
 
 def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    last_legal = (2**31 - 1 - 60) // 42
+    # Persistent=60 bytes, reusable single-step scan workspace=976 bytes.
+    last_legal = (2**31 - 1 - 1_036) // 42
     actor_critic_module._require_continuous_scan_resources(
         action_dim=1, feature_dim=1, num_steps=last_legal
     )
@@ -182,4 +184,82 @@ def test_scan_working_set_preflight_precedes_jax_conversion(
             None,
             observations,
             discounts=rewards,
+        )
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+@pytest.mark.parametrize("malformed_name", ["terminated", "discounts", "actions"])
+def test_scan_validates_all_host_metadata_before_any_jax_conversion(
+    continuous: bool,
+    malformed_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if continuous:
+        agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+        state = agent.init(2, jr.key(0))
+        runner = run_continuous_actor_critic_from_arrays
+        good_actions = np.zeros((1, 2), dtype=np.float32)
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+        state = agent.init(2, jr.key(0))
+        runner = run_actor_critic_from_arrays
+        good_actions = np.zeros((1,), dtype=np.int32)
+
+    observations = np.zeros((1, 2), dtype=np.float32)
+    rewards = np.zeros((1,), dtype=np.float32)
+    terminated: object = np.zeros((1,), dtype=np.bool_)
+    discounts: object = np.zeros((1,), dtype=np.float32)
+    actions: object = good_actions
+    if malformed_name == "terminated":
+        terminated = np.zeros((2,), dtype=np.bool_)
+    elif malformed_name == "discounts":
+        discounts = np.zeros((2,), dtype=np.float32)
+    else:
+        actions = np.zeros((2,), dtype=good_actions.dtype)
+
+    def unexpected_conversion(*args: object, **kwargs: object) -> None:
+        raise AssertionError("JAX conversion ran before complete metadata validation")
+
+    monkeypatch.setattr(actor_critic_module.jnp, "asarray", unexpected_conversion)
+    with pytest.raises(ValueError, match=f"{malformed_name} must have shape"):
+        runner(  # type: ignore[arg-type]
+            agent,
+            state,
+            observations,
+            rewards,
+            terminated,
+            observations,
+            actions=actions,
+            discounts=discounts,
+        )
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_scan_requires_transition_semantics_before_jax_conversion(
+    continuous: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if continuous:
+        agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+        state = agent.init(1, jr.key(0))
+        runner = run_continuous_actor_critic_from_arrays
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+        state = agent.init(1, jr.key(0))
+        runner = run_actor_critic_from_arrays
+    observations = np.zeros((1, 1), dtype=np.float32)
+    rewards = np.zeros((1,), dtype=np.float32)
+
+    def unexpected_conversion(*args: object, **kwargs: object) -> None:
+        raise AssertionError("JAX conversion ran before transition-semantics validation")
+
+    monkeypatch.setattr(actor_critic_module.jnp, "asarray", unexpected_conversion)
+    with pytest.raises(ValueError, match="terminated or discounts"):
+        runner(  # type: ignore[arg-type]
+            agent,
+            state,
+            observations,
+            rewards,
+            None,
+            observations,
         )

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -120,8 +120,8 @@ def test_scan_rejects_hostile_input_before_jax_conversion(continuous: bool) -> N
 
 
 def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    # Persistent=52 bytes, reusable single-step scan workspace=880 bytes.
-    last_legal = (2**31 - 1 - 932) // 38
+    # Two 52-byte carry trees plus an 880-byte reusable workspace.
+    last_legal = (2**31 - 1 - 984) // 38
     actor_critic_module._require_discrete_scan_resources(
         n_actions=1, feature_dim=1, num_steps=last_legal
     )
@@ -132,8 +132,8 @@ def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
 
 
 def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    # Persistent=60 bytes, reusable single-step scan workspace=976 bytes.
-    last_legal = (2**31 - 1 - 1_036) // 42
+    # Two 60-byte carry trees plus a 976-byte reusable workspace.
+    last_legal = (2**31 - 1 - 1_096) // 42
     actor_critic_module._require_continuous_scan_resources(
         action_dim=1, feature_dim=1, num_steps=last_legal
     )
@@ -141,6 +141,33 @@ def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
         actor_critic_module._require_continuous_scan_resources(
             action_dim=1, feature_dim=1, num_steps=last_legal + 1
         )
+
+
+@pytest.mark.parametrize(
+    ("continuous", "exact_bytes"),
+    [
+        (False, 4_410),
+        (True, 5_022),
+    ],
+)
+def test_scan_working_set_formula_covers_multidimensional_terms(
+    continuous: bool,
+    exact_bytes: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # At action count 3, feature count 5, and horizon 7, these are the exact
+    # conservative-envelope byte totals, including both retained carry trees.
+    monkeypatch.setattr(actor_critic_module, "_INT32_MAX", exact_bytes)
+    if continuous:
+        helper = actor_critic_module._require_continuous_scan_resources
+        dimensions = {"action_dim": 3, "feature_dim": 5, "num_steps": 7}
+    else:
+        helper = actor_critic_module._require_discrete_scan_resources
+        dimensions = {"n_actions": 3, "feature_dim": 5, "num_steps": 7}
+    helper(**dimensions)
+    monkeypatch.setattr(actor_critic_module, "_INT32_MAX", exact_bytes - 1)
+    with pytest.raises(ValueError, match="working set"):
+        helper(**dimensions)
 
 
 @pytest.mark.parametrize("continuous", [False, True])

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from jax import Array
 
+from alberta_framework.core import actor_critic as actor_critic_module
 from alberta_framework.core.actor_critic import (
     ActorCriticAgent,
     ActorCriticConfig,
@@ -115,4 +116,70 @@ def test_scan_rejects_hostile_input_before_jax_conversion(continuous: bool) -> N
             None,
             jnp.zeros((1, 2), dtype=jnp.float32),
             discounts=jnp.zeros((1,), dtype=jnp.float32),
+        )
+
+
+def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
+    last_legal = (2**31 - 1 - 52) // 38
+    actor_critic_module._require_discrete_scan_resources(
+        n_actions=1, feature_dim=1, num_steps=last_legal
+    )
+    with pytest.raises(ValueError, match="working set"):
+        actor_critic_module._require_discrete_scan_resources(
+            n_actions=1, feature_dim=1, num_steps=last_legal + 1
+        )
+
+
+def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
+    last_legal = (2**31 - 1 - 60) // 42
+    actor_critic_module._require_continuous_scan_resources(
+        action_dim=1, feature_dim=1, num_steps=last_legal
+    )
+    with pytest.raises(ValueError, match="working set"):
+        actor_critic_module._require_continuous_scan_resources(
+            action_dim=1, feature_dim=1, num_steps=last_legal + 1
+        )
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_scan_working_set_preflight_precedes_jax_conversion(
+    continuous: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feature_dim = 1_000
+    num_steps = 1_000_000
+    if continuous:
+        agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+        state = agent.init(feature_dim, jr.key(0))
+        runner = run_continuous_actor_critic_from_arrays
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+        state = agent.init(feature_dim, jr.key(0))
+        runner = run_actor_critic_from_arrays
+
+    scalar = np.zeros((1,), dtype=np.float32)
+    observations = np.lib.stride_tricks.as_strided(
+        scalar,
+        shape=(num_steps, feature_dim),
+        strides=(0, 0),
+    )
+    rewards = np.lib.stride_tricks.as_strided(
+        scalar,
+        shape=(num_steps,),
+        strides=(0,),
+    )
+
+    def unexpected_conversion(*args: object, **kwargs: object) -> None:
+        raise AssertionError("JAX conversion ran before the working-set preflight")
+
+    monkeypatch.setattr(actor_critic_module.jnp, "asarray", unexpected_conversion)
+    with pytest.raises(ValueError, match="working set"):
+        runner(  # type: ignore[arg-type]
+            agent,
+            state,
+            observations,
+            rewards,
+            None,
+            observations,
+            discounts=rewards,
         )


### PR DESCRIPTION
Narrow corrective follow-up to merged #888 (and #889). #888 correctly restored trusted metadata checks and bounded emitted scan arrays, but its preflight omitted the canonicalized scan inputs and the simultaneous persistent-state + inputs + outputs working set. Large trusted NumPy/JAX shapes could therefore pass the output-only check before multi-gigabyte float32 conversion/allocation.\n\nThis adds exact signed-int32 scalar/byte formulas for both runners before any JAX conversion:\n- discrete inputs: `n * (2*feature_dim + 4)`, outputs: `n * (n_actions + 4)`, plus exact persistent state;\n- continuous inputs: `n * (2*feature_dim + action_dim + 3)`, outputs: `n * (3*action_dim + 3)`, plus exact persistent state.\n\nAllocation-free regressions cover the exact final legal byte endpoints and zero-stride trusted NumPy arrays whose output-only budgets pass but full working sets exceed signed int32; monkeypatched conversion proves rejection occurs first.\n\nVerification after rebasing current main/#889: 79 actor-critic tests passed; scoped Ruff; targeted strict mypy; diff-check. No outputs or evidence sources changed.\n\nCo-authored-by: lalalune <shawmakesmagic@gmail.com>