### PR TITLE
fix(multi-head-learner): harden leftover constructor scalars with strict float32 and type validation

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -471,8 +471,17 @@ class MultiHeadMLPLearner:
             raise ValueError(
                 "per_head_gamma_lamda must be an actual tuple when constructed directly"
             )
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
+        leaky_relu_slope = validated_float32_scalar("leaky_relu_slope", leaky_relu_slope, lower=0.0)
+        gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay", utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        if type(use_layer_norm) is not bool:
+            raise ValueError("use_layer_norm must be an actual bool")
+        if not isinstance(trace_mode, TraceMode):
+            raise ValueError("trace_mode must be a TraceMode")
 
         self._n_heads = n_heads
         self._hidden_sizes = hidden_sizes
@@ -558,13 +567,9 @@ class MultiHeadMLPLearner:
             "hidden_sizes": list(self._hidden_sizes),
             "optimizer": self._optimizer.to_config(),
             "bounder": self._bounder.to_config() if self._bounder is not None else None,
-            "normalizer": (
-                self._normalizer.to_config() if self._normalizer is not None else None
-            ),
+            "normalizer": (self._normalizer.to_config() if self._normalizer is not None else None),
             "head_optimizer": (
-                self._head_optimizer.to_config()
-                if self._head_optimizer is not None
-                else None
+                self._head_optimizer.to_config() if self._head_optimizer is not None else None
             ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
@@ -621,13 +626,9 @@ class MultiHeadMLPLearner:
         bounder_cfg = config.pop("bounder", None)
         bounder = bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
         normalizer_cfg = config.pop("normalizer", None)
-        normalizer = (
-            normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
-        )
+        normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        )
+        head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
 
         per_head_gl = config.pop("per_head_gamma_lamda")
         if per_head_gl is not None:
