### PR TITLE
fix(benchmarks): validate v2 shard hyperparameters against learner domain

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -1430,7 +1430,16 @@ def _validated_partial_payload(
             raise ValueError(f"{path}: hyperparameters must be finite named numbers")
         if not math.isfinite(float(value)):
             raise ValueError(f"{path}: hyperparameters must be finite named numbers")
-
+    try:
+        resolved_hyperparameters = resolve_hyperparameters(
+            learner, dict(hyperparameters)
+        )
+    except ValueError as exc:
+        raise ValueError(f"{path}: invalid hyperparameters: {exc}") from exc
+    if dict(hyperparameters) != resolved_hyperparameters:
+        raise ValueError(
+            f"{path}: hyperparameters must contain the complete learner configuration"
+        )
     config_payload = payload.get("config")
     if not isinstance(config_payload, Mapping) or set(config_payload) != set(
         IPMNISTConfig().to_config()

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -1035,6 +1035,17 @@ class TestPartialMerge:
         with pytest.raises(ValueError, match="uint32"):
             merge_partial_results([path])
 
+    def test_merge_rejects_hyperparameters_outside_learner_domain(self, tmp_path) -> None:
+        data_x, data_y = _synthetic_dataset(6, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        shard = run_ipmnist(data_x, data_y, "adamw", seeds=(0,), config=TINY)
+        payload = partial_payload(shard)
+        payload["hyperparameters"]["step_size"] = -1.0
+        path = tmp_path / "negative-step-size.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="invalid hyperparameters"):
+            merge_partial_results([path])
+
     def test_v2_partial_is_single_seed_and_recursively_omits_legacy_marker(
         self, tmp_path, debug_run
     ):


### PR DESCRIPTION
Closes #978.

## What changed

`_validated_partial_payload` accepted v2 shard `hyperparameters` based only on names being strings and values being finite numeric scalars - never checking the learner-specific key set or parameter domains. `merge_partial_results` therefore accepted a shard claiming `learner="adamw"` with `step_size=-1.0`: the execution path itself rejects that step size, but the merged `IPMNISTRunResult` retained the impossible configuration, corrupting the benchmark's configuration attestation even though the run never actually used that step size.

## Fix

Route the imported hyperparameters through the module's own `resolve_hyperparameters` learner-specific validator (already used before execution), and require the shard to contain the complete resolved configuration rather than relying on omitted defaults during attestation.

## Reachability

Reachable via the module's own CLI: `--merge-partials` reads user-supplied shard JSON files, through `main_v2_compat` -> `merge_partial_results` -> `_merge_partial_results` -> `_validated_partial_payload`. `merge_partial_results` is module-public but not re-exported from `alberta_framework.benchmarks.__init__`'s `__all__` (only `run_ipmnist`, the producing entry point, is) - so it's reachable at the CLI/module level, not the top-level package API.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
accepted hyperparameters = {'step_size': -1.0, 'beta1': 0.0, 'beta2': 0.99, 'eps': 1e-08, 'weight_decay': 0.0}
```

- new test `test_merge_rejects_hyperparameters_outside_learner_domain` in `TestPartialMerge`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE ValueError`. restored -> passes.
- full file: `110 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: re-ran the reproduction and full mutation check myself from a clean stash, re-ran the full test file/lint/mypy, and re-traced reachability against `alberta_framework/benchmarks/__init__.py` and the CLI entry point before committing and pushing.

Attribution status: self-reported.
