### PR TITLE
fix(cbp): reject bool identities on wrapper replacement scalars

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -732,6 +732,19 @@ class ContinualBackpropTracker:
     config: ContinualBackpropConfig
     sparsity: float = 0.9
 
+    def __post_init__(self) -> None:
+        """Reject bool/non-finite sparsity identities used at replacement."""
+        object.__setattr__(
+            self,
+            "sparsity",
+            _validated_config_float(
+                "sparsity",
+                self.sparsity,
+                lower=0.0,
+                upper=1.0,
+            ),
+        )
+
 
 class CBPMultiHeadMLPLearner:
     """Multi-head MLP learner with Continual Backprop unit replacement.
@@ -804,6 +817,19 @@ class CBPMultiHeadMLPLearner:
                 hidden-unit utility diagnostics.
         """
         self._cbp_config = cbp_config or ContinualBackpropConfig()
+        if type(use_layer_norm) is not bool:
+            raise ValueError("use_layer_norm must be an actual bool")
+        sparsity = _validated_config_float(
+            "sparsity",
+            sparsity,
+            lower=0.0,
+            upper=1.0,
+        )
+        leaky_relu_slope = validated_float32_scalar(
+            "leaky_relu_slope",
+            leaky_relu_slope,
+            lower=0.0,
+        )
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope
         self._use_layer_norm = use_layer_norm

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -870,3 +870,62 @@ class TestConfigRoundtrip:
         rebuilt = CBPMultiHeadMLPLearner.from_config(cfg)
         cfg2 = rebuilt.to_config()
         assert cfg2 == cfg
+
+
+class TestCBPWrapperConstructorIdentities:
+    """CBP replacement/activation copies reject bool and non-finite identities."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"use_layer_norm": 1}, "use_layer_norm"),
+            ({"use_layer_norm": 0}, "use_layer_norm"),
+            ({"sparsity": True}, "sparsity"),
+            ({"sparsity": False}, "sparsity"),
+            ({"sparsity": float("nan")}, "sparsity"),
+            ({"sparsity": 1.1}, "sparsity"),
+            ({"leaky_relu_slope": True}, "leaky_relu_slope"),
+            ({"leaky_relu_slope": float("inf")}, "leaky_relu_slope"),
+            ({"leaky_relu_slope": -0.1}, "leaky_relu_slope"),
+        ],
+    )
+    def test_multihead_rejects_identity_aliases(
+        self, kwargs: dict[str, object], match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            CBPMultiHeadMLPLearner(n_heads=1, hidden_sizes=(4,), **kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"use_layer_norm": 1}, "use_layer_norm"),
+            ({"sparsity": True}, "sparsity"),
+            ({"leaky_relu_slope": True}, "leaky_relu_slope"),
+        ],
+    )
+    def test_single_head_adapter_rejects_identity_aliases(
+        self, kwargs: dict[str, object], match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            CBPMLPLearner(hidden_sizes=(4,), **kwargs)  # type: ignore[arg-type]
+
+    def test_tracker_rejects_boolean_sparsity(self) -> None:
+        with pytest.raises(ValueError, match="sparsity"):
+            ContinualBackpropTracker(
+                config=ContinualBackpropConfig(),
+                sparsity=True,  # type: ignore[arg-type]
+            )
+
+    def test_canonicalizes_numpy_sparsity_and_slope(self) -> None:
+        learner = CBPMultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(4,),
+            sparsity=np.float64(0.25),
+            leaky_relu_slope=np.float32(0.02),
+            use_layer_norm=False,
+        )
+        assert type(learner._sparsity) is float
+        assert type(learner._leaky_relu_slope) is float
+        assert learner._sparsity == pytest.approx(0.25)
+        assert learner._leaky_relu_slope == pytest.approx(0.02)
+        assert learner._use_layer_norm is False


### PR DESCRIPTION
Closes #1007.

## What changed

`CBPMultiHeadMLPLearner` now validates the copies it uses itself: `use_layer_norm` must be an actual bool, `sparsity` must be a finite real in `[0, 1]`, and `leaky_relu_slope` must be a finite non-negative real. `ContinualBackpropTracker` applies the same sparsity gate. The thin `CBPMLPLearner` adapter inherits the gates.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, `use_layer_norm=1` constructed and was truthy in the CBP replacement/activation path, `sparsity=True` constructed as 100% sparse replacement, and `leaky_relu_slope=True` constructed as slope `1.0`.

Legal values stay legal: omitted defaults, builtin floats, and supported NumPy scalars already accepted by `_validated_config_float` / `validated_float32_scalar`.

## Scope

- `alberta_framework/core/continual_backprop.py`
- `tests/test_continual_backprop.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, Svector `#1006`, or leftover tax on stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `f1660043e4f6516d919e7298617c3f951561805c`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `use_layer_norm=1`, `sparsity=True`, and `leaky_relu_slope=True` constructed
- `PYTHONPATH=<worktree> pytest tests/test_continual_backprop.py -q -o addopts=""` → 70 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f1660043e4f6516d919e7298617c3f951561805c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
