### PR TITLE
fix(horde): reject bool and non-finite constructor identities

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -27,9 +27,11 @@ from typing import Any, cast
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.multi_head_learner import (
     MULTI_HEAD_MLP_STATE_SCHEMA,
     AnyOptimizer,
@@ -43,6 +45,44 @@ from alberta_framework.core.normalizers import (
 )
 from alberta_framework.core.optimizers import Bounder
 from alberta_framework.core.types import HordeSpec, TraceMode
+
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
+)
+
+
+def _require_float32(
+    name: str,
+    value: object,
+    *,
+    lower: float | None = None,
+    upper: float | None = None,
+) -> float:
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    return validated_float32_scalar(name, value, lower=lower, upper=upper)
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
+def _canonical_horde_host_scalars(
+    step_size: object,
+    sparsity: object,
+    leaky_relu_slope: object,
+    use_layer_norm: object,
+) -> tuple[float, float, float, bool]:
+    """Reject bool/non-real/non-finite host identities before they reach kernels."""
+    return (
+        _require_float32("step_size", step_size, lower=0.0),
+        _require_float32("sparsity", sparsity, lower=0.0, upper=1.0),
+        _require_float32("leaky_relu_slope", leaky_relu_slope, lower=0.0),
+        _require_exact_bool("use_layer_norm", use_layer_norm),
+    )
 
 # =============================================================================
 # Types
@@ -218,6 +258,9 @@ class HordeLearner:
             trace_mode: Eligibility trace mode (ACCUMULATING or REPLACING)
             utility_decay: EMA decay for hidden-unit utility diagnostics.
         """
+        step_size, sparsity, leaky_relu_slope, use_layer_norm = _canonical_horde_host_scalars(
+            step_size, sparsity, leaky_relu_slope, use_layer_norm
+        )
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._step_size = step_size
@@ -572,6 +615,9 @@ class MixedHorde:
             IndependentDemonHorde,
         )
 
+        step_size, sparsity, leaky_relu_slope, use_layer_norm = _canonical_horde_host_scalars(
+            step_size, sparsity, leaky_relu_slope, use_layer_norm
+        )
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._optimizer = optimizer

--- a/tests/test_horde.py
+++ b/tests/test_horde.py
@@ -1,8 +1,11 @@
 """Tests for the HordeLearner, learning loops, and equivalence with MultiHeadMLPLearner."""
 
+import math
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -913,3 +916,62 @@ def test_gamma_zero_inf_next_pred_is_not_nan_target() -> None:
     )
     assert bool(jnp.isfinite(discounted.td_targets[0]))
     chex.assert_trees_all_close(discounted.td_targets[0], jnp.float32(1.25))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("step_size", True),
+        ("step_size", False),
+        ("step_size", float("nan")),
+        ("step_size", float("inf")),
+        ("step_size", -0.1),
+        ("sparsity", True),
+        ("sparsity", 1.5),
+        ("leaky_relu_slope", True),
+        ("leaky_relu_slope", -0.01),
+        ("use_layer_norm", 1),
+        ("use_layer_norm", 0),
+        ("use_layer_norm", np.bool_(True)),
+    ],
+)
+def test_horde_learner_rejects_bool_and_nonfinite_constructor_identities(
+    field: str, value: object
+) -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    with pytest.raises(ValueError, match=field):
+        HordeLearner(horde_spec=spec, hidden_sizes=(4,), **{field: value})  # type: ignore[arg-type]
+
+
+def test_horde_learner_keeps_legal_constructor_scalars() -> None:
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = HordeLearner(
+        horde_spec=spec,
+        hidden_sizes=(4,),
+        step_size=np.float64(0.0),
+        sparsity=0,
+        leaky_relu_slope=np.float32(0.01),
+        use_layer_norm=False,
+    )
+    assert horde._step_size == 0.0
+    assert horde._sparsity == 0.0
+    assert math.isfinite(horde._leaky_relu_slope)
+    assert horde._use_layer_norm is False
+
+
+def test_mixed_horde_rejects_bool_step_size_before_inner_construction() -> None:
+    from alberta_framework.core.horde import MixedHorde
+
+    spec = create_horde_spec(
+        [
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.9,
+                lamda=0.8,
+                cumulant_index=0,
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="step_size"):
+        MixedHorde(horde_spec=spec, hidden_sizes=(4,), step_size=True)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #984.

## What changed

`HordeLearner` and `MixedHorde` now canonicalize `step_size`, `sparsity`, and `leaky_relu_slope` through `validated_float32_scalar` and require an exact bool for `use_layer_norm` before storing those hosts or constructing inners.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, those hosts were assigned with no type/finite/domain gate. `step_size=True` stored a `bool` and became a unit LMS/MultiHead step. `step_size=nan` persisted. `use_layer_norm=1` stored an int. `sparsity=True` stored a `bool`.

Legal values stay legal: `step_size=0.0`, `step_size=1.0`, `sparsity=0.0`, `use_layer_norm=True` / `False`, `np.float64` / `np.float32` reals.

## Scope

- `alberta_framework/core/horde.py`
- `tests/test_horde.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `08e0788360de4cf1dec6e25d15812e243256fbf7`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `HordeLearner(step_size=True|nan)`, `HordeLearner(use_layer_norm=1)`, `HordeLearner(sparsity=True)`, and `MixedHorde(step_size=True)` constructed and stored the illegal host value
- `PYTHONPATH=<worktree> pytest tests/test_horde.py -q -o addopts=""` → 42 passed
- `PYTHONPATH=<worktree> pytest tests/test_mixed_horde.py -q -o addopts=""` → 19 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:08e0788360de4cf1dec6e25d15812e243256fbf7 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
