### PR TITLE
fix(timing): report failed after instead of completed in when timed block raises

### DIFF
--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -128,7 +128,10 @@ class Timer:
 
         if self.verbose:
             formatted = format_duration(self.duration)
-            self.print_fn(f"{self.name} completed in {formatted}")
+            if exc_type is None:
+                self.print_fn(f"{self.name} completed in {formatted}")
+            else:
+                self.print_fn(f"{self.name} failed after {formatted}")
 
     def elapsed(self) -> float:
         """Get elapsed time since timer started (can be called during execution).

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,48 @@
+"""Tests for timing utilities."""
+
+import time
+
+import pytest
+
+from alberta_framework.utils.timing import Timer, format_duration
+
+
+def test_format_duration_formatting() -> None:
+    assert format_duration(0.5) == "0.50s"
+    assert format_duration(90.5) == "1m 30.50s"
+    assert format_duration(3665) == "1h 1m 5.00s"
+    assert format_duration(59.999) == "1m 0.00s"
+    assert format_duration(3599.999) == "1h 0m 0.00s"
+
+
+def test_timer_successful_run_message() -> None:
+    messages: list[str] = []
+    with Timer("Training", print_fn=messages.append) as timer:
+        time.sleep(0.001)
+
+    assert len(messages) == 1
+    assert messages[0].startswith("Training completed in ")
+    assert timer.duration > 0.0
+    assert timer.end_time >= timer.start_time
+
+
+def test_timer_failed_run_message() -> None:
+    messages: list[str] = []
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        with Timer("Training", print_fn=messages.append) as timer:
+            time.sleep(0.001)
+            raise RuntimeError("simulated failure")
+
+    assert len(messages) == 1
+    assert messages[0].startswith("Training failed after ")
+    assert timer.duration > 0.0
+    assert timer.end_time >= timer.start_time
+
+
+def test_timer_silent_mode() -> None:
+    messages: list[str] = []
+    with Timer("Silent", verbose=False, print_fn=messages.append) as timer:
+        time.sleep(0.001)
+
+    assert len(messages) == 0
+    assert timer.duration > 0.0


### PR DESCRIPTION
## Summary
- Resolves #923.
- Modifies `Timer.__exit__` in `alberta_framework/utils/timing.py` so that when a timed code block raises an exception (`exc_type is not None`), it prints `{name} failed after {formatted}` rather than claiming `{name} completed in {formatted}`.
- Adds comprehensive unit tests in `tests/test_timing.py` covering successful runs, failed runs, and silent mode.

## Verification
- `PYTHONPATH=. pytest tests/test_timing.py tests/test_utils_smoke.py`: 19 passed
- `ruff check .`: clean
- `mypy alberta_framework/utils/timing.py`: clean