### PR TITLE
fix(baseline-optimizers): reject non-finite constructor scalars

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -41,6 +41,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.optimizers import (
     Optimizer,
     OptimizerUpdate,
@@ -242,10 +243,22 @@ class AdaGain(Optimizer[Any]):
             initial_step_size: Initial per-feature gain
             meta_step_size: Multiplicative meta-update rate
             forgetting_rate: Interpolation rate for the gradient trace
+
+        Raises:
+            ValueError: If a scalar is not a finite non-bool real in the
+                declared domain (``initial_step_size`` positive;
+                ``meta_step_size`` nonnegative; ``forgetting_rate`` in
+                ``[0, 1]``).
         """
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
-        self._forgetting_rate = forgetting_rate
+        self._initial_step_size = validated_float32_scalar(
+            "initial_step_size", initial_step_size, positive=True
+        )
+        self._meta_step_size = validated_float32_scalar(
+            "meta_step_size", meta_step_size, lower=0.0
+        )
+        self._forgetting_rate = validated_float32_scalar(
+            "forgetting_rate", forgetting_rate, lower=0.0, upper=1.0
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -405,12 +418,24 @@ class Adam(Optimizer[Any]):
             eps: Small constant added to the denominator
             weight_decay: Decoupled weight-decay coefficient (MLP path
                 only; requires passing ``param`` when nonzero)
+
+        Raises:
+            ValueError: If a scalar is not a finite non-bool real in the
+                declared domain (``step_size`` and ``eps`` positive;
+                ``beta1`` / ``beta2`` in ``[0, 1)``; ``weight_decay``
+                nonnegative).
         """
-        self._step_size = step_size
-        self._beta1 = beta1
-        self._beta2 = beta2
-        self._eps = eps
-        self._weight_decay = weight_decay
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._beta1 = validated_float32_scalar(
+            "beta1", beta1, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        self._beta2 = validated_float32_scalar(
+            "beta2", beta2, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        self._eps = validated_float32_scalar("eps", eps, positive=True)
+        self._weight_decay = validated_float32_scalar(
+            "weight_decay", weight_decay, lower=0.0
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -706,10 +731,15 @@ class RMSprop(Optimizer[Any]):
             step_size: Base learning rate alpha
             decay: Decay rate for the squared-gradient EMA
             eps: Small constant added to the denominator
+
+        Raises:
+            ValueError: If a scalar is not a finite non-bool real in the
+                declared domain (``step_size`` and ``eps`` positive;
+                ``decay`` in ``[0, 1]``).
         """
-        self._step_size = step_size
-        self._decay = decay
-        self._eps = eps
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._decay = validated_float32_scalar("decay", decay, lower=0.0, upper=1.0)
+        self._eps = validated_float32_scalar("eps", eps, positive=True)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -928,10 +958,15 @@ class NADALINE(Optimizer[Any]):
             step_size: Base learning rate alpha
             decay: EMA decay rate for the per-feature second moment
             eps: Floor on the denominator to avoid division by zero
+
+        Raises:
+            ValueError: If a scalar is not a finite non-bool real in the
+                declared domain (``step_size`` and ``eps`` positive;
+                ``decay`` in ``[0, 1]``).
         """
-        self._step_size = step_size
-        self._decay = decay
-        self._eps = eps
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._decay = validated_float32_scalar("decay", decay, lower=0.0, upper=1.0)
+        self._eps = validated_float32_scalar("eps", eps, positive=True)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/tests/test_baseline_optimizers_validation.py
+++ b/tests/test_baseline_optimizers_validation.py
@@ -1,0 +1,103 @@
+"""Constructor scalar contracts for Step 1 baseline optimizers.
+
+AdaGain, Adam, RMSprop, and NADALINE persist constructor scalars into
+``init`` / ``init_for_shape`` state. A NaN, Inf, or bool must not construct:
+IEEE-blind assignment stores the raw value, and ``jnp.array`` then writes
+NaN / Inf / ``1.0`` into every later update.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, RMSprop
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+        raise RuntimeError("untrusted ratio hook executed")
+
+
+class _ClassSpoof:
+    @property
+    def __class__(self):  # type: ignore[no-untyped-def]
+        return float
+
+    def __float__(self) -> float:  # pragma: no cover
+        return 0.1
+
+
+@pytest.mark.parametrize(
+    ("ctor", "field", "bad"),
+    [
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", float("nan")),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", float("inf")),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", 0.0),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", -0.1),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", True),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", _HostileFloat(0.05)),
+        (lambda v: AdaGain(initial_step_size=v), "initial_step_size", _ClassSpoof()),
+        (lambda v: AdaGain(meta_step_size=v), "meta_step_size", float("nan")),
+        (lambda v: AdaGain(meta_step_size=v), "meta_step_size", float("-inf")),
+        (lambda v: AdaGain(meta_step_size=v), "meta_step_size", -0.1),
+        (lambda v: AdaGain(meta_step_size=v), "meta_step_size", True),
+        (lambda v: AdaGain(forgetting_rate=v), "forgetting_rate", float("nan")),
+        (lambda v: AdaGain(forgetting_rate=v), "forgetting_rate", -0.1),
+        (lambda v: AdaGain(forgetting_rate=v), "forgetting_rate", 1.1),
+        (lambda v: AdaGain(forgetting_rate=v), "forgetting_rate", True),
+        (lambda v: Adam(step_size=v), "step_size", float("nan")),
+        (lambda v: Adam(step_size=v), "step_size", 0.0),
+        (lambda v: Adam(step_size=v), "step_size", True),
+        (lambda v: Adam(beta1=v), "beta1", 1.0),
+        (lambda v: Adam(beta1=v), "beta1", -0.1),
+        (lambda v: Adam(beta1=v), "beta1", True),
+        (lambda v: Adam(beta2=v), "beta2", 1.0),
+        (lambda v: Adam(beta2=v), "beta2", float("inf")),
+        (lambda v: Adam(eps=v), "eps", 0.0),
+        (lambda v: Adam(eps=v), "eps", float("inf")),
+        (lambda v: Adam(eps=v), "eps", True),
+        (lambda v: Adam(weight_decay=v), "weight_decay", -0.1),
+        (lambda v: Adam(weight_decay=v), "weight_decay", float("nan")),
+        (lambda v: Adam(weight_decay=v), "weight_decay", True),
+        (lambda v: RMSprop(step_size=v), "step_size", float("nan")),
+        (lambda v: RMSprop(step_size=v), "step_size", 0.0),
+        (lambda v: RMSprop(decay=v), "decay", 1.1),
+        (lambda v: RMSprop(decay=v), "decay", True),
+        (lambda v: RMSprop(eps=v), "eps", float("inf")),
+        (lambda v: NADALINE(step_size=v), "step_size", float("nan")),
+        (lambda v: NADALINE(step_size=v), "step_size", True),
+        (lambda v: NADALINE(decay=v), "decay", -0.1),
+        (lambda v: NADALINE(eps=v), "eps", 0.0),
+    ],
+)
+def test_baseline_optimizer_ctors_reject_illegal_scalars(ctor, field: str, bad: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        ctor(bad)
+
+
+def test_legal_zero_and_unit_scalars_remain_constructible() -> None:
+    adagain = AdaGain(initial_step_size=0.05, meta_step_size=0.0, forgetting_rate=1.0)
+    assert adagain.to_config()["meta_step_size"] == 0.0
+    assert adagain.to_config()["forgetting_rate"] == 1.0
+
+    adam = Adam(step_size=0.01, beta1=0.0, beta2=0.0, weight_decay=0.0)
+    assert adam.to_config()["beta1"] == 0.0
+    assert adam.to_config()["weight_decay"] == 0.0
+
+    rms = RMSprop(step_size=0.01, decay=0.0)
+    assert rms.to_config()["decay"] == 0.0
+
+    nadal = NADALINE(step_size=0.01, decay=0.0)
+    assert nadal.to_config()["decay"] == 0.0
+
+
+@pytest.mark.parametrize("np_type", [np.float32, np.float64])
+def test_baseline_optimizer_ctors_canonicalize_numpy_floats(np_type: type) -> None:
+    opt = AdaGain(
+        initial_step_size=np_type(0.05),
+        meta_step_size=np_type(0.0),
+        forgetting_rate=np_type(1.0),
+    )
+    assert opt.to_config()["initial_step_size"] == pytest.approx(0.05)
+    assert type(opt.to_config()["initial_step_size"]) is float


### PR DESCRIPTION
## What changed

Step 1 baseline constructors (`AdaGain`, `Adam`, `RMSprop`, `NADALINE`) now reject a non-finite, boolean, or out-of-domain constructor scalar before `init()` can write a poisoned step-size or moment vector.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `AdaGain(initial_step_size=nan)` constructed and `init()` wrote `[nan nan nan]`;
- `AdaGain(initial_step_size=True)` stored a `bool` and `init()` wrote `1.0`;
- `Adam(eps=inf)`, `RMSprop(decay=True)`, and `NADALINE(step_size=nan)` likewise persisted IEEE-invalid or bool values into later updates.

Those scalars are the live baseline optimizer state. A NaN step-size is not a baseline.

Legal zeros stay legal: `meta_step_size=0`, `forgetting_rate=1`, Adam `weight_decay=0`. Adam `beta1`/`beta2` stay in `[0, 1)`. IDBD / Autostep in `optimizers.py` are not touched.

## Scope

- `alberta_framework/core/baseline_optimizers.py`
- `tests/test_baseline_optimizers_validation.py`

## Why this is unowned

Live occupancy at publish time: open ASI PRs include Shaw `#890`–`#892`, ss251 `#893`/`#894`/`#898`/`#899`/`#901`/`#903`, byt61 `#895`–`#897`. Neither target file is in that map.

This is not a republish of `#899` (IDBD constructor step-sizes in `optimizers.py`), `#898` (partial-observation sentinels), `#903` (security-gym action/risk), `#901` (experiments seed counts), `#893`/`#894`, Shaw `#890`–`#892`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`. Those closed other classes — not Step 1 AdaGain/Adam/RMSprop/NADALINE constructors.

## Verification

Exact candidate head: `9ee5080cb2876fad433f1c36e4c4bbc329304b7c`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_baseline_optimizers_validation.py tests/test_baseline_optimizers.py -q -o addopts=""`: **74 passed**
- `ruff check` on the two files: clean
- `mypy alberta_framework/core/baseline_optimizers.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on Step 1 baseline constructors only. It does not change update equations, legal zero contracts, defaults, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9ee5080cb2876fad433f1c36e4c4bbc329304b7c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
