### PR TITLE
fix(upgd): validate leftover constructor scalars through validated_float32_scalar

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -543,29 +543,21 @@ class UPGDLearner:
             msg = f"perturbation_interval must be >= 1, got {perturbation_interval}"
             raise ValueError(msg)
         if perturbation_noise not in {"normal", "rademacher"}:
-            msg = (
-                "perturbation_noise must be 'normal' or 'rademacher', "
-                f"got {perturbation_noise!r}"
-            )
+            msg = f"perturbation_noise must be 'normal' or 'rademacher', got {perturbation_noise!r}"
             raise ValueError(msg)
         if perturbation_warmup_steps < 0:
-            msg = (
-                "perturbation_warmup_steps must be >= 0, "
-                f"got {perturbation_warmup_steps}"
-            )
+            msg = f"perturbation_warmup_steps must be >= 0, got {perturbation_warmup_steps}"
             raise ValueError(msg)
         if perturbation_ramp_steps < 0:
-            msg = (
-                "perturbation_ramp_steps must be >= 0, "
-                f"got {perturbation_ramp_steps}"
-            )
+            msg = f"perturbation_ramp_steps must be >= 0, got {perturbation_ramp_steps}"
             raise ValueError(msg)
-        if not 0.0 <= utility_decay < 1.0:
+        utility_decay = validated_float32_scalar(
+            "utility_decay", utility_decay, lower=0.0, upper=1.0
+        )
+        if utility_decay >= 1.0:
             msg = f"utility_decay must be in [0, 1), got {utility_decay}"
             raise ValueError(msg)
-        if not 0.0 <= sparsity <= 1.0:
-            msg = f"sparsity must be in [0, 1], got {sparsity}"
-            raise ValueError(msg)
+        sparsity = validated_float32_scalar("sparsity", sparsity, lower=0.0, upper=1.0)
         if leaky_relu_slope < 0.0:
             msg = f"leaky_relu_slope must be non-negative, got {leaky_relu_slope}"
             raise ValueError(msg)
@@ -583,28 +575,22 @@ class UPGDLearner:
             raise ValueError(msg)
         if positive_target_loss_scale < 0.0:
             msg = (
-                "positive_target_loss_scale must be non-negative, "
-                f"got {positive_target_loss_scale}"
+                f"positive_target_loss_scale must be non-negative, got {positive_target_loss_scale}"
             )
             raise ValueError(msg)
         if negative_target_loss_scale < 0.0:
             msg = (
-                "negative_target_loss_scale must be non-negative, "
-                f"got {negative_target_loss_scale}"
+                f"negative_target_loss_scale must be non-negative, got {negative_target_loss_scale}"
             )
             raise ValueError(msg)
         if head_gradient_scale not in ("none", "active_count"):
             msg = (
-                "head_gradient_scale must be 'none' or 'active_count', "
-                f"got {head_gradient_scale!r}"
+                f"head_gradient_scale must be 'none' or 'active_count', got {head_gradient_scale!r}"
             )
             raise ValueError(msg)
-        if head_step_size_multiplier <= 0.0:
-            msg = (
-                "head_step_size_multiplier must be positive, "
-                f"got {head_step_size_multiplier}"
-            )
-            raise ValueError(msg)
+        head_step_size_multiplier = validated_float32_scalar(
+            "head_step_size_multiplier", head_step_size_multiplier, positive=True
+        )
         if head_bias_step_size_multiplier < 0.0:
             msg = (
                 "head_bias_step_size_multiplier must be non-negative, "
@@ -631,15 +617,11 @@ class UPGDLearner:
             raise ValueError(msg)
         if head_repetition_multiplier < 0.0:
             msg = (
-                "head_repetition_multiplier must be non-negative, "
-                f"got {head_repetition_multiplier}"
+                f"head_repetition_multiplier must be non-negative, got {head_repetition_multiplier}"
             )
             raise ValueError(msg)
         if not 0.0 <= head_repetition_decay < 1.0:
-            msg = (
-                "head_repetition_decay must be in [0, 1), "
-                f"got {head_repetition_decay}"
-            )
+            msg = f"head_repetition_decay must be in [0, 1), got {head_repetition_decay}"
             raise ValueError(msg)
         if head_repetition_delta_threshold < 0.0:
             msg = (
@@ -660,34 +642,19 @@ class UPGDLearner:
             )
             raise ValueError(msg)
         if not 0.0 <= unit_replacement_rate <= 1.0:
-            msg = (
-                "unit_replacement_rate must be in [0, 1], "
-                f"got {unit_replacement_rate}"
-            )
+            msg = f"unit_replacement_rate must be in [0, 1], got {unit_replacement_rate}"
             raise ValueError(msg)
         if unit_maturity_threshold < 0:
-            msg = (
-                "unit_maturity_threshold must be non-negative, "
-                f"got {unit_maturity_threshold}"
-            )
+            msg = f"unit_maturity_threshold must be non-negative, got {unit_maturity_threshold}"
             raise ValueError(msg)
         if unit_utility_decay is not None and not 0.0 <= unit_utility_decay < 1.0:
-            msg = (
-                "unit_utility_decay must be in [0, 1) when set, "
-                f"got {unit_utility_decay}"
-            )
+            msg = f"unit_utility_decay must be in [0, 1) when set, got {unit_utility_decay}"
             raise ValueError(msg)
         if not 0.0 <= unit_long_utility_decay < 1.0:
-            msg = (
-                "unit_long_utility_decay must be in [0, 1), "
-                f"got {unit_long_utility_decay}"
-            )
+            msg = f"unit_long_utility_decay must be in [0, 1), got {unit_long_utility_decay}"
             raise ValueError(msg)
         if not 0.0 <= unit_gradient_decay < 1.0:
-            msg = (
-                "unit_gradient_decay must be in [0, 1), "
-                f"got {unit_gradient_decay}"
-            )
+            msg = f"unit_gradient_decay must be in [0, 1), got {unit_gradient_decay}"
             raise ValueError(msg)
         if unit_replacement_criterion not in {
             "low_utility",
@@ -756,9 +723,9 @@ class UPGDLearner:
                 f"got {adaptive_kappa_mode!r}"
             )
             raise ValueError(msg)
-        if adaptive_kappa_base <= 0.0:
-            msg = f"adaptive_kappa_base must be positive, got {adaptive_kappa_base}"
-            raise ValueError(msg)
+        adaptive_kappa_base = validated_float32_scalar(
+            "adaptive_kappa_base", adaptive_kappa_base, positive=True
+        )
         if adaptive_kappa_mode != "none" and bounder is not None:
             configured = bounder.to_config()
             if type(bounder) is not ObGDBounding:
@@ -787,10 +754,7 @@ class UPGDLearner:
             )
             raise ValueError(msg)
         if adaptive_kappa_exponent < 0.0:
-            msg = (
-                "adaptive_kappa_exponent must be non-negative, "
-                f"got {adaptive_kappa_exponent}"
-            )
+            msg = f"adaptive_kappa_exponent must be non-negative, got {adaptive_kappa_exponent}"
             raise ValueError(msg)
         if adaptive_kappa_warmup_steps < 0:
             msg = (
@@ -831,10 +795,7 @@ class UPGDLearner:
             )
             raise ValueError(msg)
         if meta_plasticity_step_size < 0.0:
