### PR TITLE
fix(recurring-feature): reject boolean protocol and criteria identities

### DIFF
--- a/alberta_framework/recurring_feature_gate.py
+++ b/alberta_framework/recurring_feature_gate.py
@@ -30,6 +30,8 @@ import numpy as np
 import numpy.typing as npt
 from jax import Array
 
+from alberta_framework._seed_validation import require_unique_jax_seeds
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
     InteractionFeatureState,
@@ -58,6 +60,33 @@ PAIRWISE_PROBE_SCOPE = (
     "archive remains counted memory, and this does not establish general feature "
     "discovery, continual control, or Alberta Plan completion."
 )
+
+
+def _require_builtin_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer")
+    if minimum is not None and maximum is not None:
+        if not minimum <= value <= maximum:
+            raise ValueError(f"{name} must be in [{minimum}, {maximum}]")
+    elif minimum is not None and value < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive")
+        raise ValueError(f"{name} must be >= {minimum}")
+    elif maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be boolean")
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,24 +127,106 @@ class RecurringFeatureProtocol:
 
     def validate(self) -> None:
         """Reject malformed protocols before allocating experiment arrays."""
+        _require_builtin_int("feature_dim", self.feature_dim)
         if self.feature_dim < 6:
             raise ValueError("feature_dim must be at least 6 for the declared task pairs")
+        _require_builtin_int("output_heads", self.output_heads)
         if self.output_heads != len(TASK_NAMES):
             raise ValueError(f"output_heads must be {len(TASK_NAMES)}")
