### PR TITLE
fix(upgd-ipmnist): require integer schema_version and exact policy booleans

### DIFF
--- a/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
@@ -50,9 +50,7 @@ V2_PROTOCOL_DEVIATIONS: list[dict[str, str]] = [
     {
         "code": "task_aligned_logging",
         "scope": "metric_blocks",
-        "description": (
-            "task blocks are [t*L, (t+1)*L); upstream logging is shifted by one step"
-        ),
+        "description": ("task blocks are [t*L, (t+1)*L); upstream logging is shifted by one step"),
     },
     {
         "code": "float32_bias_corrections",
@@ -450,9 +448,7 @@ def _parse_partials(
 ) -> tuple[list[_Shard], list[str], tuple[tuple[str, str], ...], tuple[int, ...]]:
     errors: list[str] = []
     try:
-        normalized_seeds = require_unique_jax_seeds(
-            expected_seeds, name="expected_seeds"
-        )
+        normalized_seeds = require_unique_jax_seeds(expected_seeds, name="expected_seeds")
     except ValueError as exc:
         errors.append(str(exc))
         normalized_seeds = ()
@@ -619,9 +615,7 @@ def validate_upgd_ipmnist_artifact(
     expected_seeds: Sequence[int] = EXPECTED_SEEDS,
 ) -> UPGDIPMNISTValidation:
     """Recompute and validate a v1 result artifact from its complete shards."""
-    shards, errors, digests, normalized_seeds = _parse_partials(
-        partial_paths, expected_seeds
-    )
+    shards, errors, digests, normalized_seeds = _parse_partials(partial_paths, expected_seeds)
     artifact_digest: str | None = None
     try:
         artifact, artifact_digest = _strict_json_object_with_sha256(Path(artifact_path))
@@ -865,14 +859,22 @@ def validate_upgd_ipmnist_v2_artifact(
         errors.append("v2 artifact fields do not match the strict schema")
     if artifact.get("schema") != UPGD_IPMNIST_ARTIFACT_SCHEMA_V2:
         errors.append("artifact is not an alberta.upgd_ipmnist.artifact.v2 payload")
-    if artifact.get("schema_version") != 2:
+    if type(artifact.get("schema_version")) is not int or artifact.get("schema_version") != 2:
         errors.append("v2 artifact schema_version must equal 2")
     if artifact.get("benchmark") != UPGD_IPMNIST_BENCHMARK:
         errors.append("v2 artifact benchmark identifier is unsupported")
     created = _finite_number(artifact.get("created_unix"))
     if created is None or created <= 0.0:
         errors.append("v2 artifact created_unix must be finite and positive")
-    if artifact.get("evidence_policy") != V2_NONPROMOTING_POLICY:
+    policy = artifact.get("evidence_policy")
+    if (
+        not isinstance(policy, Mapping)
+        or set(policy) != set(V2_NONPROMOTING_POLICY)
+        or policy.get("evidence_class") != "development_replication_diagnostic"
+        or policy.get("development_only") is not True
+        or policy.get("scientific_promotion_allowed") is not False
+        or policy.get("execution_attestation") is not False
+    ):
         errors.append("v2 artifact evidence policy must remain permanently nonpromoting")
     if artifact.get("deviations") != V2_PROTOCOL_DEVIATIONS:
         errors.append("v2 artifact structured deviations do not match the contract")
@@ -919,6 +921,7 @@ def validate_upgd_ipmnist_v2_artifact(
                     "sha256": hashlib.sha256(raw).hexdigest(),
                 }
             )
+
         def manifest_identity(entry: Mapping[str, object]) -> tuple[str, int]:
             learner = entry["learner"]
             seed = entry["seed_id"]
@@ -944,9 +947,7 @@ def validate_upgd_ipmnist_v2_artifact(
                 "selected_publication_configuration_match_scope": (
                     "network_task_shape_and_horizon_only"
                 ),
-                "dataset": (
-                    "OpenML mnist_784 v1, first 60000 rows (torchvision train split)"
-                ),
+                "dataset": ("OpenML mnist_784 v1, first 60000 rows (torchvision train split)"),
                 "input_scaling": "(x/255 - 0.5) / 0.5",
                 "loss": "softmax cross-entropy, one example per step",
                 "metric": "online accuracy of the pre-update prediction, averaged per task",
@@ -962,12 +963,8 @@ def validate_upgd_ipmnist_v2_artifact(
             "published_seed_count": 20,
             "exact_seed_ids_by_learner": seed_ids,
             "exact_seed_count_by_learner": seed_counts,
-            "all_learners_share_seed_ids": all(
-                seeds == schedules[0] for seeds in schedules[1:]
-            ),
-            "matches_published_seed_count": all(
-                count == 20 for count in seed_counts.values()
-            ),
+            "all_learners_share_seed_ids": all(seeds == schedules[0] for seeds in schedules[1:]),
+            "matches_published_seed_count": all(count == 20 for count in seed_counts.values()),
         }
         if artifact.get("study_design") != expected_study_design:
             errors.append("v2 artifact exact seed ids/counts do not recompute")

--- a/tests/test_upgd_ipmnist_nonpromoting.py
+++ b/tests/test_upgd_ipmnist_nonpromoting.py
@@ -36,13 +36,9 @@ from alberta_framework.evaluation.upgd_ipmnist_nonpromoting import (
 _ROOT = Path(__file__).resolve().parents[1]
 _IMMUTABLE_V1_ARTIFACT = _ROOT / "outputs/upgd_ipmnist/results.v1.json"
 _IMMUTABLE_V1_RECEIPT = _ROOT / "outputs/upgd_ipmnist/nonpromoting_receipt.v1.json"
-_IMMUTABLE_V1_RECEIPT_SHA256 = (
-    "c32595829f93ac86b96c6eefc722291bf365dbf724982a70f207d193bbcfc26e"
-)
+_IMMUTABLE_V1_RECEIPT_SHA256 = "c32595829f93ac86b96c6eefc722291bf365dbf724982a70f207d193bbcfc26e"
 _CURRENT_RECEIPT = _ROOT / "outputs/upgd_ipmnist/nonpromoting_receipt.v2.json"
-_CURRENT_RECEIPT_SHA256 = (
-    "0c36f97c60cf5d10ef5478d83f1de274920335ac592d7d6a16b1374da0c44083"
-)
+_CURRENT_RECEIPT_SHA256 = "0c36f97c60cf5d10ef5478d83f1de274920335ac592d7d6a16b1374da0c44083"
 
 
 def _partial_payload(learner: str, seed: int) -> dict[str, object]:
@@ -107,9 +103,7 @@ def _v2_partial_payload(learner: str, seed: int) -> dict[str, object]:
         "seed_count": 1,
         "config": legacy["config"],
         "matches_selected_publication_configuration": True,
-        "selected_publication_configuration_match_scope": (
-            "network_task_shape_and_horizon_only"
-        ),
+        "selected_publication_configuration_match_scope": ("network_task_shape_and_horizon_only"),
         "deviations": [dict(deviation) for deviation in PROTOCOL_DEVIATIONS],
         "per_task_accuracy": legacy["per_task_accuracy"],
         "per_task_loss": legacy["per_task_loss"],
@@ -362,8 +356,7 @@ def test_v2_validator_recursively_rejects_legacy_protocol_marker(tmp_path: Path)
     artifact_validation = validate_upgd_ipmnist_v2_artifact(artifact, paths)
     assert not artifact_validation.valid
     assert any(
-        "forbidden legacy is_protocol_exact" in error
-        for error in artifact_validation.errors
+        "forbidden legacy is_protocol_exact" in error for error in artifact_validation.errors
     )
 
     partial_payload = json.loads(paths[0].read_text(encoding="utf-8"))
@@ -466,9 +459,7 @@ def test_nonpromoting_receipt_binds_stored_shards_and_summary() -> None:
     assert hashlib.sha256(raw).hexdigest() == _CURRENT_RECEIPT_SHA256
     receipt = json.loads(raw)
 
-    assert receipt["schema_version"] == (
-        "alberta.upgd_ipmnist_nonpromoting_receipt.v2"
-    )
+    assert receipt["schema_version"] == ("alberta.upgd_ipmnist_nonpromoting_receipt.v2")
     assert receipt["receipt_role"] == "versioned_provenance_successor"
     predecessor = receipt["predecessor_receipt"]
     assert _ROOT / predecessor["path"] == _IMMUTABLE_V1_RECEIPT
@@ -478,13 +469,9 @@ def test_nonpromoting_receipt_binds_stored_shards_and_summary() -> None:
     assert predecessor["sha256"] == _IMMUTABLE_V1_RECEIPT_SHA256
     assert predecessor["preserved_byte_for_byte"] is True
     predecessor_payload = json.loads(predecessor_raw)
-    predecessor_runbook = predecessor_payload["post_hoc_reconstructed_provenance"][
-        "runbook"
-    ]
+    predecessor_runbook = predecessor_payload["post_hoc_reconstructed_provenance"]["runbook"]
     predecessor_runbook_raw = (_ROOT / predecessor_runbook["path"]).read_bytes()
-    assert hashlib.sha256(predecessor_runbook_raw).hexdigest() == (
-        predecessor_runbook["sha256"]
-    )
+    assert hashlib.sha256(predecessor_runbook_raw).hexdigest() == (predecessor_runbook["sha256"])
     assert receipt["status"] == "complete_structural_validation"
     assert receipt["development_only"] is True
     assert receipt["scientific_promotion_allowed"] is False
@@ -555,8 +542,9 @@ def test_nonpromoting_receipt_binds_stored_shards_and_summary() -> None:
     assert source_manifest["execution_attestation"] is False
     assert source_manifest["full_import_closure_snapshotted"] is False
     assert len(source_manifest["files"]) == bundle_binding["numeric_file_count"]
-    assert sum(binding["size_bytes"] for binding in source_manifest["files"]) == (
-        bundle_binding["numeric_file_size_bytes"]
+    assert (
+        sum(binding["size_bytes"] for binding in source_manifest["files"])
+        == (bundle_binding["numeric_file_size_bytes"])
     )
     for binding in source_manifest["files"]:
         source_raw = (bundle_root / binding["path"]).read_bytes()
@@ -573,8 +561,9 @@ def test_nonpromoting_receipt_binds_stored_shards_and_summary() -> None:
         sort_keys=True,
         separators=(",", ":"),
     ).encode()
-    assert hashlib.sha256(canonical_source_map).hexdigest() == (
-        provenance["numeric_source_hash_map_sha256"]
+    assert (
+        hashlib.sha256(canonical_source_map).hexdigest()
+        == (provenance["numeric_source_hash_map_sha256"])
     )
     for path_string, expected_sha256 in numeric_source_map.items():
         source_raw = (bundle_root / path_string).read_bytes()
@@ -621,3 +610,33 @@ def test_nonpromoting_receipt_binds_stored_shards_and_summary() -> None:
             "average_plasticity_mean",
         ):
             assert artifact_summary[field] == receipt_summary[field]
+
+
+@pytest.mark.unit
+def test_v2_artifact_rejects_float_schema_version_and_numeric_policy_aliases(
+    tmp_path: Path,
+) -> None:
+    paths = _write_v2_shards(tmp_path, seeds=(0,))
+    artifact = _write_v2_artifact(tmp_path, paths)
+
+    # schema_version: 2.0 (float alias)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    payload["schema_version"] = 2.0
+    artifact.write_text(json.dumps(payload), encoding="utf-8")
+    validation = validate_upgd_ipmnist_v2_artifact(artifact, paths)
+    assert not validation.valid
+    assert any("schema_version" in error for error in validation.errors)
+
+    # numeric policy aliases (development_only: 1, scientific_promotion_allowed: 0)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    payload["schema_version"] = 2
+    payload["evidence_policy"] = {
+        "evidence_class": "development_replication_diagnostic",
+        "development_only": 1,
+        "scientific_promotion_allowed": 0,
+        "execution_attestation": 0,
+    }
+    artifact.write_text(json.dumps(payload), encoding="utf-8")
+    validation = validate_upgd_ipmnist_v2_artifact(artifact, paths)
+    assert not validation.valid
+    assert any("evidence policy" in error for error in validation.errors)


### PR DESCRIPTION
## Summary
- Resolves #911.
- Hardens `validate_upgd_ipmnist_v2_artifact` in `alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py` by requiring `type(schema_version) is int and schema_version == 2` and checking policy booleans by identity (`is True` / `is False`) across the full expected key set.
- Adds unit tests in `tests/test_upgd_ipmnist_nonpromoting.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_upgd_ipmnist_nonpromoting.py`: 25 passed
- `ruff check .`: clean
- `mypy alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py`: clean