@@ -663,13 +664,9 @@ class MultiHeadMLPLearner:
             Initial state with sparse trunk weights, zero biases, and
             per-head output layers
         """
-        feature_dim = _require_int(
-            "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
-        )
+        feature_dim = _require_int("feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX)
         if self._hidden_sizes:
-            _require_int32_product(
-                "input_layer_scalars", feature_dim, self._hidden_sizes[0]
-            )
+            _require_int32_product("input_layer_scalars", feature_dim, self._hidden_sizes[0])
         else:
             _require_int32_product("linear_head_weight_scalars", self._n_heads, feature_dim)
         _validate_direct_state_resources(self._n_heads, self._hidden_sizes, feature_dim)
@@ -716,10 +713,12 @@ class MultiHeadMLPLearner:
             head_weights.append(w)
             head_biases.append(b)
             head_traces_list.append((jnp.zeros_like(w), jnp.zeros_like(b)))
-            head_opt_states_list.append((
-                head_opt.init_for_shape(w.shape),
-                head_opt.init_for_shape(b.shape),
-            ))
+            head_opt_states_list.append(
+                (
+                    head_opt.init_for_shape(w.shape),
+                    head_opt.init_for_shape(b.shape),
+                )
+            )
 
         head_params = MLPParams(
             weights=tuple(head_weights),
@@ -738,8 +737,7 @@ class MultiHeadMLPLearner:
             trunk_traces=tuple(trunk_traces),
             head_traces=tuple(head_traces_list),
             hidden_unit_utilities=tuple(
-                jnp.zeros(hidden_size, dtype=jnp.float32)
-                for hidden_size in self._hidden_sizes
+                jnp.zeros(hidden_size, dtype=jnp.float32) for hidden_size in self._hidden_sizes
             ),
             normalizer_state=normalizer_state,
             step_count=jnp.array(0, dtype=jnp.int32),
@@ -821,9 +819,7 @@ class MultiHeadMLPLearner:
     ) -> _MultiHeadCounterStatus:
         """Validate the outer clock and optional normalizer clock alignment."""
 
-        proposed_words, outer_capacity = _checked_lifetime_words_increment(
-            state.step_words
-        )
+        proposed_words, outer_capacity = _checked_lifetime_words_increment(state.step_words)
         outer_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
@@ -834,42 +830,24 @@ class MultiHeadMLPLearner:
         nested_estimator_capacity = jnp.asarray(True, dtype=jnp.bool_)
         if self._normalizer is None:
             if state.normalizer_state is not None:
-                raise ValueError(
-                    "state has normalizer_state but learner has no normalizer"
-                )
+                raise ValueError("state has normalizer_state but learner has no normalizer")
         else:
             if state.normalizer_state is None:
-                raise ValueError(
-                    "learner has a normalizer but state.normalizer_state is absent"
-                )
-            nested_status = self._normalizer.counter_status(
-                state.normalizer_state
-            )
-            aligned = jnp.all(
-                state.normalizer_state.sample_count_words == state.step_words
-            )
+                raise ValueError("learner has a normalizer but state.normalizer_state is absent")
+            nested_status = self._normalizer.counter_status(state.normalizer_state)
+            aligned = jnp.all(state.normalizer_state.sample_count_words == state.step_words)
             nested_valid = nested_status.counter_valid
-            nested_lifetime_capacity = (
-                nested_status.lifetime_capacity_available
-            )
-            nested_estimator_capacity = (
-                nested_status.estimator_capacity_available
-            )
+            nested_lifetime_capacity = nested_status.lifetime_capacity_available
+            nested_estimator_capacity = nested_status.estimator_capacity_available
         counter_valid = outer_valid & nested_valid & aligned
         lifetime_capacity = outer_capacity & nested_lifetime_capacity
-        update_available = (
-            counter_valid
-            & lifetime_capacity
-            & nested_estimator_capacity
-        )
+        update_available = counter_valid & lifetime_capacity & nested_estimator_capacity
         return _MultiHeadCounterStatus(
             proposed_step_words=proposed_words,
             lifetime_counter_valid=counter_valid,
             lifetime_capacity_available=lifetime_capacity,
             normalizer_counter_aligned=aligned,
-            normalizer_estimator_capacity_available=(
-                nested_estimator_capacity
-            ),
+            normalizer_estimator_capacity_available=(nested_estimator_capacity),
             update_available=update_available,
         )
 
@@ -950,9 +928,7 @@ class MultiHeadMLPLearner:
         n_heads = self._n_heads
         targets = jnp.asarray(targets, dtype=jnp.float32)
         if targets.shape != (n_heads,):
-            raise ValueError(
-                f"targets must have shape ({n_heads},), got {targets.shape}"
-            )
+            raise ValueError(f"targets must have shape ({n_heads},), got {targets.shape}")
         counter_status = self._counter_status(state)
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
             jnp.isfinite(targets) | jnp.isnan(targets)
@@ -962,16 +938,12 @@ class MultiHeadMLPLearner:
         previous_checked = state
         if self._gamma * self._lamda == 0.0:
             previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
-                trunk_traces=tuple(
-                    jnp.zeros_like(trace) for trace in state.trunk_traces
-                ),
+                trunk_traces=tuple(jnp.zeros_like(trace) for trace in state.trunk_traces),
             )
         checked_head_traces = []
         for i, (old_w_trace, old_b_trace) in enumerate(state.head_traces):
             head_decay_value = (
-                self._per_head_gl[i]
-                if self._per_head_gl is not None
-                else self._gamma * self._lamda
+                self._per_head_gl[i] if self._per_head_gl is not None else self._gamma * self._lamda
             )
             if head_decay_value == 0.0:
                 checked_head_traces.append(
@@ -1005,9 +977,7 @@ class MultiHeadMLPLearner:
             def update_normalizer(
                 _: None,
             ) -> tuple[Array, AnyNormalizerState, Bool[Array, ""]]:
-                result = normalizer.normalize_with_diagnostics(
-                    normalizer_state, observation
-                )
+                result = normalizer.normalize_with_diagnostics(normalizer_state, observation)
                 return result.normalized, result.state, result.update_applied
 
             def preserve_normalizer(
@@ -1066,9 +1036,7 @@ class MultiHeadMLPLearner:
             # gradients are error-weighted. This is safe because trunk
             # gamma*lamda=0 (validated in __init__), so traces reset each
             # step and the error-gradient coupling doesn't accumulate.
-            cotangent = cotangent + masked_error_i * jnp.squeeze(
-                state.head_params.weights[i]
-            )
+            cotangent = cotangent + masked_error_i * jnp.squeeze(state.head_params.weights[i])
 
         predictions_arr = jnp.array(predictions_list)
         errors_arr = jnp.array(errors_list)
@@ -1107,15 +1075,12 @@ class MultiHeadMLPLearner:
             old_wt = state.trunk_traces[2 * i]
             if replacing:
                 # Replacing: use grad where nonzero, else decay old trace
-                new_wt = jnp.where(
-                    w_grad_i != 0.0, w_grad_i, _skip_zero_scale(gamma_lamda, old_wt)
-                )
+                new_wt = jnp.where(w_grad_i != 0.0, w_grad_i, _skip_zero_scale(gamma_lamda, old_wt))
             else:
                 new_wt = _skip_zero_scale(gamma_lamda, old_wt) + w_grad_i
             new_trunk_traces.append(new_wt)
             w_step, new_w_opt, w_update_applied = _update_from_gradient_with_diagnostics(
-                self._optimizer,
-                state.trunk_optimizer_states[2 * i], new_wt, error=None
+                self._optimizer, state.trunk_optimizer_states[2 * i], new_wt, error=None
             )
             trunk_steps.append(w_step)
             new_trunk_opt_states.append(new_w_opt)
@@ -1125,15 +1090,12 @@ class MultiHeadMLPLearner:
             b_grad_i = trunk_bias_grads[i]
             old_bt = state.trunk_traces[2 * i + 1]
             if replacing:
-                new_bt = jnp.where(
-                    b_grad_i != 0.0, b_grad_i, _skip_zero_scale(gamma_lamda, old_bt)
-                )
+                new_bt = jnp.where(b_grad_i != 0.0, b_grad_i, _skip_zero_scale(gamma_lamda, old_bt))
             else:
                 new_bt = _skip_zero_scale(gamma_lamda, old_bt) + b_grad_i
             new_trunk_traces.append(new_bt)
             b_step, new_b_opt, b_update_applied = _update_from_gradient_with_diagnostics(
-                self._optimizer,
-                state.trunk_optimizer_states[2 * i + 1], new_bt, error=None
+                self._optimizer, state.trunk_optimizer_states[2 * i + 1], new_bt, error=None
             )
             trunk_steps.append(b_step)
             new_trunk_opt_states.append(new_b_opt)
@@ -1157,12 +1119,8 @@ class MultiHeadMLPLearner:
         new_trunk_weights: list[Array] = []
         new_trunk_biases: list[Array] = []
         for i in range(n_trunk_layers):
-            new_trunk_weights.append(
-                state.trunk_params.weights[i] + trunk_steps[2 * i]
-            )
-            new_trunk_biases.append(
-                state.trunk_params.biases[i] + trunk_steps[2 * i + 1]
-            )
+            new_trunk_weights.append(state.trunk_params.weights[i] + trunk_steps[2 * i])
+            new_trunk_biases.append(state.trunk_params.biases[i] + trunk_steps[2 * i + 1])
 
         new_trunk_params = MLPParams(
             weights=tuple(new_trunk_weights),
@@ -1204,9 +1162,7 @@ class MultiHeadMLPLearner:
                 new_b_trace = _skip_zero_scale(head_gl, old_b_trace) + b_grad
 
             # Error for this head (masked to 0 for inactive)
-            error_i = jnp.where(
-                active_mask[i], safe_targets[i] - predictions_list[i], 0.0
-            )
+            error_i = jnp.where(active_mask[i], safe_targets[i] - predictions_list[i], 0.0)
 
             # Optimizer step (with error for meta-learning)
             head_opt = self._head_optimizer if self._head_optimizer is not None else self._optimizer
@@ -1260,9 +1216,7 @@ class MultiHeadMLPLearner:
             raw_error_i = jnp.where(active_mask[i], error_i, jnp.nan)
             mean_ss_i = _extract_mean_step_size(new_w_opt)
             mean_ss_i = jnp.where(active_mask[i], mean_ss_i, jnp.nan)
-            per_head_metrics_list.append(
-                jnp.array([se_i, raw_error_i, mean_ss_i])
-            )
+            per_head_metrics_list.append(jnp.array([se_i, raw_error_i, mean_ss_i]))
 
         new_head_params = MLPParams(
             weights=tuple(new_head_weights),
@@ -1323,15 +1277,9 @@ class MultiHeadMLPLearner:
             ),
             pre_step_words=state.step_words,
             post_step_words=new_state.step_words,
-            lifetime_counter_valid=(
-                counter_status.lifetime_counter_valid
-            ),
-            lifetime_capacity_available=(
-                counter_status.lifetime_capacity_available
-            ),
-            normalizer_counter_aligned=(
-                counter_status.normalizer_counter_aligned
-            ),
+            lifetime_counter_valid=(counter_status.lifetime_counter_valid),
+            lifetime_capacity_available=(counter_status.lifetime_capacity_available),
+            normalizer_counter_aligned=(counter_status.normalizer_counter_aligned),
             normalizer_estimator_capacity_available=(
                 counter_status.normalizer_estimator_capacity_available
             ),
@@ -1422,18 +1370,14 @@ def migrate_legacy_multi_head_mlp_state(
     """
 
     fields = _host_field_mapping(legacy_state)
