### PR TITLE
fix(benchmarks): reject numeric-alias entries in OCI native inventory

### DIFF
--- a/alberta_framework/benchmarks/official_foragax_oci.py
+++ b/alberta_framework/benchmarks/official_foragax_oci.py
@@ -1979,7 +1979,7 @@ def _verify_native_inventory(
     for path, expected in native_entries.items():
         actual = dict(observed[path])
         actual["path"] = path
-        if actual != expected:
+        if _canonical_json_bytes(actual) != _canonical_json_bytes(expected):
             raise OfficialForagaxOciError(
                 f"native inventory entry differs from rootfs: {path}"
             )

--- a/tests/test_official_foragax_oci.py
+++ b/tests/test_official_foragax_oci.py
@@ -325,6 +325,48 @@ def test_inspected_config_digest_supports_legacy_and_containerd_stores() -> None
         oci._inspected_config_digest(inspected)
 
 
+def test_native_inventory_rejects_float_alias_for_integer_mode() -> None:
+    path = "opt/alberta-runtime/bin/tool"
+    rootfs = {
+        "entries": [
+            {
+                "mode": 0o555,
+                "path": path,
+                "sha256": "a" * 64,
+                "size": 1,
+                "type": "file",
+            }
+        ]
+    }
+    native_entries = [
+        {
+            "mode": 365.0,
+            "path": "bin/tool",
+            "sha256": "a" * 64,
+            "size": 1,
+            "type": "file",
+        }
+    ]
+    native = {
+        "entries": native_entries,
+        "hash_scheme": oci.TREE_HASH_SCHEME,
+        "root": oci.RUNTIME_ROOT.as_posix(),
+        "schema_version": oci.NATIVE_INVENTORY_SCHEMA,
+        "tree_sha256": oci._json_sha256(
+            {
+                "entries": native_entries,
+                "hash_scheme": oci.TREE_HASH_SCHEME,
+            }
+        ),
+    }
+
+    with pytest.raises(
+        oci.OfficialForagaxOciError,
+        match="native inventory entry differs from rootfs",
+    ):
+        oci._verify_native_inventory(rootfs, native)
+
+
 def test_saved_config_blob_is_extracted_exactly_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #1005.

## What changed

Same numeric-alias family already fixed across the `forager_matched_*` files and `runtime_profile.py`: `_verify_native_inventory` compared rootfs-derived and embedded native-runtime inventory entries with ordinary Python mapping equality (`actual != expected`). Python numeric equality aliases integers and equal-valued floats, so an integer file mode like `365` was treated as identical to JSON float `365.0` even though their canonical JSON bytes and hashes represent different values.

## Fix

Compare each entry through `_canonical_json_bytes`, the module's own existing identity encoding (already used elsewhere in this file), instead of bare mapping equality.

## Reachability

Reachable from the installed `alberta-foragax-oci` console entry point (`alberta_framework.console_entrypoints:official_foragax_oci_main`), via its `inspect` subcommand: `inspect_image` -> `_verify_native_inventory(exported_rootfs, embedded_native_inventory)`. The rootfs inventory is derived from the Docker-export tar; the native inventory is strict-JSON-decoded from the embedded image attestation - both real, non-hardcoded inputs. `official_foragax_oci.py` is not re-exported from `alberta_framework.benchmarks.__init__`, but the console script is a public entry point.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
mode types: int float
validator accepted: 7390cb9282dea478360feb21da898d36997b8ac6d47bbd169764b235505a2a66
```

- new test `test_native_inventory_rejects_float_alias_for_integer_mode`.
- mutation check: reverted just the source fix, reran the new test -> `DID NOT RAISE OfficialForagaxOciError`. restored -> passes.
- full file: `21 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: re-ran the reproduction and full mutation check myself from a clean stash, re-ran the full test file/lint/mypy, and re-confirmed reachability against `pyproject.toml`'s console-script entry before committing and pushing.

Attribution status: self-reported.
