### PR TITLE
fix(nexting): reject boolean and non-finite discounts and terminal values

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -36,8 +36,50 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+
+
+def _validate_gamma(name: str, gamma: object) -> float | Array:
+    if isinstance(gamma, (bool, np.bool_)):
+        raise ValueError(f"{name} must not be a boolean")
+    if isinstance(gamma, (int, float, np.number)):
+        return validated_float32_scalar(name, gamma, lower=0.0, upper=1.0)
+    arr = jnp.asarray(gamma)
+    if arr.dtype == jnp.bool_:
+        raise ValueError(f"{name} must not be a boolean")
+    return gamma  # type: ignore[return-value]
+
+
+def _validate_terminal_value(name: str, terminal_value: object) -> float | Array:
+    if isinstance(terminal_value, (bool, np.bool_)):
+        raise ValueError(f"{name} must not be a boolean")
+    if isinstance(terminal_value, (int, float, np.number)):
+        return validated_float32_scalar(name, terminal_value)
+    arr = jnp.asarray(terminal_value)
+    if arr.dtype == jnp.bool_:
+        raise ValueError(f"{name} must not be a boolean")
+    return terminal_value  # type: ignore[return-value]
+
+
+def _validate_gammas_array(name: str, gammas: object) -> Array:
+    if isinstance(gammas, (bool, np.bool_)):
+        raise ValueError(f"{name} must not be a boolean")
+    try:
+        raw_np = np.asarray(gammas)
+        if raw_np.dtype == np.bool_ or any(isinstance(x, (bool, np.bool_)) for x in raw_np.flat):
+            raise ValueError(f"{name} must not contain booleans")
+    except TypeError:
+        pass
+    arr = jnp.asarray(gammas)
+    if arr.dtype == jnp.bool_:
+        raise ValueError(f"{name} must not be a boolean array")
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D array")
+    return arr
 
 
 def forward_view_returns(
@@ -61,6 +103,8 @@ def forward_view_returns(
         Array of shape ``(T,)`` where index ``t`` is the forward-view
         return ``G_t = c_{t+1} + gamma * c_{t+2} + gamma^2 * c_{t+3} + ...``.
     """
+    _validate_gamma("gamma", gamma)
+    _validate_terminal_value("terminal_value", terminal_value)
     gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
     init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
 
@@ -94,6 +138,9 @@ def multi_horizon_returns(
         from step ``t`` at horizon ``gammas[h]``.
     """
 
+    _validate_gammas_array("gammas", gammas)
+    _validate_terminal_value("terminal_value", terminal_value)
+
     def per_gamma(g: Array) -> Array:
         return forward_view_returns(cumulants, g, terminal_value=terminal_value)
 
@@ -115,6 +162,9 @@ def multi_channel_horizon_returns(
     Returns:
         Array of shape ``(T, C, H)`` of forward-view returns.
     """
+    _validate_gammas_array("gammas", gammas)
+    _validate_terminal_value("terminal_value", terminal_value)
+
     # Vmap over channels: for each channel apply multi_horizon_returns
     def per_channel(c_series: Array) -> Array:
         return multi_horizon_returns(c_series, gammas, terminal_value=terminal_value)
@@ -192,9 +242,7 @@ def _pad_running_window(values: Array, window_size: int) -> Array:
     return jnp.concatenate([pad, values], axis=0)
 
 
-def _scaled_running_rmse_terms(
-    errors: Array, window_size: int
-) -> tuple[Array, Array, Array]:
+def _scaled_running_rmse_terms(errors: Array, window_size: int) -> tuple[Array, Array, Array]:
     """Return one global power-of-two scale and stable sliding RMS terms."""
     scale = jnp.max(jnp.abs(errors), axis=0)
     _, exponent = jnp.frexp(scale)
@@ -218,12 +266,8 @@ def _finite_running_rmse_jvp(
     tangents: tuple[Array],
 ) -> tuple[Array, Array]:
     (errors,), (errors_dot,) = primals, tangents
-    exponent, scaled_errors, scaled_running = _scaled_running_rmse_terms(
-        errors, window_size
-    )
-    running = _pad_running_window(
-        jnp.ldexp(scaled_running, exponent), window_size
-    )
+    exponent, scaled_errors, scaled_running = _scaled_running_rmse_terms(errors, window_size)
+    running = _pad_running_window(jnp.ldexp(scaled_running, exponent), window_size)
     safe_scaled_running = jnp.where(
         scaled_running > 0.0,
         scaled_running,

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -270,8 +270,7 @@ class TestRMSE:
             per_horizon_rmse(predictions, returns, burn_in=burn_in)
 
         assert str(exc_info.value) == (
-            "burn_in must satisfy 0 <= burn_in < n_steps "
-            f"(got burn_in={burn_in}, n_steps=3)"
+            f"burn_in must satisfy 0 <= burn_in < n_steps (got burn_in={burn_in}, n_steps=3)"
         )
 
     @pytest.mark.parametrize(
@@ -513,9 +512,7 @@ class TestRunningRMSE:
             np.testing.assert_array_equal(np.asarray(eager), expected)
             np.testing.assert_array_equal(np.asarray(jitted), expected)
 
-        closed_over = jax.jit(
-            lambda p, r: per_horizon_running_rmse(p, r, window_size=3)
-        )
+        closed_over = jax.jit(lambda p, r: per_horizon_running_rmse(p, r, window_size=3))
         np.testing.assert_array_equal(
             np.asarray(closed_over(predictions, returns)),
             expected_by_window[3],
@@ -567,3 +564,38 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+
+def test_nexting_discount_and_terminal_value_validation() -> None:
+    c = jnp.array([1.0, 2.0, 3.0])
+
+    # forward_view_returns gamma validation
+    with pytest.raises(ValueError, match="gamma"):
+        forward_view_returns(c, gamma=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gamma"):
+        forward_view_returns(c, gamma=False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gamma"):
+        forward_view_returns(c, gamma=float("nan"))
+    with pytest.raises(ValueError, match="gamma"):
+        forward_view_returns(c, gamma=-0.1)
+    with pytest.raises(ValueError, match="gamma"):
+        forward_view_returns(c, gamma=1.1)
+
+    # forward_view_returns terminal_value validation
+    with pytest.raises(ValueError, match="terminal_value"):
+        forward_view_returns(c, gamma=0.5, terminal_value=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="terminal_value"):
+        forward_view_returns(c, gamma=0.5, terminal_value=float("nan"))
+
+    # multi_horizon_returns gammas validation
+    with pytest.raises(ValueError, match="gammas"):
+        multi_horizon_returns(c, gammas=[True, False])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gammas"):
+        multi_horizon_returns(c, gammas=jnp.array([True, False]))
+
+    # Valid NumPy scalars
+    g1 = forward_view_returns(c, gamma=np.float32(0.5), terminal_value=np.float64(0.0))
+    assert g1.shape == (3,)
+
+    g_multi = multi_horizon_returns(c, gammas=np.array([0.0, 0.5], dtype=np.float32))
+    assert g_multi.shape == (3, 2)


### PR DESCRIPTION
## Summary
- Resolves #907.
- Hardens `forward_view_returns`, `multi_horizon_returns`, and `multi_channel_horizon_returns` in `alberta_framework/utils/nexting.py` to reject boolean discounts (`gamma=True/False`), non-finite floats, out-of-domain values outside `[0, 1]`, boolean terminal values, and boolean `gammas` arrays.

## Verification
- `PYTHONPATH=. pytest tests/test_nexting.py`: 67 passed
- `ruff check .`: clean
- `mypy alberta_framework/utils/nexting.py`: clean