### PR TITLE
fix(learners): complete exact dimension and resource contracts

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -21,12 +21,14 @@ same loop over seeds for multi-seed experiments.
 """
 
 import functools
+import operator
 import time
-from typing import Any, Protocol, TypeVar, cast
+from typing import Any, Protocol, SupportsIndex, TypeVar, cast
 
 import chex
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
@@ -74,6 +76,40 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 from alberta_framework.streams.base import ScanStream
+
+_INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
+    if type(hidden_sizes) is not tuple:
+        raise ValueError("hidden_sizes must be an actual tuple")
+    return tuple(
+        _require_int32(f"hidden_sizes[{i}]", h, minimum=1) for i, h in enumerate(hidden_sizes)
+    )
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -193,6 +229,7 @@ class LinearLearner:
         Returns:
             Initial learner state with zero weights and bias
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         optimizer_state = self._optimizer.init(feature_dim)
 
         normalizer_state = None
@@ -300,13 +337,9 @@ class LinearLearner:
                 dtype=jnp.float32,
             )
         else:
-            metrics = jnp.array(
-                [squared_error, error, mean_step_size], dtype=jnp.float32
-            )
+            metrics = jnp.array([squared_error, error, mean_step_size], dtype=jnp.float32)
 
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
-            jnp.isfinite(target)
-        )
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(target))
         update_applied = (
             floating_tree_is_finite(state)
             & inputs_valid
@@ -317,9 +350,7 @@ class LinearLearner:
             & jnp.isfinite(error)
             & jnp.all(jnp.isfinite(metrics))
         )
-        new_state = select_transaction(
-            update_applied, candidate_state, state
-        ).replace(  # type: ignore[attr-defined]
+        new_state = select_transaction(update_applied, candidate_state, state).replace(  # type: ignore[attr-defined]
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -565,9 +596,7 @@ def run_learning_loop[StreamStateT](
                 bias_ss = opt_state.step_size
 
             new_ss_hist = _maybe_record(should_record_ss, ss_hist, recording_idx, weight_ss)
-            new_ss_bias_hist = _maybe_record(
-                should_record_ss, ss_bias_hist, recording_idx, bias_ss
-            )
+            new_ss_bias_hist = _maybe_record(should_record_ss, ss_bias_hist, recording_idx, bias_ss)
             new_ss_rec = _maybe_record(should_record_ss, ss_rec, recording_idx, idx)
             # Track Autostep normalizers (v_i) if applicable
             if ss_norm is not None and hasattr(opt_state, "normalizers"):
@@ -722,8 +751,13 @@ def run_learning_loop_batched[StreamStateT](
         key: Array,
     ) -> tuple[LearnerState, Array, StepSizeHistory | None, NormalizerHistory | None]:
         result = run_learning_loop(
-            learner, stream, num_steps, key, learner_state,
-            step_size_tracking, normalizer_tracking,
+            learner,
+            stream,
+            num_steps,
+            key,
+            learner_state,
+            step_size_tracking,
+            normalizer_tracking,
         )
 
         # Unpack based on what tracking was enabled
@@ -734,9 +768,7 @@ def run_learning_loop_batched[StreamStateT](
             )
             return state, metrics, ss_history, norm_history
         elif step_size_tracking is not None:
-            state, metrics, ss_history = cast(
-                tuple[LearnerState, Array, StepSizeHistory], result
-            )
+            state, metrics, ss_history = cast(tuple[LearnerState, Array, StepSizeHistory], result)
             return state, metrics, ss_history, None
         elif normalizer_tracking is not None:
             state, metrics, norm_history = cast(
@@ -926,7 +958,7 @@ class MLPLearner:
             neuron_utility_decay: EMA decay for neuron utility (default 0.99).
                 Higher values track slower, smoother utility signals.
         """
-        self._hidden_sizes = hidden_sizes
+        self._hidden_sizes = _require_hidden_sizes(hidden_sizes)
         self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
         self._head_optimizer: AnyOptimizer | None = head_optimizer
         if not self._optimizer.supported_for_mlp():
@@ -957,9 +989,7 @@ class MLPLearner:
         return self._normalizer
 
     @staticmethod
-    def dormant_neuron_fraction(
-        state: MLPLearnerState, threshold: float = 0.01
-    ) -> float:
+    def dormant_neuron_fraction(state: MLPLearnerState, threshold: float = 0.01) -> float:
         """Fraction of hidden neurons whose utility EMA is below *threshold*.
 
         Args:
@@ -1079,9 +1109,7 @@ class MLPLearner:
             "bounder": self._bounder.to_config() if self._bounder is not None else None,
             "normalizer": self._normalizer.to_config() if self._normalizer is not None else None,
             "head_optimizer": (
-                self._head_optimizer.to_config()
-                if self._head_optimizer is not None
-                else None
+                self._head_optimizer.to_config() if self._head_optimizer is not None else None
             ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
@@ -1139,6 +1167,7 @@ class MLPLearner:
         Returns:
             Initial MLP learner state with sparse weights and zero biases
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         # Build layer sizes: [feature_dim, hidden1, hidden2, ..., 1]
         layer_sizes = [feature_dim, *self._hidden_sizes, 1]
 
@@ -1352,13 +1381,11 @@ class MLPLearner:
         for j in range(n_trace_entries):
             is_output = self._head_optimizer is not None and j >= n_trace_entries - 2
             opt = self._head_optimizer if is_output else self._optimizer
-            step, new_opt, optimizer_update_applied = (
-                _update_from_gradient_with_diagnostics(
-                    opt,
-                    state.optimizer_states[j],
-                    new_traces[j],
-                    error=error,
-                )
+            step, new_opt, optimizer_update_applied = _update_from_gradient_with_diagnostics(
+                opt,
+                state.optimizer_states[j],
+                new_traces[j],
+                error=error,
             )
             all_steps.append(step)
             new_opt_states.append(new_opt)
@@ -1384,9 +1411,7 @@ class MLPLearner:
             new_b = state.params.biases[i] + error * all_steps[2 * i + 1]
             new_biases.append(new_b)
 
-        new_params = MLPParams(
-            weights=tuple(new_weights), biases=tuple(new_biases)
-        )
+        new_params = MLPParams(weights=tuple(new_weights), biases=tuple(new_biases))
 
         # Per-hidden-unit gradient utility: EMA of row-wise L2 norm of weight gradients
         new_neuron_utility: tuple[Array, ...] | None = state.neuron_utility
@@ -1398,8 +1423,7 @@ class MLPLearner:
                     jnp.zeros_like(state.neuron_utility[i]),
                     decay * state.neuron_utility[i],
                 )
-                + (1.0 - decay)
-                * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
+                + (1.0 - decay) * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
                 for i in range(len(self._hidden_sizes))
             )
 
@@ -1418,14 +1442,9 @@ class MLPLearner:
             previous_checked = state.replace(  # type: ignore[attr-defined]
                 traces=tuple(jnp.zeros_like(trace) for trace in state.traces),
             )
-        if (
-            state.neuron_utility is not None
-            and self._neuron_utility_decay == 0.0
-        ):
+        if state.neuron_utility is not None and self._neuron_utility_decay == 0.0:
             previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
-                neuron_utility=tuple(
-                    jnp.zeros_like(utility) for utility in state.neuron_utility
-                ),
+                neuron_utility=tuple(jnp.zeros_like(utility) for utility in state.neuron_utility),
             )
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.isfinite(target_scalar)
         update_applied = (
@@ -1449,9 +1468,7 @@ class MLPLearner:
                 dtype=jnp.float32,
             )
         else:
-            metrics = jnp.array(
-                [squared_error, error, bounding_metric], dtype=jnp.float32
-            )
+            metrics = jnp.array([squared_error, error, bounding_metric], dtype=jnp.float32)
 
         return MLPUpdateResult(
             state=new_state,
@@ -1473,10 +1490,7 @@ def run_mlp_learning_loop[StreamStateT](
     key: Array,
     learner_state: MLPLearnerState | None = None,
     normalizer_tracking: NormalizerTrackingConfig | None = None,
-) -> (
-    tuple[MLPLearnerState, Array]
-    | tuple[MLPLearnerState, Array, NormalizerHistory]
-):
+) -> tuple[MLPLearnerState, Array] | tuple[MLPLearnerState, Array, NormalizerHistory]:
     """Run the MLP learning loop using jax.lax.scan.
 
     This is a JIT-compiled learning loop that uses scan for efficiency.