-            msg = (
-                "meta_plasticity_step_size must be non-negative, "
-                f"got {meta_plasticity_step_size}"
-            )
+            msg = f"meta_plasticity_step_size must be non-negative, got {meta_plasticity_step_size}"
             raise ValueError(msg)
         if meta_plasticity_min_multiplier <= 0.0:
             msg = (
@@ -885,9 +846,7 @@ class UPGDLearner:
             default_loss_mode if readout_loss_mode is None else readout_loss_mode
         )
         resolved_readout_prediction_mode = (
-            default_prediction_mode
-            if readout_prediction_mode is None
-            else readout_prediction_mode
+            default_prediction_mode if readout_prediction_mode is None else readout_prediction_mode
         )
         if resolved_readout_loss_mode not in {
             "linear_mse",
@@ -929,16 +888,12 @@ class UPGDLearner:
             raise ValueError(msg)
         if not 0.0 <= readout_adaptive_gate_start <= 1.0:
             msg = (
-                "readout_adaptive_gate_start must be in [0, 1], "
-                f"got {readout_adaptive_gate_start}"
+                f"readout_adaptive_gate_start must be in [0, 1], got {readout_adaptive_gate_start}"
             )
             raise ValueError(msg)
-        if readout_adaptive_gate_width <= 0.0:
-            msg = (
-                "readout_adaptive_gate_width must be positive, "
-                f"got {readout_adaptive_gate_width}"
-            )
-            raise ValueError(msg)
+        readout_adaptive_gate_width = validated_float32_scalar(
+            "readout_adaptive_gate_width", readout_adaptive_gate_width, positive=True
+        )
         if readout_input_mode not in {"hidden", "hidden_plus_input"}:
             msg = (
                 "readout_input_mode must be 'hidden' or 'hidden_plus_input', "
@@ -955,10 +910,7 @@ class UPGDLearner:
             msg = f"readout_margin must be non-negative, got {readout_margin}"
             raise ValueError(msg)
         if readout_margin_step_size < 0.0:
-            msg = (
-                "readout_margin_step_size must be non-negative, "
-                f"got {readout_margin_step_size}"
-            )
+            msg = f"readout_margin_step_size must be non-negative, got {readout_margin_step_size}"
             raise ValueError(msg)
         if readout_label_adapter_step_size < 0.0:
             msg = (
@@ -982,8 +934,7 @@ class UPGDLearner:
             raise ValueError(msg)
         if not 0.0 <= readout_label_adapter_floor < 1.0:
             msg = (
-                "readout_label_adapter_floor must be in [0, 1), "
-                f"got {readout_label_adapter_floor}"
+                f"readout_label_adapter_floor must be in [0, 1), got {readout_label_adapter_floor}"
             )
             raise ValueError(msg)
         if readout_fast_head_step_size_multiplier < 0.0:
@@ -1018,10 +969,7 @@ class UPGDLearner:
             )
             raise ValueError(msg)
         if not 0.0 <= readout_simplex_bias_decay <= 1.0:
-            msg = (
-                "readout_simplex_bias_decay must be in [0, 1], "
-                f"got {readout_simplex_bias_decay}"
-            )
+            msg = f"readout_simplex_bias_decay must be in [0, 1], got {readout_simplex_bias_decay}"
             raise ValueError(msg)
         if not 0.0 <= readout_simplex_bias_centering_rate <= 1.0:
             msg = (
@@ -1055,19 +1003,13 @@ class UPGDLearner:
         self._head_loss_pressure_warmup_steps = int(head_loss_pressure_warmup_steps)
         self._head_repetition_multiplier = float(head_repetition_multiplier)
         self._head_repetition_decay = float(head_repetition_decay)
-        self._head_repetition_delta_threshold = float(
-            head_repetition_delta_threshold
-        )
-        self._head_repetition_pressure_threshold = float(
-            head_repetition_pressure_threshold
-        )
+        self._head_repetition_delta_threshold = float(head_repetition_delta_threshold)
+        self._head_repetition_pressure_threshold = float(head_repetition_pressure_threshold)
         self._head_repetition_warmup_steps = int(head_repetition_warmup_steps)
         self._unit_replacement_rate = float(unit_replacement_rate)
         self._unit_maturity_threshold = int(unit_maturity_threshold)
         self._unit_utility_decay = (
-            float(utility_decay)
-            if unit_utility_decay is None
-            else float(unit_utility_decay)
+            float(utility_decay) if unit_utility_decay is None else float(unit_utility_decay)
         )
         self._unit_long_utility_decay = float(unit_long_utility_decay)
         self._unit_gradient_decay = float(unit_gradient_decay)
@@ -1077,9 +1019,7 @@ class UPGDLearner:
         self._unit_replacement_budget_mode = unit_replacement_budget_mode
         self._unit_replacement_outgoing_scale = float(unit_replacement_outgoing_scale)
         self._unit_replacement_partial_fanin = int(unit_replacement_partial_fanin)
-        self._unit_replacement_score_threshold = float(
-            unit_replacement_score_threshold
-        )
+        self._unit_replacement_score_threshold = float(unit_replacement_score_threshold)
         self._unit_outgoing_utility_weight = float(unit_outgoing_utility_weight)
         self._track_unit_utilities = bool(track_unit_utilities)
         self._track_gradient_history = bool(track_gradient_history)
@@ -1092,34 +1032,18 @@ class UPGDLearner:
         self._adaptive_kappa_exponent = float(adaptive_kappa_exponent)
         self._adaptive_kappa_warmup_steps = int(adaptive_kappa_warmup_steps)
         self._adaptive_kappa_meta_step_size = float(adaptive_kappa_meta_step_size)
-        self._adaptive_kappa_meta_min_multiplier = float(
-            adaptive_kappa_meta_min_multiplier
-        )
-        self._adaptive_kappa_meta_max_multiplier = float(
-            adaptive_kappa_meta_max_multiplier
-        )
-        self._adaptive_kappa_meta_warmup_steps = int(
-            adaptive_kappa_meta_warmup_steps
-        )
+        self._adaptive_kappa_meta_min_multiplier = float(adaptive_kappa_meta_min_multiplier)
+        self._adaptive_kappa_meta_max_multiplier = float(adaptive_kappa_meta_max_multiplier)
+        self._adaptive_kappa_meta_warmup_steps = int(adaptive_kappa_meta_warmup_steps)
         self._meta_plasticity_mode = meta_plasticity_mode
         self._meta_plasticity_step_size = float(meta_plasticity_step_size)
-        self._meta_plasticity_min_multiplier = float(
-            meta_plasticity_min_multiplier
-        )
-        self._meta_plasticity_max_multiplier = float(
-            meta_plasticity_max_multiplier
-        )
+        self._meta_plasticity_min_multiplier = float(meta_plasticity_min_multiplier)
+        self._meta_plasticity_max_multiplier = float(meta_plasticity_max_multiplier)
         self._meta_plasticity_warmup_steps = int(meta_plasticity_warmup_steps)
         self._meta_plasticity_trunk_enabled = bool(meta_plasticity_trunk_enabled)
-        self._meta_plasticity_head_weight_enabled = bool(
-            meta_plasticity_head_weight_enabled
-        )
-        self._meta_plasticity_head_bias_enabled = bool(
-            meta_plasticity_head_bias_enabled
-        )
-        self._meta_plasticity_repetition_enabled = bool(
-            meta_plasticity_repetition_enabled
-        )
+        self._meta_plasticity_head_weight_enabled = bool(meta_plasticity_head_weight_enabled)
+        self._meta_plasticity_head_bias_enabled = bool(meta_plasticity_head_bias_enabled)
+        self._meta_plasticity_repetition_enabled = bool(meta_plasticity_repetition_enabled)
         self._readout_mode = readout_mode
         self._readout_loss_mode = resolved_readout_loss_mode
         self._readout_prediction_mode = resolved_readout_prediction_mode
@@ -1130,9 +1054,7 @@ class UPGDLearner:
         self._readout_head_normalization = readout_head_normalization
         self._readout_margin = float(readout_margin)
         self._readout_margin_step_size = float(readout_margin_step_size)
-        self._readout_label_adapter_step_size = float(
-            readout_label_adapter_step_size
-        )
+        self._readout_label_adapter_step_size = float(readout_label_adapter_step_size)
         self._readout_label_adapter_identity_regularization = float(
             readout_label_adapter_identity_regularization
         )
@@ -1140,23 +1062,17 @@ class UPGDLearner:
             readout_label_adapter_entropy_regularization
         )
         self._readout_label_adapter_floor = float(readout_label_adapter_floor)
-        self._readout_fast_head_step_size_multiplier = float(
-            readout_fast_head_step_size_multiplier
-        )
+        self._readout_fast_head_step_size_multiplier = float(readout_fast_head_step_size_multiplier)
         self._readout_fast_head_bias_step_size_multiplier = float(
             readout_fast_head_bias_step_size_multiplier
         )
-        self._readout_fast_trunk_gradient_multiplier = float(
-            readout_fast_trunk_gradient_multiplier
-        )
+        self._readout_fast_trunk_gradient_multiplier = float(readout_fast_trunk_gradient_multiplier)
         self._readout_fast_head_bounder_mode = readout_fast_head_bounder_mode
         self._readout_slow_simplex_gradient_multiplier = float(
             readout_slow_simplex_gradient_multiplier
         )
         self._readout_simplex_bias_decay = float(readout_simplex_bias_decay)
-        self._readout_simplex_bias_centering_rate = float(
-            readout_simplex_bias_centering_rate
-        )
+        self._readout_simplex_bias_centering_rate = float(readout_simplex_bias_centering_rate)
 
     @property
     def n_heads(self) -> int:
@@ -1283,19 +1199,13 @@ class UPGDLearner:
                 readout_label_adapter_entropy_regularization
             ),
             readout_label_adapter_floor=readout_label_adapter_floor,
-            readout_fast_head_step_size_multiplier=(
-                readout_fast_head_step_size_multiplier
-            ),
+            readout_fast_head_step_size_multiplier=(readout_fast_head_step_size_multiplier),
             readout_fast_head_bias_step_size_multiplier=(
                 readout_fast_head_bias_step_size_multiplier
             ),
-            readout_fast_trunk_gradient_multiplier=(
-                readout_fast_trunk_gradient_multiplier
-            ),
+            readout_fast_trunk_gradient_multiplier=(readout_fast_trunk_gradient_multiplier),
             readout_fast_head_bounder_mode=readout_fast_head_bounder_mode,
-            readout_slow_simplex_gradient_multiplier=(
-                readout_slow_simplex_gradient_multiplier
-            ),
+            readout_slow_simplex_gradient_multiplier=(readout_slow_simplex_gradient_multiplier),
             track_unit_utilities=False,
             track_gradient_history=False,
         )
