### PR TITLE
fix(multi-head): reject leftover constructor scalars

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -30,7 +30,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, UInt
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.learners import _update_from_gradient_with_diagnostics
 from alberta_framework.core.normalizers import (
@@ -65,6 +65,7 @@ MULTI_HEAD_LIFETIME_COUNTER_NBYTES = 12
 MULTI_HEAD_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
+_FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _CONFIG_FIELDS = frozenset(
     {
         "type",
@@ -99,6 +100,29 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.longlong,
     np.ulonglong,
 )
+
+
+def _validated_nonnegative_float32_scalar(
+    name: str,
+    value: object,
+    *,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> float:
+    """Validate a nonnegative float32 sink without erasing a nonzero."""
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        lower=0.0,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
+    if (
+        numerator != 0
+        and numerator * _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR <= denominator
+    ):
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
 
 
 def _require_int(
@@ -471,20 +495,21 @@ class MultiHeadMLPLearner:
             raise ValueError(
                 "per_head_gamma_lamda must be an actual tuple when constructed directly"
             )
-        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
-        leaky_relu_slope = validated_float32_scalar(
-            "leaky_relu_slope", leaky_relu_slope, lower=0.0
+        sparsity = _validated_nonnegative_float32_scalar(
+            "sparsity", sparsity, upper=1.0
         )
-        gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
-        lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+        leaky_relu_slope = _validated_nonnegative_float32_scalar(
+            "leaky_relu_slope", leaky_relu_slope
+        )
+        gamma = _validated_nonnegative_float32_scalar("gamma", gamma, upper=1.0)
+        lamda = _validated_nonnegative_float32_scalar("lamda", lamda, upper=1.0)
         if type(use_layer_norm) is not bool:
             raise ValueError("use_layer_norm must be an exact bool")
         if type(trace_mode) is not TraceMode:
             raise ValueError("trace_mode must be a TraceMode")
-        utility_decay = validated_float32_scalar(
+        utility_decay = _validated_nonnegative_float32_scalar(
             "utility_decay",
             utility_decay,
-            lower=0.0,
             upper=1.0,
             upper_inclusive=False,
         )
@@ -528,6 +553,12 @@ class MultiHeadMLPLearner:
                 f"trace decay with a shared trunk."
             )
             raise ValueError(msg)
+        if gamma != 0.0 and lamda != 0.0:
+            _validated_nonnegative_float32_scalar(
+                "gamma * lamda",
+                gamma * lamda,
+                upper=1.0,
+            )
         if per_head_gamma_lamda is not None:
             if len(per_head_gamma_lamda) != self._n_heads:
                 raise ValueError(
@@ -535,10 +566,9 @@ class MultiHeadMLPLearner:
                     f"got {len(per_head_gamma_lamda)}"
                 )
             self._per_head_gl = tuple(
-                validated_float32_scalar(
+                _validated_nonnegative_float32_scalar(
                     f"per_head_gamma_lamda[{head_index}]",
                     gl,
-                    lower=0.0,
                     upper=1.0,
                 )
                 for head_index, gl in enumerate(per_head_gamma_lamda)

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -471,8 +471,23 @@ class MultiHeadMLPLearner:
             raise ValueError(
                 "per_head_gamma_lamda must be an actual tuple when constructed directly"
             )
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
+        leaky_relu_slope = validated_float32_scalar(
+            "leaky_relu_slope", leaky_relu_slope, lower=0.0
+        )
+        gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+        if type(use_layer_norm) is not bool:
+            raise ValueError("use_layer_norm must be an exact bool")
+        if type(trace_mode) is not TraceMode:
+            raise ValueError("trace_mode must be a TraceMode")
+        utility_decay = validated_float32_scalar(
+            "utility_decay",
+            utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
 
         self._n_heads = n_heads
         self._hidden_sizes = hidden_sizes

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -616,6 +616,49 @@ class TestMultiHeadConstructorValidation:
                 sparsity=Spoof(),  # type: ignore[arg-type]
             )
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"sparsity": 2.0**-150},
+            {"leaky_relu_slope": 5e-324},
+            {"gamma": 2.0**-150},
+            {"lamda": 2.0**-150},
+            {"utility_decay": 5e-324},
+            {"per_head_gamma_lamda": (2.0**-150,)},
+        ],
+    )
+    def test_rejects_nonzero_float32_underflow(self, kwargs):
+        with pytest.raises(ValueError, match="must remain nonzero"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(), **kwargs)
+
+    def test_rejects_trace_product_that_underflows_float32(self):
+        with pytest.raises(ValueError, match=r"gamma \* lamda must remain nonzero"):
+            MultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                gamma=2.0**-100,
+                lamda=2.0**-100,
+            )
+
+    def test_nonnegative_float32_sinks_preserve_zero_and_minsubnormal(self):
+        smallest_float32 = 2.0**-149
+        learner = MultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(),
+            sparsity=smallest_float32,
+            leaky_relu_slope=0.0,
+            gamma=0.0,
+            lamda=smallest_float32,
+            utility_decay=0.0,
+            per_head_gamma_lamda=(smallest_float32,),
+        )
+        config = learner.to_config()
+        assert config["sparsity"] == smallest_float32
+        assert config["leaky_relu_slope"] == 0.0
+        assert config["lamda"] == smallest_float32
+        assert config["utility_decay"] == 0.0
+        assert config["per_head_gamma_lamda"] == [smallest_float32]
+
 
 class TestMultiHeadUpdateValidation:
     """``update`` must reject targets that are not one value per head.

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -463,7 +463,7 @@ class TestMultiHeadUpdateAllActive:
 
 
 class TestMultiHeadConstructorValidation:
-    """``per_head_gamma_lamda`` values must be finite and in [0, 1]."""
+    """Constructor scalars that reach init/to_config must be finite identities."""
 
     def test_rejects_wrong_length_per_head_gamma_lamda(self):
         """The tuple must have exactly one value per head."""
@@ -517,6 +517,104 @@ class TestMultiHeadConstructorValidation:
 
         values = learner.to_config()["per_head_gamma_lamda"]
         assert all(type(value) is float for value in values)
+
+    def test_legal_sparsity_and_slope_defaults_stay_bit_identical(self):
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+        assert learner._sparsity == 0.9
+        assert type(learner._sparsity) is float
+        assert learner._leaky_relu_slope == 0.01
+        assert type(learner._leaky_relu_slope) is float
+        assert learner._gamma == 0.0
+        assert learner._lamda == 0.0
+        assert learner._use_layer_norm is True
+        assert learner._utility_decay == 0.99
+        assert type(learner._utility_decay) is float
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("sparsity", float("nan")),
+            ("sparsity", float("inf")),
+            ("sparsity", True),
+            ("sparsity", -0.1),
+            ("sparsity", 1.5),
+            ("leaky_relu_slope", float("nan")),
+            ("leaky_relu_slope", True),
+            ("leaky_relu_slope", -0.01),
+            ("gamma", float("nan")),
+            ("gamma", True),
+            ("gamma", -0.1),
+            ("lamda", float("nan")),
+            ("lamda", True),
+            ("lamda", 1.5),
+            ("utility_decay", float("nan")),
+            ("utility_decay", True),
+            ("utility_decay", 1.0),
+        ],
+    )
+    def test_rejects_non_finite_bool_and_out_of_range_constructor_scalars(
+        self, field: str, value: object
+    ):
+        kwargs: dict[str, object] = {
+            "n_heads": 1,
+            "hidden_sizes": (),
+            "sparsity": 0.0,
+            "step_size": 0.01,
+        }
+        kwargs[field] = value
+        with pytest.raises(ValueError, match=field):
+            MultiHeadMLPLearner(**kwargs)  # type: ignore[arg-type]
+
+    def test_true_sparsity_does_not_serialize_as_full_mask(self):
+        with pytest.raises(ValueError, match="sparsity"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(), sparsity=True)
+
+    def test_true_gamma_does_not_store_as_undiscounted_one(self):
+        with pytest.raises(ValueError, match="gamma"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(), gamma=True, lamda=0.0)
+
+    def test_use_layer_norm_requires_exact_bool(self):
+        with pytest.raises(ValueError, match="use_layer_norm"):
+            MultiHeadMLPLearner(n_heads=1, hidden_sizes=(), use_layer_norm=1)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="use_layer_norm"):
+            MultiHeadMLPLearner(
+                n_heads=1, hidden_sizes=(), use_layer_norm="true"  # type: ignore[arg-type]
+            )
+
+    def test_trace_mode_requires_the_enum(self):
+        with pytest.raises(ValueError, match="trace_mode"):
+            MultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                trace_mode="accumulating",  # type: ignore[arg-type]
+            )
+
+    def test_from_config_rejects_nan_sparsity_and_bool_gamma(self):
+        config = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(), sparsity=0.0).to_config()
+        poisoned = dict(config)
+        poisoned["sparsity"] = float("nan")
+        with pytest.raises(ValueError, match="sparsity"):
+            MultiHeadMLPLearner.from_config(poisoned)
+        poisoned = dict(config)
+        poisoned["gamma"] = True
+        with pytest.raises(ValueError, match="gamma"):
+            MultiHeadMLPLearner.from_config(poisoned)
+
+    def test_rejects_class_spoofed_sparsity_without_invoking_float(self):
+        class Spoof:
+            @property
+            def __class__(self) -> type[float]:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match="sparsity"):
+            MultiHeadMLPLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                sparsity=Spoof(),  # type: ignore[arg-type]
+            )
 
 
 class TestMultiHeadUpdateValidation:


### PR DESCRIPTION
Closes #929.

## What changed

`MultiHeadMLPLearner` no longer stores leftover constructor scalars that `#720` did not fence. Head counts, hidden widths, and `per_head_gamma_lamda` were already fail-closed; `sparsity`, `leaky_relu_slope`, `gamma`, `lamda`, `use_layer_norm`, and `trace_mode` were not.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`:

```text
sparsity=True|nan     ACCEPT  (True serializes as a full mask)
gamma=True, lamda=0.0 ACCEPT  (True stores as undiscounted 1)
use_layer_norm=1      ACCEPT
```

After this head those identities raise `ValueError`. Legal defaults stay bit-identical (`sparsity=0.9`, `leaky_relu_slope=0.01`, `gamma=0.0`, `lamda=0.0`, `utility_decay=0.99`). `from_config` inherits the same constructor fence.

## Scope

- `alberta_framework/core/multi_head_learner.py`
- `tests/test_multi_head_learner.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation. Closed `#720` fenced allocation and per-head traces only.

## Verification

Exact candidate head: `28f4e9ca6df754ed27cd4ab976edf1047ae8a5df`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `sparsity=True` and `gamma=True` constructed and serialized
- `PYTHONPATH=<worktree> pytest tests/test_multi_head_learner.py` → 137 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed shared-trunk constructor validation on the host. It does not start a shard, change a frozen protocol, edit registered evidence sources, rewrite `CHANGELOG.md`, or touch any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:28f4e9ca6df754ed27cd4ab976edf1047ae8a5df -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
