### PR TITLE
fix(idbd): reject non-finite constructor step sizes

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -24,6 +24,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.types import (
     AutostepGTDLambdaState,
     AutostepParamState,
@@ -703,15 +704,22 @@ class IDBD(Optimizer[IDBDState]):
                 the linear ``update()`` method always uses x^2.
 
         Raises:
-            ValueError: If ``h_decay_mode`` is not one of the valid modes
+            ValueError: If ``h_decay_mode`` is not one of the valid modes,
+                or if a step-size is not a finite non-bool real in the
+                declared domain (``initial_step_size`` positive;
+                ``meta_step_size`` nonnegative).
         """
         if h_decay_mode not in ("prediction_grads", "loss_grads"):
             raise ValueError(
                 f"Invalid h_decay_mode: {h_decay_mode!r}. "
                 "Must be 'prediction_grads' or 'loss_grads'."
             )
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
+        self._initial_step_size = validated_float32_scalar(
+            "initial_step_size", initial_step_size, positive=True
+        )
+        self._meta_step_size = validated_float32_scalar(
+            "meta_step_size", meta_step_size, lower=0.0
+        )
         self._h_decay_mode = h_decay_mode
 
     def to_config(self) -> dict[str, Any]:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -68,6 +68,22 @@ class TestIDBD:
         chex.assert_trees_all_close(state.traces, jnp.zeros(10))
         assert state.meta_step_size == pytest.approx(0.001)
 
+    @pytest.mark.parametrize("initial_step_size", [float("nan"), float("inf"), 0.0, -0.1, True])
+    def test_rejects_illegal_initial_step_size(self, initial_step_size: object) -> None:
+        with pytest.raises(ValueError, match="initial_step_size"):
+            IDBD(initial_step_size=initial_step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("meta_step_size", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_meta_step_size(self, meta_step_size: object) -> None:
+        with pytest.raises(ValueError, match="meta_step_size"):
+            IDBD(meta_step_size=meta_step_size)  # type: ignore[arg-type]
+
+    def test_zero_meta_step_size_remains_legal(self) -> None:
+        optimizer = IDBD(initial_step_size=0.01, meta_step_size=0.0)
+        state = optimizer.init(feature_dim=2)
+        assert float(state.meta_step_size) == 0.0
+        assert bool(jnp.all(jnp.isfinite(state.log_step_sizes)))
+
     def test_update_returns_correct_shapes(self, sample_observation):
         """IDBD update should return correctly shaped deltas."""
         optimizer = IDBD()


### PR DESCRIPTION
## What changed

`IDBD.__init__` now rejects a non-finite, boolean, or out-of-domain constructor step-size before `init()` can write a poisoned `log_step_sizes` vector.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `initial_step_size=nan` stored NaN and `init()` wrote `[nan, nan]` logs;
- `initial_step_size=inf` wrote `[inf, inf]` logs;
- `initial_step_size=True` was accepted as `1.0` (`log(1)=0`), so every weight started at step-size 1;
- `initial_step_size=0.0` wrote `[-inf, -inf]` logs;
- `meta_step_size=nan` / `True` were stored raw (`True` becomes meta-step 1.0).

`log_step_sizes` is the live IDBD step-size state. A NaN or `-inf` log is not an adaptive step-size.

Legal defaults (`0.01`, `0.01`) and the existing `meta_step_size=0.0` skip-adaptation contract are unchanged. Autostep is not touched.

## Scope

- `alberta_framework/core/optimizers.py`
- `tests/test_optimizers.py`

## Why this is unowned

Live occupancy at publish time: 8 open ASI PRs (Shaw `#890`–`#892`, ss251 `#893`/`#894`, byt61 `#895`–`#897`). Neither target file is in that map.

This is not a republish of `#43` (IDBD clip-guard after an update), `#549` (0×inf h-trace skip when meta-step is 0), `#859` (initializer resource contracts), `#893`/`#894`, Shaw `#890`–`#892`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`. Those closed update arithmetic and resource preflights — not constructor domains.

## Verification

Exact candidate head: `7831c1d97630f57178f1e32de3ad57fcc1cbf54c`  
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_optimizers.py -q -o addopts=""`: **82 passed**
- focused new constructor tests: **10 passed** (illegal initial/meta + legal zero meta)
- `ruff check` on the two files: clean
- `mypy alberta_framework/core/optimizers.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the IDBD constructor only. It does not change Sutton 1992 update equations, the `meta_step_size=0` skip path, defaults, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7831c1d97630f57178f1e32de3ad57fcc1cbf54c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