@@ -1393,22 +1303,14 @@ class UPGDLearner:
             "negative_target_loss_scale": self._negative_target_loss_scale,
             "head_gradient_scale": self._head_gradient_scale,
             "head_step_size_multiplier": self._head_step_size_multiplier,
-            "head_bias_step_size_multiplier": (
-                self._head_bias_step_size_multiplier
-            ),
+            "head_bias_step_size_multiplier": (self._head_bias_step_size_multiplier),
             "head_loss_pressure_gate_ratio": self._head_loss_pressure_gate_ratio,
             "head_loss_pressure_multiplier": self._head_loss_pressure_multiplier,
-            "head_loss_pressure_warmup_steps": (
-                self._head_loss_pressure_warmup_steps
-            ),
+            "head_loss_pressure_warmup_steps": (self._head_loss_pressure_warmup_steps),
             "head_repetition_multiplier": self._head_repetition_multiplier,
             "head_repetition_decay": self._head_repetition_decay,
-            "head_repetition_delta_threshold": (
-                self._head_repetition_delta_threshold
-            ),
-            "head_repetition_pressure_threshold": (
-                self._head_repetition_pressure_threshold
-            ),
+            "head_repetition_delta_threshold": (self._head_repetition_delta_threshold),
+            "head_repetition_pressure_threshold": (self._head_repetition_pressure_threshold),
             "head_repetition_warmup_steps": self._head_repetition_warmup_steps,
             "unit_replacement_rate": self._unit_replacement_rate,
             "unit_maturity_threshold": self._unit_maturity_threshold,
@@ -1417,19 +1319,11 @@ class UPGDLearner:
             "unit_gradient_decay": self._unit_gradient_decay,
             "unit_replacement_criterion": self._unit_replacement_criterion,
             "unit_replacement_fanin": self._unit_replacement_fanin,
-            "unit_replacement_loss_gate_ratio": (
-                self._unit_replacement_loss_gate_ratio
-            ),
+            "unit_replacement_loss_gate_ratio": (self._unit_replacement_loss_gate_ratio),
             "unit_replacement_budget_mode": self._unit_replacement_budget_mode,
-            "unit_replacement_outgoing_scale": (
-                self._unit_replacement_outgoing_scale
-            ),
-            "unit_replacement_partial_fanin": (
-                self._unit_replacement_partial_fanin
-            ),
-            "unit_replacement_score_threshold": (
-                self._unit_replacement_score_threshold
-            ),
+            "unit_replacement_outgoing_scale": (self._unit_replacement_outgoing_scale),
+            "unit_replacement_partial_fanin": (self._unit_replacement_partial_fanin),
+            "unit_replacement_score_threshold": (self._unit_replacement_score_threshold),
             "unit_outgoing_utility_weight": self._unit_outgoing_utility_weight,
             "track_unit_utilities": self._track_unit_utilities,
             "track_gradient_history": self._track_gradient_history,
@@ -1441,41 +1335,19 @@ class UPGDLearner:
             "adaptive_kappa_max": self._adaptive_kappa_max,
             "adaptive_kappa_exponent": self._adaptive_kappa_exponent,
             "adaptive_kappa_warmup_steps": self._adaptive_kappa_warmup_steps,
-            "adaptive_kappa_meta_step_size": (
-                self._adaptive_kappa_meta_step_size
-            ),
-            "adaptive_kappa_meta_min_multiplier": (
-                self._adaptive_kappa_meta_min_multiplier
-            ),
-            "adaptive_kappa_meta_max_multiplier": (
-                self._adaptive_kappa_meta_max_multiplier
-            ),
-            "adaptive_kappa_meta_warmup_steps": (
-                self._adaptive_kappa_meta_warmup_steps
-            ),
+            "adaptive_kappa_meta_step_size": (self._adaptive_kappa_meta_step_size),
+            "adaptive_kappa_meta_min_multiplier": (self._adaptive_kappa_meta_min_multiplier),
+            "adaptive_kappa_meta_max_multiplier": (self._adaptive_kappa_meta_max_multiplier),
+            "adaptive_kappa_meta_warmup_steps": (self._adaptive_kappa_meta_warmup_steps),
             "meta_plasticity_mode": self._meta_plasticity_mode,
             "meta_plasticity_step_size": self._meta_plasticity_step_size,
