### PR TITLE
fix(streams): reject boolean recurring start positions

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -40,6 +40,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
@@ -388,9 +389,17 @@ class RecurringTwoAgentWorld:
                 f"initial_positions must contain {N_AGENTS} values, "
                 f"got {len(initial_positions)}"
             )
-        if any(not math.isfinite(float(position)) for position in initial_positions):
-            raise ValueError("initial_positions must be finite")
-        if any(abs(position) > world_limit for position in initial_positions):
+        canonical_positions: list[float] = []
+        for position in initial_positions:
+            if isinstance(position, (bool, np.bool_)) or not isinstance(
+                position, (int, float, np.integer, np.floating)
+            ):
+                raise ValueError("initial_positions must be finite real numbers")
+            number = float(position)
+            if not math.isfinite(number):
+                raise ValueError("initial_positions must be finite")
+            canonical_positions.append(number)
+        if any(abs(position) > world_limit for position in canonical_positions):
             raise ValueError(
                 "initial_positions must lie within [-world_limit, world_limit]"
             )
@@ -403,8 +412,8 @@ class RecurringTwoAgentWorld:
         self._acceleration = float(acceleration)
         self._time_delta = float(time_delta)
         self._max_speed = float(max_speed)
-        self._initial_positions_tuple = tuple(float(value) for value in initial_positions)
-        self._initial_positions = jnp.asarray(initial_positions, dtype=jnp.float32)
+        self._initial_positions_tuple = tuple(canonical_positions)
+        self._initial_positions = jnp.asarray(canonical_positions, dtype=jnp.float32)
         self._partner_policy_is_default = partner_policy is None
         self._partner_policy = (
             scripted_meet_avoid_partner_policy

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -47,6 +47,9 @@ def _with_step_count(
         ({"time_delta": 0.0}, "time_delta"),
         ({"max_speed": 0.0}, "max_speed"),
         ({"initial_positions": (-2.0, 0.0)}, "initial_positions"),
+        ({"initial_positions": (True, False)}, "initial_positions"),
+        ({"initial_positions": (False, True)}, "initial_positions"),
+        ({"initial_positions": (1.0, False)}, "initial_positions"),
     ],
 )
 def test_invalid_configuration_is_rejected(
@@ -55,6 +58,16 @@ def test_invalid_configuration_is_rejected(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         RecurringTwoAgentWorld(**kwargs)  # type: ignore[arg-type]
+
+
+def test_initial_positions_reject_boolean_identities() -> None:
+    import numpy as np
+
+    legal = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
+    assert legal._initial_positions_tuple == (-0.5, 0.5)
+    for positions in ((True, False), (np.True_, 0.0), (1.0, np.bool_(False))):
+        with pytest.raises(ValueError, match="initial_positions"):
+            RecurringTwoAgentWorld(initial_positions=positions)
 
 
 def test_visible_context_sequence_recurs_a_b_a() -> None:


### PR DESCRIPTION
Closes #943.

## What changed

Recurring two-agent start poses no longer treat a boolean as a coordinate. `RecurringTwoAgentWorld.__init__` on origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0` only did `math.isfinite(float(position))` on `initial_positions`. `float(True) == 1.0` and `float(False) == 0.0`, and the default `world_limit` is `1.0`, so boolean identities were in-range start poses. Sibling constructor scalars in the same class already reject `bool` first.

On that SHA:

```text
initial_positions=(True, False)   -> stored (1.0, 0.0)
initial_positions=(False, True)   -> stored (0.0, 1.0)
initial_positions=(np.True_, 0.0) -> stored (1.0, 0.0)
initial_positions=(1.0, False)    -> stored (1.0, 0.0)
```

After this head, `bool` / `np.bool_` raise before the pose is stored. Legal finite pairs such as `(-0.5, 0.5)` are unchanged.

## Scope

- `alberta_framework/streams/recurring_multiagent.py`
- `tests/test_recurring_multiagent_stream.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `b93e40eef90ac5452d81cd9a88a61a327e6d6b16`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 4 DID NOT RAISE (`(True, False)`, `(False, True)`, `(1.0, False)`, plus `np.True_` / `np.bool_(False)`)
- `PYTHONPATH=<worktree> pytest tests/test_recurring_multiagent_stream.py -q -o addopts=""` → 25 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation for a stream constructor only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b93e40eef90ac5452d81cd9a88a61a327e6d6b16 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