-    current_names = {
-        field.name
-        for field in dataclasses.fields(MultiHeadMLPState)
-    }
+    current_names = {field.name for field in dataclasses.fields(MultiHeadMLPState)}
     legacy_names = current_names - {"step_words"}
     supplied_names = set(fields)
     if supplied_names != legacy_names:
         missing = sorted(legacy_names - supplied_names)
         extra = sorted(supplied_names - legacy_names)
         raise ValueError(
-            "legacy MultiHeadMLP field manifest is not exact; "
-            f"missing={missing}, extra={extra}"
+            f"legacy MultiHeadMLP field manifest is not exact; missing={missing}, extra={extra}"
         )
     step_array = jnp.asarray(fields["step_count"])
     if step_array.shape != () or step_array.dtype != jnp.dtype(jnp.int32):
@@ -1451,9 +1395,7 @@ def migrate_legacy_multi_head_mlp_state(
             normalizer_type=_legacy_normalizer_type(legacy_normalizer),
         )
         if int(normalizer_state.sample_count) != step:
-            raise ValueError(
-                "legacy learner and normalizer sample counters are not aligned"
-            )
+            raise ValueError("legacy learner and normalizer sample counters are not aligned")
         fields["normalizer_state"] = normalizer_state
     fields["step_words"] = jnp.asarray((0, step), dtype=jnp.uint32)
     return MultiHeadMLPState(**fields)