-            "meta_plasticity_min_multiplier": (
-                self._meta_plasticity_min_multiplier
-            ),
-            "meta_plasticity_max_multiplier": (
-                self._meta_plasticity_max_multiplier
-            ),
-            "meta_plasticity_warmup_steps": (
-                self._meta_plasticity_warmup_steps
-            ),
-            "meta_plasticity_trunk_enabled": (
-                self._meta_plasticity_trunk_enabled
-            ),
-            "meta_plasticity_head_weight_enabled": (
-                self._meta_plasticity_head_weight_enabled
-            ),
-            "meta_plasticity_head_bias_enabled": (
-                self._meta_plasticity_head_bias_enabled
-            ),
-            "meta_plasticity_repetition_enabled": (
-                self._meta_plasticity_repetition_enabled
-            ),
+            "meta_plasticity_min_multiplier": (self._meta_plasticity_min_multiplier),
+            "meta_plasticity_max_multiplier": (self._meta_plasticity_max_multiplier),
+            "meta_plasticity_warmup_steps": (self._meta_plasticity_warmup_steps),
+            "meta_plasticity_trunk_enabled": (self._meta_plasticity_trunk_enabled),
+            "meta_plasticity_head_weight_enabled": (self._meta_plasticity_head_weight_enabled),
+            "meta_plasticity_head_bias_enabled": (self._meta_plasticity_head_bias_enabled),
+            "meta_plasticity_repetition_enabled": (self._meta_plasticity_repetition_enabled),
             "readout_mode": self._readout_mode,
             "readout_loss_mode": self._readout_loss_mode,
             "readout_prediction_mode": self._readout_prediction_mode,
@@ -1486,9 +1358,7 @@ class UPGDLearner:
             "readout_head_normalization": self._readout_head_normalization,
             "readout_margin": self._readout_margin,
             "readout_margin_step_size": self._readout_margin_step_size,
-            "readout_label_adapter_step_size": (
-                self._readout_label_adapter_step_size
-            ),
+            "readout_label_adapter_step_size": (self._readout_label_adapter_step_size),
             "readout_label_adapter_identity_regularization": (
                 self._readout_label_adapter_identity_regularization
             ),
@@ -1510,9 +1380,7 @@ class UPGDLearner:
                 self._readout_slow_simplex_gradient_multiplier
             ),
             "readout_simplex_bias_decay": self._readout_simplex_bias_decay,
-            "readout_simplex_bias_centering_rate": (
-                self._readout_simplex_bias_centering_rate
-            ),
+            "readout_simplex_bias_centering_rate": (self._readout_simplex_bias_centering_rate),
         }
 
     @classmethod
@@ -1639,24 +1507,16 @@ class UPGDLearner:
             meta_repetition_log_scale=jnp.array(0.0, dtype=jnp.float32),
             adaptive_kappa_log_scale=jnp.array(0.0, dtype=jnp.float32),
             previous_trunk_weight_grads=(
-                tuple(jnp.zeros_like(w) for w in trunk_weights)
-                if store_gradient_history
-                else ()
+                tuple(jnp.zeros_like(w) for w in trunk_weights) if store_gradient_history else ()
             ),
             previous_trunk_bias_grads=(
-                tuple(jnp.zeros_like(b) for b in trunk_biases)
-                if store_gradient_history
-                else ()
+                tuple(jnp.zeros_like(b) for b in trunk_biases) if store_gradient_history else ()
             ),
             previous_head_weight_grads=(
-                tuple(jnp.zeros_like(w) for w in head_weights)
-                if store_gradient_history
-                else ()
+                tuple(jnp.zeros_like(w) for w in head_weights) if store_gradient_history else ()
             ),
             previous_head_bias_grads=(
-                tuple(jnp.zeros_like(b) for b in head_biases)
-                if store_gradient_history
-                else ()
+                tuple(jnp.zeros_like(b) for b in head_biases) if store_gradient_history else ()
             ),
             key=key,
             step_count=jnp.array(0, dtype=jnp.int32),
@@ -1788,10 +1648,7 @@ class UPGDLearner:
             return adaptive_gate * adapted + (1.0 - adaptive_gate) * logits
         if self._readout_prediction_mode == "two_timescale_simplex":
             fast = logits if fast_logits is None else fast_logits
-            return (
-                adaptive_gate * self._softmax_predictions(fast)
-                + (1.0 - adaptive_gate) * logits
-            )
+            return adaptive_gate * self._softmax_predictions(fast) + (1.0 - adaptive_gate) * logits
         if self._readout_prediction_mode == "unit_clip":
             return jnp.clip(logits, 0.0, 1.0)
         return logits
@@ -1812,10 +1669,7 @@ class UPGDLearner:
         scale = 1.0 / jnp.maximum(bound_magnitude, 1.0)
         collapsed = scale == 0
         return (
-            tuple(
-                zero_if_collapsed_infinity(scale * step, step, collapsed)
-                for step in steps
-            ),
+            tuple(zero_if_collapsed_infinity(scale * step, step, collapsed) for step in steps),
             scale,
         )
 
@@ -1845,8 +1699,7 @@ class UPGDLearner:
         current_norm = UPGDLearner._tuple_norm(current)
         return jnp.where(
             (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current)
-            / (previous_norm * current_norm + 1e-12),
+            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
             jnp.array(0.0, dtype=jnp.float32),
         )
 
