### PR TITLE
fix(streams): reject non-int FrequencyMismatch and Compositional dimensions

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -49,6 +49,16 @@ from alberta_framework.core.types import TimeStep
 
 _FLOAT32_MULTIPLIER_MAX = float(np.sqrt(np.finfo(np.float32).max))
 _INT32_MAX = int(np.iinfo(np.int32).max)
+
+
+def _require_positive_dimension(name: str, value: object) -> int:
+    """Return a positive builtin int inside the int32 host-dimension domain."""
+    canonical = require_positive_builtin_int(value, name=name)
+    if canonical > _INT32_MAX:
+        raise ValueError(f"{name} must be at most int32 max")
+    return canonical
+
+
 _SUPPORTED_NUMPY_REAL_SCALAR_TYPES: tuple[type[object], ...] = (
     np.int8,
     np.int16,
@@ -467,16 +477,14 @@ class FrequencyMismatchStream:
                 a centered Gaussian times this factor).
             noise_std: Standard deviation of target noise.
         """
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if n_components_per_task < 1:
-            raise ValueError("n_components_per_task must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
-        if context_length < 1:
-            raise ValueError("context_length must be positive")
+        feature_dim = _require_positive_dimension("feature_dim", feature_dim)
+        n_tasks = _require_positive_dimension("n_tasks", n_tasks)
+        n_components_per_task = _require_positive_dimension(
+            "n_components_per_task",
+            n_components_per_task,
+        )
+        n_contexts = _require_positive_dimension("n_contexts", n_contexts)
+        context_length = _require_positive_dimension("context_length", context_length)
         omega_min_float32 = _require_positive_float32(omega_min, "omega_min")
         omega_max_float32 = _require_positive_float32(omega_max, "omega_max")
         if omega_max_float32 <= omega_min_float32:
@@ -702,18 +710,15 @@ class CompositionalStream:
             amplitude_scale: Scale of per-component output amplitudes.
             noise_std: Standard deviation of target noise.
         """
-        if feature_dim < 1:
-            raise ValueError("feature_dim must be positive")
-        if n_tasks < 1:
-            raise ValueError("n_tasks must be positive")
-        if inner_hidden < 1:
-            raise ValueError("inner_hidden must be positive")
-        if outer_components < 1:
-            raise ValueError("outer_components must be positive")
-        if n_contexts < 1:
-            raise ValueError("n_contexts must be positive")
-        if context_length < 1:
-            raise ValueError("context_length must be positive")
+        feature_dim = _require_positive_dimension("feature_dim", feature_dim)
+        n_tasks = _require_positive_dimension("n_tasks", n_tasks)
+        inner_hidden = _require_positive_dimension("inner_hidden", inner_hidden)
+        outer_components = _require_positive_dimension(
+            "outer_components",
+            outer_components,
+        )
+        n_contexts = _require_positive_dimension("n_contexts", n_contexts)
+        context_length = _require_positive_dimension("context_length", context_length)
         feature_std_float32 = _require_finite_float32_multiplier(
             feature_std,
             name="feature_std",

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -643,6 +643,39 @@ class TestOutOfClassPolynomialStream:
 class TestFrequencyMismatchStream:
     """Tests for the trigonometric out-of-class stream."""
 
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "feature_dim",
+            "n_tasks",
+            "n_components_per_task",
+            "n_contexts",
+            "context_length",
+        ],
+    )
+    @pytest.mark.parametrize("value", [True, False, 1.0, np.int64(3), "3", None])
+    def test_dimensions_require_positive_builtin_ints(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            FrequencyMismatchStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "feature_dim",
+            "n_tasks",
+            "n_components_per_task",
+            "n_contexts",
+            "context_length",
+        ],
+    )
+    def test_dimensions_reject_values_above_the_int32_domain(self, field: str) -> None:
+        with pytest.raises(ValueError, match=rf"{field}.*int32 max"):
+            FrequencyMismatchStream(**{field: 2**31})  # type: ignore[arg-type]
+
     @pytest.mark.parametrize("field", ["amplitude_scale", "noise_std"])
     @pytest.mark.parametrize(
         "value",
@@ -876,6 +909,41 @@ class TestFrequencyMismatchStream:
 
 class TestCompositionalStream:
     """Tests for the 2-hidden-layer compositional out-of-class stream."""
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "feature_dim",
+            "n_tasks",
+            "inner_hidden",
+            "outer_components",
+            "n_contexts",
+            "context_length",
+        ],
+    )
+    @pytest.mark.parametrize("value", [True, False, 1.0, np.int64(3), "3", None])
+    def test_dimensions_require_positive_builtin_ints(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        with pytest.raises(ValueError, match=field):
+            CompositionalStream(**{field: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "feature_dim",
+            "n_tasks",
+            "inner_hidden",
+            "outer_components",
+            "n_contexts",
+            "context_length",
+        ],
+    )
+    def test_dimensions_reject_values_above_the_int32_domain(self, field: str) -> None:
+        with pytest.raises(ValueError, match=rf"{field}.*int32 max"):
+            CompositionalStream(**{field: 2**31})  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("field", ["feature_std", "amplitude_scale", "noise_std"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #996.

## What changed

`FrequencyMismatchStream` and `CompositionalStream` now require positive builtin ints in the int32 host-dimension domain, matching `OutOfClassPolynomialStream`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, bare `< 1` checks accepted `True` / `1.5` / `np.int64(3)` and stored those identities as the stream shape. `"3"` raised `TypeError` instead of a host `ValueError`.

Legal values stay legal: positive builtin ints, including the existing defaults `(4, 2)` and `(6, 3)`.

## Scope

- `alberta_framework/streams/out_of_class.py`
- `tests/test_out_of_class_streams.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `9dc2945d7ed7a884168fbbb0b55e50d3b1dd103a`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `FrequencyMismatchStream(feature_dim=True)` / `1.5` / `n_contexts=np.int64(3)` constructed; `CompositionalStream(feature_dim=True)` / `inner_hidden=1.0` constructed
- `PYTHONPATH=<worktree> pytest tests/test_out_of_class_streams.py -q -o addopts="" -k "not original_real_once"` → 315 passed, 2 deselected
- The two deselected tests (`test_frequency_bounds_narrow_the_original_real_once`, `test_weight_scale_narrows_the_original_real_once`) already fail on origin/main on this Darwin host where `np.longdouble` and `float` share the same 64-bit identity; they are unchanged by this PR
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9dc2945d7ed7a884168fbbb0b55e50d3b1dd103a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
