### PR TITLE
fix(delight): reject non-bool kondo_enabled identities

### DIFF
--- a/alberta_framework/core/delight.py
+++ b/alberta_framework/core/delight.py
@@ -1773,6 +1773,10 @@ class DelightfulPolicyGradientConfig:
         _validate_float32_config_value("diagnostics_epsilon", self.diagnostics_epsilon)
         if self.diagnostics_epsilon <= 0.0:
             raise ValueError("diagnostics_epsilon must be positive")
+        if type(self.kondo_enabled) is not bool:
+            raise ValueError(
+                f"kondo_enabled must be an actual bool, got {self.kondo_enabled!r}"
+            )
         if self.kondo_enabled:
             raise ValueError(
                 "Kondo compute gating is unavailable in this full-batch helper; "

--- a/tests/test_delight.py
+++ b/tests/test_delight.py
@@ -80,6 +80,16 @@ def test_delight_config_roundtrip_and_fail_closed_guards() -> None:
         DelightfulPolicyGradientConfig(diagnostics_epsilon=True)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="Kondo compute gating is unavailable"):
         DelightfulPolicyGradientConfig(kondo_enabled=True)
+    with pytest.raises(ValueError, match="kondo_enabled must be an actual bool"):
+        DelightfulPolicyGradientConfig(kondo_enabled=0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="kondo_enabled must be an actual bool"):
+        DelightfulPolicyGradientConfig(kondo_enabled=0.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="kondo_enabled must be an actual bool"):
+        DelightfulPolicyGradientConfig(kondo_enabled=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="kondo_enabled must be an actual bool"):
+        DelightfulPolicyGradientConfig(kondo_enabled="")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="kondo_enabled must be an actual bool"):
+        DelightfulPolicyGradientConfig.from_config({"kondo_enabled": 0})
 
 
 def test_learning_value_is_a_jax_pytree_without_an_implicit_sum() -> None:


### PR DESCRIPTION
Closes #992.

## What changed

`DelightfulPolicyGradientConfig` now requires an exact builtin bool for the reserved `kondo_enabled` flag before the existing `True` reject.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `kondo_enabled=0` / `None` / `""` constructed and `from_config({"kondo_enabled": 0})` restored an int. `True` was already rejected via truthiness.

Legal values stay legal: `kondo_enabled=False` only, plus the existing `True` reject.

## Scope

- `alberta_framework/core/delight.py`
- `tests/test_delight.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `1e83b3660943ca159442f5f14e31da1597675925`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `DelightfulPolicyGradientConfig(kondo_enabled=0)` / `None` / `""` constructed; `from_config({"kondo_enabled": 0})` restored an int
- `PYTHONPATH=<worktree> pytest tests/test_delight.py -q -o addopts=""` → 79 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1e83b3660943ca159442f5f14e31da1597675925 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
