### PR TITLE
fix(export): reject boolean summary statistics in exported numbers

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 def _exported_number(value: SupportsFloat) -> str:
     """Return the shortest text that round-trips one finite binary64 value."""
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"refusing to export boolean as numeric measurement: {value!r}")
     number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"refusing to export non-finite measurement: {number!r}")
@@ -78,9 +80,7 @@ def _preflight_export_results(
         for metric_name, values in aggregate.metric_arrays.items():
             qualified_name = f"AggregatedResults {name!r} metric {metric_name!r}"
             if values.ndim != 2:
-                raise ValueError(
-                    f"{qualified_name} must be a two-dimensional seed-by-step array"
-                )
+                raise ValueError(f"{qualified_name} must be a two-dimensional seed-by-step array")
             if values.shape[0] != seed_count:
                 raise ValueError(
                     f"AggregatedResults {name!r} seed count ({seed_count}) does not match "
@@ -242,10 +242,10 @@ def export_to_json(
         summary_data: dict[str, dict[str, Any]] = {}
         for metric_name, summary in agg.summary.items():
             summary_data[metric_name] = {
-                "mean": summary.mean,
-                "std": summary.std,
-                "min": summary.min,
-                "max": summary.max,
+                "mean": float(_exported_number(summary.mean)),
+                "std": float(_exported_number(summary.std)),
+                "min": float(_exported_number(summary.min)),
+                "max": float(_exported_number(summary.max)),
                 "n_seeds": summary.n_seeds,
                 "values": summary.values.tolist(),
             }
@@ -271,15 +271,16 @@ def _finite_table_summaries(
     metric: str,
 ) -> dict[str, "MetricSummary"]:
     """Return display summaries only after validating their rendered statistics."""
-    if not results:
-        raise ValueError("table results must be non-empty")
+    _preflight_export_results(results, metric=metric)
 
     summaries: dict[str, MetricSummary] = {}
     for name, aggregate in results.items():
         summary = aggregate.summary[metric]
         mean = float(_exported_number(summary.mean))
         std = float(_exported_number(summary.std))
-        summaries[name] = summary._replace(mean=mean, std=std)
+        minimum = float(_exported_number(summary.min))
+        maximum = float(_exported_number(summary.max))
+        summaries[name] = summary._replace(mean=mean, std=std, min=minimum, max=maximum)
     return summaries
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -87,9 +87,7 @@ def _result_with_nonfinite(surface: str, number: float) -> AggregatedResults:
         summary = summary._replace(values=np.asarray([number], dtype=np.float64))
         return result._replace(summary={_METRIC: summary})
     if surface == "timeseries":
-        return result._replace(
-            metric_arrays={_METRIC: np.asarray([[number]], dtype=np.float64)}
-        )
+        return result._replace(metric_arrays={_METRIC: np.asarray([[number]], dtype=np.float64)})
     raise AssertionError(f"unknown test surface: {surface}")
 
 
@@ -124,21 +122,13 @@ def _preflight_invalid_results(case: str) -> dict[str, AggregatedResults]:
     elif case == "seed_above_uint32":
         result = result._replace(seeds=[1 << 32])
     elif case == "zero_seed_axis":
-        result = result._replace(
-            metric_arrays={_METRIC: np.empty((0, 1), dtype=np.float64)}
-        )
+        result = result._replace(metric_arrays={_METRIC: np.empty((0, 1), dtype=np.float64)})
     elif case == "zero_step_axis":
-        result = result._replace(
-            metric_arrays={_METRIC: np.empty((1, 0), dtype=np.float64)}
-        )
+        result = result._replace(metric_arrays={_METRIC: np.empty((1, 0), dtype=np.float64)})
     elif case == "metric_ndim":
-        result = result._replace(
-            metric_arrays={_METRIC: np.ones((1, 1, 1), dtype=np.float64)}
-        )
+        result = result._replace(metric_arrays={_METRIC: np.ones((1, 1, 1), dtype=np.float64)})
     elif case == "metric_row_count":
-        result = result._replace(
-            metric_arrays={_METRIC: np.ones((2, 1), dtype=np.float64)}
-        )
+        result = result._replace(metric_arrays={_METRIC: np.ones((2, 1), dtype=np.float64)})
     elif case == "summary_values_ndim":
         bad_summary = summary._replace(values=np.ones((1, 1), dtype=np.float64))
         result = result._replace(summary={_METRIC: bad_summary})
@@ -157,9 +147,7 @@ def _preflight_invalid_results(case: str) -> dict[str, AggregatedResults]:
         )
     elif case == "nonfinite_unselected_summary":
         bad_summary = summary._replace(mean=math.inf)
-        result = result._replace(
-            summary={_METRIC: summary, "unselected": bad_summary}
-        )
+        result = result._replace(summary={_METRIC: summary, "unselected": bad_summary})
     elif case == "empty_metric_arrays":
         result = result._replace(metric_arrays={})
     elif case == "empty_summary":
@@ -348,9 +336,7 @@ def test_csv_preflight_requires_requested_metric_in_every_aggregate(
     valid = _constant_result("valid")
     missing = _constant_result("missing")
     if include_timeseries:
-        missing = missing._replace(
-            metric_arrays={"other": missing.metric_arrays[_METRIC]}
-        )
+        missing = missing._replace(metric_arrays={"other": missing.metric_arrays[_METRIC]})
     else:
         missing = missing._replace(summary={"other": missing.summary[_METRIC]})
     results = {"valid": valid, "missing": missing}
@@ -526,3 +512,27 @@ def test_display_only_tables_keep_four_decimal_presentation() -> None:
 
     assert r"\textbf{0.1235} $\pm$ 0.0000" in latex
     assert "**0.1235** ± 0.0000" in markdown
+
+
+@pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+@pytest.mark.parametrize("field", ["mean", "std", "min", "max"])
+def test_export_rejects_boolean_summary_statistics(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    result = _constant_result("candidate", 1.0)
+    summary = result.summary[_METRIC]._replace(**{field: value})
+    results = {"candidate": result._replace(summary={_METRIC: summary})}
+
+    with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
+        export_to_csv(results, tmp_path / "summary.csv")
+
+    with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
+        export_to_json(results, tmp_path / "summary.json")
+
+    with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
+        generate_latex_table(results)
+
+    with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
+        generate_markdown_table(results)


### PR DESCRIPTION
## Summary
- Resolves #932.
- Hardens `_exported_number` in `alberta_framework/utils/export.py` to explicitly reject `bool` / `np.bool_` measurements rather than coercing `True` -> `1.0` and `False` -> `0.0`.
- Ensures JSON export and display table preflights route summary statistics (`mean`, `std`, `min`, `max`) through `_exported_number` validation so all export formats fail closed on booleans.

## Verification
- `PYTHONPATH=. pytest tests/test_export.py`: 117 passed
- `ruff check .`: clean
- `mypy alberta_framework/utils/export.py`: clean