### PR TITLE
fix(cli): reject non-finite smoke JSON

### DIFF
--- a/alberta_framework/cli.py
+++ b/alberta_framework/cli.py
@@ -27,7 +27,7 @@ from alberta_framework.steps.step2 import (
 
 
 def _print_json(payload: dict[str, object]) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False))
 
 
 def step1_smoke_main(argv: Sequence[str] | None = None) -> int:

--- a/tests/test_cli_strict_json.py
+++ b/tests/test_cli_strict_json.py
@@ -1,0 +1,50 @@
+"""Strict JSON output contracts for the Step 1/2 smoke CLIs."""
+
+import json
+from collections.abc import Callable
+
+import pytest
+
+import alberta_framework.cli as cli
+from alberta_framework.cli import _print_json
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_cli_json_rejects_nonfinite_numbers(value: float) -> None:
+    with pytest.raises(ValueError):
+        _print_json({"final_window_mse": value, "finite": False})
+
+
+def test_cli_json_finite_payload_is_strict_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _print_json({"final_window_mse": 0.125, "finite": True})
+    text = capsys.readouterr().out
+    assert json.loads(text) == {"final_window_mse": 0.125, "finite": True}
+    assert "NaN" not in text
+    assert "Infinity" not in text
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "runner_name"),
+    [
+        (cli.step1_smoke_main, "run_step1_smoke"),
+        (cli.step2_smoke_main, "run_step2_smoke"),
+    ],
+)
+def test_smoke_entrypoint_refuses_nonfinite_result(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    entrypoint: Callable[[list[str]], int],
+    runner_name: str,
+) -> None:
+    class NonfiniteResult:
+        finite = False
+
+        def to_dict(self) -> dict[str, object]:
+            return {"final_window_mse": float("nan"), "finite": False}
+
+    monkeypatch.setattr(cli, runner_name, lambda *args, **kwargs: NonfiniteResult())
+    with pytest.raises(ValueError):
+        entrypoint([])
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Closes #915.

## What changed

Step 1/2 smoke CLIs now refuse to print RFC-invalid JSON. `_print_json` on `origin/main` `90c4613a5573de324a7bb33c89efd85e1bc09aa0` used `json.dumps` with default `allow_nan=True`, so `step1_smoke_main` / `step2_smoke_main` emitted `NaN` / `Infinity` tokens whenever a kernel reported `finite=false`.

On that SHA:

```text
{"final_window_mse": NaN, "finite": false}
```

Sibling writers (`forager_cli`, evaluation CLIs, `export.py`) already use `allow_nan=False`. A finite payload is unchanged strict JSON (`{"final_window_mse": 0.125, "finite": true}`).

This is a serialization fail-closed hole, not a constructor tax.

## Scope

- `alberta_framework/cli.py`
- `tests/test_cli_strict_json.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or another NaN-constructor / True-as-1 / schema== tax on average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `62e2efa006af055040726943c9160a45c3ed4d53`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 5 DID NOT RAISE (`NaN`, `Infinity`, `-Infinity`, both smoke entrypoints)
- `PYTHONPATH=<worktree> pytest tests/test_cli_strict_json.py -q -o addopts=""` → 6 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- finite dump sha256 before=after: `02f27a5b0841fff1b817dd4d8c60880877c9bc4da31e4728831cc4c267b61cca`

## Scientific integrity

This is fail-closed stdout serialization for the Step 1/2 smoke CLIs only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:62e2efa006af055040726943c9160a45c3ed4d53 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
