### PR TITLE
fix(benchmarks): accept numpy.float64 in npz-import ewm_decay check

### DIFF
--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -1567,8 +1567,10 @@ def import_official_foragax_npz(
     final_window: int = 100_000,
 ) -> ForagerRunResult:
     """Convert one official ``data/<seed>.npz`` archive to Alberta's schema."""
-    ewm_decay_type = type(ewm_decay)
-    if issubclass(ewm_decay_type, bool) or not issubclass(ewm_decay_type, (int, float)):
+    # NumPy's concrete float64 scalar was accepted by the historical
+    # isinstance gate. Retain that compatibility without admitting arbitrary
+    # user-defined int/float subclasses with overloaded conversion hooks.
+    if type(ewm_decay) not in (int, float, np.float64):
         raise ValueError("ewm_decay must be a finite number in [0, 1)")
     try:
         ewm_decay_as_float = float(cast(Any, ewm_decay))

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -1567,10 +1567,11 @@ def import_official_foragax_npz(
     final_window: int = 100_000,
 ) -> ForagerRunResult:
     """Convert one official ``data/<seed>.npz`` archive to Alberta's schema."""
-    if type(ewm_decay) not in (int, float):
+    ewm_decay_type = type(ewm_decay)
+    if issubclass(ewm_decay_type, bool) or not issubclass(ewm_decay_type, (int, float)):
         raise ValueError("ewm_decay must be a finite number in [0, 1)")
     try:
-        ewm_decay_as_float = float(ewm_decay)
+        ewm_decay_as_float = float(cast(Any, ewm_decay))
     except OverflowError as exc:
         raise ValueError("ewm_decay must be a finite number in [0, 1)") from exc
     if not math.isfinite(ewm_decay_as_float) or not 0.0 <= ewm_decay_as_float < 1.0:

--- a/tests/test_forager_benchmark.py
+++ b/tests/test_forager_benchmark.py
@@ -878,6 +878,23 @@ def test_official_npz_import_accepts_numpy_float64_ewm_decay(tmp_path: Path) -> 
     assert result.mean_reward == pytest.approx(1.0)
 
 
+def test_official_npz_import_rejects_user_defined_float_subclass(tmp_path: Path) -> None:
+    class FloatSubclass(float):
+        def __float__(self) -> float:
+            raise AssertionError("custom conversion must not reach the importer")
+
+    path = tmp_path / "0.npz"
+    np.savez_compressed(path, rewards=np.ones((4,), dtype=np.float32))
+
+    with pytest.raises(ValueError, match="ewm_decay must be a finite number"):
+        import_official_foragax_npz(
+            OfficialForagaxRunSpec(agent="DQN", seed=0, path=path, expected_steps=4),
+            ewm_decay=FloatSubclass(0.5),
+            record_every=1,
+            final_window=1,
+        )
+
+
 def test_protocol_attestation_cannot_be_minted_by_constructing_evidence(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_forager_benchmark.py
+++ b/tests/test_forager_benchmark.py
@@ -864,6 +864,20 @@ def test_official_npz_import_accepts_finite_endpoint_values(tmp_path: Path) -> N
     assert result.mean_reward == pytest.approx(1.0)
 
 
+def test_official_npz_import_accepts_numpy_float64_ewm_decay(tmp_path: Path) -> None:
+    path = tmp_path / "0.npz"
+    np.savez_compressed(path, rewards=np.ones((4,), dtype=np.float32))
+
+    result = import_official_foragax_npz(
+        OfficialForagaxRunSpec(agent="DQN", seed=0, path=path, expected_steps=4),
+        ewm_decay=np.float64(0.5),
+        record_every=1,
+        final_window=1,
+    )
+
+    assert result.mean_reward == pytest.approx(1.0)
+
+
 def test_protocol_attestation_cannot_be_minted_by_constructing_evidence(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #920.

## What changed

Self-correction to my own #424 (`fix(forager-results): validate npz-import decay and window params`, merged). That PR fixed a `__class__`-spoofing gap in `import_official_foragax_npz`'s `ewm_decay` check by switching to `type(ewm_decay) not in (int, float)` - an exact-type match. That's correct against spoofing, but stricter than the `isinstance`-based check it replaced in an unintended way: `numpy.float64` genuinely subclasses Python's `float` (`issubclass(np.float64, float)` is `True`), so a legitimate `np.float64` value - which the pre-#424 check accepted - is now wrongly rejected.

## Reachability / impact

No caller in the current codebase or test suite passes a numpy float here, so this was latent, not an active regression against anything today. Still worth closing cleanly: it's inconsistent with the rest of the codebase's numpy-float-tolerant conventions, and I'd rather fix my own mistake properly than leave a known gap for the next caller to trip over.

## Verification

confirmed the regression directly against the unpatched (i.e. currently-merged #424) code, isolating just the validation logic to rule out an unrelated macOS temp-dir quirk in my own repro script:
```text
np.float64 ewm_decay: REJECTED (still broken): ewm_decay must be a finite number in [0, 1)
```

- new test `test_official_npz_import_accepts_numpy_float64_ewm_decay`, added next to the existing `test_official_npz_import_accepts_finite_endpoint_values`.
- mutation check: reverted just this fix (back to #424's merged `type() not in` check), reran the new test -> fails with the exact reproduced regression. restored -> passes.
- full file: `98 passed, 3 skipped` (skips pre-existing, unrelated).
- `ruff check` and `mypy` clean on both touched files.
- spoofing protection reconfirmed still intact (not shown as a new test since #424 already covers it): a `__class__`-spoofed object and a plain `bool` are both still correctly rejected under the new `issubclass`-based check.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Found this while independently double-checking my own earlier fix shape against a same-pattern fix I was writing for `forager.py` (#919) - noticed I'd used the same exact-type-check idiom there and wanted to confirm it hadn't caused the same problem here. All verification above (mutation testing, full-suite run, lint/typecheck) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
