### PR TITLE
fix(metrics): reject boolean exposure and recovery identities

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -53,12 +53,13 @@ def _reject_boolean_numeric_trace(values: object, *, name: str) -> None:
         for index, item in enumerate(values):
             if _is_bool(item):
                 raise ValueError(f"{name}[{index}] must not be a boolean")
-            if isinstance(item, (list, tuple)):
-                for inner_index, inner in enumerate(item):
-                    if _is_bool(inner):
-                        raise ValueError(f"{name}[{index}][{inner_index}] must not be a boolean")
-    elif isinstance(values, np.ndarray) and values.dtype == np.bool_:
-        raise ValueError(f"{name} must not be a boolean array")
+            _reject_boolean_numeric_trace(item, name=f"{name}[{index}]")
+    elif isinstance(values, np.ndarray):
+        if values.dtype.kind == "b":
+            raise ValueError(f"{name} must not be a boolean array")
+        if values.dtype.kind == "O":
+            for index, item in enumerate(values.flat):
+                _reject_boolean_numeric_trace(item, name=f"{name}[{index}]")
 
 
 def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
@@ -68,11 +69,16 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         for index, item in enumerate(values):
             if not _is_index_int(item):
                 raise ValueError(f"{name}[{index}] must be an integer index, not a boolean")
+        return np.asarray(values, dtype=np.int64)
     else:
         array = np.asarray(values)
-        if array.dtype == np.bool_ or array.dtype.kind == "b":
-            raise ValueError(f"{name} must be integer indices, not booleans")
-    return np.asarray(values, dtype=np.int64)
+        if array.size == 0:
+            return np.asarray(array, dtype=np.int64)
+        if array.dtype.kind not in "iu":
+            raise ValueError(f"{name} must contain integer indices, not coerced values")
+        if array.dtype.kind == "u" and bool(np.any(array > np.iinfo(np.int64).max)):
+            raise ValueError(f"{name} contains an index outside the int64 domain")
+        return np.asarray(array, dtype=np.int64)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -15,10 +15,64 @@ References:
         Lifelong Learning: Identifying the Stability Gap."
 """
 
+import math
 from dataclasses import dataclass
+from numbers import Real
 
 import numpy as np
 from numpy.typing import NDArray
+
+
+def _is_bool(value: object) -> bool:
+    return type(value) is bool or type(value) is np.bool_
+
+
+def _is_index_int(value: object) -> bool:
+    return (type(value) is int or isinstance(value, np.integer)) and not _is_bool(value)
+
+
+def _require_positive_builtin_int(name: str, value: object) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive built-in integer")
+    return value
+
+
+def _require_finite_real(name: str, value: object) -> float:
+    if _is_bool(value) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    return number
+
+
+def _reject_boolean_numeric_trace(values: object, *, name: str) -> None:
+    if _is_bool(values):
+        raise ValueError(f"{name} must not be a boolean")
+    if isinstance(values, (list, tuple)):
+        for index, item in enumerate(values):
+            if _is_bool(item):
+                raise ValueError(f"{name}[{index}] must not be a boolean")
+            if isinstance(item, (list, tuple)):
+                for inner_index, inner in enumerate(item):
+                    if _is_bool(inner):
+                        raise ValueError(f"{name}[{index}][{inner_index}] must not be a boolean")
+    elif isinstance(values, np.ndarray) and values.dtype == np.bool_:
+        raise ValueError(f"{name} must not be a boolean array")
+
+
+def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
+    if _is_bool(values):
+        raise ValueError(f"{name} must be integer indices, not a boolean")
+    if isinstance(values, (list, tuple)):
+        for index, item in enumerate(values):
+            if not _is_index_int(item):
+                raise ValueError(f"{name}[{index}] must be an integer index, not a boolean")
+    else:
+        array = np.asarray(values)
+        if array.dtype == np.bool_ or array.dtype.kind == "b":
+            raise ValueError(f"{name} must be integer indices, not booleans")
+    return np.asarray(values, dtype=np.int64)
 
 
 @dataclass(frozen=True)
@@ -55,6 +109,7 @@ class ContinualLearningSummary:
 def _performance_matrix(
     performance_matrix: NDArray[np.floating] | list[list[float]],
 ) -> NDArray[np.float64]:
+    _reject_boolean_numeric_trace(performance_matrix, name="performance_matrix")
     matrix = np.asarray(performance_matrix, dtype=np.float64)
     if matrix.ndim != 2:
         raise ValueError("performance_matrix must have shape (checkpoints, tasks)")
@@ -69,7 +124,7 @@ def _first_exposure_rows(
     n_checkpoints: int,
     n_tasks: int,
 ) -> NDArray[np.int64]:
-    rows = np.asarray(first_exposure, dtype=np.int64)
+    rows = _require_index_vector(first_exposure, name="first_exposure")
     if rows.shape != (n_tasks,):
         raise ValueError("first_exposure must contain one row index per task")
     if np.any(rows < 0) or np.any(rows >= n_checkpoints):
@@ -201,6 +256,7 @@ def compute_prequential_performance(
 ) -> float:
     """Return mean predict-before-update performance over an online trace."""
 
+    _reject_boolean_numeric_trace(online_performance, name="online_performance")
     values = np.asarray(online_performance, dtype=np.float64)
     if values.ndim != 1 or values.size == 0:
         raise ValueError("online_performance must be a non-empty one-dimensional trace")
@@ -226,6 +282,10 @@ def compute_stability_gap(
     clipped at zero, so exceeding the reference is not treated as instability.
     """
 
