### PR TITLE
fix(idbd): complete constructor step-size validation

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -24,7 +24,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.types import (
     AutostepGTDLambdaState,
     AutostepParamState,
@@ -92,6 +92,25 @@ def _require_float32_state(name: str, scalar_count: int) -> None:
 
 def _shape_size(shape: tuple[int, ...]) -> int:
     return prod(shape, start=1)
+
+
+def _validated_idbd_step_size(
+    name: str,
+    value: object,
+    *,
+    positive: bool = False,
+) -> float:
+    """Validate an IDBD rate without silently erasing a positive host value."""
+    stored, numerator, _ = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        positive=positive,
+        lower=None if positive else 0.0,
+    )
+    narrowed = float(np.float32(stored))
+    if numerator != 0 and narrowed == 0.0:
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
 
 
 # =============================================================================
@@ -714,12 +733,10 @@ class IDBD(Optimizer[IDBDState]):
                 f"Invalid h_decay_mode: {h_decay_mode!r}. "
                 "Must be 'prediction_grads' or 'loss_grads'."
             )
-        self._initial_step_size = validated_float32_scalar(
+        self._initial_step_size = _validated_idbd_step_size(
             "initial_step_size", initial_step_size, positive=True
         )
-        self._meta_step_size = validated_float32_scalar(
-            "meta_step_size", meta_step_size, lower=0.0
-        )
+        self._meta_step_size = _validated_idbd_step_size("meta_step_size", meta_step_size)
         self._h_decay_mode = h_decay_mode
 
     def to_config(self) -> dict[str, Any]:

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -24,6 +24,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.types import (
     AutostepGTDLambdaState,
     AutostepParamState,
@@ -703,15 +704,22 @@ class IDBD(Optimizer[IDBDState]):
                 the linear ``update()`` method always uses x^2.
 
         Raises:
-            ValueError: If ``h_decay_mode`` is not one of the valid modes
+            ValueError: If ``h_decay_mode`` is not one of the valid modes,
+                or if a step-size is not a finite non-bool real in the
+                declared domain (``initial_step_size`` positive;
+                ``meta_step_size`` nonnegative).
         """
         if h_decay_mode not in ("prediction_grads", "loss_grads"):
             raise ValueError(
                 f"Invalid h_decay_mode: {h_decay_mode!r}. "
                 "Must be 'prediction_grads' or 'loss_grads'."
             )
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
+        self._initial_step_size = validated_float32_scalar(
+            "initial_step_size", initial_step_size, positive=True
+        )
+        self._meta_step_size = validated_float32_scalar(
+            "meta_step_size", meta_step_size, lower=0.0
+        )
         self._h_decay_mode = h_decay_mode
 
     def to_config(self) -> dict[str, Any]:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -84,6 +84,14 @@ class TestIDBD:
         assert float(state.meta_step_size) == 0.0
         assert bool(jnp.all(jnp.isfinite(state.log_step_sizes)))
 
+    def test_positive_meta_step_size_must_survive_float32_narrowing(self) -> None:
+        with pytest.raises(ValueError, match="remain nonzero"):
+            IDBD(meta_step_size=1e-100)
+
+        smallest_subnormal = float(np.nextafter(np.float32(0.0), np.float32(1.0)))
+        state = IDBD(meta_step_size=smallest_subnormal).init(feature_dim=2)
+        assert float(state.meta_step_size) == smallest_subnormal
+
     def test_update_returns_correct_shapes(self, sample_observation):
         """IDBD update should return correctly shaped deltas."""
         optimizer = IDBD()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -68,6 +68,22 @@ class TestIDBD:
         chex.assert_trees_all_close(state.traces, jnp.zeros(10))
         assert state.meta_step_size == pytest.approx(0.001)
 
+    @pytest.mark.parametrize("initial_step_size", [float("nan"), float("inf"), 0.0, -0.1, True])
+    def test_rejects_illegal_initial_step_size(self, initial_step_size: object) -> None:
+        with pytest.raises(ValueError, match="initial_step_size"):
+            IDBD(initial_step_size=initial_step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("meta_step_size", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_meta_step_size(self, meta_step_size: object) -> None:
+        with pytest.raises(ValueError, match="meta_step_size"):
+            IDBD(meta_step_size=meta_step_size)  # type: ignore[arg-type]
+
+    def test_zero_meta_step_size_remains_legal(self) -> None:
+        optimizer = IDBD(initial_step_size=0.01, meta_step_size=0.0)
+        state = optimizer.init(feature_dim=2)
+        assert float(state.meta_step_size) == 0.0
+        assert bool(jnp.all(jnp.isfinite(state.log_step_sizes)))
+
     def test_update_returns_correct_shapes(self, sample_observation):
         """IDBD update should return correctly shaped deltas."""
         optimizer = IDBD()


### PR DESCRIPTION
Supersedes #899 after deep review. Carries its finite/bool/domain validation, and additionally rejects positive meta step sizes that silently underflow to float32 zero (which would disable adaptation). Preserves exact zero and the smallest positive float32 subnormal. Verification: 153 optimizer/config tests passed; Ruff clean; strict mypy clean; diff check clean.