### PR TITLE
fix(benchmarks): reject class-spoofed non-real historical reward

### DIFF
--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -278,7 +278,12 @@ def _finite_reward(value: Any) -> float:
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise HistoricalForagerContractError("historical reward must be a real scalar")
-    result = float(cast(Real, value))
+    try:
+        result = float(cast(Real, value))
+    except Exception as error:
+        raise HistoricalForagerContractError(
+            "historical reward must be a finite real scalar"
+        ) from error
     if not math.isfinite(result):
         raise HistoricalForagerContractError("historical reward must be finite")
     return result

--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -275,9 +275,10 @@ def _require_environment(value: Any) -> HistoricalForagerEnvironment:
 
 
 def _finite_reward(value: Any) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise HistoricalForagerContractError("historical reward must be a real scalar")
-    result = float(value)
+    result = float(cast(Real, value))
     if not math.isfinite(result):
         raise HistoricalForagerContractError("historical reward must be finite")
     return result

--- a/tests/test_historical_forager_reconstructed.py
+++ b/tests/test_historical_forager_reconstructed.py
@@ -333,6 +333,28 @@ def test_class_spoofed_reward_is_rejected_and_never_reaches_kernel(
     assert not config.output_directory.exists()
 
 
+class _HostileFloatSubclass(float):
+    def __float__(self) -> float:
+        raise RuntimeError("hostile conversion")
+
+
+def test_hostile_real_conversion_is_translated_and_never_reaches_kernel(
+    tmp_path: Path,
+) -> None:
+    adapter, kernel, config, events, _, _ = _fake_lane(
+        tmp_path, [_HostileFloatSubclass(0.5)]
+    )
+
+    with pytest.raises(
+        HistoricalForagerContractError,
+        match="reward must be a finite real scalar",
+    ):
+        run_historical_forager(adapter, kernel, config)
+
+    assert not any(event[0] == "kernel.update" for event in events)
+    assert not config.output_directory.exists()
+
+
 @pytest.mark.parametrize("bad_action", [True, 1.0, -1, 4, np.asarray([1])])
 def test_invalid_actions_fail_closed_without_partial_artifact(
     tmp_path: Path,

--- a/tests/test_historical_forager_reconstructed.py
+++ b/tests/test_historical_forager_reconstructed.py
@@ -310,6 +310,29 @@ def test_nonempty_info_is_rejected_and_never_reaches_kernel(tmp_path: Path) -> N
     assert not config.output_directory.exists()
 
 
+class _SpoofedFloat:
+    """Mimics ``float`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return float
+
+    def __float__(self) -> float:
+        return 0.5
+
+
+def test_class_spoofed_reward_is_rejected_and_never_reaches_kernel(
+    tmp_path: Path,
+) -> None:
+    adapter, kernel, config, events, _, _ = _fake_lane(tmp_path, [_SpoofedFloat()])
+
+    with pytest.raises(HistoricalForagerContractError, match="reward must be a real scalar"):
+        run_historical_forager(adapter, kernel, config)
+
+    assert not any(event[0] == "kernel.update" for event in events)
+    assert not config.output_directory.exists()
+
+
 @pytest.mark.parametrize("bad_action", [True, 1.0, -1, 4, np.asarray([1])])
 def test_invalid_actions_fail_closed_without_partial_artifact(
     tmp_path: Path,


### PR DESCRIPTION
Closes #926.

## What changed

Same isinstance-spoofing class already fixed for `_require_int` across the step files, and for `Real`-typed scalars in `forager_results.py`/`forager.py` (#424/#919) and `representation_gradient_mixer.py`/`partner_policy_fusion.py`/`types.py`/`synthetic.py` (#569/#571/#574/#649): `_finite_reward` used `isinstance(value, bool) or not isinstance(value, Real)`. `isinstance()` consults `__class__`, which is overridable via a `@property`, so an object whose `__class__` property returns `float` passes `isinstance(value, Real)` even though `type(value) is not float`.

## Why this one is different from a JSON-only artifact validator

Several similar-looking `_finite_number`-style helpers elsewhere in the codebase only ever see `json.loads()` output, where `__class__` spoofing is unreachable (JSON can't encode a custom Python class) - I checked and skipped those. `_finite_reward` is not one of them: it validates `reward` returned directly from `environment.step(action)` in `_historical_transition`, where `environment: HistoricalForagerEnvironment` is a pluggable `Protocol` implementation. This file already treats the environment factory as untrusted elsewhere (`_require_read_only_non_tmp_factory_source`, `_verify_installed_forager_source_inventory`), so a misbehaving or adversarial environment implementation returning a spoofed reward object is a live path here, not a theoretical one.

## Reachability

`HistoricalForagerEnvironment` and `verify_historical_environment_factory` are exported from `alberta_framework.benchmarks.__all__`. `_finite_reward` runs on every transition via `_historical_transition`, called from the main `run_historical_forager` driver.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
SPOOFED reward ACCEPTED: 0.5 <class 'float'>
```

- new test `test_class_spoofed_reward_is_rejected_and_never_reaches_kernel`, using the existing `_fake_lane` test harness, added next to the existing `test_nonempty_info_is_rejected_and_never_reaches_kernel` (same shape: confirms rejection happens before the kernel or output directory are ever touched).
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE HistoricalForagerContractError`. restored -> passes.
- full file: `34 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`). Spoofing behavior reproduced empirically by me in a real interpreter session against the unpatched code before writing the fix; reachability confirmed by tracing `_finite_reward`'s only call site back to a pluggable, explicitly-untrusted environment factory. All verification above (mutation testing, full-suite run, lint/typecheck, reachability trace) performed and independently confirmed by me before pushing.

Attribution status: self-reported.
