### PR TITLE
fix(interaction): validate constructor float32 hyperparameters with validated_float32_scalar

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -24,7 +24,6 @@ import operator
 import struct
 import time
 from collections.abc import Mapping
-from numbers import Real
 from pathlib import Path
 from typing import Any, SupportsIndex, cast, get_args, get_type_hints
 
@@ -36,6 +35,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray, UInt
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -141,6 +141,7 @@ def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) ->
         if expected is not None and type(payload[name]) is not expected:
             raise ValueError(f"serialized {name} must be a JSON {expected.__name__}")
 
+
 CURATION_ACTIVE_INELIGIBLE_RANK = float.fromhex("0x1.fffffep+127")
 CURATION_CANDIDATE_INELIGIBLE_RANK = -CURATION_ACTIVE_INELIGIBLE_RANK
 """Reserved finite ranks for an enabled curation-priority override.
@@ -166,9 +167,7 @@ INTERACTION_FEATURE_LIFETIME_COUNTER_NBYTES = 12
 INTERACTION_FEATURE_LIFETIME_COUNTER_DELTA_NBYTES = 8
 INTERACTION_FEATURE_TRANSACTION_CLOCK_NBYTES = 16
 INTERACTION_FEATURE_TRANSACTION_CLOCK_DELTA_NBYTES = 12
-_LEGACY_INTERACTION_FEATURE_CHECKPOINT_SCHEMA = (
-    "alberta.interaction-feature-checkpoint.v1"
-)
+_LEGACY_INTERACTION_FEATURE_CHECKPOINT_SCHEMA = "alberta.interaction-feature-checkpoint.v1"
 
 
 def _require_array_contract(
@@ -554,23 +553,42 @@ class FixedBudgetInteractionLearner:
         ):
             if type(value) is not bool:
                 raise ValueError(f"{name} must be boolean")
+        step_size_output = validated_float32_scalar("step_size_output", step_size_output, lower=0.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay", utility_decay, lower=0.0, upper=1.0
+        )
+        if utility_decay >= 1.0:
+            raise ValueError("utility_decay must be in [0, 1)")
+        promotion_margin = validated_float32_scalar(
+            "promotion_margin", promotion_margin, positive=True
+        )
+        promotion_blend = validated_float32_scalar(
+            "promotion_blend", promotion_blend, lower=0.0, upper=1.0
+        )
+        task_activity_decay = validated_float32_scalar(
+            "task_activity_decay", task_activity_decay, lower=0.0, upper=1.0
+        )
+        if task_activity_decay >= 1.0:
+            raise ValueError("task_activity_decay must be in [0, 1)")
+        future_utility_mix = validated_float32_scalar(
+            "future_utility_mix", future_utility_mix, lower=0.0, upper=1.0
+        )
+        if utility_retention_decay is not None:
+            utility_retention_decay = validated_float32_scalar(
+                "utility_retention_decay", utility_retention_decay, lower=0.0, upper=1.0
+            )
+            if not (utility_decay <= utility_retention_decay < 1.0):
+                raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
+        utility_evidence_threshold = validated_float32_scalar(
+            "utility_evidence_threshold", utility_evidence_threshold, lower=0.0
+        )
+
         _require_state_resources(
             n_features=n_features,
             n_tasks=n_tasks,
             candidate_count=candidate_count,
             scale_robust=scale_robust,
         )
-        if not 0.0 <= utility_decay < 1.0:
-            raise ValueError("utility_decay must be in [0, 1)")
-        if (
-            isinstance(promotion_margin, bool)
-            or not isinstance(cast(object, promotion_margin), Real)
-            or not math.isfinite(float(promotion_margin))
-            or promotion_margin <= 0.0
-        ):
-            raise ValueError("promotion_margin must be finite and positive")
-        if not 0.0 <= promotion_blend <= 1.0:
-            raise ValueError("promotion_blend must be in [0, 1]")
         if candidate_strategy not in {"random", "all_pairs"}:
             raise ValueError("candidate_strategy must be 'random' or 'all_pairs'")
         if utility_aggregation not in {"mean", "max", "topk"}:
@@ -595,15 +613,9 @@ class FixedBudgetInteractionLearner:
                 try:
                     float32_weight = struct.unpack("!f", struct.pack("!f", weight))[0]
                 except OverflowError as exc:
-                    raise ValueError(
-                        "task_utility_weights must be float32 representable"
-                    ) from exc
-                if not math.isfinite(float32_weight) or (
-                    weight > 0.0 and float32_weight == 0.0
-                ):
-                    raise ValueError(
-                        "task_utility_weights must be float32 representable"
-                    )
+                    raise ValueError("task_utility_weights must be float32 representable") from exc
+                if not math.isfinite(float32_weight) or (weight > 0.0 and float32_weight == 0.0):
+                    raise ValueError("task_utility_weights must be float32 representable")
                 float32_weights.append(float32_weight)
             float32_total = sum(float32_weights)
             try:
@@ -616,19 +628,9 @@ class FixedBudgetInteractionLearner:
                     "task_utility_weights total must be float32 representable"
                 ) from exc
             if not math.isfinite(float32_total):
-                raise ValueError(
-                    "task_utility_weights total must be float32 representable"
-                )
+                raise ValueError("task_utility_weights total must be float32 representable")
             if float32_total <= 0.0:
                 raise ValueError("task_utility_weights must contain positive mass")
-        if not 0.0 <= task_activity_decay < 1.0:
-            raise ValueError("task_activity_decay must be in [0, 1)")
-        if not 0.0 <= future_utility_mix <= 1.0:
-            raise ValueError("future_utility_mix must be in [0, 1]")
-        if utility_retention_decay is not None and not (
-            utility_decay <= utility_retention_decay < 1.0
-        ):
-            raise ValueError("utility_retention_decay must be in [utility_decay, 1) when set")
         if utility_retention_grace_steps is not None and (
             isinstance(utility_retention_grace_steps, bool)
             or not isinstance(utility_retention_grace_steps, int)
@@ -637,13 +639,6 @@ class FixedBudgetInteractionLearner:
             raise ValueError(
                 "utility_retention_grace_steps must be None or an int32-safe non-negative integer"
             )
-        if (
-            isinstance(utility_evidence_threshold, bool)
-            or not isinstance(cast(object, utility_evidence_threshold), Real)
-            or not math.isfinite(float(utility_evidence_threshold))
-            or utility_evidence_threshold < 0.0
-        ):
-            raise ValueError("utility_evidence_threshold must be finite and non-negative")
         if utility_retention_grace_steps is not None and utility_evidence_threshold <= 0.0:
             raise ValueError(
                 "utility_evidence_threshold must be positive when an evidence lease is enabled"
@@ -656,8 +651,7 @@ class FixedBudgetInteractionLearner:
             or not 0 <= utility_evidence_confirmation_steps < 2**31 - 1
         ):
             raise ValueError(
-                "utility_evidence_confirmation_steps must be a non-negative "
-                "int32-safe integer"
+                "utility_evidence_confirmation_steps must be a non-negative int32-safe integer"
             )
         if evidence_gated_active_output_memory and utility_retention_grace_steps is None:
             raise ValueError(
@@ -665,8 +659,7 @@ class FixedBudgetInteractionLearner:
             )
         if evidence_gated_active_output_memory and utility_evidence_threshold <= 0.0:
             raise ValueError(
-                "evidence_gated_active_output_memory requires a positive "
-                "utility_evidence_threshold"
+                "evidence_gated_active_output_memory requires a positive utility_evidence_threshold"
             )
         if evidence_gated_active_output_memory and utility_evidence_confirmation_steps <= 0:
             raise ValueError(
@@ -679,14 +672,10 @@ class FixedBudgetInteractionLearner:
             not isinstance(relevance_probe_mode, str)
             or relevance_probe_mode not in RELEVANCE_PROBE_MODES
         ):
-            raise ValueError(
-                "relevance_probe_mode must be 'conditional_v1' or "
-                "'target_only_v1'"
-            )
+            raise ValueError("relevance_probe_mode must be 'conditional_v1' or 'target_only_v1'")
         if independent_relevance_probe and not evidence_gated_active_output_memory:
             raise ValueError(
-                "independent_relevance_probe requires "
-                "evidence_gated_active_output_memory"
+                "independent_relevance_probe requires evidence_gated_active_output_memory"
             )
         if not isinstance(retire_stale_features, bool):
             raise ValueError("retire_stale_features must be boolean")
@@ -698,16 +687,11 @@ class FixedBudgetInteractionLearner:
             or not 1 <= stale_retirement_interval <= _INT32_MAX
         ):
             raise ValueError(
-                "stale_retirement_interval must be None or a positive "
-                "int32-safe integer"
+                "stale_retirement_interval must be None or a positive int32-safe integer"
             )
-        if (
-            isinstance(candidate_promotion_floor, bool)
-            or not isinstance(cast(object, candidate_promotion_floor), Real)
-            or not math.isfinite(float(candidate_promotion_floor))
-            or candidate_promotion_floor < 0.0
-        ):
-            raise ValueError("candidate_promotion_floor must be finite and non-negative")
+        candidate_promotion_floor = validated_float32_scalar(
+            "candidate_promotion_floor", candidate_promotion_floor, lower=0.0
+        )
         if (
             retire_stale_features
             and stale_retirement_interval is None
@@ -725,8 +709,7 @@ class FixedBudgetInteractionLearner:
             or not 1 <= candidate_promotion_confirmation_steps < 2**31 - 1
         ):
             raise ValueError(
-                "candidate_promotion_confirmation_steps must be a positive "
-                "int32-safe integer"
+                "candidate_promotion_confirmation_steps must be a positive int32-safe integer"
             )
         if (
             isinstance(candidate_reacquisition_confirmation_steps, bool)
@@ -734,8 +717,7 @@ class FixedBudgetInteractionLearner:
             or not 1 <= candidate_reacquisition_confirmation_steps < 2**31 - 1
         ):
             raise ValueError(
-                "candidate_reacquisition_confirmation_steps must be a positive "
-                "int32-safe integer"
+                "candidate_reacquisition_confirmation_steps must be a positive int32-safe integer"
             )
         # Only a retirement raises candidate_reacquisition_required. A value
         # above one is intentionally allowed in the matched no-retirement arm,
@@ -745,16 +727,26 @@ class FixedBudgetInteractionLearner:
                 "candidate_reacquisition_confirmation_steps greater than one "
                 "requires independent_relevance_probe"
             )
-        if candidate_utility_retention_decay is not None and not (
-            utility_decay <= candidate_utility_retention_decay < 1.0
-        ):
-            raise ValueError(
-                "candidate_utility_retention_decay must be in [utility_decay, 1) when set"
+        if candidate_utility_retention_decay is not None:
+            candidate_utility_retention_decay = validated_float32_scalar(
+                "candidate_utility_retention_decay",
+                candidate_utility_retention_decay,
+                lower=0.0,
+                upper=1.0,
             )
-        if not 0.0 <= scale_normalizer_decay < 1.0:
+            if not (utility_decay <= candidate_utility_retention_decay < 1.0):
+                raise ValueError(
+                    "candidate_utility_retention_decay must be in [utility_decay, 1) when set"
+                )
+        obgd_kappa = validated_float32_scalar("obgd_kappa", obgd_kappa, positive=True)
+        scale_normalizer_decay = validated_float32_scalar(
+            "scale_normalizer_decay", scale_normalizer_decay, lower=0.0, upper=1.0
+        )
+        if scale_normalizer_decay >= 1.0:
             raise ValueError("scale_normalizer_decay must be in [0, 1)")
-        if scale_normalizer_epsilon <= 0.0:
-            raise ValueError("scale_normalizer_epsilon must be positive")
+        scale_normalizer_epsilon = validated_float32_scalar(
+            "scale_normalizer_epsilon", scale_normalizer_epsilon, positive=True
+        )
         if scale_robust and future_utility_mix != 0.0:
             raise ValueError(
                 "future_utility_mix must be 0 when scale_robust=True; "
@@ -796,9 +788,7 @@ class FixedBudgetInteractionLearner:
         self._retire_stale_features = retire_stale_features
         self._stale_retirement_interval = stale_retirement_interval
         self._candidate_promotion_floor = candidate_promotion_floor
-        self._candidate_promotion_confirmation_steps = (
-            candidate_promotion_confirmation_steps
-        )
+        self._candidate_promotion_confirmation_steps = candidate_promotion_confirmation_steps
         self._candidate_reacquisition_confirmation_steps = (
             candidate_reacquisition_confirmation_steps
         )
@@ -963,8 +953,7 @@ class FixedBudgetInteractionLearner:
             return replacement_phase == jnp.asarray(0, dtype=jnp.int32)
         exact_phase = _exact_words_modulo(step_words, self._replacement_interval)
         phase_in_range = (replacement_phase >= 0) & (
-            replacement_phase
-            < jnp.asarray(self._replacement_interval, dtype=jnp.int32)
+            replacement_phase < jnp.asarray(self._replacement_interval, dtype=jnp.int32)
         )
         return phase_in_range & (replacement_phase.astype(jnp.uint32) == exact_phase)
 
@@ -999,9 +988,7 @@ class FixedBudgetInteractionLearner:
             feature_dim,
         )
         active_vacancy = (state.feature_left == -1) & (state.feature_right == -1)
-        candidate_vacancy = (state.candidate_left == -1) & (
-            state.candidate_right == -1
-        )
+        candidate_vacancy = (state.candidate_left == -1) & (state.candidate_right == -1)
         lineage_values_valid = jnp.asarray(True, dtype=jnp.bool_)
         for lineage in (
             state.feature_parent_a,
@@ -1013,11 +1000,9 @@ class FixedBudgetInteractionLearner:
                 (lineage >= -1) & (lineage < self._n_features)
             )
         generator_values_valid = jnp.all(
-            (state.feature_generator >= -1)
-            & (state.feature_generator <= GENERATOR_IMPRINT)
+            (state.feature_generator >= -1) & (state.feature_generator <= GENERATOR_IMPRINT)
         ) & jnp.all(
-            (state.candidate_generator >= -1)
-            & (state.candidate_generator <= GENERATOR_IMPRINT)
+            (state.candidate_generator >= -1) & (state.candidate_generator <= GENERATOR_IMPRINT)
         )
         counters_valid = (
             jnp.all(state.evidence_idle_steps >= 0)
@@ -1117,8 +1102,7 @@ class FixedBudgetInteractionLearner:
             "relevance_probe_bias_scalars": self._n_tasks,
             "relevance_probe_bias_bytes": int(state.relevance_probe_biases.nbytes),
             "relevance_probe_bytes": int(
-                state.relevance_probe_weights.nbytes
-                + state.relevance_probe_biases.nbytes
+                state.relevance_probe_weights.nbytes + state.relevance_probe_biases.nbytes
             ),
             "candidate_output_weight_scalars": self._n_tasks * self._candidate_count,
             "candidate_promotion_evidence_streak_scalars": int(
@@ -1140,9 +1124,7 @@ class FixedBudgetInteractionLearner:
             "active_output_memory_committed_scalars": int(
                 state.active_output_memory_committed.size
             ),
-            "active_output_memory_committed_bytes": int(
-                state.active_output_memory_committed.size
-            ),
+            "active_output_memory_committed_bytes": int(state.active_output_memory_committed.size),
             "normalizer_scalars": int(normalizer_scalars),
             "normalizer_bytes": int(normalizer_scalars) * 4,
             "lifetime_counter_bytes": INTERACTION_FEATURE_LIFETIME_COUNTER_NBYTES,
@@ -1172,21 +1154,15 @@ class FixedBudgetInteractionLearner:
             "utility_top_k": self._utility_top_k,
             "utility_task_balancing": self._utility_task_balancing,
             "task_utility_weights": (
-                None
-                if self._task_utility_weights is None
-                else list(self._task_utility_weights)
+                None if self._task_utility_weights is None else list(self._task_utility_weights)
             ),
             "task_activity_decay": self._task_activity_decay,
             "future_utility_mix": self._future_utility_mix,
             "utility_retention_decay": self._utility_retention_decay,
             "utility_retention_grace_steps": self._utility_retention_grace_steps,
             "utility_evidence_threshold": self._utility_evidence_threshold,
-            "evidence_gated_active_output_memory": (
-                self._evidence_gated_active_output_memory
-            ),
-            "utility_evidence_confirmation_steps": (
-                self._utility_evidence_confirmation_steps
-            ),
+            "evidence_gated_active_output_memory": (self._evidence_gated_active_output_memory),
+            "utility_evidence_confirmation_steps": (self._utility_evidence_confirmation_steps),
             "independent_relevance_probe": self._independent_relevance_probe,
             "relevance_probe_mode": self._relevance_probe_mode,
             "retire_stale_features": self._retire_stale_features,
@@ -1233,8 +1209,7 @@ class FixedBudgetInteractionLearner:
         if "relevance_probe_mode" not in payload:
             if payload.get("independent_relevance_probe", False):
                 raise ValueError(
-                    "probe-enabled legacy config is ambiguous; set "
-                    "relevance_probe_mode explicitly"
+                    "probe-enabled legacy config is ambiguous; set relevance_probe_mode explicitly"
                 )
             payload["relevance_probe_mode"] = RELEVANCE_PROBE_MODE_CONDITIONAL_V1
         payload.setdefault("task_utility_weights", None)
@@ -1244,8 +1219,10 @@ class FixedBudgetInteractionLearner:
             raise ValueError("interaction-feature config fields do not match its schema")
         _require_serialized_scalars(payload, cls)
         generator_mix = payload.pop("generator_mix")
-        if type(generator_mix) is not list or len(generator_mix) != 3 or any(
-            type(value) is not float for value in generator_mix
+        if (
+            type(generator_mix) is not list
+            or len(generator_mix) != 3
+            or any(type(value) is not float for value in generator_mix)
         ):
             raise ValueError("serialized generator_mix must be an exact three-float JSON list")
         raw_task_utility_weights = payload.pop("task_utility_weights")
@@ -1878,8 +1855,7 @@ class FixedBudgetInteractionLearner:
             clip,
         )
         insertion_gain = jnp.maximum(
-            normalized_error * normalized_contribution
-            - 0.5 * normalized_contribution**2,
+            normalized_error * normalized_contribution - 0.5 * normalized_contribution**2,
             0.0,
         )
         bounded_gain = insertion_gain / (1.0 + insertion_gain)
@@ -2004,9 +1980,7 @@ class FixedBudgetInteractionLearner:
         evidence_refreshed = live & jnp.asarray(evidence_refreshed, dtype=jnp.bool_)
         refresh_lease = live & jnp.asarray(retention_evidence_refreshed, dtype=jnp.bool_)
         idle_cap = jnp.asarray(2**31 - 1, dtype=jnp.int32)
-        incremented = (
-            jnp.minimum(jnp.maximum(old_idle_steps, 0), idle_cap - 1) + 1
-        )
+        incremented = jnp.minimum(jnp.maximum(old_idle_steps, 0), idle_cap - 1) + 1
         idle_steps = jnp.where(
             live,
             jnp.where(refresh_lease, 0, incremented),
@@ -2172,9 +2146,7 @@ class FixedBudgetInteractionLearner:
         external = (
             jnp.ones((self._n_features,), dtype=jnp.bool_)
             if external_read_mask is None
-            else jnp.asarray(external_read_mask, dtype=jnp.bool_).reshape(
-                (self._n_features,)
-            )
+            else jnp.asarray(external_read_mask, dtype=jnp.bool_).reshape((self._n_features,))
         )
         live = self._live_descriptor_mask(
             state.feature_left,
@@ -2222,25 +2194,22 @@ class FixedBudgetInteractionLearner:
         )
         feature_dim = raw_observation.shape[0]
         self._require_state_contract(state, feature_dim=feature_dim)
-        proposed_step_words, lifetime_capacity_available = (
-            _checked_lifetime_words_increment(state.step_words)
+        proposed_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
+            state.step_words
         )
         lifetime_counter_valid = _lifetime_counter_valid(
             state.step_words,
             state.step_count,
         )
         replacement_phase_valid = self._replacement_phase_valid(
-            state.step_words,
-            state.replacement_phase
+            state.step_words, state.replacement_phase
         )
         state_valid = (
             lifetime_counter_valid
             & replacement_phase_valid
             & self._state_values_valid(state, feature_dim=feature_dim)
         )
-        proposed_replacement_phase = self._next_replacement_phase(
-            state.replacement_phase
-        )
+        proposed_replacement_phase = self._next_replacement_phase(state.replacement_phase)
         external = (
             jnp.ones((self._n_features,), dtype=jnp.bool_)
             if external_read_mask is None
@@ -2267,8 +2236,7 @@ class FixedBudgetInteractionLearner:
             priority_override = curation_priority_override
         else:
             raise TypeError(
-                "curation_priority_override must be an "
-                "InteractionCurationPriorityOverride"
+                "curation_priority_override must be an InteractionCurationPriorityOverride"
             )
         priority_override_enabled = _require_array_contract(
             priority_override.enabled,
@@ -2288,9 +2256,9 @@ class FixedBudgetInteractionLearner:
             shape=(self._candidate_count,),
             dtype=jnp.dtype(jnp.float32),
         )
-        priority_override_valid = jnp.all(
-            jnp.isfinite(raw_active_priority_ranks)
-        ) & jnp.all(jnp.isfinite(raw_candidate_priority_ranks))
+        priority_override_valid = jnp.all(jnp.isfinite(raw_active_priority_ranks)) & jnp.all(
+            jnp.isfinite(raw_candidate_priority_ranks)
+        )
         active_priority_ranks = jnp.where(
             jnp.isfinite(raw_active_priority_ranks),
             raw_active_priority_ranks,
@@ -2368,9 +2336,7 @@ class FixedBudgetInteractionLearner:
                 (self._n_tasks, self._n_features),
             )
             candidate_learning_errors = target_only_errors
-            input_valid = input_valid & jnp.all(
-                jnp.isfinite(state.relevance_probe_biases)
-            )
+            input_valid = input_valid & jnp.all(jnp.isfinite(state.relevance_probe_biases))
 
         candidate_features = jnp.zeros(self._candidate_count, dtype=jnp.float32)
         if self._candidate_count > 0:
@@ -2428,10 +2394,7 @@ class FixedBudgetInteractionLearner:
                     candidate_errors = jnp.where(
                         active_mask[:, None],
                         candidate_learning_errors[:, None]
-                        - (
-                            state.candidate_output_weights
-                            * candidate_features[None, :]
-                        ),
+                        - (state.candidate_output_weights * candidate_features[None, :]),
                         0.0,
                     )
                     candidate_output_delta = (
@@ -2453,10 +2416,7 @@ class FixedBudgetInteractionLearner:
 
         bounding_scale = jnp.array(1.0, dtype=jnp.float32)
         if self._use_obgd and not self._scale_robust:
-            total_step = (
-                jnp.sum(jnp.abs(output_delta))
-                + jnp.sum(jnp.abs(output_bias_delta))
-            )
+            total_step = jnp.sum(jnp.abs(output_delta)) + jnp.sum(jnp.abs(output_bias_delta))
             if not self._independent_relevance_probe:
                 total_step = total_step + jnp.sum(jnp.abs(candidate_output_delta))
             err_norm = jnp.linalg.norm(errors)
@@ -2548,9 +2508,7 @@ class FixedBudgetInteractionLearner:
         )
         if self._independent_relevance_probe:
             first_commit = (
-                live_features
-                & ~state.active_output_memory_committed
-                & retention_evidence_refreshed
+                live_features & ~state.active_output_memory_committed & retention_evidence_refreshed
             )
             output_weights = jnp.where(
                 state.active_output_memory_committed[None, :],
@@ -2566,8 +2524,7 @@ class FixedBudgetInteractionLearner:
             )
         elif self._evidence_gated_active_output_memory:
             output_write_gate = (
-                ~state.active_output_memory_committed
-                | retention_evidence_refreshed
+                ~state.active_output_memory_committed | retention_evidence_refreshed
             ) & live_features
             output_weights = jnp.where(
                 output_write_gate[None, :],
@@ -2575,14 +2532,11 @@ class FixedBudgetInteractionLearner:
                 state.output_weights,
             )
             active_output_memory_committed = live_features & (
-                state.active_output_memory_committed
-                | retention_evidence_refreshed
+                state.active_output_memory_committed | retention_evidence_refreshed
             )
         else:
             output_weights = proposed_output_weights
-            active_output_memory_committed = jnp.zeros_like(
-                state.active_output_memory_committed
-            )
+            active_output_memory_committed = jnp.zeros_like(state.active_output_memory_committed)
         (
             new_utilities,
             evidence_idle_steps,
@@ -2666,12 +2620,8 @@ class FixedBudgetInteractionLearner:
                     )
                 )
             )
-        candidate_promotion_evidence_streak_pre = (
-            state.candidate_promotion_evidence_streak
-        )
-        candidate_reacquisition_required_pre = (
-            state.candidate_reacquisition_required
-        )
+        candidate_promotion_evidence_streak_pre = state.candidate_promotion_evidence_streak
+        candidate_reacquisition_required_pre = state.candidate_reacquisition_required
         candidate_reacquisition_required = (
             candidate_reacquisition_required_pre
             & candidate_live
@@ -2696,9 +2646,8 @@ class FixedBudgetInteractionLearner:
             candidate_reacquisition_confirmation_cap,
             candidate_promotion_confirmation_cap,
         )
-        candidate_confirmation_gate_active = (
-            self._independent_relevance_probe
-            & (candidate_required_confirmation_steps > 1)
+        candidate_confirmation_gate_active = self._independent_relevance_probe & (
+            candidate_required_confirmation_steps > 1
         )
         candidate_incremented_streak = (
             jnp.minimum(
@@ -2714,22 +2663,14 @@ class FixedBudgetInteractionLearner:
         )
         candidate_promotion_confirmed = candidate_live & (
             ~candidate_confirmation_gate_active
-            | (
-                candidate_promotion_evidence_streak_updated
-                >= candidate_required_confirmation_steps
-            )
+            | (candidate_promotion_evidence_streak_updated >= candidate_required_confirmation_steps)
         )
         candidate_reacquisition_confirmed = (
             candidate_live
             & candidate_reacquisition_required
-            & (
-                candidate_promotion_evidence_streak_updated
-                >= candidate_required_confirmation_steps
-            )
+            & (candidate_promotion_evidence_streak_updated >= candidate_required_confirmation_steps)
         )
-        candidate_promotion_evidence_streak = (
-            candidate_promotion_evidence_streak_updated
-        )
+        candidate_promotion_evidence_streak = candidate_promotion_evidence_streak_updated
         ages = jnp.where(
             live_features,
             _saturating_int32_increment(state.ages),
@@ -2775,9 +2716,7 @@ class FixedBudgetInteractionLearner:
             candidate_output_weights=candidate_output_weights,
             candidate_utilities=new_candidate_utilities,
             candidate_ages=candidate_ages,
-            candidate_promotion_evidence_streak=(
-                candidate_promotion_evidence_streak
-            ),
+            candidate_promotion_evidence_streak=(candidate_promotion_evidence_streak),
             candidate_reacquisition_required=candidate_reacquisition_required,
             feature_second_moments=feature_second_moments,
             candidate_second_moments=candidate_second_moments,
@@ -2810,10 +2749,7 @@ class FixedBudgetInteractionLearner:
             if self._stale_retirement_interval is None
             else self._stale_retirement_interval
         )
-        should_try_retire = (
-            retirement_interval > 0
-            and self._retire_stale_features
-        ) & (
+        should_try_retire = (retirement_interval > 0 and self._retire_stale_features) & (
             _exact_words_modulo(proposed_step_words, max(retirement_interval, 1))
             == jnp.asarray(0, dtype=jnp.uint32)
         )
@@ -2834,9 +2770,7 @@ class FixedBudgetInteractionLearner:
         stale_slot = jnp.argmax(stale_scores).astype(jnp.int32)
         has_stale_slot = jnp.any(stale_scores >= 0)
         has_vacancy_before = jnp.any(~live_features)
-        should_retire = (
-            should_try_retire & has_stale_slot & ~has_vacancy_before
-        )
+        should_retire = should_try_retire & has_stale_slot & ~has_vacancy_before
         retired_slot = jnp.where(should_retire, stale_slot, retired_slot)
         retired_left = jnp.where(
             should_retire,
@@ -3012,8 +2946,10 @@ class FixedBudgetInteractionLearner:
                 axis=1,
             )
             eligible_candidates = (
-                candidate_ages >= self._candidate_min_age
-            ) & ~candidate_matches_active & candidate_promotion_confirmed
+                (candidate_ages >= self._candidate_min_age)
+                & ~candidate_matches_active
+                & candidate_promotion_confirmed
+            )
             # Retirement resets every archive entry with the retired identity.
             # The confirmation booleans above describe pre-reset evidence, so
             # this explicit post-reset exclusion prevents same-transaction
@@ -3051,10 +2987,7 @@ class FixedBudgetInteractionLearner:
             should_promote = (
                 (
                     (should_try_replace & ~should_retire)
-                    | (
-                        should_retire
-                        & (self._stale_retirement_interval is not None)
-                    )
+                    | (should_retire & (self._stale_retirement_interval is not None))
                 )
                 & has_destination
                 & has_candidate
@@ -3070,14 +3003,9 @@ class FixedBudgetInteractionLearner:
                 )
             )
             should_refresh_candidate = (
-                ~should_promote
-                & should_try_replace
-                & ~should_retire
-                & self._refresh_candidates
+                ~should_promote & should_try_replace & ~should_retire & self._refresh_candidates
             )
-            should_refresh_promoted_candidate = (
-                should_promote & self._refresh_promoted_candidate
-            )
+            should_refresh_promoted_candidate = should_promote & self._refresh_promoted_candidate
             refreshed_candidate = jnp.where(
                 should_refresh_promoted_candidate,
                 best_candidate,
@@ -3232,8 +3160,7 @@ class FixedBudgetInteractionLearner:
                 return fl, fr, ow, util, age, cl, cr, cow, cutil, cage, fpa, fpb, fg, cpa, cpb, cg
 
             promoted_probe_seed = (
-                self._promotion_blend
-                * candidate_output_weights[:, best_candidate]
+                self._promotion_blend * candidate_output_weights[:, best_candidate]
             )
             carry = (
                 feature_left,
@@ -3272,9 +3199,7 @@ class FixedBudgetInteractionLearner:
                 candidate_generator,
             ) = jax.lax.cond(should_promote, promote_branch, refresh_candidate_branch, carry)
             candidate_indices = jnp.arange(self._candidate_count, dtype=jnp.int32)
-            promoted_candidate_reset = should_promote & (
-                candidate_indices == best_candidate
-            )
+            promoted_candidate_reset = should_promote & (candidate_indices == best_candidate)
             refreshed_candidate_reset = (
                 ~should_promote
                 & should_try_replace
@@ -3299,9 +3224,7 @@ class FixedBudgetInteractionLearner:
             )
             relevance_probe_weights = jax.lax.select(
                 should_promote,
-                relevance_probe_weights.at[:, destination_slot].set(
-                    probe_destination_value
-                ),
+                relevance_probe_weights.at[:, destination_slot].set(probe_destination_value),
                 relevance_probe_weights,
             )
             if self._independent_relevance_probe:
@@ -3452,9 +3375,7 @@ class FixedBudgetInteractionLearner:
             candidate_output_weights=candidate_output_weights,
             candidate_utilities=new_candidate_utilities,
             candidate_ages=candidate_ages,
-            candidate_promotion_evidence_streak=(
-                candidate_promotion_evidence_streak
-            ),
+            candidate_promotion_evidence_streak=(candidate_promotion_evidence_streak),
             candidate_reacquisition_required=candidate_reacquisition_required,
             feature_second_moments=feature_second_moments,
             candidate_second_moments=candidate_second_moments,
@@ -3595,9 +3516,7 @@ class FixedBudgetInteractionLearner:
                     false_candidates,
                 )
             ),
-            candidate_promotion_evidence_streak_pre=(
-                candidate_promotion_evidence_streak_pre
-            ),
+            candidate_promotion_evidence_streak_pre=(candidate_promotion_evidence_streak_pre),
             candidate_promotion_evidence_streak_updated=(
                 jnp.where(
                     input_valid,
@@ -3610,9 +3529,7 @@ class FixedBudgetInteractionLearner:
                 candidate_promotion_confirmed,
                 false_candidates,
             ),
-            candidate_reacquisition_required_pre=(
-                candidate_reacquisition_required_pre
-            ),
+            candidate_reacquisition_required_pre=(candidate_reacquisition_required_pre),
             candidate_reacquisition_required_post=(
                 jnp.where(
                     input_valid,
@@ -3659,9 +3576,7 @@ class FixedBudgetInteractionLearner:
             curation_priority_override_enabled=priority_override_enabled,
             curation_attempted=input_valid & (should_try_replace | should_retire),
             curation_priority_override_applied=(
-                input_valid
-                & (should_try_replace | should_retire)
-                & priority_override_enabled
+                input_valid & (should_try_replace | should_retire) & priority_override_enabled
             ),
             curation_selected_active_worst_slot=jnp.where(
                 input_valid & (should_try_replace | should_retire),
@@ -3746,9 +3661,7 @@ def migrate_legacy_interaction_feature_state(
         or not isinstance(replacement_interval, int)
         or not 0 <= replacement_interval <= _INT32_MAX
     ):
-        raise ValueError(
-            "replacement_interval must be an int32-safe non-negative integer"
-        )
+        raise ValueError("replacement_interval must be an int32-safe non-negative integer")
     if isinstance(legacy_state, Mapping):
         fields = dict(legacy_state)
     elif dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
@@ -3800,9 +3713,7 @@ def save_interaction_feature_checkpoint(
     learner._require_state_contract(state, feature_dim=feature_dim)
     if not bool(_lifetime_counter_valid(state.step_words, state.step_count)):
         raise ValueError("interaction-feature checkpoint lifetime counter is invalid")
-    if not bool(
-        learner._replacement_phase_valid(state.step_words, state.replacement_phase)
-    ):
+    if not bool(learner._replacement_phase_valid(state.step_words, state.replacement_phase)):
         raise ValueError("interaction-feature checkpoint replacement phase is invalid")
     if not bool(learner._state_values_valid(state, feature_dim=feature_dim)):
         raise ValueError("interaction-feature checkpoint state values are invalid")

--- a/tests/test_interaction_feature_validation.py
+++ b/tests/test_interaction_feature_validation.py
@@ -194,3 +194,45 @@ def test_config_normalizes_hostile_mapping_failure() -> None:
 
     with pytest.raises(ValueError, match="could not be read"):
         FixedBudgetInteractionLearner.from_config(HostileMapping())
+
+
+def test_constructor_scalars_reject_booleans_and_nans() -> None:
+    # step_size_output
+    with pytest.raises(ValueError, match="step_size_output"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, step_size_output=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="step_size_output"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, step_size_output=float("nan"))
+    with pytest.raises(ValueError, match="step_size_output"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, step_size_output=float("inf"))
+
+    # obgd_kappa
+    with pytest.raises(ValueError, match="obgd_kappa"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, obgd_kappa=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="obgd_kappa"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, obgd_kappa=float("nan"))
+    with pytest.raises(ValueError, match="obgd_kappa"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, obgd_kappa=0.0)
+
+    # utility_decay
+    with pytest.raises(ValueError, match="utility_decay"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, utility_decay=False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="utility_decay"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, utility_decay=1.0)
+
+    # promotion_blend & future_utility_mix
+    with pytest.raises(ValueError, match="promotion_blend"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, promotion_blend=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="future_utility_mix"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, future_utility_mix=True)  # type: ignore[arg-type]
+
+    # task_activity_decay & scale_normalizer_decay
+    with pytest.raises(ValueError, match="task_activity_decay"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, task_activity_decay=False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="scale_normalizer_decay"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, scale_normalizer_decay=False)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="scale_normalizer_epsilon"):
+        FixedBudgetInteractionLearner(n_features=2, n_tasks=2, scale_normalizer_epsilon=True)  # type: ignore[arg-type]
+
+    # Valid construction
+    learner = FixedBudgetInteractionLearner(n_features=2, n_tasks=2, step_size_output=0.0)
+    assert learner._step_size_output == 0.0


### PR DESCRIPTION
## Summary
- Resolves #944.
- Hardens `FixedBudgetInteractionLearner.__init__` in `alberta_framework/core/interaction_features.py` by routing leftover constructor scalars (`step_size_output`, `utility_decay`, `promotion_margin`, `promotion_blend`, `task_activity_decay`, `future_utility_mix`, `utility_retention_decay`, `utility_evidence_threshold`, `candidate_promotion_floor`, `candidate_utility_retention_decay`, `obgd_kappa`, `scale_normalizer_decay`, `scale_normalizer_epsilon`) through `validated_float32_scalar` to reject booleans, NaNs, and infinite floats.
- Adds comprehensive unit tests in `tests/test_interaction_feature_validation.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_interaction_feature_validation.py`: 36 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/interaction_features.py`: clean