### PR TITLE
fix(streams): reject non-finite partial-observation sentinels

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -94,7 +94,9 @@ class PartialObservationWrapper[InnerStateT]:
             expectation.
         schedule: Tuple of boolean masks of shape ``(feature_dim,)``;
             cycled each step under PERIODIC mode.
-        sentinel: Value that replaces masked entries (default ``0.0``).
+        sentinel: Finite real that replaces masked entries (default ``0.0``).
+            Boolean and non-finite values are rejected so a hidden channel
+            cannot silently become ``1.0``, ``NaN``, or ``Inf``.
 
     Examples
     --------
@@ -122,7 +124,7 @@ class PartialObservationWrapper[InnerStateT]:
         self._inner = inner
         self._mode = mode
         self._mask_prob = mask_prob
-        self._sentinel = sentinel
+        self._sentinel = validated_float32_scalar("sentinel", sentinel)
 
         feature_dim = inner.feature_dim
 

--- a/tests/test_partial_observation.py
+++ b/tests/test_partial_observation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -243,3 +245,37 @@ class TestDeterminism:
         out1 = run()
         out2 = run()
         chex.assert_trees_all_close(out1, out2)
+
+
+class TestSentinel:
+    def test_legal_nonzero_sentinel_fills_hidden_channels(self) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.0)
+        mask = jnp.array([True, False, True, False])
+        wrapper = PartialObservationWrapper(
+            inner, mode=MaskMode.FIXED, fixed_mask=mask, sentinel=-1.0
+        )
+        timestep, _ = wrapper.step(wrapper.init(jr.key(0)), jnp.array(0))
+        assert float(timestep.observation[1]) == -1.0
+        assert float(timestep.observation[3]) == -1.0
+        assert math.isfinite(float(timestep.observation[0]))
+        assert math.isfinite(float(timestep.observation[2]))
+
+    @pytest.mark.parametrize("sentinel", [float("nan"), float("inf"), float("-inf"), True])
+    def test_rejects_non_finite_or_bool_sentinel(self, sentinel: object) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        mask = jnp.array([True, False, True, False])
+        with pytest.raises(ValueError, match="sentinel"):
+            PartialObservationWrapper(
+                inner, mode=MaskMode.FIXED, fixed_mask=mask, sentinel=sentinel
+            )
+
+    def test_rejects_non_real_sentinel(self) -> None:
+        inner = RandomWalkStream(feature_dim=4, drift_rate=0.0)
+        mask = jnp.array([True, False, True, False])
+        with pytest.raises(ValueError, match="sentinel"):
+            PartialObservationWrapper(
+                inner,
+                mode=MaskMode.FIXED,
+                fixed_mask=mask,
+                sentinel="0.0",  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
## What changed

`PartialObservationWrapper` now rejects a non-finite or boolean `sentinel` before a hidden channel can be replaced.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `sentinel=nan` wrote `NaN` into every masked observation channel;
- `sentinel=inf` wrote `Inf` into those channels;
- `sentinel=True` wrote `1.0` (bool subclass of int) instead of the documented default `0.0`.

Those values are the POMDP observation the history-feature / learner path consumes. A NaN hidden channel is not a masked channel.

Legal finite sentinels, including the default `0.0` and a nonzero `-1.0`, are unchanged. `mask_prob` validation for `MaskMode.RANDOM` is unchanged.

## Scope

- `alberta_framework/streams/partial_observation.py`
- `tests/test_partial_observation.py`

## Why this is unowned

Live occupancy at publish time: 8 open ASI PRs (Shaw `#890`–`#892`, ss251 `#893`/`#894`, byt61 `#895`–`#897`). Neither target file is in that map.

This is not a republish of `#768` (class-spoofed `mask_prob`), `#893`/`#894`, Shaw `#890`–`#892`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`. `#768` closed the `mask_prob` host gate and left `sentinel` raw.

## Verification

Exact candidate head: `891a9d78aa6a910b051d0ef1002426764cca5af3`  
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_partial_observation.py -q -o addopts=""`: **24 passed**
- `ruff check` on the two files: clean
- `mypy alberta_framework/streams/partial_observation.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the wrapper constructor only. It does not change masking modes, default `0.0` replacement, stream RNG, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:891a9d78aa6a910b051d0ef1002426764cca5af3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