@@ -1537,9 +1479,7 @@ def run_multi_head_learning_loop_batched(
 
     def single_run(key: Array) -> tuple[MultiHeadMLPState, Array, Array]:
         init_state = learner.init(feature_dim, key)
-        result = run_multi_head_learning_loop(
-            learner, init_state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, init_state, observations, targets)
         return result.state, result.per_head_metrics, result.updates_applied
 
     t0 = time.time()

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -44,6 +44,7 @@ class _HostileDict(dict[str, object]):
     def __iter__(self):
         raise AssertionError("dict subclass hook must not run")
 
+
 # =============================================================================
 # Init tests
 # =============================================================================
@@ -122,9 +123,7 @@ class TestMultiHeadInit:
         assert type(config["hidden_sizes"][0]) is int
 
     @pytest.mark.parametrize("feature_dim", [True, np.bool_(True), 1.5, "2", 0, -1, 2**31])
-    def test_init_rejects_invalid_feature_dimension_before_allocation(
-        self, feature_dim: object
-    ):
+    def test_init_rejects_invalid_feature_dimension_before_allocation(self, feature_dim: object):
         learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
         with pytest.raises(ValueError, match="feature_dim"):
             learner.init(feature_dim, jr.key(0))  # type: ignore[arg-type]
@@ -226,9 +225,7 @@ class TestMultiHeadInit:
 
     def test_trunk_shapes_single_hidden(self):
         """Trunk with one hidden layer has correct shapes."""
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(32,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(32,), sparsity=0.0)
         state = learner.init(feature_dim=10, key=jr.key(42))
 
         # Trunk: 10 -> 32
@@ -238,9 +235,7 @@ class TestMultiHeadInit:
 
     def test_trunk_shapes_two_hidden(self):
         """Trunk with two hidden layers has correct shapes."""
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(64, 32), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(64, 32), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         assert len(state.trunk_params.weights) == 2
@@ -251,9 +246,7 @@ class TestMultiHeadInit:
 
     def test_head_shapes(self):
         """Each head has a (1, H_last) weight and (1,) bias."""
-        learner = MultiHeadMLPLearner(
-            n_heads=4, hidden_sizes=(64, 32), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=4, hidden_sizes=(64, 32), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         assert len(state.head_params.weights) == 4
@@ -264,9 +257,7 @@ class TestMultiHeadInit:
 
     def test_traces_initialized_to_zero(self):
         """All trunk and head traces should be zero."""
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(16,), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         for trace in state.trunk_traces:
@@ -278,9 +269,7 @@ class TestMultiHeadInit:
 
     def test_biases_initialized_to_zero(self):
         """All trunk and head biases should be zero."""
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(16,), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         for bias in state.trunk_params.biases:
@@ -291,9 +280,7 @@ class TestMultiHeadInit:
 
     def test_sparsity_applied(self):
         """Trunk and head weights should be sparse when sparsity > 0."""
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(32,), sparsity=0.9
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(32,), sparsity=0.9)
         state = learner.init(feature_dim=10, key=jr.key(42))
 
         # Trunk layer: expect ~90% sparse
@@ -304,16 +291,16 @@ class TestMultiHeadInit:
 
     def test_step_count_starts_at_zero(self):
         """step_count should be 0 after init."""
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(16,), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
         assert int(state.step_count) == 0
 
     def test_normalizer_state_init(self):
         """Normalizer state should be created when normalizer is provided."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -333,9 +320,7 @@ class TestMultiHeadPredict:
 
     def test_returns_n_heads_scalars(self):
         """predict should return array of shape (n_heads,)."""
-        learner = MultiHeadMLPLearner(
-            n_heads=4, hidden_sizes=(16,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=4, hidden_sizes=(16,), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         obs = jnp.ones(5)
@@ -346,9 +331,7 @@ class TestMultiHeadPredict:
 
     def test_deterministic(self):
         """Same state and observation should give same predictions."""
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(16,), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         obs = jnp.array([1.0, 0.5, -0.3, 0.2, 0.8])
@@ -369,7 +352,9 @@ class TestMultiHeadUpdateAllActive:
     def test_correct_result_types(self):
         """Update should return MultiHeadMLPUpdateResult."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -385,7 +370,9 @@ class TestMultiHeadUpdateAllActive:
         """Metrics, predictions, errors should have correct shapes."""
         n_heads = 4
         learner = MultiHeadMLPLearner(
-            n_heads=n_heads, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=n_heads,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -403,7 +390,9 @@ class TestMultiHeadUpdateAllActive:
     def test_no_nan_when_all_active(self):
         """All metrics should be finite when all heads are active."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -420,7 +409,10 @@ class TestMultiHeadUpdateAllActive:
     def test_error_reduction(self):
         """Multiple updates should reduce error on a fixed target."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), step_size=0.1, sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            step_size=0.1,
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -443,7 +435,9 @@ class TestMultiHeadUpdateAllActive:
     def test_step_count_increments(self):
         """step_count should increment by 1 each update."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -532,7 +526,10 @@ class TestMultiHeadUpdateValidation:
     @pytest.mark.parametrize("shape", [(1,), (), (4, 1), (5,)])
     def test_update_rejects_targets_that_are_not_one_per_head(self, shape):
         learner = MultiHeadMLPLearner(
-            n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01,
+            n_heads=4,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
         )
         state = learner.init(feature_dim=3, key=jr.key(0))
         obs = jnp.array([1.0, -0.5, 0.25])
@@ -550,7 +547,10 @@ class TestMultiHeadUpdateValidation:
         instead of raising).
         """
         learner = MultiHeadMLPLearner(
-            n_heads=4, hidden_sizes=(8,), sparsity=0.0, step_size=0.01,
+            n_heads=4,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
         )
         state = learner.init(feature_dim=3, key=jr.key(0))
         obs = jnp.array([1.0, -0.5, 0.25])
@@ -569,7 +569,9 @@ class TestMultiHeadUpdatePartialActive:
     def test_nan_metrics_for_inactive(self):
         """Inactive heads should have NaN in errors and metrics."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -590,7 +592,9 @@ class TestMultiHeadUpdatePartialActive:
     def test_inactive_head_params_unchanged(self):
         """Inactive head params should not change."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -619,7 +623,9 @@ class TestMultiHeadUpdatePartialActive:
     def test_predictions_always_computed(self):
         """Predictions should be computed for all heads, even inactive ones."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -643,7 +649,9 @@ class TestMultiHeadUpdateNoneActive:
     def test_head_params_unchanged(self):
         """All head params should remain unchanged when no heads are active."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -665,7 +673,9 @@ class TestMultiHeadUpdateNoneActive:
     def test_normalizer_still_updates(self):
         """Normalizer should update even when no heads are active."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -684,7 +694,9 @@ class TestMultiHeadUpdateNoneActive:
     def test_step_count_still_increments(self):
         """step_count should still increment even with no active heads."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -704,7 +716,9 @@ class TestMultiHeadComposition:
     def test_with_obgd_bounding(self):
         """Should work with ObGDBounding."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -719,7 +733,9 @@ class TestMultiHeadComposition:
     def test_with_agc_bounding(self):
         """Should work with AGCBounding."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=AGCBounding(clip_factor=0.01),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -733,7 +749,9 @@ class TestMultiHeadComposition:
     def test_with_ema_normalizer(self):
         """Should work with EMANormalizer."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             normalizer=EMANormalizer(decay=0.95),
             bounder=ObGDBounding(kappa=2.0),
         )
@@ -749,7 +767,9 @@ class TestMultiHeadComposition:
     def test_with_welford_normalizer(self):
         """Should work with WelfordNormalizer."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             normalizer=WelfordNormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -763,7 +783,9 @@ class TestMultiHeadComposition:
     def test_with_autostep_optimizer(self):
         """Should work with Autostep optimizer."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
         )
@@ -788,7 +810,9 @@ class TestMultiHeadGradientCorrectness:
     def test_vjp_matches_separate_grads(self):
         """Accumulated VJP cotangent should match sum of per-head grads."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -799,21 +823,13 @@ class TestMultiHeadGradientCorrectness:
         ln = learner._use_layer_norm
 
         # Compute via N separate jax.grad calls
-        accumulated_w_grads = [
-            jnp.zeros_like(w) for w in state.trunk_params.weights
-        ]
-        accumulated_b_grads = [
-            jnp.zeros_like(b) for b in state.trunk_params.biases
-        ]
+        accumulated_w_grads = [jnp.zeros_like(w) for w in state.trunk_params.weights]
+        accumulated_b_grads = [jnp.zeros_like(b) for b in state.trunk_params.biases]
 
         for i in range(3):
             # Full forward: trunk + head_i
-            def full_forward_i(
-                trunk_w: tuple, trunk_b: tuple, head_idx: int = i
-            ) -> jax.Array:
-                hidden = MultiHeadMLPLearner._trunk_forward(
-                    trunk_w, trunk_b, obs, slope, ln
-                )
+            def full_forward_i(trunk_w: tuple, trunk_b: tuple, head_idx: int = i) -> jax.Array:
+                hidden = MultiHeadMLPLearner._trunk_forward(trunk_w, trunk_b, obs, slope, ln)
                 return MultiHeadMLPLearner._head_forward(
                     state.head_params.weights[head_idx],
                     state.head_params.biases[head_idx],
@@ -829,18 +845,12 @@ class TestMultiHeadGradientCorrectness:
             )
 
             for j in range(len(accumulated_w_grads)):
-                accumulated_w_grads[j] = (
-                    accumulated_w_grads[j] + error_i * w_grads[j]
-                )
-                accumulated_b_grads[j] = (
-                    accumulated_b_grads[j] + error_i * b_grads[j]
-                )
+                accumulated_w_grads[j] = accumulated_w_grads[j] + error_i * w_grads[j]
+                accumulated_b_grads[j] = accumulated_b_grads[j] + error_i * b_grads[j]
 
         # Compute via VJP (as the learner does)
         def trunk_fn(weights, biases):
-            return MultiHeadMLPLearner._trunk_forward(
-                weights, biases, obs, slope, ln
-            )
+            return MultiHeadMLPLearner._trunk_forward(weights, biases, obs, slope, ln)
 
         hidden, trunk_vjp_fn = jax.vjp(
             trunk_fn,
@@ -858,20 +868,14 @@ class TestMultiHeadGradientCorrectness:
                 hidden,
             )
             error_i = targets[i] - pred_i
-            cotangent = cotangent + error_i * jnp.squeeze(
-                state.head_params.weights[i]
-            )
+            cotangent = cotangent + error_i * jnp.squeeze(state.head_params.weights[i])
 
         vjp_w_grads, vjp_b_grads = trunk_vjp_fn(cotangent)
 
         # Compare
         for j in range(len(accumulated_w_grads)):
-            chex.assert_trees_all_close(
-                vjp_w_grads[j], accumulated_w_grads[j], atol=1e-5
-            )
-            chex.assert_trees_all_close(
-                vjp_b_grads[j], accumulated_b_grads[j], atol=1e-5
-            )
+            chex.assert_trees_all_close(vjp_w_grads[j], accumulated_w_grads[j], atol=1e-5)
+            chex.assert_trees_all_close(vjp_b_grads[j], accumulated_b_grads[j], atol=1e-5)
 
 
 # =============================================================================
@@ -885,7 +889,9 @@ class TestMultiHeadMetricsToDicts:
     def test_all_active(self):
         """All active heads should produce dicts."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -905,7 +911,9 @@ class TestMultiHeadMetricsToDicts:
     def test_partial_active(self):
         """Inactive heads should produce None."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -922,7 +930,9 @@ class TestMultiHeadMetricsToDicts:
     def test_none_active(self):
         """All NaN targets should produce all None."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -951,7 +961,9 @@ class TestRunMultiHeadLearningLoop:
         feature_dim = 5
 
         learner = MultiHeadMLPLearner(
-            n_heads=n_heads, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=n_heads,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=feature_dim, key=jr.key(0))
@@ -962,19 +974,17 @@ class TestRunMultiHeadLearningLoop:
         observations = jr.normal(k1, (num_steps, feature_dim))
         targets = jr.normal(k2, (num_steps, n_heads))
 
-        result = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, state, observations, targets)
 
         assert isinstance(result, MultiHeadLearningResult)
-        chex.assert_shape(
-            result.per_head_metrics, (num_steps, n_heads, 3)
-        )
+        chex.assert_shape(result.per_head_metrics, (num_steps, n_heads, 3))
 
     def test_deterministic(self):
         """Same inputs should give identical results."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(0))
@@ -984,21 +994,17 @@ class TestRunMultiHeadLearningLoop:
         observations = jr.normal(k1, (30, 5))
         targets = jr.normal(k2, (30, 2))
 
-        result1 = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
-        result2 = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result1 = run_multi_head_learning_loop(learner, state, observations, targets)
+        result2 = run_multi_head_learning_loop(learner, state, observations, targets)
 
-        chex.assert_trees_all_close(
-            result1.per_head_metrics, result2.per_head_metrics
-        )
+        chex.assert_trees_all_close(result1.per_head_metrics, result2.per_head_metrics)
 
     def test_nan_target_handling(self):
         """Should handle NaN targets correctly in scan loop."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(0))
@@ -1008,9 +1014,7 @@ class TestRunMultiHeadLearningLoop:
         targets = jr.normal(jr.key(99), (20, 2))
         targets = targets.at[10:, 1].set(jnp.nan)
 
-        result = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, state, observations, targets)
 
         # Head 0 metrics should all be finite
         assert jnp.all(jnp.isfinite(result.per_head_metrics[:, 0, :]))
@@ -1022,7 +1026,9 @@ class TestRunMultiHeadLearningLoop:
     def test_with_normalizer(self):
         """Should work with normalizer in scan loop."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             normalizer=EMANormalizer(),
             bounder=ObGDBounding(kappa=2.0),
         )
@@ -1031,9 +1037,7 @@ class TestRunMultiHeadLearningLoop:
         observations = jr.normal(jr.key(42), (30, 5))
         targets = jr.normal(jr.key(99), (30, 2))
 
-        result = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, state, observations, targets)
 
         chex.assert_shape(result.per_head_metrics, (30, 2, 3))
         # Normalizer should have updated
