### PR TITLE
fix(update-safety): reject bool and float action-domain identities

### DIFF
--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -2,12 +2,45 @@
 
 from __future__ import annotations
 
-from typing import cast
+import operator
+from typing import SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool
+
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
+def _require_non_negative_int(name: str, value: object) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a non-negative integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return number
 
 
 def safe_discrete_action(
@@ -25,8 +58,8 @@ def safe_discrete_action(
     conventional ``-1`` episode-start sentinel.
     """
 
-    if n_actions < 0:
-        raise ValueError("n_actions must be non-negative")
+    n_actions = _require_non_negative_int("n_actions", n_actions)
+    allow_unset = _require_exact_bool("allow_unset", allow_unset)
     if n_actions == 0:
         return (
             jnp.asarray(0, dtype=jnp.int32),

--- a/tests/test_update_safety.py
+++ b/tests/test_update_safety.py
@@ -1,0 +1,70 @@
+"""Tests for fail-closed host identities on discrete-action safety."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.update_safety import safe_discrete_action
+
+
+def test_legal_action_in_domain_is_valid() -> None:
+    safe, valid = safe_discrete_action(1, 3, allow_unset=False)
+    assert int(safe) == 1
+    assert bool(valid)
+
+
+def test_legal_unset_sentinel_is_valid() -> None:
+    safe, valid = safe_discrete_action(-1, 3, allow_unset=True)
+    assert int(safe) == -1
+    assert bool(valid)
+
+
+def test_integer_zero_actions_keeps_empty_domain_branch() -> None:
+    safe, valid = safe_discrete_action(0, 0, allow_unset=False)
+    assert int(safe) == 0
+    assert bool(valid)
+
+
+def test_out_of_range_action_is_invalid() -> None:
+    safe, valid = safe_discrete_action(3, 3, allow_unset=False)
+    assert int(safe) == 0
+    assert not bool(valid)
+
+
+@pytest.mark.parametrize(
+    "n_actions",
+    [
+        pytest.param(True, id="bool-true"),
+        pytest.param(False, id="bool-false"),
+        pytest.param(1.5, id="float-alias"),
+        pytest.param("2", id="string-two"),
+        pytest.param(np.bool_(True), id="numpy-bool-true"),
+    ],
+)
+def test_n_actions_rejects_non_int_identities(n_actions) -> None:
+    with pytest.raises(ValueError, match="n_actions"):
+        safe_discrete_action(0, n_actions, allow_unset=False)
+
+
+@pytest.mark.parametrize(
+    "allow_unset",
+    [
+        pytest.param(1, id="int-one"),
+        pytest.param(0, id="int-zero"),
+        pytest.param("yes", id="string-yes"),
+        pytest.param(np.bool_(True), id="numpy-bool-true"),
+        pytest.param(np.bool_(False), id="numpy-bool-false"),
+    ],
+)
+def test_allow_unset_rejects_non_bool_identities(allow_unset) -> None:
+    with pytest.raises(ValueError, match="allow_unset"):
+        safe_discrete_action(0, 2, allow_unset=allow_unset)
+
+
+def test_numpy_int_n_actions_remains_legal() -> None:
+    safe, valid = safe_discrete_action(1, np.int32(3), allow_unset=False)
+    assert int(safe) == 1
+    assert bool(valid)
+    assert jnp.issubdtype(safe.dtype, jnp.integer)


### PR DESCRIPTION
Closes #981.

## What changed

`safe_discrete_action` now rejects bool/non-int `n_actions` and requires an exact bool for `allow_unset` before the empty-set and unset-sentinel branches.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, those hosts used ordered comparison and truthiness only. `n_actions=True` became a 1-action domain. `n_actions=False` took the empty-set branch. `n_actions=1.5` treated actions `0` and `1` as in-range. `allow_unset=1` admitted `-1`.

Legal integer domains stay legal: `n_actions=3`, `n_actions=0`, `np.int32(3)`, `allow_unset=True`, `allow_unset=False`.

## Scope

- `alberta_framework/core/update_safety.py`
- `tests/test_update_safety.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `451af31599777d77404bee14d433c8b16a9b63eb`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: 10 failed, 5 passed (`DID NOT RAISE` for True/False/1.5/`np.bool_` `n_actions` and 1/0/`"yes"` `allow_unset`; `"2"` TypeErrored instead of ValueError)
- `PYTHONPATH=<worktree> pytest tests/test_update_safety.py -q -o addopts=""` → 15 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:451af31599777d77404bee14d433c8b16a9b63eb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