+    _reject_boolean_numeric_trace(online_performance, name="online_performance")
+    _reject_boolean_numeric_trace(reference_performance, name="reference_performance")
+    if not isinstance(reference_performance, (list, tuple, np.ndarray)):
+        _require_finite_real("reference_performance", reference_performance)
     values = np.asarray(online_performance, dtype=np.float64)
     if values.ndim != 1 or values.size == 0:
         raise ValueError("online_performance must be a non-empty one-dimensional trace")
@@ -266,8 +326,11 @@ def compute_recovery_lengths(
     recovered before the next change point (or the end of the stream).
     """
 
+    _reject_boolean_numeric_trace(online_performance, name="online_performance")
     values = np.asarray(online_performance, dtype=np.float64)
-    points = np.asarray(change_points, dtype=np.int64)
+    points = _require_index_vector(change_points, name="change_points")
+    window_size = _require_positive_builtin_int("window_size", window_size)
+    _require_finite_real("threshold", threshold)
     if values.ndim != 1 or values.size == 0:
         raise ValueError("online_performance must be a non-empty one-dimensional trace")
     if points.ndim != 1 or points.size == 0:
@@ -276,8 +339,6 @@ def compute_recovery_lengths(
         raise ValueError("change_points must index online_performance")
     if np.any(np.diff(points) <= 0):
         raise ValueError("change_points must be strictly increasing")
-    if window_size < 1:
-        raise ValueError("window_size must be positive")
 
     recoveries = np.full(points.shape, -1, dtype=np.int64)
     for point_index, start in enumerate(points):

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -258,3 +258,70 @@ def test_tracking_error_shorter_than_window_has_no_computable_values() -> None:
 def test_running_mean_rejects_invalid_window_size(window_size: object) -> None:
     with pytest.raises(ValueError, match="window_size"):
         compute_running_mean([1.0, 2.0, 3.0], window_size=window_size)  # type: ignore[arg-type]
+
+
+def test_first_exposure_true_is_not_checkpoint_row_one() -> None:
+    """Boolean True is a subclass of int, so asarray(..., int64) stored row 1.
+
+    On a one-task matrix that hides 0.05 forgetting when the legal first
+    exposure is row 0. The exposure index is the task-identity axis for
+    forgetting and backward transfer.
+    """
+
+    performance = np.array([[0.80], [0.60], [0.75]])
+
+    with pytest.raises(ValueError, match="first_exposure"):
+        compute_per_task_forgetting(performance, [True])
+
+    np.testing.assert_allclose(compute_per_task_forgetting(performance, [0]), [0.05])
+    np.testing.assert_allclose(compute_per_task_forgetting(performance, [1]), [0.0])
+
+
+@pytest.mark.parametrize("window_size", [True, False, np.int64(2), 2.0, 0, -1])
+def test_recovery_rejects_non_canonical_window_size(window_size: object) -> None:
+    with pytest.raises(ValueError, match="window_size"):
+        compute_recovery_lengths(
+            [0.9, 0.2, 0.8, 0.9],
+            change_points=[1],
+            threshold=0.8,
+            window_size=window_size,  # type: ignore[arg-type]
+        )
+
+
+def test_recovery_rejects_boolean_change_point() -> None:
+    """change_points=[True] used to start at index 1 instead of failing."""
+
+    online = [0.1, 0.9, 0.9]
+    with pytest.raises(ValueError, match="change_points"):
+        compute_recovery_lengths(online, change_points=[True], threshold=0.8, window_size=1)
+
+    np.testing.assert_array_equal(
+        compute_recovery_lengths(online, change_points=[0], threshold=0.8, window_size=1),
+        [2],
+    )
+    np.testing.assert_array_equal(
+        compute_recovery_lengths(online, change_points=[1], threshold=0.8, window_size=1),
+        [1],
+    )
+
+
+@pytest.mark.parametrize("threshold", [True, False, float("nan"), float("inf")])
+def test_recovery_rejects_boolean_or_nonfinite_threshold(threshold: object) -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        compute_recovery_lengths(
+            [0.0, 1.0, 1.0],
+            change_points=[0],
+            threshold=threshold,  # type: ignore[arg-type]
+            window_size=1,
+        )
+
+
+def test_stability_and_prequential_reject_boolean_identities() -> None:
+    with pytest.raises(ValueError, match="reference_performance"):
+        compute_stability_gap([0.0, 1.0, 0.5], True)
+    with pytest.raises(ValueError, match="online_performance"):
+        compute_prequential_performance([True, False])
+
+    gap = compute_stability_gap([0.0, 1.0, 0.5], 1.0)
+    np.testing.assert_allclose(gap.per_step, [1.0, 0.0, 0.5])
+    assert compute_prequential_performance([0.0, 1.0]) == pytest.approx(0.5)

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -305,6 +305,30 @@ def test_recovery_rejects_boolean_change_point() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "change_points",
+    [
+        np.array([1.0]),
+        np.array([1.5]),
+        np.array([np.nan]),
+        np.array([np.iinfo(np.uint64).max], dtype=np.uint64),
+    ],
+)
+def test_recovery_rejects_coerced_numpy_change_points(change_points: object) -> None:
+    with pytest.raises(ValueError, match="change_points"):
+        compute_recovery_lengths(
+            [0.1, 0.9, 0.9],
+            change_points=change_points,  # type: ignore[arg-type]
+            threshold=0.8,
+            window_size=1,
+        )
+
+
+def test_nested_numpy_boolean_trace_is_rejected() -> None:
+    with pytest.raises(ValueError, match="online_performance"):
+        compute_prequential_performance([np.array(True), np.array(False)])
+
+
 @pytest.mark.parametrize("threshold", [True, False, float("nan"), float("inf")])
 def test_recovery_rejects_boolean_or_nonfinite_threshold(threshold: object) -> None:
     with pytest.raises(ValueError, match="threshold"):


### PR DESCRIPTION
Closes #906.

## What changed

`first_exposure`, `change_points`, recovery `window_size`, and recovery `threshold` now reject boolean and non-canonical identities before a publication metric can mint a false checkpoint or window.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `first_exposure=[True]` reported forgetting `0.0` on `[[0.80],[0.60],[0.75]]` instead of the legal `0.05` at `[0]`;
- `change_points=[True]` started recovery at index 1;
- `window_size=True` was a one-step recovery window;
- `threshold=True` was `1.0`; `threshold=nan` reported `[-1]`.

The exposure index is the aligned task-identity axis for forgetting and backward transfer. A boolean is not a checkpoint.

Legal `first_exposure=[0]` / `[1]`, `change_points=[0]` / `[1]`, and `window_size=1` are unchanged.

## Scope

- `alberta_framework/utils/metrics.py`
- `tests/test_continual_metrics.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or constructor taxes on `experiments.py` / `security.py`.

## Verification

Exact candidate head: `8d67ed69d6dc720eb08e3bbd4e4be4f6c34b1ab2`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `PYTHONPATH=<worktree> pytest tests/test_continual_metrics.py -q -o addopts=""` → 40 passed
- focused first-exposure / recovery-identity tests
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the continual-metrics helpers only. It does not change learning-loop equations, aggregation formulas, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:8d67ed69d6dc720eb08e3bbd4e4be4f6c34b1ab2 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
