### PR TITLE
fix(statistics): complete publication count validation

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -5,15 +5,21 @@ effect sizes, and multiple comparison corrections.
 """
 
 import math
+import operator
 from collections.abc import Mapping
 from numbers import Real
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple, SupportsIndex, cast
 
 import numpy as np
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
     from alberta_framework.utils.experiments import AggregatedResults
+
+
+_ACTUAL_INT_TYPES = frozenset(
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
+)
 
 
 class StatisticalSummary(NamedTuple):
@@ -116,11 +122,11 @@ def _require_alpha(alpha: object) -> float:
 
 def _require_positive_int(name: str, value: object) -> int:
     """Reject bool/float aliases that ordered comparisons treat as legal counts."""
-    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
-        raise ValueError(f"{name} must be a positive integer (got {value!r})")
-    count = int(value)
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a positive integer")
+    count = operator.index(cast(SupportsIndex, value))
     if count <= 0:
-        raise ValueError(f"{name} must be a positive integer (got {value})")
+        raise ValueError(f"{name} must be a positive integer")
     return count
 
 

--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -114,6 +114,16 @@ def _require_alpha(alpha: object) -> float:
     return _require_probability(alpha, name="alpha", strict=True)
 
 
+def _require_positive_int(name: str, value: object) -> int:
+    """Reject bool/float aliases that ordered comparisons treat as legal counts."""
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be a positive integer (got {value!r})")
+    count = int(value)
+    if count <= 0:
+        raise ValueError(f"{name} must be a positive integer (got {value})")
+    return count
+
+
 def _require_p_value(value: object, *, name: str) -> float:
     return _require_probability(value, name=name, strict=False)
 
@@ -666,8 +676,7 @@ def pairwise_comparisons(
     from alberta_framework.utils.experiments import AggregatedResults
 
     alpha_value = _require_alpha(alpha)
-    if window <= 0:
-        raise ValueError(f"window must be positive (got {window})")
+    window = _require_positive_int("window", window)
 
     names = list(results.keys())
     n = len(names)
@@ -817,8 +826,7 @@ def bootstrap_ci(
             f"statistic must be either 'mean' or 'median' (got {statistic!r})"
         )
     _validate_confidence_level(confidence_level)
-    if n_bootstrap <= 0:
-        raise ValueError(f"n_bootstrap must be positive (got {n_bootstrap})")
+    n_bootstrap = _require_positive_int("n_bootstrap", n_bootstrap)
     rng = np.random.default_rng(seed)
 
     stat_func = np.mean if statistic == "mean" else np.median

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -495,6 +495,17 @@ class TestBootstrapCI:
             with pytest.raises(ValueError, match="n_bootstrap.*positive integer"):
                 bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=n_bootstrap, seed=0)  # type: ignore[arg-type]
 
+    def test_hostile_bootstrap_count_is_rejected_without_hooks(self) -> None:
+        class HostileInt(int):
+            def __index__(self) -> int:  # pragma: no cover
+                raise AssertionError("index hook executed")
+
+            def __repr__(self) -> str:  # pragma: no cover
+                raise AssertionError("repr hook executed")
+
+        with pytest.raises(ValueError, match="n_bootstrap.*positive integer"):
+            bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=HostileInt(10))
+
     @pytest.mark.parametrize("confidence_level", [0.0, 1.0, -0.1, 1.1, float("nan")])
     def test_invalid_confidence_level_rejected_without_warnings(
         self,

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -485,6 +485,16 @@ class TestBootstrapCI:
             with pytest.raises(ValueError, match="n_bootstrap.*positive"):
                 bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=n_bootstrap)
 
+    @pytest.mark.parametrize("n_bootstrap", [True, False, 1.0, float("nan"), float("inf")])
+    def test_bool_and_noninteger_bootstrap_count_rejected_without_warnings(
+        self,
+        n_bootstrap: object,
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="n_bootstrap.*positive integer"):
+                bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=n_bootstrap, seed=0)  # type: ignore[arg-type]
+
     @pytest.mark.parametrize("confidence_level", [0.0, 1.0, -0.1, 1.1, float("nan")])
     def test_invalid_confidence_level_rejected_without_warnings(
         self,
@@ -965,6 +975,16 @@ class TestPairwiseComparisons:
             warnings.simplefilter("error")
             with pytest.raises(ValueError, match="window.*positive"):
                 pairwise_comparisons(self._results(), window=window)
+
+    @pytest.mark.parametrize("window", [True, False, 1.0, float("nan"), float("inf")])
+    def test_bool_and_noninteger_window_rejected_without_warnings(
+        self,
+        window: object,
+    ) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(ValueError, match="window.*positive integer"):
+                pairwise_comparisons(self._results(), window=window)  # type: ignore[arg-type]
 
     def test_zero_step_metric_rejected_without_warnings(self) -> None:
         empty_steps = AggregatedResults(


### PR DESCRIPTION
Supersedes #894 after deep review. Retains its positive integer enforcement for bootstrap/window counts, while using an exact concrete integer whitelist and hostile-safe messages so int subclasses cannot execute conversion or repr hooks. Legal NumPy integer scalars remain accepted. Verification: 285 statistics/forager-matched tests passed; Ruff and strict mypy clean; diff check clean.