@@ -1056,7 +1060,9 @@ class TestRunMultiHeadLearningLoopBatched:
         n_seeds = 4
 
         learner = MultiHeadMLPLearner(
-            n_heads=n_heads, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=n_heads,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
 
@@ -1066,14 +1072,10 @@ class TestRunMultiHeadLearningLoopBatched:
         targets = jr.normal(k2, (num_steps, n_heads))
         keys = jr.split(k3, n_seeds)
 
-        result = run_multi_head_learning_loop_batched(
-            learner, observations, targets, keys
-        )
+        result = run_multi_head_learning_loop_batched(learner, observations, targets, keys)
 
         assert isinstance(result, BatchedMultiHeadResult)
-        chex.assert_shape(
-            result.per_head_metrics, (n_seeds, num_steps, n_heads, 3)
-        )
+        chex.assert_shape(result.per_head_metrics, (n_seeds, num_steps, n_heads, 3))
 
     def test_matches_sequential(self):
         """Batched results should match sequential for each seed."""
@@ -1083,7 +1085,9 @@ class TestRunMultiHeadLearningLoopBatched:
         n_seeds = 3
 
         learner = MultiHeadMLPLearner(
-            n_heads=n_heads, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=n_heads,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
 
@@ -1094,16 +1098,12 @@ class TestRunMultiHeadLearningLoopBatched:
         keys = jr.split(k3, n_seeds)
 
         # Batched
-        batched_result = run_multi_head_learning_loop_batched(
-            learner, observations, targets, keys
-        )
+        batched_result = run_multi_head_learning_loop_batched(learner, observations, targets, keys)
 
         # Sequential
         for i in range(n_seeds):
             state_i = learner.init(feature_dim, keys[i])
-            seq_result = run_multi_head_learning_loop(
-                learner, state_i, observations, targets
-            )
+            seq_result = run_multi_head_learning_loop(learner, state_i, observations, targets)
             chex.assert_trees_all_close(
                 batched_result.per_head_metrics[i],
                 seq_result.per_head_metrics,
@@ -1113,7 +1113,9 @@ class TestRunMultiHeadLearningLoopBatched:
     def test_different_seeds_different_results(self):
         """Different seeds should produce different metrics."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
 
@@ -1123,14 +1125,10 @@ class TestRunMultiHeadLearningLoopBatched:
         targets = jr.normal(k2, (30, 2))
         keys = jr.split(k3, 3)
 
-        result = run_multi_head_learning_loop_batched(
-            learner, observations, targets, keys
-        )
+        result = run_multi_head_learning_loop_batched(learner, observations, targets, keys)
 
         # Different seeds should give different final metrics
-        assert not jnp.allclose(
-            result.per_head_metrics[0], result.per_head_metrics[1]
-        )
+        assert not jnp.allclose(result.per_head_metrics[0], result.per_head_metrics[1])
 
 
 class TestMultiHeadLifecycleTracking:
@@ -1190,9 +1188,7 @@ class TestMultiHeadLifecycleTracking:
 
         obs2 = jr.normal(k4, (50, 5))
         tgt2 = jr.normal(k5, (50, 2))
-        result2 = run_multi_head_learning_loop(
-            learner, result1.state, obs2, tgt2
-        )
+        result2 = run_multi_head_learning_loop(learner, result1.state, obs2, tgt2)
         assert result2.state.uptime_s > uptime_after_first
 
 
@@ -1209,7 +1205,9 @@ class TestMultiHeadHybridOptimizer:
         from alberta_framework.core.types import AutostepParamState, LMSState
 
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -1228,7 +1226,9 @@ class TestMultiHeadHybridOptimizer:
     def test_hybrid_update_runs(self):
         """Update with hybrid optimizer should work."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -1246,7 +1246,9 @@ class TestMultiHeadHybridOptimizer:
     def test_hybrid_scan_loop(self):
         """Full scan loop with hybrid optimizer should work."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -1258,9 +1260,7 @@ class TestMultiHeadHybridOptimizer:
         observations = jr.normal(k2, (50, 5))
         targets = jr.normal(k3, (50, 2))
 
-        result = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, state, observations, targets)
 
         assert isinstance(result, MultiHeadLearningResult)
         chex.assert_shape(result.per_head_metrics, (50, 2, 3))
@@ -1273,12 +1273,18 @@ class TestMultiHeadHybridOptimizer:
         targets = jr.normal(k3, (30, 2))
 
         learner_default = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
-            step_size=1.0, bounder=ObGDBounding(kappa=2.0),
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            step_size=1.0,
+            bounder=ObGDBounding(kappa=2.0),
         )
         learner_explicit = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0,
-            step_size=1.0, head_optimizer=None,
+            n_heads=2,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            step_size=1.0,
+            head_optimizer=None,
             bounder=ObGDBounding(kappa=2.0),
         )
 
@@ -1308,9 +1314,7 @@ class TestMultiHeadLinearBaseline:
 
     def test_init_succeeds(self):
         """hidden_sizes=() should init without error."""
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         # No trunk layers
@@ -1321,9 +1325,7 @@ class TestMultiHeadLinearBaseline:
 
     def test_head_shapes_match_input(self):
         """Heads should project from feature_dim directly."""
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         assert len(state.head_params.weights) == 3
@@ -1333,9 +1335,7 @@ class TestMultiHeadLinearBaseline:
 
     def test_predict_correct_shape(self):
         """predict should return (n_heads,) array."""
-        learner = MultiHeadMLPLearner(
-            n_heads=4, hidden_sizes=(), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=4, hidden_sizes=(), sparsity=0.0)
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         obs = jnp.ones(5)
@@ -1347,7 +1347,9 @@ class TestMultiHeadLinearBaseline:
     def test_update_correct_shape(self):
         """update should return correct shapes."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -1366,7 +1368,10 @@ class TestMultiHeadLinearBaseline:
     def test_state_updates(self):
         """Head params should change after update."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), step_size=0.1, sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(),
+            step_size=0.1,
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -1386,7 +1391,10 @@ class TestMultiHeadLinearBaseline:
     def test_error_reduction(self):
         """Multiple updates on fixed target should reduce error."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), step_size=0.1, sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(),
+            step_size=0.1,
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -1409,7 +1417,9 @@ class TestMultiHeadLinearBaseline:
     def test_nan_masking(self):
         """NaN targets should leave inactive heads unchanged."""
         learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(), sparsity=0.0,
+            n_heads=3,
+            hidden_sizes=(),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -1429,7 +1439,9 @@ class TestMultiHeadLinearBaseline:
     def test_scan_loop(self):
         """Should work in scan-based learning loop."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(),
+            sparsity=0.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(0))
@@ -1439,9 +1451,7 @@ class TestMultiHeadLinearBaseline:
         observations = jr.normal(k1, (30, 5))
         targets = jr.normal(k2, (30, 2))
 
-        result = run_multi_head_learning_loop(
-            learner, state, observations, targets
-        )
+        result = run_multi_head_learning_loop(learner, state, observations, targets)
 
         assert isinstance(result, MultiHeadLearningResult)
         chex.assert_shape(result.per_head_metrics, (30, 2, 3))
@@ -1449,7 +1459,9 @@ class TestMultiHeadLinearBaseline:
     def test_with_normalizer(self):
         """Should work with EMANormalizer."""
         learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), sparsity=0.0,
+            n_heads=2,
+            hidden_sizes=(),
+            sparsity=0.0,
             normalizer=EMANormalizer(),
             bounder=ObGDBounding(kappa=2.0),
         )
@@ -1464,13 +1476,10 @@ class TestMultiHeadLinearBaseline:
 
     def test_zero_trace_decay_does_not_multiply_inf_head_traces(self) -> None:
         """Default gamma*lamda is 0; 0 * inf head traces is NaN and would freeze."""
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), sparsity=0.0, optimizer=LMS(0.1)
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0, optimizer=LMS(0.1))
         state = learner.init(feature_dim=3, key=jr.key(2))
         poisoned = [
-            (jnp.full_like(w, jnp.inf), jnp.full_like(b, jnp.inf))
-            for w, b in state.head_traces
+            (jnp.full_like(w, jnp.inf), jnp.full_like(b, jnp.inf)) for w, b in state.head_traces
         ]
         state = state.replace(head_traces=tuple(poisoned))
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
@@ -1495,9 +1504,7 @@ class TestMultiHeadLinearBaseline:
         )
         state = learner.init(feature_dim=3, key=jr.key(3))
         state = state.replace(
-            trunk_traces=tuple(
-                jnp.full_like(trace, jnp.inf) for trace in state.trunk_traces
-            )
+            trunk_traces=tuple(jnp.full_like(trace, jnp.inf) for trace in state.trunk_traces)
         )
 
         result = learner.update(
@@ -1520,9 +1527,7 @@ class TestMultiHeadLinearBaseline:
         )
         state = learner.init(feature_dim=3, key=jr.key(4))
         old_w, old_b = state.head_traces[0]
-        state = state.replace(
-            head_traces=((jnp.full_like(old_w, jnp.inf), old_b),)
-        )
+        state = state.replace(head_traces=((jnp.full_like(old_w, jnp.inf), old_b),))
 
         result = learner.update(
             state,
@@ -1583,8 +1588,7 @@ class TestMultiHeadLinearBaseline:
         state = learner.init(feature_dim=3, key=jr.key(6))
         state = state.replace(
             hidden_unit_utilities=tuple(
-                jnp.full_like(utility, jnp.inf)
-                for utility in state.hidden_unit_utilities
+                jnp.full_like(utility, jnp.inf) for utility in state.hidden_unit_utilities
             )
         )
 
@@ -1597,3 +1601,68 @@ class TestMultiHeadLinearBaseline:
         assert bool(result.update_applied)
         for utility in result.state.hidden_unit_utilities:
             assert bool(jnp.all(jnp.isfinite(utility)))
+
+
+def test_multi_head_mlp_leftover_scalars_validation() -> None:
+    # sparsity validation
+    with pytest.raises(ValueError, match="sparsity"):
+        MultiHeadMLPLearner(n_heads=2, sparsity=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="sparsity"):
+        MultiHeadMLPLearner(n_heads=2, sparsity=float("nan"))
+    with pytest.raises(ValueError, match="sparsity"):
+        MultiHeadMLPLearner(n_heads=2, sparsity=-0.1)
+    with pytest.raises(ValueError, match="sparsity"):
+        MultiHeadMLPLearner(n_heads=2, sparsity=1.5)
+
+    # leaky_relu_slope validation
+    with pytest.raises(ValueError, match="leaky_relu_slope"):
+        MultiHeadMLPLearner(n_heads=2, leaky_relu_slope=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="leaky_relu_slope"):
+        MultiHeadMLPLearner(n_heads=2, leaky_relu_slope=float("nan"))
+    with pytest.raises(ValueError, match="leaky_relu_slope"):
+        MultiHeadMLPLearner(n_heads=2, leaky_relu_slope=-0.01)
+
+    # gamma / lamda validation
+    with pytest.raises(ValueError, match="gamma"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), gamma=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gamma"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), gamma=float("nan"))
+    with pytest.raises(ValueError, match="lamda"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), lamda=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="lamda"):
+        MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), lamda=float("nan"))
+
+    # utility_decay validation
+    with pytest.raises(ValueError, match="utility_decay"):
+        MultiHeadMLPLearner(n_heads=2, utility_decay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="utility_decay"):
+        MultiHeadMLPLearner(n_heads=2, utility_decay=1.0)
+    with pytest.raises(ValueError, match="utility_decay"):
+        MultiHeadMLPLearner(n_heads=2, utility_decay=-0.1)
+
+    # use_layer_norm validation
+    with pytest.raises(ValueError, match="use_layer_norm"):
+        MultiHeadMLPLearner(n_heads=2, use_layer_norm=1)  # type: ignore[arg-type]
+
+    # trace_mode validation
+    with pytest.raises(ValueError, match="trace_mode"):
+        MultiHeadMLPLearner(n_heads=2, trace_mode="accumulating")  # type: ignore[arg-type]
+
+    learner = MultiHeadMLPLearner(
+        n_heads=2,
+        sparsity=np.float32(0.5),
+        leaky_relu_slope=np.float64(0.02),
+        gamma=np.float32(0.0),
+        lamda=np.float32(0.0),
+        utility_decay=np.float32(0.95),
+    )
+    assert learner._sparsity == 0.5
+    assert type(learner._sparsity) is float
+    assert learner._leaky_relu_slope == pytest.approx(0.02)
+    assert type(learner._leaky_relu_slope) is float
+    assert learner._gamma == 0.0
+    assert type(learner._gamma) is float
+    assert learner._lamda == 0.0
+    assert type(learner._lamda) is float
+    assert learner._utility_decay == pytest.approx(0.95)
+    assert type(learner._utility_decay) is float


### PR DESCRIPTION
## Summary
- Resolves #929.
- Hardens `MultiHeadMLPLearner` constructor scalars with `validated_float32_scalar` and exact identity validation: `sparsity` in `[0, 1]`, `leaky_relu_slope` >= 0, `gamma` / `lamda` in `[0, 1]`, `utility_decay` in `[0, 1)`, `use_layer_norm` exact `bool`, and `trace_mode` exact `TraceMode` instance.

## Verification
- `PYTHONPATH=. pytest tests/test_multi_head_learner.py`: 114 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/multi_head_learner.py`: clean