### PR TITLE
fix(streams): complete recurring start-position contracts

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -40,6 +40,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
@@ -388,9 +389,17 @@ class RecurringTwoAgentWorld:
                 f"initial_positions must contain {N_AGENTS} values, "
                 f"got {len(initial_positions)}"
             )
-        if any(not math.isfinite(float(position)) for position in initial_positions):
-            raise ValueError("initial_positions must be finite")
-        if any(abs(position) > world_limit for position in initial_positions):
+        canonical_positions: list[float] = []
+        for position in initial_positions:
+            if isinstance(position, (bool, np.bool_)) or not isinstance(
+                position, (int, float, np.integer, np.floating)
+            ):
+                raise ValueError("initial_positions must be finite real numbers")
+            number = float(position)
+            if not math.isfinite(number):
+                raise ValueError("initial_positions must be finite")
+            canonical_positions.append(number)
+        if any(abs(position) > world_limit for position in canonical_positions):
             raise ValueError(
                 "initial_positions must lie within [-world_limit, world_limit]"
             )
@@ -403,8 +412,8 @@ class RecurringTwoAgentWorld:
         self._acceleration = float(acceleration)
         self._time_delta = float(time_delta)
         self._max_speed = float(max_speed)
-        self._initial_positions_tuple = tuple(float(value) for value in initial_positions)
-        self._initial_positions = jnp.asarray(initial_positions, dtype=jnp.float32)
+        self._initial_positions_tuple = tuple(canonical_positions)
+        self._initial_positions = jnp.asarray(canonical_positions, dtype=jnp.float32)
         self._partner_policy_is_default = partner_policy is None
         self._partner_policy = (
             scripted_meet_avoid_partner_policy

--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -40,10 +40,10 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
+from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
     load_checkpoint_metadata,
@@ -70,9 +70,7 @@ _UINT32_MAX = 2**32 - 1
 RECURRING_TWO_AGENT_CONFIG_SCHEMA = "alberta.recurring-two-agent-config.v2"
 RECURRING_TWO_AGENT_STATE_SCHEMA = "alberta.recurring-two-agent-state.v2"
 RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA = "alberta.recurring-two-agent-checkpoint.v2"
-_LEGACY_RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA = (
-    "alberta.recurring-two-agent-checkpoint.v1"
-)
+_LEGACY_RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA = "alberta.recurring-two-agent-checkpoint.v1"
 RECURRING_TWO_AGENT_CLOCK_NBYTES = 12
 RECURRING_TWO_AGENT_CLOCK_DELTA_NBYTES = 8
 
@@ -136,9 +134,7 @@ def _divmod_words_by_u32(words: Array, divisor: int | Array) -> tuple[Array, Arr
         doubled = remainder + remainder + bit
         subtract = doubled >= divisor_array
         remainder = jnp.where(subtract, doubled - divisor_array, doubled)
-        mask = jnp.left_shift(
-            jnp.asarray(1, dtype=jnp.uint32), bit_index.astype(jnp.uint32)
-        )
+        mask = jnp.left_shift(jnp.asarray(1, dtype=jnp.uint32), bit_index.astype(jnp.uint32))
         quotient_high = jnp.where(
             in_high & subtract,
             jnp.bitwise_or(quotient_high, mask),
@@ -288,8 +284,7 @@ def scripted_meet_avoid_partner_policy(
     del key
     relative_position = partner_observation[RELATIVE_POSITION_INDEX]
     objective_direction = (
-        partner_observation[MEET_CONTEXT_INDEX]
-        - partner_observation[AVOID_CONTEXT_INDEX]
+        partner_observation[MEET_CONTEXT_INDEX] - partner_observation[AVOID_CONTEXT_INDEX]
     )
     return jnp.sign(relative_position) * objective_direction
 
@@ -351,9 +346,7 @@ class RecurringTwoAgentWorld:
             or not isinstance(context_length, int)
             or context_length <= 0
         ):
-            raise ValueError(
-                f"context_length must be positive, got {context_length}"
-            )
+            raise ValueError(f"context_length must be positive, got {context_length}")
         if context_length > _INT32_MAX // 2:
             raise ValueError("2 * context_length must fit in signed schedule telemetry")
         if isinstance(nuisance_dim, bool) or not isinstance(nuisance_dim, int) or nuisance_dim < 0:
@@ -371,9 +364,7 @@ class RecurringTwoAgentWorld:
             if not math.isfinite(float(value)):
                 raise ValueError(f"{name} must be finite")
         if nuisance_scale < 0.0:
-            raise ValueError(
-                f"nuisance_scale must be non-negative, got {nuisance_scale}"
-            )
+            raise ValueError(f"nuisance_scale must be non-negative, got {nuisance_scale}")
         if world_limit <= 0.0:
             raise ValueError(f"world_limit must be positive, got {world_limit}")
         if not 0.0 <= damping < 1.0:
@@ -384,25 +375,14 @@ class RecurringTwoAgentWorld:
             raise ValueError(f"time_delta must be positive, got {time_delta}")
         if max_speed <= 0.0:
             raise ValueError(f"max_speed must be positive, got {max_speed}")
-        if len(initial_positions) != N_AGENTS:
-            raise ValueError(
-                f"initial_positions must contain {N_AGENTS} values, "
-                f"got {len(initial_positions)}"
-            )
-        canonical_positions: list[float] = []
-        for position in initial_positions:
-            if isinstance(position, (bool, np.bool_)) or not isinstance(
-                position, (int, float, np.integer, np.floating)
-            ):
-                raise ValueError("initial_positions must be finite real numbers")
-            number = float(position)
-            if not math.isfinite(number):
-                raise ValueError("initial_positions must be finite")
-            canonical_positions.append(number)
+        if type(initial_positions) is not tuple or len(initial_positions) != N_AGENTS:
+            raise ValueError(f"initial_positions must be an exact {N_AGENTS}-tuple")
+        canonical_positions = tuple(
+            validated_float32_scalar(f"initial_positions[{index}]", position)
+            for index, position in enumerate(initial_positions)
+        )
         if any(abs(position) > world_limit for position in canonical_positions):
-            raise ValueError(
-                "initial_positions must lie within [-world_limit, world_limit]"
-            )
+            raise ValueError("initial_positions must lie within [-world_limit, world_limit]")
 
         self._context_length = int(context_length)
         self._nuisance_dim = int(nuisance_dim)
@@ -412,13 +392,11 @@ class RecurringTwoAgentWorld:
         self._acceleration = float(acceleration)
         self._time_delta = float(time_delta)
         self._max_speed = float(max_speed)
-        self._initial_positions_tuple = tuple(canonical_positions)
+        self._initial_positions_tuple = canonical_positions
         self._initial_positions = jnp.asarray(canonical_positions, dtype=jnp.float32)
         self._partner_policy_is_default = partner_policy is None
         self._partner_policy = (
-            scripted_meet_avoid_partner_policy
-            if partner_policy is None
-            else partner_policy
+            scripted_meet_avoid_partner_policy if partner_policy is None else partner_policy
         )
 
     @property
@@ -569,21 +547,15 @@ class RecurringTwoAgentWorld:
         segment_words, _remainder = _divmod_words_by_u32(
             cast(Array, state.step_words), self._context_length
         )
-        return jnp.bitwise_and(
-            segment_words[1], jnp.asarray(1, dtype=jnp.uint32)
-        ).astype(jnp.int32)
+        return jnp.bitwise_and(segment_words[1], jnp.asarray(1, dtype=jnp.uint32)).astype(jnp.int32)
 
-    def _schedule_identities(
-        self, words: Array
-    ) -> tuple[Array, Array, Array, Array]:
+    def _schedule_identities(self, words: Array) -> tuple[Array, Array, Array, Array]:
         """Return exact segment/cycle identities and bounded schedule phase."""
-        segment_words, segment_step = _divmod_words_by_u32(
-            words, self._context_length
-        )
+        segment_words, segment_step = _divmod_words_by_u32(words, self._context_length)
         cycle_words, _parity = _divmod_words_by_u32(segment_words, 2)
-        context = jnp.bitwise_and(
-            segment_words[1], jnp.asarray(1, dtype=jnp.uint32)
-        ).astype(jnp.int32)
+        context = jnp.bitwise_and(segment_words[1], jnp.asarray(1, dtype=jnp.uint32)).astype(
+            jnp.int32
+        )
         return segment_words, cycle_words, segment_step.astype(jnp.int32), context
 
     def init(self, key: Array) -> RecurringTwoAgentState:
@@ -605,9 +577,7 @@ class RecurringTwoAgentWorld:
 
         other = jnp.array([1, 0], dtype=jnp.int32)
         own_positions = state.positions / self._world_limit
-        relative_positions = (
-            state.positions[other] - state.positions
-        ) / (2.0 * self._world_limit)
+        relative_positions = (state.positions[other] - state.positions) / (2.0 * self._world_limit)
         own_velocities = state.velocities / self._max_speed
         other_velocities = state.velocities[other] / self._max_speed
 
@@ -682,9 +652,7 @@ class RecurringTwoAgentWorld:
         )
         learner_action_array = jnp.asarray(learner_action, dtype=jnp.float32)
         if partner_action.size != 1:
-            raise ValueError(
-                "partner policy must return a scalar or one-element action"
-            )
+            raise ValueError("partner policy must return a scalar or one-element action")
         if learner_action_array.size != 1:
             raise ValueError("learner_action must be scalar or one-element")
         joint_action = jnp.stack(
@@ -713,8 +681,7 @@ class RecurringTwoAgentWorld:
         requested_actions = jnp.asarray(joint_action)
         if requested_actions.shape != (N_AGENTS,):
             raise ValueError(
-                f"joint_action must have shape ({N_AGENTS},), "
-                f"got {requested_actions.shape}"
+                f"joint_action must have shape ({N_AGENTS},), got {requested_actions.shape}"
             )
         if requested_actions.dtype != jnp.dtype(jnp.float32):
             raise TypeError("joint_action must have dtype float32")
@@ -726,18 +693,13 @@ class RecurringTwoAgentWorld:
         safe_actions = jnp.where(jnp.isfinite(requested_actions), requested_actions, 0.0)
         applied_actions = jnp.clip(safe_actions, -1.0, 1.0)
 
-        accelerated = (
-            self._damping * state.velocities
-            + self._acceleration * applied_actions
-        )
+        accelerated = self._damping * state.velocities + self._acceleration * applied_actions
         candidate_velocities = jnp.clip(
             accelerated,
             -self._max_speed,
             self._max_speed,
         )
-        candidate_positions = (
-            state.positions + self._time_delta * candidate_velocities
-        )
+        candidate_positions = state.positions + self._time_delta * candidate_velocities
         positions = jnp.clip(
             candidate_positions,
             -self._world_limit,
@@ -774,10 +736,7 @@ class RecurringTwoAgentWorld:
         )
         candidate_state_valid = self.state_is_valid(candidate_state)
         update_applied = (
-            state_valid
-            & input_valid
-            & lifetime_capacity_available
-            & candidate_state_valid
+            state_valid & input_valid & lifetime_capacity_available & candidate_state_valid
         )
         new_state = cast(
             RecurringTwoAgentState,
@@ -904,9 +863,7 @@ def _restore_recurring_empty_arrays(
         RecurringTwoAgentState,
         jax.tree.map(
             lambda stored, expected: (
-                expected
-                if isinstance(expected, Array) and expected.size == 0
-                else stored
+                expected if isinstance(expected, Array) and expected.size == 0 else stored
             ),
             restored,
             template,
@@ -1006,9 +963,7 @@ def load_recurring_two_agent_checkpoint(
     )
     if restored_metadata != metadata:
         raise ValueError("recurring two-agent checkpoint metadata changed between reads")
-    state = _restore_recurring_empty_arrays(
-        cast(RecurringTwoAgentState, restored), template
-    )
+    state = _restore_recurring_empty_arrays(cast(RecurringTwoAgentState, restored), template)
     world._require_state_contract(state)
     if not bool(jax.device_get(world.state_is_valid(state))):
         raise ValueError("restored recurring two-agent state is invalid")

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -8,6 +8,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.streams import (
@@ -226,8 +227,7 @@ def test_meet_and_avoid_rewards_use_post_action_distance() -> None:
     assert float(meet_transition.oracle.meet_reward) == pytest.approx(0.25)
     assert float(meet_transition.oracle.avoid_reward) == pytest.approx(0.75)
     assert float(
-        meet_transition.oracle.meet_reward
-        + meet_transition.oracle.avoid_reward
+        meet_transition.oracle.meet_reward + meet_transition.oracle.avoid_reward
     ) == pytest.approx(1.0)
 
 
@@ -496,9 +496,7 @@ def test_jitted_scan_runs_continually_and_remains_bounded() -> None:
     ) = outputs
 
     expected_contexts = (jnp.arange(num_steps) // world.context_length) % 2
-    expected_next_contexts = (
-        (jnp.arange(num_steps) + 1) // world.context_length
-    ) % 2
+    expected_next_contexts = ((jnp.arange(num_steps) + 1) // world.context_length) % 2
     chex.assert_trees_all_equal(contexts, expected_contexts)
     chex.assert_trees_all_equal(switched, contexts != expected_next_contexts)
     assert int(final_state.step_count) == num_steps
@@ -508,6 +506,26 @@ def test_jitted_scan_runs_continually_and_remains_bounded() -> None:
     assert jnp.all(jnp.abs(velocities) <= world.max_speed)
     chex.assert_shape(rewards, (num_steps, 2))
     chex.assert_shape(observations, (num_steps, 2, world.observation_dim))
-    chex.assert_tree_all_finite(
-        (rewards, discounts, positions, velocities, observations)
-    )
+    chex.assert_tree_all_finite((rewards, discounts, positions, velocities, observations))
+
+
+def test_recurring_two_agent_world_initial_positions_reject_booleans() -> None:
+    # Boolean initial positions
+    with pytest.raises(ValueError, match="initial_positions"):
+        RecurringTwoAgentWorld(initial_positions=(True, False))  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="initial_positions"):
+        RecurringTwoAgentWorld(initial_positions=(False, True))  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="initial_positions"):
+        RecurringTwoAgentWorld(initial_positions=(np.True_, 0.0))  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="initial_positions"):
+        RecurringTwoAgentWorld(initial_positions=(1.0, False))  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="initial_positions"):
+        RecurringTwoAgentWorld(initial_positions=(float("nan"), 0.5))
+
+    # Valid initial positions
+    world = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
+    assert world.to_config()["initial_positions"] == [-0.5, 0.5]

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -62,13 +62,37 @@ def test_invalid_configuration_is_rejected(
 
 
 def test_initial_positions_reject_boolean_identities() -> None:
-    import numpy as np
-
     legal = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
     assert legal._initial_positions_tuple == (-0.5, 0.5)
     for positions in ((True, False), (np.True_, 0.0), (1.0, np.bool_(False))):
         with pytest.raises(ValueError, match="initial_positions"):
             RecurringTwoAgentWorld(initial_positions=positions)
+
+
+def test_initial_positions_validate_container_and_numeric_hooks_before_allocation() -> None:
+    class HostileTuple(tuple):
+        def __len__(self) -> int:
+            raise AssertionError("hostile length hook executed")
+
+    class ExplodingFloat(float):
+        def as_integer_ratio(self) -> tuple[int, int]:
+            raise RuntimeError("hostile ratio hook")
+
+        def __repr__(self) -> str:
+            raise AssertionError("hostile repr hook executed")
+
+    with pytest.raises(ValueError, match="exact 2-tuple"):
+        RecurringTwoAgentWorld(initial_positions=HostileTuple((-0.5, 0.5)))
+    with pytest.raises(ValueError, match=r"initial_positions\[0\]"):
+        RecurringTwoAgentWorld(initial_positions=(ExplodingFloat(0.25), 0.5))
+
+
+def test_initial_positions_canonicalize_supported_numpy_scalars() -> None:
+    world = RecurringTwoAgentWorld(
+        initial_positions=(np.float64(-0.25), np.int16(0)),
+    )
+    assert world._initial_positions_tuple == (-0.25, 0.0)
+    assert all(type(value) is float for value in world._initial_positions_tuple)
 
 
 def test_visible_context_sequence_recurs_a_b_a() -> None:

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -47,6 +47,9 @@ def _with_step_count(
         ({"time_delta": 0.0}, "time_delta"),
         ({"max_speed": 0.0}, "max_speed"),
         ({"initial_positions": (-2.0, 0.0)}, "initial_positions"),
+        ({"initial_positions": (True, False)}, "initial_positions"),
+        ({"initial_positions": (False, True)}, "initial_positions"),
+        ({"initial_positions": (1.0, False)}, "initial_positions"),
     ],
 )
 def test_invalid_configuration_is_rejected(
@@ -55,6 +58,16 @@ def test_invalid_configuration_is_rejected(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         RecurringTwoAgentWorld(**kwargs)  # type: ignore[arg-type]
+
+
+def test_initial_positions_reject_boolean_identities() -> None:
+    import numpy as np
+
+    legal = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
+    assert legal._initial_positions_tuple == (-0.5, 0.5)
+    for positions in ((True, False), (np.True_, 0.0), (1.0, np.bool_(False))):
+        with pytest.raises(ValueError, match="initial_positions"):
+            RecurringTwoAgentWorld(initial_positions=positions)
 
 
 def test_visible_context_sequence_recurs_a_b_a() -> None:


### PR DESCRIPTION
Supersedes duplicate PRs #946 and #966 while preserving both contributor commits. Closes #943.

This consolidates their boolean/non-real rejection and tightens the public boundary to an exact two-tuple, guarded float32-consumed scalar validation, canonical supported NumPy values, and normalized hostile-hook failures before JAX allocation.

Verification: 28 recurring-world tests; Ruff; strict mypy; diff-check. No outputs or evidence sources changed.