@@ -1852,9 +1866,7 @@ class TDLinearLearner:
             & jnp.isfinite(td_error)
             & jnp.all(jnp.isfinite(metrics))
         )
-        new_state = select_transaction(
-            update_applied, candidate_state, state
-        ).replace(  # type: ignore[attr-defined]
+        new_state = select_transaction(update_applied, candidate_state, state).replace(  # type: ignore[attr-defined]
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -1919,6 +1931,7 @@ class TrueOnlineTDLearner:
 
     def init(self, feature_dim: int) -> TrueOnlineTDState:
         """Initialize learner state."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         return TrueOnlineTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -1968,16 +1981,8 @@ class TrueOnlineTDLearner:
 
         correction = value - state.v_old
         update_scale = alpha * (td_error + correction)
-        new_weights = (
-            state.weights
-            + update_scale * new_traces
-            - alpha * correction * observation
-        )
-        new_bias = (
-            state.bias
-            + update_scale * new_bias_trace
-            - alpha * correction
-        )
+        new_weights = state.weights + update_scale * new_traces - alpha * correction * observation
+        new_bias = state.bias + update_scale * new_bias_trace - alpha * correction
 
         terminal = gamma_scalar == 0.0
         stored_traces = jnp.where(terminal, jnp.zeros_like(new_traces), new_traces)

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -78,6 +78,7 @@ from alberta_framework.core.update_safety import (
 from alberta_framework.streams.base import ScanStream
 
 _INT32_MAX = 2**31 - 1
+_MAX_RESOURCE_BYTES = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -95,12 +96,12 @@ _ACTUAL_INT_TYPES = frozenset(
 )
 
 
-def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+def _require_int32(name: str, value: object, *, minimum: int) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
     canonical = operator.index(cast(SupportsIndex, value))
-    if not minimum <= canonical <= maximum:
-        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    if not minimum <= canonical <= _INT32_MAX:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
     return canonical
 
 
@@ -108,8 +109,17 @@ def _require_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
     if type(hidden_sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
     return tuple(
-        _require_int32(f"hidden_sizes[{i}]", h, minimum=1) for i, h in enumerate(hidden_sizes)
+        _require_int32(f"hidden_sizes[{index}]", width, minimum=1)
+        for index, width in enumerate(hidden_sizes)
     )
+
+
+def _preflight_float32_resources(name: str, scalar_count: int) -> None:
+    byte_count = 4 * scalar_count
+    if scalar_count > _INT32_MAX or byte_count > _INT32_MAX:
+        raise ValueError(f"{name} resource must fit signed-int32 scalar and byte bounds")
+    if byte_count > _MAX_RESOURCE_BYTES:
+        raise ValueError(f"{name} resource must not exceed the 256 MiB budget")
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -230,6 +240,7 @@ class LinearLearner:
             Initial learner state with zero weights and bias
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_float32_resources("linear learner state", feature_dim + 2)
         optimizer_state = self._optimizer.init(feature_dim)
 
         normalizer_state = None
@@ -337,9 +348,13 @@ class LinearLearner:
                 dtype=jnp.float32,
             )
         else:
-            metrics = jnp.array([squared_error, error, mean_step_size], dtype=jnp.float32)
+            metrics = jnp.array(
+                [squared_error, error, mean_step_size], dtype=jnp.float32
+            )
 
-        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(jnp.isfinite(target))
+        inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.all(
+            jnp.isfinite(target)
+        )
         update_applied = (
             floating_tree_is_finite(state)
             & inputs_valid
@@ -350,7 +365,9 @@ class LinearLearner:
             & jnp.isfinite(error)
             & jnp.all(jnp.isfinite(metrics))
         )
-        new_state = select_transaction(update_applied, candidate_state, state).replace(  # type: ignore[attr-defined]
+        new_state = select_transaction(
+            update_applied, candidate_state, state
+        ).replace(  # type: ignore[attr-defined]
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -596,7 +613,9 @@ def run_learning_loop[StreamStateT](
                 bias_ss = opt_state.step_size
 
             new_ss_hist = _maybe_record(should_record_ss, ss_hist, recording_idx, weight_ss)
-            new_ss_bias_hist = _maybe_record(should_record_ss, ss_bias_hist, recording_idx, bias_ss)
+            new_ss_bias_hist = _maybe_record(
+                should_record_ss, ss_bias_hist, recording_idx, bias_ss
+            )
             new_ss_rec = _maybe_record(should_record_ss, ss_rec, recording_idx, idx)
             # Track Autostep normalizers (v_i) if applicable
             if ss_norm is not None and hasattr(opt_state, "normalizers"):
@@ -751,13 +770,8 @@ def run_learning_loop_batched[StreamStateT](
         key: Array,
     ) -> tuple[LearnerState, Array, StepSizeHistory | None, NormalizerHistory | None]:
         result = run_learning_loop(
-            learner,
-            stream,
-            num_steps,
-            key,
-            learner_state,
-            step_size_tracking,
-            normalizer_tracking,
+            learner, stream, num_steps, key, learner_state,
+            step_size_tracking, normalizer_tracking,
         )
 
         # Unpack based on what tracking was enabled
@@ -768,7 +782,9 @@ def run_learning_loop_batched[StreamStateT](
             )
             return state, metrics, ss_history, norm_history
         elif step_size_tracking is not None:
-            state, metrics, ss_history = cast(tuple[LearnerState, Array, StepSizeHistory], result)
+            state, metrics, ss_history = cast(
+                tuple[LearnerState, Array, StepSizeHistory], result
+            )
             return state, metrics, ss_history, None
         elif normalizer_tracking is not None:
             state, metrics, norm_history = cast(
@@ -989,7 +1005,9 @@ class MLPLearner:
         return self._normalizer
 
     @staticmethod
-    def dormant_neuron_fraction(state: MLPLearnerState, threshold: float = 0.01) -> float:
+    def dormant_neuron_fraction(
+        state: MLPLearnerState, threshold: float = 0.01
+    ) -> float:
         """Fraction of hidden neurons whose utility EMA is below *threshold*.
 
         Args:
@@ -1109,7 +1127,9 @@ class MLPLearner:
             "bounder": self._bounder.to_config() if self._bounder is not None else None,
             "normalizer": self._normalizer.to_config() if self._normalizer is not None else None,
             "head_optimizer": (
-                self._head_optimizer.to_config() if self._head_optimizer is not None else None
+                self._head_optimizer.to_config()
+                if self._head_optimizer is not None
+                else None
             ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
@@ -1168,8 +1188,19 @@ class MLPLearner:
             Initial MLP learner state with sparse weights and zero biases
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        # Build layer sizes: [feature_dim, hidden1, hidden2, ..., 1]
         layer_sizes = [feature_dim, *self._hidden_sizes, 1]
+        parameter_count = sum(
+            fan_out * (fan_in + 1)
+            for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:])
+        )
+        utility_count = sum(self._hidden_sizes) if self._track_neuron_utility else 0
+        # Parameters, traces, optimizer working/state copies, and optional utility.
+        _preflight_float32_resources(
+            "MLP learner state and initialization work",
+            8 * parameter_count + utility_count + 3,
+        )
+
+        # Build layer sizes: [feature_dim, hidden1, hidden2, ..., 1]
 
         weights_list = []
         biases_list = []
@@ -1381,11 +1412,13 @@ class MLPLearner:
         for j in range(n_trace_entries):
             is_output = self._head_optimizer is not None and j >= n_trace_entries - 2
             opt = self._head_optimizer if is_output else self._optimizer
-            step, new_opt, optimizer_update_applied = _update_from_gradient_with_diagnostics(
-                opt,
-                state.optimizer_states[j],
-                new_traces[j],
-                error=error,
+            step, new_opt, optimizer_update_applied = (
+                _update_from_gradient_with_diagnostics(
+                    opt,
+                    state.optimizer_states[j],
+                    new_traces[j],
+                    error=error,
+                )
             )
             all_steps.append(step)
             new_opt_states.append(new_opt)
@@ -1411,7 +1444,9 @@ class MLPLearner:
             new_b = state.params.biases[i] + error * all_steps[2 * i + 1]
             new_biases.append(new_b)
 
-        new_params = MLPParams(weights=tuple(new_weights), biases=tuple(new_biases))
+        new_params = MLPParams(
+            weights=tuple(new_weights), biases=tuple(new_biases)
+        )
 
         # Per-hidden-unit gradient utility: EMA of row-wise L2 norm of weight gradients
         new_neuron_utility: tuple[Array, ...] | None = state.neuron_utility
@@ -1423,7 +1458,8 @@ class MLPLearner:
                     jnp.zeros_like(state.neuron_utility[i]),
                     decay * state.neuron_utility[i],
                 )
-                + (1.0 - decay) * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
+                + (1.0 - decay)
+                * jnp.sqrt(jnp.sum(weight_grads[i] ** 2, axis=1) + 1e-12)
                 for i in range(len(self._hidden_sizes))
             )
 
