### PR TITLE
fix(resource-manager): complete Hedge theorem boundaries

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -207,6 +207,21 @@ def _weighted_cost_terms(costs: Array, cost_weight: float) -> tuple[Array, Array
     return terms, valid
 
 
+def _require_theorem_real(name: str, value: object, *, positive: bool) -> float:
+    """Reject bool/non-finite host scalars without changing legal float values."""
+    if type(value) not in _ACTUAL_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    real = float(cast(Any, value))
+    if not math.isfinite(real):
+        raise ValueError(f"{name} must be finite")
+    if positive:
+        if real <= 0.0:
+            raise ValueError(f"{name} must be positive")
+    elif real < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return real
+
+
 def optimal_hedge_learning_rate(
     n_actions: int,
     horizon: int,
@@ -221,12 +236,9 @@ def optimal_hedge_learning_rate(
     Cesa-Bianchi & Lugosi 2006, ch. 2).  For ``n_actions == 1`` the regret is
     identically zero, so the returned learning rate is ``0.0``.
     """
-    if n_actions < 1:
-        raise ValueError("n_actions must be positive")
-    if horizon < 1:
-        raise ValueError("horizon must be positive")
-    if loss_bound <= 0.0:
-        raise ValueError("loss_bound must be positive")
+    n_actions = _require_int32("n_actions", n_actions, minimum=1)
+    horizon = _require_int32("horizon", horizon, minimum=1)
+    loss_bound = _require_theorem_real("loss_bound", loss_bound, positive=True)
     if n_actions == 1:
         return 0.0
     return math.sqrt(8.0 * math.log(n_actions) / (horizon * loss_bound**2))
@@ -250,14 +262,10 @@ def finite_candidate_hedge_regret_bound(
     promote/delete rules require separate terms and must not cite this helper
     as a proof.
     """
-    if n_actions < 1:
-        raise ValueError("n_actions must be positive")
-    if horizon < 1:
-        raise ValueError("horizon must be positive")
-    if learning_rate < 0.0:
-        raise ValueError("learning_rate must be non-negative")
-    if loss_bound <= 0.0:
-        raise ValueError("loss_bound must be positive")
+    n_actions = _require_int32("n_actions", n_actions, minimum=1)
+    horizon = _require_int32("horizon", horizon, minimum=1)
+    learning_rate = _require_theorem_real("learning_rate", learning_rate, positive=False)
+    loss_bound = _require_theorem_real("loss_bound", loss_bound, positive=True)
     if n_actions == 1:
         return 0.0
     if learning_rate == 0.0:

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -241,7 +241,10 @@ def optimal_hedge_learning_rate(
     loss_bound = _require_theorem_real("loss_bound", loss_bound, positive=True)
     if n_actions == 1:
         return 0.0
-    return math.sqrt(8.0 * math.log(n_actions) / (horizon * loss_bound**2))
+    rate = math.sqrt(8.0 * math.log(n_actions) / horizon) / loss_bound
+    if not math.isfinite(rate):
+        raise ValueError("the theorem preconditions must produce a finite learning rate")
+    return rate
 
 
 def finite_candidate_hedge_regret_bound(
@@ -270,7 +273,13 @@ def finite_candidate_hedge_regret_bound(
         return 0.0
     if learning_rate == 0.0:
         return math.inf
-    return math.log(n_actions) / learning_rate + learning_rate * horizon * loss_bound**2 / 8.0
+    first_term = math.log(n_actions) / learning_rate
+    # Multiplication intentionally replaces ``loss_bound**2``: finite large
+    # bounds should conservatively saturate to infinity, not raise OverflowError.
+    second_term = learning_rate * loss_bound
+    second_term *= loss_bound
+    second_term *= horizon / 8.0
+    return first_term + second_term
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -236,6 +236,59 @@ class TestLearnedResourceManager:
         with pytest.raises(ValueError):
             finite_candidate_hedge_regret_bound(2, 10, 0.1, loss_bound=0.0)
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"n_actions": True, "horizon": 8},
+            {"n_actions": 3, "horizon": True},
+            {"n_actions": 3.0, "horizon": 8},
+            {"n_actions": float("nan"), "horizon": 8},
+            {"n_actions": 3, "horizon": float("inf")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": float("nan")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": float("inf")},
+            {"n_actions": 3, "horizon": 8, "loss_bound": True},
+        ],
+    )
+    def test_optimal_hedge_rate_rejects_bool_and_nonfinite_preconditions(
+        self,
+        kwargs: dict[str, object],
+    ) -> None:
+        with pytest.raises(ValueError):
+            optimal_hedge_learning_rate(**kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"n_actions": True, "horizon": 8, "learning_rate": 0.1},
+            {"n_actions": 3, "horizon": True, "learning_rate": 0.1},
+            {"n_actions": 3, "horizon": 8, "learning_rate": float("nan")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": float("inf")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": True},
+            {"n_actions": 3, "horizon": 8, "learning_rate": 0.1, "loss_bound": float("nan")},
+            {"n_actions": 3, "horizon": 8, "learning_rate": 0.1, "loss_bound": True},
+        ],
+    )
+    def test_hedge_regret_bound_rejects_bool_and_nonfinite_preconditions(
+        self,
+        kwargs: dict[str, object],
+    ) -> None:
+        with pytest.raises(ValueError):
+            finite_candidate_hedge_regret_bound(**kwargs)  # type: ignore[arg-type]
+
+    def test_manager_regret_bound_rejects_nonfinite_horizon_and_loss_bound(self) -> None:
+        manager = LearnedResourceManager(
+            n_actions=3,
+            learning_rate=0.1,
+            discount=1.0,
+            exploration=0.0,
+        )
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(float("nan"))  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(True)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            manager.fixed_candidate_regret_bound(8, loss_bound=float("nan"))
+
 
 class TestGeneratorMetaResourceManager:
     """Behavioral checks for generator-internal meta-resource policies."""

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -289,6 +289,22 @@ class TestLearnedResourceManager:
         with pytest.raises(ValueError):
             manager.fixed_candidate_regret_bound(8, loss_bound=float("nan"))
 
+    def test_theorem_helpers_fail_closed_or_saturate_at_finite_extremes(self) -> None:
+        with pytest.raises(ValueError, match="finite learning rate"):
+            optimal_hedge_learning_rate(
+                2,
+                1,
+                loss_bound=float.fromhex("0x0.0000000000001p-1022"),
+            )
+
+        bound = finite_candidate_hedge_regret_bound(
+            2,
+            1,
+            learning_rate=1.0,
+            loss_bound=1e308,
+        )
+        assert math.isinf(bound)
+
 
 class TestGeneratorMetaResourceManager:
     """Behavioral checks for generator-internal meta-resource policies."""


### PR DESCRIPTION
Supersedes #893 after deep review. Retains its exact finite precondition validation, then closes two residual numerical paths: the optimal-rate formula no longer divides by a squared value that can underflow to zero, and the regret bound no longer raises OverflowError on a large finite loss bound. Nonrepresentable optimal rates fail closed; conservative bounds saturate to infinity. Verification: 114 resource/compositional tests passed; Ruff and strict mypy clean; diff check clean.