### PR TITLE
fix(checkpoints): reject non-finite checkpoint metadata

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -33,6 +33,7 @@ assert meta["epoch"] == 1
 ```
 """
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,14 @@ _FORMAT_VERSION = 2
 
 # Internal metadata key — stripped from user-facing metadata
 _VERSION_KEY = "_format_version"
+
+
+def _require_json_safe_metadata(metadata: dict[str, Any]) -> None:
+    """Reject metadata that cannot round-trip as finite JSON."""
+    try:
+        json.dumps(metadata, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("checkpoint metadata must be JSON-safe and finite") from exc
 
 
 def save_checkpoint(
@@ -67,10 +76,11 @@ def save_checkpoint(
             the checkpoint (e.g. epoch, learner config, etc.)
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
 
     meta_to_save = dict(metadata) if metadata is not None else {}
+    _require_json_safe_metadata(meta_to_save)
     meta_to_save[_VERSION_KEY] = _FORMAT_VERSION
+    path.parent.mkdir(parents=True, exist_ok=True)
 
     with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
         ckptr.save(
@@ -129,6 +139,7 @@ def load_checkpoint(
 
     user_metadata = dict(loaded.metadata)
     user_metadata.pop(_VERSION_KEY, None)
+    _require_json_safe_metadata(user_metadata)
     return loaded.state, user_metadata
 
 
@@ -162,6 +173,7 @@ def load_checkpoint_metadata(path: str | Path) -> dict[str, Any]:
 
     user_metadata = dict(loaded.metadata)
     user_metadata.pop(_VERSION_KEY, None)
+    _require_json_safe_metadata(user_metadata)
     return user_metadata
 
 

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -205,6 +205,54 @@ class TestMetadata:
 
         assert dict(restored.metadata) == {"_format_version": 2, "epoch": 7}
 
+    def test_rejects_nonfinite_metadata_without_writing(self, tmp_path):
+        """NaN metadata used to persist and reload as a real metric."""
+        learner = LinearLearner()
+        state = learner.init(feature_dim=5)
+        path = tmp_path / "nan_meta"
+
+        with pytest.raises(ValueError, match="JSON-safe and finite"):
+            save_checkpoint(state, path, metadata={"loss": float("nan"), "ok": True})
+        assert not path.exists()
+
+    def test_rejects_nested_infinite_metadata_without_writing(self, tmp_path):
+        learner = LinearLearner()
+        state = learner.init(feature_dim=5)
+        path = tmp_path / "inf_meta"
+
+        with pytest.raises(ValueError, match="JSON-safe and finite"):
+            save_checkpoint(state, path, metadata={"metrics": {"loss": float("inf")}})
+        assert not path.exists()
+
+    def test_keeps_legal_bool_and_finite_metadata(self, tmp_path):
+        learner = LinearLearner()
+        state = learner.init(feature_dim=5)
+        metadata = {"epoch": 42, "ok": True, "mae": 0.15, "tags": ["a", 1]}
+
+        save_checkpoint(state, tmp_path / "legal_meta", metadata=metadata)
+        _, loaded = load_checkpoint(state, tmp_path / "legal_meta")
+
+        assert loaded == metadata
+
+    def test_load_rejects_poisoned_nonfinite_metadata(self, tmp_path):
+        learner = LinearLearner()
+        state = learner.init(feature_dim=5)
+        path = tmp_path / "poisoned"
+
+        with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
+            ckptr.save(
+                str(path),
+                args=ocp.args.Composite(
+                    state=ocp.args.StandardSave(state),
+                    metadata=ocp.args.JsonSave({"loss": float("nan"), "_format_version": 2}),
+                ),
+            )
+
+        with pytest.raises(ValueError, match="JSON-safe and finite"):
+            load_checkpoint(state, path)
+        with pytest.raises(ValueError, match="JSON-safe and finite"):
+            load_checkpoint_metadata(path)
+
     def test_checkpoint_directory_created(self, tmp_path):
         """Checkpoint should be saved as a directory with state/ subdirectory."""
         learner = LinearLearner()


### PR DESCRIPTION
Closes #989.

## What changed

`save_checkpoint` now rejects metadata that cannot round-trip as finite JSON before creating the checkpoint directory. `load_checkpoint` and `load_checkpoint_metadata` reject the same payload so a poisoned checkpoint cannot return NaN as a metric.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, Orbax `JsonSave` persisted `{"loss": nan, "ok": True}` and reload returned that NaN. Nested `inf` also persisted.

Legal values stay legal: `epoch`, strings, lists, JSON bools, and finite numbers already used by the suite.

## Scope

- `alberta_framework/core/checkpoints.py`
- `tests/test_checkpoints.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on micro-continual shard JSON, export bool identities, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `953bc5dd164bc79fa14204e7021e1097da854233`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `save_checkpoint(..., metadata={"loss": nan, "ok": True})` wrote and reloaded NaN; nested `inf` also persisted
- `PYTHONPATH=<worktree> pytest tests/test_checkpoints.py -q -o addopts=""` → 28 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:953bc5dd164bc79fa14204e7021e1097da854233 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
