### PR TITLE
fix(memory): restore trusted runtime and exact schema contracts

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -17,6 +17,7 @@ import functools
 import operator
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from fractions import Fraction
 from typing import Any, Literal, SupportsIndex, cast
 
 import chex
@@ -58,7 +59,23 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
     np.longlong,
     np.ulonglong,
 )
+_ACTUAL_REAL_TYPES: frozenset[type] = frozenset(
+    (*_ACTUAL_INT_TYPES, float, np.float16, np.float32, np.float64, np.longdouble, Fraction)
+)
 _MIN_LOG_ROUNDTRIP_FLOAT32 = 2.0 * float(np.finfo(np.float32).tiny)
+
+
+def _is_trusted_jax_value(value: object) -> bool:
+    """Return whether the actual runtime type is a JAX array or tracer."""
+    actual_type = type(value)
+    return issubclass(actual_type, jax.Array) or issubclass(
+        actual_type, jax.core.Tracer
+    )
+
+
+def _is_trusted_array(value: object) -> bool:
+    """Return whether ``value`` has an actual trusted JAX/NumPy runtime type."""
+    return type(value) is np.ndarray or _is_trusted_jax_value(value)
 
 
 def _require_resource(
@@ -115,9 +132,12 @@ def _combined_state_resource_counts(
 def _require_array(
     name: str, value: object, shape: tuple[int, ...], dtype: Any
 ) -> None:
+    if not _is_trusted_array(value):
+        raise TypeError(f"{name} must be a NumPy or JAX array")
+    trusted = cast(Any, value)
     try:
-        actual_shape = tuple(getattr(value, "shape"))
-        actual_dtype = jnp.dtype(getattr(value, "dtype"))
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = jnp.dtype(trusted.dtype)
         expected_dtype = jnp.dtype(dtype)
     except Exception as error:
         raise TypeError(f"{name} must expose valid array shape and dtype metadata") from error
@@ -127,12 +147,23 @@ def _require_array(
         raise TypeError(f"{name} must have dtype {expected_dtype}")
 
 
+def _trusted_array_metadata(name: str, value: object) -> tuple[tuple[int, ...], np.dtype[Any]]:
+    """Read metadata only from a concrete NumPy or JAX array."""
+    if not _is_trusted_array(value):
+        raise TypeError(f"{name} must expose trusted array metadata")
+    trusted = cast(Any, value)
+    return tuple(trusted.shape), np.dtype(trusted.dtype)
+
+
 def _require_typed_key(name: str, value: object) -> Array:
     """Require one scalar typed Threefry key without accepting legacy words."""
+    if not _is_trusted_jax_value(value):
+        raise TypeError(f"{name} must be a typed scalar threefry2x32 key")
+    trusted = cast(Any, value)
     try:
-        implementation = str(jr.key_impl(value))  # type: ignore[arg-type]
-        words = jr.key_data(value)  # type: ignore[arg-type]
-        shape = tuple(getattr(value, "shape"))
+        implementation = str(jr.key_impl(trusted))
+        words = jr.key_data(trusted)
+        shape = tuple(trusted.shape)
     except Exception as error:
         raise TypeError(f"{name} must be a typed scalar threefry2x32 key") from error
     if (
@@ -145,15 +176,23 @@ def _require_typed_key(name: str, value: object) -> Array:
     return cast(Array, value)
 
 
+def _trusted_real(name: str, value: object) -> None:
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+
+
 def _require_real(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(name, value)
 
 
 def _require_unit_interval(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
 
 
 def _require_half_open_unit_interval(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(
         name,
         value,
@@ -163,6 +202,7 @@ def _require_half_open_unit_interval(name: str, value: object) -> float:
 
 
 def _require_half_open_zero_one_interval(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(
         name,
         value,
@@ -173,18 +213,22 @@ def _require_half_open_zero_one_interval(name: str, value: object) -> float:
 
 
 def _require_nonnegative_real(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(name, value, lower=0.0)
 
 
 def _require_positive_real(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(name, value, positive=True)
 
 
 def _require_positive_normal_real(name: str, value: object) -> float:
+    _trusted_real(name, value)
     return validated_float32_scalar(name, value, lower=_FLOAT32_MIN_NORMAL)
 
 
 def _require_positive_log_real(name: str, value: object) -> float:
+    _trusted_real(name, value)
     canonical = validated_float32_scalar(name, value, positive=True)
     if canonical < _MIN_LOG_ROUNDTRIP_FLOAT32:
         raise ValueError(
@@ -1145,16 +1189,10 @@ def run_upgd_memory_arrays(
     if type(learner) is not UPGDMemoryLearner:
         raise TypeError("learner must be a UPGDMemoryLearner")
     learner._validate_state_static_contract(state)  # noqa: SLF001
-    try:
-        observation_shape = tuple(getattr(observations, "shape"))
-        observation_dtype = jnp.dtype(getattr(observations, "dtype"))
-    except Exception as error:
-        raise TypeError("observations must expose valid array metadata") from error
-    try:
-        target_shape = tuple(getattr(targets, "shape"))
-        target_dtype = jnp.dtype(getattr(targets, "dtype"))
-    except Exception as error:
-        raise TypeError("targets must expose valid array metadata") from error
+    observation_shape, observation_dtype = _trusted_array_metadata(
+        "observations", observations
+    )
+    target_shape, target_dtype = _trusted_array_metadata("targets", targets)
     if len(observation_shape) != 2 or observation_shape[1:] != (
         learner.config.feature_dim,
     ):

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Iterator, Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from typing import Any, cast
 
 import chex
@@ -112,7 +112,10 @@ class WorkingMemoryConfig:
             payload = dict(config)
         except Exception as error:
             raise ValueError("WorkingMemoryConfig mapping could not be read") from error
-        payload.pop("type", None)
+        if payload.pop("type", None) != "WorkingMemoryConfig":
+            raise ValueError("WorkingMemoryConfig type is invalid")
+        if set(payload) != {field.name for field in fields(cls)}:
+            raise ValueError("WorkingMemoryConfig fields do not match its schema")
         for key in (
             "observation_decay_rates",
             "action_decay_rates",
@@ -124,12 +127,25 @@ class WorkingMemoryConfig:
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
-        try:
-            return cls(**payload)
-        except ValueError:
-            raise
-        except Exception as error:
-            raise ValueError("serialized WorkingMemoryConfig is invalid") from error
+                if any(type(item) is not float for item in payload[key]):
+                    raise ValueError(f"serialized {key} values must be JSON numbers")
+        for key in ("observation_dim", "action_dim", "reward_dim"):
+            if type(payload[key]) is not int:
+                raise ValueError(f"serialized {key} must be a JSON integer")
+        for key in (
+            "include_current_observation",
+            "include_current_action",
+            "include_current_reward",
+            "include_traces",
+            "include_innovations",
+            "gated_update",
+        ):
+            if type(payload[key]) is not bool:
+                raise ValueError(f"serialized {key} must be a JSON boolean")
+        for key in ("gate_threshold", "gate_temperature"):
+            if type(payload[key]) is not float:
+                raise ValueError(f"serialized {key} must be a JSON number")
+        return cls(**payload)
 
 
 @chex.dataclass(frozen=True)
@@ -462,7 +478,11 @@ class WorkingMemoryFeaturizer:
             payload = dict(config)
         except Exception as error:
             raise ValueError("WorkingMemoryFeaturizer mapping could not be read") from error
-        inner = payload.get("config")
+        if set(payload) != {"type", "config"}:
+            raise ValueError("WorkingMemoryFeaturizer fields do not match its schema")
+        if payload["type"] != "WorkingMemoryFeaturizer":
+            raise ValueError("WorkingMemoryFeaturizer type is invalid")
+        inner = payload["config"]
         if not issubclass(type(inner), Mapping):
             raise ValueError("WorkingMemoryFeaturizer config must be a mapping")
         return cls(WorkingMemoryConfig.from_config(cast(Mapping[str, Any], inner)))

--- a/tests/test_upgd_memory_validation.py
+++ b/tests/test_upgd_memory_validation.py
@@ -43,18 +43,44 @@ class _RaisingRepr:
 
 
 class _RaisingMetadata:
+    shape_calls = 0
+    dtype_calls = 0
+
     @property
     def shape(self):  # type: ignore[no-untyped-def]
+        type(self).shape_calls += 1
         raise RuntimeError("shape hook must not escape")
 
     @property
     def dtype(self):  # type: ignore[no-untyped-def]
+        type(self).dtype_calls += 1
         raise RuntimeError("dtype hook must not escape")
 
 
 class _RaisingEquality:
     def __eq__(self, other: object) -> bool:  # pragma: no cover
         raise RuntimeError("equality hook must not run")
+
+
+class _SpoofedJaxArray:
+    class_calls = 0
+    shape_calls = 0
+    dtype_calls = 0
+
+    @property
+    def __class__(self):  # type: ignore[no-untyped-def]
+        type(self).class_calls += 1
+        return jax.Array
+
+    @property
+    def shape(self):  # type: ignore[no-untyped-def]
+        type(self).shape_calls += 1
+        raise RuntimeError("shape hook must not run")
+
+    @property
+    def dtype(self):  # type: ignore[no-untyped-def]
+        type(self).dtype_calls += 1
+        raise RuntimeError("dtype hook must not run")
 
 
 def _base_cfg(**overrides: object) -> UPGDMemoryConfig:
@@ -189,7 +215,22 @@ def test_upgd_memory_float_validators_reject_nonfinite_and_hostile() -> None:
             _base_cfg(**{field: bad})  # type: ignore[arg-type]
 
 
-def test_upgd_memory_float_validators_reject_hostile_ratio() -> None:
+@pytest.mark.parametrize(
+    "field",
+    [
+        "initial_memory_logit",
+        "target_allocation_rate",
+        "memory_update_rate",
+        "reliability_decay",
+        "novelty_adaptation_rate",
+        "upgd_step_size",
+        "memory_bandwidth",
+        "initial_novelty_threshold",
+    ],
+)
+def test_upgd_memory_float_validators_reject_hostile_ratio_without_hook(
+    field: str,
+) -> None:
     class HostileFloat(float):
         calls = 0
 
@@ -197,9 +238,10 @@ def test_upgd_memory_float_validators_reject_hostile_ratio() -> None:
             type(self).calls += 1
             raise RuntimeError("ratio hook")
 
-    with pytest.raises(ValueError, match="upgd_step_size"):
-        _base_cfg(upgd_step_size=HostileFloat(1.0))  # type: ignore[arg-type]
-    assert HostileFloat.calls == 1
+    HostileFloat.calls = 0
+    with pytest.raises(ValueError, match=field):
+        _base_cfg(**{field: HostileFloat(1.0)})
+    assert HostileFloat.calls == 0
 
 
 def test_upgd_memory_dimensions_preflight_without_allocation() -> None:
@@ -338,6 +380,27 @@ def test_upgd_memory_requires_exact_threefry_key_resource_contract(
             jnp.ones((4,), dtype=jnp.float32),
         )
 
+    class HostileKey:
+        calls = 0
+
+        @property
+        def shape(self):  # type: ignore[no-untyped-def]
+            type(self).calls += 1
+            raise RuntimeError("key metadata hook")
+
+    with pytest.raises(TypeError, match="threefry2x32"):
+        learner.init(HostileKey())  # type: ignore[arg-type]
+    assert HostileKey.calls == 0
+
+    _SpoofedJaxArray.class_calls = 0
+    _SpoofedJaxArray.shape_calls = 0
+    _SpoofedJaxArray.dtype_calls = 0
+    with pytest.raises(TypeError, match="threefry2x32"):
+        learner.init(_SpoofedJaxArray())  # type: ignore[arg-type]
+    assert _SpoofedJaxArray.class_calls == 0
+    assert _SpoofedJaxArray.shape_calls == 0
+    assert _SpoofedJaxArray.dtype_calls == 0
+
 
 def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
     learner = UPGDMemoryLearner(_base_cfg())
@@ -353,11 +416,15 @@ def test_upgd_memory_validates_nested_and_wrapper_state_metadata() -> None:
     )
     with pytest.raises(ValueError, match=r"utilities\[0\].*shape"):
         learner.predict(state.replace(upgd_state=malformed_upgd), observation)
-    with pytest.raises(TypeError, match="valid array shape and dtype metadata"):
+    _RaisingMetadata.shape_calls = 0
+    _RaisingMetadata.dtype_calls = 0
+    with pytest.raises(TypeError, match="NumPy or JAX array"):
         learner.predict(
             state.replace(memory_logit=_RaisingMetadata()),  # type: ignore[arg-type]
             observation,
         )
+    assert _RaisingMetadata.shape_calls == 0
+    assert _RaisingMetadata.dtype_calls == 0
 
 
 def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
@@ -380,17 +447,50 @@ def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
             jnp.ones((2, 4), dtype=jnp.float32),
             jnp.ones((1, 2), dtype=jnp.float32),
         )
-    with pytest.raises(TypeError, match="observations must expose valid array metadata"):
+    _RaisingMetadata.shape_calls = 0
+    _RaisingMetadata.dtype_calls = 0
+    with pytest.raises(TypeError, match="observations must expose trusted array metadata"):
         run_upgd_memory_arrays(
             learner,
             state,
             _RaisingMetadata(),  # type: ignore[arg-type]
             jnp.ones((1, 2), dtype=jnp.float32),
         )
+    assert _RaisingMetadata.shape_calls == 0
+    assert _RaisingMetadata.dtype_calls == 0
+
+    _SpoofedJaxArray.class_calls = 0
+    _SpoofedJaxArray.shape_calls = 0
+    _SpoofedJaxArray.dtype_calls = 0
+    with pytest.raises(TypeError, match="observation must be a NumPy or JAX array"):
+        learner.predict(
+            state,
+            _SpoofedJaxArray(),  # type: ignore[arg-type]
+        )
+    assert _SpoofedJaxArray.class_calls == 0
+    assert _SpoofedJaxArray.shape_calls == 0
+    assert _SpoofedJaxArray.dtype_calls == 0
+
+    _SpoofedJaxArray.class_calls = 0
+    _SpoofedJaxArray.shape_calls = 0
+    _SpoofedJaxArray.dtype_calls = 0
+    with pytest.raises(TypeError, match="observations must expose trusted array metadata"):
+        run_upgd_memory_arrays(
+            learner,
+            state,
+            _SpoofedJaxArray(),  # type: ignore[arg-type]
+            jnp.ones((1, 2), dtype=jnp.float32),
+        )
+    assert _SpoofedJaxArray.class_calls == 0
+    assert _SpoofedJaxArray.shape_calls == 0
+    assert _SpoofedJaxArray.dtype_calls == 0
 
     class HostileLeaf:
+        calls = 0
+
         @property
         def shape(self):  # type: ignore[no-untyped-def]
+            type(self).calls += 1
             raise RuntimeError("shape hook")
 
         def __jax_array__(self):  # type: ignore[no-untyped-def]
@@ -402,6 +502,7 @@ def test_upgd_memory_public_input_metadata_fails_before_tracing() -> None:
     malformed = state.replace(memory_logit=HostileLeaf())
     with pytest.raises(TypeError, match="state.memory_logit"):
         learner.predict(malformed, jnp.ones((4,), dtype=jnp.float32))
+    assert HostileLeaf.calls == 0
 
 
 def test_upgd_memory_log_and_division_positive_endpoints() -> None:
@@ -427,44 +528,30 @@ def test_upgd_memory_batch_aggregate_preflight_precedes_jax_conversion() -> None
     learner = UPGDMemoryLearner(_base_cfg())
     state = learner.init()
 
-    class OversizedBatch:
-        dtype = np.dtype(np.float32)
-
-        def __init__(self, shape: tuple[int, ...]) -> None:
-            self.shape = shape
-
-        def __jax_array__(self):  # type: ignore[no-untyped-def]
-            raise AssertionError("JAX conversion must not run")
-
     steps = 100_000_000
+    observations = np.broadcast_to(
+        np.zeros((1, 1), dtype=np.float32), (steps, learner.config.feature_dim)
+    )
+    targets = np.broadcast_to(
+        np.zeros((1, 1), dtype=np.float32), (steps, learner.config.n_heads)
+    )
     with pytest.raises(ValueError, match="batch aggregate"):
-        run_upgd_memory_arrays(
-            learner,
-            state,
-            OversizedBatch((steps, 4)),  # type: ignore[arg-type]
-            OversizedBatch((steps, 2)),  # type: ignore[arg-type]
-        )
+        run_upgd_memory_arrays(learner, state, observations, targets)
 
 
 def test_upgd_memory_scan_preflights_aggregate_working_set_without_allocation() -> None:
     learner = UPGDMemoryLearner(_base_cfg())
     state = learner.init(jax.random.key(0))
-
-    class HugeObservations:
-        shape = (10_000_000, 4)
-        dtype = jnp.float32
-
-    class HugeTargets:
-        shape = (10_000_000, 2)
-        dtype = jnp.float32
+    steps = 10_000_000
+    observations = np.broadcast_to(
+        np.zeros((1, 1), dtype=np.float32), (steps, learner.config.feature_dim)
+    )
+    targets = np.broadcast_to(
+        np.zeros((1, 1), dtype=np.float32), (steps, learner.config.n_heads)
+    )
 
     with pytest.raises(ValueError, match="working set"):
-        run_upgd_memory_arrays(
-            learner,
-            state,
-            HugeObservations(),  # type: ignore[arg-type]
-            HugeTargets(),  # type: ignore[arg-type]
-        )
+        run_upgd_memory_arrays(learner, state, observations, targets)
 
 
 def test_upgd_memory_all_lifetime_counters_saturate() -> None:

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -262,20 +262,28 @@ def test_working_state_preflight_feature_dim_boundary() -> None:
         _base_cfg(observation_dim=600_000_000, action_dim=600_000_000, reward_dim=600_000_000)
 
 
-def test_working_serialization_preserves_historical_constructor_compatibility() -> None:
+def test_working_serialized_schema_preserves_only_exact_list_tuple_compatibility() -> None:
     config = _base_cfg()
     payload = config.to_config()
     payload["observation_decay_rates"] = tuple(payload["observation_decay_rates"])
     assert WorkingMemoryConfig.from_config(MappingProxyType(payload)) == config
 
-    payload["type"] = "historical-marker"
-    payload["observation_dim"] = np.int32(2)
-    payload["gate_threshold"] = np.float32(0.0)
-    assert WorkingMemoryConfig.from_config(payload) == config
-    partial = {"observation_dim": 2, "action_dim": 1, "reward_dim": 1}
-    assert WorkingMemoryConfig.from_config(partial) == config
-    with pytest.raises(ValueError, match="serialized WorkingMemoryConfig"):
-        WorkingMemoryConfig.from_config({**config.to_config(), "extra": 1})
+    for mutation, match in (
+        ({"type": "OtherConfig"}, "type"),
+        ({"observation_dim": np.int32(2)}, "observation_dim"),
+        ({"gate_threshold": np.float32(0.0)}, "gate_threshold"),
+        ({"include_traces": 1}, "include_traces"),
+        ({"observation_decay_rates": [np.float32(0.5)]}, "JSON numbers"),
+        ({"extra": 1}, "fields"),
+    ):
+        invalid = config.to_config()
+        invalid.update(mutation)
+        with pytest.raises(ValueError, match=match):
+            WorkingMemoryConfig.from_config(invalid)
+    missing = config.to_config()
+    missing.pop("gate_temperature")
+    with pytest.raises(ValueError, match="fields"):
+        WorkingMemoryConfig.from_config(missing)
 
 
 def test_working_mapping_hooks_are_normalized_without_class_spoofing() -> None:
@@ -304,14 +312,14 @@ def test_working_mapping_hooks_are_normalized_without_class_spoofing() -> None:
             loader(MappingSpoof())  # type: ignore[arg-type]
 
 
-def test_working_featurizer_preserves_historical_outer_metadata() -> None:
+def test_working_featurizer_serialized_envelope_is_exact() -> None:
     memory = WorkingMemoryFeaturizer(_base_cfg())
     payload = memory.to_config()
     assert WorkingMemoryFeaturizer.from_config(MappingProxyType(payload)).config == memory.config
-    restored = WorkingMemoryFeaturizer.from_config(
-        {**payload, "type": "historical-marker", "extra": 1}
-    )
-    assert restored.config == memory.config
+    with pytest.raises(ValueError, match="type"):
+        WorkingMemoryFeaturizer.from_config({**payload, "type": "OtherFeaturizer"})
+    with pytest.raises(ValueError, match="fields"):
+        WorkingMemoryFeaturizer.from_config({**payload, "extra": 1})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Post-merge corrective for #883 and #835.

Preserves both audited contributor chains while closing two independently verified regressions:

- UPGDMemory now rejects hostile array/key/scalar hooks before metadata or ratio APIs, retaining genuine NumPy/JAX arrays, framework tracers, and documented Fraction support; zero-hook and class-spoof regressions are committed.
- WorkingMemory restores exact config discriminator/field/JSON-scalar gates and the exact featurizer envelope while retaining #835 operation/resource safety and documented Mapping/tuple compatibility.

Verification on exact current main 90c4613:
- 524 focused UPGD/WorkingMemory/PrototypeMemory tests passed
- Ruff passed
- strict mypy passed across 168 source files
- git diff --check clean
- no outputs or registered evidence sources changed