### PR TITLE
fix(true-online-td): reject non-finite constructor scalars

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -30,6 +30,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.normalizers import (
     EMANormalizerState,
@@ -1914,8 +1915,10 @@ class TrueOnlineTDLearner:
 
     def __init__(self, step_size: float = 0.05, trace_decay: float = 0.9):
         """Initialize the learner."""
-        self._step_size = step_size
-        self._trace_decay = trace_decay
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._trace_decay = validated_float32_scalar(
+            "trace_decay", trace_decay, lower=0.0, upper=1.0
+        )
 
     def init(self, feature_dim: int) -> TrueOnlineTDState:
         """Initialize learner state."""

--- a/tests/test_true_online_td.py
+++ b/tests/test_true_online_td.py
@@ -16,6 +16,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
+import pytest
 
 from alberta_framework import (
     LMS,
@@ -48,6 +49,20 @@ class TestInit:
         state = learner.init(3)
         pred = learner.predict(state, jnp.array([1.0, 2.0, 3.0]))
         chex.assert_trees_all_close(pred, jnp.array([0.0]))
+
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True])
+    def test_rejects_illegal_step_size(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            TrueOnlineTDLearner(step_size=step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("trace_decay", [float("nan"), float("inf"), -0.1, 1.5, True])
+    def test_rejects_illegal_trace_decay(self, trace_decay: object) -> None:
+        with pytest.raises(ValueError, match="trace_decay"):
+            TrueOnlineTDLearner(trace_decay=trace_decay)  # type: ignore[arg-type]
+
+    def test_legal_zero_trace_decay_is_td0(self) -> None:
+        learner = TrueOnlineTDLearner(step_size=0.05, trace_decay=0.0)
+        assert learner._trace_decay == 0.0
 
     def test_inf_reward_silent_feature_holds_finite_state(self) -> None:
         """Inf reward * a silent feature is 0*inf = NaN in the Dutch-trace update.


### PR DESCRIPTION
## What changed

`TrueOnlineTDLearner.__init__` now rejects a non-finite, boolean, or out-of-domain constructor scalar before `update()` can write a poisoned `alpha` / `lambda` into the Dutch-trace update.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `step_size=nan` / `inf` stored raw and became the live `alpha`;
- `step_size=True` stored a `bool` and became `1.0`;
- `step_size=0.0` constructed a no-learning learner with no documented skip contract;
- `trace_decay=nan` / `True` / `1.5` stored raw (`True` becomes lambda 1.0; `1.5` is outside `[0, 1]`).

`alpha` and `lambda` are the live True Online TD(lambda) update scales (van Seijen & Sutton 2014). A NaN step-size is not a learner.

Legal defaults (`0.05`, `0.9`) and legal `trace_decay=0` (TD(0)) are unchanged. IDBD / Autostep / Step 1 baselines are not touched.

## Scope

- `alberta_framework/core/learners.py`
- `tests/test_true_online_td.py`

## Why this is unowned

Live occupancy at publish time: open ASI PRs include Shaw `#890`–`#892`, ss251 `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`, byt61 `#895`–`#897`. Neither target file is in that map.

This is not a republish of `#899` (IDBD constructor step-sizes), `#904` (AdaGain/Adam/RMSprop/NADALINE constructors), `#898` (partial-observation sentinels), `#903` (security-gym action/risk), `#901` (experiments), `#893`/`#894`, Shaw `#890`–`#892`, scooped `step_size` / `#861` / `#711`, or HEIR `#4`. Those closed other classes — not True Online TD(lambda) constructor domains.

## Verification

Exact candidate head: `27699653e0172c92141fec321a8954cd92258da4`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `pytest tests/test_true_online_td.py -q -o addopts=""`: **24 passed**
- `ruff check` on the two files: clean
- `mypy alberta_framework/core/learners.py`: clean
- `scope-check.sh --max-files 2`: PASS
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the True Online TD constructor only. It does not change van Seijen & Sutton 2014 update equations, the existing inf-reward silent-feature hold, defaults, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:27699653e0172c92141fec321a8954cd92258da4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
