### PR TITLE
fix(oak): reject non-bool enable_option_planning identities

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -115,6 +115,12 @@ def _require_uint64(
     return canonical
 
 
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an actual bool")
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Default config helper
 # ---------------------------------------------------------------------------
@@ -1676,6 +1682,9 @@ class OaKAgent:
     ) -> OaKTracedUpdateResult:
         """Evaluate STOMP exactly once and return its transient adoption trace."""
 
+        enable_option_planning = _require_exact_bool(
+            "enable_option_planning", enable_option_planning
+        )
         stomp_result: STOMPUpdateResult = self._stomp.update(
             state.stomp_state,
             env_reward,

--- a/tests/test_oak_authoritative_stomp_adoption.py
+++ b/tests/test_oak_authoritative_stomp_adoption.py
@@ -480,3 +480,31 @@ def test_external_adoption_resource_budget_is_zero_recompute_and_zero_growth() -
     assert budget.source_result_integrity_checked is True
     assert budget.caller_authority_required is True
     assert budget.caller_authenticated is False
+
+
+@pytest.mark.parametrize("alias", [1, 0, np.bool_(True), "true"])
+def test_update_rejects_non_bool_enable_option_planning(alias: object) -> None:
+    """Planning is a host-boundary switch; numeric aliases must not enable it."""
+    agent = OaKAgent(_config(planning_backups=1))
+    observation = jnp.asarray([0.2, -0.4], dtype=jnp.float32)
+    state = agent.start(agent.init(jr.key(7)), observation)
+    reward = jnp.asarray(0.3, dtype=jnp.float32)
+    next_observation = jnp.asarray([-0.1, 0.8], dtype=jnp.float32)
+    discount = jnp.asarray(0.9, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="enable_option_planning must be an actual bool"):
+        agent.update(
+            state,
+            reward,
+            next_observation,
+            discount,
+            enable_option_planning=alias,  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="enable_option_planning must be an actual bool"):
+        agent.update_with_stomp_trace(
+            state,
+            reward,
+            next_observation,
+            discount,
+            enable_option_planning=alias,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Closes #1011.

## What changed

`OaKAgent.update` / `update_with_stomp_trace` now require `enable_option_planning` to be an exact Python `bool` before forwarding it to STOMP.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, `enable_option_planning=1` was accepted and treated as truthy, so a numeric alias could silently enable option-model backups.

Exact `True` / `False` still work.

## Scope

- `alberta_framework/core/oak.py`
- `tests/test_oak_authoritative_stomp_adoption.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, Svector `#1006`, or leftover tax on dreaming action_features, RTU zero-state, stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `98012b17fbe7d317bbf8317e00e64ec7e8f13743`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `enable_option_planning=1` accepted
- `PYTHONPATH=<worktree> pytest tests/test_oak_authoritative_stomp_adoption.py -q -o addopts=""` → 23 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:98012b17fbe7d317bbf8317e00e64ec7e8f13743 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
