### PR TITLE
fix(timing): report failed after, not completed

### DIFF
--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -122,13 +122,16 @@ class Timer:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Stop the timer and optionally print the duration."""
+        """Stop the timer and report completion or failure, never both."""
         self.end_time = time.perf_counter()
         self.duration = self.end_time - self.start_time
 
         if self.verbose:
             formatted = format_duration(self.duration)
-            self.print_fn(f"{self.name} completed in {formatted}")
+            if exc_type is None:
+                self.print_fn(f"{self.name} completed in {formatted}")
+            else:
+                self.print_fn(f"{self.name} failed after {formatted}")
 
     def elapsed(self) -> float:
         """Get elapsed time since timer started (can be called during execution).

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,39 @@
+"""Timer must not report a failed block as completed."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.utils.timing import Timer
+
+pytestmark = pytest.mark.unit
+
+
+def test_timer_reports_completed_only_on_success() -> None:
+    messages: list[str] = []
+    with Timer("Training", print_fn=messages.append):
+        pass
+
+    assert len(messages) == 1
+    assert messages[0].startswith("Training completed in ")
+    assert "failed after" not in messages[0]
+
+
+def test_timer_reports_failed_after_on_exception() -> None:
+    messages: list[str] = []
+    with pytest.raises(RuntimeError, match="boom"):
+        with Timer("Training", print_fn=messages.append):
+            raise RuntimeError("boom")
+
+    assert len(messages) == 1
+    assert messages[0].startswith("Training failed after ")
+    assert "completed in" not in messages[0]
+
+
+def test_timer_still_records_duration_when_the_block_raises() -> None:
+    with pytest.raises(ValueError):
+        with Timer("Experiment", verbose=False) as timer:
+            raise ValueError("no result")
+
+    assert timer.duration > 0.0
+    assert timer.end_time >= timer.start_time


### PR DESCRIPTION
Closes #923.

## What changed

`Timer.__exit__` no longer prints `completed in` when the timed block raised. Experiment logs that wrap training or evaluation in `Timer("Training")` were recording failed runs as successful durations.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

```text
Timer("Training") + RuntimeError("boom") → "Training completed in 0.00s"
```

After this head:

- success still prints `completed in`
- exception prints `failed after` and re-raises
- `duration` is still recorded on the failure path

Existing `test_utils_smoke` timing cases stay green.

## Scope

- `alberta_framework/utils/timing.py`
- `tests/test_timing.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or another stderr-n<2 / NaN-JSON / NaN-constructor / True-as-1 / schema== tax on label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `a0f6a59db5ef12b09e99a103298e94e3a339ae1f`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: exception path printed `Training completed in 0.00s`
- `PYTHONPATH=<worktree> pytest tests/test_timing.py` plus the three existing timing smoke tests → 6 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean

## Scientific integrity

This is fail-closed experiment-log wording on the host Timer only. It does not start a shard, change a frozen protocol, edit registered evidence sources, rewrite `CHANGELOG.md`, or touch any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a0f6a59db5ef12b09e99a103298e94e3a339ae1f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
