### PR TITLE
fix(off-policy-horde): validate ratio clips and min_behavior_probability with _require_float32

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -323,14 +323,11 @@ class OffPolicyHordeLearner:
             trace_ratio_clip: Clip for the eligibility-trace ratio.
             min_behavior_probability: Denominator floor for probability API.
         """
-        if ratio_clip <= 0.0:
-            raise ValueError(f"ratio_clip must be positive; got {ratio_clip}")
-        if trace_ratio_clip <= 0.0:
-            raise ValueError(f"trace_ratio_clip must be positive; got {trace_ratio_clip}")
-        if min_behavior_probability <= 0.0:
-            raise ValueError(
-                f"min_behavior_probability must be positive; got {min_behavior_probability}"
-            )
+        ratio_clip = _require_float32("ratio_clip", ratio_clip, positive=True)
+        trace_ratio_clip = _require_float32("trace_ratio_clip", trace_ratio_clip, positive=True)
+        min_behavior_probability = _require_float32(
+            "min_behavior_probability", min_behavior_probability, positive=True
+        )
 
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
@@ -1414,23 +1411,15 @@ class NonlinearSharedGTDHordeLearner:
         )
         return NonlinearSharedGTDHordeUpdateResult(  # type: ignore[call-arg]
             state=new_state,
-            predictions=jnp.where(
-                update_applied, predictions, jnp.zeros_like(predictions)
-            ),
+            predictions=jnp.where(update_applied, predictions, jnp.zeros_like(predictions)),
             next_predictions=jnp.where(
                 update_applied,
                 reported_next_predictions,
                 jnp.zeros_like(reported_next_predictions),
             ),
-            td_targets=jnp.where(
-                update_applied, td_targets, jnp.zeros_like(td_targets)
-            ),
-            td_errors=jnp.where(
-                update_applied, td_errors, jnp.zeros_like(td_errors)
-            ),
-            clipped_rhos=jnp.where(
-                update_applied, clipped_rhos, jnp.zeros_like(clipped_rhos)
-            ),
+            td_targets=jnp.where(update_applied, td_targets, jnp.zeros_like(td_targets)),
+            td_errors=jnp.where(update_applied, td_errors, jnp.zeros_like(td_errors)),
+            clipped_rhos=jnp.where(update_applied, clipped_rhos, jnp.zeros_like(clipped_rhos)),
             correction_norms=jnp.where(
                 update_applied,
                 correction_norms_array,

--- a/tests/test_off_policy_horde.py
+++ b/tests/test_off_policy_horde.py
@@ -814,3 +814,41 @@ def test_nonlinear_shared_gtd_rejection_neutralizes_complete_result() -> None:
         result.secondary_norms,
     ):
         chex.assert_trees_all_equal(value, jnp.zeros_like(value))
+
+
+def test_off_policy_horde_ratio_clip_scalars_reject_booleans_and_nans() -> None:
+    spec = _spec(gammas=(1.0,))
+
+    # ratio_clip
+    with pytest.raises(ValueError, match="ratio_clip"):
+        OffPolicyHordeLearner(spec, ratio_clip=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="ratio_clip"):
+        OffPolicyHordeLearner(spec, ratio_clip=float("nan"))
+    with pytest.raises(ValueError, match="ratio_clip"):
+        OffPolicyHordeLearner(spec, ratio_clip=float("inf"))
+    with pytest.raises(ValueError, match="ratio_clip"):
+        OffPolicyHordeLearner(spec, ratio_clip=0.0)
+
+    # trace_ratio_clip
+    with pytest.raises(ValueError, match="trace_ratio_clip"):
+        OffPolicyHordeLearner(spec, trace_ratio_clip=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="trace_ratio_clip"):
+        OffPolicyHordeLearner(spec, trace_ratio_clip=float("nan"))
+    with pytest.raises(ValueError, match="trace_ratio_clip"):
+        OffPolicyHordeLearner(spec, trace_ratio_clip=0.0)
+
+    # min_behavior_probability
+    with pytest.raises(ValueError, match="min_behavior_probability"):
+        OffPolicyHordeLearner(spec, min_behavior_probability=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="min_behavior_probability"):
+        OffPolicyHordeLearner(spec, min_behavior_probability=float("nan"))
+    with pytest.raises(ValueError, match="min_behavior_probability"):
+        OffPolicyHordeLearner(spec, min_behavior_probability=0.0)
+
+    # Valid construction
+    learner = OffPolicyHordeLearner(
+        spec, ratio_clip=2, trace_ratio_clip=1.0, min_behavior_probability=1e-6
+    )
+    assert learner._ratio_clip == 2.0
+    assert learner._trace_ratio_clip == 1.0
+    assert learner._min_behavior_probability == 1e-6


### PR DESCRIPTION
## Summary
- Resolves #970.
- Hardens `OffPolicyHordeLearner.__init__` in `alberta_framework/core/off_policy_horde.py` by routing `ratio_clip`, `trace_ratio_clip`, and `min_behavior_probability` through `_require_float32(..., positive=True)` to reject booleans, NaNs, and infinite floats.
- Adds unit tests in `tests/test_off_policy_horde.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_off_policy_horde.py`: 28 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/off_policy_horde.py`: clean