### PR TITLE
fix(average-reward): reject non-finite differential step sizes

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -37,7 +37,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
 from alberta_framework.core.multi_head_learner import MultiHeadMLPLearner, MultiHeadMLPState
 from alberta_framework.core.optimizers import Autostep, AutostepParamState, optimizer_from_config
@@ -47,6 +50,7 @@ from alberta_framework.core.update_safety import (
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+_FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -91,6 +95,32 @@ def _require_state_resources(name: str, *, scalars: int, nbytes: int) -> None:
         raise ValueError(f"{name} state scalars must fit signed int32")
     if nbytes > _INT32_MAX:
         raise ValueError(f"{name} state bytes must fit signed int32")
+
+
+def _validated_nonnegative_float32_scalar(
+    name: str,
+    value: object,
+    *,
+    upper: float | None = None,
+) -> float:
+    """Validate a nonnegative float32 sink without losing a nonzero value.
+
+    Exact zero is a supported way to disable these updates. A positive host
+    value that rounds to binary32 zero is not: accepting it would silently
+    turn an enabled learning rate or trace into the disabled configuration.
+    """
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        lower=0.0,
+        upper=upper,
+    )
+    if (
+        numerator != 0
+        and numerator * _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR <= denominator
+    ):
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
 
 
 def _preflight_actor_state(
@@ -212,15 +242,14 @@ class DifferentialTDConfig:
             object.__setattr__(
                 self,
                 name,
-                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+                _validated_nonnegative_float32_scalar(name, getattr(self, name)),
             )
         object.__setattr__(
             self,
             "trace_decay",
-            validated_float32_scalar(
+            _validated_nonnegative_float32_scalar(
                 "trace_decay",
                 self.trace_decay,
-                lower=0.0,
                 upper=1.0,
             ),
         )
@@ -320,15 +349,14 @@ class DifferentialGTDConfig:
             object.__setattr__(
                 self,
                 name,
-                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+                _validated_nonnegative_float32_scalar(name, getattr(self, name)),
             )
         object.__setattr__(
             self,
             "trace_decay",
-            validated_float32_scalar(
+            _validated_nonnegative_float32_scalar(
                 "trace_decay",
                 self.trace_decay,
-                lower=0.0,
                 upper=1.0,
             ),
         )
@@ -973,15 +1001,13 @@ class AverageRewardHordeLearner:
         """Initialize the average-reward Horde."""
         if n_demons < 1:
             raise ValueError("n_demons must be positive")
-        average_reward_step_size = validated_float32_scalar(
+        average_reward_step_size = _validated_nonnegative_float32_scalar(
             "average_reward_step_size",
             average_reward_step_size,
-            lower=0.0,
         )
-        trace_decay = validated_float32_scalar(
+        trace_decay = _validated_nonnegative_float32_scalar(
             "trace_decay",
             trace_decay,
-            lower=0.0,
             upper=1.0,
         )
         self._n_demons = n_demons

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -208,12 +208,22 @@ class DifferentialTDConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if self.step_size < 0.0:
-            raise ValueError("step_size must be non-negative")
-        if self.average_reward_step_size < 0.0:
-            raise ValueError("average_reward_step_size must be non-negative")
-        if not 0.0 <= self.trace_decay <= 1.0:
-            raise ValueError("trace_decay must be in [0, 1]")
+        for name in ("step_size", "average_reward_step_size"):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+            )
+        object.__setattr__(
+            self,
+            "trace_decay",
+            validated_float32_scalar(
+                "trace_decay",
+                self.trace_decay,
+                lower=0.0,
+                upper=1.0,
+            ),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this config to a dictionary."""
@@ -302,16 +312,31 @@ class DifferentialGTDConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar hyperparameters."""
-        if self.value_step_size < 0.0:
-            raise ValueError("value_step_size must be non-negative")
-        if self.secondary_step_size < 0.0:
-            raise ValueError("secondary_step_size must be non-negative")
-        if self.average_reward_step_size < 0.0:
-            raise ValueError("average_reward_step_size must be non-negative")
-        if not 0.0 <= self.trace_decay <= 1.0:
-            raise ValueError("trace_decay must be in [0, 1]")
-        if self.ratio_clip <= 0.0:
-            raise ValueError("ratio_clip must be positive")
+        for name in (
+            "value_step_size",
+            "secondary_step_size",
+            "average_reward_step_size",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                validated_float32_scalar(name, getattr(self, name), lower=0.0),
+            )
+        object.__setattr__(
+            self,
+            "trace_decay",
+            validated_float32_scalar(
+                "trace_decay",
+                self.trace_decay,
+                lower=0.0,
+                upper=1.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "ratio_clip",
+            validated_float32_scalar("ratio_clip", self.ratio_clip, positive=True),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this config to a dictionary."""
@@ -948,10 +973,17 @@ class AverageRewardHordeLearner:
         """Initialize the average-reward Horde."""
         if n_demons < 1:
             raise ValueError("n_demons must be positive")
-        if average_reward_step_size < 0.0:
-            raise ValueError("average_reward_step_size must be non-negative")
-        if not 0.0 <= trace_decay <= 1.0:
-            raise ValueError("trace_decay must be in [0, 1]")
+        average_reward_step_size = validated_float32_scalar(
+            "average_reward_step_size",
+            average_reward_step_size,
+            lower=0.0,
+        )
+        trace_decay = validated_float32_scalar(
+            "trace_decay",
+            trace_decay,
+            lower=0.0,
+            upper=1.0,
+        )
         self._n_demons = n_demons
         self._hidden_sizes = hidden_sizes
         self._step_size = step_size

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -937,6 +937,63 @@ def test_average_reward_horde_rejects_nonfinite_reward_rate_scalars() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("config_type", "field"),
+    [
+        (DifferentialTDConfig, "step_size"),
+        (DifferentialTDConfig, "average_reward_step_size"),
+        (DifferentialTDConfig, "trace_decay"),
+        (DifferentialGTDConfig, "value_step_size"),
+        (DifferentialGTDConfig, "secondary_step_size"),
+        (DifferentialGTDConfig, "average_reward_step_size"),
+        (DifferentialGTDConfig, "trace_decay"),
+    ],
+)
+def test_differential_configs_reject_nonzero_float32_underflow(
+    config_type: type[DifferentialTDConfig] | type[DifferentialGTDConfig],
+    field: str,
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must remain nonzero"):
+        config_type(**{field: 2.0**-150})
+    with pytest.raises(ValueError, match=f"{field} must remain nonzero"):
+        config_type(**{field: 5e-324})
+
+
+def test_nonnegative_average_reward_float32_sinks_preserve_zero_and_minsubnormal() -> None:
+    smallest_float32 = 2.0**-149
+    td = DifferentialTDConfig(
+        step_size=0.0,
+        average_reward_step_size=smallest_float32,
+        trace_decay=smallest_float32,
+    )
+    gtd = DifferentialGTDConfig(
+        value_step_size=smallest_float32,
+        secondary_step_size=0.0,
+        average_reward_step_size=smallest_float32,
+        trace_decay=0.0,
+    )
+    horde = AverageRewardHordeLearner(
+        n_demons=2,
+        hidden_sizes=(4,),
+        average_reward_step_size=smallest_float32,
+        trace_decay=0.0,
+    )
+
+    assert td.step_size == 0.0
+    assert td.average_reward_step_size == smallest_float32
+    assert td.trace_decay == smallest_float32
+    assert gtd.value_step_size == smallest_float32
+    assert gtd.secondary_step_size == 0.0
+    assert horde.to_config()["average_reward_step_size"] == smallest_float32
+
+
+def test_average_reward_horde_rejects_nonzero_float32_underflow() -> None:
+    with pytest.raises(ValueError, match="average_reward_step_size must remain nonzero"):
+        AverageRewardHordeLearner(n_demons=2, average_reward_step_size=2.0**-150)
+    with pytest.raises(ValueError, match="trace_decay must remain nonzero"):
+        AverageRewardHordeLearner(n_demons=2, trace_decay=5e-324)
+
+
 def test_average_reward_configs_canonicalize_float32_sink_values() -> None:
     actor = AverageRewardHordeActorCriticConfig(
         n_actions=2,

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -898,6 +898,16 @@ def test_average_reward_decoders_reject_schema_and_container_ambiguity() -> None
         (DifferentialSARSAConfig, "trace_decay", 1.0 + 1.0e-10),
         (DifferentialSARSAConfig, "epsilon_start", 1.0e100),
         (DifferentialSARSAConfig, "use_bias", np.bool_(True)),
+        (DifferentialTDConfig, "step_size", float("nan")),
+        (DifferentialTDConfig, "step_size", float("inf")),
+        (DifferentialTDConfig, "average_reward_step_size", float("nan")),
+        (DifferentialTDConfig, "trace_decay", float("nan")),
+        (DifferentialGTDConfig, "value_step_size", float("nan")),
+        (DifferentialGTDConfig, "secondary_step_size", float("inf")),
+        (DifferentialGTDConfig, "average_reward_step_size", float("-inf")),
+        (DifferentialGTDConfig, "trace_decay", float("nan")),
+        (DifferentialGTDConfig, "ratio_clip", float("nan")),
+        (DifferentialGTDConfig, "ratio_clip", 0.0),
     ),
 )
 def test_average_reward_configs_reject_invalid_float32_sink_values(
@@ -905,9 +915,26 @@ def test_average_reward_configs_reject_invalid_float32_sink_values(
     field: str,
     value: object,
 ) -> None:
-    kwargs = {"n_actions": 2, field: value}
+    kwargs: dict[str, object] = {field: value}
+    if config_type in (AverageRewardHordeActorCriticConfig, DifferentialSARSAConfig):
+        kwargs["n_actions"] = 2
     with pytest.raises(ValueError, match=field):
         config_type(**kwargs)
+
+
+def test_average_reward_horde_rejects_nonfinite_reward_rate_scalars() -> None:
+    with pytest.raises(ValueError, match="average_reward_step_size"):
+        AverageRewardHordeLearner(n_demons=2, average_reward_step_size=float("nan"))
+    with pytest.raises(ValueError, match="average_reward_step_size"):
+        AverageRewardHordeLearner(n_demons=2, average_reward_step_size=float("inf"))
+    with pytest.raises(ValueError, match="trace_decay"):
+        AverageRewardHordeLearner(n_demons=2, trace_decay=float("nan"))
+    AverageRewardHordeLearner(
+        n_demons=2,
+        hidden_sizes=(4,),
+        average_reward_step_size=0.0,
+        trace_decay=0.0,
+    )
 
 
 def test_average_reward_configs_canonicalize_float32_sink_values() -> None:
@@ -919,11 +946,17 @@ def test_average_reward_configs_canonicalize_float32_sink_values() -> None:
         n_actions=2,
         epsilon_start=np.float64(0.2),
     )
+    td = DifferentialTDConfig(step_size=np.float64(0.2))
+    gtd = DifferentialGTDConfig(value_step_size=np.float64(0.2))
 
     assert type(actor.critic_step_size) is float
     assert actor.critic_step_size == float(np.float32(0.2))
     assert type(sarsa.epsilon_start) is float
     assert sarsa.epsilon_start == float(np.float32(0.2))
+    assert type(td.step_size) is float
+    assert td.step_size == float(np.float32(0.2))
+    assert type(gtd.value_step_size) is float
+    assert gtd.value_step_size == float(np.float32(0.2))
 
 
 def test_average_reward_actor_preflights_state_before_allocation() -> None:


### PR DESCRIPTION
Closes #910.

## What changed

`DifferentialTDConfig`, `DifferentialGTDConfig`, and `AverageRewardHordeLearner` now reject non-finite host step-sizes and traces before a differential update can mint a silent no-op learner.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- `DifferentialTDConfig(step_size=nan)` constructed; one update then fail-closed forever (`update_applied=False`, `average_reward=0.0`)
- `DifferentialGTDConfig(ratio_clip=nan)` constructed
- `AverageRewardHordeLearner(average_reward_step_size=nan)` constructed; `rbar += nan * td` would refuse every later transaction

Sibling `AverageRewardHordeActorCriticConfig` / `DifferentialSARSAConfig` already used `validated_float32_scalar`. This closes the leftover IEEE-blind comparisons in the same module.

Legal `step_size=0.0` and `trace_decay=0.0` are unchanged.

## Scope

- `alberta_framework/core/average_reward.py`
- `tests/test_average_reward.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or a bool/True-as-1 identity tax on metrics / nexting / experiments / security / IDBD / true-online-td / baseline-optimizers / partial-observation.

## Verification

Exact candidate head: `fb8719c65e9897dd8ee7a90bf857869e079ae698`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `PYTHONPATH=<worktree> pytest tests/test_average_reward.py -q -o addopts=""` → 65 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean

## Scientific integrity

This is fail-closed host-boundary validation on Step 5/6 constructors only. It does not change the Wan/Naik/Sutton differential update equations, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:fb8719c65e9897dd8ee7a90bf857869e079ae698 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