@@ -1931,9 +1784,7 @@ class UPGDLearner:
         """
         targets = jnp.asarray(targets, dtype=jnp.float32)
         if targets.shape != (self._n_heads,):
-            raise ValueError(
-                f"targets must have shape ({self._n_heads},), got {targets.shape}"
-            )
+            raise ValueError(f"targets must have shape ({self._n_heads},), got {targets.shape}")
         slope = self._leaky_relu_slope
         ln = self._use_layer_norm
         sigma = jnp.array(self._perturbation_sigma, dtype=jnp.float32)
@@ -1960,22 +1811,14 @@ class UPGDLearner:
         safe_targets = jnp.where(active_mask, targets, 0.0)
         n_active = jnp.maximum(jnp.sum(active_mask.astype(jnp.float32)), 1.0)
         n_nonzero_targets = jnp.maximum(
-            jnp.sum(
-                jnp.logical_and(active_mask, jnp.abs(safe_targets) > 1e-8).astype(
-                    jnp.float32
-                )
-            ),
+            jnp.sum(jnp.logical_and(active_mask, jnp.abs(safe_targets) > 1e-8).astype(jnp.float32)),
             1.0,
         )
         active_targets = jnp.where(active_mask, safe_targets, 0.0)
         target_mass = jnp.sum(jnp.where(active_mask, active_targets, 0.0))
-        has_negative_target = jnp.any(
-            jnp.logical_and(active_mask, active_targets < -1e-6)
-        )
+        has_negative_target = jnp.any(jnp.logical_and(active_mask, active_targets < -1e-6))
         simplex_like_target = (
-            (~has_negative_target)
-            & (target_mass > 1e-8)
-            & (jnp.abs(target_mass - 1.0) <= 1e-5)
+            (~has_negative_target) & (target_mass > 1e-8) & (jnp.abs(target_mass - 1.0) <= 1e-5)
         )
         adaptive_simplex_gate = jnp.where(
             simplex_like_target & (self._n_heads > 1),
@@ -2033,8 +1876,7 @@ class UPGDLearner:
                 )
                 target_probs = jnp.where(
                     active_mask,
-                    jnp.maximum(safe_targets, 0.0)
-                    / jnp.maximum(active_target_mass, 1e-12),
+                    jnp.maximum(safe_targets, 0.0) / jnp.maximum(active_target_mass, 1e-12),
                     0.0,
                 )
                 ce = -jnp.sum(target_probs * jnp.log(probs + 1e-8))
@@ -2043,17 +1885,13 @@ class UPGDLearner:
                     ce,
                     jnp.array(0.0, dtype=ce.dtype),
                 )
-                brier = 0.5 * jnp.sum(
-                    jnp.where(active_mask, (probs - target_probs) ** 2, 0.0)
-                )
+                brier = 0.5 * jnp.sum(jnp.where(active_mask, (probs - target_probs) ** 2, 0.0))
                 brier_loss = jnp.where(
                     active_target_mass > 0.0,
                     brier,
                     jnp.array(0.0, dtype=brier.dtype),
                 )
-                target_confidence = jnp.sum(
-                    target_probs * (probs ** robust_q)
-                )
+                target_confidence = jnp.sum(target_probs * (probs**robust_q))
                 gce = (1.0 - target_confidence) / robust_q
                 gce_loss = jnp.where(
                     active_target_mass > 0.0,
@@ -2091,23 +1929,20 @@ class UPGDLearner:
                 elif self._readout_loss_mode == "adaptive_gce":
                     loss = jnp.where(
                         simplex_like_target,
-                        adaptive_simplex_gate * ce_loss
-                        + (1.0 - adaptive_simplex_gate) * gce_loss,
+                        adaptive_simplex_gate * ce_loss + (1.0 - adaptive_simplex_gate) * gce_loss,
                         mse_loss,
                     )
                 elif self._readout_loss_mode == "adaptive_factorized_simplex":
                     loss = jnp.where(
                         simplex_like_target,
-                        adaptive_simplex_gate * ce_loss
-                        + (1.0 - adaptive_simplex_gate) * mse_loss,
+                        adaptive_simplex_gate * ce_loss + (1.0 - adaptive_simplex_gate) * mse_loss,
                         mse_loss,
                     )
                 elif self._readout_loss_mode == "two_timescale_simplex":
                     loss = slow_simplex_gradient_scale * mse_loss
                 else:
                     loss = (
-                        adaptive_simplex_gate * ce_loss
-                        + (1.0 - adaptive_simplex_gate) * mse_loss
+                        adaptive_simplex_gate * ce_loss + (1.0 - adaptive_simplex_gate) * mse_loss
                     )
                 # The gradient-budget scale shapes the differentiated objective only;
                 # the reported loss stays the unscaled prediction loss.
@@ -2152,6 +1987,7 @@ class UPGDLearner:
             )
             trunk_w_grads, trunk_b_grads, head_w_grads, head_b_grads = grads
         else:
+
             def trunk_fn(
                 weights: tuple[Array, ...],
                 biases: tuple[Array, ...],
@@ -2192,19 +2028,12 @@ class UPGDLearner:
             loss_value = 0.5 * jnp.sum(sq_masked) / denom
             logit_grads = jnp.where(
                 active_mask,
-                slow_simplex_gradient_scale
-                * target_loss_weights
-                * (logits - safe_targets)
-                / denom,
+                slow_simplex_gradient_scale * target_loss_weights * (logits - safe_targets) / denom,
                 0.0,
             )
             head_w_grad_matrix = logit_grads[:, None] * hidden_for_readout[None, :]
-            head_w_grads = tuple(
-                head_w_grad_matrix[i : i + 1] for i in range(self._n_heads)
-            )
-            head_b_grads = tuple(
-                logit_grads[i : i + 1] for i in range(self._n_heads)
-            )
+            head_w_grads = tuple(head_w_grad_matrix[i : i + 1] for i in range(self._n_heads))
+            head_b_grads = tuple(logit_grads[i : i + 1] for i in range(self._n_heads))
             if self._readout_input_mode == "hidden_plus_input" and n_trunk > 0:
                 hidden_dim = raw_hidden.shape[0]
                 head_cotangent = head_matrix[:, :hidden_dim].T @ logit_grads
@@ -2212,12 +2041,8 @@ class UPGDLearner:
                 head_cotangent = head_matrix.T @ logit_grads
             trunk_w_grads, trunk_b_grads = trunk_vjp_fn(head_cotangent)
         fast_logits = logits
-        fast_head_w_grads = tuple(
-            jnp.zeros_like(w) for w in state.readout_fast_head_params.weights
-        )
-        fast_head_b_grads = tuple(
-            jnp.zeros_like(b) for b in state.readout_fast_head_params.biases
-        )
+        fast_head_w_grads = tuple(jnp.zeros_like(w) for w in state.readout_fast_head_params.weights)
+        fast_head_b_grads = tuple(jnp.zeros_like(b) for b in state.readout_fast_head_params.biases)
         if self._readout_prediction_mode == "two_timescale_simplex":
             fast_head_matrix = jnp.concatenate(
                 state.readout_fast_head_params.weights,
@@ -2235,8 +2060,7 @@ class UPGDLearner:
             )
             fast_target_probs = jnp.where(
                 active_mask,
-                jnp.maximum(safe_targets, 0.0)
-                / jnp.maximum(active_target_mass, 1e-12),
+                jnp.maximum(safe_targets, 0.0) / jnp.maximum(active_target_mass, 1e-12),
                 0.0,
             )
             fast_logit_grads = jnp.where(
@@ -2244,24 +2068,18 @@ class UPGDLearner:
                 fast_probs - fast_target_probs,
                 0.0,
             )
-            fast_head_w_grad_matrix = (
-                fast_logit_grads[:, None] * hidden_for_readout[None, :]
-            )
+            fast_head_w_grad_matrix = fast_logit_grads[:, None] * hidden_for_readout[None, :]
             fast_head_w_grads = tuple(
                 fast_head_w_grad_matrix[i : i + 1] for i in range(self._n_heads)
             )
-            fast_head_b_grads = tuple(
-                fast_logit_grads[i : i + 1] for i in range(self._n_heads)
-            )
+            fast_head_b_grads = tuple(fast_logit_grads[i : i + 1] for i in range(self._n_heads))
             if self._readout_fast_trunk_gradient_multiplier > 0.0:
                 fast_head_cotangent = (
                     fast_head_matrix[:, : raw_hidden.shape[0]].T @ fast_logit_grads
                     if self._readout_input_mode == "hidden_plus_input" and n_trunk > 0
                     else fast_head_matrix.T @ fast_logit_grads
                 )
-                fast_trunk_w_grads, fast_trunk_b_grads = trunk_vjp_fn(
-                    fast_head_cotangent
-                )
+                fast_trunk_w_grads, fast_trunk_b_grads = trunk_vjp_fn(fast_head_cotangent)
                 fast_trunk_scale = (
                     jnp.asarray(
                         self._readout_fast_trunk_gradient_multiplier,
@@ -2270,12 +2088,10 @@ class UPGDLearner:
                     * adaptive_simplex_gate
                 )
                 trunk_w_grads = tuple(
-                    g + fast_trunk_scale * fg
-                    for g, fg in zip(trunk_w_grads, fast_trunk_w_grads)
+                    g + fast_trunk_scale * fg for g, fg in zip(trunk_w_grads, fast_trunk_w_grads)
                 )
                 trunk_b_grads = tuple(
-                    g + fast_trunk_scale * fg
-                    for g, fg in zip(trunk_b_grads, fast_trunk_b_grads)
+                    g + fast_trunk_scale * fg for g, fg in zip(trunk_b_grads, fast_trunk_b_grads)
                 )
         predictions = self._prediction_from_logits(
             logits,
@@ -2289,12 +2105,10 @@ class UPGDLearner:
         fast_decay = jnp.asarray(self._loss_fast_decay, dtype=jnp.float32)
         slow_decay = jnp.asarray(self._loss_slow_decay, dtype=jnp.float32)
         new_loss_fast_ema = (
-            _skip_zero_scale(fast_decay, state.loss_fast_ema)
-            + (1.0 - fast_decay) * step_mse
+            _skip_zero_scale(fast_decay, state.loss_fast_ema) + (1.0 - fast_decay) * step_mse
         )
         new_loss_slow_ema = (
-            _skip_zero_scale(slow_decay, state.loss_slow_ema)
-            + (1.0 - slow_decay) * step_mse
+            _skip_zero_scale(slow_decay, state.loss_slow_ema) + (1.0 - slow_decay) * step_mse
         )
         loss_pressure = jnp.array(1.0, dtype=jnp.float32)
         if self._unit_replacement_loss_gate_ratio > 0.0:
@@ -2310,10 +2124,7 @@ class UPGDLearner:
                 1.0,
             )
         head_loss_pressure = jnp.array(0.0, dtype=jnp.float32)
-        if (
-            self._head_loss_pressure_gate_ratio > 0.0
-            and self._head_loss_pressure_multiplier > 0.0
-        ):
+        if self._head_loss_pressure_gate_ratio > 0.0 and self._head_loss_pressure_multiplier > 0.0:
             head_threshold = jnp.asarray(
                 self._head_loss_pressure_gate_ratio,
                 dtype=jnp.float32,
@@ -2339,14 +2150,12 @@ class UPGDLearner:
             dtype=jnp.float32,
         )
         repetition_decay = jnp.asarray(self._head_repetition_decay, dtype=jnp.float32)
-        new_target_repeat_ema = (
-            _skip_zero_scale(repetition_decay, state.target_repeat_ema)
-            + (1.0 - repetition_decay) * repeat_now.astype(jnp.float32)
-        )
-        new_target_simplex_ema = (
-            _skip_zero_scale(repetition_decay, state.target_simplex_ema)
-            + (1.0 - repetition_decay) * simplex_like_target.astype(jnp.float32)
-        )
+        new_target_repeat_ema = _skip_zero_scale(repetition_decay, state.target_repeat_ema) + (
+            1.0 - repetition_decay
+        ) * repeat_now.astype(jnp.float32)
+        new_target_simplex_ema = _skip_zero_scale(repetition_decay, state.target_simplex_ema) + (
+            1.0 - repetition_decay
+        ) * simplex_like_target.astype(jnp.float32)
         repetition_warm = state.step_count >= jnp.asarray(
             self._head_repetition_warmup_steps,
             dtype=jnp.int32,
@@ -2423,19 +2232,18 @@ class UPGDLearner:
             )
             * repetition_meta_scale
         )
-        head_scale = head_scale * (
-            1.0
-            + effective_repetition_multiplier * head_repetition_pressure
-        )
+        head_scale = head_scale * (1.0 + effective_repetition_multiplier * head_repetition_pressure)
         head_w_scale = head_scale * head_weight_meta_scale
-        head_b_scale = head_scale * head_bias_meta_scale * jnp.asarray(
-            self._head_bias_step_size_multiplier,
-            dtype=jnp.float32,
+        head_b_scale = (
+            head_scale
+            * head_bias_meta_scale
+            * jnp.asarray(
+                self._head_bias_step_size_multiplier,
+                dtype=jnp.float32,
+            )
         )
         if self._readout_head_normalization == "hidden_norm":
-            norm_scale = 1.0 / (
-                1.0 + jnp.sum(jnp.square(hidden_for_readout))
-            )
+            norm_scale = 1.0 / (1.0 + jnp.sum(jnp.square(hidden_for_readout)))
             head_w_scale = head_w_scale * norm_scale
             head_b_scale = head_b_scale * norm_scale
         head_w_steps = tuple(-step_size * head_w_scale * g for g in head_w_grads)
@@ -2451,12 +2259,8 @@ class UPGDLearner:
         if self._readout_head_normalization == "hidden_norm":
             fast_head_w_scale = fast_head_w_scale * norm_scale
             fast_head_b_scale = fast_head_b_scale * norm_scale
-        fast_head_w_steps = tuple(
-            -step_size * fast_head_w_scale * g for g in fast_head_w_grads
-        )
-        fast_head_b_steps = tuple(
-            -step_size * fast_head_b_scale * g for g in fast_head_b_grads
-        )
+        fast_head_w_steps = tuple(-step_size * fast_head_w_scale * g for g in fast_head_w_grads)
+        fast_head_b_steps = tuple(-step_size * fast_head_b_scale * g for g in fast_head_b_grads)
         bound_fast_readout = self._readout_prediction_mode == "two_timescale_simplex"
         bound_fast_readout_shared = (
             bound_fast_readout and self._readout_fast_head_bounder_mode == "shared"
@@ -2498,9 +2302,7 @@ class UPGDLearner:
                     dtype=jnp.float32,
                 )
                 if self._adaptive_kappa_mode == "loss_ratio":
-                    loss_ratio_for_kappa = new_loss_fast_ema / (
-                        new_loss_slow_ema + 1e-12
-                    )
+                    loss_ratio_for_kappa = new_loss_fast_ema / (new_loss_slow_ema + 1e-12)
                     raw_kappa = raw_kappa / (
                         jnp.maximum(loss_ratio_for_kappa, 1e-6)
                         ** jnp.asarray(
@@ -2538,17 +2340,11 @@ class UPGDLearner:
             trunk_w_steps = tuple(bounded_steps[idx + 2 * i] for i in range(n_trunk))
             trunk_b_steps = tuple(bounded_steps[idx + 2 * i + 1] for i in range(n_trunk))
             idx = 2 * n_trunk
-            head_w_steps = tuple(
-                bounded_steps[idx + 2 * i] for i in range(self._n_heads)
-            )
-            head_b_steps = tuple(
-                bounded_steps[idx + 2 * i + 1] for i in range(self._n_heads)
-            )
+            head_w_steps = tuple(bounded_steps[idx + 2 * i] for i in range(self._n_heads))
+            head_b_steps = tuple(bounded_steps[idx + 2 * i + 1] for i in range(self._n_heads))
             if bound_fast_readout_shared:
                 idx = idx + 2 * self._n_heads
-                fast_head_w_steps = tuple(
-                    bounded_steps[idx + 2 * i] for i in range(self._n_heads)
-                )
+                fast_head_w_steps = tuple(bounded_steps[idx + 2 * i] for i in range(self._n_heads))
                 fast_head_b_steps = tuple(
                     bounded_steps[idx + 2 * i + 1] for i in range(self._n_heads)
                 )
@@ -2566,9 +2362,7 @@ class UPGDLearner:
                         dtype=jnp.float32,
                     )
                     if self._adaptive_kappa_mode == "loss_ratio":
-                        loss_ratio_for_kappa = new_loss_fast_ema / (
-                            new_loss_slow_ema + 1e-12
-                        )
+                        loss_ratio_for_kappa = new_loss_fast_ema / (new_loss_slow_ema + 1e-12)
                         raw_kappa = raw_kappa / (
                             jnp.maximum(loss_ratio_for_kappa, 1e-6)
                             ** jnp.asarray(
@@ -2603,9 +2397,7 @@ class UPGDLearner:
                         mean_abs_err,
                         tuple(fast_params),
                     )
-                fast_head_w_steps = tuple(
-                    bounded_fast_steps[2 * i] for i in range(self._n_heads)
-                )
+                fast_head_w_steps = tuple(bounded_fast_steps[2 * i] for i in range(self._n_heads))
                 fast_head_b_steps = tuple(
                     bounded_fast_steps[2 * i + 1] for i in range(self._n_heads)
                 )
@@ -2618,12 +2410,10 @@ class UPGDLearner:
             state.trunk_params.biases[i] + trunk_b_steps[i] for i in range(n_trunk)
         )
         new_head_weights = tuple(
-            state.head_params.weights[i] + head_w_steps[i]
-            for i in range(self._n_heads)
+            state.head_params.weights[i] + head_w_steps[i] for i in range(self._n_heads)
         )
         new_head_biases = tuple(
-            state.head_params.biases[i] + head_b_steps[i]
-            for i in range(self._n_heads)
+            state.head_params.biases[i] + head_b_steps[i] for i in range(self._n_heads)
         )
         new_fast_head_weights = tuple(
             state.readout_fast_head_params.weights[i] + fast_head_w_steps[i]
@@ -2637,12 +2427,8 @@ class UPGDLearner:
         new_head_biases_list = list(new_head_biases)
 
         if self._readout_margin_step_size > 0.0 and self._n_heads > 1:
-            target_mass = jnp.sum(
-                jnp.where(active_mask, jnp.maximum(safe_targets, 0.0), 0.0)
-            )
-            true_idx = jnp.argmax(
-                jnp.where(active_mask, safe_targets, -jnp.inf)
-            ).astype(jnp.int32)
+            target_mass = jnp.sum(jnp.where(active_mask, jnp.maximum(safe_targets, 0.0), 0.0))
+            true_idx = jnp.argmax(jnp.where(active_mask, safe_targets, -jnp.inf)).astype(jnp.int32)
             head_indices = jnp.arange(self._n_heads, dtype=jnp.int32)
             wrong_logits = jnp.where(
                 jnp.logical_and(active_mask, head_indices != true_idx),
@@ -2655,9 +2441,8 @@ class UPGDLearner:
                 target_mass > 0.0,
                 margin < jnp.asarray(self._readout_margin, dtype=jnp.float32),
             )
-            margin_scale = (
-                jnp.asarray(self._readout_margin_step_size, dtype=jnp.float32)
-                / (1.0 + jnp.sum(jnp.square(hidden_for_readout)))
+            margin_scale = jnp.asarray(self._readout_margin_step_size, dtype=jnp.float32) / (
+                1.0 + jnp.sum(jnp.square(hidden_for_readout))
             )
             margin_delta = margin_scale * hidden_for_readout
             bias_delta = jnp.asarray(self._readout_margin_step_size, dtype=jnp.float32)
@@ -2668,12 +2453,8 @@ class UPGDLearner:
                     jnp.where(h == wrong_idx, jnp.float32(-1.0), jnp.float32(0.0)),
                 )
                 signed = jnp.where(do_margin, sign, jnp.float32(0.0))
-                new_head_weights_list[h] = (
-                    new_head_weights_list[h] + signed * margin_delta[None, :]
-                )
-                new_head_biases_list[h] = (
-                    new_head_biases_list[h] + signed * bias_delta
-                )
+                new_head_weights_list[h] = new_head_weights_list[h] + signed * margin_delta[None, :]
+                new_head_biases_list[h] = new_head_biases_list[h] + signed * bias_delta
 
         if (
             self._readout_simplex_bias_decay > 0.0
@@ -2690,9 +2471,7 @@ class UPGDLearner:
                 (1.0 - bias_decay) * bias_vector,
                 bias_vector,
             )
-            active_mean_bias = (
-                jnp.sum(active_bias_mask * decayed_bias_vector) / n_active
-            )
+            active_mean_bias = jnp.sum(active_bias_mask * decayed_bias_vector) / n_active
             centering_rate = jnp.asarray(
                 self._readout_simplex_bias_centering_rate,
                 dtype=jnp.float32,
@@ -2708,14 +2487,11 @@ class UPGDLearner:
                 centered_bias_vector,
                 bias_vector,
             )
-            new_head_biases_list = [
-                anti_drift_bias_vector[h : h + 1] for h in range(self._n_heads)
-            ]
+            new_head_biases_list = [anti_drift_bias_vector[h : h + 1] for h in range(self._n_heads)]
 
         new_readout_label_adapter = state.readout_label_adapter
         if (
-            self._readout_prediction_mode
-            in {"factorized_simplex", "adaptive_factorized_simplex"}
+            self._readout_prediction_mode in {"factorized_simplex", "adaptive_factorized_simplex"}
             and self._n_heads > 1
         ):
             adapter_eta = jnp.asarray(
@@ -2777,10 +2553,7 @@ class UPGDLearner:
         new_unit_ages: list[Array] = []
         for i in range(n_trunk):
             instantaneous = jnp.abs(state.trunk_params.weights[i] * trunk_w_grads[i])
-            u_new = (
-                _skip_zero_scale(decay, state.utilities[i])
-                + (1.0 - decay) * instantaneous
-            )
+            u_new = _skip_zero_scale(decay, state.utilities[i]) + (1.0 - decay) * instantaneous
             new_utilities.append(u_new)
 
             if track_unit_utilities:
@@ -2791,10 +2564,7 @@ class UPGDLearner:
                 unit_signal = jnp.mean(instantaneous, axis=1)
                 if self._unit_outgoing_utility_weight > 0.0:
                     if i < n_trunk - 1:
-                        outgoing = jnp.abs(
-                            state.trunk_params.weights[i + 1]
-                            * trunk_w_grads[i + 1]
-                        )
+                        outgoing = jnp.abs(state.trunk_params.weights[i + 1] * trunk_w_grads[i + 1])
                         outgoing_signal = jnp.mean(outgoing, axis=0)
                     else:
                         layer_size = state.trunk_params.weights[i].shape[0]
@@ -3017,10 +2787,7 @@ class UPGDLearner:
                 # right now, as in the reference GnT scheduler; immature units
                 # earn no budget, so warm-up cannot bank a replacement burst.
                 n_mature = jnp.sum(mature).astype(jnp.float32)
-                accum = (
-                    state.unit_replacement_accumulators[i]
-                    + rate * n_mature * rate_scale
-                )
+                accum = state.unit_replacement_accumulators[i] + rate * n_mature * rate_scale
                 do_replace = accum >= 1.0
                 gated = jnp.logical_and(
                     jnp.logical_and(
@@ -3045,10 +2812,14 @@ class UPGDLearner:
                     )
                     utility_scores = new_utilities[i][unit_idx]
                     bottom_idx = jax.lax.top_k(-utility_scores, replace_count)[1]
-                    partial_mask = jnp.zeros(
-                        (layer_w.shape[1],),
-                        dtype=jnp.float32,
-                    ).at[bottom_idx].set(1.0)
+                    partial_mask = (
+                        jnp.zeros(
+                            (layer_w.shape[1],),
+                            dtype=jnp.float32,
+                        )
+                        .at[bottom_idx]
+                        .set(1.0)
+                    )
                     sampled = jnp.where(
                         partial_mask > 0.0,
                         sampled,
@@ -3120,9 +2891,7 @@ class UPGDLearner:
                     jnp.where(gated, jnp.int32(0), unit_age[unit_idx])
                 )
                 # Never carry more than the one replacement a step can deliver.
-                new_accumulators.append(
-                    jnp.minimum(jnp.where(gated, accum - 1.0, accum), 1.0)
-                )
+                new_accumulators.append(jnp.minimum(jnp.where(gated, accum - 1.0, accum), 1.0))
                 new_replacement_counts.append(
                     unit_replacement_counts[i] + gated.astype(jnp.float32)
                 )
@@ -3188,8 +2957,7 @@ class UPGDLearner:
                 trunk_w_grads + trunk_b_grads + head_w_grads + head_b_grads,
             )
             updated_kappa_log_scale = jnp.clip(
-                state.adaptive_kappa_log_scale
-                - kappa_meta_eta * global_alignment,
+                state.adaptive_kappa_log_scale - kappa_meta_eta * global_alignment,
                 kappa_min_log,
                 kappa_max_log,
             )
@@ -3305,9 +3073,7 @@ class UPGDLearner:
             uptime_s=state.uptime_s,
         )
 
-        metrics = jnp.stack(
-            [loss_value, mean_utility, min_utility, max_perturbation_magnitude]
-        )
+        metrics = jnp.stack([loss_value, mean_utility, min_utility, max_perturbation_magnitude])
 
         return UPGDUpdateResult(  # type: ignore[call-arg]
             state=new_state,
@@ -3342,9 +3108,7 @@ def run_upgd_arrays(
         4-column metrics array.
     """
 