@@ -1442,9 +1478,14 @@ class MLPLearner:
             previous_checked = state.replace(  # type: ignore[attr-defined]
                 traces=tuple(jnp.zeros_like(trace) for trace in state.traces),
             )
-        if state.neuron_utility is not None and self._neuron_utility_decay == 0.0:
+        if (
+            state.neuron_utility is not None
+            and self._neuron_utility_decay == 0.0
+        ):
             previous_checked = previous_checked.replace(  # type: ignore[attr-defined]
-                neuron_utility=tuple(jnp.zeros_like(utility) for utility in state.neuron_utility),
+                neuron_utility=tuple(
+                    jnp.zeros_like(utility) for utility in state.neuron_utility
+                ),
             )
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.isfinite(target_scalar)
         update_applied = (
@@ -1468,7 +1509,9 @@ class MLPLearner:
                 dtype=jnp.float32,
             )
         else:
-            metrics = jnp.array([squared_error, error, bounding_metric], dtype=jnp.float32)
+            metrics = jnp.array(
+                [squared_error, error, bounding_metric], dtype=jnp.float32
+            )
 
         return MLPUpdateResult(
             state=new_state,
@@ -1490,7 +1533,10 @@ def run_mlp_learning_loop[StreamStateT](
     key: Array,
     learner_state: MLPLearnerState | None = None,
     normalizer_tracking: NormalizerTrackingConfig | None = None,
-) -> tuple[MLPLearnerState, Array] | tuple[MLPLearnerState, Array, NormalizerHistory]:
+) -> (
+    tuple[MLPLearnerState, Array]
+    | tuple[MLPLearnerState, Array, NormalizerHistory]
+):
     """Run the MLP learning loop using jax.lax.scan.
 
     This is a JIT-compiled learning loop that uses scan for efficiency.
@@ -1762,6 +1808,8 @@ class TDLinearLearner:
         Returns:
             Initial TD learner state with zero weights and bias
         """
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_float32_resources("TD learner state", feature_dim + 2)
         optimizer_state = self._optimizer.init(feature_dim)
 
         return TDLearnerState(
@@ -1866,7 +1914,9 @@ class TDLinearLearner:
             & jnp.isfinite(td_error)
             & jnp.all(jnp.isfinite(metrics))
         )
-        new_state = select_transaction(update_applied, candidate_state, state).replace(  # type: ignore[attr-defined]
+        new_state = select_transaction(
+            update_applied, candidate_state, state
+        ).replace(  # type: ignore[attr-defined]
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -1932,6 +1982,7 @@ class TrueOnlineTDLearner:
     def init(self, feature_dim: int) -> TrueOnlineTDState:
         """Initialize learner state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        _preflight_float32_resources("true-online TD state", 2 * feature_dim + 5)
         return TrueOnlineTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -1981,8 +2032,16 @@ class TrueOnlineTDLearner:
 
         correction = value - state.v_old
         update_scale = alpha * (td_error + correction)
-        new_weights = state.weights + update_scale * new_traces - alpha * correction * observation
-        new_bias = state.bias + update_scale * new_bias_trace - alpha * correction
+        new_weights = (
+            state.weights
+            + update_scale * new_traces
+            - alpha * correction * observation
+        )
+        new_bias = (
+            state.bias
+            + update_scale * new_bias_trace
+            - alpha * correction
+        )
 
         terminal = gamma_scalar == 0.0
         stored_traces = jnp.where(terminal, jnp.zeros_like(new_traces), new_traces)

--- a/tests/test_learners.py
+++ b/tests/test_learners.py
@@ -5,6 +5,7 @@ import time
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -26,6 +27,7 @@ from alberta_framework import (
     run_learning_loop,
     run_learning_loop_batched,
 )
+from alberta_framework.core.learners import TDLinearLearner, TrueOnlineTDLearner
 
 
 class TestLinearLearnerNormalizerVeto:
@@ -944,3 +946,34 @@ class TestLifecycleUtilities:
 
         state, _ = run_learning_loop(learner, stream, num_steps=100, key=rng_key)
         assert agent_uptime_s(state) > 0.0
+
+
+def test_learners_feature_dim_integer_validation() -> None:
+    linear = LinearLearner()
+    td_linear = TDLinearLearner()
+    true_online = TrueOnlineTDLearner()
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        linear.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        linear.init(feature_dim=0)
+    with pytest.raises(ValueError, match="feature_dim"):
+        linear.init(feature_dim=4.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        td_linear.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        td_linear.init(feature_dim=0)
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        true_online.init(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        true_online.init(feature_dim=0)
+
+    s1 = linear.init(feature_dim=np.int32(4))
+    s2 = td_linear.init(feature_dim=np.int64(4))
+    s3 = true_online.init(feature_dim=np.int32(4))
+
+    assert s1.weights.shape == (4,)
+    assert s2.weights.shape == (4,)
+    assert s3.weights.shape == (4,)

--- a/tests/test_learners.py
+++ b/tests/test_learners.py
@@ -948,32 +948,17 @@ class TestLifecycleUtilities:
         assert agent_uptime_s(state) > 0.0
 
 
-def test_learners_feature_dim_integer_validation() -> None:
-    linear = LinearLearner()
-    td_linear = TDLinearLearner()
-    true_online = TrueOnlineTDLearner()
+@pytest.mark.parametrize(
+    "learner",
+    [LinearLearner(), TDLinearLearner(), TrueOnlineTDLearner()],
+)
+def test_linear_family_feature_dimensions_are_exact_and_preflighted(learner) -> None:
+    for invalid in (True, 0, 4.5, 2**31, np.uint64(2**63)):
+        with pytest.raises(ValueError, match="feature_dim"):
+            learner.init(invalid)
 
-    with pytest.raises(ValueError, match="feature_dim"):
-        linear.init(feature_dim=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_dim"):
-        linear.init(feature_dim=0)
-    with pytest.raises(ValueError, match="feature_dim"):
-        linear.init(feature_dim=4.5)  # type: ignore[arg-type]
+    state = learner.init(np.longlong(4))
+    assert state.weights.shape == (4,)
 
-    with pytest.raises(ValueError, match="feature_dim"):
-        td_linear.init(feature_dim=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_dim"):
-        td_linear.init(feature_dim=0)
-
-    with pytest.raises(ValueError, match="feature_dim"):
-        true_online.init(feature_dim=True)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_dim"):
-        true_online.init(feature_dim=0)
-
-    s1 = linear.init(feature_dim=np.int32(4))
-    s2 = td_linear.init(feature_dim=np.int64(4))
-    s3 = true_online.init(feature_dim=np.int32(4))
-
-    assert s1.weights.shape == (4,)
-    assert s2.weights.shape == (4,)
-    assert s3.weights.shape == (4,)
+    with pytest.raises(ValueError, match="resource"):
+        learner.init(2**26)

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -116,8 +116,12 @@ class TestMLPLearner:
         state = learner.init(feature_dim=3, key=jr.key(0))
         observation = jnp.ones(3, dtype=jnp.float32)
 
-        poisoned = learner.update(state, observation, jnp.array(jnp.inf, dtype=jnp.float32))
-        for new_w, old_w in zip(poisoned.state.params.weights, state.params.weights, strict=True):
+        poisoned = learner.update(
+            state, observation, jnp.array(jnp.inf, dtype=jnp.float32)
+        )
+        for new_w, old_w in zip(
+            poisoned.state.params.weights, state.params.weights, strict=True
+        ):
             assert bool(jnp.all(jnp.isfinite(new_w)))
             chex.assert_trees_all_close(new_w, old_w)
         assert int(poisoned.state.step_count) == int(state.step_count)
@@ -126,7 +130,9 @@ class TestMLPLearner:
         chex.assert_trees_all_close(poisoned.error, jnp.zeros_like(poisoned.error))
         chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-        recovered = learner.update(poisoned.state, observation, jnp.array(1.0, dtype=jnp.float32))
+        recovered = learner.update(
+            poisoned.state, observation, jnp.array(1.0, dtype=jnp.float32)
+        )
         for new_w in recovered.state.params.weights:
             assert bool(jnp.all(jnp.isfinite(new_w)))
         assert bool(recovered.update_applied)
@@ -135,13 +141,17 @@ class TestMLPLearner:
         """Default gamma*lamda is 0; 0 * inf traces is NaN and would freeze."""
         learner = MLPLearner(hidden_sizes=(4,), sparsity=0.0, optimizer=LMS(0.1))
         state = learner.init(feature_dim=3, key=jr.key(1))
-        poisoned_traces = tuple(jnp.full_like(trace, jnp.inf) for trace in state.traces)
+        poisoned_traces = tuple(
+            jnp.full_like(trace, jnp.inf) for trace in state.traces
+        )
         state = state.replace(traces=poisoned_traces)
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
         assert not bool(jnp.isfinite(raw))
 
         observation = jnp.ones(3, dtype=jnp.float32)
-        result = learner.update(state, observation, jnp.array(1.0, dtype=jnp.float32))
+        result = learner.update(
+            state, observation, jnp.array(1.0, dtype=jnp.float32)
+        )
         assert bool(result.update_applied)
         for trace in result.state.traces:
             assert bool(jnp.all(jnp.isfinite(trace)))
@@ -242,9 +252,13 @@ class TestRunMLPLearningLoop:
     def test_scan_loop_produces_correct_shapes(self):
         """Scan loop should return metrics with shape (num_steps, 3)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -256,24 +270,29 @@ class TestRunMLPLearningLoop:
     def test_scan_loop_deterministic(self):
         """Same key should produce identical results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
 
-        _, metrics1 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
-        _, metrics2 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        _, metrics1 = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
+        _, metrics2 = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
 
         chex.assert_trees_all_close(metrics1, metrics2)
 
     def test_scan_loop_with_provided_state(self):
         """Should accept a pre-initialized state."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
         initial_state = learner.init(feature_dim=5, key=jr.key(0))
 
         state, metrics = run_mlp_learning_loop(
-            learner,
-            stream,
-            num_steps=50,
-            key=jr.key(42),
+            learner, stream, num_steps=50, key=jr.key(42),
             learner_state=initial_state,
         )
 
@@ -287,12 +306,16 @@ class TestBatchedMLPLearningLoop:
     def test_batched_returns_correct_shapes(self):
         """Batched loop should return metrics with shape (num_seeds, num_steps, 3)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
         num_seeds = 4
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=num_steps, keys=keys
+        )
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 3))
@@ -307,7 +330,9 @@ class TestBatchedMLPLearningLoop:
     def test_batched_matches_sequential(self):
         """Batched results should match sequential results for each seed."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
         num_seeds = 3
         num_steps = 50
 
@@ -323,27 +348,39 @@ class TestBatchedMLPLearningLoop:
             state_i, metrics_i = run_mlp_learning_loop(
                 learner, stream, num_steps=num_steps, key=keys[i]
             )
-            chex.assert_trees_all_close(batched_result.metrics[i], metrics_i, rtol=1e-4)
+            chex.assert_trees_all_close(
+                batched_result.metrics[i], metrics_i, rtol=1e-4
+            )
 
     def test_batched_deterministic(self):
         """Same keys should produce identical batched results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
 
         keys = jr.split(jr.key(42), 3)
 
-        result1 = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
-        result2 = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
+        result1 = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=50, keys=keys
+        )
+        result2 = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=50, keys=keys
+        )
 
         chex.assert_trees_all_close(result1.metrics, result2.metrics)
 
     def test_batched_different_keys_different_results(self):
         """Different seeds should produce different metrics."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
+        )
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=50, keys=keys
+        )
 
         # Different seeds should give different final metrics
         assert not jnp.allclose(result.metrics[0], result.metrics[1])
