### PR TITLE
fix(upgd): reject leftover constructor scalar identities

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -533,6 +533,27 @@ class UPGDLearner:
             msg = f"hidden_sizes must contain only positive sizes, got {hidden_sizes!r}"
             raise ValueError(msg)
         validated_step_size = validated_float32_scalar("step_size", step_size, lower=0.0)
+        utility_decay = validated_float32_scalar(
+            "utility_decay",
+            utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
+        head_step_size_multiplier = validated_float32_scalar(
+            "head_step_size_multiplier",
+            head_step_size_multiplier,
+            positive=True,
+        )
+        adaptive_kappa_base = validated_float32_scalar(
+            "adaptive_kappa_base", adaptive_kappa_base, positive=True
+        )
+        readout_adaptive_gate_width = validated_float32_scalar(
+            "readout_adaptive_gate_width",
+            readout_adaptive_gate_width,
+            positive=True,
+        )
         if perturbation_sigma < 0.0:
             msg = f"perturbation_sigma must be non-negative, got {perturbation_sigma}"
             raise ValueError(msg)

--- a/tests/test_upgd_leftover_constructor_identities.py
+++ b/tests/test_upgd_leftover_constructor_identities.py
@@ -1,0 +1,57 @@
+"""Leftover UPGD constructor identities must not persist as bool or NaN."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.core.upgd import UPGDLearner
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"utility_decay": False},
+        {"utility_decay": True},
+        {"utility_decay": float("nan")},
+        {"sparsity": True},
+        {"sparsity": False},
+        {"sparsity": float("nan")},
+        {"head_step_size_multiplier": True},
+        {"head_step_size_multiplier": float("nan")},
+        {"head_step_size_multiplier": float("inf")},
+        {"adaptive_kappa_base": True},
+        {"adaptive_kappa_base": float("nan")},
+        {"readout_adaptive_gate_width": True},
+        {"readout_adaptive_gate_width": float("nan")},
+    ],
+)
+def test_leftover_upgd_identities_reject_bool_and_nonfinite(
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        UPGDLearner(n_heads=2, hidden_sizes=(4,), **kwargs)
+
+
+def test_legal_leftover_upgd_identities_stay_canonical() -> None:
+    learner = UPGDLearner(
+        n_heads=2,
+        hidden_sizes=(4,),
+        utility_decay=0.0,
+        sparsity=0.0,
+        head_step_size_multiplier=2,
+        adaptive_kappa_base=0.5,
+        readout_adaptive_gate_width=1.0,
+    )
+    assert type(learner._utility_decay) is float and learner._utility_decay == 0.0
+    assert type(learner._sparsity) is float and learner._sparsity == 0.0
+    assert (
+        type(learner._head_step_size_multiplier) is float
+        and learner._head_step_size_multiplier == 2.0
+    )
+    assert type(learner._adaptive_kappa_base) is float
+    assert learner._adaptive_kappa_base == 0.5
+    assert type(learner._readout_adaptive_gate_width) is float
+    assert learner._readout_adaptive_gate_width == 1.0
+    assert math.isfinite(learner._head_step_size_multiplier)


### PR DESCRIPTION
Closes #971.

## What changed

`UPGDLearner` now canonicalizes leftover constructor scalars through the already-imported `validated_float32_scalar`: `utility_decay` in `[0, 1)`, `sparsity` in `[0, 1]`, and the three positive multipliers (`head_step_size_multiplier`, `adaptive_kappa_base`, `readout_adaptive_gate_width`).

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `step_size` was already validated but those leftovers used ordered comparisons only. `True` became `1.0` (legal positive / 100% sparse wipe). `False` became `0.0` (legal sparsity / vacuous EMA). `nan` survived on the positive multipliers.

Legal zeros stay legal: `utility_decay=0.0`, `sparsity=0.0`, `sparsity=1.0`. This is `alberta_framework/core/upgd.py` only — not `upgd-ipmnist`.

## Scope

- `alberta_framework/core/upgd.py`
- `tests/test_upgd_leftover_constructor_identities.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `391d7633b301eba44026b2fd856dc41be01bd2d2`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 10 failed, 4 passed (`DID NOT RAISE` for leftover True/False/nan/inf identities; `utility_decay=True` already rejected)
- `PYTHONPATH=<worktree> pytest tests/test_upgd_leftover_constructor_identities.py -q -o addopts=""` → 14 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:391d7633b301eba44026b2fd856dc41be01bd2d2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
