### PR TITLE
fix(dreaming): reject non-int action_features n_actions identities

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -884,8 +884,7 @@ def action_features(action: Array, n_actions: int | None = None) -> Array:
     """Return float action features for training-item conversion."""
     if n_actions is None:
         return jnp.ravel(jnp.asarray(action, dtype=jnp.float32))
-    if n_actions < 1:
-        raise ValueError("n_actions must be positive when provided")
+    n_actions = _require_exact_int(n_actions, "n_actions", minimum=1)
     action_index = jnp.squeeze(jnp.asarray(action, dtype=jnp.int32))
     return jax.nn.one_hot(action_index, n_actions, dtype=jnp.float32)
 

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -19,6 +19,7 @@ from alberta_framework.core.dreaming import (
     DreamWorldModelPrediction,
     GuardedDreamer,
     RecentObservationBuffer,
+    action_features,
     dream_one_step,
     dream_rollout,
     imagined_rollout_to_gvf_items,
@@ -594,3 +595,20 @@ def test_dream_rollout_config_rejects_invalid_rollout_horizon(bad: object) -> No
 def test_dream_rollout_config_rejects_non_bool_stop_on_terminal(bad: object) -> None:
     with pytest.raises(ValueError, match="stop_on_terminal"):
         DreamRolloutConfig(stop_on_terminal=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [True, False, 1.5, 0, -1, 2**31, float("nan"), "2"])
+def test_action_features_rejects_non_int_n_actions(bad: object) -> None:
+    action = jnp.asarray(0, dtype=jnp.int32)
+    with pytest.raises(ValueError, match="n_actions"):
+        action_features(action, bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_action_features_accepts_numpy_ints_and_omitted_width() -> None:
+    action = jnp.asarray(1, dtype=jnp.int32)
+    one_hot = action_features(action, np.int64(3))
+    chex.assert_trees_all_close(one_hot, jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32))
+    raw = action_features(action)
+    chex.assert_trees_all_close(raw, jnp.array([1.0], dtype=jnp.float32))


### PR DESCRIPTION
Closes #1001.

## What changed

`action_features` now validates `n_actions` with the existing dreaming `_require_exact_int` helper (`minimum=1`) before `jax.nn.one_hot`.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, bare `n_actions < 1` accepted `True` and handed it to JAX as one-hot width 1. `1.5` / `nan` raised JAX `TypeError` instead of a host `ValueError`.

Legal values stay legal: omitted `n_actions`, positive ints, and numpy integer scalars already accepted by `_require_exact_int`.

## Scope

- `alberta_framework/core/dreaming.py`
- `tests/test_dreaming.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `281f5f7591ac57c08e54b1a28d42c132e08bb64d`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `action_features(action, True)` constructed with shape `(1,)`; `1.5` / `nan` raised JAX `TypeError`
- `PYTHONPATH=<worktree> pytest tests/test_dreaming.py -q -o addopts=""` → 77 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:281f5f7591ac57c08e54b1a28d42c132e08bb64d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
