### PR TITLE
fix(nexting): reject boolean discount identities

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -32,9 +32,7 @@ References:
 
 from __future__ import annotations
 
-import math
 from functools import partial
-from numbers import Real
 
 import jax
 import jax.numpy as jnp
@@ -47,37 +45,58 @@ def _is_bool(value: object) -> bool:
     return type(value) is bool or type(value) is np.bool_
 
 
-def _require_host_discount(name: str, value: object) -> object:
+def _concrete_numeric_array(
+    name: str,
+    value: object,
+    *,
+    ndim: int,
+) -> np.ndarray | None:
+    """Return a concrete numeric host view, or ``None`` for a JAX tracer."""
+    if isinstance(value, jax.core.Tracer):
+        if value.ndim != ndim:
+            raise ValueError(f"{name} must be {ndim}-dimensional")
+        if jnp.issubdtype(value.dtype, jnp.bool_):
+            raise ValueError(f"{name} must not be boolean")
+        return None
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+    if array.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}-dimensional")
+    if array.dtype.kind not in "biuf":
+        raise ValueError(f"{name} must be real-valued")
+    return array
+
+
+def _require_host_discount[T](name: str, value: T, *, ndim: int) -> T:
     """Reject boolean / non-finite host discounts before they become 0/1 identities."""
     if _is_bool(value):
         raise ValueError(f"{name} must be a finite discount in [0, 1], not a boolean")
-    if isinstance(value, Real):
-        number = float(value)
-        if not math.isfinite(number) or not 0.0 <= number <= 1.0:
-            raise ValueError(f"{name} must be a finite discount in [0, 1]")
+    array = _concrete_numeric_array(name, value, ndim=ndim)
+    if array is None:
         return value
-    dtype = getattr(value, "dtype", None)
-    if dtype is not None and jnp.issubdtype(dtype, jnp.bool_):
+    if array.dtype.kind == "b":
         raise ValueError(f"{name} must be a finite discount in [0, 1], not a boolean")
-    if dtype is not None:
-        return value
-    raise ValueError(f"{name} must be a finite discount in [0, 1]")
+    if not bool(np.all(np.isfinite(array))) or not bool(
+        np.all((array >= 0.0) & (array <= 1.0))
+    ):
+        raise ValueError(f"{name} must be a finite discount in [0, 1]")
+    return value
 
 
-def _require_host_finite_real(name: str, value: object) -> object:
+def _require_host_finite_real[T](name: str, value: T) -> T:
     """Reject boolean / non-finite host scalars before they become 0/1 bootstraps."""
     if _is_bool(value):
         raise ValueError(f"{name} must be a finite real number, not a boolean")
-    if isinstance(value, Real):
-        if not math.isfinite(float(value)):
-            raise ValueError(f"{name} must be a finite real number")
+    array = _concrete_numeric_array(name, value, ndim=0)
+    if array is None:
         return value
-    dtype = getattr(value, "dtype", None)
-    if dtype is not None and jnp.issubdtype(dtype, jnp.bool_):
+    if array.dtype.kind == "b":
         raise ValueError(f"{name} must be a finite real number, not a boolean")
