### PR TITLE
fix(benchmarks): reject __class__-spoofed non-real reward in historical_forager

### DIFF
--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -275,7 +275,8 @@ def _require_environment(value: Any) -> HistoricalForagerEnvironment:
 
 
 def _finite_reward(value: Any) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
         raise HistoricalForagerContractError("historical reward must be a real scalar")
     result = float(value)
     if not math.isfinite(result):

--- a/tests/test_historical_forager_reconstructed.py
+++ b/tests/test_historical_forager_reconstructed.py
@@ -548,3 +548,33 @@ def test_metric_rejects_nonfinite_or_unbounded_shapes() -> None:
         historical_fov_metrics(np.asarray([[1.0]]))
     with pytest.raises(HistoricalForagerContractError):
         historical_fov_metrics(np.asarray([math.nan]))
+
+
+def test_finite_reward_rejects_class_spoofed_non_real_reward() -> None:
+    from alberta_framework.benchmarks.historical_forager import _finite_reward
+
+    class SpoofedReward:
+        @property
+        def __class__(self) -> type:
+            return float
+
+        def __float__(self) -> float:
+            return 0.5
+
+    spoofed = SpoofedReward()
+    assert isinstance(spoofed, float)  # isinstance fooled by __class__ property
+
+    with pytest.raises(
+        HistoricalForagerContractError, match="historical reward must be a real scalar"
+    ):
+        _finite_reward(spoofed)
+
+    # Rejects bool
+    with pytest.raises(
+        HistoricalForagerContractError, match="historical reward must be a real scalar"
+    ):
+        _finite_reward(True)
+
+    # Valid reward
+    assert _finite_reward(0.5) == 0.5
+    assert _finite_reward(np.float64(0.5)) == 0.5


### PR DESCRIPTION
## Summary
- Resolves #926.
- Hardens `_finite_reward` in `alberta_framework/benchmarks/historical_forager.py` by inspecting the genuine type slot `actual_type = type(value)` and checking `issubclass(actual_type, bool) or not issubclass(actual_type, Real)` to prevent spoofed `__class__` property objects from passing validation.
- Adds unit tests in `tests/test_historical_forager_reconstructed.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_historical_forager_reconstructed.py`: 34 passed
- `ruff check .`: clean
- `mypy alberta_framework/benchmarks/historical_forager.py`: clean