### PR TITLE
fix(ci): restore post-hardening compatibility contracts

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -1270,11 +1270,14 @@ class CompositionalFeatureLearner:
         step_size_theta = _validated_float32_scalar(
             "step_size_theta", step_size_theta, lower=0.0
         )
+        utility_decay_input = utility_decay
         utility_decay = canonical_float32_ema_decay(
             "utility_decay",
             utility_decay,
         )
-        utility_decay_config = utility_decay
+        utility_decay_config = (
+            utility_decay_input if type(utility_decay_input) is float else utility_decay
+        )
         promotion_margin = _validated_float32_scalar(
             "promotion_margin", promotion_margin, lower=0.0
         )
@@ -1462,11 +1465,16 @@ class CompositionalFeatureLearner:
             raise ValueError("candidate_selector_exploration must be in [0, 1)")
         if candidate_selector == CANDIDATE_SELECTOR_EXP3 and candidate_selector_exploration <= 0.0:
             raise ValueError("exp3 candidate_selector requires positive exploration")
+        retention_slow_utility_decay_input = retention_slow_utility_decay
         retention_slow_utility_decay = canonical_float32_ema_decay(
             "retention_slow_utility_decay",
             retention_slow_utility_decay,
         )
-        retention_slow_utility_decay_config = retention_slow_utility_decay
+        retention_slow_utility_decay_config = (
+            retention_slow_utility_decay_input
+            if type(retention_slow_utility_decay_input) is float
+            else retention_slow_utility_decay
+        )
         if retention_tanh_min_count < 0:
             raise ValueError("retention_tanh_min_count must be non-negative")
         if retention_product_min_count < 0:

--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -337,11 +337,14 @@ class FixedBudgetFeatureLearner:
         step_size_feature = validated_float32_scalar(
             "step_size_feature", step_size_feature, lower=0.0
         )
+        utility_decay_input = utility_decay
         utility_decay = canonical_float32_ema_decay(
             "utility_decay",
             utility_decay,
         )
-        utility_decay_config = utility_decay
+        utility_decay_config = (
+            utility_decay_input if type(utility_decay_input) is float else utility_decay
+        )
         promotion_margin = validated_float32_scalar(
             "promotion_margin", promotion_margin, positive=True
         )
@@ -405,13 +408,20 @@ class FixedBudgetFeatureLearner:
             "future_utility_rare_task_power", future_utility_rare_task_power, lower=0.0
         )
         if utility_retention_decay is not None:
+            utility_retention_decay_input = utility_retention_decay
             utility_retention_decay = canonical_float32_ema_decay(
                 "utility_retention_decay",
                 utility_retention_decay,
             )
             if utility_retention_decay < utility_decay:
                 raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
-        utility_retention_decay_config = utility_retention_decay
+            utility_retention_decay_config = (
+                utility_retention_decay_input
+                if type(utility_retention_decay_input) is float
+                else utility_retention_decay
+            )
+        else:
+            utility_retention_decay_config = None
 
         if type(generator_mix) is not tuple or len(generator_mix) != 3:
             raise ValueError("generator_mix must have three entries")

