### PR TITLE
fix(step2): reject invalid Step2AssociativeConfig identities

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -104,6 +104,31 @@ _STEP2_MEMORY_CONFIG_KEYS = frozenset(
         "bandwidth",
     }
 )
+_STEP2_ASSOCIATIVE_CONFIG_KEYS = frozenset(
+    {
+        "vocab_size",
+        "block_size",
+        "suffix_length",
+        "feature_family",
+        "max_features",
+        "write_lr",
+        "retention",
+        "utility_lr",
+        "utility_decay",
+        "min_weight",
+        "max_weight",
+        "logit_scale",
+        "normalize_by_weight",
+        "adaptive_feature_family",
+        "adaptive_window",
+        "adaptive_budget",
+        "scope_lr",
+        "budget_lr",
+        "initial_budget_fraction",
+        "min_effective_budget",
+        "scope_logit_clip",
+    }
+)
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -458,6 +483,12 @@ class Step2AssociativeConfig:
     min_effective_budget: int = 1
     scope_logit_clip: float = 8.0
 
+    def __post_init__(self) -> None:
+        """Reject invalid parameters and canonicalize via the core config."""
+        core = self.to_core_config()
+        for name in _STEP2_ASSOCIATIVE_CONFIG_KEYS:
+            object.__setattr__(self, name, getattr(core, name))
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         return asdict(self)
@@ -465,6 +496,7 @@ class Step2AssociativeConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step2AssociativeConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        _require_exact_keys(cls.__name__, payload, _STEP2_ASSOCIATIVE_CONFIG_KEYS)
         return cls(**cast(Any, payload))
 
     def to_core_config(self) -> AssociativeMemoryConfig:

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -724,6 +724,36 @@ def test_associative_memory_config_rejects_invalid_inputs(kwargs: dict[str, obje
         AssociativeMemoryConfig(**kwargs)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize("kwargs", _INVALID_ASSOCIATIVE_CONFIGS)
+def test_step2_associative_config_rejects_invalid_inputs(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        Step2AssociativeConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_step2_associative_config_rejects_non_bool_adaptive_flags() -> None:
+    with pytest.raises(ValueError, match="adaptive_budget must be a boolean"):
+        Step2AssociativeConfig(adaptive_budget=0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="adaptive_window must be a boolean"):
+        Step2AssociativeConfig(adaptive_window=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="adaptive_feature_family must be a boolean"):
+        Step2AssociativeConfig(adaptive_feature_family="")  # type: ignore[arg-type]
+
+
+def test_step2_associative_from_dict_rejects_unknown_and_partial_keys() -> None:
+    payload = Step2AssociativeConfig().to_dict()
+    extra = dict(payload)
+    extra["extra"] = True
+    with pytest.raises(ValueError, match="payload keys must be exactly"):
+        Step2AssociativeConfig.from_dict(extra)
+    partial = {"vocab_size": 8, "block_size": 5}
+    with pytest.raises(ValueError, match="payload keys must be exactly"):
+        Step2AssociativeConfig.from_dict(partial)
+    illegal = dict(payload)
+    illegal["write_lr"] = float("nan")
+    with pytest.raises(ValueError):
+        Step2AssociativeConfig.from_dict(illegal)
+
+
 @pytest.mark.parametrize(
     "ratio",
     [


### PR DESCRIPTION
Closes #993.

## What changed

`Step2AssociativeConfig` now validates through the core associative-memory contract at construct time, canonicalizes stored fields, and requires exact `from_dict` keys.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `write_lr=nan`, `vocab_size=True`, `normalize_by_weight=1`, and `adaptive_budget=0` constructed on the public facade and could persist through `to_dict()` / `from_dict()`. Sibling Step 2 configs already fail-closed; the core `AssociativeMemoryConfig` already rejected the same stand-ins.

Legal values stay legal: the existing smoke defaults and a full valid `to_dict()` / `from_dict()` round-trip.

## Scope

- `alberta_framework/steps/step2.py`
- `tests/test_associative_memory.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `0fe355c854afaf8e464af7d0042d5c0654259843`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `Step2AssociativeConfig(write_lr=nan)` / `vocab_size=True` / `normalize_by_weight=1` / `adaptive_budget=0` constructed
- `PYTHONPATH=<worktree> pytest tests/test_associative_memory.py -q -o addopts=""` → 186 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - Cursor session was not uploaded to slop

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0fe355c854afaf8e464af7d0042d5c0654259843 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
