### PR TITLE
fix(export): reject boolean measurement identities

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 def _exported_number(value: SupportsFloat) -> str:
     """Return the shortest text that round-trips one finite binary64 value."""
+    if type(value) is bool or type(value) is np.bool_:
+        raise ValueError(f"refusing to export a boolean as a measurement: {value!r}")
     number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"refusing to export non-finite measurement: {number!r}")
@@ -242,10 +244,10 @@ def export_to_json(
         summary_data: dict[str, dict[str, Any]] = {}
         for metric_name, summary in agg.summary.items():
             summary_data[metric_name] = {
-                "mean": summary.mean,
-                "std": summary.std,
-                "min": summary.min,
-                "max": summary.max,
+                "mean": float(_exported_number(summary.mean)),
+                "std": float(_exported_number(summary.std)),
+                "min": float(_exported_number(summary.min)),
+                "max": float(_exported_number(summary.max)),
                 "n_seeds": summary.n_seeds,
                 "values": summary.values.tolist(),
             }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -481,6 +481,49 @@ def test_atomic_publish_failure_preserves_destination_and_removes_temporary_file
 
 
 @pytest.mark.parametrize("field", ["mean", "std"])
+@pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+def test_display_tables_reject_boolean_summaries(field: str, value: object) -> None:
+    result = _constant_result("invalid")
+    summary = result.summary[_METRIC]._replace(**{field: value})
+    results = {"invalid": result._replace(summary={_METRIC: summary})}
+
+    for render in (generate_latex_table, generate_markdown_table):
+        with pytest.raises(ValueError, match="boolean"):
+            render(results)
+
+
+@pytest.mark.parametrize("format_name", ["csv", "json"])
+@pytest.mark.parametrize("field", ["mean", "std", "min", "max"])
+def test_boolean_export_rejects_before_any_destination_mutation(
+    format_name: str,
+    field: str,
+    tmp_path: Path,
+) -> None:
+    result = _constant_result("invalid")
+    summary = result.summary[_METRIC]._replace(**{field: True})
+    results = {"invalid": result._replace(summary={_METRIC: summary})}
+
+    def export(path: Path) -> None:
+        if format_name == "csv":
+            export_to_csv(results, path)
+        else:
+            export_to_json(results, path)
+
+    existing = tmp_path / f"existing.{format_name}"
+    sentinel = "existing artifact\n"
+    existing.write_text(sentinel, encoding="utf-8")
+    with pytest.raises(ValueError, match="boolean"):
+        export(existing)
+    assert existing.read_text(encoding="utf-8") == sentinel
+
+    absent = tmp_path / "not-created" / f"absent.{format_name}"
+    with pytest.raises(ValueError, match="boolean"):
+        export(absent)
+    assert not absent.exists()
+    assert not absent.parent.exists()
+
+
+@pytest.mark.parametrize("field", ["mean", "std"])
 @pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
 def test_display_tables_reject_nonfinite_summaries(field: str, value: float) -> None:
     result = _constant_result("invalid")


### PR DESCRIPTION
Closes #932.

## What changed

Export no longer treats a boolean as a measurement. `_exported_number` on origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0` did `float(value)` then rejected only non-finite results, so `True` became `'1.0'` and `False` became `'0.0'`. JSON bypassed that helper and wrote `true` / `false`. Seed validation already refuses `seeds=[True]`; summary statistics did not.

On that SHA:

```text
_exported_number(True)  -> '1.0'
export_to_json(... mean=True) -> "mean": true
```

After this head, `bool` / `np.bool_` raise before any destination is written. CSV, JSON, LaTeX, and markdown share the same helper. Legal finite floats are unchanged.

## Scope

- `alberta_framework/utils/export.py`
- `tests/test_export.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `29e1b654a714bab2f9dc23aa9eac4579e55b3674`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 16 DID NOT RAISE (display tables + CSV/JSON mutation guards)
- `PYTHONPATH=<worktree> pytest tests/test_export.py -q -o addopts=""` → 117 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary export for publication tables and machine-readable dumps only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:29e1b654a714bab2f9dc23aa9eac4579e55b3674 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
