### PR TITLE
fix(resource-manager): reject non-finite hedge theorem inputs

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -207,6 +207,21 @@ def _weighted_cost_terms(costs: Array, cost_weight: float) -> tuple[Array, Array
     return terms, valid
 
 
+def _require_theorem_real(name: str, value: object, *, positive: bool) -> float:
+    """Reject bool/non-finite host scalars without changing legal float values."""
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    real = float(cast(Any, value))
+    if not math.isfinite(real):
+        raise ValueError(f"{name} must be finite")
+    if positive:
+        if real <= 0.0:
+            raise ValueError(f"{name} must be positive")
+    elif real < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return real
+
+
 def optimal_hedge_learning_rate(
     n_actions: int,
     horizon: int,
@@ -221,12 +236,9 @@ def optimal_hedge_learning_rate(
     Cesa-Bianchi & Lugosi 2006, ch. 2).  For ``n_actions == 1`` the regret is
     identically zero, so the returned learning rate is ``0.0``.
     """
-    if n_actions < 1:
-        raise ValueError("n_actions must be positive")
-    if horizon < 1:
-        raise ValueError("horizon must be positive")
-    if loss_bound <= 0.0:
-        raise ValueError("loss_bound must be positive")
+    n_actions = _require_int32("n_actions", n_actions, minimum=1)
+    horizon = _require_int32("horizon", horizon, minimum=1)
+    loss_bound = _require_theorem_real("loss_bound", loss_bound, positive=True)
     if n_actions == 1:
         return 0.0
     return math.sqrt(8.0 * math.log(n_actions) / (horizon * loss_bound**2))
@@ -250,14 +262,10 @@ def finite_candidate_hedge_regret_bound(
     promote/delete rules require separate terms and must not cite this helper
     as a proof.
     """
-    if n_actions < 1:
-        raise ValueError("n_actions must be positive")
-    if horizon < 1:
-        raise ValueError("horizon must be positive")
-    if learning_rate < 0.0:
-        raise ValueError("learning_rate must be non-negative")
-    if loss_bound <= 0.0:
-        raise ValueError("loss_bound must be positive")
+    n_actions = _require_int32("n_actions", n_actions, minimum=1)
+    horizon = _require_int32("horizon", horizon, minimum=1)
+    learning_rate = _require_theorem_real("learning_rate", learning_rate, positive=False)
+    loss_bound = _require_theorem_real("loss_bound", loss_bound, positive=True)
     if n_actions == 1:
         return 0.0
     if learning_rate == 0.0:

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -236,6 +236,59 @@ class TestLearnedResourceManager:
         with pytest.raises(ValueError):
             finite_candidate_hedge_regret_bound(2, 10, 0.1, loss_bound=0.0)
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"n_actions": True, "horizon": 8},
+            {"n_actions": 3, "horizon": True},
+            {"n_actions": 3.0, "horizon": 8},
+            {"n_actions": float("nan"), "horizon": 8},
+            {"n_actions": 3, "horizon": float("inf")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": float("nan")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": float("inf")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": True},
+        ],
+    )
+    def test_optimal_hedge_rate_rejects_bool_and_nonfinite_preconditions(
+        self,
+        kwargs: dict[str, object],
+    ) -> None:
+        with pytest.raises(ValueError):
+            optimal_hedge_learning_rate(**kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"n_actions": True, "horizon": 8, "learning_rate": 0.1},
+            {"n_actions": 3, "horizon": True, "learning_rate": 0.1},
+            {"n_actions": 3, "horizon": 8, "learning_rate": float("nan")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": float("inf")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": True},
+            {"n_actions": 3, "horizon": 8, "learning_rate": 0.1, "loss_bound": float("nan")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": 0.1, "loss_bound": True},
+        ],
+    )
+    def test_hedge_regret_bound_rejects_bool_and_nonfinite_preconditions(
+        self,
+        kwargs: dict[str, object],
+    ) -> None:
+        with pytest.raises(ValueError):
+            finite_candidate_hedge_regret_bound(**kwargs)  # type: ignore[arg-type]
+
+    def test_manager_regret_bound_rejects_nonfinite_horizon_and_loss_bound(self) -> None:
+        manager = LearnedResourceManager(
+            n_actions=3,
+            learning_rate=0.1,
+            discount=1.0,
+            exploration=0.0,
+        )
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(float("nan"))  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(True)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(8, loss_bound=float("nan"))
+
 
 class TestGeneratorMetaResourceManager:
     """Behavioral checks for generator-internal meta-resource policies."""


### PR DESCRIPTION
## What changed

`optimal_hedge_learning_rate` and `finite_candidate_hedge_regret_bound` now reject boolean, non-integer, and non-finite theorem preconditions before they can mint a NaN or silently remapped Hedge rate.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `loss_bound=nan` returned a NaN learning rate (`nan <= 0.0` is false);
- `n_actions=True` returned `0.0` (the one-action shortcut);
- `horizon=True` minted a finite rate for a one-step "horizon";
- `LearnedResourceManager.fixed_candidate_regret_bound(nan)` returned NaN.

Those helpers are the published regret-bound surface. A NaN bound is not a bound.

Legal finite integer/real preconditions, the `n_actions == 1 → 0.0` shortcut, and the `learning_rate == 0.0 → inf` bound are unchanged. The rate for `(3, 8)` remains `1.048147073968205`.

## Scope

- `alberta_framework/core/resource_manager.py`
- `tests/test_resource_manager.py`

## Why this is unowned

Live occupancy at publish time: 3 open ASI PRs, all Shaw (`#890` actor-critic, `#891`/`#892` compositional-features / future-utility). Neither target file is in that map.

This is not a republish of `#677` (UPGD step sizes), `#861` (option-duration), world-model `step_size`, Kayvan `#711` (latent-world-model integers), or HEIR `#4`. Prior resource-manager merges (`#840`, `#867`, `#103`, `#215`) hardened constructors, serialized schemas, and 0×inf update arithmetic — not these theorem helpers.

## Verification

Exact candidate head: `85902f406c6c5112d6d303ab3bbe873d5b222981`  
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_resource_manager.py -q -o addopts=""`: **63 passed**
- focused new/legal regret tests: **18 passed**
- `ruff check` on the two files: clean
- `mypy alberta_framework/core/resource_manager.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the theorem helpers only. It does not change Hedge update equations, defaults, discounting, exploration, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:85902f406c6c5112d6d303ab3bbe873d5b222981 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
