### PR TITLE
fix(gauntlet): reject boolean scorecard window identities

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -994,6 +994,18 @@ def load_lifetime_gauntlet_checkpoint(
     return stream, state
 
 
+def _require_positive_builtin_int(value: object, *, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{name} must be a positive built-in integer")
+    return value
+
+
+def _require_scorecard_window(window: object, *, maximum: int) -> int:
+    if type(window) is not int or not 1 <= window <= maximum:
+        raise ValueError(f"window must be a built-in integer in [1, {maximum}]")
+    return window
+
+
 def lifetime_scorecard(
     sq_errors: Array, config: GauntletConfig, n_cycles: int, window: int = 200
 ) -> dict[str, Array]:
@@ -1019,7 +1031,9 @@ def lifetime_scorecard(
           cycle-0 entry error divided by each later cycle's entry error.
         - ``nan_steps``: non-finite step count (must be 0 for life).
     """
+    n_cycles = _require_positive_builtin_int(n_cycles, name="n_cycles")
     length = config.segment_length
+    window = _require_scorecard_window(window, maximum=length)
     cycle_len = LifetimeGauntletStream.SUB_SEGMENTS * length
     trimmed = sq_errors[..., : n_cycles * cycle_len]
     per_cycle = trimmed.reshape(
@@ -1203,6 +1217,7 @@ def early_window_mse(
     retention: the learner re-enters the task near its old solution instead
     of relearning from scratch.
     """
+    window = _require_scorecard_window(window, maximum=segment_length)
     seg = segment_slice(sq_errors, segment, segment_length)
     return jnp.mean(seg[..., :window], axis=-1)
 
@@ -1223,6 +1238,7 @@ def savings_ratio(
     steps-to-criterion because it stays informative for learners whose
     asymptotic error sits near the criterion threshold.)
     """
+    window = _require_scorecard_window(window, maximum=segment_length)
     first = early_window_mse(sq_errors, first_segment, segment_length, window)
     revisit = early_window_mse(sq_errors, revisit_segment, segment_length, window)
     return first / jnp.maximum(revisit, 1e-8)

--- a/tests/test_gauntlet_scorecard_window.py
+++ b/tests/test_gauntlet_scorecard_window.py
@@ -1,0 +1,55 @@
+"""Host-boundary identities for gauntlet scorecard windows."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.streams.gauntlet import (
+    GauntletConfig,
+    early_window_mse,
+    lifetime_scorecard,
+    savings_ratio,
+)
+
+
+def _lifetime_errors(*, n_cycles: int = 2, segment_length: int = 8) -> jnp.ndarray:
+    return jnp.arange(n_cycles * 4 * segment_length, dtype=jnp.float32)
+
+
+def test_legal_windows_stay_accepted() -> None:
+    errors = jnp.asarray([1.0, 3.0, 5.0, 7.0], dtype=jnp.float32)
+    assert float(early_window_mse(errors, 0, 4, window=2)) == 2.0
+    assert float(savings_ratio(errors, 0, 0, 4, window=2)) == 1.0
+    config = GauntletConfig(segment_length=8, relevant_dim=2, irrelevant_dim=0)
+    card = lifetime_scorecard(_lifetime_errors(), config, n_cycles=2, window=3)
+    assert card["fresh_early"].shape == (2,)
+
+
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 0, -1, 1.0, 9])
+def test_early_window_mse_rejects_non_builtin_or_oob_window(invalid: object) -> None:
+    errors = jnp.arange(8, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="window"):
+        early_window_mse(errors, segment=0, segment_length=8, window=invalid)
+
+
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 0, -1, 1.0, 9])
+def test_savings_ratio_rejects_non_builtin_or_oob_window(invalid: object) -> None:
+    errors = jnp.arange(16, dtype=jnp.float32)
+    with pytest.raises(ValueError, match="window"):
+        savings_ratio(errors, 0, 1, 8, window=invalid)
+
+
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 0, -1, 1.0, 9])
+def test_lifetime_scorecard_rejects_non_builtin_or_oob_window(invalid: object) -> None:
+    config = GauntletConfig(segment_length=8, relevant_dim=2, irrelevant_dim=0)
+    with pytest.raises(ValueError, match="window"):
+        lifetime_scorecard(_lifetime_errors(), config, n_cycles=2, window=invalid)
+
+
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 0, -1, 1.0])
+def test_lifetime_scorecard_rejects_non_builtin_n_cycles(invalid: object) -> None:
+    config = GauntletConfig(segment_length=8, relevant_dim=2, irrelevant_dim=0)
+    with pytest.raises(ValueError, match="n_cycles"):
+        lifetime_scorecard(_lifetime_errors(), config, n_cycles=invalid, window=2)


### PR DESCRIPTION
Closes #957.

## What changed

`lifetime_scorecard`, `early_window_mse`, and `savings_ratio` now reject boolean and non-integer windows before they slice a life. `n_cycles` must be a positive builtin int.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `window=True` was a 1-step early window and `window=False` was an empty slice. That silently corrupts savings and recovery MSE. `GauntletConfig` already rejected bool scalars; the scorecard window did not.

Legal builtin windows such as `1` and `segment_length` stay accepted.

## Scope

- `alberta_framework/streams/gauntlet.py`
- `tests/test_gauntlet_scorecard_window.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `d949fc1d0e80064ab3fe607225c8e8b6bd78398f`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 27 failed, 1 passed (`DID NOT RAISE` / JAX TypeError on float windows)
- `PYTHONPATH=<worktree> pytest tests/test_gauntlet_scorecard_window.py -q -o addopts=""` → 28 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d949fc1d0e80064ab3fe607225c8e8b6bd78398f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
