### PR TITLE
fix(statistics): reject bool and non-integer publication counts

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -114,6 +114,16 @@ def _require_alpha(alpha: object) -> float:
     return _require_probability(alpha, name="alpha", strict=True)
 
 
+def _require_positive_int(name: str, value: object) -> int:
+    """Reject bool/float aliases that ordered comparisons treat as legal counts."""
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be a positive integer (got {value!r})")
+    count = int(value)
+    if count <= 0:
+        raise ValueError(f"{name} must be a positive integer (got {value})")
+    return count
+
+
 def _require_p_value(value: object, *, name: str) -> float:
     return _require_probability(value, name=name, strict=False)
 
@@ -666,8 +676,7 @@ def pairwise_comparisons(
     from alberta_framework.utils.experiments import AggregatedResults
 
     alpha_value = _require_alpha(alpha)
-    if window <= 0:
-        raise ValueError(f"window must be positive (got {window})")
+    window = _require_positive_int("window", window)
 
     names = list(results.keys())
     n = len(names)
@@ -817,8 +826,7 @@ def bootstrap_ci(
             f"statistic must be either 'mean' or 'median' (got {statistic!r})"
         )
     _validate_confidence_level(confidence_level)
-    if n_bootstrap <= 0:
-        raise ValueError(f"n_bootstrap must be positive (got {n_bootstrap})")
+    n_bootstrap = _require_positive_int("n_bootstrap", n_bootstrap)
     rng = np.random.default_rng(seed)
 
     stat_func = np.mean if statistic == "mean" else np.median

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -485,6 +485,16 @@ class TestBootstrapCI:
             with pytest.raises(ValueError, match="n_bootstrap.*positive"):
                 bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=n_bootstrap)
 
+    @pytest.mark.parametrize("n_bootstrap", [True, False, 1.0, float("nan"), float("inf")])
+    def test_bool_and_noninteger_bootstrap_count_rejected_without_warnings(
+        self,
+        n_bootstrap: object,
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="n_bootstrap.*positive integer"):
+                bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=n_bootstrap, seed=0)  # type: ignore[arg-type]
+
     @pytest.mark.parametrize("confidence_level", [0.0, 1.0, -0.1, 1.1, float("nan")])
     def test_invalid_confidence_level_rejected_without_warnings(
         self,
@@ -965,6 +975,16 @@ class TestPairwiseComparisons:
             warnings.simplefilter("error")
             with pytest.raises(ValueError, match="window.*positive"):
                 pairwise_comparisons(self._results(), window=window)
+
+    @pytest.mark.parametrize("window", [True, False, 1.0, float("nan"), float("inf")])
+    def test_bool_and_noninteger_window_rejected_without_warnings(
+        self,
+        window: object,
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="window.*positive integer"):
+                pairwise_comparisons(self._results(), window=window)  # type: ignore[arg-type]
 
     def test_zero_step_metric_rejected_without_warnings(self) -> None:
         empty_steps = AggregatedResults(


### PR DESCRIPTION
## What changed

Publication-count arguments that are consumed as `range(...)` / final-window lengths are now required to be actual positive integers.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `bootstrap_ci(..., n_bootstrap=True)` accepted the boolean and returned the degenerate interval `(2.0, 2.333..., 2.333...)` — a one-resample "confidence interval";
- `n_bootstrap=1.0` / `nan` leaked a `TypeError` from `range()` instead of a field-named `ValueError`;
- `pairwise_comparisons(..., window=True)` used the same IEEE-blind `<= 0` check.

`_require_positive_int` binds `n_bootstrap` and `window` the same way `_require_alpha` already binds probabilities: reject `bool` first, then require an integer, then require `> 0`. Existing `0` / `-1` rejections stay.

Legal integer counts (`n_bootstrap=20`, `window=1|100`) and the existing finite-sample / one-sample-per-seed contracts are unchanged.

## Scope

- `alberta_framework/utils/statistics.py`
- `tests/test_statistics_validation.py`

## Why this is unowned

Live occupancy at publish time: 3 open ASI PRs, all Shaw, none of these files. Closed statistics work (`#292` non-finite samples, `#194`/`#199` publication samples, `#410` alpha/p-value, `#312` common final window, `#338` one sample per seed) did not bind bootstrap/window *type identity*. Boolean `True` still minted a one-draw CI.

This is not a republish of `#677`, `#861`, world-model `step_size`, Kayvan `#711`, or HEIR `#4`.

## Verification

Exact candidate head: `b7ce0873cee30337242e3303ebeeb77aec549d34`  
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_statistics_validation.py -q -o addopts=""`: **232 passed**
- `ruff check` on the two files: clean
- `mypy alberta_framework/utils/statistics.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on publication counts only. It does not change estimators, p-value formulas, confidence-level math, correction methods, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b7ce0873cee30337242e3303ebeeb77aec549d34 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
