### PR TITLE
fix(label-emnist): refuse vacuous n<2 stderr

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -725,13 +725,21 @@ def load_emnist_balanced_train(
 
 def _stderr(values: np.ndarray) -> float:
     if values.shape[0] < 2:
-        return 0.0
+        raise ValueError(
+            "stderr is undefined for fewer than two observations; "
+            "refusing to report a look-alike zero"
+        )
     return float(values.std(ddof=1) / math.sqrt(values.shape[0]))
 
 
 def summarize_result(result: LabelEMNISTRunResult) -> dict[str, Any]:
     """Reduce one learner's run to JSON-serializable summary statistics."""
     accuracy = result.average_online_accuracy
+    if accuracy.shape[0] < 2:
+        raise ValueError(
+            "stderr is undefined for fewer than two observations; "
+            "refusing to report a look-alike zero"
+        )
     quarter = max(1, result.config.n_tasks // 4)
     per_seed_first = result.per_task_accuracy[:, :quarter].mean(axis=1)
     per_seed_last = result.per_task_accuracy[:, -quarter:].mean(axis=1)

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -22,6 +22,7 @@ from alberta_framework.benchmarks.upgd_label_emnist import (
     UPGD_EMA_NORM_SIGMA0_HYPERPARAMETERS,
     UPGD_W_PROTOCOL_HYPERPARAMETERS,
     LabelEMNISTConfig,
+    LabelEMNISTRunResult,
     build_artifact,
     build_comparison,
     build_plan_payload,
@@ -702,9 +703,39 @@ class TestPlanShardMergeAccounting:
         with pytest.raises(ValueError, match="not planned"):
             merge_partials(plan, [path], allow_incomplete=True)
 
+    def _synthetic_result(self, accuracies: np.ndarray) -> LabelEMNISTRunResult:
+        n_seeds = int(accuracies.shape[0])
+        return LabelEMNISTRunResult(
+            learner="adamw",
+            hyperparameters=dict(ADAMW_PROTOCOL_HYPERPARAMETERS),
+            seeds=tuple(range(n_seeds)),
+            config=TINY,
+            per_task_accuracy=np.broadcast_to(
+                accuracies[:, None], (n_seeds, TINY.n_tasks)
+            ).copy(),
+            per_task_loss=np.zeros((n_seeds, TINY.n_tasks)),
+            per_task_plasticity=np.zeros((n_seeds, TINY.n_tasks)),
+            average_online_accuracy=np.asarray(accuracies, dtype=np.float64),
+            wall_clock_seconds=0.0,
+        )
+
+    def test_summarize_result_refuses_vacuous_single_seed_stderr(self):
+        with pytest.raises(ValueError, match="fewer than two observations"):
+            summarize_result(self._synthetic_result(np.asarray([0.5])))
+        with pytest.raises(ValueError, match="fewer than two observations"):
+            summarize_result(self._synthetic_result(np.asarray([], dtype=np.float64)))
+
+    def test_summarize_result_two_seed_stderr_is_sample_se(self):
+        values = np.asarray([0.25, 0.75], dtype=np.float64)
+        summary = summarize_result(self._synthetic_result(values))
+        expected = float(values.std(ddof=1) / np.sqrt(values.shape[0]))
+        assert summary["n_seeds"] == 2
+        assert summary["average_online_accuracy_stderr"] == expected
+
     def test_summary_and_comparison_flag_logic(self):
-        upgd = self._result("upgd_w", 0)
-        adam = self._result("adamw", 0)
+        x, y = _tiny_data()
+        upgd = run_label_emnist(x, y, "upgd_w", seeds=[0, 1], config=TINY)
+        adam = run_label_emnist(x, y, "adamw", seeds=[0, 1], config=TINY)
         summaries = {"upgd_w": summarize_result(upgd), "adamw": summarize_result(adam)}
         comparison = build_comparison(summaries)
         assert set(comparison["learners"]) == {"upgd_w", "adamw"}


### PR DESCRIPTION
Closes #914.

## What changed

Label-EMNIST `summarize_result` now refuses to publish `average_online_accuracy_stderr` when `n < 2`. The leftover `_stderr` helper on `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0` returned `0.0` for one-seed and empty vectors, so a legal `run_label_emnist(..., seeds=[0])` serialized a look-alike certain mean.

On that SHA:

- `_stderr([0.5])` → `0.0`
- `_stderr([])` → `0.0`
- one-seed `summarize_result` → `average_online_accuracy_stderr=0.0`, `n_seeds=1`

Sample SE is undefined below two observations. Two-seed sample SE is unchanged (`[0.25, 0.75]` → `0.25`). One-seed shard runs stay legal; they just cannot publish a vacuous stderr.

The existing comparison test was updated from one-seed `_result` fixtures to a two-seed run, which is the publication path.

## Scope

- `alberta_framework/benchmarks/upgd_label_emnist.py`
- `tests/test_upgd_label_emnist.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or another NaN-constructor / True-as-1 / schema== tax on average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `bee4ad5b874ad46504dba657a960693f68f940dd`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `test_summarize_result_refuses_vacuous_single_seed_stderr` DID NOT RAISE
- `PYTHONPATH=<worktree> pytest tests/test_upgd_label_emnist.py -q -o addopts=""` → 81 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- two-seed legal summary sha256 (wall-clock excluded): `556833e52a568051df248ae2039dba26cd7b703217231942bf76841010deacb8`

## Scientific integrity

This is fail-closed publication-summary validation on the nonpromoting Label-EMNIST helper only. It does not start a shard, change a frozen protocol, edit registered evidence sources, rewrite `CHANGELOG.md`, or touch any `outputs/**` artifact.

<!-- evidence-head:bee4ad5b874ad46504dba657a960693f68f940dd -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
