### PR TITLE
test(experiments): make the wide-longdouble coordinate fixture platform-honest (fixes #937)

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -493,6 +493,12 @@ class _NonfiniteFloatThatConvertsFinite(float):
         return 0j
 
 
+def _platform_longdouble_1e4000() -> np.longdouble:
+    """Parse the cross-platform boundary without leaking an expected warning."""
+    with np.errstate(over="ignore", invalid="ignore"):
+        return np.longdouble("1e4000")
+
+
 @pytest.mark.parametrize(
     "coordinate",
     [
@@ -502,7 +508,7 @@ class _NonfiniteFloatThatConvertsFinite(float):
         # and stays a finite extended value where it is wider (x86-64): the
         # validator must classify by the platform's actual value, not the
         # literal, so this case is finite-or-rejected but never a crash.
-        np.longdouble("1e4000"),
+        _platform_longdouble_1e4000(),
     ],
 )
 def test_extract_hyperparameter_results_classifies_longdouble_by_platform_value(

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -493,6 +493,30 @@ class _NonfiniteFloatThatConvertsFinite(float):
         return 0j
 
 
+@pytest.mark.parametrize(
+    "coordinate",
+    [
+        np.longdouble("inf"),
+        np.longdouble("nan"),
+        # Overflows to inf at parse wherever longdouble is float64 (aarch64),
+        # and stays a finite extended value where it is wider (x86-64): the
+        # validator must classify by the platform's actual value, not the
+        # literal, so this case is finite-or-rejected but never a crash.
+        np.longdouble("1e4000"),
+    ],
+)
+def test_extract_hyperparameter_results_classifies_longdouble_by_platform_value(
+    coordinate: object,
+) -> None:
+    trace = {"candidate": _flat_trace("candidate", 1.0)}
+    if bool(np.isfinite(coordinate)):
+        extracted = extract_hyperparameter_results(trace, param_extractor=lambda _: coordinate)
+        assert next(iter(extracted)) is coordinate
+    else:
+        with pytest.raises(ValueError, match=r"noncanonical coordinate"):
+            extract_hyperparameter_results(trace, param_extractor=lambda _: coordinate)
+
+
 def test_extract_hyperparameter_results_rejects_spoofed_numeric_subclasses() -> None:
     coordinate = _NonfiniteFloatThatConvertsFinite()
     assert coordinate == float("inf")
@@ -510,7 +534,12 @@ def test_extract_hyperparameter_results_rejects_spoofed_numeric_subclasses() -> 
         10**1000,
         Fraction(10**1000, 3),
         Decimal("1e4000"),
-        np.longdouble("1e4000"),
+        # The widest finite value the platform's longdouble can hold. On x86-64
+        # this is an 80-bit extended value far outside float64 range; on
+        # aarch64 (macOS arm64) longdouble *is* float64, so a literal such as
+        # ``np.longdouble("1e4000")`` overflows to inf at parse and can never
+        # be a "finite" fixture there.
+        np.finfo(np.longdouble).max,
     ],
 )
 def test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates(


### PR DESCRIPTION
<!-- evidence-head:e1fd635e104eb5286d316eb8debc3b3f6042d7c4 -->

Fixes #937.

## What

`test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates[coordinate3]` is deterministically red on macOS arm64 at current `main` because its fixture `np.longdouble("1e4000")` overflows to `inf` at parse there — on aarch64 NumPy's `longdouble` **is** binary64 (`np.finfo(np.longdouble).bits == 64`, `max == float64.max`), so no finite longdouble outside float64 range exists on the platform. The validator correctly rejects the non-finite coordinate; the fixture's claim ("finite") is what's wrong. **Test-only change; no production code touched.**

## Fix

- Replace the fixture with `np.finfo(np.longdouble).max` — the widest finite longdouble the platform actually has (extended-range on x86-64, exactly `float64.max` on aarch64, finite everywhere). Same intent, platform-honest.
- Add `test_extract_hyperparameter_results_classifies_longdouble_by_platform_value`: `np.longdouble("inf")`/`("nan")` must be **rejected** everywhere, and the `"1e4000"` literal must be *kept-if-finite / rejected-if-not* according to the platform's actual value. This exercises the platform-dependent case instead of skipping it, and gives the `longdouble` finiteness rejection direct coverage the old fixture only accidentally exercised on arm64.

## Evidence (macOS arm64, M1 Pro; `macOS-26.2-arm64`, numpy 2.5.2, longdouble bits 64)

Failing-test-first — the existing test **is** the red test. Commands run from a clean worktree:

```text
# base 90c4613 (main), file at base:
pytest tests/test_experiments_validation.py -q -o addopts="" -k wide_finite_numeric
FAILED ...::test_extract_hyperparameter_results_keeps_wide_finite_numeric_coordinates[coordinate3]
1 failed, 3 passed, 94 deselected

# head e1fd635e:
pytest tests/test_experiments_validation.py -q -o addopts=""
101 passed, 1 warning

pytest ... -k "wide_finite_numeric or longdouble_by_platform"
7 passed, 94 deselected

ruff check .        -> All checks passed!
mypy (repo config)  -> Success: no issues found in 168 source files
git diff --check    -> clean
```

<!-- evidence-row:logs -->
- [x] logs — exact command transcript above (also bound as the trajectory in the receipt below); the red run reproduces on `main` with no diff applied.

## Scope / integrity

Test fixture only. Does not touch `alberta_framework/`, any registered evidence source, frozen protocol, pinned `outputs/**` artifact, or `CHANGELOG.md`. Motivation: the project's sanctioned campaign runner is macOS arm64 (hosted `macos-14` M1 for the #51/#184 preregistration workflow, local arm64 dev boxes), so the suite should be green there; this is the same platform class confirmed on the now-closed #190. Fixture introduced in `ae6ab0a`; no open PR or issue claims it (searched `wide_finite_numeric` / `_NUMPY_COORDINATE_TYPES` / `extract_hyperparameter_results` / `longdouble`).

Deviations from pre-registration: none — #937 filed first, PR follows exactly as described there.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9040169c8355166375297ed18a8823bd8bf030c2:skills/contribute-to-asi","run":{"schema_version":"1","run_id":"run_01M06XC5XJP0ACJPZWEV4XSZ7Q","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-17T03:48:49.714Z","completed_at":"2026-08-17T03:48:51.002Z","skill_sha256":"fb3f7ed89890ac48bfe2e8b78b1b46fc7b6c5a776e67b9a60821500859705959","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7cd2040b1c4dbe41be6eede614446ac6c9f6d16c0666e10c09aec3613190a30c","signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"WMun7YhhLmWUH-dZI7KObMdV_pa9v7-9xA4UMrxkPpoKUrDPCGUmf9sF0nqY42lgsvOfTS8tGyLs1Kb5g8FeCQ"}} -->