@@ -371,10 +408,8 @@ class TestNormalizedMLPLearner:
     def test_predict_returns_scalar(self):
         """Predict should return a 1-d array."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -387,10 +422,8 @@ class TestNormalizedMLPLearner:
     def test_update_returns_correct_shapes(self):
         """Update should return MLPUpdateResult with 4-column metrics."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -407,10 +440,8 @@ class TestNormalizedMLPLearner:
     def test_normalizer_state_updates(self):
         """Normalizer state should change after an update."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -420,11 +451,15 @@ class TestNormalizedMLPLearner:
         result = learner.update(state, observation, target)
 
         # Mean should have changed from zeros
-        assert not jnp.allclose(result.state.normalizer_state.mean, state.normalizer_state.mean)
+        assert not jnp.allclose(
+            result.state.normalizer_state.mean, state.normalizer_state.mean
+        )
 
     def test_works_with_ema_normalizer(self):
         """Should work with EMANormalizer."""
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, normalizer=EMANormalizer(decay=0.95))
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, normalizer=EMANormalizer(decay=0.95)
+        )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         observation = jnp.ones(5)
@@ -436,7 +471,9 @@ class TestNormalizedMLPLearner:
 
     def test_works_with_welford_normalizer(self):
         """Should work with WelfordNormalizer."""
-        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, normalizer=WelfordNormalizer())
+        learner = MLPLearner(
+            hidden_sizes=(16,), sparsity=0.0, normalizer=WelfordNormalizer()
+        )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         observation = jnp.ones(5)
@@ -454,13 +491,13 @@ class TestRunMLPNormalizedLearningLoop:
         """Scan loop should return metrics with shape (num_steps, 4)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 4))
         chex.assert_tree_all_finite(metrics)
@@ -473,14 +510,16 @@ class TestRunMLPNormalizedLearningLoop:
         """Same key should produce identical results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
 
-        _, metrics1 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
-        _, metrics2 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        _, metrics1 = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
+        _, metrics2 = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
 
         chex.assert_trees_all_close(metrics1, metrics2)
 
@@ -488,18 +527,13 @@ class TestRunMLPNormalizedLearningLoop:
         """With normalizer tracking, should return 3-tuple."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         config = NormalizerTrackingConfig(interval=10)
 
         result = run_mlp_learning_loop(
-            learner,
-            stream,
-            num_steps=100,
-            key=jr.key(42),
+            learner, stream, num_steps=100, key=jr.key(42),
             normalizer_tracking=config,
         )
 
@@ -515,27 +549,19 @@ class TestRunMLPNormalizedLearningLoop:
         """Invalid tracking interval should raise ValueError."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
 
         with pytest.raises(ValueError, match="must be >= 1"):
             run_mlp_learning_loop(
-                learner,
-                stream,
-                num_steps=100,
-                key=jr.key(42),
+                learner, stream, num_steps=100, key=jr.key(42),
                 normalizer_tracking=NormalizerTrackingConfig(interval=0),
             )
 
         with pytest.raises(ValueError, match="must be <= num_steps"):
             run_mlp_learning_loop(
-                learner,
-                stream,
-                num_steps=100,
-                key=jr.key(42),
+                learner, stream, num_steps=100, key=jr.key(42),
                 normalizer_tracking=NormalizerTrackingConfig(interval=200),
             )
 
@@ -543,18 +569,13 @@ class TestRunMLPNormalizedLearningLoop:
         """Should accept a pre-initialized state."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         initial_state = learner.init(feature_dim=5, key=jr.key(0))
 
         state, metrics = run_mlp_learning_loop(
-            learner,
-            stream,
-            num_steps=50,
-            key=jr.key(42),
+            learner, stream, num_steps=50, key=jr.key(42),
             learner_state=initial_state,
         )
 
@@ -569,16 +590,16 @@ class TestBatchedMLPNormalizedLearningLoop:
         """Batched loop should return metrics with shape (num_seeds, num_steps, 4)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         num_seeds = 4
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=num_steps, keys=keys
+        )
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 4))
@@ -586,17 +607,19 @@ class TestBatchedMLPNormalizedLearningLoop:
         assert result.normalizer_history is None
 
         # Check batched param shapes
-        chex.assert_shape(result.states.params.weights[0], (num_seeds, 16, 5))
-        chex.assert_shape(result.states.params.weights[1], (num_seeds, 1, 16))
+        chex.assert_shape(
+            result.states.params.weights[0], (num_seeds, 16, 5)
+        )
+        chex.assert_shape(
+            result.states.params.weights[1], (num_seeds, 1, 16)
+        )
 
     def test_batched_matches_sequential(self):
         """Batched results should match sequential results for each seed."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         num_seeds = 3
         num_steps = 50
