### PR TITLE
fix(streams): reject bool/NaN closed-loop config identities

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -160,6 +160,33 @@ def _normalized_finite_float32_reward(name: str, value: object) -> float:
     return narrowed
 
 
+def _canonical_two_state_payoffs(
+    name: str, raw_payoff: object
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return one 2x2 payoff matrix after rejecting bool/NaN identities."""
+    try:
+        payoff_shape = tuple(np.shape(cast(Any, raw_payoff)))
+    except Exception as error:
+        raise ValueError(f"{name} shape must be readable") from error
+    if payoff_shape != (_TWO_STATE_N, _TWO_STATE_ACTIONS):
+        raise ValueError(f"{name} must be 2x2 (state x action)")
+    try:
+        object_payoff = np.asarray(raw_payoff, dtype=object)
+    except Exception as error:
+        raise ValueError(f"{name} must be readable") from error
+    normalized = tuple(
+        _normalized_finite_float32_reward(
+            f"{name}[{index // _TWO_STATE_ACTIONS}][{index % _TWO_STATE_ACTIONS}]",
+            value,
+        )
+        for index, value in enumerate(object_payoff.flat)
+    )
+    return (
+        (normalized[0], normalized[1]),
+        (normalized[2], normalized[3]),
+    )
+
+
 def _normalized_positive_float32_probability(
     name: str, value: object
 ) -> tuple[float, int, int]:
@@ -234,6 +261,21 @@ class SwitchingTwoStateConfig:
     payoffs_a: tuple[tuple[float, float], tuple[float, float]] = ((0.0, 1.0), (1.0, 0.0))
     payoffs_b: tuple[tuple[float, float], tuple[float, float]] = ((1.0, 0.0), (0.0, 1.0))
 
+    def __post_init__(self) -> None:
+        """Reject bool/NaN identities before the record can be serialized."""
+        try:
+            phase_length = _require_int32("phase_length", self.phase_length, minimum=1)
+        except ValueError:
+            raise ValueError(
+                f"phase_length must be a positive integer in [1, {_INT32_MAX}]"
+            ) from None
+        canonical_payoffs: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        for name in ("payoffs_a", "payoffs_b"):
+            canonical_payoffs.append(_canonical_two_state_payoffs(name, getattr(self, name)))
+        object.__setattr__(self, "phase_length", phase_length)
+        object.__setattr__(self, "payoffs_a", canonical_payoffs[0])
+        object.__setattr__(self, "payoffs_b", canonical_payoffs[1])
+
 
 @chex.dataclass(frozen=True)
 class SwitchingTwoStateState:
@@ -276,28 +318,7 @@ class SwitchingTwoStateMDP:
         phase_payoffs: list[np.ndarray] = []
         canonical_payoffs: list[tuple[tuple[float, float], tuple[float, float]]] = []
         for name in ("payoffs_a", "payoffs_b"):
-            raw_payoff = getattr(config, name)
-            try:
-                payoff_shape = tuple(np.shape(cast(Any, raw_payoff)))
-            except Exception as error:
-                raise ValueError(f"{name} shape must be readable") from error
-            if payoff_shape != (_TWO_STATE_N, _TWO_STATE_ACTIONS):
-                raise ValueError(f"{name} must be 2x2 (state x action)")
-            try:
-                object_payoff = np.asarray(raw_payoff, dtype=object)
-            except Exception as error:
-                raise ValueError(f"{name} must be readable") from error
-            normalized = tuple(
-                _normalized_finite_float32_reward(
-                    f"{name}[{index // _TWO_STATE_ACTIONS}][{index % _TWO_STATE_ACTIONS}]",
-                    value,
-                )
-                for index, value in enumerate(object_payoff.flat)
-            )
-            canonical = (
-                (normalized[0], normalized[1]),
-                (normalized[2], normalized[3]),
-            )
+            canonical = _canonical_two_state_payoffs(name, getattr(config, name))
             payoff = np.asarray(canonical, dtype=np.float32)
             phase_payoffs.append(payoff)
             canonical_payoffs.append(canonical)
@@ -468,6 +489,41 @@ class RiverSwimConfig:
     reward_left: float = 0.005
     reward_right: float = 1.0
     initial_state: int = 0
+
+    def __post_init__(self) -> None:
+        """Reject bool/NaN identities before the record can be serialized."""
+        n_states = _require_int32("n_states", self.n_states, minimum=2)
+        initial_state = _require_int32(
+            "initial_state", self.initial_state, minimum=0, maximum=n_states - 1
+        )
+        _riverswim_persistent_resources(n_states)
+        p_right_up, up_numerator, up_denominator = _normalized_positive_float32_probability(
+            "p_right_up",
+            self.p_right_up,
+        )
+        (
+            p_right_down,
+            down_numerator,
+            down_denominator,
+        ) = _normalized_positive_float32_probability(
+            "p_right_down",
+            self.p_right_down,
+        )
+        if (
+            up_numerator * down_denominator + down_numerator * up_denominator
+            > up_denominator * down_denominator
+        ):
+            raise ValueError("p_right_up + p_right_down must not exceed 1")
+        reward_left = _normalized_finite_float32_reward("reward_left", self.reward_left)
+        reward_right = _normalized_finite_float32_reward("reward_right", self.reward_right)
+        if p_right_up + p_right_down > 1.0:
+            raise ValueError("p_right_up + p_right_down must not exceed 1")
+        object.__setattr__(self, "n_states", n_states)
+        object.__setattr__(self, "initial_state", initial_state)
+        object.__setattr__(self, "p_right_up", p_right_up)
+        object.__setattr__(self, "p_right_down", p_right_down)
+        object.__setattr__(self, "reward_left", reward_left)
+        object.__setattr__(self, "reward_right", reward_right)
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -168,6 +168,18 @@ class TestSwitchingTwoStateDynamics:
         assert int(env.phase_id(state)) == PHASE_A
         assert int(jax.jit(env.phase_id)(state)) == PHASE_A
 
+    def test_switching_config_rejects_bool_and_nan_identities(self):
+        """Switching payoff records must not persist True/NaN identities."""
+        with pytest.raises(
+            ValueError,
+            match=rf"phase_length must be a positive integer in \[1, {_INT32_MAX}\]",
+        ):
+            SwitchingTwoStateConfig(phase_length=True)
+        with pytest.raises(ValueError, match="finite"):
+            SwitchingTwoStateConfig(payoffs_a=((True, 1.0), (1.0, 0.0)))
+        with pytest.raises(ValueError, match="finite"):
+            SwitchingTwoStateConfig(payoffs_b=((1.0, 0.0), (0.0, float("nan"))))
+
     def test_invalid_payoff_shape_raises(self):
         """Payoff matrices must preserve the fixed state/action shape."""
         with pytest.raises(ValueError, match="2x2"):
@@ -501,6 +513,17 @@ class TestRiverSwim:
         with pytest.raises(ValueError, match="policy"):
             RiverSwimMDP(RiverSwimConfig(n_states=3)).policy_average_reward([0, 1])
 
+    def test_riverswim_config_rejects_bool_and_nan_identities(self):
+        """The public config record must not persist True/NaN step identities."""
+        with pytest.raises(ValueError, match="p_right_up must be finite"):
+            RiverSwimConfig(p_right_up=True)
+        with pytest.raises(ValueError, match="p_right_up must be finite"):
+            RiverSwimConfig(p_right_up=float("nan"))
+        with pytest.raises(ValueError, match="n_states"):
+            RiverSwimConfig(n_states=True)
+        with pytest.raises(ValueError, match="reward_left"):
+            RiverSwimConfig(reward_left=True)
+
     @pytest.mark.parametrize(
         "value",
         [
@@ -626,16 +649,14 @@ def test_closed_loop_integer_rejection_never_invokes_hostile_hooks() -> None:
         def __repr__(self) -> str:
             raise AssertionError("untrusted repr hook executed")
 
-    for config in (
-        SwitchingTwoStateConfig(phase_length=HostileInt(2)),
-        SwitchingTwoStateConfig(phase_length=ClassSpoof()),  # type: ignore[arg-type]
-    ):
-        with pytest.raises(ValueError, match="phase_length"):
-            SwitchingTwoStateMDP(config)
+    with pytest.raises(ValueError, match="phase_length"):
+        SwitchingTwoStateConfig(phase_length=HostileInt(2))
+    with pytest.raises(ValueError, match="phase_length"):
+        SwitchingTwoStateConfig(phase_length=ClassSpoof())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="n_states"):
-        RiverSwimMDP(RiverSwimConfig(n_states=ClassSpoof()))  # type: ignore[arg-type]
+        RiverSwimConfig(n_states=ClassSpoof())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="initial_state"):
-        RiverSwimMDP(RiverSwimConfig(initial_state=HostileInt(0)))
+        RiverSwimConfig(initial_state=HostileInt(0))
 
 
 def test_riverswim_resource_formula_matches_resident_arrays() -> None:


### PR DESCRIPTION
Closes #1012.

## What changed

`RiverSwimConfig` and `SwitchingTwoStateConfig` now validate and canonicalize their host scalars in `__post_init__`, so `True`/`NaN` identities cannot persist in the public records.

On origin/main `3de3fb3c323cd587ce35230a45b4b31ce81dd192`, `RiverSwimConfig(p_right_up=True)` and `RiverSwimConfig(p_right_up=float("nan"))` constructed and stored those identities. The MDPs later rejected them, but the config objects themselves were serializable with the invalid values.

Legal configs still construct and run. Existing MDP rejection tests stay green.

## Scope

- `alberta_framework/streams/closed_loop.py`
- `tests/test_closed_loop_env.py`

## Why this is unowned

Live occupancy at publish time: neither target file is in the open ASI PR map. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, Svector `#1006`, or leftover tax on dreaming action_features, RTU zero-state, stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `3b6a2b501938406ab39fee36bc13fe2d29e9b19d`
Base: `3de3fb3c323cd587ce35230a45b4b31ce81dd192`

- Red on base: `RiverSwimConfig(p_right_up=True)` and `RiverSwimConfig(p_right_up=nan)` construct
- `PYTHONPATH=<worktree> pytest tests/test_closed_loop_env.py -q -o addopts=""` → 112 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:3b6a2b501938406ab39fee36bc13fe2d29e9b19d -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
