### PR TITLE
fix(cli): pass allow_nan=False when serializing smoke output to strict JSON

### DIFF
--- a/alberta_framework/cli.py
+++ b/alberta_framework/cli.py
@@ -27,7 +27,7 @@ from alberta_framework.steps.step2 import (
 
 
 def _print_json(payload: dict[str, object]) -> None:
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False))
 
 
 def step1_smoke_main(argv: Sequence[str] | None = None) -> int:
@@ -67,6 +67,7 @@ def step1_smoke_main(argv: Sequence[str] | None = None) -> int:
     )
     _print_json(result.to_dict())
     return 0 if result.finite else 1
+
 
 def step2_smoke_main(argv: Sequence[str] | None = None) -> int:
     """Entry point for ``alberta-step2-smoke``."""

--- a/tests/test_cli_strict_json.py
+++ b/tests/test_cli_strict_json.py
@@ -1,0 +1,42 @@
+"""Tests for CLI strict JSON output."""
+
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+
+from alberta_framework.cli import _print_json, step1_smoke_main, step2_smoke_main
+
+
+def test_print_json_rejects_non_finite_values() -> None:
+    with pytest.raises(ValueError, match="Out of range float values are not JSON compliant"):
+        _print_json({"final_window_mse": float("nan"), "finite": False})
+
+    with pytest.raises(ValueError, match="Out of range float values are not JSON compliant"):
+        _print_json({"final_window_mse": float("inf"), "finite": False})
+
+
+def test_print_json_emits_valid_json() -> None:
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        _print_json({"final_window_mse": 0.05, "finite": True})
+    output = buf.getvalue()
+    parsed = json.loads(output)
+    assert parsed == {"final_window_mse": 0.05, "finite": True}
+
+
+def test_step1_and_step2_smoke_main_cli_execution() -> None:
+    buf = io.StringIO()
+    with patch("sys.stdout", buf):
+        code1 = step1_smoke_main(["--steps", "16", "--seed", "0", "--final-window", "8"])
+    assert code1 == 0
+    parsed1 = json.loads(buf.getvalue())
+    assert parsed1["finite"] is True
+
+    buf2 = io.StringIO()
+    with patch("sys.stdout", buf2):
+        code2 = step2_smoke_main(["--steps", "16", "--seed", "0", "--final-window", "8"])
+    assert code2 == 0
+    parsed2 = json.loads(buf2.getvalue())
+    assert parsed2["finite"] is True


### PR DESCRIPTION
## Summary
- Resolves #915.
- Updates `_print_json` in `alberta_framework/cli.py` with `allow_nan=False` so that smoke test outputs printed on stdout strictly adhere to RFC 8259 JSON compliance and fail-close rather than emitting non-standard `NaN` or `Infinity` tokens.
- Adds comprehensive unit tests in `tests/test_cli_strict_json.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_cli_strict_json.py`: 3 passed
- `ruff check .`: clean
- `mypy alberta_framework/cli.py`: clean