-    if dtype is not None:
-        return value
-    raise ValueError(f"{name} must be a finite real number")
+    if not bool(np.isfinite(array)):
+        raise ValueError(f"{name} must be a finite real number")
+    return value
 
 
 def forward_view_returns(
@@ -101,7 +120,7 @@ def forward_view_returns(
         Array of shape ``(T,)`` where index ``t`` is the forward-view
         return ``G_t = c_{t+1} + gamma * c_{t+2} + gamma^2 * c_{t+3} + ...``.
     """
-    gamma = _require_host_discount("gamma", gamma)
+    gamma = _require_host_discount("gamma", gamma, ndim=0)
     terminal_value = _require_host_finite_real("terminal_value", terminal_value)
     gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
     init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
@@ -135,7 +154,7 @@ def multi_horizon_returns(
         Array of shape ``(T, H)`` -- ``[t, h]`` is the forward-view return
         from step ``t`` at horizon ``gammas[h]``.
     """
-    gammas = _require_host_discount("gammas", gammas)
+    gammas = _require_host_discount("gammas", gammas, ndim=1)
     terminal_value = _require_host_finite_real("terminal_value", terminal_value)
 
     def per_gamma(g: Array) -> Array:

--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -32,12 +32,52 @@ References:
 
 from __future__ import annotations
 
+import math
 from functools import partial
+from numbers import Real
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
+
+
+def _is_bool(value: object) -> bool:
+    return type(value) is bool or type(value) is np.bool_
+
+
+def _require_host_discount(name: str, value: object) -> object:
+    """Reject boolean / non-finite host discounts before they become 0/1 identities."""
+    if _is_bool(value):
+        raise ValueError(f"{name} must be a finite discount in [0, 1], not a boolean")
+    if isinstance(value, Real):
+        number = float(value)
+        if not math.isfinite(number) or not 0.0 <= number <= 1.0:
+            raise ValueError(f"{name} must be a finite discount in [0, 1]")
+        return value
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and jnp.issubdtype(dtype, jnp.bool_):
+        raise ValueError(f"{name} must be a finite discount in [0, 1], not a boolean")
+    if dtype is not None:
+        return value
+    raise ValueError(f"{name} must be a finite discount in [0, 1]")
+
+
+def _require_host_finite_real(name: str, value: object) -> object:
+    """Reject boolean / non-finite host scalars before they become 0/1 bootstraps."""
+    if _is_bool(value):
+        raise ValueError(f"{name} must be a finite real number, not a boolean")
+    if isinstance(value, Real):
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be a finite real number")
+        return value
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and jnp.issubdtype(dtype, jnp.bool_):
+        raise ValueError(f"{name} must be a finite real number, not a boolean")
+    if dtype is not None:
+        return value
+    raise ValueError(f"{name} must be a finite real number")
 
 
 def forward_view_returns(
@@ -61,6 +101,8 @@ def forward_view_returns(
         Array of shape ``(T,)`` where index ``t`` is the forward-view
         return ``G_t = c_{t+1} + gamma * c_{t+2} + gamma^2 * c_{t+3} + ...``.
     """
+    gamma = _require_host_discount("gamma", gamma)
+    terminal_value = _require_host_finite_real("terminal_value", terminal_value)
     gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
     init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
 
@@ -93,6 +135,8 @@ def multi_horizon_returns(
         Array of shape ``(T, H)`` -- ``[t, h]`` is the forward-view return
         from step ``t`` at horizon ``gammas[h]``.
     """
+    gammas = _require_host_discount("gammas", gammas)
+    terminal_value = _require_host_finite_real("terminal_value", terminal_value)
 
     def per_gamma(g: Array) -> Array:
         return forward_view_returns(cumulants, g, terminal_value=terminal_value)

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -64,6 +64,36 @@ class TestForwardViewReturns:
         g = forward_view_returns(c, gamma=1.0, terminal_value=10.0)
         chex.assert_trees_all_close(g, jnp.array([11.0, 11.0, 11.0]))
 
+    @pytest.mark.parametrize("gamma", [True, False, float("nan"), float("inf"), -0.1, 1.1])
+    def test_gamma_rejects_boolean_and_non_discount_host_values(self, gamma: object) -> None:
+        """True used to compile as undiscounted gamma=1.0; False as gamma=0.0."""
+
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        with pytest.raises(ValueError, match="gamma"):
+            forward_view_returns(c, gamma=cast(float, gamma))
+
+    def test_gamma_true_is_not_the_undiscounted_identity(self) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        legal = forward_view_returns(c, gamma=1.0)
+        chex.assert_trees_all_close(legal, jnp.array([6.0, 5.0, 3.0]))
+        with pytest.raises(ValueError, match="boolean"):
+            forward_view_returns(c, gamma=True)
+
+    @pytest.mark.parametrize("terminal_value", [True, False, float("nan"), float("inf")])
+    def test_terminal_value_rejects_boolean_and_nonfinite_hosts(
+        self, terminal_value: object
+    ) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        with pytest.raises(ValueError, match="terminal_value"):
+            forward_view_returns(c, gamma=0.0, terminal_value=cast(float, terminal_value))
+
+    def test_bool_gamma_vector_is_not_the_one_zero_horizon_pair(self) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        legal = multi_horizon_returns(c, jnp.array([1.0, 0.0], dtype=jnp.float32))
+        chex.assert_shape(legal, (3, 2))
+        with pytest.raises(ValueError, match="gammas"):
+            multi_horizon_returns(c, jnp.array([True, False]))
+
 
 class TestMultiHorizon:
     def test_shape(self) -> None:

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -94,6 +94,26 @@ class TestForwardViewReturns:
         with pytest.raises(ValueError, match="gammas"):
             multi_horizon_returns(c, jnp.array([True, False]))
 
+    @pytest.mark.parametrize("array_type", [np.asarray, jnp.asarray])
+    @pytest.mark.parametrize("gamma", [float("nan"), float("inf"), -0.1, 1.1])
+    def test_concrete_array_gamma_is_validated(self, array_type, gamma: float) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        with pytest.raises(ValueError, match="gamma"):
+            forward_view_returns(c, gamma=array_type(gamma))
+
+    @pytest.mark.parametrize("array_type", [np.asarray, jnp.asarray])
+    def test_concrete_gamma_vector_values_are_validated(self, array_type) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        with pytest.raises(ValueError, match="gammas"):
+            multi_horizon_returns(c, array_type([0.5, float("nan")]))
+        with pytest.raises(ValueError, match="gammas"):
+            multi_horizon_returns(c, array_type([0.5, 1.1]))
+
+    def test_jit_traced_legal_gamma_remains_supported(self) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        actual = jax.jit(forward_view_returns)(c, jnp.array(0.5, dtype=jnp.float32))
+        chex.assert_trees_all_close(actual, jnp.array([2.75, 3.5, 3.0]))
+
 
 class TestMultiHorizon:
     def test_shape(self) -> None:


### PR DESCRIPTION
Closes #907.

## What changed

`forward_view_returns` and `multi_horizon_returns` now reject boolean and non-canonical host discounts before a nexting evaluation can mint a false return identity.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `gamma=True` compiled as undiscounted `gamma=1.0` (`[6, 5, 3]` on `[1, 2, 3]`);
- `gamma=False` compiled as `gamma=0.0`;
- `gamma=nan` wrote an all-NaN return series;
- `gammas=[True, False]` was the `[1, 0]` horizon pair;
- `terminal_value=True` bootstrapped `1.0`.

The discount is the Modayil/White/Sutton nexting identity. A boolean is not a gamma.

Legal `gamma=0.0` / `0.5` / `1.0` and `terminal_value=10.0` are unchanged.

## Scope

- `alberta_framework/utils/nexting.py`
- `tests/test_nexting.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or constructor taxes on `experiments.py` / `security.py`.

## Verification

Exact candidate head: `5111a876eed27412f7b4845d97b5f61c523c46be`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `PYTHONPATH=<worktree> pytest tests/test_nexting.py -q -o addopts=""` → 78 passed
- focused gamma / terminal-value identity tests
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on the nexting evaluation harness only. It does not change learning-loop equations, GVF updates, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:5111a876eed27412f7b4845d97b5f61c523c46be -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
