### PR TITLE
fix(micro-continual): refuse non-finite shard JSON

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1077,9 +1077,14 @@ def micro_shard_payload(result: MicroRunResult) -> dict[str, Any]:
     }
 
 
+def _strict_json_text(payload: dict[str, Any]) -> str:
+    """Serialize one object as RFC-valid JSON (no NaN / Infinity tokens)."""
+    return json.dumps(payload, indent=1, sort_keys=True, allow_nan=False) + "\n"
+
+
 def write_micro_shard(path: Path | str, payload: dict[str, Any]) -> None:
     """Atomically publish one immutable shard (refuses an occupied path)."""
-    encoded = (json.dumps(payload, indent=1, sort_keys=True) + "\n").encode("utf-8")
+    encoded = _strict_json_text(payload).encode("utf-8")
     atomic_write_new(Path(path), encoded)
 
 
@@ -1590,7 +1595,7 @@ def _atomic_replace_json(path: Path, payload: dict[str, Any]) -> None:
     """Atomically (re)write one derived JSON artifact (summaries are
     regenerable from immutable shards, so replacement is allowed here)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    encoded = json.dumps(payload, indent=1, sort_keys=True) + "\n"
+    encoded = _strict_json_text(payload)
     fd, temporary = tempfile.mkstemp(
         dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
     )

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -48,6 +48,7 @@ from alberta_framework.benchmarks.micro_continual import (
     MicroStream,
     MicroStreamConfig,
     MicroTaskConfig,
+    _atomic_replace_json,
     assemble_observed,
     bayes_predict,
     bayes_reference,
@@ -1298,6 +1299,29 @@ class TestShards:
         write_micro_shard(path, payload)
         with pytest.raises(FileExistsError):
             write_micro_shard(path, payload)
+
+    @pytest.mark.parametrize(
+        "number",
+        [math.nan, math.inf, -math.inf],
+        ids=["nan", "inf", "-inf"],
+    )
+    def test_write_refuses_nonfinite_json(self, tmp_path: Path, number: float):
+        """Shard bytes must be RFC-valid JSON; NaN / Infinity tokens are not."""
+        path = tmp_path / "nonfinite-shard.json"
+        with pytest.raises(ValueError, match="JSON compliant"):
+            write_micro_shard(path, {"wall_clock_seconds": number, "ok": 1})
+        assert not path.exists()
+
+    @pytest.mark.parametrize(
+        "number",
+        [math.nan, math.inf, -math.inf],
+        ids=["nan", "inf", "-inf"],
+    )
+    def test_derived_json_replace_refuses_nonfinite(self, tmp_path: Path, number: float):
+        path = tmp_path / "nonfinite-summary.json"
+        with pytest.raises(ValueError, match="JSON compliant"):
+            _atomic_replace_json(path, {"average_online_accuracy": number})
+        assert not path.exists()
 
     def test_load_rejects_wrong_schema(self, tmp_path: Path):
         payload = micro_shard_payload(self._result())


### PR DESCRIPTION
Closes #933.

## What changed

Micro shard and summary writers now refuse RFC-invalid JSON. `write_micro_shard` and `_atomic_replace_json` on origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0` used `json.dumps` with default `allow_nan=True`, so a non-finite payload wrote `NaN` / `Infinity` tokens. `load_micro_shard` already rejects those tokens via `load_strict_json_object`, so the public write API could publish a shard the public loader cannot read.

On that SHA:

```text
write_micro_shard(path, {"wall_clock_seconds": nan})  # writes { "wall_clock_seconds": NaN }
```

Sibling writers (`forager_cli`, evaluation CLIs, `export.py`) already use `allow_nan=False`. A finite shard is unchanged strict JSON. This is a write/load serialization split, not a constructor tax and not the Step 1/2 smoke CLI.

## Scope

- `alberta_framework/benchmarks/micro_continual.py`
- `tests/test_micro_continual.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `653880783957aa6c32e87f452d23a9f81132d248`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 6 DID NOT RAISE (`NaN`, `Infinity`, `-Infinity` on both dump sites)
- `PYTHONPATH=<worktree> pytest tests/test_micro_continual.py -q -o addopts=""` → 217 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary JSON for micro shards and regenerable summaries only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:653880783957aa6c32e87f452d23a9f81132d248 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
