### PR TITLE
fix(gvf): reject leftover GVFSpec identities

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -18,7 +18,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.normalizers import (
     AnyNormalizerState,
 )
@@ -29,6 +29,7 @@ Target = Array  # y*_t: desired output
 Prediction = Array  # y_t: model output
 Reward = float  # r_t: scalar reward
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
@@ -706,6 +707,21 @@ def _require_gvf_cumulant_index(value: object) -> int:
     return number
 
 
+def _validated_gvf_reward(value: object) -> float:
+    """Validate a float32 reward without silently erasing an exact nonzero."""
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        "terminal_reward", value
+    )
+    if (
+        numerator != 0
+        and abs(numerator) * _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR <= denominator
+    ):
+        raise ValueError(
+            "terminal_reward must remain nonzero once narrowed to float32"
+        )
+    return stored
+
+
 @chex.dataclass(frozen=True)
 class GVFSpec:
     """One GVF demon's question functions (Sutton et al. 2011).
@@ -737,9 +753,7 @@ class GVFSpec:
         gamma = _normalized_gvf_probability("gamma", self.gamma)
         lamda = _normalized_gvf_probability("lamda", self.lamda)
         cumulant_index = _require_gvf_cumulant_index(self.cumulant_index)
-        terminal_reward = validated_float32_scalar(
-            "terminal_reward", self.terminal_reward
-        )
+        terminal_reward = _validated_gvf_reward(self.terminal_reward)
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "lamda", lamda)

--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -6,10 +6,11 @@ using chex dataclasses for JAX compatibility and jaxtyping for shape annotations
 
 import enum
 import math
+import operator
 import time
 from collections.abc import Sequence
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -17,6 +18,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.normalizers import (
     AnyNormalizerState,
 )
@@ -27,6 +29,10 @@ Target = Array  # y*_t: desired output
 Prediction = Array  # y_t: model output
 Reward = float  # r_t: scalar reward
 _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
 
 
 @chex.dataclass(frozen=True)
@@ -685,6 +691,21 @@ def _normalized_gvf_probability(name: str, value: object) -> float:
     return normalized
 
 
+def _require_gvf_name(value: object) -> str:
+    if type(value) is not str or value == "":
+        raise ValueError("name must be a nonempty string")
+    return value
+
+
+def _require_gvf_cumulant_index(value: object) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError("cumulant_index must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if not -1 <= number <= _INT32_MAX:
+        raise ValueError(f"cumulant_index must be an integer in [-1, {_INT32_MAX}]")
+    return number
+
+
 @chex.dataclass(frozen=True)
 class GVFSpec:
     """One GVF demon's question functions (Sutton et al. 2011).
@@ -709,11 +730,21 @@ class GVFSpec:
     terminal_reward: float = 0.0
 
     def __post_init__(self) -> None:
-        """Reject invalid discount and trace-decay parameters."""
+        """Reject invalid GVF question parameters before they can be serialized."""
+        name = _require_gvf_name(self.name)
+        if type(self.demon_type) is not DemonType:
+            raise ValueError("demon_type must be a DemonType")
         gamma = _normalized_gvf_probability("gamma", self.gamma)
         lamda = _normalized_gvf_probability("lamda", self.lamda)
+        cumulant_index = _require_gvf_cumulant_index(self.cumulant_index)
+        terminal_reward = validated_float32_scalar(
+            "terminal_reward", self.terminal_reward
+        )
+        object.__setattr__(self, "name", name)
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "lamda", lamda)
+        object.__setattr__(self, "cumulant_index", cumulant_index)
+        object.__setattr__(self, "terminal_reward", terminal_reward)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict.
@@ -759,6 +790,13 @@ class HordeSpec:
     gammas: Float[Array, " n_demons"]
     lamdas: Float[Array, " n_demons"]
 
+    def __post_init__(self) -> None:
+        """Reject an empty or type-spoofed demon collection."""
+        if type(self.demons) is not tuple or not self.demons:
+            raise ValueError("demons must be a nonempty tuple of GVFSpec")
+        if any(type(demon) is not GVFSpec for demon in self.demons):
+            raise ValueError("demons must be a nonempty tuple of GVFSpec")
+
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict.
 
