### PR TITLE
fix(streams): reject non-bool log_spaced spacing identities

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -58,6 +58,12 @@ def _require_positive_int(name: str, value: object) -> int:
     return number
 
 
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
 def _require_float32_resource(
     name: str,
     *,
@@ -975,6 +981,7 @@ def make_scale_range(
     """
     feature_dim = _require_positive_int("feature_dim", feature_dim)
     _require_float32_resource("scale range", vector_scalars=feature_dim)
+    log_spaced = _require_exact_bool("log_spaced", log_spaced)
     if log_spaced:
         min_bound = _require_normal_float32_scale("min_scale", min_scale)
         max_bound = _require_normal_float32_scale("max_scale", max_scale)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -611,6 +611,21 @@ class TestMakeScaleRange:
         chex.assert_trees_all_close(scales[0], jnp.array(0.001), rtol=1e-5)
         chex.assert_trees_all_close(scales[-1], jnp.array(1000.0), rtol=1e-5)
 
+    @pytest.mark.parametrize(
+        "log_spaced",
+        [
+            pytest.param(1, id="int-one"),
+            pytest.param(0, id="int-zero"),
+            pytest.param("yes", id="string-yes"),
+            pytest.param(np.bool_(True), id="numpy-bool-true"),
+            pytest.param(np.bool_(False), id="numpy-bool-false"),
+        ],
+    )
+    def test_log_spaced_rejects_non_bool_identities(self, log_spaced):
+        """Spacing must be an exact bool; 1/'yes' must not pick geomspace."""
+        with pytest.raises(ValueError, match="log_spaced"):
+            make_scale_range(5, min_scale=0.01, max_scale=100.0, log_spaced=log_spaced)
+
 
 class TestDynamicScaleShiftStream:
     """Tests for the DynamicScaleShiftStream class."""


### PR DESCRIPTION
Closes #980.

## What changed

`make_scale_range` now canonicalizes `log_spaced` through `_require_exact_bool` before choosing `geomspace` vs `linspace`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, that flag used `if log_spaced:` only. `1` and `"yes"` took the geometric schedule. `0` took the linear schedule. Legal `True` / `False` stay legal.

## Scope

- `alberta_framework/streams/synthetic.py`
- `tests/test_streams.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `326d57ba93b35223d5fe854db2d4c6da52e3d1c5`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 5 failed (`DID NOT RAISE` for `1`, `0`, `"yes"`, `np.bool_(True)`, `np.bool_(False)`)
- `PYTHONPATH=<worktree> pytest tests/test_streams.py::TestMakeScaleRange -q -o addopts=""` → 33 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:326d57ba93b35223d5fe854db2d4c6da52e3d1c5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
