### PR TITLE
fix(pavlovian): complete protocol, resource, and runtime contracts

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -40,6 +40,7 @@ References
 from __future__ import annotations
 
 import math
+from fractions import Fraction
 from numbers import Real
 from typing import cast
 
@@ -56,6 +57,36 @@ from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
 _INT32_MAX = 2**31 - 1
+_UINT32_MAX = 4_294_967_295
+_ACTUAL_INT_TYPES: frozenset[type] = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+_ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
+_ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+
+
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
+    total_scalars = vector_scalars + fixed_scalars
+    if total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * total_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
 
 
 def _require_finite_real(
@@ -65,24 +96,19 @@ def _require_finite_real(
     nonnegative: bool = False,
 ) -> float:
     """Return a finite real, rejecting bools, NaN, and infinities."""
-    # ``isinstance(value, Real)`` consults the overridable ``__class__``
-    # attribute, so an object whose ``__class__`` property returns ``float``
-    # passes the check even though its true type is not a registered
-    # ``Real``. Use the non-spoofable ``type()`` slot instead, and do not
-    # interpolate the untrusted value into the rejection message before its
-    # type is confirmed safe.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist prevents ``__class__`` spoofing and hostile
+    # ``as_integer_ratio`` subclasses from reaching the narrowing routine.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a finite real")
     real_value = cast(Real, value)
     try:
         number = float(real_value)
-    except (OverflowError, ValueError) as error:
-        raise ValueError(f"{name} must be a finite real, got {value!r}") from error
+    except Exception as error:
+        raise ValueError(f"{name} must be a finite real") from error
     if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real, got {value!r}")
+        raise ValueError(f"{name} must be a finite real")
     if nonnegative and number < 0.0:
-        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+        raise ValueError(f"{name} must be a non-negative finite real")
     return number
 
 
@@ -93,37 +119,42 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     below the float32 subnormal range are accepted as exact zero, matching the
     noise-free trajectory they produce in the stream's float32 arithmetic.
     """
-    # See ``_require_finite_real``: ``type()`` cannot be spoofed through a
-    # ``__class__`` property override the way ``isinstance`` can.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist rejects hostile subclasses before ``as_integer_ratio``
+    # is ever consulted — mirrors the world-model ensemble gate.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a non-negative finite real")
     real_value = cast(Real, value)
-    if real_value < 0:
-        raise ValueError(f"{name} must be a non-negative finite real, got {value!r}")
+    try:
+        is_negative = bool(real_value < 0)
+    except Exception as error:
+        raise ValueError(f"{name} must be a non-negative finite real") from error
+    if is_negative:
+        raise ValueError(f"{name} must be a non-negative finite real")
     try:
         narrowed = round_real_to_float32(real_value)
-    except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
+    except Exception as error:
         raise ValueError(
-            f"{name} must remain finite when rounded to float32, got {value!r}"
+            f"{name} must remain finite when rounded to float32"
         ) from error
     if not bool(np.isfinite(narrowed)):
         raise ValueError(
-            f"{name} must remain finite when rounded to float32, got {value!r}"
+            f"{name} must remain finite when rounded to float32"
         )
     return narrowed
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:
     """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
-    # See ``_require_finite_real``: ``type()`` cannot be spoofed through a
-    # ``__class__`` property override the way ``isinstance`` can.
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    # Exact-type whitelist — hostile ``float`` subclasses are rejected before
+    # any ``__float__`` or ratio hook runs.
+    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be in [0, 1]")
-    number = float(cast(Real, value))
+    try:
+        number = float(cast(Real, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be in [0, 1]") from error
     if not math.isfinite(number) or not 0.0 <= number <= 1.0:
-        raise ValueError(f"{name} must be in [0, 1], got {value!r}")
+        raise ValueError(f"{name} must be in [0, 1]")
     return number
 
 
@@ -136,11 +167,11 @@ def _require_builtin_int(
 ) -> int:
     """Return a built-in int at or above ``minimum``; reject bool and numpy ints."""
     if type(value) is not int:
-        raise ValueError(f"{name} must be a built-in integer, got {value!r}")
+        raise ValueError(f"{name} must be a built-in integer")
     if value < minimum:
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+        raise ValueError(f"{name} must be >= {minimum}")
     if value > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return value
 
 # =============================================================================
@@ -333,15 +364,13 @@ class ClassicalConditioningStream:
         )
 
         for phase in phases:
+            if type(phase.name) is not str:
+                raise ValueError("phase name must be a string")
             try:
                 _require_unit_interval(
                     phase.cs_us_contingency, name="cs_us_contingency"
                 )
             except ValueError as error:
-                # ``phase.cs_us_contingency`` is untrusted here (validation
-                # just rejected it); do not format it through its own
-                # __repr__/__str__ hook, which a hostile object can make
-                # raise an arbitrary exception instead of this ValueError.
                 raise ValueError(
                     f"phase {phase.name!r} cs_us_contingency must be in [0, 1]"
                 ) from error
@@ -349,22 +378,37 @@ class ClassicalConditioningStream:
             compound_index = _require_builtin_int(
                 phase.compound_index, name="compound_index", minimum=-1
             )
+            if not isinstance(phase.cs_active, tuple):
+                raise ValueError("phase cs_active must be a tuple of integers")
             for cs_idx in phase.cs_active:
                 if type(cs_idx) is not int:
                     raise ValueError(
-                        f"phase {phase.name!r} cs_active index must be a "
-                        f"built-in integer, got {cs_idx!r}"
+                        f"phase {phase.name!r} cs_active index must be a built-in integer"
                     )
                 if not (0 <= cs_idx < n_cs):
                     raise ValueError(
-                        f"phase {phase.name!r} references cs_active index {cs_idx}, "
-                        f"but n_cs={n_cs}"
+                        f"phase {phase.name!r} references cs_active index out of range"
                     )
             if compound_index >= n_cs:
                 raise ValueError(
-                    f"phase {phase.name!r} has compound_index={phase.compound_index} "
-                    f"but n_cs={n_cs}"
+                    f"phase {phase.name!r} has compound_index out of range"
                 )
+
+        # Derived allocations must fit signed int32 without allocating JAX arrays
+        feature_dim = int(n_cs) + int(n_distractors)
+        if feature_dim > _INT32_MAX:
+            raise ValueError("feature_dim must fit signed int32")
+        _require_float32_resource(
+            "Pavlovian phase mask",
+            vector_scalars=len(phases) * int(n_cs),
+        )
+        _require_float32_resource(
+            "Pavlovian feature state",
+            vector_scalars=feature_dim,
+            fixed_scalars=4,
+        )
+        if len(phases) > _INT32_MAX:
+            raise ValueError("n_phases must fit signed int32")
 
         self._phases = tuple(phases)
         self._n_cs = int(n_cs)

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -39,10 +39,9 @@ References
 
 from __future__ import annotations
 
-import math
 from fractions import Fraction
 from numbers import Real
-from typing import cast
+from typing import Any, cast
 
 import chex
 import jax
@@ -52,12 +51,16 @@ import numpy as np
 from jax import Array
 from jaxtyping import Int, PRNGKeyArray
 
-from alberta_framework._float32 import round_real_to_float32
+from alberta_framework._float32 import (
+    round_real_to_float32,
+    round_real_to_float32_with_ratio,
+)
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream  # noqa: F401  (re-exported)
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 4_294_967_295
+_MAX_PAVLOVIAN_NUMERIC_BYTES = 64 * 1024 * 1024
 _ACTUAL_INT_TYPES: frozenset[type] = frozenset(
     {
         int,
@@ -89,27 +92,34 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
-def _require_finite_real(
-    value: object,
-    *,
-    name: str,
-    nonnegative: bool = False,
-) -> float:
-    """Return a finite real, rejecting bools, NaN, and infinities."""
-    # Exact-type whitelist prevents ``__class__`` spoofing and hostile
-    # ``as_integer_ratio`` subclasses from reaching the narrowing routine.
-    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
-        raise ValueError(f"{name} must be a finite real")
-    real_value = cast(Real, value)
-    try:
-        number = float(real_value)
-    except Exception as error:
-        raise ValueError(f"{name} must be a finite real") from error
-    if not math.isfinite(number):
-        raise ValueError(f"{name} must be a finite real")
-    if nonnegative and number < 0.0:
-        raise ValueError(f"{name} must be a non-negative finite real")
-    return number
+def _pavlovian_resource_budget(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> dict[str, int]:
+    """Return the complete resident numeric envelope before JAX allocation."""
+    phase_vector_scalars = 4 * n_phases
+    phase_mask_scalars = n_phases * n_cs
+    persistent_scalars = phase_vector_scalars + phase_mask_scalars
+    persistent_bytes = 4 * persistent_scalars
+    state_scalars = n_cs + n_distractors + 4
+    state_bytes = 4 * state_scalars + 8  # four int32 scalars and one Threefry key
+    for name, scalars, nbytes in (
+        ("Pavlovian persistent arrays", persistent_scalars, persistent_bytes),
+        ("Pavlovian state", state_scalars, state_bytes),
+    ):
+        if scalars > _INT32_MAX:
+            raise ValueError(f"{name} scalar count must fit signed int32")
+        if nbytes > _INT32_MAX:
+            raise ValueError(f"{name} byte count must fit signed int32")
+        if nbytes > _MAX_PAVLOVIAN_NUMERIC_BYTES:
+            raise ValueError(f"{name} exceeds the 64 MiB numeric budget")
+    return {
+        "phase_vector_scalars": phase_vector_scalars,
+        "phase_mask_scalars": phase_mask_scalars,
+        "persistent_scalars": persistent_scalars,
+        "persistent_bytes": persistent_bytes,
+        "state_scalars": state_scalars,
+        "state_bytes": state_bytes,
+    }
 
 
 def _require_nonnegative_float32(value: object, *, name: str) -> float:
@@ -144,18 +154,38 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
 
 
 def _require_unit_interval(value: object, *, name: str) -> float:
-    """Return a finite real in ``[0, 1]``, rejecting bool aliases."""
-    # Exact-type whitelist — hostile ``float`` subclasses are rejected before
-    # any ``__float__`` or ratio hook runs.
+    """Return an exact-host and float32-valid probability."""
     if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be in [0, 1]")
     try:
-        number = float(cast(Real, value))
+        numerator, denominator, narrowed = round_real_to_float32_with_ratio(
+            cast(Real, value)
+        )
     except Exception as error:
         raise ValueError(f"{name} must be in [0, 1]") from error
-    if not math.isfinite(number) or not 0.0 <= number <= 1.0:
+    if not 0 <= numerator <= denominator or not 0.0 <= narrowed <= 1.0:
         raise ValueError(f"{name} must be in [0, 1]")
-    return number
+    return narrowed
+
+
+def _require_state_array(
+    value: Any,
+    *,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: jnp.dtype,
+) -> Array:
+    array = jnp.asarray(value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if array.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}")
+    return array
+
+
+def _saturating_nonnegative_increment(value: Array) -> Array:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.minimum(jnp.maximum(value, 0), maximum - 1) + 1
 
 
 def _require_builtin_int(
@@ -336,8 +366,8 @@ class ClassicalConditioningStream:
                 scientific scalar, or ``noise_std`` becomes non-finite when
                 rounded to the stream's float32 execution dtype.
         """
-        if not phases:
-            raise ValueError("phases must be non-empty")
+        if type(phases) is not tuple or not phases:
+            raise ValueError("phases must be a non-empty exact tuple")
         n_cs = _require_builtin_int(n_cs, name="n_cs", minimum=1)
         n_distractors = _require_builtin_int(
             n_distractors, name="n_distractors", minimum=0
@@ -363,23 +393,31 @@ class ClassicalConditioningStream:
             distractor_prob, name="distractor_prob"
         )
 
+        resources = _pavlovian_resource_budget(
+            n_phases=len(phases),
+            n_cs=n_cs,
+            n_distractors=n_distractors,
+        )
+        canonical_phases: list[PavlovianPhase] = []
         for phase in phases:
+            if type(phase) is not PavlovianPhase:
+                raise ValueError("phases entries must be actual PavlovianPhase records")
             if type(phase.name) is not str:
                 raise ValueError("phase name must be a string")
             try:
-                _require_unit_interval(
+                contingency = _require_unit_interval(
                     phase.cs_us_contingency, name="cs_us_contingency"
                 )
             except ValueError as error:
                 raise ValueError(
                     f"phase {phase.name!r} cs_us_contingency must be in [0, 1]"
                 ) from error
-            _require_builtin_int(phase.n_steps, name="n_steps", minimum=1)
+            n_steps = _require_builtin_int(phase.n_steps, name="n_steps", minimum=1)
             compound_index = _require_builtin_int(
                 phase.compound_index, name="compound_index", minimum=-1
             )
-            if not isinstance(phase.cs_active, tuple):
-                raise ValueError("phase cs_active must be a tuple of integers")
+            if type(phase.cs_active) is not tuple or not phase.cs_active:
+                raise ValueError("phase cs_active must be a non-empty exact tuple")
             for cs_idx in phase.cs_active:
                 if type(cs_idx) is not int:
                     raise ValueError(
@@ -389,28 +427,25 @@ class ClassicalConditioningStream:
                     raise ValueError(
                         f"phase {phase.name!r} references cs_active index out of range"
                     )
+            if len(set(phase.cs_active)) != len(phase.cs_active):
+                raise ValueError("phase cs_active indices must be unique")
             if compound_index >= n_cs:
                 raise ValueError(
                     f"phase {phase.name!r} has compound_index out of range"
                 )
+            if compound_index in phase.cs_active:
+                raise ValueError("phase compound_index must be additional to cs_active")
+            canonical_phases.append(
+                PavlovianPhase(
+                    name=phase.name,
+                    n_steps=n_steps,
+                    cs_us_contingency=contingency,
+                    cs_active=phase.cs_active,
+                    compound_index=compound_index,
+                )
+            )
 
-        # Derived allocations must fit signed int32 without allocating JAX arrays
-        feature_dim = int(n_cs) + int(n_distractors)
-        if feature_dim > _INT32_MAX:
-            raise ValueError("feature_dim must fit signed int32")
-        _require_float32_resource(
-            "Pavlovian phase mask",
-            vector_scalars=len(phases) * int(n_cs),
-        )
-        _require_float32_resource(
-            "Pavlovian feature state",
-            vector_scalars=feature_dim,
-            fixed_scalars=4,
-        )
-        if len(phases) > _INT32_MAX:
-            raise ValueError("n_phases must fit signed int32")
-
-        self._phases = tuple(phases)
+        self._phases = tuple(canonical_phases)
         self._n_cs = int(n_cs)
         self._n_distractors = int(n_distractors)
         self._cs_us_delay = int(cs_us_delay)
@@ -419,20 +454,23 @@ class ClassicalConditioningStream:
         self._iti_max = int(iti_max)
         self._noise_std = float(noise_std)
         self._distractor_prob = float(distractor_prob)
+        self._resource_budget = resources
 
         # Pre-compute JAX arrays for phase fields used inside step().
-        self._phase_n_steps = jnp.array([p.n_steps for p in phases], dtype=jnp.int32)
+        self._phase_n_steps = jnp.array(
+            [p.n_steps for p in self._phases], dtype=jnp.int32
+        )
         self._phase_contingency = jnp.array(
-            [p.cs_us_contingency for p in phases], dtype=jnp.float32
+            [p.cs_us_contingency for p in self._phases], dtype=jnp.float32
         )
         self._phase_compound = jnp.array(
-            [p.compound_index for p in phases], dtype=jnp.int32
+            [p.compound_index for p in self._phases], dtype=jnp.int32
         )
         # Build a per-phase ``(n_phases, n_cs)`` mask so a phase's
         # ``cs_active`` set can be sampled from inside ``jit``.
-        cs_active_mask = jnp.zeros((len(phases), n_cs), dtype=jnp.float32)
-        cs_active_count = jnp.zeros(len(phases), dtype=jnp.int32)
-        for i, phase in enumerate(phases):
+        cs_active_mask = jnp.zeros((len(self._phases), n_cs), dtype=jnp.float32)
+        cs_active_count = jnp.zeros(len(self._phases), dtype=jnp.int32)
+        for i, phase in enumerate(self._phases):
             for cs_idx in phase.cs_active:
                 cs_active_mask = cs_active_mask.at[i, cs_idx].set(1.0)
             cs_active_count = cs_active_count.at[i].set(len(phase.cs_active))
@@ -465,6 +503,11 @@ class ClassicalConditioningStream:
         return self._phases
 
     @property
+    def resource_budget(self) -> dict[str, int]:
+        """Complete resident numeric payload accounting."""
+        return dict(self._resource_budget)
+
+    @property
     def cs_us_delay(self) -> int:
         """Configured CS-to-US delay."""
         return self._cs_us_delay
@@ -473,6 +516,49 @@ class ClassicalConditioningStream:
     def cs_duration(self) -> int:
         """Configured CS active duration."""
         return self._cs_duration
+
+    def _require_state_contract(self, state: object) -> PavlovianState:
+        """Validate every static state boundary before indexed JAX work."""
+        if type(state) is not PavlovianState:
+            raise TypeError("state must be an actual PavlovianState")
+        record = state
+        key = jnp.asarray(record.key)
+        if key.shape != () or not jnp.issubdtype(key.dtype, jax.dtypes.prng_key):
+            raise TypeError("state.key must be a scalar PRNG key")
+        for name, value, shape in (
+            (
+                "cs_active_steps_remaining",
+                record.cs_active_steps_remaining,
+                (self._n_cs,),
+            ),
+            ("us_pending_steps_remaining", record.us_pending_steps_remaining, ()),
+            ("phase_idx", record.phase_idx, ()),
+            ("step_in_phase", record.step_in_phase, ()),
+            (
+                "n_distractor_active",
+                record.n_distractor_active,
+                (self._n_distractors,),
+            ),
+            ("iti_steps_remaining", record.iti_steps_remaining, ()),
+        ):
+            _require_state_array(
+                value,
+                name=f"state.{name}",
+                shape=shape,
+                dtype=jnp.dtype(jnp.int32),
+            )
+        return record
+
+    def _state_values_valid(self, state: PavlovianState) -> Array:
+        return (
+            jnp.all(state.cs_active_steps_remaining >= 0)
+            & (state.us_pending_steps_remaining >= -1)
+            & (state.phase_idx >= 0)
+            & (state.phase_idx < len(self._phases))
+            & (state.step_in_phase >= 0)
+            & jnp.all(state.n_distractor_active >= 0)
+            & (state.iti_steps_remaining >= 0)
+        )
 
     def init(self, key: Array) -> PavlovianState:
         """Initialize stream state.
@@ -487,7 +573,12 @@ class ClassicalConditioningStream:
         Returns:
             Initial ``PavlovianState``.
         """
-        key, k_iti = jr.split(key)
+        key_array = jnp.asarray(key)
+        if key_array.shape != () or not jnp.issubdtype(
+            key_array.dtype, jax.dtypes.prng_key
+        ):
+            raise TypeError("key must be a scalar PRNG key")
+        key, k_iti = jr.split(key_array)
         iti = jr.randint(k_iti, (), self._iti_min, self._iti_max + 1)
         return PavlovianState(
             key=key,
@@ -515,6 +606,8 @@ class ClassicalConditioningStream:
             ``(1,)`` containing the US indicator.
         """
         del idx  # unused
+        state = self._require_state_contract(state)
+        state_valid = self._state_values_valid(state)
 
         (
             key,
@@ -532,7 +625,7 @@ class ClassicalConditioningStream:
         # 1. Phase progression
         # ------------------------------------------------------------------
         # If we have spent >= n_steps in this phase, advance (clamped).
-        cur_phase = state.phase_idx
+        cur_phase = jnp.clip(state.phase_idx, 0, n_phases - 1)
         cur_phase_steps = self._phase_n_steps[cur_phase]
         # Only advance phases that have a successor; the final phase repeats.
         on_last_phase = cur_phase >= (n_phases - 1)
@@ -678,16 +771,39 @@ class ClassicalConditioningStream:
             observation=observation,
             target=jnp.atleast_1d(target),
         )
-        new_state = PavlovianState(
+        candidate_state = PavlovianState(
             key=key,
             cs_active_steps_remaining=new_cs_active.astype(jnp.int32),
             us_pending_steps_remaining=new_us_pending.astype(jnp.int32),
             phase_idx=new_phase_idx.astype(jnp.int32),
-            step_in_phase=(new_step_in_phase + 1).astype(jnp.int32),
+            step_in_phase=_saturating_nonnegative_increment(new_step_in_phase),
             n_distractor_active=new_distractor_active.astype(jnp.int32),
             iti_steps_remaining=new_iti_remaining.astype(jnp.int32),
         )
-        return timestep, new_state
+        update_applied = state_valid & self._state_values_valid(candidate_state)
+        new_state = cast(
+            PavlovianState,
+            jax.tree.map(
+                lambda proposed, current: jnp.where(
+                    update_applied, proposed, current
+                ),
+                candidate_state,
+                state,
+            ),
+        )
+        safe_timestep = TimeStep(
+            observation=jnp.where(
+                update_applied,
+                timestep.observation,
+                jnp.zeros_like(timestep.observation),
+            ),
+            target=jnp.where(
+                update_applied,
+                timestep.target,
+                jnp.zeros_like(timestep.target),
+            ),
+        )
+        return safe_timestep, new_state
 
 
 # =============================================================================

--- a/tests/test_pavlovian_validation.py
+++ b/tests/test_pavlovian_validation.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
+import chex
+import jax
+import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.streams.pavlovian import (
     ClassicalConditioningStream,
     PavlovianPhase,
+    PavlovianState,
+    _pavlovian_resource_budget,
     _require_float32_resource,
 )
 
@@ -143,6 +151,30 @@ def test_pavlovian_cs_active_hostile_and_range() -> None:
         _stream(phases=(_phase(cs_active=[0]),))  # type: ignore[arg-type]
 
 
+def test_pavlovian_phase_schema_rejects_empty_duplicate_and_overlapping_cs() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        _stream(phases=(_phase(cs_active=()),))
+    with pytest.raises(ValueError, match="unique"):
+        _stream(phases=(_phase(cs_active=(0, 0)),))
+    with pytest.raises(ValueError, match="additional"):
+        _stream(phases=(_phase(cs_active=(0,), compound_index=0),))
+
+
+def test_pavlovian_probability_uses_exact_host_and_float32_domains() -> None:
+    above_one = Fraction(1, 1) + Fraction(1, 2**100)
+    with pytest.raises(ValueError, match="distractor_prob"):
+        _stream(distractor_prob=above_one)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _stream(phases=(_phase(cs_us_contingency=above_one),))
+
+    stream = _stream(
+        distractor_prob=Fraction(1, 10),
+        phases=(_phase(cs_us_contingency=Fraction(1, 5)),),
+    )
+    assert stream._distractor_prob == float(np.float32(0.1))
+    assert stream.phases[0].cs_us_contingency == float(np.float32(0.2))
+
+
 def test_pavlovian_require_float32_resource_boundaries() -> None:
     legal = _INT32_MAX // 4
     _require_float32_resource("test", vector_scalars=legal)
@@ -182,10 +214,84 @@ def test_pavlovian_resource_preflight_without_allocation() -> None:
         )
 
 
-def test_pavlovian_valid_construction_and_jit() -> None:
-    import jax.numpy as jnp
-    import jax.random as jr
+def test_pavlovian_resource_budget_matches_resident_arrays_and_state() -> None:
+    stream = _stream(
+        n_cs=2,
+        n_distractors=3,
+        phases=(_phase(), _phase(name="ext")),
+    )
+    state = stream.init(jr.key(0))
+    persistent_bytes = sum(
+        int(array.nbytes)
+        for array in (
+            stream._phase_n_steps,
+            stream._phase_contingency,
+            stream._phase_compound,
+            stream._phase_cs_mask,
+            stream._phase_cs_count,
+        )
+    )
+    state_bytes = sum(int(leaf.nbytes) for leaf in jax.tree.leaves(state))
+    assert stream.resource_budget == _pavlovian_resource_budget(
+        n_phases=2,
+        n_cs=2,
+        n_distractors=3,
+    )
+    assert stream.resource_budget["persistent_bytes"] == persistent_bytes
+    assert stream.resource_budget["state_bytes"] == state_bytes
 
+
+def test_pavlovian_resource_budget_fails_before_jax_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def allocation_started(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("JAX allocation started")
+
+    monkeypatch.setattr(jnp, "array", allocation_started)
+    monkeypatch.setattr(jnp, "zeros", allocation_started)
+    with pytest.raises(ValueError, match="64 MiB"):
+        _stream(n_cs=16_777_216)
+
+
+def test_pavlovian_step_rejects_invalid_dynamic_state_atomically_under_jit() -> None:
+    stream = _stream(n_cs=2, n_distractors=1)
+    valid = stream.init(jr.key(3))
+    invalid = valid.replace(phase_idx=jnp.asarray(-1, dtype=jnp.int32))
+    timestep, returned = jax.jit(stream.step)(invalid, jnp.asarray(0, dtype=jnp.int32))
+    chex.assert_trees_all_equal(returned, invalid)
+    chex.assert_trees_all_equal(
+        timestep.observation,
+        jnp.zeros((stream.feature_dim,), dtype=jnp.float32),
+    )
+    chex.assert_trees_all_equal(timestep.target, jnp.zeros((1,), dtype=jnp.float32))
+
+
+def test_pavlovian_final_phase_clock_saturates() -> None:
+    stream = _stream()
+    state = stream.init(jr.key(4)).replace(
+        step_in_phase=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(state, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_in_phase) == _INT32_MAX
+
+
+def test_pavlovian_static_state_contract_fails_before_indexing() -> None:
+    stream = _stream(n_cs=2)
+    state = stream.init(jr.key(5))
+    invalid = PavlovianState(
+        key=state.key,
+        cs_active_steps_remaining=jnp.zeros((1,), dtype=jnp.int32),
+        us_pending_steps_remaining=state.us_pending_steps_remaining,
+        phase_idx=state.phase_idx,
+        step_in_phase=state.step_in_phase,
+        n_distractor_active=state.n_distractor_active,
+        iti_steps_remaining=state.iti_steps_remaining,
+    )
+    with pytest.raises(ValueError, match="cs_active_steps_remaining"):
+        stream.step(invalid, jnp.asarray(0, dtype=jnp.int32))
+
+
+def test_pavlovian_valid_construction_and_jit() -> None:
     stream = _stream(n_cs=2, n_distractors=1, noise_std=0.01, distractor_prob=0.1)
     state = stream.init(jr.key(0))
     ts, _ = stream.step(state, jnp.array(0))

--- a/tests/test_pavlovian_validation.py
+++ b/tests/test_pavlovian_validation.py
@@ -1,0 +1,193 @@
+"""Focused validation for Pavlovian stream (hostile + resource)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.pavlovian import (
+    ClassicalConditioningStream,
+    PavlovianPhase,
+    _require_float32_resource,
+)
+
+_INT32_MAX = 2**31 - 1
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("repr executed")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:  # type: ignore[override]
+        type(self).calls += 1
+        raise RuntimeError("ratio hook")
+
+
+class _ClassSpoof:
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:  # type: ignore[no-untyped-def]
+        return float
+
+    def __float__(self) -> float:  # pragma: no cover
+        return 0.1
+
+
+class _RaisingRepr:
+    def __repr__(self) -> str:  # pragma: no cover
+        raise RuntimeError("repr hook must not run")
+
+
+def _phase(**overrides: object) -> PavlovianPhase:
+    base: dict[str, object] = {
+        "name": "acq",
+        "n_steps": 10,
+        "cs_us_contingency": 1.0,
+        "cs_active": (0,),
+    }
+    base.update(overrides)
+    return PavlovianPhase(**base)  # type: ignore[arg-type]
+
+
+def _stream(**overrides: object) -> ClassicalConditioningStream:
+    phases = overrides.pop("phases", (_phase(),))
+    return ClassicalConditioningStream(phases=phases, **overrides)  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_reject_hostile_without_hook() -> None:
+    for field, ctor in [
+        ("n_cs", lambda v: _stream(n_cs=v)),
+        ("n_distractors", lambda v: _stream(n_distractors=v)),
+        ("cs_us_delay", lambda v: _stream(cs_us_delay=v)),
+        ("cs_duration", lambda v: _stream(cs_duration=v)),
+    ]:
+        with pytest.raises(ValueError, match=field):
+            ctor(_HostileInt(2))  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=field):
+            ctor(_HostileInt(2))  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_do_not_run_repr() -> None:
+    for ctor in [
+        lambda v: _stream(n_cs=v),
+        lambda v: _stream(cs_us_delay=v),
+    ]:
+        with pytest.raises(ValueError):
+            ctor(_RaisingRepr())  # type: ignore[arg-type]
+
+
+def test_pavlovian_int_validators_reject_bool_and_numpy() -> None:
+    for field in ("n_cs", "cs_us_delay", "cs_duration"):
+        for bad in (True, np.bool_(True), np.int64(2), 1.0, "2"):
+            with pytest.raises(ValueError, match=field):
+                _stream(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_pavlovian_float_validators_reject_hostile_ratio() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="noise_std"):
+        _stream(noise_std=_HostileFloat(0.1))  # type: ignore[arg-type]
+    # Hostile as_integer_ratio must not be invoked (ratio check is guarded)
+    assert _HostileFloat.calls == 0
+
+
+def test_pavlovian_float_validators_reject_spoof_and_nan() -> None:
+    for field, bad in [
+        ("noise_std", float("nan")),
+        ("noise_std", float("inf")),
+        ("noise_std", -0.1),
+        ("noise_std", _ClassSpoof()),  # type: ignore[arg-type]
+        ("distractor_prob", float("nan")),
+        ("distractor_prob", 1.5),
+        ("distractor_prob", -0.1),
+        ("distractor_prob", _ClassSpoof()),  # type: ignore[arg-type]
+    ]:
+        with pytest.raises(ValueError, match=field):
+            _stream(**{field: bad})  # type: ignore[arg-type]
+
+
+def test_pavlovian_phase_contingency_hostile_is_suppressed() -> None:
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _stream(phases=(_phase(cs_us_contingency=_HostileFloat(0.5)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _stream(phases=(_phase(cs_us_contingency=_ClassSpoof()),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_phase_name_requires_exact_str() -> None:
+    with pytest.raises(ValueError, match="phase name"):
+        _stream(phases=(_phase(name=_HostileInt(1)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="phase name"):
+        _stream(phases=(_phase(name=b"acq"),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_cs_active_hostile_and_range() -> None:
+    # hostile int subclass must be rejected without running index hook
+    with pytest.raises(ValueError, match="cs_active"):
+        _stream(phases=(_phase(cs_active=(_HostileInt(0),)),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        _stream(phases=(_phase(cs_active=(_RaisingRepr(),)),))  # type: ignore[arg-type]
+    # out of range
+    with pytest.raises(ValueError, match="out of range"):
+        _stream(phases=(_phase(cs_active=(5,)),), n_cs=2)
+    # compound out of range
+    with pytest.raises(ValueError, match="compound_index"):
+        _stream(phases=(_phase(compound_index=5),), n_cs=2)
+    # tuple type check
+    with pytest.raises(ValueError, match="cs_active"):
+        _stream(phases=(_phase(cs_active=[0]),))  # type: ignore[arg-type]
+
+
+def test_pavlovian_require_float32_resource_boundaries() -> None:
+    legal = _INT32_MAX // 4
+    _require_float32_resource("test", vector_scalars=legal)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=legal + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX + 1)
+    with pytest.raises(ValueError, match="scalar count must fit signed int32"):
+        _require_float32_resource("test", vector_scalars=_INT32_MAX, fixed_scalars=1)
+
+
+def test_pavlovian_resource_preflight_without_allocation() -> None:
+    # feature_dim = n_cs + n_distractors, mask = n_phases * n_cs
+    # small case passes
+    s = _stream(n_cs=2, n_distractors=1, phases=(_phase(), _phase(name="ext")))
+    assert s.feature_dim == 3
+    # helper reflects same bound used in __init__
+    _require_float32_resource("Pavlovian phase mask", vector_scalars=2 * 2)
+    # large mask: n_phases=1, n_cs = INT32//4+1 -> byte overflow
+    legal_mask = _INT32_MAX // 4
+    _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask)
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource("Pavlovian phase mask", vector_scalars=legal_mask + 1)
+    # feature state: vector = n_cs + n_distractors = INT32, fixed=4 -> scalar overflow
+    with pytest.raises(ValueError, match="scalar count"):
+        _require_float32_resource(
+            "Pavlovian feature state", vector_scalars=_INT32_MAX, fixed_scalars=4
+        )
+    # feature state byte overflow without scalar overflow: total = INT32//4 is max byte-pass
+    legal_feature = _INT32_MAX // 4 - 4
+    _require_float32_resource(
+        "Pavlovian feature state", vector_scalars=legal_feature, fixed_scalars=4
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        _require_float32_resource(
+            "Pavlovian feature state", vector_scalars=legal_feature + 1, fixed_scalars=4
+        )
+
+
+def test_pavlovian_valid_construction_and_jit() -> None:
+    import jax.numpy as jnp
+    import jax.random as jr
+
+    stream = _stream(n_cs=2, n_distractors=1, noise_std=0.01, distractor_prob=0.1)
+    state = stream.init(jr.key(0))
+    ts, _ = stream.step(state, jnp.array(0))
+    assert ts.observation.shape == (3,)
+    assert ts.target.shape == (1,)


### PR DESCRIPTION
Supersedes #896 while preserving its contributor commit.

The review found gaps beyond its constructor checks: probability bounds were evaluated after lossy host conversion; duplicate/empty/overlapping CS sets could corrupt sampling or double activation duration; resource accounting omitted four resident phase vectors and the PRNG key; and an int32 final-phase clock wrapped. This branch adds exact-host plus float32 probability validation, canonical exact phase schemas, a verified 64 MiB numeric envelope, static state contracts, saturating clocks, and atomic neutral rollback for dynamically invalid states.

Verification: 18 focused validation tests + 102 retained Pavlovian tests; Ruff; strict mypy; diff-check. No outputs, benchmarks, or evidence sources changed.