### PR TITLE
fix(update-safety): bind action domains to int32 sink

### DIFF
--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -26,6 +26,7 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_INT32_MAX = int(np.iinfo(np.int32).max)
 
 
 def _require_exact_bool(name: str, value: object) -> bool:
@@ -36,10 +37,10 @@ def _require_exact_bool(name: str, value: object) -> bool:
 
 def _require_non_negative_int(name: str, value: object) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be a non-negative integer")
+        raise ValueError(f"{name} must be an integer in [0, {_INT32_MAX}]")
     number = operator.index(cast(SupportsIndex, value))
-    if number < 0:
-        raise ValueError(f"{name} must be non-negative")
+    if not 0 <= number <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [0, {_INT32_MAX}]")
     return number
 
 

--- a/tests/test_update_safety.py
+++ b/tests/test_update_safety.py
@@ -68,3 +68,16 @@ def test_numpy_int_n_actions_remains_legal() -> None:
     assert int(safe) == 1
     assert bool(valid)
     assert jnp.issubdtype(safe.dtype, jnp.integer)
+
+
+@pytest.mark.parametrize(
+    "n_actions",
+    [
+        pytest.param(-1, id="negative"),
+        pytest.param(2**31, id="builtin-above-int32"),
+        pytest.param(np.uint64(2**32), id="numpy-above-int32"),
+    ],
+)
+def test_n_actions_must_fit_the_int32_action_sink(n_actions: object) -> None:
+    with pytest.raises(ValueError, match=r"n_actions.*\[0, 2147483647\]"):
+        safe_discrete_action(0, n_actions)  # type: ignore[arg-type]


### PR DESCRIPTION
Follow-up to #983.

The identity gate still admitted positive integers above the signed-int32 action output domain. This caps `n_actions` before JAX work so no accepted domain can produce an unrepresentable action code.

Verification: 18 focused tests; Ruff; strict mypy; diff-check. No outputs or evidence sources changed.