### PR TITLE
fix(benchmarks): reject float alias of imageio-ffmpeg executable mode

### DIFF
--- a/alberta_framework/benchmarks/runtime_profile.py
+++ b/alberta_framework/benchmarks/runtime_profile.py
@@ -395,6 +395,7 @@ def validate_environment_runtime_profile(
         ffmpeg["distribution"] != "imageio-ffmpeg"
         or ffmpeg["version"] != ffmpeg_record["version"]
         or ffmpeg["record_sha256"] != ffmpeg_record["record_sha256"]
+        or type(ffmpeg["mode"]) is not int
         or ffmpeg["mode"] != 0o555
         or PurePosixPath(ffmpeg_relative_path).is_absolute()
         or ".." in PurePosixPath(ffmpeg_relative_path).parts

--- a/tests/test_runtime_profile.py
+++ b/tests/test_runtime_profile.py
@@ -422,6 +422,15 @@ def test_runtime_profile_rejects_identity_drift(
         validate_environment_runtime_profile(profile)
 
 
+def test_runtime_profile_rejects_non_integer_executable_mode() -> None:
+    profile = _matched_gpu_profile()
+    executable = profile["bundled_executables"]["imageio-ffmpeg"]  # type: ignore[index]
+    executable["mode"] = 365.0  # type: ignore[index]
+
+    with pytest.raises(ValueError, match="imageio-ffmpeg identity"):
+        validate_environment_runtime_profile(profile)
+
+
 def test_runtime_profile_rejects_duplicate_environment_variable() -> None:
     profile = _matched_gpu_profile()
     environment = profile["container_environment"]


### PR DESCRIPTION
Closes #953.

## What changed

Same numeric-alias family already fixed across the `forager_matched_*` files: `validate_environment_runtime_profile` checked the attested imageio-ffmpeg executable mode with bare numeric equality (`ffmpeg["mode"] != 0o555`). Python considers `365.0 == 0o555` true, so a runtime-profile JSON object with a floating-point `mode` passed structural validation even though the producer contract obtains the mode as a genuine integer via `stat.S_IMODE(...)`.

## Reachability

`validate_environment_runtime_profile` is exported from `alberta_framework.benchmarks.__all__`. `environment_runtime_profile_sha256` calls it before hashing runtime-profile data; `validate_environment_runtime_identity` calls it while verifying an externally supplied runtime profile and its reported digest. `forager_matrix.py` and `forager_results.py` both call into this validation chain on execution-envelope / official-import data - reachable with non-hardcoded, JSON-sourced input at the serialization boundary.

## Verification

confirmed the underlying claim directly:
```text
>>> 365.0 == 0o555
True
```

- new test `test_runtime_profile_rejects_non_integer_executable_mode`, added next to the existing `test_runtime_profile_rejects_identity_drift`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `24 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: re-ran the reproduction and full mutation check myself from a clean stash, confirmed the underlying `365.0 == 0o555` claim directly in a fresh interpreter, re-ran lint/mypy/full-suite, and re-traced reachability against the current `alberta_framework/benchmarks/__init__.py` before committing and pushing.

Attribution status: self-reported.
