### PR TITLE
fix(security): reject boolean actions and non-finite risk scores

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
 import time
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
@@ -281,15 +282,20 @@ def coerce_security_action(action: SecurityAction | int | str) -> SecurityAction
     """Coerce an integer or name to ``SecurityAction``."""
     if isinstance(action, SecurityAction):
         return action
-    if isinstance(action, int):
-        return SecurityAction(action)
-    normalized = action.strip().lower()
-    if normalized in _ACTION_ALIASES:
-        return _ACTION_ALIASES[normalized]
-    for candidate in SecurityAction:
-        if candidate.name.lower() == normalized:
-            return candidate
-    raise ValueError(f"unknown security action: {action!r}")
+    if type(action) is int:
+        try:
+            return SecurityAction(action)
+        except ValueError as exc:
+            raise ValueError("unknown security action") from exc
+    if type(action) is str:
+        normalized = action.strip().lower()
+        if normalized in _ACTION_ALIASES:
+            return _ACTION_ALIASES[normalized]
+        for candidate in SecurityAction:
+            if candidate.name.lower() == normalized:
+                return candidate
+        raise ValueError(f"unknown security action: {action!r}")
+    raise ValueError("unknown security action")
 
 
 def security_gym_action_name(action: SecurityAction | int | str) -> str:
@@ -307,7 +313,12 @@ def to_security_gym_action(
     ``action`` id and a one-element ``risk_score`` array. A one-element tuple is
     accepted by the environment and keeps this module dependency-free.
     """
-    clipped_risk = min(10.0, max(0.0, float(risk_score)))
+    if type(risk_score) is bool or type(risk_score) not in (int, float):
+        raise ValueError("risk_score must be a finite real number")
+    score = float(risk_score)
+    if not math.isfinite(score):
+        raise ValueError("risk_score must be a finite real number")
+    clipped_risk = min(10.0, max(0.0, score))
     return {
         "action": int(coerce_security_action(action)),
         "risk_score": (clipped_risk,),

--- a/tests/test_security_integration.py
+++ b/tests/test_security_integration.py
@@ -43,6 +43,21 @@ def test_security_action_indices_are_stable() -> None:
     assert coerce_security_action(5) == SecurityAction.ISOLATE
 
 
+@pytest.mark.parametrize("action", [True, False, 1.0, 99])
+def test_coerce_security_action_rejects_noncanonical_actions(action: object) -> None:
+    with pytest.raises(ValueError, match="security action"):
+        coerce_security_action(action)  # type: ignore[arg-type]
+
+
+def test_to_security_gym_action_rejects_boolean_and_nonfinite_risk() -> None:
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action("pass", risk_score=True)
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action("pass", risk_score=float("nan"))
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action("pass", risk_score=float("inf"))
+
+
 def test_security_gym_action_adapter_matches_sibling_contract() -> None:
     assert SECURITY_GYM_ACTION_NAMES == (
         "pass",


### PR DESCRIPTION
## What changed

`coerce_security_action` and `to_security_gym_action` now reject boolean actions and non-finite risk scores before they can be recorded as defense actions.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `coerce_security_action(True)` returned `SecurityAction.ALERT`;
- `coerce_security_action(False)` returned `SecurityAction.PASS`;
- `risk_score=True` became `1.0`;
- `risk_score=nan` stayed NaN after `min/max` clip.

Those values are the published security-gym action contract. A boolean is not an action index.

Legal `coerce_security_action(5) == ISOLATE` and `risk_score=11.0 → 10.0` clip are unchanged.

## Scope

- `alberta_framework/security.py`
- `tests/test_security_integration.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, prior `fix/security-throughput-json`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`.

## Verification

Exact candidate head: `ed41152f021a69964deed6c243d21ab7c6fb1860`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_security_integration.py -q -o addopts=""`
- focused new coerce / risk_score tests
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the security-gym adapter only. It does not change reward tables, action indices, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ed41152f021a69964deed6c243d21ab7c6fb1860 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
