### PR TITLE
fix(experiments): reject boolean seed counts and windows

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -24,6 +24,7 @@ import jax.random as jr
 import numpy as np
 from numpy.typing import NDArray
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.learners import (
     LinearLearner,
     metrics_to_dicts,
@@ -31,7 +32,6 @@ from alberta_framework.core.learners import (
 )
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
-from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.utils.statistics import common_final_window
 
 _NUMPY_COORDINATE_TYPES = frozenset(
@@ -368,7 +368,7 @@ def run_multi_seed_experiment(
                 "of unique built-in integer seeds"
             )
         try:
-            raw_seeds = tuple(seeds)
+            raw_seeds = tuple(cast(Iterable[int], seeds))
         except TypeError as exc:
             raise ValueError(
                 "seeds must be a positive built-in integer count or a sequence "

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -31,6 +31,7 @@ from alberta_framework.core.learners import (
 )
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.utils.statistics import common_final_window
 
 _NUMPY_COORDINATE_TYPES = frozenset(
@@ -336,8 +337,9 @@ def run_multi_seed_experiment(
         Dictionary mapping config name to AggregatedResults
 
     Raises:
-        ValueError: If two or more configurations have the same name, or if the
-            explicit seed list contains duplicates
+        ValueError: If two or more configurations have the same name, if the
+            seed count is not a positive built-in integer, or if the explicit
+            seed list is empty, non-canonical, or contains duplicates
     """
     seen_names: set[str] = set()
     duplicate_names: set[str] = set()
@@ -353,11 +355,33 @@ def run_multi_seed_experiment(
             f"Experiment configuration names must be unique; duplicates: {formatted_names}"
         )
 
-    # Convert seeds to list
-    if isinstance(seeds, int):
+    # Convert seeds to list. Bool is a subclass of int, so isinstance(seeds, int)
+    # would treat True as a one-seed experiment and False as an empty run.
+    if type(seeds) is int:
+        if seeds < 1:
+            raise ValueError("seeds count must be a positive built-in integer")
         seed_list = list(range(seeds))
     else:
-        seed_list = list(seeds)
+        if isinstance(seeds, (str, bytes, bytearray)):
+            raise ValueError(
+                "seeds must be a positive built-in integer count or a sequence "
+                "of unique built-in integer seeds"
+            )
+        try:
+            raw_seeds = tuple(seeds)
+        except TypeError as exc:
+            raise ValueError(
+                "seeds must be a positive built-in integer count or a sequence "
+                "of unique built-in integer seeds"
+            ) from exc
+        if not raw_seeds:
+            raise ValueError(
+                "seeds must be a non-empty sequence of unique built-in integer seeds"
+            )
+        seed_list = [
+            require_jax_seed(seed, name=f"seeds[{index}]")
+            for index, seed in enumerate(raw_seeds)
+        ]
 
     seen_seeds: set[int] = set()
     duplicate_seeds: set[int] = set()
@@ -481,6 +505,8 @@ def get_final_performance(
             trace, so the helper refuses rather than silently reporting a
             full-horizon mean.
     """
+    if type(window) is not int:
+        raise ValueError("window must be a positive built-in integer")
     if window <= 0:
         raise ValueError(f"window must be positive (got {window})")
 

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -139,6 +139,48 @@ def test_multiple_duplicate_seeds_are_reported_deterministically() -> None:
     assert str(exc_info.value) == "Experiment seeds must be unique; duplicates: 3, 7"
 
 
+@pytest.mark.parametrize("seeds", [True, False, 0, -1, 1.0])
+def test_noncanonical_seed_count_rejects_before_factories_execute(seeds: object) -> None:
+    configs = [
+        _config(
+            "baseline",
+            learner_factory=_fail_if_called,
+            stream_factory=_fail_if_called,
+        )
+    ]
+    with pytest.raises(ValueError, match="seeds"):
+        run_multi_seed_experiment(configs, seeds=seeds, parallel=False, show_progress=False)
+
+
+@pytest.mark.parametrize("seeds", [[True], [False], [1.0], []])
+def test_noncanonical_seed_identities_reject_before_factories_execute(seeds: object) -> None:
+    configs = [
+        _config(
+            "baseline",
+            learner_factory=_fail_if_called,
+            stream_factory=_fail_if_called,
+        )
+    ]
+    with pytest.raises(ValueError, match="seeds"):
+        run_multi_seed_experiment(configs, seeds=seeds, parallel=False, show_progress=False)
+
+
+def test_integer_seed_count_still_aligns_identities() -> None:
+    results = run_multi_seed_experiment(
+        [_config("baseline")],
+        seeds=2,
+        parallel=False,
+        show_progress=False,
+    )
+    assert results["baseline"].seeds == [0, 1]
+
+
+@pytest.mark.parametrize("window", [True, False, 1.0])
+def test_get_final_performance_rejects_noncanonical_window(window: object) -> None:
+    with pytest.raises(ValueError, match="window"):
+        get_final_performance({"candidate": _two_seed_trace()}, window=window)
+
+
 def test_unique_names_preserve_config_and_seed_order() -> None:
     results = run_multi_seed_experiment(
         [_config("second"), _config("first")],


### PR DESCRIPTION
## What changed

`run_multi_seed_experiment` and `get_final_performance` now reject boolean and non-canonical seed counts / windows before a publication run can mint a false seed axis.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `seeds=True` ran a one-seed experiment (`range(True) -> [0]`);
- `seeds=False` / `0` produced an empty `{}` result;
- `seeds=[True]` used True as a seed identity;
- `window=True` averaged the last one step.

The seed list is the aligned identity axis for paired significance tests. A boolean is not a seed count.

Legal count `seeds=2` still yields `[0, 1]`. Explicit `[0, 1]` / `[7, 3]` and existing duplicate-seed messages are unchanged.

## Scope

- `alberta_framework/utils/experiments.py`
- `tests/test_experiments_validation.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894` (hedge / statistics counts), Shaw `#890`–`#892`, byt61 `#895`–`#897`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`.

## Verification

Exact candidate head: `7fe279198b9978928f7d9144cf5b43cffed06e31`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_experiments_validation.py -q -o addopts=""`
- focused new seed-count / window tests
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the experiment runner only. It does not change learning-loop equations, aggregation formulas, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7fe279198b9978928f7d9144cf5b43cffed06e31 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
