### PR TITLE
fix(off-policy-horde): reject boolean and non-finite ratio-clip identities

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -323,14 +323,13 @@ class OffPolicyHordeLearner:
             trace_ratio_clip: Clip for the eligibility-trace ratio.
             min_behavior_probability: Denominator floor for probability API.
         """
-        if ratio_clip <= 0.0:
-            raise ValueError(f"ratio_clip must be positive; got {ratio_clip}")
-        if trace_ratio_clip <= 0.0:
-            raise ValueError(f"trace_ratio_clip must be positive; got {trace_ratio_clip}")
-        if min_behavior_probability <= 0.0:
-            raise ValueError(
-                f"min_behavior_probability must be positive; got {min_behavior_probability}"
-            )
+        ratio_clip = _require_float32("ratio_clip", ratio_clip, positive=True)
+        trace_ratio_clip = _require_float32(
+            "trace_ratio_clip", trace_ratio_clip, positive=True
+        )
+        min_behavior_probability = _require_float32(
+            "min_behavior_probability", min_behavior_probability, positive=True
+        )
 
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -65,6 +65,42 @@ def test_invalid_clips_raise() -> None:
         OffPolicyHordeLearner(_spec(), min_behavior_probability=0.0)
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"ratio_clip": True}, "ratio_clip"),
+        ({"ratio_clip": False}, "ratio_clip"),
+        ({"ratio_clip": float("nan")}, "ratio_clip"),
+        ({"ratio_clip": float("inf")}, "ratio_clip"),
+        ({"trace_ratio_clip": True}, "trace_ratio_clip"),
+        ({"trace_ratio_clip": float("nan")}, "trace_ratio_clip"),
+        ({"min_behavior_probability": True}, "min_behavior_probability"),
+        ({"min_behavior_probability": float("nan")}, "min_behavior_probability"),
+    ],
+)
+def test_ratio_identities_reject_bool_and_nonfinite(
+    kwargs: dict[str, object], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        OffPolicyHordeLearner(_spec(), **kwargs)
+
+
+def test_legal_ratio_identities_stay_builtin_floats() -> None:
+    learner = OffPolicyHordeLearner(
+        _spec(),
+        hidden_sizes=(),
+        ratio_clip=2,
+        trace_ratio_clip=1.0,
+        min_behavior_probability=1e-6,
+    )
+    assert type(learner.ratio_clip) is float and learner.ratio_clip == 2.0
+    assert type(learner.trace_ratio_clip) is float and learner.trace_ratio_clip == 1.0
+    assert (
+        type(learner._min_behavior_probability) is float
+        and learner._min_behavior_probability == 1e-6
+    )
+
+
 def test_update_finite_and_shapes() -> None:
     learner = OffPolicyHordeLearner(
         _spec(),


### PR DESCRIPTION
Closes #970.

## What changed

`OffPolicyHordeLearner` now canonicalizes `ratio_clip`, `trace_ratio_clip`, and `min_behavior_probability` through the existing `_require_float32(..., positive=True)` helper already used by `NonlinearSharedGTDHordeLearner` in the same file.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, those three fields used `<= 0.0` only. `True` passed and was stored as a Python `bool`. `nan` and `inf` also passed. `to_config()` would serialize `"ratio_clip": true`.

`ratio_clip=False` already raised. Legal positives stay legal and become builtin floats: `ratio_clip=2`, `trace_ratio_clip=1.0`, `min_behavior_probability=1e-6`.

## Scope

- `alberta_framework/core/off_policy_horde.py`
- `tests/test_off_policy_horde.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `1df1659ec4b47d4f552a0decbd6c004e0895ad34`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 8 failed, 1 passed (`DID NOT RAISE` for True/nan/inf; `False` already rejected; legal int `2` was not a builtin float)
- `PYTHONPATH=<worktree> pytest tests/test_off_policy_horde.py -q -o addopts=""` → 36 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1df1659ec4b47d4f552a0decbd6c004e0895ad34 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
