### PR TITLE
fix(types): harden GVFSpec and HordeSpec fields with strict validation

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -6,10 +6,11 @@ using chex dataclasses for JAX compatibility and jaxtyping for shape annotations
 
 import enum
 import math
+import operator
 import time
 from collections.abc import Sequence
 from numbers import Real
-from typing import Any, cast
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
@@ -17,6 +18,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float, Int
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.normalizers import (
     AnyNormalizerState,
 )
@@ -245,9 +247,7 @@ class LearnerState:
 
     weights: Float[Array, " feature_dim"]
     bias: Float[Array, ""]
-    optimizer_state: (
-        LMSState | IDBDState | AutostepState | AutostepGTDLambdaState | ObGDState
-    )
+    optimizer_state: LMSState | IDBDState | AutostepState | AutostepGTDLambdaState | ObGDState
     normalizer_state: AnyNormalizerState | None = None
     step_count: Int[Array, ""] = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
@@ -685,6 +685,33 @@ def _normalized_gvf_probability(name: str, value: object) -> float:
     return normalized
 
 
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 @chex.dataclass(frozen=True)
 class GVFSpec:
     """One GVF demon's question functions (Sutton et al. 2011).
@@ -710,10 +737,18 @@ class GVFSpec:
 
     def __post_init__(self) -> None:
         """Reject invalid discount and trace-decay parameters."""
+        if type(self.name) is not str or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if not isinstance(self.demon_type, DemonType):
+            raise ValueError("demon_type must be a DemonType")
         gamma = _normalized_gvf_probability("gamma", self.gamma)
         lamda = _normalized_gvf_probability("lamda", self.lamda)
+        cumulant_index = _require_int32("cumulant_index", self.cumulant_index, minimum=-1)
+        terminal_reward = validated_float32_scalar("terminal_reward", self.terminal_reward)
         object.__setattr__(self, "gamma", gamma)
         object.__setattr__(self, "lamda", lamda)
+        object.__setattr__(self, "cumulant_index", cumulant_index)
+        object.__setattr__(self, "terminal_reward", terminal_reward)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict.
@@ -759,6 +794,13 @@ class HordeSpec:
     gammas: Float[Array, " n_demons"]
     lamdas: Float[Array, " n_demons"]
 
+    def __post_init__(self) -> None:
+        if not self.demons:
+            raise ValueError("demons must be non-empty")
+        for i, d in enumerate(self.demons):
+            if not isinstance(d, GVFSpec):
+                raise ValueError(f"demons[{i}] must be a GVFSpec")
+
     def to_config(self) -> dict[str, Any]:
         """Serialize to dict.
 
@@ -794,7 +836,12 @@ def create_horde_spec(demons: Sequence[GVFSpec]) -> HordeSpec:
     Returns:
         HordeSpec with pre-computed arrays
     """
+    if not demons:
+        raise ValueError("demons must be non-empty")
     demons_tuple = tuple(demons)
+    for i, d in enumerate(demons_tuple):
+        if not isinstance(d, GVFSpec):
+            raise ValueError(f"demons[{i}] must be a GVFSpec")
     gammas = jnp.array([d.gamma for d in demons_tuple], dtype=jnp.float32)
     lamdas = jnp.array([d.lamda for d in demons_tuple], dtype=jnp.float32)
     return HordeSpec(demons=demons_tuple, gammas=gammas, lamdas=lamdas)

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -349,3 +349,76 @@ class TestHordeSpec:
         ]
         spec = create_horde_spec(demons)
         assert isinstance(spec.demons, tuple)
+
+
+def test_gvf_spec_name_demon_type_cumulant_index_terminal_reward_validation() -> None:
+    # name validation
+    with pytest.raises(ValueError, match="name"):
+        GVFSpec(name="", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=0)
+    with pytest.raises(ValueError, match="name"):
+        GVFSpec(name=123, demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=0)  # type: ignore[arg-type]
+
+    # demon_type validation
+    with pytest.raises(ValueError, match="demon_type"):
+        GVFSpec(name="d", demon_type="prediction", gamma=0.0, lamda=0.0, cumulant_index=0)  # type: ignore[arg-type]
+
+    # cumulant_index validation
+    with pytest.raises(ValueError, match="cumulant_index"):
+        GVFSpec(
+            name="d", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=True
+        )  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="cumulant_index"):
+        GVFSpec(name="d", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=-2)
+
+    spec_idx = GVFSpec(
+        name="d", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=np.int64(-1)
+    )
+    assert spec_idx.cumulant_index == -1
+    assert type(spec_idx.cumulant_index) is int
+
+    # terminal_reward validation
+    with pytest.raises(ValueError, match="terminal_reward"):
+        GVFSpec(
+            name="d",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=float("nan"),
+        )
+    with pytest.raises(ValueError, match="terminal_reward"):
+        GVFSpec(
+            name="d",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=float("inf"),
+        )
+    with pytest.raises(ValueError, match="terminal_reward"):
+        GVFSpec(
+            name="d",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=True,
+        )  # type: ignore[arg-type]
+
+    spec_tr = GVFSpec(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.0,
+        lamda=0.0,
+        cumulant_index=0,
+        terminal_reward=np.float32(2.5),
+    )
+    assert spec_tr.terminal_reward == 2.5
+    assert type(spec_tr.terminal_reward) is float
+
+
+def test_horde_spec_rejects_empty_or_non_gvf_demons() -> None:
+    with pytest.raises(ValueError, match="demons"):
+        create_horde_spec([])
+    with pytest.raises(ValueError, match="demons"):
+        create_horde_spec([123])  # type: ignore[list-item]


### PR DESCRIPTION
## Summary
- Resolves #928.
- Hardens `GVFSpec` fields with complete class validation: non-empty string `name`, exact `DemonType` `demon_type`, exact integer `cumulant_index` in `[-1, 2**31 - 1]` rejecting booleans, and finite float32 `terminal_reward` rejecting booleans and NaNs.
- Hardens `HordeSpec` and `create_horde_spec` to reject empty demon collections and ensure every item is an actual `GVFSpec` instance.

## Verification
- `PYTHONPATH=. pytest tests/test_gvf_types.py`: 49 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/types.py`: clean