### PR TITLE
fix(independent-demon-horde): reject bool and non-finite step_size identities

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -339,6 +339,7 @@ class IndependentDemonHorde:
         hidden_sizes = tuple(
             _require_int32(f"hidden_sizes[{i}]", v, minimum=1) for i, v in enumerate(hidden_sizes)
         )
+        step_size = _require_float32("step_size", step_size, lower=0.0)
         sparsity = _require_float32("sparsity", sparsity, lower=0.0, upper=1.0)
         leaky_relu_slope = _require_float32(
             "leaky_relu_slope", leaky_relu_slope, lower=0.0

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -655,6 +655,11 @@ class _SequenceSpoof:
 @pytest.mark.parametrize(
     ("field", "value"),
     [
+        ("step_size", True),
+        ("step_size", False),
+        ("step_size", float("nan")),
+        ("step_size", float("inf")),
+        ("step_size", -0.1),
         ("sparsity", True),
         ("sparsity", _HostileFloat(0.5)),
         ("sparsity", np.float64(1.0 + 1e-10)),
@@ -674,9 +679,11 @@ def test_independent_horde_config_accepts_mapping_and_exact_list_or_tuple() -> N
     horde = IndependentDemonHorde(
         horde_spec=spec,
         hidden_sizes=(np.int32(4),),
+        step_size=np.float64(0.0),
         sparsity=np.float64(0.5),
         leaky_relu_slope=np.float32(0.125),
     )
+    assert horde._step_size == 0.0
     config = horde.to_config()
     clone = IndependentDemonHorde.from_config(MappingProxyType(config))
     assert clone.to_config() == config


### PR DESCRIPTION
Closes #985.

## What changed

`IndependentDemonHorde` now runs `step_size` through the existing `_require_float32(..., lower=0.0)` helper before `LMS(step_size=...)` and before storing `_step_size`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `sparsity` / `leaky_relu_slope` / `use_layer_norm` were already gated. `step_size` was not. `step_size=True` stored a `bool` and `LMS` persisted it. `step_size=nan` constructed and persisted.

Legal values stay legal: `step_size=0.0`, `step_size=1.0`, `np.float64(0.0)`.

## Scope

- `alberta_framework/core/independent_demon_horde.py`
- `tests/test_independent_demon_horde.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `093d01ec4710180779442de6bf6c6d624af6fe0e`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `IndependentDemonHorde(step_size=True)` and `IndependentDemonHorde(step_size=nan)` constructed; `use_layer_norm=1` and `sparsity=True` already raised
- `PYTHONPATH=<worktree> pytest tests/test_independent_demon_horde.py -q -o addopts=""` → 34 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:093d01ec4710180779442de6bf6c6d624af6fe0e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
