### PR TITLE
fix(security): reject boolean actions and invalid risk_score values

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
 import time
 from collections.abc import Mapping, Sequence
 from enum import IntEnum
@@ -279,16 +280,23 @@ def validate_security_oracle_experience(
 
 def coerce_security_action(action: SecurityAction | int | str) -> SecurityAction:
     """Coerce an integer or name to ``SecurityAction``."""
+    if isinstance(action, bool):
+        raise ValueError(f"action must not be a boolean: {action!r}")
     if isinstance(action, SecurityAction):
         return action
-    if isinstance(action, int):
-        return SecurityAction(action)
-    normalized = action.strip().lower()
-    if normalized in _ACTION_ALIASES:
-        return _ACTION_ALIASES[normalized]
-    for candidate in SecurityAction:
-        if candidate.name.lower() == normalized:
-            return candidate
+    if type(action) is int:
+        try:
+            return SecurityAction(action)
+        except ValueError as exc:
+            raise ValueError(f"unknown security action: {action!r}") from exc
+    if isinstance(action, str):
+        normalized = action.strip().lower()
+        if normalized in _ACTION_ALIASES:
+            return _ACTION_ALIASES[normalized]
+        for candidate in SecurityAction:
+            if candidate.name.lower() == normalized:
+                return candidate
+        raise ValueError(f"unknown security action: {action!r}")
     raise ValueError(f"unknown security action: {action!r}")
 
 
@@ -307,7 +315,15 @@ def to_security_gym_action(
     ``action`` id and a one-element ``risk_score`` array. A one-element tuple is
     accepted by the environment and keeps this module dependency-free.
     """
-    clipped_risk = min(10.0, max(0.0, float(risk_score)))
+    if isinstance(risk_score, bool):
+        raise ValueError("risk_score must not be a boolean")
+    try:
+        val = float(risk_score)
+        if not math.isfinite(val):
+            raise ValueError(f"risk_score must be finite, got {risk_score!r}")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"risk_score must be a finite real number, got {risk_score!r}") from exc
+    clipped_risk = min(10.0, max(0.0, val))
     return {
         "action": int(coerce_security_action(action)),
         "risk_score": (clipped_risk,),

--- a/tests/test_security_integration.py
+++ b/tests/test_security_integration.py
@@ -57,9 +57,7 @@ def test_security_gym_action_adapter_matches_sibling_contract() -> None:
         "action": 3,
         "risk_score": (10.0,),
     }
-    assert security_gym_action_reward(SecurityAction.BLOCK, is_malicious=True) == pytest.approx(
-        1.0
-    )
+    assert security_gym_action_reward(SecurityAction.BLOCK, is_malicious=True) == pytest.approx(1.0)
     assert security_gym_action_reward(SecurityAction.BLOCK, is_malicious=False) == pytest.approx(
         -1.0
     )
@@ -202,3 +200,24 @@ def test_security_to_dict_rejects_nonfinite_numbers() -> None:
         step.to_dict()
     with pytest.raises(ValueError, match="RFC-compliant JSON"):
         experience.to_dict()
+
+
+def test_coerce_security_action_and_to_security_gym_action_scalars_validation() -> None:
+    # coerce_security_action rejects boolean
+    with pytest.raises(ValueError, match="action"):
+        coerce_security_action(True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action"):
+        coerce_security_action(False)  # type: ignore[arg-type]
+
+    # to_security_gym_action rejects boolean or non-finite risk_score
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action(SecurityAction.PASS, risk_score=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action(SecurityAction.PASS, risk_score=False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action(SecurityAction.PASS, risk_score=float("nan"))
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action(SecurityAction.PASS, risk_score=float("inf"))
+
+    res = to_security_gym_action("alert", risk_score=5.5)
+    assert res == {"action": 1, "risk_score": (5.5,)}


### PR DESCRIPTION
## Summary
- Resolves #902.
- Hardens `coerce_security_action` in `alberta_framework/security.py` to reject boolean values (`action=True/False`), requiring exact integer types, strings, or `SecurityAction` instances.
- Hardens `to_security_gym_action` to reject boolean and non-finite `risk_score` values.

## Verification
- `PYTHONPATH=. pytest tests/test_security_integration.py`: 13 passed
- `ruff check .`: clean
- `mypy alberta_framework/security.py`: clean