### PR TITLE
fix(future-utility): reject bool half-life identities

### DIFF
--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -18,6 +18,7 @@ from jax import Array
 from jaxtyping import Bool, Float
 
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _ACTUAL_DECAY_TYPES = frozenset(
     {
@@ -94,7 +95,13 @@ def trace_decay_from_half_life(half_life: float | Array) -> Float[Array, ""]:
     A half-life of ``0`` disables the trace.  Positive half-lives use
     ``0.5 ** (1 / half_life)`` so the trace contribution decays by half after
     that many time steps.
+
+    Host scalars are validated before JAX conversion so ``True`` cannot become
+    half-life ``1`` (decay ``0.5``) and non-finite values cannot become
+    ``nan``/``1.0`` decays. JAX arrays and tracers keep the device formula.
     """
+    if not isinstance(half_life, Array) and not hasattr(half_life, "aval"):
+        half_life = validated_float32_scalar("half_life", half_life, lower=0.0)
     half_life_arr = jnp.asarray(half_life, dtype=jnp.float32)
     return jnp.where(
         half_life_arr <= 0.0,

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -155,6 +155,16 @@ def test_contribution_trace_has_no_future_label_leakage() -> None:
 def test_trace_decay_from_half_life() -> None:
     assert float(trace_decay_from_half_life(0.0)) == 0.0
     assert abs(float(trace_decay_from_half_life(10.0) ** 10) - 0.5) < 1e-6
+    assert abs(float(trace_decay_from_half_life(np.float64(10.0)) ** 10) - 0.5) < 1e-6
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, float("nan"), float("inf"), -1.0],
+)
+def test_trace_decay_from_half_life_rejects_host_identities(value: object) -> None:
+    with pytest.raises(ValueError, match="half_life"):
+        trace_decay_from_half_life(value)  # type: ignore[arg-type]
 
 
 def test_future_utility_normalization_is_finite_and_causal() -> None:


### PR DESCRIPTION
Closes #1009.

## What changed

`trace_decay_from_half_life` now validates host scalars with `validated_float32_scalar("half_life", ..., lower=0.0)` before `jnp.asarray`. JAX arrays and tracers keep the existing device formula.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, `True` became decay `0.5`, `False`/`-1` became decay `0.0`, `inf` became decay `1.0`, and `nan` became `nan`.

Legal values stay legal: `0`, `10`, and `np.float64(10)` still produce the documented decays.

## Scope

- `alberta_framework/core/future_utility.py`
- `tests/test_future_utility.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, Svector `#1006`, or leftover tax on stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `452a065c6fe29389712f3353fa897024bcc5c2b0`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `True` → decay `0.5`; `False`/`-1` → decay `0.0`; `inf` → decay `1.0`; `nan` → `nan`
- `PYTHONPATH=<worktree> pytest tests/test_future_utility.py -q -o addopts=""` → 42 passed
- `ruff check` on the two changed files: clean
- `git diff --check`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:452a065c6fe29389712f3353fa897024bcc5c2b0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
