### PR TITLE
fix(label-emnist): require at least two seeds in _stderr and summarize_result

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -164,8 +164,7 @@ PROTOCOL_DEVIATIONS: tuple[dict[str, str], ...] = (
         "code": "seeded_streams",
         "scope": "rng_schedule",
         "description": (
-            "label-permutation and example streams are seed-derived; upstream streams "
-            "are unseeded"
+            "label-permutation and example streams are seed-derived; upstream streams are unseeded"
         ),
     },
     {
@@ -239,9 +238,7 @@ def _validated_hyperparameter(name: str, value: object) -> float:
     if name in {"step_size", "eps", "norm_epsilon"}:
         return validated_float32_scalar(label, value, positive=True)
     if name in {"utility_decay", "beta1", "beta2", "norm_decay"}:
-        return validated_float32_scalar(
-            label, value, lower=0.0, upper=1.0, upper_inclusive=False
-        )
+        return validated_float32_scalar(label, value, lower=0.0, upper=1.0, upper_inclusive=False)
     return validated_float32_scalar(label, value, lower=0.0)
 
 
@@ -684,9 +681,7 @@ def load_emnist_balanced_train(
     x_all = np.asarray(raw.data, dtype=np.float32)
     y_all = np.asarray(raw.target, dtype=np.int32)
     if x_all.shape != (EMNIST_TOTAL_ROWS, 784) or y_all.shape != (EMNIST_TOTAL_ROWS,):
-        raise RuntimeError(
-            f"unexpected EMNIST_Balanced shape: x={x_all.shape} y={y_all.shape}"
-        )
+        raise RuntimeError(f"unexpected EMNIST_Balanced shape: x={x_all.shape} y={y_all.shape}")
     counts_first = np.bincount(y_all[:EMNIST_TRAIN_ROWS], minlength=47)
     counts_tail = np.bincount(y_all[EMNIST_TRAIN_ROWS:], minlength=47)
     ordering_consistent = bool(
@@ -725,12 +720,17 @@ def load_emnist_balanced_train(
 
 def _stderr(values: np.ndarray) -> float:
     if values.shape[0] < 2:
-        return 0.0
+        raise ValueError("sample standard error requires at least two observations")
     return float(values.std(ddof=1) / math.sqrt(values.shape[0]))
 
 
 def summarize_result(result: LabelEMNISTRunResult) -> dict[str, Any]:
     """Reduce one learner's run to JSON-serializable summary statistics."""
+    if len(result.seeds) < 2:
+        raise ValueError(
+            f"summarize_result requires at least two seeds to compute sample standard error; "
+            f"got {len(result.seeds)}"
+        )
     accuracy = result.average_online_accuracy
     quarter = max(1, result.config.n_tasks // 4)
     per_seed_first = result.per_task_accuracy[:, :quarter].mean(axis=1)
@@ -751,8 +751,7 @@ def summarize_result(result: LabelEMNISTRunResult) -> dict[str, Any]:
             round(float(v), 6) for v in result.per_task_accuracy.mean(axis=0)
         ],
         "per_task_accuracy_stderr": [
-            round(_stderr(result.per_task_accuracy[:, t]), 6)
-            for t in range(result.config.n_tasks)
+            round(_stderr(result.per_task_accuracy[:, t]), 6) for t in range(result.config.n_tasks)
         ],
         "per_seed_per_task_accuracy": [
             [round(float(v), 6) for v in row] for row in result.per_task_accuracy
@@ -955,9 +954,7 @@ def load_plan(path: Path) -> dict[str, Any]:
         if sorted(resolved) != sorted(provided) or any(
             resolved[name].hex() != provided[name].hex() for name in provided
         ):
-            raise ValueError(
-                f"{path}: {learner} hyperparameters must list the complete arm"
-            )
+            raise ValueError(f"{path}: {learner} hyperparameters must list the complete arm")
     raw_seeds = body.get("seed_ids")
     if not isinstance(raw_seeds, list):
         raise ValueError(f"{path}: plan seed_ids must be a list")
@@ -969,9 +966,7 @@ def load_plan(path: Path) -> dict[str, Any]:
     return payload
 
 
-def partial_payload(
-    result: LabelEMNISTRunResult, plan_sha256: str
-) -> dict[str, Any]:
+def partial_payload(result: LabelEMNISTRunResult, plan_sha256: str) -> dict[str, Any]:
     """Serialize one single-seed run shard bound to its plan hash."""
     seeds = require_unique_jax_seeds(result.seeds, name="result seeds")
     if len(seeds) != 1:
@@ -1060,9 +1055,7 @@ def merge_partials(
     if not paths:
         raise ValueError("no partial result files given")
     body = plan["plan"]
-    config = LabelEMNISTConfig(
-        **{k: v for k, v in body["config"].items() if k != "n_steps"}
-    )
+    config = LabelEMNISTConfig(**{k: v for k, v in body["config"].items() if k != "n_steps"})
     seen: dict[tuple[str, int], dict[str, Any]] = {}
     for path in paths:
         payload = _validated_partial(Path(path), plan)
@@ -1070,9 +1063,7 @@ def merge_partials(
         if identity in seen:
             raise ValueError(f"duplicate shard for learner={identity[0]} seed={identity[1]}")
         seen[identity] = payload
-    planned = {
-        (learner, seed) for learner in body["learner_ids"] for seed in body["seed_ids"]
-    }
+    planned = {(learner, seed) for learner in body["learner_ids"] for seed in body["seed_ids"]}
     missing = sorted(planned - set(seen))
     if missing and not allow_incomplete:
         raise ValueError(f"missing planned shards: {missing}")
@@ -1178,9 +1169,7 @@ def _cmd_shard(args: argparse.Namespace) -> None:
     for field in ("x_sha256", "y_sha256"):
         if meta[field] != body["dataset"][field]:
             raise SystemExit(f"dataset {field} differs from the plan; refusing to run")
-    config = LabelEMNISTConfig(
-        **{k: v for k, v in body["config"].items() if k != "n_steps"}
-    )
+    config = LabelEMNISTConfig(**{k: v for k, v in body["config"].items() if k != "n_steps"})
     hp = {k: float(v) for k, v in body["hyperparameters"][args.learner_id].items()}
     logger.info(
         "shard learner=%s seed=%d tasks=%d task_length=%d",
@@ -1209,12 +1198,8 @@ def _cmd_shard(args: argparse.Namespace) -> None:
 
 def _cmd_merge(args: argparse.Namespace) -> None:
     plan = load_plan(args.plan)
-    results, coverage = merge_partials(
-        plan, args.partials, allow_incomplete=args.allow_incomplete
-    )
-    artifact = build_artifact(
-        plan, results, coverage, partial_paths=args.partials, notes=args.note
-    )
+    results, coverage = merge_partials(plan, args.partials, allow_incomplete=args.allow_incomplete)
+    artifact = build_artifact(plan, results, coverage, partial_paths=args.partials, notes=args.note)
     atomic_write_new_json(args.output, artifact)
     logger.info(
         "merged %d shards -> %s (coverage complete=%s)",
@@ -1233,8 +1218,9 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     plan_parser = sub.add_parser("plan", help="issue an immutable pre-run plan")
     plan_parser.add_argument("--plan-out", type=Path, required=True)
-    plan_parser.add_argument("--seed-list", required=True,
-                             help="explicit comma-separated sorted unique seeds")
+    plan_parser.add_argument(
+        "--seed-list", required=True, help="explicit comma-separated sorted unique seeds"
+    )
     plan_parser.add_argument("--learners", default="upgd_w,adamw")
     plan_parser.add_argument("--n-tasks", type=int, default=400)
     plan_parser.add_argument("--task-length", type=int, default=2500)
@@ -1255,8 +1241,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     merge_parser.add_argument("--plan", type=Path, required=True)
     merge_parser.add_argument("--partials", type=Path, nargs="+", required=True)
     merge_parser.add_argument("--output", type=Path, required=True)
-    merge_parser.add_argument("--allow-incomplete", action="store_true",
-                              help="permit missing planned shards; coverage records them")
+    merge_parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="permit missing planned shards; coverage records them",
+    )
     merge_parser.add_argument("--note", action="append", default=[])
     merge_parser.set_defaults(func=_cmd_merge)
 

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -35,9 +35,7 @@ from alberta_framework.benchmarks.upgd_label_emnist import (
     task_index_for_step,
 )
 
-TINY = LabelEMNISTConfig(
-    n_tasks=3, task_length=8, input_dim=6, hidden1=8, hidden2=4, n_classes=5
-)
+TINY = LabelEMNISTConfig(n_tasks=3, task_length=8, input_dim=6, hidden1=8, hidden2=4, n_classes=5)
 
 DATASET_META = {
     "source": "synthetic:test",
@@ -225,9 +223,7 @@ class TestScheduleExactness:
         for task in range(config.n_tasks):
             fresh = np.asarray(jr.permutation(jr.fold_in(key_perm, task), config.n_classes))
             expected = fresh[previous]
-            np.testing.assert_array_equal(
-                np.asarray(schedule.label_permutations[task]), expected
-            )
+            np.testing.assert_array_equal(np.asarray(schedule.label_permutations[task]), expected)
             previous = expected
 
     def test_example_indices_sample_without_replacement(self):
@@ -291,9 +287,7 @@ class TestSeedBoundary:
             )
 
     @pytest.mark.parametrize("seeds", [(True,), (np.int64(0),), (-1,), (2**32,)])
-    def test_plan_rejects_noncanonical_seed_identities(
-        self, seeds: tuple[object, ...]
-    ) -> None:
+    def test_plan_rejects_noncanonical_seed_identities(self, seeds: tuple[object, ...]) -> None:
         with pytest.raises(ValueError, match="seed IDs"):
             build_plan_payload(
                 TINY,
@@ -308,9 +302,7 @@ class TestSeedBoundary:
             del args, kwargs
             raise AssertionError("invalid CLI seeds reached dataset loading")
 
-        monkeypatch.setattr(
-            upgd_label_emnist, "load_emnist_balanced_train", unexpected_load
-        )
+        monkeypatch.setattr(upgd_label_emnist, "load_emnist_balanced_train", unexpected_load)
         with pytest.raises(ValueError, match=r"seed IDs\[1\].*uint32"):
             upgd_label_emnist.main(
                 [
@@ -346,9 +338,7 @@ class TestEMNISTArrayCache:
         metadata = self._metadata(x, y)
         self._write_cache(tmp_path, x, y, json.dumps(metadata))
 
-        loaded_x, loaded_y, loaded_metadata = (
-            upgd_label_emnist.load_emnist_balanced_train(tmp_path)
-        )
+        loaded_x, loaded_y, loaded_metadata = upgd_label_emnist.load_emnist_balanced_train(tmp_path)
 
         np.testing.assert_array_equal(loaded_x, x)
         np.testing.assert_array_equal(loaded_y, y)
@@ -449,13 +439,10 @@ def test_run_label_emnist_rejects_boundary_gaps_before_setup(
 def debug_run():
     """Run the shared tiny diagnostic once for this test module."""
     x, y = _tiny_data()
-    return run_label_emnist(
-        x, y, "upgd_w", seeds=[0, 1], config=TINY, return_per_step=True
-    )
+    return run_label_emnist(x, y, "upgd_w", seeds=[0, 1], config=TINY, return_per_step=True)
 
 
 class TestTinySmokeRun:
-
     def test_shapes_and_bounds(self, debug_run):
         assert debug_run.per_task_accuracy.shape == (2, TINY.n_tasks)
         assert debug_run.per_step_accuracy.shape == (2, TINY.n_tasks, TINY.task_length)
@@ -491,9 +478,7 @@ class TestTinySmokeRun:
                 for name, value in debug_run.initial_params.items()
             }
             example = int(debug_run.example_indices[seed_row, 0, 0])
-            permuted_label = int(
-                debug_run.label_permutations[seed_row, 0, int(y[example])]
-            )
+            permuted_label = int(debug_run.label_permutations[seed_row, 0, int(y[example])])
             logits = mlp_logits(params, jnp.asarray(x[example]))
             expected = float(int(np.argmax(np.asarray(logits))) == permuted_label)
             assert debug_run.per_step_accuracy[seed_row, 0, 0] == expected
@@ -569,12 +554,14 @@ class TestNormalizedTransferArms:
         x, y = _tiny_data()
         sigma0 = run_label_emnist(x, y, "upgd_ema_norm_sigma0", seeds=[3], config=TINY)
         override = run_label_emnist(
-            x, y, "upgd_ema_norm", seeds=[3], config=TINY,
+            x,
+            y,
+            "upgd_ema_norm",
+            seeds=[3],
+            config=TINY,
             hyperparameters={"noise_std": 0.0},
         )
-        np.testing.assert_array_equal(
-            sigma0.per_task_accuracy, override.per_task_accuracy
-        )
+        np.testing.assert_array_equal(sigma0.per_task_accuracy, override.per_task_accuracy)
         np.testing.assert_array_equal(sigma0.per_task_loss, override.per_task_loss)
 
     def test_sgd_ema_norm_runs_and_is_deterministic(self):
@@ -703,8 +690,9 @@ class TestPlanShardMergeAccounting:
             merge_partials(plan, [path], allow_incomplete=True)
 
     def test_summary_and_comparison_flag_logic(self):
-        upgd = self._result("upgd_w", 0)
-        adam = self._result("adamw", 0)
+        x, y = _tiny_data()
+        upgd = run_label_emnist(x, y, "upgd_w", seeds=[0, 1], config=TINY)
+        adam = run_label_emnist(x, y, "adamw", seeds=[0, 1], config=TINY)
         summaries = {"upgd_w": summarize_result(upgd), "adamw": summarize_result(adam)}
         comparison = build_comparison(summaries)
         assert set(comparison["learners"]) == {"upgd_w", "adamw"}
@@ -731,9 +719,7 @@ class TestPlanShardFloatAliasIntake:
         payload = build_plan_payload(TINY, [0, 1], DATASET_META)
         if mutate is not None:
             mutate(payload["plan"])
-            payload["plan_sha256"] = upgd_label_emnist.canonical_json_sha256(
-                payload["plan"]
-            )
+            payload["plan_sha256"] = upgd_label_emnist.canonical_json_sha256(payload["plan"])
         path = tmp_path / "plan.json"
         atomic_write_new_json(path, payload)
         return path
@@ -818,3 +804,19 @@ class TestPlanShardFloatAliasIntake:
         atomic_write_new_json(path, payload)
         with pytest.raises(ValueError, match="differ from the plan"):
             merge_partials(plan, [path], allow_incomplete=True)
+
+
+def test_stderr_and_summarize_result_reject_one_seed() -> None:
+    from alberta_framework.benchmarks.upgd_label_emnist import _stderr, summarize_result
+
+    with pytest.raises(ValueError, match="at least two observations"):
+        _stderr(np.asarray([0.5]))
+    with pytest.raises(ValueError, match="at least two observations"):
+        _stderr(np.asarray([]))
+
+    assert _stderr(np.asarray([0.25, 0.75])) == pytest.approx(0.25)
+
+    x, y = _tiny_data()
+    one_seed_result = run_label_emnist(x, y, "upgd_w", seeds=[0], config=TINY)
+    with pytest.raises(ValueError, match="at least two seeds"):
+        summarize_result(one_seed_result)


### PR DESCRIPTION
## Summary
- Resolves #914.
- Refuses `n < 2` in `_stderr` and at the start of `summarize_result` in `alberta_framework/benchmarks/upgd_label_emnist.py` rather than reporting vacuous `stderr=0.0` on undefined single-observation samples.
- Updates multi-seed comparison test fixtures and adds unit tests verifying the rejection of one-seed summaries.

## Verification
- `PYTHONPATH=. pytest tests/test_upgd_label_emnist.py`: 80 passed
- `ruff check .`: clean
- `mypy alberta_framework/benchmarks/upgd_label_emnist.py`: clean