### PR TITLE
fix(upgd-ipmnist): bind v2 schema and policy by identity

### DIFF
--- a/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
@@ -865,14 +865,23 @@ def validate_upgd_ipmnist_v2_artifact(
         errors.append("v2 artifact fields do not match the strict schema")
     if artifact.get("schema") != UPGD_IPMNIST_ARTIFACT_SCHEMA_V2:
         errors.append("artifact is not an alberta.upgd_ipmnist.artifact.v2 payload")
-    if artifact.get("schema_version") != 2:
-        errors.append("v2 artifact schema_version must equal 2")
+    schema_version = artifact.get("schema_version")
+    if type(schema_version) is not int or schema_version != 2:
+        errors.append("v2 artifact schema_version must be integer 2")
     if artifact.get("benchmark") != UPGD_IPMNIST_BENCHMARK:
         errors.append("v2 artifact benchmark identifier is unsupported")
     created = _finite_number(artifact.get("created_unix"))
     if created is None or created <= 0.0:
         errors.append("v2 artifact created_unix must be finite and positive")
-    if artifact.get("evidence_policy") != V2_NONPROMOTING_POLICY:
+    policy = artifact.get("evidence_policy")
+    if (
+        not isinstance(policy, Mapping)
+        or set(policy) != set(V2_NONPROMOTING_POLICY)
+        or policy.get("evidence_class") != V2_NONPROMOTING_POLICY["evidence_class"]
+        or policy.get("development_only") is not True
+        or policy.get("scientific_promotion_allowed") is not False
+        or policy.get("execution_attestation") is not False
+    ):
         errors.append("v2 artifact evidence policy must remain permanently nonpromoting")
     if artifact.get("deviations") != V2_PROTOCOL_DEVIATIONS:
         errors.append("v2 artifact structured deviations do not match the contract")

--- a/tests/test_upgd_ipmnist_nonpromoting.py
+++ b/tests/test_upgd_ipmnist_nonpromoting.py
@@ -447,6 +447,56 @@ def test_v2_expected_manifest_stable_shards_match_file_digest(tmp_path: Path) ->
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("schema_version", [2.0, "2"])
+def test_v2_artifact_rejects_non_int_schema_version(
+    tmp_path: Path, schema_version: object
+) -> None:
+    paths = _write_v2_shards(tmp_path, seeds=(0,))
+    artifact = _write_v2_artifact(tmp_path, paths)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    payload["schema_version"] = schema_version
+    artifact.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+    validation = validate_upgd_ipmnist_v2_artifact(artifact, paths)
+
+    assert not validation.valid
+    assert any("schema_version" in error for error in validation.errors)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "policy_updates",
+    [
+        {
+            "development_only": 1,
+            "scientific_promotion_allowed": 0,
+            "execution_attestation": 0,
+        },
+        {
+            "development_only": 1.0,
+            "scientific_promotion_allowed": 0.0,
+            "execution_attestation": 0.0,
+        },
+    ],
+)
+def test_v2_artifact_rejects_numeric_policy_aliases(
+    tmp_path: Path, policy_updates: dict[str, object]
+) -> None:
+    paths = _write_v2_shards(tmp_path, seeds=(0,))
+    artifact = _write_v2_artifact(tmp_path, paths)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    policy = dict(payload["evidence_policy"])
+    policy.update(policy_updates)
+    payload["evidence_policy"] = policy
+    artifact.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+    validation = validate_upgd_ipmnist_v2_artifact(artifact, paths)
+
+    assert not validation.valid
+    assert any("evidence policy" in error for error in validation.errors)
+
+
+@pytest.mark.unit
 def test_v2_validator_rejects_v1_schema_even_when_filename_says_v2(tmp_path: Path) -> None:
     v1_paths = _write_shards(tmp_path, seeds=(0,))
     misleading_path = tmp_path / "results.reconciled_nonpromoting.v2.json"


### PR DESCRIPTION
Closes #911.

## What changed

The permanently nonpromoting UPGD-IPMNIST v2 artifact validator now binds `schema_version` and `evidence_policy` by type and identity, matching v1 schema-version checks and v2 provenance identity checks.

On `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

- legal `schema_version: 2` + boolean policy → `valid=True`
- `schema_version: 2.0` → `valid=True` (`2.0 == 2`)
- policy `development_only: 1`, `scientific_promotion_allowed: 0`, `execution_attestation: 0` → `valid=True` (`1 == True`, `0 == False`)

Those aliases are not the frozen integer/boolean contract. The module remains permanently nonpromoting (`scientific_promotion_allowed` stays `False`).

## Scope

- `alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py`
- `tests/test_upgd_ipmnist_nonpromoting.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or a bool/True-as-1 constructor tax on metrics / nexting / experiments / security / IDBD / true-online-td / baseline-optimizers / partial-observation.

## Verification

Exact candidate head: `183c2630d023c2e63ab29945dd552d14f945d85c`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- `PYTHONPATH=<worktree> pytest tests/test_upgd_ipmnist_nonpromoting.py -q -o addopts=""` → 28 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean

## Scientific integrity

This is fail-closed validator-identity binding on a permanently nonpromoting development artifact. It does not change shard aggregation, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:183c2630d023c2e63ab29945dd552d14f945d85c -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