--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -8,14 +8,25 @@ current residual.
 """
 
 import math
+from fractions import Fraction
 from numbers import Real
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework._float32 import round_real_to_float32
+
+_ACTUAL_DECAY_TYPES = frozenset(
+    {
+        int,
+        float,
+        Fraction,
+        *(np.dtype(code).type for code in "bBhHiIlLqQpefdg"),
+    }
+)
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -26,10 +37,10 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 def canonical_float32_ema_decay(name: str, value: object) -> float:
     """Validate and canonicalize an EMA decay at its float32 execution sink."""
     message = f"{name} must narrow to a finite float32 in [0, 1)"
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if type(value) not in _ACTUAL_DECAY_TYPES:
         raise ValueError(message)
     try:
-        narrowed = round_real_to_float32(value)
+        narrowed = round_real_to_float32(cast(Real, value))
     except (OverflowError, TypeError, ValueError) as error:
         raise ValueError(message) from error
     if not math.isfinite(narrowed) or not 0.0 <= narrowed < 1.0:

--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -17,7 +17,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 _ACTUAL_DECAY_TYPES = frozenset(
     {
@@ -35,15 +35,29 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 
 
 def canonical_float32_ema_decay(name: str, value: object) -> float:
-    """Validate and canonicalize an EMA decay at its float32 execution sink."""
+    """Validate an exact EMA decay and canonicalize its float32 execution value.
+
+    The exact-ratio checks retain domain facts that float32 narrowing can erase:
+    a tiny negative must not become an accepted ``-0.0``, and a positive decay
+    must not silently become the disabled-decay endpoint ``0.0``.
+    """
     message = f"{name} must narrow to a finite float32 in [0, 1)"
     if type(value) not in _ACTUAL_DECAY_TYPES:
         raise ValueError(message)
     try:
-        narrowed = round_real_to_float32(cast(Real, value))
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(
+            cast(Real, value)
+        )
     except (OverflowError, TypeError, ValueError) as error:
         raise ValueError(message) from error
-    if not math.isfinite(narrowed) or not 0.0 <= narrowed < 1.0:
+    exact_in_domain = 0 <= numerator < denominator
+    positive_underflow = numerator > 0 and narrowed == 0.0
+    if (
+        not exact_in_domain
+        or positive_underflow
+        or not math.isfinite(narrowed)
+        or not 0.0 <= narrowed < 1.0
+    ):
         raise ValueError(message)
     return narrowed
 

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -1,6 +1,7 @@
 """Tests for causal future-utility estimators."""
 
 from collections.abc import Callable
+from fractions import Fraction
 
 import chex
 import jax
@@ -320,6 +321,27 @@ def test_utility_decay_serialization_preserves_builtin_and_canonicalizes_numpy()
         np.float32(0.95)
     )
 
+    exact_fixed = FixedBudgetFeatureLearner(
+        n_features=2,
+        n_tasks=1,
+        utility_decay=Fraction(9, 10),
+        utility_retention_decay=Fraction(19, 20),
+    )
+    int_compositional = CompositionalFeatureLearner(
+        n_features=3,
+        n_tasks=1,
+        utility_decay=0,
+        retention_slow_utility_decay=Fraction(19, 20),
+    )
+    assert exact_fixed.to_config()["utility_decay"] == float(np.float32(0.9))
+    assert type(exact_fixed.to_config()["utility_decay"]) is float
+    assert exact_fixed.to_config()["utility_retention_decay"] == float(np.float32(0.95))
+    assert int_compositional.to_config()["utility_decay"] == 0.0
+    assert type(int_compositional.to_config()["utility_decay"]) is float
+    assert int_compositional.to_config()["retention_slow_utility_decay"] == float(
+        np.float32(0.95)
+    )
+
 
 def test_utility_decay_rejects_hostile_float_subclasses_before_ratio_hook() -> None:
     class HostileFloat(float):
@@ -375,6 +397,68 @@ def test_utility_ema_decay_rejects_values_narrowing_to_float32_one(
 ) -> None:
     with pytest.raises(ValueError, match="finite float32 in \\[0, 1\\)"):
         factory()
+
+
+@pytest.mark.parametrize(
+    "decay",
+    [
+        Fraction(-1, 2**200),
+        -float.fromhex("0x1p-150"),
+        Fraction(1, 2**200),
+        float.fromhex("0x1p-150"),
+    ],
+)
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda decay: FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            utility_decay=decay,
+        ),
+        lambda decay: FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            utility_decay=0.5,
+            utility_retention_decay=decay,
+        ),
+        lambda decay: CompositionalFeatureLearner(
+            n_features=3,
+            n_tasks=1,
+            utility_decay=decay,
+        ),
+        lambda decay: CompositionalFeatureLearner(
+            n_features=3,
+            n_tasks=1,
+            retention_slow_utility_decay=decay,
+        ),
+    ],
+)
+def test_utility_ema_decay_rejects_exact_values_erased_at_float32_zero(
+    factory: Callable[[object], object],
+    decay: object,
+) -> None:
+    with pytest.raises(ValueError, match="finite float32 in \\[0, 1\\)"):
+        factory(decay)
+
+
+def test_utility_ema_decay_accepts_smallest_positive_float32_exactly() -> None:
+    decay = Fraction(1, 2**149)
+    fixed = FixedBudgetFeatureLearner(
+        n_features=2,
+        n_tasks=1,
+        utility_decay=decay,
+    )
+    compositional = CompositionalFeatureLearner(
+        n_features=3,
+        n_tasks=1,
+        utility_decay=decay,
+    )
+    expected = float.fromhex("0x1p-149")
+    assert fixed._utility_decay == expected
+    assert fixed.to_config()["utility_decay"] == expected
+    assert compositional._utility_decay == expected
+    assert compositional.to_config()["utility_decay"] == expected
 
 
 def test_feature_discovery_future_utility_config_roundtrip_extended_knobs() -> None:

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -283,6 +283,67 @@ def test_compositional_ema_and_age_correction_share_float32_decay() -> None:
     assert near_one.to_config()["utility_decay"] == 0.9999999
 
 
+def test_utility_decay_serialization_preserves_builtin_and_canonicalizes_numpy() -> None:
+    fixed = FixedBudgetFeatureLearner(
+        n_features=2,
+        n_tasks=1,
+        utility_decay=0.9,
+        utility_retention_decay=0.95,
+    )
+    compositional = CompositionalFeatureLearner(
+        n_features=3,
+        n_tasks=1,
+        utility_decay=0.9,
+        retention_slow_utility_decay=0.95,
+    )
+    assert fixed.to_config()["utility_decay"] == 0.9
+    assert fixed.to_config()["utility_retention_decay"] == 0.95
+    assert compositional.to_config()["utility_decay"] == 0.9
+    assert compositional.to_config()["retention_slow_utility_decay"] == 0.95
+
+    numpy_fixed = FixedBudgetFeatureLearner(
+        n_features=2,
+        n_tasks=1,
+        utility_decay=np.float64(0.9),
+        utility_retention_decay=np.float64(0.95),
+    )
+    numpy_compositional = CompositionalFeatureLearner(
+        n_features=3,
+        n_tasks=1,
+        utility_decay=np.float64(0.9),
+        retention_slow_utility_decay=np.float64(0.95),
+    )
+    assert numpy_fixed.to_config()["utility_decay"] == float(np.float32(0.9))
+    assert numpy_fixed.to_config()["utility_retention_decay"] == float(np.float32(0.95))
+    assert numpy_compositional.to_config()["utility_decay"] == float(np.float32(0.9))
+    assert numpy_compositional.to_config()["retention_slow_utility_decay"] == float(
+        np.float32(0.95)
+    )
+
+
+def test_utility_decay_rejects_hostile_float_subclasses_before_ratio_hook() -> None:
+    class HostileFloat(float):
+        calls = 0
+
+        def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+            type(self).calls += 1
+            raise RuntimeError("hostile ratio hook")
+
+    with pytest.raises(ValueError, match="utility_decay"):
+        FixedBudgetFeatureLearner(
+            n_features=2,
+            n_tasks=1,
+            utility_decay=HostileFloat(0.9),
+        )
+    with pytest.raises(ValueError, match="retention_slow_utility_decay"):
+        CompositionalFeatureLearner(
+            n_features=3,
+            n_tasks=1,
+            retention_slow_utility_decay=HostileFloat(0.95),
+        )
+    assert HostileFloat.calls == 0
+
+
 @pytest.mark.parametrize(
     "factory",
     [

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -322,9 +322,9 @@ def test_step10_stomp_int_dimensions_stay_within_int32() -> None:
 
 @pytest.mark.unit
 def test_step10_stomp_feature_index_stays_within_int32() -> None:
-    # An out-of-int32 feature_index can only pass the observation_dim bound
-    # check if observation_dim itself escapes int32, so both must reject.
-    with pytest.raises(ValueError, match="observation_dim"):
+    # SubtaskSpec now rejects its own out-of-int32 index before the enclosing
+    # Step10 configuration can inspect observation_dim.
+    with pytest.raises(ValueError, match="feature_index"):
         Step10STOMPConfig(
             subtask_specs=(SubtaskSpec(feature_index=2**35),),
             observation_dim=2**40,

--- a/tests/test_world_model_ensemble_validation.py
+++ b/tests/test_world_model_ensemble_validation.py
@@ -212,11 +212,13 @@ def test_wm_ensemble_dimensions_preflight_without_allocation() -> None:
         _base_cfg(ensemble_size=600_000_000)
 
 
-def test_wm_ensemble_state_preflight_bytes_without_allocation() -> None:
-    # This base has 61 scalars/member; total persistent bytes are 270*ensemble + 60.
-    last_legal = (2**31 - 1 - 60) // 270
+def test_wm_ensemble_result_preflight_bytes_without_allocation() -> None:
+    # This base has 61 member-state scalars and target_dim=4. Persistent bytes
+    # are 270*ensemble+60; the complete update result is the stricter
+    # 324*ensemble+196 after the aggregate result contract added in #868.
+    last_legal = (2**31 - 1 - 196) // 324
     _base_cfg(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="persistent state bytes"):
+    with pytest.raises(ValueError, match="update-result bytes"):
         _base_cfg(ensemble_size=last_legal + 1)
     with pytest.raises(ValueError, match="fit signed int32"):
         _base_cfg(ensemble_size=500_000_000)


### PR DESCRIPTION
Repairs the five baseline failures exposed after the strict scalar/resource integrations, without weakening their production contracts. Step10 now expects the exact SubtaskSpec feature-index failure that necessarily occurs before enclosing observation-dimension validation. The world-model-ensemble boundary test uses the complete update-result formula (`324 * ensemble_size + 196` bytes), which is stricter than the older persistent-only formula. Fixed-budget and compositional learners retain exact built-in float payloads for historical `to_config` round trips while using separately canonicalized float32 execution decays; NumPy/integer/Fraction inputs remain canonicalized, and hostile float subclasses are rejected before conversion hooks. No #886/#887 zero-step work is duplicated. Verification on latest main: five relevant files, 396 passed; exact failure subset after rebase, 22 passed; Ruff clean; full strict mypy, 168 source files clean; diff-check clean. These learner source identities already changed in the preceding hardening merge; this corrective restores serialized compatibility but does not promote or rerun any evidence, and no outputs were touched.