-        if self.steps_per_phase < 1:
-            raise ValueError("steps_per_phase must be positive")
-        if self.target_amplitude <= 0.0:
-            raise ValueError("target_amplitude must be positive")
-        if self.active_pair_budget < 1:
-            raise ValueError("active_pair_budget must be positive")
-        if self.candidate_pair_budget < 1:
-            raise ValueError("candidate_pair_budget must be positive")
-        if self.heldout_samples < 1:
-            raise ValueError("heldout_samples must be positive")
-        if not 1 <= self.recovery_window <= self.steps_per_phase:
-            raise ValueError("recovery_window must be in [1, steps_per_phase]")
-        if self.recovery_nmse_threshold <= 0.0:
-            raise ValueError("recovery_nmse_threshold must be positive")
+        _require_builtin_int("steps_per_phase", self.steps_per_phase, minimum=1)
+        _require_builtin_int("active_pair_budget", self.active_pair_budget, minimum=1)
+        _require_builtin_int("candidate_pair_budget", self.candidate_pair_budget, minimum=1)
+        _require_builtin_int("heldout_samples", self.heldout_samples, minimum=1)
+        _require_builtin_int("replacement_interval", self.replacement_interval, minimum=0)
+        _require_builtin_int("min_feature_age", self.min_feature_age, minimum=0)
+        _require_builtin_int("candidate_min_age", self.candidate_min_age, minimum=0)
+        _require_builtin_int(
+            "recovery_window",
+            self.recovery_window,
+            minimum=1,
+            maximum=self.steps_per_phase,
+        )
+        object.__setattr__(
+            self,
+            "target_amplitude",
+            validated_float32_scalar("target_amplitude", self.target_amplitude, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "recovery_nmse_threshold",
+            validated_float32_scalar(
+                "recovery_nmse_threshold", self.recovery_nmse_threshold, positive=True
+            ),
+        )
+        object.__setattr__(
+            self,
+            "step_size_output",
+            validated_float32_scalar("step_size_output", self.step_size_output, lower=0.0),
+        )
+        utility_decay = validated_float32_scalar(
+            "utility_decay",
+            self.utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(
+            self,
+            "retained_utility_decay",
+            validated_float32_scalar(
+                "retained_utility_decay",
+                self.retained_utility_decay,
+                lower=utility_decay,
+                upper=1.0,
+                upper_inclusive=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "promotion_margin",
+            validated_float32_scalar("promotion_margin", self.promotion_margin, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "promotion_blend",
+            validated_float32_scalar(
+                "promotion_blend", self.promotion_blend, lower=0.0, upper=1.0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "future_utility_mix",
+            validated_float32_scalar(
+                "future_utility_mix", self.future_utility_mix, lower=0.0, upper=1.0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "obgd_kappa",
+            validated_float32_scalar("obgd_kappa", self.obgd_kappa, positive=True),
+        )
+        if self.candidate_utility_retention_decay is not None:
+            object.__setattr__(
+                self,
+                "candidate_utility_retention_decay",
+                validated_float32_scalar(
+                    "candidate_utility_retention_decay",
+                    self.candidate_utility_retention_decay,
+                    lower=utility_decay,
+                    upper=1.0,
+                    upper_inclusive=False,
+                ),
+            )
+        if self.candidate_strategy != "all_pairs":
+            raise ValueError("candidate_strategy must be 'all_pairs'")
+        if self.utility_aggregation != "max":
+            raise ValueError("utility_aggregation must be 'max'")
+        if self.utility_task_balancing != "active":
+            raise ValueError("utility_task_balancing must be 'active'")
+        _require_exact_bool("refresh_candidates", self.refresh_candidates)
+        _require_exact_bool("refresh_promoted_candidate", self.refresh_promoted_candidate)
+        _require_exact_bool("use_obgd", self.use_obgd)
 
 
 @dataclass(frozen=True, slots=True)
@@ -292,6 +403,71 @@ class RecurringFeatureGateCriteria:
     minimum_retention_rate_gain_over_baseline: float = 0.5
     minimum_critical_nmse_gain_over_baseline: float = 0.5
     require_recurrence_faster_than_acquisition: bool = True
+
+    def validate(self) -> None:
+        """Reject boolean or non-finite criteria before comparing evidence."""
+        _require_builtin_int("minimum_seeds", self.minimum_seeds, minimum=1)
+        _require_builtin_int(
+            "minimum_heldout_samples", self.minimum_heldout_samples, minimum=1
+        )
+        object.__setattr__(
+            self,
+            "minimum_retained_all_critical_rate",
+            validated_float32_scalar(
+                "minimum_retained_all_critical_rate",
+                self.minimum_retained_all_critical_rate,
+                lower=0.0,
+                upper=1.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_obsolete_eviction_rate",
+            validated_float32_scalar(
+                "minimum_obsolete_eviction_rate",
+                self.minimum_obsolete_eviction_rate,
+                lower=0.0,
+                upper=1.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_median_critical_nmse",
+            validated_float32_scalar(
+                "maximum_median_critical_nmse",
+                self.maximum_median_critical_nmse,
+                lower=0.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_median_obsolete_nmse",
+            validated_float32_scalar(
+                "minimum_median_obsolete_nmse",
+                self.minimum_median_obsolete_nmse,
+                lower=0.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_retention_rate_gain_over_baseline",
+            validated_float32_scalar(
+                "minimum_retention_rate_gain_over_baseline",
+                self.minimum_retention_rate_gain_over_baseline,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_critical_nmse_gain_over_baseline",
+            validated_float32_scalar(
+                "minimum_critical_nmse_gain_over_baseline",
+                self.minimum_critical_nmse_gain_over_baseline,
+            ),
+        )
+        _require_exact_bool(
+            "require_recurrence_faster_than_acquisition",
+            self.require_recurrence_faster_than_acquisition,
+        )
 
 
 class RecurringFeatureGateError(AssertionError):
@@ -612,13 +788,7 @@ def run_recurring_feature_gate(
     """
     chosen_protocol = protocol or RecurringFeatureProtocol()
     chosen_protocol.validate()
-    chosen_seeds = tuple(seeds)
-    if not chosen_seeds:
-        raise ValueError("seeds must contain at least one seed")
-    if len(set(chosen_seeds)) != len(chosen_seeds):
-        raise ValueError("seeds must be unique")
-    if any(seed < 0 or seed > np.iinfo(np.uint32).max for seed in chosen_seeds):
-        raise ValueError("seeds must be uint32-compatible non-negative integers")
+    chosen_seeds = require_unique_jax_seeds(tuple(seeds))
 
     retained_learner = _make_learner(
         chosen_protocol,
@@ -749,6 +919,7 @@ def evaluate_recurring_feature_gate(
 ) -> RecurringFeatureGateDecision:
     """Recompute a fail-closed decision from raw per-seed evidence."""
     chosen = criteria or RecurringFeatureGateCriteria()
+    chosen.validate()
     failures = _canonical_protocol_failures(result.protocol)
     failures.extend(_seed_failures(result))
 

--- a/tests/test_recurring_feature_protocol_validation.py
+++ b/tests/test_recurring_feature_protocol_validation.py
@@ -1,0 +1,149 @@
+"""Host-boundary identities for the recurring-feature protocol and criteria."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from alberta_framework.recurring_feature_gate import (
+    RecurringFeatureGateCriteria,
+    RecurringFeatureProtocol,
+    run_recurring_feature_gate,
+)
+
+
+def test_canonical_protocol_and_criteria_remain_legal() -> None:
+    RecurringFeatureProtocol().validate()
+    RecurringFeatureGateCriteria().validate()
+    protocol = replace(
+        RecurringFeatureProtocol(),
+        step_size_output=0.0,
+        utility_decay=0.0,
+        retained_utility_decay=0.0,
+        replacement_interval=0,
+        min_feature_age=0,
+        candidate_min_age=0,
+        promotion_blend=0.0,
+        future_utility_mix=0.0,
+        candidate_utility_retention_decay=None,
+    )
+    protocol.validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "steps_per_phase",
+        "active_pair_budget",
+        "candidate_pair_budget",
+        "heldout_samples",
+        "recovery_window",
+        "replacement_interval",
+        "min_feature_age",
+        "candidate_min_age",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 1.0, np.int64(1)])
+def test_protocol_integer_fields_reject_bool_and_non_builtin(
+    field: str, invalid: object
+) -> None:
+    overrides: dict[str, object] = {field: invalid}
+    if field == "steps_per_phase":
+        overrides["recovery_window"] = 1
+    with pytest.raises(ValueError, match=f"{field} must"):
+        replace(RecurringFeatureProtocol(), **overrides).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "target_amplitude",
+        "recovery_nmse_threshold",
+        "step_size_output",
+        "utility_decay",
+        "retained_utility_decay",
+        "promotion_margin",
+        "promotion_blend",
+        "future_utility_mix",
+        "obgd_kappa",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), math.nan, math.inf])
+def test_protocol_float_fields_reject_bool_and_non_finite(
+    field: str, invalid: object
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        replace(RecurringFeatureProtocol(), **{field: invalid}).validate()
+
+
+def test_protocol_optional_retention_decay_rejects_bool_and_non_finite() -> None:
+    for invalid in (True, False, np.bool_(True), math.nan, math.inf):
+        with pytest.raises(ValueError, match="candidate_utility_retention_decay"):
+            replace(
+                RecurringFeatureProtocol(),
+                candidate_utility_retention_decay=invalid,
+            ).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["refresh_candidates", "refresh_promoted_candidate", "use_obgd"],
+)
+def test_protocol_flags_require_exact_bool(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(RecurringFeatureProtocol(), **{field: 1}).validate()
+    with pytest.raises(ValueError, match=field):
+        replace(RecurringFeatureProtocol(), **{field: np.bool_(True)}).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "minimum_seeds",
+        "minimum_heldout_samples",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 1.0])
+def test_criteria_integer_fields_reject_bool(field: str, invalid: object) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        RecurringFeatureGateCriteria(**{field: invalid}).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "minimum_retained_all_critical_rate",
+        "minimum_obsolete_eviction_rate",
+        "maximum_median_critical_nmse",
+        "minimum_median_obsolete_nmse",
+        "minimum_retention_rate_gain_over_baseline",
+        "minimum_critical_nmse_gain_over_baseline",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), math.nan, math.inf])
+def test_criteria_float_fields_reject_bool_and_non_finite(
+    field: str, invalid: object
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        RecurringFeatureGateCriteria(**{field: invalid}).validate()
+
+
+def test_criteria_recurrence_flag_requires_exact_bool() -> None:
+    with pytest.raises(ValueError, match="require_recurrence_faster_than_acquisition"):
+        RecurringFeatureGateCriteria(
+            require_recurrence_faster_than_acquisition=1
+        ).validate()
+
+
+def test_run_rejects_boolean_seed_before_allocation() -> None:
+    protocol = replace(
+        RecurringFeatureProtocol(),
+        steps_per_phase=1,
+        recovery_window=1,
+        heldout_samples=1,
+    )
+    with pytest.raises(ValueError, match="seeds"):
+        run_recurring_feature_gate((True,), protocol=protocol)


### PR DESCRIPTION
Closes #956.

## What changed

`RecurringFeatureProtocol.validate()` and the new `RecurringFeatureGateCriteria.validate()` now reject boolean and non-finite identities before the recurring-feature gate allocates arrays or compares evidence. Seed IDs go through `require_unique_jax_seeds`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, protocol `validate()` used ordered comparisons only. `True` passed every positive-int / positive-float check. `minimum_seeds=False` made the seed-count gate vacuous. `True` was a legal JAX seed.

Legal zeros stay legal: `step_size_output=0.0`, `utility_decay=0.0`, `replacement_interval=0`, `min_feature_age=0`. Builtin legal floats stay bit-identical.

## Scope

- `alberta_framework/recurring_feature_gate.py`
- `tests/test_recurring_feature_protocol_validation.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `a48ece8de04b977c0b6e4ffdb185aa5196108d9a`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 123 failed, 7 passed (`DID NOT RAISE` / missing `validate`)
- `PYTHONPATH=<worktree> pytest tests/test_recurring_feature_protocol_validation.py -q -o addopts=""` → 130 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a48ece8de04b977c0b6e4ffdb185aa5196108d9a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