@@ -613,16 +636,16 @@ class TestBatchedMLPNormalizedLearningLoop:
             state_i, metrics_i = run_mlp_learning_loop(
                 learner, stream, num_steps=num_steps, key=keys[i]
             )
-            chex.assert_trees_all_close(batched_result.metrics[i], metrics_i, rtol=1e-4)
+            chex.assert_trees_all_close(
+                batched_result.metrics[i], metrics_i, rtol=1e-4
+            )
 
     def test_batched_with_tracking(self):
         """Batched with tracking should return correct shapes."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0),
-            normalizer=EMANormalizer(),
+            hidden_sizes=(16,), sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
         )
         num_seeds = 3
         num_steps = 50
@@ -630,10 +653,7 @@ class TestBatchedMLPNormalizedLearningLoop:
 
         keys = jr.split(jr.key(42), num_seeds)
         result = run_mlp_learning_loop_batched(
-            learner,
-            stream,
-            num_steps=num_steps,
-            keys=keys,
+            learner, stream, num_steps=num_steps, keys=keys,
             normalizer_tracking=config,
         )
 
@@ -728,7 +748,9 @@ class TestAGCBounding:
             hidden_sizes=(16,), sparsity=0.0, bounder=AGCBounding(clip_factor=0.01)
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -736,10 +758,8 @@ class TestAGCBounding:
     def test_mlp_agc_reduces_error(self):
         """Multi-step MLP training with AGC should reduce error."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            step_size=0.1,
-            bounder=AGCBounding(clip_factor=0.01),
-            sparsity=0.0,
+            hidden_sizes=(16,), step_size=0.1,
+            bounder=AGCBounding(clip_factor=0.01), sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -763,9 +783,7 @@ class TestLayerNormToggle:
     def test_layer_norm_disabled_runs(self):
         """MLPLearner with use_layer_norm=False can init, predict, and update."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            use_layer_norm=False,
+            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -786,14 +804,10 @@ class TestLayerNormToggle:
     def test_layer_norm_disabled_different_predictions(self):
         """Predictions differ between use_layer_norm=True and False."""
         learner_ln = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            use_layer_norm=True,
+            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=True,
         )
         learner_no_ln = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            use_layer_norm=False,
+            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
         )
 
         # Same key -> same initial weights
@@ -811,9 +825,7 @@ class TestLayerNormToggle:
         """Default MLPLearner should use layer norm (backwards compatible)."""
         learner_default = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
         learner_explicit = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            use_layer_norm=True,
+            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=True,
         )
 
         state_default = learner_default.init(feature_dim=5, key=jr.key(42))
@@ -830,16 +842,16 @@ class TestLayerNormToggle:
         """run_mlp_learning_loop_batched works with use_layer_norm=False."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
-            use_layer_norm=False,
+            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
             bounder=ObGDBounding(kappa=2.0),
         )
         num_seeds = 3
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=num_steps, keys=keys
+        )
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 3))
@@ -889,7 +901,9 @@ class TestMLPLifecycleTracking:
         stream = RandomWalkStream(feature_dim=5)
         learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
 
-        state, _ = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        state, _ = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
         assert state.uptime_s > 0.0
 
     def test_step_count_after_loop(self):
@@ -897,7 +911,9 @@ class TestMLPLifecycleTracking:
         stream = RandomWalkStream(feature_dim=5)
         learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
 
-        state, _ = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, _ = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
         assert int(state.step_count) == 100
 
 
@@ -909,8 +925,7 @@ class TestHybridOptimizer:
         from alberta_framework.core.types import AutostepParamState, LMSState
 
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -927,8 +942,7 @@ class TestHybridOptimizer:
     def test_hybrid_update_runs(self):
         """Basic update with LMS trunk + Autostep head should work."""
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -948,14 +962,15 @@ class TestHybridOptimizer:
         """Full learning loop should work with hybrid optimizer."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -966,14 +981,12 @@ class TestHybridOptimizer:
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
 
         learner_default = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         learner_explicit = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             head_optimizer=None,
             bounder=ObGDBounding(kappa=2.0),
@@ -993,8 +1006,7 @@ class TestHybridOptimizer:
         from alberta_framework.core.types import AutostepParamState, LMSState
 
         learner = MLPLearner(
-            hidden_sizes=(32, 16),
-            sparsity=0.0,
+            hidden_sizes=(32, 16), sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -1012,7 +1024,9 @@ class TestHybridOptimizer:
 
         # Should run without error
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
         chex.assert_shape(metrics, (50, 3))
         chex.assert_tree_all_finite(metrics)
 
@@ -1020,15 +1034,16 @@ class TestHybridOptimizer:
         """Batched loop should work with hybrid optimizer."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,),
-            sparsity=0.0,
+            hidden_sizes=(16,), sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
         )
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=50, keys=keys
+        )
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (3, 50, 3))
@@ -1082,7 +1097,9 @@ class TestMLPLearnerWithIDBD:
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -1102,7 +1119,9 @@ class TestMLPLearnerWithIDBD:
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -1127,7 +1146,9 @@ class TestMLPLearnerWithIDBD:
         assert isinstance(state.optimizer_states[3], IDBDParamState)
 
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=50, key=jr.key(42)
+        )
         chex.assert_shape(metrics, (50, 3))
         chex.assert_tree_all_finite(metrics)
 
@@ -1142,7 +1163,9 @@ class TestMLPLearnerWithIDBD:
         )
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
+        result = run_mlp_learning_loop_batched(
+            learner, stream, num_steps=50, keys=keys
+        )
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (3, 50, 3))
@@ -1159,7 +1182,9 @@ class TestMLPLearnerWithIDBD:
             normalizer=EMANormalizer(decay=0.99),
         )
 
-        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
+        state, metrics = run_mlp_learning_loop(
+            learner, stream, num_steps=100, key=jr.key(42)
+        )
 
         chex.assert_shape(metrics, (100, 4))
         chex.assert_tree_all_finite(metrics)
@@ -1208,9 +1233,7 @@ class TestNeuronUtility:
         """After one update, utility should equal (1 - decay) * grad_norm."""
         decay = 0.9
         learner = MLPLearner(
-            hidden_sizes=(4,),
-            sparsity=0.0,
-            track_neuron_utility=True,
+            hidden_sizes=(4,), sparsity=0.0, track_neuron_utility=True,
             neuron_utility_decay=decay,
         )
         state = learner.init(feature_dim=4, key=jr.key(4))
@@ -1230,9 +1253,7 @@ class TestNeuronUtility:
 
     def test_dormant_fraction_decreases_after_updates(self):
         learner = MLPLearner(
-            hidden_sizes=(8,),
-            sparsity=0.0,
-            track_neuron_utility=True,
+            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
             neuron_utility_decay=0.5,  # faster convergence
         )
         state = learner.init(feature_dim=4, key=jr.key(6))
@@ -1251,25 +1272,23 @@ class TestNeuronUtility:
 
     def test_reset_dormant_neurons_reduces_dormant_fraction(self):
         learner = MLPLearner(
-            hidden_sizes=(8,),
-            sparsity=0.0,
-            track_neuron_utility=True,
+            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
         )
         state = learner.init(feature_dim=4, key=jr.key(9))
         # All utility = 0 → all dormant at very low threshold
         assert MLPLearner.dormant_neuron_fraction(state, threshold=1.0) == 1.0
         state_reset = learner.reset_dormant_neurons(state, jr.key(10), threshold=1.0)
         # Weights should have changed
-        assert not jnp.allclose(state_reset.params.weights[0], state.params.weights[0])
+        assert not jnp.allclose(
+            state_reset.params.weights[0], state.params.weights[0]
+        )
         # Utility for reset neurons is zeroed
         assert state_reset.neuron_utility is not None
         assert float(jnp.sum(state_reset.neuron_utility[0])) == 0.0
 
     def test_config_roundtrip_with_tracking(self):
         learner = MLPLearner(
-            hidden_sizes=(8,),
-            sparsity=0.0,
-            track_neuron_utility=True,
+            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
             neuron_utility_decay=0.95,
         )
         cfg = learner.to_config()
