### PR TITLE
fix(average-reward): harden differential learners feature dimensions with strict integer validation

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -123,6 +123,17 @@ def _validated_nonnegative_float32_scalar(
     return stored
 
 
+def _validated_float32_scalar_preserving_nonzero(name: str, value: object) -> float:
+    """Validate a signed float32 scalar without erasing an exact nonzero."""
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(name, value)
+    if (
+        numerator != 0
+        and abs(numerator) * _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR <= denominator
+    ):
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
+
+
 def _preflight_actor_state(
     n_actions: int,
     observation_dim: int,
@@ -142,7 +153,12 @@ def _preflight_actor_state(
     # every trunk and head weight/bias array, in addition to parameters,
     # traces, utilities, counters, and its average-reward vector.
     critic_lms_state_scalars = 2 * len(hidden_sizes) + 2
-    critic_scalar_count = 2 * critic_parameters + sum(hidden_sizes) + critic_lms_state_scalars + 5
+    critic_scalar_count = (
+        2 * critic_parameters
+        + sum(hidden_sizes)
+        + critic_lms_state_scalars
+        + 5
+    )
     scalar_count = actor_scalar_count + critic_scalar_count
     _require_state_resources(
         "average-reward actor-critic",
@@ -158,6 +174,24 @@ def _preflight_differential_sarsa_state(n_actions: int, feature_dim: int) -> Non
     scalar_count = float32_scalars + 6
     _require_state_resources(
         "differential SARSA",
+        scalars=scalar_count,
+        nbytes=4 * scalar_count,
+    )
+
+
+def _preflight_differential_td_state(feature_dim: int) -> None:
+    scalar_count = 2 * feature_dim + 4
+    _require_state_resources(
+        "differential TD",
+        scalars=scalar_count,
+        nbytes=4 * scalar_count,
+    )
+
+
+def _preflight_differential_gtd_state(feature_dim: int) -> None:
+    scalar_count = 3 * feature_dim + 5
+    _require_state_resources(
+        "differential GTD",
         scalars=scalar_count,
         nbytes=4 * scalar_count,
     )
@@ -701,7 +735,9 @@ class AverageRewardHordeActorCriticAgent:
         """Initialize critic and actor state."""
         observation_dim = _require_int32("observation_dim", observation_dim, minimum=1)
         actor_dim = self._config.hidden_sizes[-1] if self._config.hidden_sizes else observation_dim
-        _preflight_actor_state(self._config.n_actions, observation_dim, self._config.hidden_sizes)
+        _preflight_actor_state(
+            self._config.n_actions, observation_dim, self._config.hidden_sizes
+        )
         key, critic_key = jr.split(key)
         critic_state = self._critic.init(observation_dim, critic_key)
         actor_opt_w = self._actor_optimizer.init_for_shape((self._config.n_actions, actor_dim))
@@ -1210,7 +1246,10 @@ class DifferentialGTDLearner:
     ) -> DifferentialGTDState:
         """Initialize primary weights, secondary weights, and traces."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        average_reward = validated_float32_scalar("average_reward", average_reward)
+        _preflight_differential_gtd_state(feature_dim)
+        average_reward = _validated_float32_scalar_preserving_nonzero(
+            "average_reward", average_reward
+        )
         return DifferentialGTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -1372,7 +1411,10 @@ class DifferentialTDLearner:
     ) -> DifferentialTDState:
         """Initialize value weights, traces, and reward-rate estimate."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        average_reward = validated_float32_scalar("average_reward", average_reward)
+        _preflight_differential_td_state(feature_dim)
+        average_reward = _validated_float32_scalar_preserving_nonzero(
+            "average_reward", average_reward
+        )
         return DifferentialTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -142,12 +142,7 @@ def _preflight_actor_state(
     # every trunk and head weight/bias array, in addition to parameters,
     # traces, utilities, counters, and its average-reward vector.
     critic_lms_state_scalars = 2 * len(hidden_sizes) + 2
-    critic_scalar_count = (
-        2 * critic_parameters
-        + sum(hidden_sizes)
-        + critic_lms_state_scalars
-        + 5
-    )
+    critic_scalar_count = 2 * critic_parameters + sum(hidden_sizes) + critic_lms_state_scalars + 5
     scalar_count = actor_scalar_count + critic_scalar_count
     _require_state_resources(
         "average-reward actor-critic",
@@ -706,9 +701,7 @@ class AverageRewardHordeActorCriticAgent:
         """Initialize critic and actor state."""
         observation_dim = _require_int32("observation_dim", observation_dim, minimum=1)
         actor_dim = self._config.hidden_sizes[-1] if self._config.hidden_sizes else observation_dim
-        _preflight_actor_state(
-            self._config.n_actions, observation_dim, self._config.hidden_sizes
-        )
+        _preflight_actor_state(self._config.n_actions, observation_dim, self._config.hidden_sizes)
         key, critic_key = jr.split(key)
         critic_state = self._critic.init(observation_dim, critic_key)
         actor_opt_w = self._actor_optimizer.init_for_shape((self._config.n_actions, actor_dim))
@@ -1064,8 +1057,7 @@ class AverageRewardHordeLearner:
 
     def init(self, feature_dim: int, key: Array) -> AverageRewardHordeState:
         """Initialize shared-trunk and per-demon reward-rate state."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return AverageRewardHordeState(
             learner_state=self._learner.init(feature_dim, key),
             average_rewards=jnp.zeros(self._n_demons, dtype=jnp.float32),
@@ -1217,8 +1209,8 @@ class DifferentialGTDLearner:
         average_reward: float = 0.0,
     ) -> DifferentialGTDState:
         """Initialize primary weights, secondary weights, and traces."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        average_reward = validated_float32_scalar("average_reward", average_reward)
         return DifferentialGTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -1379,8 +1371,8 @@ class DifferentialTDLearner:
         average_reward: float = 0.0,
     ) -> DifferentialTDState:
         """Initialize value weights, traces, and reward-rate estimate."""
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        average_reward = validated_float32_scalar("average_reward", average_reward)
         return DifferentialTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -1040,3 +1040,34 @@ def test_differential_sarsa_preflights_state_before_allocation() -> None:
         agent.init(last_legal_feature_dim + 1, jr.key(0))
     with pytest.raises(ValueError, match="feature_dim"):
         agent.init(True, jr.key(0))  # type: ignore[arg-type]
+
+
+def test_differential_learners_integer_validation() -> None:
+    gtd = DifferentialGTDLearner(DifferentialGTDConfig())
+    td = DifferentialTDLearner(DifferentialTDConfig())
+    horde = AverageRewardHordeLearner(n_demons=2, hidden_sizes=(16,))
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        gtd.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        gtd.init(feature_dim=0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        gtd.init(feature_dim=4.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        td.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        td.init(feature_dim=0)
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        horde.init(feature_dim=0, key=jr.key(0))
+
+    s_gtd = gtd.init(feature_dim=np.int32(4))
+    s_td = td.init(feature_dim=np.int64(4))
+    s_horde = horde.init(feature_dim=np.int32(4), key=jr.key(0))
+
+    assert s_gtd.weights.shape == (4,)
+    assert s_td.weights.shape == (4,)
+    assert s_horde.average_rewards.shape == (2,)

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -1071,3 +1071,45 @@ def test_differential_learners_integer_validation() -> None:
     assert s_gtd.weights.shape == (4,)
     assert s_td.weights.shape == (4,)
     assert s_horde.average_rewards.shape == (2,)
+
+
+def test_differential_initializers_preflight_state_before_allocation() -> None:
+    gtd = DifferentialGTDLearner(DifferentialGTDConfig())
+    td = DifferentialTDLearner(DifferentialTDConfig())
+    max_float32_scalars = (2**31 - 1) // 4
+    last_legal_td_dim = (max_float32_scalars - 4) // 2
+    last_legal_gtd_dim = (max_float32_scalars - 5) // 3
+
+    with pytest.raises(ValueError, match="differential TD state bytes"):
+        td.init(feature_dim=last_legal_td_dim + 1)
+    with pytest.raises(ValueError, match="differential GTD state bytes"):
+        gtd.init(feature_dim=last_legal_gtd_dim + 1)
+
+
+@pytest.mark.parametrize("learner_type", [DifferentialTDLearner, DifferentialGTDLearner])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_differential_initializers_reject_nonfinite_average_reward(
+    learner_type, value
+) -> None:
+    learner = learner_type()
+    with pytest.raises(ValueError, match="average_reward"):
+        learner.init(feature_dim=1, average_reward=value)
+
+
+@pytest.mark.parametrize("learner_type", [DifferentialTDLearner, DifferentialGTDLearner])
+@pytest.mark.parametrize("value", [2.0**-150, -(2.0**-150), 5e-324, -5e-324])
+def test_differential_initializers_reject_average_reward_underflow(
+    learner_type, value
+) -> None:
+    learner = learner_type()
+    with pytest.raises(ValueError, match="average_reward must remain nonzero"):
+        learner.init(feature_dim=1, average_reward=value)
+
+
+@pytest.mark.parametrize("learner_type", [DifferentialTDLearner, DifferentialGTDLearner])
+@pytest.mark.parametrize("value", [0.0, 2.0**-149, -(2.0**-149)])
+def test_differential_initializers_preserve_zero_and_float32_minsubnormal(
+    learner_type, value
+) -> None:
+    state = learner_type().init(feature_dim=1, average_reward=value)
+    assert float(state.average_reward) == value


### PR DESCRIPTION
## Summary
- Hardens `DifferentialGTDLearner`, `DifferentialTDLearner`, and `AverageRewardHordeLearner` state initialization (`feature_dim`) with `_require_int32` to reject booleans and non-integer floats while accepting and canonicalizing the full NumPy integer family.
- Validates optional `average_reward` initializer scalar with `validated_float32_scalar`.

## Verification
- `PYTHONPATH=. pytest tests/test_average_reward.py`: 55 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/average_reward.py`: clean