### PR TITLE
fix(rtu): reject non-int zero-state and init dimensions

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -607,6 +607,7 @@ def leaky_relu(inputs: Array, negative_slope: float = 0.01) -> Array:
 
 def zero_rtu_state(hidden_size: int, dtype: jnp.dtype[Any] = jnp.float32) -> RTUState:
     """Construct a zero RTU state."""
+    hidden_size = _require_int32("hidden_size", hidden_size, minimum=1)
     zeros = jnp.zeros((hidden_size,), dtype=dtype)
     return RTUState(real=zeros, imaginary=zeros)
 
@@ -617,6 +618,8 @@ def zero_rtu_sensitivities(
     dtype: jnp.dtype[Any] = jnp.float32,
 ) -> RTUSensitivities:
     """Construct zero compressed RTRL sensitivities."""
+    hidden_size = _require_int32("hidden_size", hidden_size, minimum=1)
+    input_dim = _require_int32("input_dim", input_dim, minimum=1)
     recurrent = jnp.zeros((2, hidden_size), dtype=dtype)
     inputs = jnp.zeros((2, hidden_size, input_dim), dtype=dtype)
     return RTUSensitivities(
@@ -1567,6 +1570,8 @@ def initialize_rtu_network_parameters(
     config: RecurrentTraceActorCriticConfig,
 ) -> RTUNetworkParameters:
     """Initialize sparse feedforward/head blocks and a dense-input RTU."""
+    input_dim = _require_int32("input_dim", input_dim, minimum=1)
+    output_dim = _require_int32("output_dim", output_dim, minimum=1)
     encoder_key, rtu_key, output_key, head_key = jr.split(key, 4)
     return RTUNetworkParameters(
         encoder_weights=_live_sparse_init(

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -2304,6 +2304,63 @@ def test_rtac_config_accepts_and_canonicalizes_numpy_integers() -> None:
     assert cfg.output_width == 32
 
 
+@pytest.mark.parametrize("bad", [True, False, 1.5, 0, -1, 2**31, float("nan"), "3"])
+def test_zero_rtu_state_rejects_non_integer_hidden_size(bad: object) -> None:
+    with pytest.raises(ValueError, match="hidden_size"):
+        zero_rtu_state(bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "input_dim", "match"),
+    [
+        (True, 3, "hidden_size"),
+        (1.5, 3, "hidden_size"),
+        (3, True, "input_dim"),
+        (3, 1.5, "input_dim"),
+        (3, 0, "input_dim"),
+        (0, 3, "hidden_size"),
+    ],
+)
+def test_zero_rtu_sensitivities_rejects_non_integer_dimensions(
+    hidden_size: object,
+    input_dim: object,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        zero_rtu_sensitivities(hidden_size, input_dim)  # type: ignore[arg-type]
+
+
+def test_zero_rtu_helpers_accept_numpy_integers() -> None:
+    state = zero_rtu_state(np.int64(2))
+    assert state.real.shape == (2,)
+    sensitivities = zero_rtu_sensitivities(np.int32(2), np.int64(3))
+    assert sensitivities.nu_log.shape == (2, 2)
+    assert sensitivities.b_real.shape == (2, 2, 3)
+
+
+@pytest.mark.parametrize(
+    ("input_dim", "output_dim", "match"),
+    [
+        (True, 3, "input_dim"),
+        (1.5, 3, "input_dim"),
+        (2, True, "output_dim"),
+        (2, 1.5, "output_dim"),
+    ],
+)
+def test_initialize_rtu_network_parameters_rejects_non_integer_dimensions(
+    input_dim: object,
+    output_dim: object,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        initialize_rtu_network_parameters(
+            jr.key(0),
+            input_dim,  # type: ignore[arg-type]
+            output_dim,  # type: ignore[arg-type]
+            _small_config(),
+        )
+
+
 @pytest.mark.parametrize(
     "field",
     ("gamma", "actor_lamda", "critic_lamda", "sparsity", "beta2"),


### PR DESCRIPTION
Closes #1002.

## What changed

`zero_rtu_state`, `zero_rtu_sensitivities`, and `initialize_rtu_network_parameters` now validate caller dimensions with the existing RTU `_require_int32` helper (`minimum=1`) before JAX allocation.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, `zero_rtu_state(True)` and `zero_rtu_sensitivities(True, 3)` / `(3, True)` constructed width-1 arrays. `1.5` / `nan` raised JAX `TypeError` instead of a host `ValueError`. Config construction was already fail-closed; these public helpers were not.

Legal values stay legal: positive ints, including numpy integer scalars already accepted by `_require_int32`.

## Scope

- `alberta_framework/core/recurrent_trace_actor_critic.py`
- `tests/test_recurrent_trace_actor_critic.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `8787d557949eece0095c1c1ae34970791924f82b`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `zero_rtu_state(True)` constructed shape `(1,)`; `zero_rtu_sensitivities(True, 3)` / `(3, True)` constructed; `1.5` / `nan` raised JAX `TypeError`
- `PYTHONPATH=<worktree> pytest tests/test_recurrent_trace_actor_critic.py -q -o addopts=""` → 131 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8787d557949eece0095c1c1ae34970791924f82b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
