### PR TITLE
fix(visualization): reject non-bool best/CI identities and non-finite style scalars

### DIFF
--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -49,7 +49,7 @@ def _require_exact_bool(name: str, value: object) -> bool:
 def _require_finite_positive(name: str, value: object) -> float:
     if type(value) not in _ACTUAL_REAL_TYPES:
         raise ValueError(f"{name} must be a real number")
-    number = float(value)
+    number = float(cast(Any, value))
     if not math.isfinite(number) or number <= 0.0:
         raise ValueError(f"{name} must be a finite positive number")
     return number
@@ -80,7 +80,7 @@ def set_publication_style(
         figure_height: Default figure height (auto if None)
         style: Matplotlib style to use
     """
-    font_size = _require_finite_positive("font_size", font_size)
+    font_size_value = _require_finite_positive("font_size", font_size)
     use_latex = _require_exact_bool("use_latex", use_latex)
     figure_width = _require_finite_positive("figure_width", figure_width)
     if figure_height is not None:
@@ -92,7 +92,7 @@ def set_publication_style(
         raise ImportError("matplotlib is required. Install with: pip install matplotlib")
 
     # Update current style
-    _current_style["font_size"] = font_size
+    _current_style["font_size"] = font_size_value
     _current_style["figure_width"] = figure_width
     _current_style["use_latex"] = use_latex
     if figure_height is not None:
@@ -110,12 +110,12 @@ def set_publication_style(
     # Configure matplotlib
     plt.rcParams.update(
         {
-            "font.size": font_size,
-            "axes.labelsize": font_size,
-            "axes.titlesize": font_size + 1,
-            "xtick.labelsize": font_size - 1,
-            "ytick.labelsize": font_size - 1,
-            "legend.fontsize": font_size - 1,
+            "font.size": font_size_value,
+            "axes.labelsize": font_size_value,
+            "axes.titlesize": font_size_value + 1,
+            "xtick.labelsize": font_size_value - 1,
+            "ytick.labelsize": font_size_value - 1,
+            "legend.fontsize": font_size_value - 1,
             "figure.figsize": (_current_style["figure_width"], _current_style["figure_height"]),
             "figure.dpi": _current_style["dpi"],
             "savefig.dpi": _current_style["dpi"],

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -5,8 +5,9 @@ including learning curves, bar plots, heatmaps, and multi-panel figures.
 """
 
 import math
+import operator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, SupportsIndex, cast
 
 import numpy as np
 
@@ -31,6 +32,13 @@ _DEFAULT_STYLE = {
 
 _current_style = _DEFAULT_STYLE.copy()
 
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
+    {float, *(np.dtype(code).type for code in "efdg")}
+)
+
 
 def _require_exact_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
@@ -39,7 +47,7 @@ def _require_exact_bool(name: str, value: object) -> bool:
 
 
 def _require_finite_positive(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in _ACTUAL_REAL_TYPES:
         raise ValueError(f"{name} must be a real number")
     number = float(value)
     if not math.isfinite(number) or number <= 0.0:
@@ -48,11 +56,12 @@ def _require_finite_positive(name: str, value: object) -> float:
 
 
 def _require_positive_int(name: str, value: object) -> int:
-    if type(value) is not int:
-        raise ValueError(f"{name} must be an exact int")
-    if value <= 0:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if number <= 0:
         raise ValueError(f"{name} must be a positive int")
-    return value
+    return number
 
 
 def set_publication_style(

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -4,6 +4,7 @@ Provides functions for creating figures suitable for academic papers,
 including learning curves, bar plots, heatmaps, and multi-panel figures.
 """
 
+import math
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -31,6 +32,29 @@ _DEFAULT_STYLE = {
 _current_style = _DEFAULT_STYLE.copy()
 
 
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
+def _require_finite_positive(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a real number")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{name} must be a finite positive number")
+    return number
+
+
+def _require_positive_int(name: str, value: object) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an exact int")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive int")
+    return value
+
+
 def set_publication_style(
     font_size: int = 10,
     use_latex: bool = False,
@@ -47,6 +71,12 @@ def set_publication_style(
         figure_height: Default figure height (auto if None)
         style: Matplotlib style to use
     """
+    font_size = _require_finite_positive("font_size", font_size)
+    use_latex = _require_exact_bool("use_latex", use_latex)
+    figure_width = _require_finite_positive("figure_width", figure_width)
+    if figure_height is not None:
+        figure_height = _require_finite_positive("figure_height", figure_height)
+
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -123,6 +153,10 @@ def plot_learning_curves(
     Returns:
         Tuple of (figure, axes)
     """
+    show_ci = _require_exact_bool("show_ci", show_ci)
+    log_scale = _require_exact_bool("log_scale", log_scale)
+    window_size = _require_positive_int("window_size", window_size)
+
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -206,6 +240,9 @@ def plot_final_performance_bars(
     Returns:
         Tuple of (figure, axes)
     """
+    show_significance = _require_exact_bool("show_significance", show_significance)
+    lower_is_better = _require_exact_bool("lower_is_better", lower_is_better)
+
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -304,6 +341,8 @@ def plot_hyperparameter_heatmap(
     Returns:
         Tuple of (figure, axes)
     """
+    lower_is_better = _require_exact_bool("lower_is_better", lower_is_better)
+
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -377,6 +416,8 @@ def plot_step_size_evolution(
     Returns:
         Tuple of (figure, axes)
     """
+    show_ci = _require_exact_bool("show_ci", show_ci)
+
     try:
         import matplotlib.pyplot as plt
     except ImportError:

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -395,3 +395,23 @@ def test_set_publication_style_keeps_legal_hosts() -> None:
         assert plt.rcParams["text.usetex"] is False
     finally:
         plt.rcParams.update(before)
+
+
+def test_visualization_keeps_concrete_numpy_numeric_hosts(results) -> None:
+    """Scientific callers commonly source style and window values from NumPy."""
+    before = dict(plt.rcParams)
+    try:
+        set_publication_style(
+            font_size=np.int32(10),
+            figure_width=np.float32(3.5),
+            figure_height=np.float64(2.8),
+        )
+        _, ax = plot_learning_curves(
+            results,
+            show_ci=False,
+            log_scale=False,
+            window_size=np.int32(5),
+        )
+        assert ax.lines
+    finally:
+        plt.rcParams.update(before)

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -12,6 +12,7 @@ import matplotlib
 
 matplotlib.use("Agg", force=True)
 
+import matplotlib.colors as mcolors  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
@@ -27,6 +28,7 @@ from alberta_framework.utils.visualization import (  # noqa: E402
     plot_hyperparameter_heatmap,
     plot_learning_curves,
     plot_step_size_evolution,
+    set_publication_style,
 )
 
 pytestmark = pytest.mark.unit
@@ -282,3 +284,114 @@ def test_create_comparison_figure_has_four_panels(results) -> None:
     titles = {ax.get_title() for ax in fig.axes}
     assert "Learning Curves" in titles
     assert "Final Performance" in titles
+
+
+def _bars_with_means(low: float, high: float) -> dict[str, AggregatedResults]:
+    return {
+        "low": _aggregated_from_error("low", np.full((2, 4), low)),
+        "high": _aggregated_from_error("high", np.full((2, 4), high)),
+    }
+
+
+def _gold_index(ax: plt.Axes) -> int:
+    gold = mcolors.to_rgba("gold")
+    for index, patch in enumerate(ax.patches):
+        if patch.get_linewidth() >= 2 and np.allclose(patch.get_edgecolor(), gold, atol=1e-3):
+            return index
+    raise AssertionError("no gold-marked bar")
+
+
+def test_plot_final_performance_bars_rejects_string_false_without_crowning_loser() -> None:
+    """A non-empty string is truthy, so 'false' used to mark the lowest mean gold."""
+    results = _bars_with_means(1.0, 2.0)
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_final_performance_bars(results, lower_is_better="false")
+    assert tuple(plt.get_fignums()) == before
+
+
+@pytest.mark.parametrize("value", [1, 0, "true", np.bool_(True)])
+def test_plot_final_performance_bars_rejects_non_bool_identities_without_figure(
+    value: object,
+) -> None:
+    results = _bars_with_means(1.0, 2.0)
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_final_performance_bars(results, lower_is_better=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_final_performance_bars(results, show_significance=value)  # type: ignore[arg-type]
+    assert tuple(plt.get_fignums()) == before
+
+
+def test_plot_final_performance_bars_marks_highest_when_lower_is_better_is_false() -> None:
+    results = _bars_with_means(1.0, 2.0)
+    _, ax = plot_final_performance_bars(results, lower_is_better=False, show_significance=False)
+    assert _gold_index(ax) == 1
+
+
+def test_plot_final_performance_bars_marks_lowest_when_lower_is_better_is_true() -> None:
+    results = _bars_with_means(1.0, 2.0)
+    _, ax = plot_final_performance_bars(results, lower_is_better=True, show_significance=False)
+    assert _gold_index(ax) == 0
+
+
+def test_plot_learning_curves_rejects_string_false_ci_without_drawing_band(results) -> None:
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_learning_curves(results, show_ci="false", window_size=5)
+    assert tuple(plt.get_fignums()) == before
+
+
+def test_plot_learning_curves_omits_band_when_show_ci_is_false(results) -> None:
+    _, ax = plot_learning_curves(results, show_ci=False, log_scale=False, window_size=5)
+    assert len(ax.collections) == 0
+
+
+def test_plot_step_size_evolution_rejects_non_bool_show_ci_without_figure(results) -> None:
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_step_size_evolution(results, show_ci="false")
+    assert tuple(plt.get_fignums()) == before
+
+
+def test_plot_hyperparameter_heatmap_rejects_non_bool_lower_is_better(results) -> None:
+    before = tuple(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="exact bool"):
+        plot_hyperparameter_heatmap(
+            results,
+            param1_name="optimizer",
+            param1_values=["lms", "idbd"],
+            param2_name="suffix",
+            param2_values=[""],
+            name_pattern="{p1}{p2}",
+            lower_is_better="false",
+        )
+    assert tuple(plt.get_fignums()) == before
+
+
+def test_set_publication_style_rejects_non_bool_and_nonfinite_hosts() -> None:
+    before = dict(plt.rcParams)
+    try:
+        with pytest.raises(ValueError, match="exact bool"):
+            set_publication_style(use_latex=1)
+        with pytest.raises(ValueError, match="real number"):
+            set_publication_style(font_size=True)
+        with pytest.raises(ValueError, match="finite positive"):
+            set_publication_style(figure_width=float("nan"))
+    finally:
+        plt.rcParams.update(before)
+
+
+def test_set_publication_style_keeps_legal_hosts() -> None:
+    before = dict(plt.rcParams)
+    try:
+        set_publication_style(font_size=10, use_latex=False, figure_width=3.5)
+        assert plt.rcParams["font.size"] == 10
+        assert plt.rcParams["text.usetex"] is False
+    finally:
+        plt.rcParams.update(before)


### PR DESCRIPTION
Closes #988.

## What changed

Publication helpers now require an exact builtin bool for `lower_is_better`, `show_ci`, `show_significance`, `log_scale`, and `use_latex`, and a finite positive real for style scalars, before a figure is created or rcParams are written.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `lower_is_better="false"` is truthy, so `plot_final_performance_bars` used argmin and crowned the lowest mean gold. `lower_is_better=0` is falsy and used argmax. `show_ci="false"` still drew CI bands. `set_publication_style(font_size=True, figure_width=nan, use_latex=1)` constructed and wrote illegal rcParams.

Legal values stay legal: `True` / `False` for those flags, finite positive `font_size` / `figure_width`, and the existing finite-mean reject.

## Scope

- `alberta_framework/utils/visualization.py`
- `tests/test_utils_smoke.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on export bool identities, metrics, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `4dd02b8315e7d4c2734c0e06290265ec0c95fa41`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `plot_final_performance_bars(..., lower_is_better="false")` constructed and crowned the lowest mean; `show_ci="false"` drew a band; `set_publication_style(use_latex=1, font_size=True, figure_width=nan)` constructed
- `PYTHONPATH=<worktree> pytest tests/test_utils_smoke.py -q -o addopts=""` → 28 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4dd02b8315e7d4c2734c0e06290265ec0c95fa41 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
