### PR TITLE
fix(interaction): reject leftover constructor scalars

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -36,6 +36,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -560,8 +561,15 @@ class FixedBudgetInteractionLearner:
             candidate_count=candidate_count,
             scale_robust=scale_robust,
         )
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
+        step_size_output = validated_float32_scalar(
+            "step_size_output", step_size_output, lower=0.0
+        )
+        utility_decay = validated_float32_scalar(
+            "utility_decay", utility_decay, lower=0.0, upper=1.0, upper_inclusive=False
+        )
+        promotion_blend = validated_float32_scalar(
+            "promotion_blend", promotion_blend, lower=0.0, upper=1.0
+        )
         if (
             isinstance(promotion_margin, bool)
             or not isinstance(cast(object, promotion_margin), Real)
@@ -569,8 +577,6 @@ class FixedBudgetInteractionLearner:
             or promotion_margin <= 0.0
         ):
             raise ValueError("promotion_margin must be finite and positive")
-        if not 0.0 <= promotion_blend <= 1.0:
-            raise ValueError("promotion_blend must be in [0, 1]")
         if candidate_strategy not in {"random", "all_pairs"}:
             raise ValueError("candidate_strategy must be 'random' or 'all_pairs'")
         if utility_aggregation not in {"mean", "max", "topk"}:
@@ -621,14 +627,28 @@ class FixedBudgetInteractionLearner:
                 )
             if float32_total <= 0.0:
                 raise ValueError("task_utility_weights must contain positive mass")
-        if not 0.0 <= task_activity_decay < 1.0:
-            raise ValueError("task_activity_decay must be in [0, 1)")
-        if not 0.0 <= future_utility_mix <= 1.0:
-            raise ValueError("future_utility_mix must be in [0, 1]")
-        if utility_retention_decay is not None and not (
-            utility_decay <= utility_retention_decay < 1.0
-        ):
-            raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
+        task_activity_decay = validated_float32_scalar(
+            "task_activity_decay",
+            task_activity_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        future_utility_mix = validated_float32_scalar(
+            "future_utility_mix", future_utility_mix, lower=0.0, upper=1.0
+        )
+        if utility_retention_decay is not None:
+            utility_retention_decay = validated_float32_scalar(
+                "utility_retention_decay",
+                utility_retention_decay,
+                lower=0.0,
+                upper=1.0,
+                upper_inclusive=False,
+            )
+            if utility_retention_decay < utility_decay:
+                raise ValueError(
+                    "utility_retention_decay must be in [utility_decay, 1) when set"
+                )
         if utility_retention_grace_steps is not None and (
             isinstance(utility_retention_grace_steps, bool)
             or not isinstance(utility_retention_grace_steps, int)
@@ -745,16 +765,29 @@ class FixedBudgetInteractionLearner:
                 "candidate_reacquisition_confirmation_steps greater than one "
                 "requires independent_relevance_probe"
             )
-        if candidate_utility_retention_decay is not None and not (
-            utility_decay <= candidate_utility_retention_decay < 1.0
-        ):
-            raise ValueError(
-                "candidate_utility_retention_decay must be in [utility_decay, 1) when set"
+        if candidate_utility_retention_decay is not None:
+            candidate_utility_retention_decay = validated_float32_scalar(
+                "candidate_utility_retention_decay",
+                candidate_utility_retention_decay,
+                lower=0.0,
+                upper=1.0,
+                upper_inclusive=False,
             )
-        if not 0.0 <= scale_normalizer_decay < 1.0:
-            raise ValueError("scale_normalizer_decay must be in [0, 1)")
-        if scale_normalizer_epsilon <= 0.0:
-            raise ValueError("scale_normalizer_epsilon must be positive")
+            if candidate_utility_retention_decay < utility_decay:
+                raise ValueError(
+                    "candidate_utility_retention_decay must be in [utility_decay, 1) when set"
+                )
+        scale_normalizer_decay = validated_float32_scalar(
+            "scale_normalizer_decay",
+            scale_normalizer_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        scale_normalizer_epsilon = validated_float32_scalar(
+            "scale_normalizer_epsilon", scale_normalizer_epsilon, positive=True
+        )
+        obgd_kappa = validated_float32_scalar("obgd_kappa", obgd_kappa, positive=True)
         if scale_robust and future_utility_mix != 0.0:
             raise ValueError(
                 "future_utility_mix must be 0 when scale_robust=True; "

--- a/tests/test_interaction_feature_validation.py
+++ b/tests/test_interaction_feature_validation.py
@@ -194,3 +194,42 @@ def test_config_normalizes_hostile_mapping_failure() -> None:
 
     with pytest.raises(ValueError, match="could not be read"):
         FixedBudgetInteractionLearner.from_config(HostileMapping())
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "step_size_output",
+        "obgd_kappa",
+        "utility_decay",
+        "promotion_blend",
+        "future_utility_mix",
+        "task_activity_decay",
+        "scale_normalizer_decay",
+        "scale_normalizer_epsilon",
+    ],
+)
+def test_leftover_constructor_scalars_reject_bool_and_nonfinite(field: str) -> None:
+    for invalid in (True, False, np.bool_(True), float("nan"), float("inf")):
+        with pytest.raises(ValueError, match=field):
+            _construct(**{field: invalid})
+
+
+def test_leftover_constructor_scalars_keep_legal_floats() -> None:
+    learner = _construct(
+        step_size_output=0.0,
+        obgd_kappa=2.0,
+        utility_decay=0.0,
+        promotion_blend=1.0,
+        future_utility_mix=0.0,
+        task_activity_decay=0.0,
+        scale_normalizer_decay=0.0,
+        scale_normalizer_epsilon=1e-6,
+    )
+    payload = learner.to_config()
+    assert payload["step_size_output"] == 0.0
+    assert payload["obgd_kappa"] == 2.0
+    assert payload["utility_decay"] == 0.0
+    assert payload["promotion_blend"] == 1.0
+    assert type(payload["step_size_output"]) is float
+    assert type(payload["obgd_kappa"]) is float


### PR DESCRIPTION
Closes #944.

## What changed

`FixedBudgetInteractionLearner` no longer stores leftover constructor rates as boolean or non-finite identities. On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `from_config` already required JSON numbers via `_require_serialized_scalars`, but the constructor path left these fields on ordered comparisons only. `0.0 <= False < 1.0` is true, and `step_size_output` / `obgd_kappa` had no finite-real gate.

On that SHA these were accepted and stored:

```text
step_size_output=True/False/nan/inf
obgd_kappa=True/False/nan
utility_decay=False
promotion_blend=True/False
future_utility_mix=True
task_activity_decay=False
scale_normalizer_decay=False
scale_normalizer_epsilon=True
```

After this head, those leftover rates go through `validated_float32_scalar`. Builtin legal floats stay bit-identical. `step_size_output=0.0` and `utility_decay=0.0` remain legal. `obgd_kappa` stays positive.

## Scope

- `alberta_framework/core/interaction_features.py`
- `tests/test_interaction_feature_validation.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, Kayvan `#936`, or leftover tax on micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `12c2c15a2246c663ae564aa2d03cee8d794ef2df`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 8 DID NOT RAISE (one per leftover field, each covering `True`/`False`/`np.bool_`/`nan`/`inf`)
- `PYTHONPATH=<worktree> pytest tests/test_interaction_feature_validation.py -q -o addopts=""` → 44 passed
- Related interaction tests: 32 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary constructor validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:12c2c15a2246c663ae564aa2d03cee8d794ef2df -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