-    def step_fn(
-        carry: UPGDState, inputs: tuple[Array, Array]
-    ) -> tuple[UPGDState, Array]:
+    def step_fn(carry: UPGDState, inputs: tuple[Array, Array]) -> tuple[UPGDState, Array]:
         obs, tgt = inputs
         result = learner.update(carry, obs, tgt)
         return result.state, result.metrics
@@ -3389,9 +3153,7 @@ def run_upgd_loop[StreamStateT](
 
     n_heads = learner.n_heads
 
-    def step_fn(
-        carry: tuple[UPGDState, Any], idx: Array
-    ) -> tuple[tuple[UPGDState, Any], Array]:
+    def step_fn(carry: tuple[UPGDState, Any], idx: Array) -> tuple[tuple[UPGDState, Any], Array]:
         l_state, s_state = carry
         timestep, new_s_state = stream.step(s_state, idx)
         # Broadcast scalar/single-element target across heads.

--- a/tests/test_upgd_leftover_constructor_identities.py
+++ b/tests/test_upgd_leftover_constructor_identities.py
@@ -1,0 +1,75 @@
+"""Tests for UPGDLearner constructor scalar validation."""
+
+import pytest
+
+from alberta_framework.core.upgd import UPGDLearner
+
+
+def test_upgd_constructor_scalars_reject_booleans_and_nans() -> None:
+    # utility_decay
+    with pytest.raises(ValueError, match="utility_decay"):
+        UPGDLearner(n_heads=1, utility_decay=False)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="utility_decay"):
+        UPGDLearner(n_heads=1, utility_decay=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="utility_decay"):
+        UPGDLearner(n_heads=1, utility_decay=float("nan"))
+
+    with pytest.raises(ValueError, match="utility_decay"):
+        UPGDLearner(n_heads=1, utility_decay=1.0)
+
+    # sparsity
+    with pytest.raises(ValueError, match="sparsity"):
+        UPGDLearner(n_heads=1, sparsity=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="sparsity"):
+        UPGDLearner(n_heads=1, sparsity=False)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="sparsity"):
+        UPGDLearner(n_heads=1, sparsity=float("nan"))
+
+    # head_step_size_multiplier
+    with pytest.raises(ValueError, match="head_step_size_multiplier"):
+        UPGDLearner(n_heads=1, head_step_size_multiplier=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="head_step_size_multiplier"):
+        UPGDLearner(n_heads=1, head_step_size_multiplier=float("nan"))
+
+    with pytest.raises(ValueError, match="head_step_size_multiplier"):
+        UPGDLearner(n_heads=1, head_step_size_multiplier=float("inf"))
+
+    with pytest.raises(ValueError, match="head_step_size_multiplier"):
+        UPGDLearner(n_heads=1, head_step_size_multiplier=0.0)
+
+    # adaptive_kappa_base
+    with pytest.raises(ValueError, match="adaptive_kappa_base"):
+        UPGDLearner(n_heads=1, adaptive_kappa_base=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="adaptive_kappa_base"):
+        UPGDLearner(n_heads=1, adaptive_kappa_base=float("nan"))
+
+    with pytest.raises(ValueError, match="adaptive_kappa_base"):
+        UPGDLearner(n_heads=1, adaptive_kappa_base=0.0)
+
+    # readout_adaptive_gate_width
+    with pytest.raises(ValueError, match="readout_adaptive_gate_width"):
+        UPGDLearner(n_heads=1, readout_adaptive_gate_width=True)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="readout_adaptive_gate_width"):
+        UPGDLearner(n_heads=1, readout_adaptive_gate_width=float("nan"))
+
+    with pytest.raises(ValueError, match="readout_adaptive_gate_width"):
+        UPGDLearner(n_heads=1, readout_adaptive_gate_width=0.0)
+
+    # Valid construction
+    learner = UPGDLearner(
+        n_heads=1,
+        utility_decay=0.0,
+        sparsity=0.0,
+        head_step_size_multiplier=1.0,
+        adaptive_kappa_base=0.5,
+        readout_adaptive_gate_width=0.3,
+    )
+    assert learner._utility_decay == 0.0
+    assert learner._sparsity == 0.0


### PR DESCRIPTION
## Summary
- Resolves #971.
- Hardens `UPGDLearner.__init__` in `alberta_framework/core/upgd.py` by routing leftover constructor scalars (`utility_decay`, `sparsity`, `head_step_size_multiplier`, `adaptive_kappa_base`, `readout_adaptive_gate_width`) through `validated_float32_scalar` to reject booleans, NaNs, and infinite floats.
- Adds unit tests in `tests/test_upgd_leftover_constructor_identities.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_upgd_leftover_constructor_identities.py`: 1 passed
- `PYTHONPATH=. pytest tests/test_upgd.py tests/test_canonical_upgd.py tests/test_canonical_adaupgd.py`: 182 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/upgd.py`: clean