### PR TITLE
fix(pipeline): reject non-int observation-channel cumulant dimensions

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -786,14 +786,12 @@ def observation_channel_cumulant_fn(
     n_demons: int, observation_dim: int
 ) -> CumulantFn:
     """Return a cumulant function that maps demons to observation channels."""
-    if n_demons < 1:
-        msg = f"n_demons must be positive, got {n_demons}"
-        raise ValueError(msg)
-    if observation_dim < 1:
-        msg = f"observation_dim must be positive, got {observation_dim}"
-        raise ValueError(msg)
+    n_demons = _require_int("n_demons", n_demons, minimum=1, maximum=_INT32_MAX)
+    observation_dim = _require_int(
+        "observation_dim", observation_dim, minimum=1, maximum=_INT32_MAX
+    )
 
-    indices = jnp.arange(n_demons) % max(observation_dim, 1)
+    indices = jnp.arange(n_demons) % observation_dim
 
     def cumulant_fn(
         observation: Array, _reward: Array, _terminated: Array

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -568,6 +568,35 @@ def test_observation_channel_cumulant_fn_rejects_invalid_shapes() -> None:
         observation_channel_cumulant_fn(n_demons=1, observation_dim=0)
 
 
+@pytest.mark.parametrize(
+    ("n_demons", "observation_dim"),
+    [
+        (True, 3),
+        (1.5, 3),
+        ("3", 3),
+        (1, True),
+        (1, 1.5),
+        (1, "3"),
+    ],
+)
+def test_observation_channel_cumulant_fn_rejects_non_integer_identities(
+    n_demons: object,
+    observation_dim: object,
+) -> None:
+    with pytest.raises(ValueError, match="must be an integer"):
+        observation_channel_cumulant_fn(
+            n_demons=n_demons,  # type: ignore[arg-type]
+            observation_dim=observation_dim,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("field", ["n_demons", "observation_dim"])
+def test_observation_channel_cumulant_fn_rejects_int32_overflow(field: str) -> None:
+    kwargs = {"n_demons": 5, "observation_dim": 3, field: 2**31}
+    with pytest.raises(ValueError, match="must be <="):
+        observation_channel_cumulant_fn(**kwargs)
+
+
 _INVALID_PIPELINE_FEATURE_FIELDS: tuple[tuple[str, object], ...] = (
     ("observation_dim", 0),
     ("observation_dim", -1),


### PR DESCRIPTION
Closes #997.

## What changed

`observation_channel_cumulant_fn` now validates `n_demons` and `observation_dim` with the existing pipeline `_require_int` helper (`minimum=1`, `maximum=_INT32_MAX`) before `jnp.arange`.

On origin/main `90c4613a5573de324a7bb33c89efd85e1bc09aa0`, `n_demons=True` leaked into JAX as `TypeError: iota does not accept dtype bool`, `observation_dim=True` constructed (`max(True, 1)` remapped to 1), and `n_demons=1.5` constructed with a float index domain.

Legal values stay legal: positive ints, including the existing `(5, 3)` wrap test.

## Scope

- `alberta_framework/pipeline.py`
- `tests/test_pipeline.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `79751acc6fd9af685b5164e6037ef5621ee392d0`
Base: `90c4613a5573de324a7bb33c89efd85e1bc09aa0`

- Red on base: `n_demons=True` → JAX TypeError; `observation_dim=True` constructed; `n_demons=1.5` constructed
- `PYTHONPATH=<worktree> pytest tests/test_pipeline.py -q -o addopts=""` → 170 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:79751acc6fd9af685b5164e6037ef5621ee392d0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
