### PR TITLE
fix(core): saturate RLS reward model step_count instead of wrapping

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -76,6 +76,13 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 
 
+def _saturating_int32_increment(value: Array) -> Array:
+    """Increment a diagnostic counter without signed-int32 wraparound."""
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    counter = jnp.asarray(value, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(counter, 0), maximum - 1) + 1
+
+
 @dataclass(frozen=True)
 class RLSRewardModelConfig:
     """Configuration for a linear recursive-least-squares reward model.
@@ -276,7 +283,7 @@ class RLSRewardModel:
             weights=next_weights,
             covariance=next_covariance,
             abs_error_ema=next_abs_error_ema,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_increment(state.step_count),
         )
         # Inf reward * a silent feature's zero gain is 0*inf = NaN, and
         # that channel stays poisoned. Hold the previous finite state.

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -235,6 +235,16 @@ def test_zero_error_decay_does_not_multiply_inf_ema() -> None:
     assert bool(jnp.isfinite(result.state.abs_error_ema))
 
 
+def test_reward_model_step_count_saturates_at_int32_max() -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=1, forgetting=1.0))
+    state = model.init().replace(step_count=jnp.array(2**31 - 1, dtype=jnp.int32))
+
+    result = model.update(state, jnp.array([1.0], dtype=jnp.float32), jnp.array(1.0))
+
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
+
+
 def test_rls_reward_model_config_integer_and_scalar_validation() -> None:
     with pytest.raises(ValueError, match="feature_dim"):
         RLSRewardModelConfig(feature_dim=True)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1017.

## What changed

Same int32-wraparound-instead-of-saturation class already fixed in `option_value_duration.py` and `canonical_upgd.py`: `RLSRewardModel.update` incremented `state.step_count` with plain addition on a signed int32 array. Once `step_count` reaches `INT32_MAX`, the next increment wraps to `INT32_MIN` instead of staying bounded.

## Fix

Add `_saturating_int32_increment` (same pattern as the other two files) and route `step_count` through it.

## Reachability

`RLSRewardModel`/`RLSRewardModelConfig` are exported from `alberta_framework.core.__init__`'s `__all__` - publicly reachable, and `step_count` increments on every `update` call, so any sufficiently long-running model instance would eventually hit this.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
step_count after increment from INT32_MAX: -2147483648
```

- new test `test_reward_model_step_count_saturates_at_int32_max`.
- mutation check: reverted just the source fix, reran the new test -> fails with the exact wraparound value (`-2147483648 == 2147483647` mismatch). restored -> passes.
- full file: `62 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter). The Codex session hit an API quota exhaustion (`403: user quota is not enough`) partway through and never wrote its own report or committed - I recovered the real, uncommitted diff from the working tree and independently verified the entire thing from scratch with no report to lean on: re-reproduced the wraparound myself against the unpatched code, ran the full mutation check, full test file, lint, mypy, and reachability trace before committing and pushing.

Attribution status: self-reported.