@@ -1324,7 +1343,9 @@ class TestResetDormantOptimizerState:
 
         # Force exactly the first N_RESET neurons dormant.
         assert state.neuron_utility is not None
-        forced = jnp.where(jnp.arange(self.N_HIDDEN) < self.N_RESET, 0.0, 1.0).astype(jnp.float32)
+        forced = jnp.where(
+            jnp.arange(self.N_HIDDEN) < self.N_RESET, 0.0, 1.0
+        ).astype(jnp.float32)
         state = state.replace(neuron_utility=(forced,))
         reset_state = learner.reset_dormant_neurons(state, jr.key(2), threshold=0.5)
 
@@ -1346,9 +1367,13 @@ class TestResetDormantOptimizerState:
                 else:
                     sel = mask[:, None] if new.ndim == 2 else mask
                     # Reset slices equal fresh init_for_shape values.
-                    assert jnp.allclose(jnp.where(sel, new, 0.0), jnp.where(sel, ref, 0.0))
+                    assert jnp.allclose(
+                        jnp.where(sel, new, 0.0), jnp.where(sel, ref, 0.0)
+                    )
                     # Non-reset slices are untouched.
-                    assert jnp.allclose(jnp.where(sel, 0.0, new), jnp.where(sel, 0.0, old))
+                    assert jnp.allclose(
+                        jnp.where(sel, 0.0, new), jnp.where(sel, 0.0, old)
+                    )
 
         # Recovery: 1000 further updates must stay finite and reduce error.
         state = reset_state
@@ -1371,23 +1396,16 @@ class TestResetDormantOptimizerState:
         assert mse_last < mse_first
 
 
-def test_mlp_learner_hidden_sizes_and_feature_dim_integer_validation() -> None:
-    with pytest.raises(ValueError, match="hidden_sizes"):
-        MLPLearner(hidden_sizes=[128, 128])  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="hidden_sizes"):
-        MLPLearner(hidden_sizes=(True, 128))  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="hidden_sizes"):
-        MLPLearner(hidden_sizes=(128, 0))
+def test_mlp_dimensions_are_exact_canonical_and_preflighted() -> None:
+    for invalid in ([8], (True,), (0,), (2**31,)):
+        with pytest.raises(ValueError, match="hidden_sizes"):
+            MLPLearner(hidden_sizes=invalid)  # type: ignore[arg-type]
 
-    learner = MLPLearner(hidden_sizes=(np.int32(64), np.int64(32)))
-    assert learner._hidden_sizes == (64, 32)
+    learner = MLPLearner(hidden_sizes=(np.longlong(8),))
+    assert learner._hidden_sizes == (8,)
     assert type(learner._hidden_sizes[0]) is int
-    assert type(learner._hidden_sizes[1]) is int
 
     with pytest.raises(ValueError, match="feature_dim"):
-        learner.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="feature_dim"):
-        learner.init(feature_dim=0, key=jr.key(0))
-
-    state = learner.init(feature_dim=np.int32(10), key=jr.key(0))
-    assert state.params.weights[0].shape == (64, 10)
+        learner.init(True, jr.key(0))
+    with pytest.raises(ValueError, match="resource"):
+        MLPLearner(hidden_sizes=(2**26,)).init(2, jr.key(0))

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -7,6 +7,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework import (
@@ -115,12 +116,8 @@ class TestMLPLearner:
         state = learner.init(feature_dim=3, key=jr.key(0))
         observation = jnp.ones(3, dtype=jnp.float32)
 
-        poisoned = learner.update(
-            state, observation, jnp.array(jnp.inf, dtype=jnp.float32)
-        )
-        for new_w, old_w in zip(
-            poisoned.state.params.weights, state.params.weights, strict=True
-        ):
+        poisoned = learner.update(state, observation, jnp.array(jnp.inf, dtype=jnp.float32))
+        for new_w, old_w in zip(poisoned.state.params.weights, state.params.weights, strict=True):
             assert bool(jnp.all(jnp.isfinite(new_w)))
             chex.assert_trees_all_close(new_w, old_w)
         assert int(poisoned.state.step_count) == int(state.step_count)
@@ -129,9 +126,7 @@ class TestMLPLearner:
         chex.assert_trees_all_close(poisoned.error, jnp.zeros_like(poisoned.error))
         chex.assert_trees_all_close(poisoned.metrics, jnp.zeros_like(poisoned.metrics))
 
-        recovered = learner.update(
-            poisoned.state, observation, jnp.array(1.0, dtype=jnp.float32)
-        )
+        recovered = learner.update(poisoned.state, observation, jnp.array(1.0, dtype=jnp.float32))
         for new_w in recovered.state.params.weights:
             assert bool(jnp.all(jnp.isfinite(new_w)))
         assert bool(recovered.update_applied)
@@ -140,17 +135,13 @@ class TestMLPLearner:
         """Default gamma*lamda is 0; 0 * inf traces is NaN and would freeze."""
         learner = MLPLearner(hidden_sizes=(4,), sparsity=0.0, optimizer=LMS(0.1))
         state = learner.init(feature_dim=3, key=jr.key(1))
-        poisoned_traces = tuple(
-            jnp.full_like(trace, jnp.inf) for trace in state.traces
-        )
+        poisoned_traces = tuple(jnp.full_like(trace, jnp.inf) for trace in state.traces)
         state = state.replace(traces=poisoned_traces)
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
         assert not bool(jnp.isfinite(raw))
 
         observation = jnp.ones(3, dtype=jnp.float32)
-        result = learner.update(
-            state, observation, jnp.array(1.0, dtype=jnp.float32)
-        )
+        result = learner.update(state, observation, jnp.array(1.0, dtype=jnp.float32))
         assert bool(result.update_applied)
         for trace in result.state.traces:
             assert bool(jnp.all(jnp.isfinite(trace)))
@@ -251,13 +242,9 @@ class TestRunMLPLearningLoop:
     def test_scan_loop_produces_correct_shapes(self):
         """Scan loop should return metrics with shape (num_steps, 3)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -269,29 +256,24 @@ class TestRunMLPLearningLoop:
     def test_scan_loop_deterministic(self):
         """Same key should produce identical results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
 
-        _, metrics1 = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
-        _, metrics2 = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
+        _, metrics1 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        _, metrics2 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
 
         chex.assert_trees_all_close(metrics1, metrics2)
 
     def test_scan_loop_with_provided_state(self):
         """Should accept a pre-initialized state."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
         initial_state = learner.init(feature_dim=5, key=jr.key(0))
 
         state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42),
+            learner,
+            stream,
+            num_steps=50,
+            key=jr.key(42),
             learner_state=initial_state,
         )
 
@@ -305,16 +287,12 @@ class TestBatchedMLPLearningLoop:
     def test_batched_returns_correct_shapes(self):
         """Batched loop should return metrics with shape (num_seeds, num_steps, 3)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
         num_seeds = 4
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=num_steps, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 3))
@@ -329,9 +307,7 @@ class TestBatchedMLPLearningLoop:
     def test_batched_matches_sequential(self):
         """Batched results should match sequential results for each seed."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
         num_seeds = 3
         num_steps = 50
 
@@ -347,39 +323,27 @@ class TestBatchedMLPLearningLoop:
             state_i, metrics_i = run_mlp_learning_loop(
                 learner, stream, num_steps=num_steps, key=keys[i]
             )
-            chex.assert_trees_all_close(
-                batched_result.metrics[i], metrics_i, rtol=1e-4
-            )
+            chex.assert_trees_all_close(batched_result.metrics[i], metrics_i, rtol=1e-4)
 
     def test_batched_deterministic(self):
         """Same keys should produce identical batched results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
 
         keys = jr.split(jr.key(42), 3)
 