@@ -795,6 +833,8 @@ def create_horde_spec(demons: Sequence[GVFSpec]) -> HordeSpec:
         HordeSpec with pre-computed arrays
     """
     demons_tuple = tuple(demons)
+    if not demons_tuple or any(type(demon) is not GVFSpec for demon in demons_tuple):
+        raise ValueError("demons must be a nonempty sequence of GVFSpec")
     gammas = jnp.array([d.gamma for d in demons_tuple], dtype=jnp.float32)
     lamdas = jnp.array([d.lamda for d in demons_tuple], dtype=jnp.float32)
     return HordeSpec(demons=demons_tuple, gammas=gammas, lamdas=lamdas)

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -381,6 +381,30 @@ class TestGVFSpecRemainingFields:
         assert spec.terminal_reward == -1.0
         assert spec.to_config()["terminal_reward"] == -1.0
 
+    @pytest.mark.parametrize("value", [2.0**-150, -(2.0**-150), 5e-324, -5e-324])
+    def test_terminal_reward_rejects_nonzero_float32_underflow(self, value):
+        with pytest.raises(ValueError, match="terminal_reward must remain nonzero"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+                terminal_reward=value,
+            )
+
+    @pytest.mark.parametrize("value", [0.0, 2.0**-149, -(2.0**-149)])
+    def test_terminal_reward_preserves_zero_and_float32_minsubnormal(self, value):
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=value,
+        )
+        assert spec.terminal_reward == value
+
     @pytest.mark.parametrize(
         "value",
         [float("nan"), float("inf"), float("-inf"), True, False, "0.0", None],

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -349,3 +349,145 @@ class TestHordeSpec:
         ]
         spec = create_horde_spec(demons)
         assert isinstance(spec.demons, tuple)
+
+
+class TestGVFSpecRemainingFields:
+    """Name, cumulant index, terminal reward, and empty hordes must fail closed."""
+
+    def test_legal_defaults_stay_bit_identical(self):
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+        )
+        assert spec.name == "d0"
+        assert spec.cumulant_index == 0
+        assert type(spec.cumulant_index) is int
+        assert spec.terminal_reward == 0.0
+        assert type(spec.terminal_reward) is float
+
+    def test_negative_terminal_reward_is_a_legal_pseudo_reward(self):
+        spec = GVFSpec(
+            name="z",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=-1,
+            terminal_reward=-1.0,
+        )
+        assert spec.cumulant_index == -1
+        assert spec.terminal_reward == -1.0
+        assert spec.to_config()["terminal_reward"] == -1.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), float("-inf"), True, False, "0.0", None],
+    )
+    def test_terminal_reward_rejects_non_finite_and_non_real_identities(self, value):
+        with pytest.raises(ValueError, match="terminal_reward"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+                terminal_reward=value,
+            )
+        with pytest.raises(ValueError, match="terminal_reward"):
+            GVFSpec.from_config(
+                {
+                    "name": "d0",
+                    "demon_type": "prediction",
+                    "gamma": 0.0,
+                    "lamda": 0.0,
+                    "cumulant_index": 0,
+                    "terminal_reward": value,
+                }
+            )
+
+    def test_terminal_reward_rejects_class_spoofed_float(self):
+        class _SpoofedFloat:
+            @property
+            def __class__(self) -> type:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match="terminal_reward"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+                terminal_reward=_SpoofedFloat(),
+            )
+
+    @pytest.mark.parametrize(
+        "value",
+        [True, False, 1.5, float("nan"), "0", None, 2**31],
+    )
+    def test_cumulant_index_rejects_bool_float_and_out_of_range(self, value):
+        with pytest.raises(ValueError, match="cumulant_index"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=value,
+            )
+
+    def test_true_cumulant_index_does_not_silently_select_channel_one(self):
+        with pytest.raises(ValueError, match="cumulant_index"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=True,
+            )
+
+    def test_numpy_cumulant_index_canonicalizes_to_int(self):
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=np.int64(2),
+        )
+        assert spec.cumulant_index == 2
+        assert type(spec.cumulant_index) is int
+
+    @pytest.mark.parametrize("value", ["", None, True, 0])
+    def test_name_must_be_a_nonempty_string(self, value):
+        with pytest.raises(ValueError, match="name"):
+            GVFSpec(
+                name=value,
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+            )
+
+    def test_demon_type_must_be_the_enum(self):
+        with pytest.raises(ValueError, match="demon_type"):
+            GVFSpec(
+                name="d0",
+                demon_type="prediction",
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+            )
+
+    def test_create_horde_spec_rejects_empty_and_non_gvf_items(self):
+        with pytest.raises(ValueError, match="nonempty"):
+            create_horde_spec([])
+        with pytest.raises(ValueError, match="GVFSpec"):
+            create_horde_spec(["d0"])  # type: ignore[list-item]
+
+    def test_from_config_rejects_empty_horde(self):
+        with pytest.raises(ValueError, match="nonempty"):
+            HordeSpec.from_config({"demons": []})


### PR DESCRIPTION
Closes #928.

## What changed

`GVFSpec` no longer accepts a lying leftover question. `__post_init__` only normalized `gamma` / `lamda`, so `terminal_reward=nan`, `cumulant_index=True` (channel 1), empty names, and `create_horde_spec([])` survived into `to_config` / `HordeSpec.from_config`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

```text
GVFSpec(..., terminal_reward=nan|True) ACCEPT
GVFSpec(..., cumulant_index=True)      ACCEPT  (selects 1)
create_horde_spec([])                  ACCEPT
```

After this head:

- `terminal_reward` is a finite non-bool real (`0.0` and `-1.0` stay legal)
- `cumulant_index` is an exact non-bool int (`-1` stays legal)
- `name` is a nonempty string; `demon_type` is a `DemonType`
- empty HordeSpec is rejected
- legal defaults stay bit-identical

## Scope

- `alberta_framework/core/types.py`
- `tests/test_gvf_types.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation. Closed `#168` only fenced `gamma`/`lamda`.

## Verification

Exact candidate head: `9641de6ca5148a18557bf92af1fda951a8b47350`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `terminal_reward=nan` and `cumulant_index=True` constructed and serialized
- `PYTHONPATH=<worktree> pytest tests/test_gvf_types.py` → 73 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed GVF question construction on the host. It does not start a shard, change a frozen protocol, edit registered evidence sources, rewrite `CHANGELOG.md`, or touch any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9641de6ca5148a18557bf92af1fda951a8b47350 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
