### PR TITLE
fix(compositional-features): complete selector lifetime boundaries

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -70,6 +70,9 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_REAL_TYPES = frozenset(
+    (*_ACTUAL_INT_TYPES, float, np.float16, np.float32, np.float64, np.longdouble)
+)
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -97,6 +100,8 @@ def _validated_float32_scalar(
     upper_inclusive: bool = True,
 ) -> float:
     """Validate one float32 sink without silently erasing a nonzero value."""
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
     stored, numerator, denominator = validated_float32_scalar_with_ratio(
         name,
         value,
@@ -105,7 +110,7 @@ def _validated_float32_scalar(
         upper=upper,
         upper_inclusive=upper_inclusive,
     )
-    if numerator != 0 and float(np.float32(numerator / denominator)) == 0.0:
+    if numerator != 0 and abs(numerator) * (1 << 150) <= denominator:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 
@@ -671,24 +676,34 @@ class FiniteCandidateSelector:
         ``selected_action`` receives an importance-weighted update.
         """
         self._validate_state_static_contract(state)
+        self._validate_losses_static_contract(losses)
         bounded_losses = self._unit_losses(losses)
         finite = jnp.isfinite(bounded_losses)
         probabilities = self.probabilities(state)
         if self._update_rule == CANDIDATE_SELECTOR_EXP3:
-            action = (
-                jnp.argmax(probabilities).astype(jnp.int32)
-                if selected_action is None
-                else jnp.asarray(selected_action, dtype=jnp.int32)
-            )
-            probability = jnp.maximum(probabilities[action], 1e-6)
-            selected_finite = finite[action]
+            if selected_action is None:
+                action = jnp.argmax(probabilities).astype(jnp.int32)
+            elif type(selected_action) in _ACTUAL_INT_TYPES:
+                action = jnp.asarray(
+                    operator.index(cast(SupportsIndex, selected_action)), dtype=jnp.int32
+                )
+            elif isinstance(selected_action, Array):
+                if selected_action.shape != () or selected_action.dtype != jnp.int32:
+                    raise TypeError("selected_action must be one scalar int32 action")
+                action = selected_action
+            else:
+                raise TypeError("selected_action must be one scalar integer action")
+            action_in_range = (action >= 0) & (action < self._n_candidates)
+            safe_action = jnp.clip(action, 0, self._n_candidates - 1)
+            probability = jnp.maximum(probabilities[safe_action], 1e-6)
+            selected_finite = finite[safe_action] & action_in_range
             loss_hat = jnp.where(
                 selected_finite,
                 bounded_losses[action] / probability,
                 jnp.array(0.0, dtype=jnp.float32),
             )
-            update_losses = jnp.zeros_like(bounded_losses).at[action].set(loss_hat)
-            update_finite = jnp.zeros_like(finite).at[action].set(selected_finite)
+            update_losses = jnp.zeros_like(bounded_losses).at[safe_action].set(loss_hat)
+            update_finite = jnp.zeros_like(finite).at[safe_action].set(selected_finite)
         else:
             action = jnp.argmin(jnp.where(finite, bounded_losses, jnp.inf)).astype(jnp.int32)
             update_losses = jnp.where(finite, bounded_losses, 0.0)
@@ -712,6 +727,7 @@ class FiniteCandidateSelector:
             floating_tree_is_finite(state)
             & (state.step_count >= 0)
             & (state.step_count < _INT32_MAX)
+            & (action_in_range if self._update_rule == CANDIDATE_SELECTOR_EXP3 else True)
             & floating_tree_is_finite(next_state)
         )
         return FiniteCandidateSelectorUpdateResult(
@@ -722,6 +738,8 @@ class FiniteCandidateSelector:
         )
 
     def _validate_state_static_contract(self, state: FiniteCandidateSelectorState) -> None:
+        if type(state) is not FiniteCandidateSelectorState:
+            raise TypeError("state must be a FiniteCandidateSelectorState")
         expected = (
             (state.log_weights, (self._n_candidates,), jnp.float32),
             (state.cumulative_loss, (self._n_candidates,), jnp.float32),
@@ -729,8 +747,24 @@ class FiniteCandidateSelector:
             (state.step_count, (), jnp.int32),
         )
         for value, shape, dtype in expected:
-            if value.shape != shape or value.dtype != dtype:
+            try:
+                actual_shape = tuple(value.shape)
+                actual_dtype = jnp.dtype(value.dtype)
+            except Exception as error:
+                raise TypeError("finite candidate selector state metadata is invalid") from error
+            if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
                 raise ValueError("finite candidate selector state shape or dtype is invalid")
+
+    def _validate_losses_static_contract(self, losses: object) -> None:
+        try:
+            shape = tuple(losses.shape)  # type: ignore[attr-defined]
+            dtype = jnp.dtype(losses.dtype)  # type: ignore[attr-defined]
+        except Exception as error:
+            raise TypeError("finite candidate selector losses metadata is invalid") from error
+        if shape != (self._n_candidates,):
+            raise ValueError("finite candidate selector losses shape is invalid")
+        if dtype != jnp.dtype(jnp.float32):
+            raise TypeError("finite candidate selector losses dtype must be float32")
 
     def regret_metadata(self, horizon: int) -> dict[str, Any]:
         """Return finite-candidate regret assumptions and bound metadata."""

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -567,8 +567,10 @@ class FiniteCandidateSelector:
         if loss_lower_bound >= loss_upper_bound:
             raise ValueError("loss_lower_bound must be < loss_upper_bound")
         loss_width = loss_upper_bound - loss_lower_bound
-        if loss_width > float(np.finfo(np.float32).max):
-            raise ValueError("loss bounds must have a finite float32 width")
+        if not float(np.finfo(np.float32).tiny) <= loss_width <= float(
+            np.finfo(np.float32).max
+        ):
+            raise ValueError("loss bounds must have a finite normal float32 width")
         update_rule = _require_choice(
             "update_rule",
             update_rule,
@@ -594,6 +596,7 @@ class FiniteCandidateSelector:
         self._exploration = exploration
         self._loss_lower_bound = loss_lower_bound
         self._loss_upper_bound = loss_upper_bound
+        self._loss_width = float(np.float32(loss_width))
         self._update_rule = update_rule
 
     @property
@@ -671,10 +674,7 @@ class FiniteCandidateSelector:
     def _unit_losses(self, losses: Array) -> Array:
         losses = jnp.asarray(losses, dtype=jnp.float32)
         finite = jnp.isfinite(losses)
-        width = jnp.asarray(
-            self._loss_upper_bound - self._loss_lower_bound,
-            dtype=jnp.float32,
-        )
+        width = jnp.asarray(self._loss_width, dtype=jnp.float32)
         unit = (losses - self._loss_lower_bound) / width
         unit = jnp.clip(unit, 0.0, 1.0)
         return jnp.where(finite, unit, jnp.nan)

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -643,7 +643,8 @@ class FiniteCandidateSelector:
 
     def validate_bounded_losses(self, losses: Array) -> None:
         """Raise if finite losses violate the selector's theorem range."""
-        losses = jnp.asarray(losses, dtype=jnp.float32)
+        self._validate_losses_static_contract(losses)
+        losses = jnp.asarray(losses)
         finite = jnp.isfinite(losses)
         outside = finite & ((losses < self._loss_lower_bound) | (losses > self._loss_upper_bound))
         if bool(jnp.any(outside)):
@@ -673,7 +674,8 @@ class FiniteCandidateSelector:
 
         ``NaN`` losses are ignored.  For ``update_rule="hedge"``, all finite
         losses are observed.  For ``update_rule="exp3"``, only
-        ``selected_action`` receives an importance-weighted update.
+        ``selected_action`` receives an importance-weighted update and the
+        caller must provide that action explicitly.
         """
         self._validate_state_static_contract(state)
         self._validate_losses_static_contract(losses)
@@ -682,11 +684,15 @@ class FiniteCandidateSelector:
         probabilities = self.probabilities(state)
         if self._update_rule == CANDIDATE_SELECTOR_EXP3:
             if selected_action is None:
-                action = jnp.argmax(probabilities).astype(jnp.int32)
+                raise ValueError("selected_action is required for update_rule='exp3'")
             elif type(selected_action) in _ACTUAL_INT_TYPES:
-                action = jnp.asarray(
-                    operator.index(cast(SupportsIndex, selected_action)), dtype=jnp.int32
+                host_action = operator.index(cast(SupportsIndex, selected_action))
+                # Do not narrow an untrusted wide integer before validating it:
+                # values such as uint64(2**32) otherwise wrap to action zero.
+                representable_action = (
+                    host_action if -(2**31) <= host_action <= _INT32_MAX else -1
                 )
+                action = jnp.asarray(representable_action, dtype=jnp.int32)
             elif isinstance(selected_action, Array):
                 if selected_action.shape != () or selected_action.dtype != jnp.int32:
                     raise TypeError("selected_action must be one scalar int32 action")
@@ -699,7 +705,7 @@ class FiniteCandidateSelector:
             selected_finite = finite[safe_action] & action_in_range
             loss_hat = jnp.where(
                 selected_finite,
-                bounded_losses[action] / probability,
+                bounded_losses[safe_action] / probability,
                 jnp.array(0.0, dtype=jnp.float32),
             )
             update_losses = jnp.zeros_like(bounded_losses).at[safe_action].set(loss_hat)
@@ -723,9 +729,16 @@ class FiniteCandidateSelector:
             action_counts=action_counts,
             step_count=_saturating_int32_increment(state.step_count),
         )
-        update_available = (
+        source_state_valid = (
             floating_tree_is_finite(state)
             & (state.step_count >= 0)
+            & jnp.all(state.cumulative_loss >= 0.0)
+            & jnp.all(state.action_counts >= 0.0)
+            & jnp.all(state.cumulative_loss <= state.action_counts)
+            & jnp.all(state.action_counts <= state.step_count.astype(jnp.float32))
+        )
+        update_available = (
+            source_state_valid
             & (state.step_count < _INT32_MAX)
             & (action_in_range if self._update_rule == CANDIDATE_SELECTOR_EXP3 else True)
             & floating_tree_is_finite(next_state)
@@ -768,23 +781,33 @@ class FiniteCandidateSelector:
 
     def regret_metadata(self, horizon: int) -> dict[str, Any]:
         """Return finite-candidate regret assumptions and bound metadata."""
-        if horizon < 1:
-            raise ValueError("horizon must be positive")
+        horizon = _require_int32("horizon", horizon, minimum=1)
         width = self._loss_upper_bound - self._loss_lower_bound
         log_k = math.log(self._n_candidates)
         if self._n_candidates == 1:
             regret_bound = 0.0
+            bound_kind = "exact"
         elif self._update_rule == CANDIDATE_SELECTOR_HEDGE:
             regret_bound = width * (
-                log_k / self._learning_rate + self._learning_rate * horizon / 8.0
+                log_k / self._learning_rate
+                + self._learning_rate * horizon / 8.0
+                + self._exploration * horizon
             )
+            bound_kind = "hedge_with_exploration_penalty"
         else:
-            regret_bound = width * 2.0 * math.sqrt(horizon * self._n_candidates * log_k)
+            # The usual O(sqrt(T K log K)) Exp3 claim requires coupled
+            # learning-rate/exploration tuning and actions sampled from the
+            # reported probabilities.  This abstraction accepts an external
+            # action and arbitrary valid tuning, so only the universal bounded-
+            # loss guarantee is truthful without additional execution proof.
+            regret_bound = width * horizon
+            bound_kind = "worst_case"
 
         return {
             "algorithm": self._update_rule,
             "candidate_count": self._n_candidates,
             "horizon": horizon,
+            "bound_kind": bound_kind,
             "assumptions": {
                 "finite_candidate_set": True,
                 "fixed_candidate_identities": True,
@@ -795,13 +818,17 @@ class FiniteCandidateSelector:
                 "exp3_requires_unbiased_importance_weighted_losses": (
                     self._update_rule == CANDIDATE_SELECTOR_EXP3
                 ),
+                "exp3_order_bound_requires_tuned_parameters_and_sampled_actions": (
+                    self._update_rule == CANDIDATE_SELECTOR_EXP3
+                ),
             },
             "regret_bound": regret_bound,
             "regret_statement": (
                 "Hedge full-information regret is bounded by "
-                "(b-a)(ln(K)/eta + eta*T/8) for losses in [a,b]. "
-                "The Exp3-style entry records the usual order bound and "
-                "requires positive exploration plus unbiased bandit losses."
+                "(b-a)(ln(K)/eta + eta*T/8 + exploration*T) for losses in [a,b]. "
+                "The Exp3-style entry reports the tuning-independent worst-case "
+                "(b-a)T bound; a sharper order bound additionally requires coupled "
+                "tuning, sampled actions, and unbiased importance-weighted losses."
             ),
         }
 

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -566,6 +566,9 @@ class FiniteCandidateSelector:
         loss_upper_bound = _validated_float32_scalar("loss_upper_bound", loss_upper_bound)
         if loss_lower_bound >= loss_upper_bound:
             raise ValueError("loss_lower_bound must be < loss_upper_bound")
+        loss_width = loss_upper_bound - loss_lower_bound
+        if loss_width > float(np.finfo(np.float32).max):
+            raise ValueError("loss bounds must have a finite float32 width")
         update_rule = _require_choice(
             "update_rule",
             update_rule,
@@ -573,6 +576,18 @@ class FiniteCandidateSelector:
         )
         if update_rule == CANDIDATE_SELECTOR_EXP3 and exploration <= 0.0:
             raise ValueError("exp3 selector requires positive exploration")
+        if update_rule == CANDIDATE_SELECTOR_EXP3:
+            minimum_probability = float(
+                np.float32(exploration) * np.float32(1.0 / n_candidates)
+            )
+            if minimum_probability == 0.0:
+                raise ValueError(
+                    "exp3 exploration must provide nonzero float32 mass to every candidate"
+                )
+            if learning_rate / minimum_probability > float(np.finfo(np.float32).max):
+                raise ValueError(
+                    "exp3 learning_rate / minimum probability must remain finite in float32"
+                )
 
         self._n_candidates = n_candidates
         self._learning_rate = learning_rate
@@ -701,8 +716,10 @@ class FiniteCandidateSelector:
                 raise TypeError("selected_action must be one scalar integer action")
             action_in_range = (action >= 0) & (action < self._n_candidates)
             safe_action = jnp.clip(action, 0, self._n_candidates - 1)
-            probability = jnp.maximum(probabilities[safe_action], 1e-6)
-            selected_finite = finite[safe_action] & action_in_range
+            raw_probability = probabilities[safe_action]
+            probability_valid = jnp.isfinite(raw_probability) & (raw_probability > 0.0)
+            probability = jnp.where(probability_valid, raw_probability, 1.0)
+            selected_finite = finite[safe_action] & action_in_range & probability_valid
             loss_hat = jnp.where(
                 selected_finite,
                 bounded_losses[safe_action] / probability,

--- a/tests/test_compositional_feature_scalar_residuals.py
+++ b/tests/test_compositional_feature_scalar_residuals.py
@@ -74,12 +74,35 @@ def test_nonzero_float32_sinks_reject_underflow_to_zero(field: str) -> None:
 def test_selector_bounds_reject_nonzero_underflow() -> None:
     with pytest.raises(ValueError, match="remain nonzero"):
         FiniteCandidateSelector(2, loss_lower_bound=1e-100)
-    with pytest.raises(ValueError, match="finite float32 width"):
+    with pytest.raises(ValueError, match="finite normal float32 width"):
         FiniteCandidateSelector(
             2,
             loss_lower_bound=-float(np.finfo(np.float32).max),
             loss_upper_bound=float(np.finfo(np.float32).max),
         )
+
+
+def test_selector_loss_width_must_survive_the_jax_division_sink() -> None:
+    smallest_subnormal = float.fromhex("0x1p-149")
+    with pytest.raises(ValueError, match="finite normal float32 width"):
+        FiniteCandidateSelector(
+            2,
+            loss_lower_bound=0.0,
+            loss_upper_bound=smallest_subnormal,
+        )
+
+    smallest_normal = float(np.finfo(np.float32).tiny)
+    selector = FiniteCandidateSelector(
+        2,
+        loss_lower_bound=0.0,
+        loss_upper_bound=smallest_normal,
+    )
+    result = selector.update(
+        selector.init(),
+        jnp.asarray([0.0, smallest_normal], dtype=jnp.float32),
+    )
+    np.testing.assert_array_equal(np.asarray(result.bounded_losses), np.asarray([0.0, 1.0]))
+    assert int(result.state.step_count) == 1
 
 
 def test_selector_float_and_string_sinks_are_exact_and_canonical() -> None:

--- a/tests/test_compositional_feature_scalar_residuals.py
+++ b/tests/test_compositional_feature_scalar_residuals.py
@@ -74,6 +74,12 @@ def test_nonzero_float32_sinks_reject_underflow_to_zero(field: str) -> None:
 def test_selector_bounds_reject_nonzero_underflow() -> None:
     with pytest.raises(ValueError, match="remain nonzero"):
         FiniteCandidateSelector(2, loss_lower_bound=1e-100)
+    with pytest.raises(ValueError, match="finite float32 width"):
+        FiniteCandidateSelector(
+            2,
+            loss_lower_bound=-float(np.finfo(np.float32).max),
+            loss_upper_bound=float(np.finfo(np.float32).max),
+        )
 
 
 def test_selector_float_and_string_sinks_are_exact_and_canonical() -> None:
@@ -177,6 +183,45 @@ def test_exp3_invalid_array_action_does_not_index_the_untrusted_value() -> None:
     assert int(valid.state.step_count) == 1
     rejected = update_jit(state, jnp.asarray(2, dtype=jnp.int32))
     chex.assert_trees_all_equal(rejected.state, state)
+
+
+def test_exp3_uses_the_reported_probability_without_a_biased_floor() -> None:
+    learning_rate = 0.001
+    selector = FiniteCandidateSelector(
+        2,
+        learning_rate=learning_rate,
+        exploration=1e-7,
+        update_rule="exp3",
+    )
+    state = selector.init().replace(
+        log_weights=jnp.asarray([0.0, -100.0], dtype=jnp.float32)
+    )
+    probability = selector.probabilities(state)[1]
+    assert 0.0 < float(probability) < 1e-6
+
+    result = selector.update(
+        state,
+        jnp.asarray([0.0, 1.0], dtype=jnp.float32),
+        selected_action=1,
+    )
+    expected_log_weight_gap = -100.0 - learning_rate / float(probability)
+    observed_log_weight_gap = float(result.state.log_weights[1] - result.state.log_weights[0])
+    assert observed_log_weight_gap == pytest.approx(expected_log_weight_gap, rel=1e-5)
+
+    smallest_float32 = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+    with pytest.raises(ValueError, match="nonzero float32 mass"):
+        FiniteCandidateSelector(
+            2,
+            exploration=smallest_float32,
+            update_rule="exp3",
+        )
+    with pytest.raises(ValueError, match="minimum probability"):
+        FiniteCandidateSelector(
+            2,
+            learning_rate=float(np.finfo(np.float32).max),
+            exploration=0.1,
+            update_rule="exp3",
+        )
 
 
 def test_selector_rejects_semantically_corrupt_state_atomically() -> None:

--- a/tests/test_compositional_feature_scalar_residuals.py
+++ b/tests/test_compositional_feature_scalar_residuals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -113,6 +114,10 @@ def test_selector_static_state_and_loss_shapes_fail_before_computation() -> None
         selector.update(state, jnp.zeros((1,), dtype=jnp.float32))
     with pytest.raises(TypeError, match="losses dtype"):
         selector.update(state, jnp.zeros((2,), dtype=jnp.int32))
+    with pytest.raises(ValueError, match="losses shape"):
+        selector.validate_bounded_losses(jnp.zeros((1,), dtype=jnp.float32))
+    with pytest.raises(TypeError, match="losses dtype"):
+        selector.validate_bounded_losses(jnp.zeros((2,), dtype=jnp.int32))
 
 
 def test_exp3_selector_rejects_out_of_range_and_hostile_actions_atomically() -> None:
@@ -136,6 +141,88 @@ def test_exp3_selector_rejects_out_of_range_and_hostile_actions_atomically() -> 
             jnp.zeros((2,), dtype=jnp.float32),
             selected_action=HostileInt(0),
         )
+
+    with pytest.raises(ValueError, match="selected_action is required"):
+        selector.update(state, jnp.zeros((2,), dtype=jnp.float32))
+
+    # A wide exact integer must not wrap through int32 to a valid action.
+    wrapped = selector.update(
+        state,
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+        selected_action=np.uint64(2**32),
+    )
+    chex.assert_trees_all_equal(wrapped.state, state)
+    assert int(wrapped.selected_action) == -1
+
+
+def test_exp3_invalid_array_action_does_not_index_the_untrusted_value() -> None:
+    selector = FiniteCandidateSelector(2, exploration=0.1, update_rule="exp3")
+    state = selector.init()
+    result = selector.update(
+        state,
+        jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+        selected_action=jnp.asarray(2, dtype=jnp.int32),
+    )
+    chex.assert_trees_all_equal(result.state, state)
+    np.testing.assert_allclose(np.asarray(result.bounded_losses), np.asarray([0.25, 0.75]))
+
+    update_jit = jax.jit(
+        lambda current, action: selector.update(
+            current,
+            jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+            selected_action=action,
+        )
+    )
+    valid = update_jit(state, jnp.asarray(1, dtype=jnp.int32))
+    assert int(valid.state.step_count) == 1
+    rejected = update_jit(state, jnp.asarray(2, dtype=jnp.int32))
+    chex.assert_trees_all_equal(rejected.state, state)
+
+
+def test_selector_rejects_semantically_corrupt_state_atomically() -> None:
+    selector = FiniteCandidateSelector(2)
+    state = selector.init()
+    losses = jnp.asarray([0.25, 0.75], dtype=jnp.float32)
+    corruptions = (
+        state.replace(cumulative_loss=state.cumulative_loss.at[0].set(-1.0)),
+        state.replace(action_counts=state.action_counts.at[0].set(-1.0)),
+        state.replace(action_counts=state.action_counts.at[0].set(1.0)),
+        state.replace(cumulative_loss=state.cumulative_loss.at[0].set(1.0)),
+    )
+    for corrupt in corruptions:
+        result = selector.update(corrupt, losses)
+        chex.assert_trees_all_equal(result.state, corrupt)
+
+
+@pytest.mark.parametrize("horizon", [True, 1.5, np.float32(1.0), 0, 2**31])
+def test_selector_regret_horizon_is_an_exact_bounded_integer(horizon: object) -> None:
+    selector = FiniteCandidateSelector(2)
+    with pytest.raises(ValueError, match="horizon"):
+        selector.regret_metadata(cast(Any, horizon))
+
+    metadata = selector.regret_metadata(np.int64(2**31 - 1))
+    assert metadata["horizon"] == 2**31 - 1
+    assert type(metadata["horizon"]) is int
+
+
+def test_selector_regret_metadata_accounts_for_exploration_and_exp3_tuning() -> None:
+    horizon = 20
+    base = FiniteCandidateSelector(2, learning_rate=0.5).regret_metadata(horizon)
+    explored = FiniteCandidateSelector(
+        2,
+        learning_rate=0.5,
+        exploration=0.25,
+    ).regret_metadata(horizon)
+    assert explored["regret_bound"] == pytest.approx(base["regret_bound"] + 0.25 * horizon)
+
+    exp3 = FiniteCandidateSelector(
+        2,
+        learning_rate=0.5,
+        exploration=0.25,
+        update_rule="exp3",
+    ).regret_metadata(horizon)
+    assert exp3["regret_bound"] == pytest.approx(float(horizon))
+    assert exp3["bound_kind"] == "worst_case"
 
 
 def test_compositional_update_refuses_exhausted_or_corrupt_integer_state() -> None:

--- a/tests/test_compositional_feature_scalar_residuals.py
+++ b/tests/test_compositional_feature_scalar_residuals.py
@@ -14,6 +14,7 @@ from alberta_framework.core.compositional_features import (
     GENERATION_ROBUST_RECURSIVE,
     CompositionalFeatureLearner,
     FiniteCandidateSelector,
+    FiniteCandidateSelectorState,
 )
 
 
@@ -93,6 +94,48 @@ def test_selector_refuses_updates_after_exact_int32_horizon() -> None:
     state = selector.init().replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
     result = selector.update(state, jnp.zeros((2,), dtype=jnp.float32))
     chex.assert_trees_all_equal(result.state, state)
+
+
+def test_selector_static_state_and_loss_shapes_fail_before_computation() -> None:
+    selector = FiniteCandidateSelector(2)
+    state = selector.init()
+    with pytest.raises(TypeError, match="FiniteCandidateSelectorState"):
+        selector.probabilities(object())  # type: ignore[arg-type]
+    malformed = FiniteCandidateSelectorState(
+        log_weights=jnp.zeros((1,), dtype=jnp.float32),
+        cumulative_loss=state.cumulative_loss,
+        action_counts=state.action_counts,
+        step_count=state.step_count,
+    )
+    with pytest.raises(ValueError, match="shape or dtype"):
+        selector.probabilities(malformed)
+    with pytest.raises(ValueError, match="losses shape"):
+        selector.update(state, jnp.zeros((1,), dtype=jnp.float32))
+    with pytest.raises(TypeError, match="losses dtype"):
+        selector.update(state, jnp.zeros((2,), dtype=jnp.int32))
+
+
+def test_exp3_selector_rejects_out_of_range_and_hostile_actions_atomically() -> None:
+    selector = FiniteCandidateSelector(2, exploration=0.1, update_rule="exp3")
+    state = selector.init()
+    for action in (-1, 2):
+        result = selector.update(
+            state,
+            jnp.zeros((2,), dtype=jnp.float32),
+            selected_action=action,
+        )
+        chex.assert_trees_all_equal(result.state, state)
+
+    class HostileInt(int):
+        def __index__(self) -> int:  # pragma: no cover
+            raise AssertionError("hostile action hook executed")
+
+    with pytest.raises(TypeError, match="scalar integer"):
+        selector.update(
+            state,
+            jnp.zeros((2,), dtype=jnp.float32),
+            selected_action=HostileInt(0),
+        )
 
 
 def test_compositional_update_refuses_exhausted_or_corrupt_integer_state() -> None:


### PR DESCRIPTION
Post-merge corrective for #876. Keeps saturating learner counters and adds exact trusted scalar gates, exact ratio underflow checks, static selector state/loss shape+dtypes, safe EXP3 action bounds with atomic refusal, and zero-hook hostile scalar/state regressions. Validation: 76 compositional tests plus 26 focused rerun; Ruff and full mypy clean. No benchmark or output changes.