### PR TITLE
fix(pavlovian): complete stream and resource contracts

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -40,6 +40,7 @@ References
 from __future__ import annotations
 
 import math
+from fractions import Fraction
 from numbers import Real
 from typing import cast
 
@@ -56,6 +57,36 @@ from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
 _INT32_MAX = 2**31 - 1
+_UINT32_MAX = 4_294_967_295
+_ACTUAL_INT_TYPES: frozenset[type] = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+_ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
+_ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+
+
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def _require_finite_real(
@@ -65,24 +96,19 @@ def _require_finite_real(
     nonnegative: bool = False,
 ) -> float:
     """Return a finite real, rejecting bools, NaN, and infinities."""
-    # ``isinstance(value, Real)`` consults the overridable ``__class__``
-    # attribute, so an object whose ``__class__`` property returns ``float``
-    # passes the check even though its true type is not a registered
-    # ``Real``. Use the non-spoofable ``type()`` slot instead, and do not
-    # interpolate the untrusted value into the rejection message before its
-    # type is confirmed safe.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist prevents ``__class__`` spoofing and hostile
+    # ``as_integer_ratio`` subclasses from reaching the narrowing routine.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a finite real")
     real_value = cast(Real, value)
     try:
         number = float(real_value)
-    except (OverflowError, ValueError) as error:
-        raise ValueError(f"{name} must be a finite real, got {value!r}") from error
+    except Exception as error:
+        raise ValueError(f"{name} must be a finite real") from error
     if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real, got {value!r}")
+        raise ValueError(f"{name} must be a finite real")
     if nonnegative and number < 0.0:
-        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+        raise ValueError(f"{name} must be a non-negative finite real")
     return number
 
 
@@ -93,37 +119,42 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     below the float32 subnormal range are accepted as exact zero, matching the
     noise-free trajectory they produce in the stream's float32 arithmetic.
     """
-    # See ``_require_finite_real``: ``type()`` cannot be spoofed through a
-    # ``__class__`` property override the way ``isinstance`` can.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist rejects hostile subclasses before ``as_integer_ratio``
+    # is ever consulted — mirrors the world-model ensemble gate.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a non-negative finite real")
     real_value = cast(Real, value)
-    if real_value < 0:
-        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+    try:
+        is_negative = bool(real_value < 0)
+    except Exception as error:
+        raise ValueError(f"{name} must be a non-negative finite real") from error
+    if is_negative:
+        raise ValueError(f"{name} must be a non-negative finite real")
     try:
         narrowed = round_real_to_float32(real_value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+    except Exception as error:
         raise ValueError(
-            f"{name} must remain finite when rounded to float32, got {value!r}"
+            f"{name} must remain finite when rounded to float32"
         ) from error
     if not bool(np.isfinite(narrowed)):
         raise ValueError(
-            f"{name} must remain finite when rounded to float32, got {value!r}"
+            f"{name} must remain finite when rounded to float32"
         )
     return narrowed
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:
     """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
-    # See ``_require_finite_real``: ``type()`` cannot be spoofed through a
-    # ``__class__`` property override the way ``isinstance`` can.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist — hostile ``float`` subclasses are rejected before
+    # any ``__float__`` or ratio hook runs.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be in [0, 1]")
-    number = float(cast(Real, value))
+    try:
+        number = float(cast(Real, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be in [0, 1]") from error
     if not math.isfinite(number) or not 0.0 <= number <= 1.0:
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in [0, 1]")
     return number
 
 
@@ -136,11 +167,11 @@ def _require_builtin_int(
 ) -> int:
     """Return a built-in int at or above ``minimum``; reject bool and numpy ints."""
     if type(value) is not int:
-        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+        raise ValueError(f"{name} must be a built-in integer")
     if value < minimum:
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}")
     if value > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return value
 
 # =============================================================================
@@ -333,15 +364,13 @@ class ClassicalConditioningStream:
         )
 
         for phase in phases:
+            if type(phase.name) is not str:
+                raise ValueError("phase name must be a string")
             try:
                 _require_unit_interval(
                     phase.cs_us_contingency, name="cs_us_contingency"
                 )
             except ValueError as error:
-                # ``phase.cs_us_contingency`` is untrusted here (validation
-                # just rejected it); do not format it through its own
-                # __repr__/__str__ hook, which a hostile object can make
-                # raise an arbitrary exception instead of this ValueError.
                 raise ValueError(
                     f"phase {phase.name!r} cs_us_contingency must be in [0, 1]"
                 ) from error
@@ -349,22 +378,37 @@ class ClassicalConditioningStream:
             compound_index = _require_builtin_int(
                 phase.compound_index, name="compound_index", minimum=-1
             )
+            if not isinstance(phase.cs_active, tuple):
+                raise ValueError("phase cs_active must be a tuple of integers")
             for cs_idx in phase.cs_active:
                 if type(cs_idx) is not int:
                     raise ValueError(
-                        f"phase {phase.name!r} cs_active index must be a "
-                        f"built-in integer, got {cs_idx!r}"
+                        f"phase {phase.name!r} cs_active index must be a built-in integer"
                     )
                 if not (0 <= cs_idx < n_cs):
                     raise ValueError(
-                        f"phase {phase.name!r} references cs_active index {cs_idx}, "
-                        f"but n_cs={n_cs}"
+                        f"phase {phase.name!r} references cs_active index out of range"
                     )
             if compound_index >= n_cs:
                 raise ValueError(
-                    f"phase {phase.name!r} has compound_index={phase.compound_index} "
-                    f"but n_cs={n_cs}"
+                    f"phase {phase.name!r} has compound_index out of range"
                 )
+
+        # Derived allocations must fit signed int32 without allocating JAX arrays
+        feature_dim = int(n_cs) + int(n_distractors)
+        if feature_dim > _INT32_MAX:
+            raise ValueError("feature_dim must fit signed int32")
+        _require_float32_resource(
+            "Pavlovian phase mask",
+            vector_scalars=len(phases) * int(n_cs),
+        )
+        _require_float32_resource(
+            "Pavlovian feature state",
+            vector_scalars=feature_dim,
+            fixed_scalars=4,
+        )
+        if len(phases) > _INT32_MAX:
+            raise ValueError("n_phases must fit signed int32")
 
         self._phases = tuple(phases)
         self._n_cs = int(n_cs)

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -57,7 +57,6 @@ from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
 _INT32_MAX = 2**31 - 1
-_UINT32_MAX = 4_294_967_295
 _ACTUAL_INT_TYPES: frozenset[type] = frozenset(
     {
         int,
@@ -79,14 +78,18 @@ _ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
 _ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
-def _require_float32_resource(
-    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+def _require_pavlovian_resources(
+    *, n_phases: int, n_cs: int, n_distractors: int
 ) -> None:
-    total_scalars = vector_scalars + fixed_scalars
+    """Preflight all persistent JAX arrays owned by the stream and its state."""
+    static_scalars = n_phases * n_cs + 4 * n_phases
+    # State owns feature countdowns, four int32 counters, and one two-word key.
+    state_scalars = n_cs + n_distractors + 6
+    total_scalars = static_scalars + state_scalars
     if total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} scalar count must fit signed int32")
+        raise ValueError("Pavlovian persistent scalar count must fit signed int32")
     if 4 * total_scalars > _INT32_MAX:
-        raise ValueError(f"{name} byte count must fit signed int32")
+        raise ValueError("Pavlovian persistent byte count must fit signed int32")
 
 
 def _require_finite_real(
@@ -336,8 +339,8 @@ class ClassicalConditioningStream:
                 scientific scalar, or ``noise_std`` becomes non-finite when
                 rounded to the stream's float32 execution dtype.
         """
-        if not phases:
-            raise ValueError("phases must be non-empty")
+        if type(phases) is not tuple or not phases:
+            raise ValueError("phases must be a non-empty exact tuple")
         n_cs = _require_builtin_int(n_cs, name="n_cs", minimum=1)
         n_distractors = _require_builtin_int(
             n_distractors, name="n_distractors", minimum=0
@@ -363,22 +366,25 @@ class ClassicalConditioningStream:
             distractor_prob, name="distractor_prob"
         )
 
+        canonical_phases: list[PavlovianPhase] = []
         for phase in phases:
+            if type(phase) is not PavlovianPhase:
+                raise ValueError("each phase must be an exact PavlovianPhase")
             if type(phase.name) is not str:
                 raise ValueError("phase name must be a string")
             try:
-                _require_unit_interval(
+                contingency = _require_unit_interval(
                     phase.cs_us_contingency, name="cs_us_contingency"
                 )
             except ValueError as error:
                 raise ValueError(
                     f"phase {phase.name!r} cs_us_contingency must be in [0, 1]"
                 ) from error
-            _require_builtin_int(phase.n_steps, name="n_steps", minimum=1)
+            n_steps = _require_builtin_int(phase.n_steps, name="n_steps", minimum=1)
             compound_index = _require_builtin_int(
                 phase.compound_index, name="compound_index", minimum=-1
             )
-            if not isinstance(phase.cs_active, tuple):
+            if type(phase.cs_active) is not tuple:
                 raise ValueError("phase cs_active must be a tuple of integers")
             for cs_idx in phase.cs_active:
                 if type(cs_idx) is not int:
@@ -393,22 +399,25 @@ class ClassicalConditioningStream:
                 raise ValueError(
                     f"phase {phase.name!r} has compound_index out of range"
                 )
+            canonical_phases.append(
+                PavlovianPhase(
+                    name=phase.name,
+                    n_steps=n_steps,
+                    cs_us_contingency=contingency,
+                    cs_active=phase.cs_active,
+                    compound_index=compound_index,
+                )
+            )
 
-        # Derived allocations must fit signed int32 without allocating JAX arrays
+        phases = tuple(canonical_phases)
         feature_dim = int(n_cs) + int(n_distractors)
         if feature_dim > _INT32_MAX:
             raise ValueError("feature_dim must fit signed int32")
-        _require_float32_resource(
-            "Pavlovian phase mask",
-            vector_scalars=len(phases) * int(n_cs),
+        _require_pavlovian_resources(
+            n_phases=len(phases),
+            n_cs=n_cs,
+            n_distractors=n_distractors,
         )
-        _require_float32_resource(
-            "Pavlovian feature state",
-            vector_scalars=feature_dim,
-            fixed_scalars=4,
-        )
-        if len(phases) > _INT32_MAX:
-            raise ValueError("n_phases must fit signed int32")
 
         self._phases = tuple(phases)
         self._n_cs = int(n_cs)
@@ -599,7 +608,9 @@ class ClassicalConditioningStream:
             jax.nn.one_hot(jnp.maximum(compound_idx, 0), self._n_cs, dtype=jnp.int32),
             jnp.zeros(self._n_cs, dtype=jnp.int32),
         )
-        cs_activations = (chosen_cs_oh + compound_oh) * jnp.int32(self._cs_duration)
+        cs_activations = jnp.maximum(chosen_cs_oh, compound_oh) * jnp.int32(
+            self._cs_duration
+        )
 
         # ------------------------------------------------------------------
         # 5. Update CS / US / ITI counters
@@ -683,7 +694,9 @@ class ClassicalConditioningStream:
             cs_active_steps_remaining=new_cs_active.astype(jnp.int32),
             us_pending_steps_remaining=new_us_pending.astype(jnp.int32),
             phase_idx=new_phase_idx.astype(jnp.int32),
-            step_in_phase=(new_step_in_phase + 1).astype(jnp.int32),
+            step_in_phase=(
+                jnp.minimum(jnp.maximum(new_step_in_phase, 0), _INT32_MAX - 1) + 1
+            ).astype(jnp.int32),
             n_distractor_active=new_distractor_active.astype(jnp.int32),
             iti_steps_remaining=new_iti_remaining.astype(jnp.int32),
         )

--- a/tests/test_pavlovian_validation.py
+++ b/tests/test_pavlovian_validation.py
@@ -1,0 +1,193 @@
+"""Focused validation for Pavlovian stream (hostile + resource)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.pavlovian import (
+    ClassicalConditioningStream,
+    PavlovianPhase,
+    _require_float32_resource,
+)
+
+_INT32_MAX = 2**31 - 1
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:  # type: ignore[override]
+        type(self).calls += 1
+        raise RuntimeError("ratio hook")
+
+
+class _ClassSpoof:
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:  # type: ignore[no-untyped-def]
+        return float
+
+    def __float__(self) -> float:  # pragma: no cover
+        return 0.1
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _phase(**overrides: object) -> PavlovianPhase:
+    base: dict[str, object] = {
+        "name": "acq",
+        "n_steps": 10,
+        "cs_us_contingency": 1.0,
+        "cs_active": (0,),
+    }
+    base.update(overrides)
+    return PavlovianPhase(**base)  # type: ignore[arg-type]
+
+
+def _stream(**overrides: object) -> ClassicalConditioningStream:
+    phases = overrides.pop("phases", (_phase(),))
+    return ClassicalConditioningStream(phases=phases, **overrides)  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_reject_hostile_without_hook() -> None:
+    for field, ctor in [
+        ("n_cs", lambda v: _stream(n_cs=v)),
+        ("n_distractors", lambda v: _stream(n_distractors=v)),
+        ("cs_us_delay", lambda v: _stream(cs_us_delay=v)),
+        ("cs_duration", lambda v: _stream(cs_duration=v)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            ctor(_HostileInt(2))  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=field):
+            ctor(_HostileInt(2))  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_do_not_run_repr() -> None:
+    for ctor in [
+        lambda v: _stream(n_cs=v),
+        lambda v: _stream(cs_us_delay=v),
+    ]:
+        with pytest.raises(ValueError):
+            ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_reject_bool_and_numpy() -> None:
+    for field in ("n_cs", "cs_us_delay", "cs_duration"):
+        for bad in (True, np.bool_(True), np.int64(2), 1.0, "2"):
+            with pytest.raises(ValueError, match=field):
+                _stream(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_pavlovian_float_validators_reject_hostile_ratio() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="noise_std"):
+        _stream(noise_std=_HostileFloat(0.1))  # type: ignore[arg-type]
+    # Hostile as_integer_ratio must not be invoked (ratio check is guarded)
+    assert _HostileFloat.calls == 0
+
+
+def test_pavlovian_float_validators_reject_spoof_and_nan() -> None:
+    for field, bad in [
+        ("noise_std", float("nan")),
+        ("noise_std", float("inf")),
+        ("noise_std", -0.1),
+        ("noise_std", _ClassSpoof()),  # type: ignore[arg-type]
+        ("distractor_prob", float("nan")),
+        ("distractor_prob", 1.5),
+        ("distractor_prob", -0.1),
+        ("distractor_prob", _ClassSpoof()),  # type: ignore[arg-type]
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _stream(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_pavlovian_phase_contingency_hostile_is_suppressed() -> None:
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _stream(phases=(_phase(cs_us_contingency=_HostileFloat(0.5)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _stream(phases=(_phase(cs_us_contingency=_ClassSpoof()),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_phase_name_requires_exact_str() -> None:
+    with pytest.raises(ValueError, match="phase name"):
+        _stream(phases=(_phase(name=_HostileInt(1)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase name"):
+        _stream(phases=(_phase(name=b"acq"),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_cs_active_hostile_and_range() -> None:
+    # hostile int subclass must be rejected without running index hook
+    with pytest.raises(ValueError, match="cs_active"):
+        _stream(phases=(_phase(cs_active=(_HostileInt(0),)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _stream(phases=(_phase(cs_active=(_RaisingRepr(),)),))  # type: ignore[arg-type]
+    # out of range
+    with pytest.raises(ValueError, match="out of range"):
+        _stream(phases=(_phase(cs_active=(5,)),), n_cs=2)
+    # compound out of range
+    with pytest.raises(ValueError, match="compound_index"):
+        _stream(phases=(_phase(compound_index=5),), n_cs=2)
+    # tuple type check
+    with pytest.raises(ValueError, match="cs_active"):
+        _stream(phases=(_phase(cs_active=[0]),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_require_float32_resource_boundaries() -> None:
+    legal = _INT32_MAX // 4
+    _require_float32_resource("test", vector_scalars=legal)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=legal + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX, fixed_scalars=1)
+
+
+def test_pavlovian_resource_preflight_without_allocation() -> None:
+    # feature_dim = n_cs + n_distractors, mask = n_phases * n_cs
+    # small case passes
+    s = _stream(n_cs=2, n_distractors=1, phases=(_phase(), _phase(name="ext")))
+    assert s.feature_dim == 3
+    # helper reflects same bound used in __init__
+    _require_float32_resource("Pavlovian phase mask", vector_scalars=2 * 2)
+    # large mask: n_phases=1, n_cs = INT32//4+1 -> byte overflow
+    legal_mask = _INT32_MAX // 4
+    _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask + 1)
+    # feature state: vector = n_cs + n_distractors = INT32, fixed=4 -> scalar overflow
+    with pytest.raises(ValueError, match="scalar count"):
+        _require_float32_resource(
+            "Pavlovian feature state", vector_scalars=_INT32_MAX, fixed_scalars=4
+        )
+    # feature state byte overflow without scalar overflow: total = INT32//4 is max byte-pass
+    legal_feature = _INT32_MAX // 4 - 4
+    _require_float32_resource(
+        "Pavlovian feature state", vector_scalars=legal_feature, fixed_scalars=4
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource(
+            "Pavlovian feature state", vector_scalars=legal_feature + 1, fixed_scalars=4
+        )
+
+
+def test_pavlovian_valid_construction_and_jit() -> None:
+    import jax.numpy as jnp
+    import jax.random as jr
+
+    stream = _stream(n_cs=2, n_distractors=1, noise_std=0.01, distractor_prob=0.1)
+    state = stream.init(jr.key(0))
+    ts, _ = stream.step(state, jnp.array(0))
+    assert ts.observation.shape == (3,)
+    assert ts.target.shape == (1,)

--- a/tests/test_pavlovian_validation.py
+++ b/tests/test_pavlovian_validation.py
@@ -8,7 +8,7 @@ import pytest
 from alberta_framework.streams.pavlovian import (
     ClassicalConditioningStream,
     PavlovianPhase,
-    _require_float32_resource,
+    _require_pavlovian_resources,
 )
 
 _INT32_MAX = 2**31 - 1
@@ -143,15 +143,14 @@ def test_pavlovian_cs_active_hostile_and_range() -> None:
         _stream(phases=(_phase(cs_active=[0]),))  # type: ignore[arg-type]
 
 
-def test_pavlovian_require_float32_resource_boundaries() -> None:
-    legal = _INT32_MAX // 4
-    _require_float32_resource("test", vector_scalars=legal)
+def test_pavlovian_resource_boundaries_include_static_arrays_state_and_key() -> None:
+    _require_pavlovian_resources(n_phases=1, n_cs=1, n_distractors=0)
     with pytest.raises(ValueError, match="byte count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=legal + 1)
-    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
-    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
-        _require_float32_resource("test", vector_scalars=_INT32_MAX, fixed_scalars=1)
+        _require_pavlovian_resources(
+            n_phases=1,
+            n_cs=_INT32_MAX // 4,
+            n_distractors=0,
+        )
 
 
 def test_pavlovian_resource_preflight_without_allocation() -> None:
@@ -159,27 +158,45 @@ def test_pavlovian_resource_preflight_without_allocation() -> None:
     # small case passes
     s = _stream(n_cs=2, n_distractors=1, phases=(_phase(), _phase(name="ext")))
     assert s.feature_dim == 3
-    # helper reflects same bound used in __init__
-    _require_float32_resource("Pavlovian phase mask", vector_scalars=2 * 2)
-    # large mask: n_phases=1, n_cs = INT32//4+1 -> byte overflow
-    legal_mask = _INT32_MAX // 4
-    _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask)
-    with pytest.raises(ValueError, match="byte count"):
-        _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask + 1)
-    # feature state: vector = n_cs + n_distractors = INT32, fixed=4 -> scalar overflow
+    _require_pavlovian_resources(n_phases=2, n_cs=2, n_distractors=1)
     with pytest.raises(ValueError, match="scalar count"):
-        _require_float32_resource(
-            "Pavlovian feature state", vector_scalars=_INT32_MAX, fixed_scalars=4
+        _require_pavlovian_resources(
+            n_phases=_INT32_MAX,
+            n_cs=_INT32_MAX,
+            n_distractors=0,
         )
-    # feature state byte overflow without scalar overflow: total = INT32//4 is max byte-pass
-    legal_feature = _INT32_MAX // 4 - 4
-    _require_float32_resource(
-        "Pavlovian feature state", vector_scalars=legal_feature, fixed_scalars=4
+
+
+def test_pavlovian_phase_container_and_values_are_canonicalized() -> None:
+    from fractions import Fraction
+
+    with pytest.raises(ValueError, match="exact tuple"):
+        _stream(phases=[_phase()])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact PavlovianPhase"):
+        _stream(phases=({"name": "bad"},))  # type: ignore[arg-type]
+
+    stream = _stream(phases=(_phase(cs_us_contingency=Fraction(1, 2)),))
+    assert type(stream.phases[0].cs_us_contingency) is float
+
+
+def test_pavlovian_counters_saturate_and_compound_does_not_double_activate() -> None:
+    import jax.numpy as jnp
+    import jax.random as jr
+
+    stream = _stream(
+        phases=(_phase(cs_active=(0,), compound_index=0),),
+        cs_duration=_INT32_MAX,
+        iti_min=0,
+        iti_max=0,
+        noise_std=0.0,
     )
-    with pytest.raises(ValueError, match="byte count"):
-        _require_float32_resource(
-            "Pavlovian feature state", vector_scalars=legal_feature + 1, fixed_scalars=4
-        )
+    state = stream.init(jr.key(0)).replace(
+        iti_steps_remaining=jnp.asarray(0, dtype=jnp.int32),
+        step_in_phase=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+    _, next_state = stream.step(state, jnp.asarray(0, dtype=jnp.int32))
+    assert int(next_state.cs_active_steps_remaining[0]) == _INT32_MAX
+    assert int(next_state.step_in_phase) == _INT32_MAX
 
 
 def test_pavlovian_valid_construction_and_jit() -> None:


### PR DESCRIPTION
Supersedes #896 after deep review. Preserves its hostile-safe scalar/type gates and replaces partial per-array estimates with one exact persistent-state/static-array preflight including phase vectors and PRNG-key words. It also canonicalizes validated phase contingencies before JAX conversion, requires exact phase containers/descriptors, saturates the lifelong phase counter, and prevents a compound CS from double-activating/overflowing when it equals the primary CS. Verification: 117 Pavlovian stream/learning/validation tests passed; Ruff and strict mypy clean; diff check clean.