### PR TITLE
fix(model-replay): enforce exact schema and preflight composition

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -34,13 +34,16 @@ import dataclasses
 import functools
 import hashlib
 import json
+import operator
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 
 from alberta_framework.core.checkpoints import (
@@ -73,6 +76,50 @@ MECHANISM_STATUS = "model-only-replay-mechanism-no-scientific-claim"
 _INT32_MAX = 2_147_483_647
 _UINT32_MAX = 4_294_967_295
 _MAX_EXACT_FLOAT32_INTEGER = 16_777_216
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+
+
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
+def _require_int(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if number > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return number
+
+
+def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
+    if not issubclass(type(payload), Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    try:
+        return dict(cast(Mapping[str, Any], payload))
+    except Exception as error:
+        raise ValueError(f"{name} must be a readable mapping") from error
+
 
 ReplayActionEncoding = Literal["scalar_index", "one_hot"]
 
@@ -86,10 +133,35 @@ class ModelReplayRehearsalConfig:
     action_encoding: ReplayActionEncoding = "one_hot"
 
     def __post_init__(self) -> None:
+        if not isinstance(self.ensemble, WorldModelEnsembleConfig):
+            raise TypeError("ensemble must be a WorldModelEnsembleConfig")
+        if not isinstance(self.replay, DualReplayConfig):
+            raise TypeError("replay must be a DualReplayConfig")
+        if type(self.action_encoding) is not str:
+            raise ValueError("action_encoding must be 'scalar_index' or 'one_hot'")
         if self.ensemble.model.observation_dim != self.replay.observation_dim:
             raise ValueError("ensemble and replay observation dimensions must match")
         if self.ensemble.model.n_actions > _MAX_EXACT_FLOAT32_INTEGER:
             raise ValueError("n_actions exceeds exact float32 action-index storage")
+        # Derived config dimensions must fit signed int32 without allocation
+        _require_int(
+            "ensemble.model.n_actions",
+            self.ensemble.model.n_actions,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
+        _require_int(
+            "replay.action_dim",
+            self.replay.action_dim,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
+        _require_int(
+            "replay.batch_size",
+            self.replay.batch_size,
+            minimum=1,
+            maximum=_INT32_MAX,
+        )
         if self.action_encoding == "scalar_index":
             if self.replay.action_dim != 1:
                 raise ValueError("scalar_index requires replay.action_dim == 1")
@@ -119,6 +191,7 @@ class ModelReplayRehearsalConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> ModelReplayRehearsalConfig:
         """Reconstruct an exact v1 configuration."""
+        values = _copy_mapping(payload, name="model replay config")
         expected = {
             "schema",
             "type",
@@ -128,24 +201,24 @@ class ModelReplayRehearsalConfig:
             "action_encoding",
             "accepted_scientific_evidence",
         }
-        if set(payload) != expected:
+        if set(values) != expected:
             raise ValueError("model replay config fields do not match the v1 schema")
-        if payload.get("schema") != MODEL_REPLAY_REHEARSAL_SCHEMA:
+        if values.get("schema") != MODEL_REPLAY_REHEARSAL_SCHEMA:
             raise ValueError("unexpected model replay rehearsal schema")
-        if payload.get("type") != "ModelReplayRehearsalConfig":
+        if values.get("type") != "ModelReplayRehearsalConfig":
             raise ValueError("unexpected model replay rehearsal config type")
-        if payload.get("mechanism_status") != MECHANISM_STATUS:
+        if values.get("mechanism_status") != MECHANISM_STATUS:
             raise ValueError("model replay rehearsal must remain mechanism-only")
-        if payload.get("accepted_scientific_evidence") is not False:
+        if values.get("accepted_scientific_evidence") is not False:
             raise ValueError("model replay rehearsal has no accepted scientific evidence")
-        ensemble_payload = payload.get("ensemble")
-        replay_payload = payload.get("replay")
+        ensemble_payload = values.get("ensemble")
+        replay_payload = values.get("replay")
         if not isinstance(ensemble_payload, dict) or not isinstance(replay_payload, dict):
             raise ValueError("ensemble and replay configs must be mappings")
         return cls(
             ensemble=WorldModelEnsembleConfig.from_config(ensemble_payload),
             replay=DualReplayConfig.from_config(replay_payload),
-            action_encoding=cast(ReplayActionEncoding, payload.get("action_encoding")),
+            action_encoding=cast(ReplayActionEncoding, values.get("action_encoding")),
         )
 
 
@@ -390,6 +463,12 @@ class ModelReplayRehearsal:
         self._replay = DualReplayMemory(config.replay)
         template = self._make_initial_state(jr.key(0), persistent_bytes=0)
         persistent_scalars, persistent_bytes = _logical_tree_size(template)
+        _require_float32_resource(
+            "ModelReplayRehearsal state",
+            vector_scalars=persistent_scalars,
+        )
+        if persistent_bytes > _INT32_MAX:
+            raise ValueError("ModelReplayRehearsal state byte count must fit signed int32")
         if persistent_bytes > _UINT32_MAX:
             raise ValueError("model replay rehearsal state exceeds uint32 byte accounting")
         self._persistent_bytes = persistent_bytes
@@ -423,11 +502,12 @@ class ModelReplayRehearsal:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> ModelReplayRehearsal:
         """Reconstruct from an exact :meth:`to_config` payload."""
-        if set(payload) != {"type", "config"}:
+        values = _copy_mapping(payload, name="model replay rehearsal construction")
+        if set(values) != {"type", "config"}:
             raise ValueError("model replay rehearsal construction fields are invalid")
-        if payload.get("type") != "ModelReplayRehearsal":
+        if values.get("type") != "ModelReplayRehearsal":
             raise ValueError("unexpected model replay rehearsal construction type")
-        config = payload.get("config")
+        config = values.get("config")
         if not isinstance(config, dict):
             raise ValueError("model replay rehearsal construction is missing config")
         return cls(ModelReplayRehearsalConfig.from_config(config))
@@ -975,6 +1055,14 @@ class ModelReplayRehearsal:
         composer_bytes = persistent_bytes - ensemble_bytes - replay_bytes
         if persistent_bytes != self._persistent_bytes or composer_bytes != 28:
             raise ValueError("model replay rehearsal resource allocation is invalid")
+        _require_float32_resource(
+            "ModelReplayRehearsal state",
+            vector_scalars=scalars,
+        )
+        if persistent_bytes > _INT32_MAX:
+            raise ValueError("ModelReplayRehearsal state byte count must fit signed int32")
+        if persistent_bytes > _UINT32_MAX:
+            raise ValueError("model replay rehearsal state exceeds uint32 byte accounting")
         ensemble_size = self._config.ensemble.ensemble_size
         quota = self._config.replay_quota
         max_real = _INT32_MAX // quota

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -34,16 +34,14 @@ import dataclasses
 import functools
 import hashlib
 import json
-import operator
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal, SupportsIndex, cast
+from typing import Any, Literal, cast
 
 import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import numpy as np
 from jax import Array
 
 from alberta_framework.core.checkpoints import (
@@ -58,6 +56,7 @@ from alberta_framework.core.dual_replay import (
     ReplayEntries,
     ReplayOutcome,
     ReplayPrediction,
+    _allocation_sizes,
 )
 from alberta_framework.core.learning_signals import (
     LearningSignalAvailability,
@@ -69,6 +68,7 @@ from alberta_framework.core.world_model_ensemble import (
     WorldModelEnsembleDiagnostics,
     WorldModelEnsemblePrediction,
     WorldModelEnsembleState,
+    _ensemble_state_resource_counts,
 )
 
 MODEL_REPLAY_REHEARSAL_SCHEMA = "alberta.model_replay_rehearsal.v1"
@@ -76,49 +76,28 @@ MECHANISM_STATUS = "model-only-replay-mechanism-no-scientific-claim"
 _INT32_MAX = 2_147_483_647
 _UINT32_MAX = 4_294_967_295
 _MAX_EXACT_FLOAT32_INTEGER = 16_777_216
-_ACTUAL_INT_TYPES: tuple[type, ...] = (
-    int,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.longlong,
-    np.ulonglong,
-)
-
-
-def _require_float32_resource(
-    name: str, *, vector_scalars: int, fixed_scalars: int = 0
-) -> None:
-    total_scalars = vector_scalars + fixed_scalars
-    if total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} scalar count must fit signed int32")
-    if 4 * total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} byte count must fit signed int32")
-
-
-def _require_int(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{name} must be an integer")
-    number = operator.index(cast(SupportsIndex, value))
-    if number < minimum:
-        raise ValueError(f"{name} must be >= {minimum}")
-    if number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}")
-    return number
-
-
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
     if not issubclass(type(payload), Mapping):
         raise ValueError(f"{name} must be a mapping")
     try:
-        return dict(cast(Mapping[str, Any], payload))
+        values = dict(cast(Mapping[str, Any], payload))
     except Exception as error:
         raise ValueError(f"{name} must be a readable mapping") from error
+    if any(type(key) is not str for key in values):
+        raise ValueError(f"{name} keys must be exact strings")
+    return values
+
+
+def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) -> None:
+    """Reject an oversized combined state before either child allocates arrays."""
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=config.ensemble.model,
+        ensemble_size=config.ensemble.ensemble_size,
+    )
+    _, replay_bytes = _allocation_sizes(config.replay)
+    persistent_bytes = ensemble_bytes + replay_bytes + 7 * 4
+    if persistent_bytes > _INT32_MAX:
+        raise ValueError("model replay rehearsal state byte count must fit signed int32")
 
 
 ReplayActionEncoding = Literal["scalar_index", "one_hot"]
@@ -133,35 +112,16 @@ class ModelReplayRehearsalConfig:
     action_encoding: ReplayActionEncoding = "one_hot"
 
     def __post_init__(self) -> None:
-        if not isinstance(self.ensemble, WorldModelEnsembleConfig):
-            raise TypeError("ensemble must be a WorldModelEnsembleConfig")
-        if not isinstance(self.replay, DualReplayConfig):
-            raise TypeError("replay must be a DualReplayConfig")
+        if type(self.ensemble) is not WorldModelEnsembleConfig:
+            raise TypeError("ensemble must be an exact WorldModelEnsembleConfig")
+        if type(self.replay) is not DualReplayConfig:
+            raise TypeError("replay must be an exact DualReplayConfig")
         if type(self.action_encoding) is not str:
             raise ValueError("action_encoding must be 'scalar_index' or 'one_hot'")
         if self.ensemble.model.observation_dim != self.replay.observation_dim:
             raise ValueError("ensemble and replay observation dimensions must match")
         if self.ensemble.model.n_actions > _MAX_EXACT_FLOAT32_INTEGER:
             raise ValueError("n_actions exceeds exact float32 action-index storage")
-        # Derived config dimensions must fit signed int32 without allocation
-        _require_int(
-            "ensemble.model.n_actions",
-            self.ensemble.model.n_actions,
-            minimum=1,
-            maximum=_INT32_MAX,
-        )
-        _require_int(
-            "replay.action_dim",
-            self.replay.action_dim,
-            minimum=1,
-            maximum=_INT32_MAX,
-        )
-        _require_int(
-            "replay.batch_size",
-            self.replay.batch_size,
-            minimum=1,
-            maximum=_INT32_MAX,
-        )
         if self.action_encoding == "scalar_index":
             if self.replay.action_dim != 1:
                 raise ValueError("scalar_index requires replay.action_dim == 1")
@@ -203,21 +163,27 @@ class ModelReplayRehearsalConfig:
         }
         if set(values) != expected:
             raise ValueError("model replay config fields do not match the v1 schema")
-        if values.get("schema") != MODEL_REPLAY_REHEARSAL_SCHEMA:
+        if (
+            type(values.get("schema")) is not str
+            or values["schema"] != MODEL_REPLAY_REHEARSAL_SCHEMA
+        ):
             raise ValueError("unexpected model replay rehearsal schema")
-        if values.get("type") != "ModelReplayRehearsalConfig":
+        if type(values.get("type")) is not str or values["type"] != "ModelReplayRehearsalConfig":
             raise ValueError("unexpected model replay rehearsal config type")
-        if values.get("mechanism_status") != MECHANISM_STATUS:
+        if (
+            type(values.get("mechanism_status")) is not str
+            or values["mechanism_status"] != MECHANISM_STATUS
+        ):
             raise ValueError("model replay rehearsal must remain mechanism-only")
         if values.get("accepted_scientific_evidence") is not False:
             raise ValueError("model replay rehearsal has no accepted scientific evidence")
         ensemble_payload = values.get("ensemble")
         replay_payload = values.get("replay")
-        if not isinstance(ensemble_payload, dict) or not isinstance(replay_payload, dict):
-            raise ValueError("ensemble and replay configs must be mappings")
+        ensemble_values = _copy_mapping(ensemble_payload, name="ensemble config")
+        replay_values = _copy_mapping(replay_payload, name="replay config")
         return cls(
-            ensemble=WorldModelEnsembleConfig.from_config(ensemble_payload),
-            replay=DualReplayConfig.from_config(replay_payload),
+            ensemble=WorldModelEnsembleConfig.from_config(ensemble_values),
+            replay=DualReplayConfig.from_config(replay_values),
             action_encoding=cast(ReplayActionEncoding, values.get("action_encoding")),
         )
 
@@ -458,15 +424,14 @@ class ModelReplayRehearsal:
     """Causal, atomic composition of real model learning and model-only replay."""
 
     def __init__(self, config: ModelReplayRehearsalConfig):
+        if type(config) is not ModelReplayRehearsalConfig:
+            raise ValueError("config must be an exact ModelReplayRehearsalConfig")
+        _preflight_model_replay_state_resources(config)
         self._config = config
         self._ensemble = WorldModelEnsemble(config.ensemble)
         self._replay = DualReplayMemory(config.replay)
         template = self._make_initial_state(jr.key(0), persistent_bytes=0)
         persistent_scalars, persistent_bytes = _logical_tree_size(template)
-        _require_float32_resource(
-            "ModelReplayRehearsal state",
-            vector_scalars=persistent_scalars,
-        )
         if persistent_bytes > _INT32_MAX:
             raise ValueError("ModelReplayRehearsal state byte count must fit signed int32")
         if persistent_bytes > _UINT32_MAX:
@@ -505,12 +470,11 @@ class ModelReplayRehearsal:
         values = _copy_mapping(payload, name="model replay rehearsal construction")
         if set(values) != {"type", "config"}:
             raise ValueError("model replay rehearsal construction fields are invalid")
-        if values.get("type") != "ModelReplayRehearsal":
+        if type(values.get("type")) is not str or values["type"] != "ModelReplayRehearsal":
             raise ValueError("unexpected model replay rehearsal construction type")
         config = values.get("config")
-        if not isinstance(config, dict):
-            raise ValueError("model replay rehearsal construction is missing config")
-        return cls(ModelReplayRehearsalConfig.from_config(config))
+        config_values = _copy_mapping(config, name="model replay rehearsal config")
+        return cls(ModelReplayRehearsalConfig.from_config(config_values))
 
     def _make_initial_state(
         self,
@@ -1055,10 +1019,6 @@ class ModelReplayRehearsal:
         composer_bytes = persistent_bytes - ensemble_bytes - replay_bytes
         if persistent_bytes != self._persistent_bytes or composer_bytes != 28:
             raise ValueError("model replay rehearsal resource allocation is invalid")
-        _require_float32_resource(
-            "ModelReplayRehearsal state",
-            vector_scalars=scalars,
-        )
         if persistent_bytes > _INT32_MAX:
             raise ValueError("ModelReplayRehearsal state byte count must fit signed int32")
         if persistent_bytes > _UINT32_MAX:

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -139,9 +139,9 @@ def _member_state_scalars(config: ActionConditionedWorldModelConfig) -> int:
     )
 
 
-def _preflight_ensemble_state_resources(
+def _ensemble_state_resource_counts(
     *, model: ActionConditionedWorldModelConfig, ensemble_size: int
-) -> None:
+) -> tuple[int, int]:
     target_dim = model.observation_dim + 2
     members = ensemble_size * _member_state_scalars(model)
     residuals = ensemble_size * target_dim
@@ -173,6 +173,7 @@ def _preflight_ensemble_state_resources(
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
+    return logical_scalars, logical_bytes
 
 
 def _safe_mean(values: Array, *, axis: int | None = None) -> Array:
@@ -286,7 +287,7 @@ class WorldModelEnsembleConfig:
             self, "residual_variance_warmup_steps", residual_variance_warmup_steps
         )
         object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
-        _preflight_ensemble_state_resources(model=self.model, ensemble_size=ensemble_size)
+        _ensemble_state_resource_counts(model=self.model, ensemble_size=ensemble_size)
 
     @property
     def target_dim(self) -> int:

--- a/tests/test_model_replay_rehearsal_validation.py
+++ b/tests/test_model_replay_rehearsal_validation.py
@@ -13,7 +13,7 @@ from alberta_framework.core.learning_signals import LearningSignalEstimatorConfi
 from alberta_framework.core.model_replay_rehearsal import (
     ModelReplayRehearsal,
     ModelReplayRehearsalConfig,
-    _require_float32_resource,
+    _preflight_model_replay_state_resources,
 )
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 from alberta_framework.core.world_model_ensemble import WorldModelEnsembleConfig
@@ -274,29 +274,19 @@ def test_float_hostile_ratio_is_suppressed() -> None:
     assert _HostileFloat.calls == 0
 
 
-def test_require_float32_resource_boundaries_without_allocation() -> None:
-    legal = _INT32_MAX // 4
-    _require_float32_resource("test", vector_scalars=legal)
-    with pytest.raises(ValueError, match="byte count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=legal + 1)
-    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
-    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=_INT32_MAX, fixed_scalars=1)
-
-
 def test_composer_persistent_bytes_preflight_without_allocation() -> None:
-    # Small composer is well within limits
     comp = _composer()
+    _preflight_model_replay_state_resources(comp)
     rehearsal = ModelReplayRehearsal(comp)
     budget = rehearsal.resource_budget()
     assert budget.persistent_state_bytes <= _INT32_MAX
     assert budget.persistent_state_bytes <= _UINT32_MAX
-    # Helper reflects the same bound used in __init__/resource_budget
-    _require_float32_resource(
-        "ModelReplayRehearsal state",
-        vector_scalars=budget.persistent_state_scalars,
+
+    oversized = _composer(
+        replay=_replay(total_capacity=24_000_000, short_term_capacity=1)
     )
+    with pytest.raises(ValueError, match="state byte count must fit signed int32"):
+        _preflight_model_replay_state_resources(oversized)
 
 
 def test_from_config_requires_exact_schema() -> None:

--- a/tests/test_model_replay_rehearsal_validation.py
+++ b/tests/test_model_replay_rehearsal_validation.py
@@ -1,0 +1,333 @@
+"""Focused validation for model-replay rehearsal composition."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.dual_replay import DualReplayConfig
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.model_replay_rehearsal import (
+    ModelReplayRehearsal,
+    ModelReplayRehearsalConfig,
+    _require_float32_resource,
+)
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import WorldModelEnsembleConfig
+
+_INT32_MAX = 2**31 - 1
+_UINT32_MAX = 4_294_967_295
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _HostileStr(str):
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _ClassSpoof:
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:  # type: ignore[no-untyped-def]
+        return str
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:  # type: ignore[override]
+        type(self).calls += 1
+        raise RuntimeError("ratio hook")
+
+
+def _ensemble(
+    *,
+    observation_dim: int = 2,
+    n_actions: int = 2,
+    ensemble_size: int = 2,
+    **overrides: Any,
+) -> WorldModelEnsembleConfig:
+    target_dim = observation_dim + 2
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        hidden_sizes=(),
+        gamma=0.95,
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=ensemble_size,
+        target_dim=target_dim,
+        progress_warmup_steps=2,
+        change_calibration_steps=2,
+        fast_loss_decay=0.5,
+        slow_loss_decay=0.9,
+        max_input_magnitude=100.0,
+        max_predicted_variance=10_000.0,
+        max_observed_loss=10_000.0,
+    )
+    base: dict[str, Any] = {
+        "model": model,
+        "signal_estimator": signals,
+        "ensemble_size": ensemble_size,
+        "bootstrap_probability": 0.5,
+        "residual_variance_decay": 0.8,
+        "residual_variance_warmup_steps": 1,
+        "residual_variance_floor": 1e-6,
+    }
+    base.update(overrides)
+    if "ensemble_size" in overrides:
+        es = int(overrides["ensemble_size"])  # type: ignore[arg-type]
+        # keep signals in sync unless explicitly overridden
+        if "signal_estimator" not in overrides:
+            signals = LearningSignalEstimatorConfig(
+                ensemble_size=es,
+                target_dim=target_dim,
+                progress_warmup_steps=2,
+                change_calibration_steps=2,
+                fast_loss_decay=0.5,
+                slow_loss_decay=0.9,
+                max_input_magnitude=100.0,
+                max_predicted_variance=10_000.0,
+                max_observed_loss=10_000.0,
+            )
+            base["signal_estimator"] = signals
+    return WorldModelEnsembleConfig(**base)  # type: ignore[arg-type]
+
+
+def _replay(
+    *,
+    observation_dim: int = 2,
+    action_dim: int = 2,
+    total_capacity: int = 2,
+    short_term_capacity: int = 1,
+    short_term_sample_size: int = 1,
+    long_term_sample_size: int = 1,
+) -> DualReplayConfig:
+    return DualReplayConfig(
+        total_capacity=total_capacity,
+        short_term_capacity=short_term_capacity,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        short_term_sample_size=short_term_sample_size,
+        long_term_sample_size=long_term_sample_size,
+    )
+
+
+def _composer(**overrides: Any) -> ModelReplayRehearsalConfig:
+    ensemble = _ensemble()
+    replay = _replay()
+    values: dict[str, Any] = {
+        "ensemble": ensemble,
+        "replay": replay,
+        "action_encoding": "one_hot",
+    }
+    values.update(overrides)
+    return ModelReplayRehearsalConfig(**values)  # type: ignore[arg-type]
+
+
+def test_composer_accepts_both_encodings() -> None:
+    one_hot = _composer(action_encoding="one_hot")
+    assert one_hot.action_encoding == "one_hot"
+    scalar = _composer(replay=_replay(action_dim=1), action_encoding="scalar_index")
+    assert scalar.action_encoding == "scalar_index"
+    # round-trip via mapping preserves exact strings
+    payload = one_hot.to_config()
+    restored = ModelReplayRehearsalConfig.from_config(MappingProxyType(payload))
+    assert restored.action_encoding == "one_hot"
+
+
+def test_action_encoding_requires_exact_str_without_repr() -> None:
+    with pytest.raises(ValueError, match="action_encoding"):
+        _composer(action_encoding=_HostileStr("one_hot"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_encoding"):
+        _composer(action_encoding=_ClassSpoof())  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _composer(action_encoding=_RaisingRepr())  # type: ignore[arg-type]
+    for bad in (True, 1, 1.0, None, b"one_hot"):
+        with pytest.raises(ValueError, match="action_encoding"):
+            _composer(action_encoding=bad)  # type: ignore[arg-type]
+
+
+def test_composer_rejects_invalid_encoding_value() -> None:
+    with pytest.raises(ValueError, match="action_encoding"):
+        _composer(action_encoding="invalid")  # type: ignore[arg-type]
+
+
+def test_composer_rejects_ensemble_replay_type_mismatch() -> None:
+    with pytest.raises(TypeError, match="ensemble"):
+        ModelReplayRehearsalConfig(
+            ensemble="not_ensemble",  # type: ignore[arg-type]
+            replay=_replay(),
+            action_encoding="one_hot",
+        )
+    with pytest.raises(TypeError, match="replay"):
+        ModelReplayRehearsalConfig(
+            ensemble=_ensemble(),
+            replay="not_replay",  # type: ignore[arg-type]
+            action_encoding="one_hot",
+        )
+
+
+def test_composer_rejects_observation_dim_mismatch() -> None:
+    ensemble = _ensemble(observation_dim=3)
+    replay = _replay(observation_dim=2, action_dim=2)
+    with pytest.raises(ValueError, match="observation dimensions must match"):
+        ModelReplayRehearsalConfig(
+            ensemble=ensemble, replay=replay, action_encoding="one_hot"
+        )
+
+
+def test_composer_rejects_n_actions_exceeds_exact_float32() -> None:
+    # _MAX_EXACT_FLOAT32_INTEGER is 16_777_216
+    ensemble = _ensemble(n_actions=16_777_217)
+    replay = _replay(action_dim=16_777_217)
+    with pytest.raises(ValueError, match="exceeds exact float32"):
+        ModelReplayRehearsalConfig(
+            ensemble=ensemble, replay=replay, action_encoding="one_hot"
+        )
+
+
+def test_composer_rejects_action_dim_mismatch_for_encodings() -> None:
+    ensemble = _ensemble(n_actions=4)
+    # scalar_index requires action_dim == 1
+    with pytest.raises(ValueError, match="scalar_index"):
+        ModelReplayRehearsalConfig(
+            ensemble=ensemble,
+            replay=_replay(action_dim=2),
+            action_encoding="scalar_index",
+        )
+    # one_hot requires action_dim == n_actions
+    with pytest.raises(ValueError, match="one_hot"):
+        ModelReplayRehearsalConfig(
+            ensemble=ensemble,
+            replay=_replay(action_dim=3),
+            action_encoding="one_hot",
+        )
+
+
+def test_int_validators_reject_hostile_subclass_without_hook() -> None:
+    # Directly exercise the hostile int path via DualReplayConfig (shared gate)
+    with pytest.raises(ValueError, match="must be an integer"):
+        _replay(action_dim=_HostileInt(2))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be an integer"):
+        _ensemble(ensemble_size=_HostileInt(2))  # type: ignore[arg-type]
+
+
+def test_int_validators_do_not_run_repr_hook() -> None:
+    with pytest.raises(ValueError):
+        _replay(action_dim=_RaisingRepr())  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _ensemble(ensemble_size=_RaisingRepr())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "np_type",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,  # noqa: E501
+        np.ulonglong,
+    ],
+)
+def test_numpy_integer_family_canonicalizes(np_type: type) -> None:
+    cfg = _composer(
+        ensemble=_ensemble(ensemble_size=np_type(2)),
+        replay=_replay(action_dim=np_type(2)),
+    )
+    assert cfg.ensemble.ensemble_size == 2
+    assert type(cfg.ensemble.ensemble_size) is int
+    assert cfg.replay.action_dim == 2
+    assert type(cfg.replay.action_dim) is int
+
+
+def test_float_hostile_ratio_is_suppressed() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="bootstrap_probability"):
+        _ensemble(bootstrap_probability=_HostileFloat(0.5))  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+
+
+def test_require_float32_resource_boundaries_without_allocation() -> None:
+    legal = _INT32_MAX // 4
+    _require_float32_resource("test", vector_scalars=legal)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=legal + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX, fixed_scalars=1)
+
+
+def test_composer_persistent_bytes_preflight_without_allocation() -> None:
+    # Small composer is well within limits
+    comp = _composer()
+    rehearsal = ModelReplayRehearsal(comp)
+    budget = rehearsal.resource_budget()
+    assert budget.persistent_state_bytes <= _INT32_MAX
+    assert budget.persistent_state_bytes <= _UINT32_MAX
+    # Helper reflects the same bound used in __init__/resource_budget
+    _require_float32_resource(
+        "ModelReplayRehearsal state",
+        vector_scalars=budget.persistent_state_scalars,
+    )
+
+
+def test_from_config_requires_exact_schema() -> None:
+    cfg = _composer()
+    payload = cfg.to_config()
+    restored = ModelReplayRehearsalConfig.from_config(MappingProxyType(payload))
+    assert restored.to_config() == payload
+    bad = dict(payload)
+    bad["type"] = "Wrong"
+    with pytest.raises(ValueError, match="type"):
+        ModelReplayRehearsalConfig.from_config(bad)
+    bad2 = dict(payload)
+    bad2["extra"] = 1
+    with pytest.raises(ValueError, match="fields do not match"):
+        ModelReplayRehearsalConfig.from_config(bad2)
+
+
+def test_hostile_mapping_is_normalized() -> None:
+    from collections.abc import Mapping
+
+    class HostileMapping(Mapping[str, Any]):  # type: ignore[type-arg]
+        def __getitem__(self, key: str) -> Any:
+            raise RuntimeError("hook")
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("hook")
+
+        def __len__(self) -> int:
+            return 1
+
+    with pytest.raises(ValueError, match="mapping"):
+        ModelReplayRehearsal(  # type: ignore[arg-type]
+            ModelReplayRehearsalConfig.from_config(HostileMapping())  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Supersedes #895 after deep review. Preserves its useful exact action-encoding/child/schema validation, hardens all mapping keys and marker identities, and replaces the post-allocation pseudo-preflight with an exact combined ensemble+replay+composer byte calculation executed before either child allocates. Refactors the ensemble resource formula to return its already-validated exact counts. Verification: 268 model-replay/world-model-ensemble/dual-replay tests passed; Ruff and strict mypy clean; diff check clean.