### PR TITLE
fix(gauntlet): validate window, segment, and n_cycles as positive built-in integers

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -140,9 +140,7 @@ def _divmod_lifetime_words(words: Array, divisor: int | Array) -> tuple[Array, A
         doubled = remainder + remainder + bit
         subtract = doubled >= divisor_array
         remainder = jnp.where(subtract, doubled - divisor_array, doubled)
-        mask = jnp.left_shift(
-            jnp.asarray(1, dtype=jnp.uint32), bit_index.astype(jnp.uint32)
-        )
+        mask = jnp.left_shift(jnp.asarray(1, dtype=jnp.uint32), bit_index.astype(jnp.uint32))
         quotient_high = jnp.where(
             in_high & subtract,
             jnp.bitwise_or(quotient_high, mask),
@@ -158,6 +156,7 @@ def _divmod_lifetime_words(words: Array, divisor: int | Array) -> tuple[Array, A
     zero = jnp.asarray(0, dtype=jnp.uint32)
     remainder, high, low = jax.lax.fori_loop(0, 64, body, (zero, zero, zero))
     return jnp.stack((high, low)).astype(jnp.uint32), remainder
+
 
 SEGMENT_NAMES = (
     "stationary_a",
@@ -624,10 +623,7 @@ class LifetimeGauntletStream:
         cycle_length = self.SUB_SEGMENTS * self._config.segment_length
         if cycle_length > _INT32_MAX:
             raise ValueError("lifetime gauntlet cycle length must fit in int32")
-        if (
-            scale_cycle_period > 0
-            and cycle_length * scale_cycle_period > _INT32_MAX
-        ):
+        if scale_cycle_period > 0 and cycle_length * scale_cycle_period > _INT32_MAX:
             raise ValueError("scale stress schedule period must fit in int32")
         self._scale_period = scale_cycle_period
         # Reuse GauntletStream's task-drawing convention.
@@ -739,9 +735,7 @@ class LifetimeGauntletStream:
             & jnp.all(jnp.isfinite(state.w_d))
         )
 
-    def _schedule_position(
-        self, words: Array
-    ) -> tuple[Array, Array, Array, Array]:
+    def _schedule_position(self, words: Array) -> tuple[Array, Array, Array, Array]:
         """Derive exact cycle identity and bounded phases from exact time."""
         cycle_words, cycle_step = _divmod_lifetime_words(words, self.cycle_length)
         sub = jnp.floor_divide(
@@ -751,9 +745,7 @@ class LifetimeGauntletStream:
             cycle_step, jnp.asarray(self._config.segment_length, dtype=jnp.uint32)
         ).astype(jnp.int32)
         if self._scale_period > 0:
-            _scale_quotient, cycle_mod = _divmod_lifetime_words(
-                cycle_words, self._scale_period
-            )
+            _scale_quotient, cycle_mod = _divmod_lifetime_words(cycle_words, self._scale_period)
             scaled = (cycle_mod == self._scale_period - 1) & (sub == 0)
         else:
             scaled = jnp.asarray(False, dtype=jnp.bool_)
@@ -776,9 +768,7 @@ class LifetimeGauntletStream:
         step_array = jnp.asarray(step)
         if step_array.shape == (2,) and step_array.dtype == jnp.dtype(jnp.uint32):
             return self._schedule_position(step_array)[1]
-        return ((step_array // self._config.segment_length) % self.SUB_SEGMENTS).astype(
-            jnp.int32
-        )
+        return ((step_array // self._config.segment_length) % self.SUB_SEGMENTS).astype(jnp.int32)
 
     def cycle_of(self, step: Array) -> Array:
         """Cycle ordinal at *step*."""
@@ -1019,6 +1009,12 @@ def lifetime_scorecard(
           cycle-0 entry error divided by each later cycle's entry error.
         - ``nan_steps``: non-finite step count (must be 0 for life).
     """
+    if type(n_cycles) is not int or n_cycles < 1:
+        raise ValueError("n_cycles must be a positive integer")
+    if type(window) is not int or window < 1 or window > config.segment_length:
+        raise ValueError(
+            f"window must be an integer in [1, {config.segment_length}], got {window!r}"
+        )
     length = config.segment_length
     cycle_len = LifetimeGauntletStream.SUB_SEGMENTS * length
     trimmed = sq_errors[..., : n_cycles * cycle_len]
@@ -1177,6 +1173,10 @@ def steps_to_criterion(sq_segment: Array, threshold: float) -> Array:
 
 def segment_slice(sq_errors: Array, segment: int, segment_length: int) -> Array:
     """Slice per-step squared errors down to one segment (last axis)."""
+    if type(segment) is not int or segment < 0:
+        raise ValueError("segment must be a non-negative integer")
+    if type(segment_length) is not int or segment_length < 1:
+        raise ValueError("segment_length must be a positive integer")
     start = segment * segment_length
     return sq_errors[..., start : start + segment_length]
 
@@ -1203,6 +1203,12 @@ def early_window_mse(
     retention: the learner re-enters the task near its old solution instead
     of relearning from scratch.
     """
+    if type(segment) is not int or segment < 0:
+        raise ValueError("segment must be a non-negative integer")
+    if type(segment_length) is not int or segment_length < 1:
+        raise ValueError("segment_length must be a positive integer")
+    if type(window) is not int or window < 1 or window > segment_length:
+        raise ValueError(f"window must be an integer in [1, {segment_length}], got {window!r}")
     seg = segment_slice(sq_errors, segment, segment_length)
     return jnp.mean(seg[..., :window], axis=-1)
 

--- a/tests/test_gauntlet_scorecard_window.py
+++ b/tests/test_gauntlet_scorecard_window.py
@@ -1,0 +1,82 @@
+"""Tests for gauntlet scorecard and window scalar validation."""
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.streams.gauntlet import (
+    GauntletConfig,
+    early_window_mse,
+    lifetime_scorecard,
+    savings_ratio,
+    segment_slice,
+)
+
+
+def test_early_window_mse_and_savings_ratio_reject_boolean_and_invalid_window() -> None:
+    errors = jnp.ones((400,), dtype=jnp.float32)
+
+    # Boolean window
+    with pytest.raises(ValueError, match="window"):
+        early_window_mse(errors, segment=0, segment_length=100, window=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="window"):
+        early_window_mse(errors, segment=0, segment_length=100, window=False)  # type: ignore[arg-type]
+
+    # Non-integer / out-of-range window
+    with pytest.raises(ValueError, match="window"):
+        early_window_mse(errors, segment=0, segment_length=100, window=0)
+
+    with pytest.raises(ValueError, match="window"):
+        early_window_mse(errors, segment=0, segment_length=100, window=101)
+
+    # Invalid segment / segment_length
+    with pytest.raises(ValueError, match="segment"):
+        early_window_mse(errors, segment=True, segment_length=100, window=50)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="segment"):
+        early_window_mse(errors, segment=-1, segment_length=100, window=50)
+
+    with pytest.raises(ValueError, match="segment_length"):
+        early_window_mse(errors, segment=0, segment_length=0, window=50)
+
+    # savings_ratio propagates window validation
+    with pytest.raises(ValueError, match="window"):
+        savings_ratio(errors, first_segment=0, revisit_segment=2, segment_length=100, window=True)  # type: ignore[arg-type]
+
+    # Valid evaluation
+    res = early_window_mse(errors, segment=0, segment_length=100, window=50)
+    assert float(res) == pytest.approx(1.0)
+
+
+def test_lifetime_scorecard_rejects_boolean_and_invalid_arguments() -> None:
+    config = GauntletConfig(segment_length=50)
+    errors = jnp.ones((2, 400), dtype=jnp.float32)
+
+    # Boolean / invalid n_cycles
+    with pytest.raises(ValueError, match="n_cycles"):
+        lifetime_scorecard(errors, config, n_cycles=True, window=20)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="n_cycles"):
+        lifetime_scorecard(errors, config, n_cycles=0, window=20)
+
+    # Boolean / invalid window
+    with pytest.raises(ValueError, match="window"):
+        lifetime_scorecard(errors, config, n_cycles=2, window=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="window"):
+        lifetime_scorecard(errors, config, n_cycles=2, window=0)
+
+    with pytest.raises(ValueError, match="window"):
+        lifetime_scorecard(errors, config, n_cycles=2, window=51)
+
+    card = lifetime_scorecard(errors, config, n_cycles=2, window=20)
+    assert "fresh_early" in card
+    assert "savings_c" in card
+
+
+def test_segment_slice_rejects_boolean_and_negative_indices() -> None:
+    errors = jnp.ones((100,), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="segment"):
+        segment_slice(errors, segment=True, segment_length=50)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="segment_length"):
+        segment_slice(errors, segment=0, segment_length=False)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Resolves #957.
- Hardens `lifetime_scorecard`, `early_window_mse`, and `segment_slice` in `alberta_framework/streams/gauntlet.py` by requiring `window` to be an exact built-in integer in `[1, segment_length]`, `segment` to be a non-negative built-in integer, `segment_length` to be a positive built-in integer, and `n_cycles` to be a positive built-in integer.
- Adds unit tests in `tests/test_gauntlet_scorecard_window.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_gauntlet_scorecard_window.py`: 3 passed
- `ruff check .`: clean
- `mypy alberta_framework/streams/gauntlet.py`: clean