-        result1 = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=50, keys=keys
-        )
-        result2 = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=50, keys=keys
-        )
+        result1 = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
+        result2 = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
 
         chex.assert_trees_all_close(result1.metrics, result2.metrics)
 
     def test_batched_different_keys_different_results(self):
         """Different seeds should produce different metrics."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, bounder=ObGDBounding(kappa=2.0))
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=50, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
 
         # Different seeds should give different final metrics
         assert not jnp.allclose(result.metrics[0], result.metrics[1])
@@ -407,8 +371,10 @@ class TestNormalizedMLPLearner:
     def test_predict_returns_scalar(self):
         """Predict should return a 1-d array."""
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -421,8 +387,10 @@ class TestNormalizedMLPLearner:
     def test_update_returns_correct_shapes(self):
         """Update should return MLPUpdateResult with 4-column metrics."""
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -439,8 +407,10 @@ class TestNormalizedMLPLearner:
     def test_normalizer_state_updates(self):
         """Normalizer state should change after an update."""
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -450,15 +420,11 @@ class TestNormalizedMLPLearner:
         result = learner.update(state, observation, target)
 
         # Mean should have changed from zeros
-        assert not jnp.allclose(
-            result.state.normalizer_state.mean, state.normalizer_state.mean
-        )
+        assert not jnp.allclose(result.state.normalizer_state.mean, state.normalizer_state.mean)
 
     def test_works_with_ema_normalizer(self):
         """Should work with EMANormalizer."""
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, normalizer=EMANormalizer(decay=0.95)
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, normalizer=EMANormalizer(decay=0.95))
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         observation = jnp.ones(5)
@@ -470,9 +436,7 @@ class TestNormalizedMLPLearner:
 
     def test_works_with_welford_normalizer(self):
         """Should work with WelfordNormalizer."""
-        learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, normalizer=WelfordNormalizer()
-        )
+        learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0, normalizer=WelfordNormalizer())
         state = learner.init(feature_dim=5, key=jr.key(42))
 
         observation = jnp.ones(5)
@@ -490,13 +454,13 @@ class TestRunMLPNormalizedLearningLoop:
         """Scan loop should return metrics with shape (num_steps, 4)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 4))
         chex.assert_tree_all_finite(metrics)
@@ -509,16 +473,14 @@ class TestRunMLPNormalizedLearningLoop:
         """Same key should produce identical results."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
 
-        _, metrics1 = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
-        _, metrics2 = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
+        _, metrics1 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
+        _, metrics2 = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
 
         chex.assert_trees_all_close(metrics1, metrics2)
 
@@ -526,13 +488,18 @@ class TestRunMLPNormalizedLearningLoop:
         """With normalizer tracking, should return 3-tuple."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         config = NormalizerTrackingConfig(interval=10)
 
         result = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42),
+            learner,
+            stream,
+            num_steps=100,
+            key=jr.key(42),
             normalizer_tracking=config,
         )
 
@@ -548,19 +515,27 @@ class TestRunMLPNormalizedLearningLoop:
         """Invalid tracking interval should raise ValueError."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
 
         with pytest.raises(ValueError, match="must be >= 1"):
             run_mlp_learning_loop(
-                learner, stream, num_steps=100, key=jr.key(42),
+                learner,
+                stream,
+                num_steps=100,
+                key=jr.key(42),
                 normalizer_tracking=NormalizerTrackingConfig(interval=0),
             )
 
         with pytest.raises(ValueError, match="must be <= num_steps"):
             run_mlp_learning_loop(
-                learner, stream, num_steps=100, key=jr.key(42),
+                learner,
+                stream,
+                num_steps=100,
+                key=jr.key(42),
                 normalizer_tracking=NormalizerTrackingConfig(interval=200),
             )
 
@@ -568,13 +543,18 @@ class TestRunMLPNormalizedLearningLoop:
         """Should accept a pre-initialized state."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         initial_state = learner.init(feature_dim=5, key=jr.key(0))
 
         state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42),
+            learner,
+            stream,
+            num_steps=50,
+            key=jr.key(42),
             learner_state=initial_state,
         )
 
@@ -589,16 +569,16 @@ class TestBatchedMLPNormalizedLearningLoop:
         """Batched loop should return metrics with shape (num_seeds, num_steps, 4)."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         num_seeds = 4
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=num_steps, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 4))
@@ -606,19 +586,17 @@ class TestBatchedMLPNormalizedLearningLoop:
         assert result.normalizer_history is None
 
         # Check batched param shapes
-        chex.assert_shape(
-            result.states.params.weights[0], (num_seeds, 16, 5)
-        )
-        chex.assert_shape(
-            result.states.params.weights[1], (num_seeds, 1, 16)
-        )
+        chex.assert_shape(result.states.params.weights[0], (num_seeds, 16, 5))
+        chex.assert_shape(result.states.params.weights[1], (num_seeds, 1, 16))
 
     def test_batched_matches_sequential(self):
         """Batched results should match sequential results for each seed."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         num_seeds = 3
         num_steps = 50
@@ -635,16 +613,16 @@ class TestBatchedMLPNormalizedLearningLoop:
             state_i, metrics_i = run_mlp_learning_loop(
                 learner, stream, num_steps=num_steps, key=keys[i]
             )
-            chex.assert_trees_all_close(
-                batched_result.metrics[i], metrics_i, rtol=1e-4
-            )
+            chex.assert_trees_all_close(batched_result.metrics[i], metrics_i, rtol=1e-4)
 
     def test_batched_with_tracking(self):
         """Batched with tracking should return correct shapes."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
-            bounder=ObGDBounding(kappa=2.0), normalizer=EMANormalizer(),
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            bounder=ObGDBounding(kappa=2.0),
+            normalizer=EMANormalizer(),
         )
         num_seeds = 3
         num_steps = 50
@@ -652,7 +630,10 @@ class TestBatchedMLPNormalizedLearningLoop:
 
         keys = jr.split(jr.key(42), num_seeds)
         result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=num_steps, keys=keys,
+            learner,
+            stream,
+            num_steps=num_steps,
+            keys=keys,
             normalizer_tracking=config,
         )
 
@@ -747,9 +728,7 @@ class TestAGCBounding:
             hidden_sizes=(16,), sparsity=0.0, bounder=AGCBounding(clip_factor=0.01)
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -757,8 +736,10 @@ class TestAGCBounding:
     def test_mlp_agc_reduces_error(self):
         """Multi-step MLP training with AGC should reduce error."""
         learner = MLPLearner(
-            hidden_sizes=(16,), step_size=0.1,
-            bounder=AGCBounding(clip_factor=0.01), sparsity=0.0,
+            hidden_sizes=(16,),
+            step_size=0.1,
+            bounder=AGCBounding(clip_factor=0.01),
+            sparsity=0.0,
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
 
@@ -782,7 +763,9 @@ class TestLayerNormToggle:
     def test_layer_norm_disabled_runs(self):
         """MLPLearner with use_layer_norm=False can init, predict, and update."""
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            use_layer_norm=False,
             bounder=ObGDBounding(kappa=2.0),
         )
         state = learner.init(feature_dim=5, key=jr.key(42))
@@ -803,10 +786,14 @@ class TestLayerNormToggle:
     def test_layer_norm_disabled_different_predictions(self):
         """Predictions differ between use_layer_norm=True and False."""
         learner_ln = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=True,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            use_layer_norm=True,
         )
         learner_no_ln = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            use_layer_norm=False,
         )
 
         # Same key -> same initial weights
@@ -824,7 +811,9 @@ class TestLayerNormToggle:
         """Default MLPLearner should use layer norm (backwards compatible)."""
         learner_default = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
         learner_explicit = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=True,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            use_layer_norm=True,
         )
 
         state_default = learner_default.init(feature_dim=5, key=jr.key(42))
@@ -841,16 +830,16 @@ class TestLayerNormToggle:
         """run_mlp_learning_loop_batched works with use_layer_norm=False."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0, use_layer_norm=False,
+            hidden_sizes=(16,),
+            sparsity=0.0,
+            use_layer_norm=False,
             bounder=ObGDBounding(kappa=2.0),
         )
         num_seeds = 3
         num_steps = 50
 
         keys = jr.split(jr.key(42), num_seeds)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=num_steps, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=num_steps, keys=keys)
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (num_seeds, num_steps, 3))
@@ -900,9 +889,7 @@ class TestMLPLifecycleTracking:
         stream = RandomWalkStream(feature_dim=5)
         learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
 
-        state, _ = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
+        state, _ = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
         assert state.uptime_s > 0.0
 
     def test_step_count_after_loop(self):
@@ -910,9 +897,7 @@ class TestMLPLifecycleTracking:
         stream = RandomWalkStream(feature_dim=5)
         learner = MLPLearner(hidden_sizes=(16,), sparsity=0.0)
 
-        state, _ = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, _ = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
         assert int(state.step_count) == 100
 
 
@@ -924,7 +909,8 @@ class TestHybridOptimizer:
         from alberta_framework.core.types import AutostepParamState, LMSState
 
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -941,7 +927,8 @@ class TestHybridOptimizer:
     def test_hybrid_update_runs(self):
         """Basic update with LMS trunk + Autostep head should work."""
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -961,15 +948,14 @@ class TestHybridOptimizer:
         """Full learning loop should work with hybrid optimizer."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -980,12 +966,14 @@ class TestHybridOptimizer:
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
 
         learner_default = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             bounder=ObGDBounding(kappa=2.0),
         )
         learner_explicit = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=None,
             bounder=ObGDBounding(kappa=2.0),
@@ -1005,7 +993,8 @@ class TestHybridOptimizer:
         from alberta_framework.core.types import AutostepParamState, LMSState
 
         learner = MLPLearner(
-            hidden_sizes=(32, 16), sparsity=0.0,
+            hidden_sizes=(32, 16),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
@@ -1023,9 +1012,7 @@ class TestHybridOptimizer:
 
         # Should run without error
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
         chex.assert_shape(metrics, (50, 3))
         chex.assert_tree_all_finite(metrics)
 
@@ -1033,16 +1020,15 @@ class TestHybridOptimizer:
         """Batched loop should work with hybrid optimizer."""
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
         learner = MLPLearner(
-            hidden_sizes=(16,), sparsity=0.0,
+            hidden_sizes=(16,),
+            sparsity=0.0,
             step_size=1.0,
             head_optimizer=Autostep(initial_step_size=0.01),
             bounder=ObGDBounding(kappa=2.0),
         )
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=50, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (3, 50, 3))
@@ -1096,9 +1082,7 @@ class TestMLPLearnerWithIDBD:
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -1118,9 +1102,7 @@ class TestMLPLearnerWithIDBD:
             bounder=ObGDBounding(kappa=2.0),
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 3))
         chex.assert_tree_all_finite(metrics)
@@ -1145,9 +1127,7 @@ class TestMLPLearnerWithIDBD:
         assert isinstance(state.optimizer_states[3], IDBDParamState)
 
         stream = RandomWalkStream(feature_dim=5, drift_rate=0.001)
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=50, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=50, key=jr.key(42))
         chex.assert_shape(metrics, (50, 3))
         chex.assert_tree_all_finite(metrics)
 
@@ -1162,9 +1142,7 @@ class TestMLPLearnerWithIDBD:
         )
 
         keys = jr.split(jr.key(42), 3)
-        result = run_mlp_learning_loop_batched(
-            learner, stream, num_steps=50, keys=keys
-        )
+        result = run_mlp_learning_loop_batched(learner, stream, num_steps=50, keys=keys)
 
         assert isinstance(result, BatchedMLPResult)
         chex.assert_shape(result.metrics, (3, 50, 3))
@@ -1181,9 +1159,7 @@ class TestMLPLearnerWithIDBD:
             normalizer=EMANormalizer(decay=0.99),
         )
 
-        state, metrics = run_mlp_learning_loop(
-            learner, stream, num_steps=100, key=jr.key(42)
-        )
+        state, metrics = run_mlp_learning_loop(learner, stream, num_steps=100, key=jr.key(42))
 
         chex.assert_shape(metrics, (100, 4))
         chex.assert_tree_all_finite(metrics)
@@ -1232,7 +1208,9 @@ class TestNeuronUtility:
         """After one update, utility should equal (1 - decay) * grad_norm."""
         decay = 0.9
         learner = MLPLearner(
-            hidden_sizes=(4,), sparsity=0.0, track_neuron_utility=True,
+            hidden_sizes=(4,),
+            sparsity=0.0,
+            track_neuron_utility=True,
             neuron_utility_decay=decay,
         )
         state = learner.init(feature_dim=4, key=jr.key(4))
@@ -1252,7 +1230,9 @@ class TestNeuronUtility:
 
     def test_dormant_fraction_decreases_after_updates(self):
         learner = MLPLearner(
-            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            track_neuron_utility=True,
             neuron_utility_decay=0.5,  # faster convergence
         )
         state = learner.init(feature_dim=4, key=jr.key(6))
@@ -1271,23 +1251,25 @@ class TestNeuronUtility:
 
     def test_reset_dormant_neurons_reduces_dormant_fraction(self):
         learner = MLPLearner(
-            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            track_neuron_utility=True,
         )
         state = learner.init(feature_dim=4, key=jr.key(9))
         # All utility = 0 → all dormant at very low threshold
         assert MLPLearner.dormant_neuron_fraction(state, threshold=1.0) == 1.0
         state_reset = learner.reset_dormant_neurons(state, jr.key(10), threshold=1.0)
         # Weights should have changed
-        assert not jnp.allclose(
-            state_reset.params.weights[0], state.params.weights[0]
-        )
+        assert not jnp.allclose(state_reset.params.weights[0], state.params.weights[0])
         # Utility for reset neurons is zeroed
         assert state_reset.neuron_utility is not None
         assert float(jnp.sum(state_reset.neuron_utility[0])) == 0.0
 
     def test_config_roundtrip_with_tracking(self):
         learner = MLPLearner(
-            hidden_sizes=(8,), sparsity=0.0, track_neuron_utility=True,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            track_neuron_utility=True,
             neuron_utility_decay=0.95,
         )
         cfg = learner.to_config()
@@ -1342,9 +1324,7 @@ class TestResetDormantOptimizerState:
 
         # Force exactly the first N_RESET neurons dormant.
         assert state.neuron_utility is not None
-        forced = jnp.where(
-            jnp.arange(self.N_HIDDEN) < self.N_RESET, 0.0, 1.0
-        ).astype(jnp.float32)
+        forced = jnp.where(jnp.arange(self.N_HIDDEN) < self.N_RESET, 0.0, 1.0).astype(jnp.float32)
         state = state.replace(neuron_utility=(forced,))
         reset_state = learner.reset_dormant_neurons(state, jr.key(2), threshold=0.5)
 
@@ -1366,13 +1346,9 @@ class TestResetDormantOptimizerState:
                 else:
                     sel = mask[:, None] if new.ndim == 2 else mask
                     # Reset slices equal fresh init_for_shape values.
-                    assert jnp.allclose(
-                        jnp.where(sel, new, 0.0), jnp.where(sel, ref, 0.0)
-                    )
+                    assert jnp.allclose(jnp.where(sel, new, 0.0), jnp.where(sel, ref, 0.0))
                     # Non-reset slices are untouched.
-                    assert jnp.allclose(
-                        jnp.where(sel, 0.0, new), jnp.where(sel, 0.0, old)
-                    )
+                    assert jnp.allclose(jnp.where(sel, 0.0, new), jnp.where(sel, 0.0, old))
 
         # Recovery: 1000 further updates must stay finite and reduce error.
         state = reset_state
@@ -1393,3 +1369,25 @@ class TestResetDormantOptimizerState:
         mse_first = sum(sq_errors[:100]) / 100.0
         mse_last = sum(sq_errors[-100:]) / 100.0
         assert mse_last < mse_first
+
+
+def test_mlp_learner_hidden_sizes_and_feature_dim_integer_validation() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        MLPLearner(hidden_sizes=[128, 128])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        MLPLearner(hidden_sizes=(True, 128))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="hidden_sizes"):
+        MLPLearner(hidden_sizes=(128, 0))
+
+    learner = MLPLearner(hidden_sizes=(np.int32(64), np.int64(32)))
+    assert learner._hidden_sizes == (64, 32)
+    assert type(learner._hidden_sizes[0]) is int
+    assert type(learner._hidden_sizes[1]) is int
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(feature_dim=True, key=jr.key(0))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="feature_dim"):
+        learner.init(feature_dim=0, key=jr.key(0))
+
+    state = learner.init(feature_dim=np.int32(10), key=jr.key(0))
+    assert state.params.weights[0].shape == (64, 10)


### PR DESCRIPTION
Reconstructs and supersedes #936 on current main while preserving Kayvan Zahiri authorship. It retains exact built-in and NumPy integer admission for Linear, MLP, TDLinear, and TrueOnlineTD, adds the missing TDLinear gate, canonicalizes dimensions before JAX, requires an exact hidden-size tuple, and preflights direct and derived float32 state plus MLP initialization working resources before allocation. Verification: 142 focused learner and MLP tests passed after one corrected test run; final boundary subset 4 passed; scoped Ruff, strict source mypy, and diff-check pass. No outputs or registered evidence source files changed.