### PR TITLE
fix(recurring-feature): complete protocol identity and resource contracts

### DIFF
--- a/alberta_framework/recurring_feature_gate.py
+++ b/alberta_framework/recurring_feature_gate.py
@@ -62,6 +62,46 @@ PAIRWISE_PROBE_SCOPE = (
 )
 
 
+def _require_builtin_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be a built-in integer")
+    if minimum is not None and maximum is not None:
+        if not minimum <= value <= maximum:
+            raise ValueError(f"{name} must be in [{minimum}, {maximum}]")
+    elif minimum is not None and value < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive")
+        raise ValueError(f"{name} must be >= {minimum}")
+    elif maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be boolean")
+    return value
+
+
+def _preflight_seed_array_resources(
+    *, feature_dim: int, output_heads: int, total_steps: int, heldout_samples: int
+) -> None:
+    scalar_count = total_steps * (feature_dim + output_heads + 2) + heldout_samples * (
+        feature_dim + output_heads
+    )
+    byte_count = 4 * scalar_count
+    if scalar_count > 2**31 - 1 or byte_count > 2**31 - 1:
+        raise ValueError("per-seed arrays must fit signed-int32 scalar and byte resources")
+    if byte_count > 256 * 1024 * 1024:
+        raise ValueError("per-seed arrays must fit the 256 MiB resource budget")
+
+
 @dataclass(frozen=True, slots=True)
 class RecurringFeatureProtocol:
     """Fully specified stream and learner settings for the recurring probe."""
@@ -100,59 +140,112 @@ class RecurringFeatureProtocol:
 
     def validate(self) -> None:
         """Reject malformed protocols before allocating experiment arrays."""
-        if type(self.feature_dim) is not int or self.feature_dim < 6:
+        _require_builtin_int("feature_dim", self.feature_dim)
+        if self.feature_dim < 6:
             raise ValueError("feature_dim must be at least 6 for the declared task pairs")
-        if type(self.output_heads) is not int or self.output_heads != len(TASK_NAMES):
+        _require_builtin_int("output_heads", self.output_heads)
+        if self.output_heads != len(TASK_NAMES):
             raise ValueError(f"output_heads must be {len(TASK_NAMES)}")
-        if type(self.steps_per_phase) is not int or self.steps_per_phase < 1:
-            raise ValueError("steps_per_phase must be a positive integer")
-        if type(self.active_pair_budget) is not int or self.active_pair_budget < 1:
-            raise ValueError("active_pair_budget must be a positive integer")
-        if type(self.candidate_pair_budget) is not int or self.candidate_pair_budget < 1:
-            raise ValueError("candidate_pair_budget must be a positive integer")
-        if type(self.replacement_interval) is not int or self.replacement_interval < 0:
-            raise ValueError("replacement_interval must be a non-negative integer")
-        if type(self.min_feature_age) is not int or self.min_feature_age < 0:
-            raise ValueError("min_feature_age must be a non-negative integer")
-        if type(self.candidate_min_age) is not int or self.candidate_min_age < 0:
-            raise ValueError("candidate_min_age must be a non-negative integer")
-        if type(self.heldout_samples) is not int or self.heldout_samples < 1:
-            raise ValueError("heldout_samples must be a positive integer")
-        if (
-            type(self.recovery_window) is not int
-            or not 1 <= self.recovery_window <= self.steps_per_phase
-        ):
-            raise ValueError("recovery_window must be an integer in [1, steps_per_phase]")
-
-        validated_float32_scalar("target_amplitude", self.target_amplitude, positive=True)
-        validated_float32_scalar("step_size_output", self.step_size_output, lower=0.0)
-        validated_float32_scalar("utility_decay", self.utility_decay, lower=0.0, upper=1.0)
-        validated_float32_scalar(
-            "retained_utility_decay", self.retained_utility_decay, lower=0.0, upper=1.0
+        _require_builtin_int("steps_per_phase", self.steps_per_phase, minimum=1)
+        _require_builtin_int("active_pair_budget", self.active_pair_budget, minimum=1)
+        _require_builtin_int("candidate_pair_budget", self.candidate_pair_budget, minimum=1)
+        _require_builtin_int("heldout_samples", self.heldout_samples, minimum=1)
+        _require_builtin_int("replacement_interval", self.replacement_interval, minimum=0)
+        _require_builtin_int("min_feature_age", self.min_feature_age, minimum=0)
+        _require_builtin_int("candidate_min_age", self.candidate_min_age, minimum=0)
+        _require_builtin_int(
+            "recovery_window",
+            self.recovery_window,
+            minimum=1,
+            maximum=self.steps_per_phase,
         )
-        validated_float32_scalar("promotion_margin", self.promotion_margin, lower=0.0)
-        validated_float32_scalar("promotion_blend", self.promotion_blend, lower=0.0, upper=1.0)
-        validated_float32_scalar(
-            "future_utility_mix", self.future_utility_mix, lower=0.0, upper=1.0
+        _preflight_seed_array_resources(
+            feature_dim=self.feature_dim,
+            output_heads=self.output_heads,
+            total_steps=self.total_steps,
+            heldout_samples=self.heldout_samples,
+        )
+        object.__setattr__(
+            self,
+            "target_amplitude",
+            validated_float32_scalar("target_amplitude", self.target_amplitude, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "recovery_nmse_threshold",
+            validated_float32_scalar(
+                "recovery_nmse_threshold", self.recovery_nmse_threshold, positive=True
+            ),
+        )
+        object.__setattr__(
+            self,
+            "step_size_output",
+            validated_float32_scalar("step_size_output", self.step_size_output, lower=0.0),
+        )
+        utility_decay = validated_float32_scalar(
+            "utility_decay",
+            self.utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        object.__setattr__(self, "utility_decay", utility_decay)
+        object.__setattr__(
+            self,
+            "retained_utility_decay",
+            validated_float32_scalar(
+                "retained_utility_decay",
+                self.retained_utility_decay,
+                lower=utility_decay,
+                upper=1.0,
+                upper_inclusive=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "promotion_margin",
+            validated_float32_scalar("promotion_margin", self.promotion_margin, positive=True),
+        )
+        object.__setattr__(
+            self,
+            "promotion_blend",
+            validated_float32_scalar(
+                "promotion_blend", self.promotion_blend, lower=0.0, upper=1.0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "future_utility_mix",
+            validated_float32_scalar(
+                "future_utility_mix", self.future_utility_mix, lower=0.0, upper=1.0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "obgd_kappa",
+            validated_float32_scalar("obgd_kappa", self.obgd_kappa, positive=True),
         )
         if self.candidate_utility_retention_decay is not None:
-            validated_float32_scalar(
+            object.__setattr__(
+                self,
                 "candidate_utility_retention_decay",
-                self.candidate_utility_retention_decay,
-                lower=0.0,
-                upper=1.0,
+                validated_float32_scalar(
+                    "candidate_utility_retention_decay",
+                    self.candidate_utility_retention_decay,
+                    lower=utility_decay,
+                    upper=1.0,
+                    upper_inclusive=False,
+                ),
             )
-        validated_float32_scalar("obgd_kappa", self.obgd_kappa, positive=True)
-        validated_float32_scalar(
-            "recovery_nmse_threshold", self.recovery_nmse_threshold, positive=True
-        )
-
-        if type(self.refresh_candidates) is not bool:
-            raise ValueError("refresh_candidates must be an actual bool")
-        if type(self.refresh_promoted_candidate) is not bool:
-            raise ValueError("refresh_promoted_candidate must be an actual bool")
-        if type(self.use_obgd) is not bool:
-            raise ValueError("use_obgd must be an actual bool")
+        if self.candidate_strategy != "all_pairs":
+            raise ValueError("candidate_strategy must be 'all_pairs'")
+        if self.utility_aggregation != "max":
+            raise ValueError("utility_aggregation must be 'max'")
+        if self.utility_task_balancing != "active":
+            raise ValueError("utility_task_balancing must be 'active'")
+        _require_exact_bool("refresh_candidates", self.refresh_candidates)
+        _require_exact_bool("refresh_promoted_candidate", self.refresh_promoted_candidate)
+        _require_exact_bool("use_obgd", self.use_obgd)
 
 
 @dataclass(frozen=True, slots=True)
@@ -330,38 +423,70 @@ class RecurringFeatureGateCriteria:
     minimum_critical_nmse_gain_over_baseline: float = 0.5
     require_recurrence_faster_than_acquisition: bool = True
 
-    def __post_init__(self) -> None:
-        """Validate criteria thresholds."""
-        if type(self.minimum_seeds) is not int or self.minimum_seeds < 1:
-            raise ValueError("minimum_seeds must be a positive integer")
-        if type(self.minimum_heldout_samples) is not int or self.minimum_heldout_samples < 1:
-            raise ValueError("minimum_heldout_samples must be a positive integer")
-        validated_float32_scalar(
+    def validate(self) -> None:
+        """Reject boolean or non-finite criteria before comparing evidence."""
+        _require_builtin_int("minimum_seeds", self.minimum_seeds, minimum=1)
+        _require_builtin_int(
+            "minimum_heldout_samples", self.minimum_heldout_samples, minimum=1
+        )
+        object.__setattr__(
+            self,
             "minimum_retained_all_critical_rate",
-            self.minimum_retained_all_critical_rate,
-            lower=0.0,
-            upper=1.0,
+            validated_float32_scalar(
+                "minimum_retained_all_critical_rate",
+                self.minimum_retained_all_critical_rate,
+                lower=0.0,
+                upper=1.0,
+            ),
         )
-        validated_float32_scalar(
+        object.__setattr__(
+            self,
             "minimum_obsolete_eviction_rate",
-            self.minimum_obsolete_eviction_rate,
-            lower=0.0,
-            upper=1.0,
+            validated_float32_scalar(
+                "minimum_obsolete_eviction_rate",
+                self.minimum_obsolete_eviction_rate,
+                lower=0.0,
+                upper=1.0,
+            ),
         )
-        validated_float32_scalar(
-            "maximum_median_critical_nmse", self.maximum_median_critical_nmse, lower=0.0
+        object.__setattr__(
+            self,
+            "maximum_median_critical_nmse",
+            validated_float32_scalar(
+                "maximum_median_critical_nmse",
+                self.maximum_median_critical_nmse,
+                lower=0.0,
+            ),
         )
-        validated_float32_scalar("minimum_median_obsolete_nmse", self.minimum_median_obsolete_nmse)
-        validated_float32_scalar(
+        object.__setattr__(
+            self,
+            "minimum_median_obsolete_nmse",
+            validated_float32_scalar(
+                "minimum_median_obsolete_nmse",
+                self.minimum_median_obsolete_nmse,
+                lower=0.0,
+            ),
+        )
+        object.__setattr__(
+            self,
             "minimum_retention_rate_gain_over_baseline",
-            self.minimum_retention_rate_gain_over_baseline,
+            validated_float32_scalar(
+                "minimum_retention_rate_gain_over_baseline",
+                self.minimum_retention_rate_gain_over_baseline,
+            ),
         )
-        validated_float32_scalar(
+        object.__setattr__(
+            self,
             "minimum_critical_nmse_gain_over_baseline",
-            self.minimum_critical_nmse_gain_over_baseline,
+            validated_float32_scalar(
+                "minimum_critical_nmse_gain_over_baseline",
+                self.minimum_critical_nmse_gain_over_baseline,
+            ),
         )
-        if type(self.require_recurrence_faster_than_acquisition) is not bool:
-            raise ValueError("require_recurrence_faster_than_acquisition must be an actual bool")
+        _require_exact_bool(
+            "require_recurrence_faster_than_acquisition",
+            self.require_recurrence_faster_than_acquisition,
+        )
 
 
 class RecurringFeatureGateError(AssertionError):
@@ -682,7 +807,7 @@ def run_recurring_feature_gate(
     """
     chosen_protocol = protocol or RecurringFeatureProtocol()
     chosen_protocol.validate()
-    chosen_seeds = tuple(require_unique_jax_seeds(tuple(seeds), name="seeds"))
+    chosen_seeds = require_unique_jax_seeds(tuple(seeds))
 
     retained_learner = _make_learner(
         chosen_protocol,
@@ -813,6 +938,7 @@ def evaluate_recurring_feature_gate(
 ) -> RecurringFeatureGateDecision:
     """Recompute a fail-closed decision from raw per-seed evidence."""
     chosen = criteria or RecurringFeatureGateCriteria()
+    chosen.validate()
     failures = _canonical_protocol_failures(result.protocol)
     failures.extend(_seed_failures(result))
 

--- a/tests/test_recurring_feature_protocol_validation.py
+++ b/tests/test_recurring_feature_protocol_validation.py
@@ -1,5 +1,11 @@
-"""Tests for RecurringFeatureProtocol, criteria, and seed validation."""
+"""Host-boundary identities for the recurring-feature protocol and criteria."""
 
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import numpy as np
 import pytest
 
 from alberta_framework.recurring_feature_gate import (
@@ -9,81 +15,151 @@ from alberta_framework.recurring_feature_gate import (
 )
 
 
-def test_protocol_validate_rejects_booleans_and_nans() -> None:
-    # Boolean integers
-    with pytest.raises(ValueError, match="feature_dim"):
-        RecurringFeatureProtocol(feature_dim=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="steps_per_phase"):
-        RecurringFeatureProtocol(steps_per_phase=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="active_pair_budget"):
-        RecurringFeatureProtocol(active_pair_budget=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="heldout_samples"):
-        RecurringFeatureProtocol(heldout_samples=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="recovery_window"):
-        RecurringFeatureProtocol(recovery_window=True).validate()  # type: ignore[arg-type]
-
-    # Boolean / NaN floats
-    with pytest.raises(ValueError, match="target_amplitude"):
-        RecurringFeatureProtocol(target_amplitude=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="target_amplitude"):
-        RecurringFeatureProtocol(target_amplitude=float("nan")).validate()
-
-    with pytest.raises(ValueError, match="step_size_output"):
-        RecurringFeatureProtocol(step_size_output=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="step_size_output"):
-        RecurringFeatureProtocol(step_size_output=float("nan")).validate()
-
-    with pytest.raises(ValueError, match="utility_decay"):
-        RecurringFeatureProtocol(utility_decay=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="utility_decay"):
-        RecurringFeatureProtocol(utility_decay=float("nan")).validate()
-
-    with pytest.raises(ValueError, match="recovery_nmse_threshold"):
-        RecurringFeatureProtocol(recovery_nmse_threshold=True).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="recovery_nmse_threshold"):
-        RecurringFeatureProtocol(recovery_nmse_threshold=float("nan")).validate()
-
-    # Boolean flags
-    with pytest.raises(ValueError, match="refresh_candidates"):
-        RecurringFeatureProtocol(refresh_candidates=1).validate()  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="use_obgd"):
-        RecurringFeatureProtocol(use_obgd=1).validate()  # type: ignore[arg-type]
-
-    # Valid protocol
+def test_canonical_protocol_and_criteria_remain_legal() -> None:
     RecurringFeatureProtocol().validate()
+    RecurringFeatureGateCriteria().validate()
+    protocol = replace(
+        RecurringFeatureProtocol(),
+        step_size_output=0.0,
+        utility_decay=0.0,
+        retained_utility_decay=0.0,
+        replacement_interval=0,
+        min_feature_age=0,
+        candidate_min_age=0,
+        promotion_blend=0.0,
+        future_utility_mix=0.0,
+        candidate_utility_retention_decay=None,
+    )
+    protocol.validate()
 
 
-def test_criteria_rejects_booleans_and_nans() -> None:
-    with pytest.raises(ValueError, match="minimum_seeds"):
-        RecurringFeatureGateCriteria(minimum_seeds=False)  # type: ignore[arg-type]
+@pytest.mark.parametrize(
+    "field",
+    [
+        "steps_per_phase",
+        "active_pair_budget",
+        "candidate_pair_budget",
+        "heldout_samples",
+        "recovery_window",
+        "replacement_interval",
+        "min_feature_age",
+        "candidate_min_age",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 1.0, np.int64(1)])
+def test_protocol_integer_fields_reject_bool_and_non_builtin(
+    field: str, invalid: object
+) -> None:
+    overrides: dict[str, object] = {field: invalid}
+    if field == "steps_per_phase":
+        overrides["recovery_window"] = 1
+    with pytest.raises(ValueError, match=f"{field} must"):
+        replace(RecurringFeatureProtocol(), **overrides).validate()
 
-    with pytest.raises(ValueError, match="minimum_heldout_samples"):
-        RecurringFeatureGateCriteria(minimum_heldout_samples=False)  # type: ignore[arg-type]
 
-    with pytest.raises(ValueError, match="minimum_retained_all_critical_rate"):
-        RecurringFeatureGateCriteria(minimum_retained_all_critical_rate=float("nan"))
+@pytest.mark.parametrize(
+    "field",
+    [
+        "target_amplitude",
+        "recovery_nmse_threshold",
+        "step_size_output",
+        "utility_decay",
+        "retained_utility_decay",
+        "promotion_margin",
+        "promotion_blend",
+        "future_utility_mix",
+        "obgd_kappa",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), math.nan, math.inf])
+def test_protocol_float_fields_reject_bool_and_non_finite(
+    field: str, invalid: object
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        replace(RecurringFeatureProtocol(), **{field: invalid}).validate()
 
+
+def test_protocol_optional_retention_decay_rejects_bool_and_non_finite() -> None:
+    for invalid in (True, False, np.bool_(True), math.nan, math.inf):
+        with pytest.raises(ValueError, match="candidate_utility_retention_decay"):
+            replace(
+                RecurringFeatureProtocol(),
+                candidate_utility_retention_decay=invalid,
+            ).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["refresh_candidates", "refresh_promoted_candidate", "use_obgd"],
+)
+def test_protocol_flags_require_exact_bool(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(RecurringFeatureProtocol(), **{field: 1}).validate()
+    with pytest.raises(ValueError, match=field):
+        replace(RecurringFeatureProtocol(), **{field: np.bool_(True)}).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "minimum_seeds",
+        "minimum_heldout_samples",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), 1.0])
+def test_criteria_integer_fields_reject_bool(field: str, invalid: object) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        RecurringFeatureGateCriteria(**{field: invalid}).validate()
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "minimum_retained_all_critical_rate",
+        "minimum_obsolete_eviction_rate",
+        "maximum_median_critical_nmse",
+        "minimum_median_obsolete_nmse",
+        "minimum_retention_rate_gain_over_baseline",
+        "minimum_critical_nmse_gain_over_baseline",
+    ],
+)
+@pytest.mark.parametrize("invalid", [True, False, np.bool_(True), math.nan, math.inf])
+def test_criteria_float_fields_reject_bool_and_non_finite(
+    field: str, invalid: object
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} must"):
+        RecurringFeatureGateCriteria(**{field: invalid}).validate()
+
+
+def test_criteria_recurrence_flag_requires_exact_bool() -> None:
     with pytest.raises(ValueError, match="require_recurrence_faster_than_acquisition"):
-        RecurringFeatureGateCriteria(require_recurrence_faster_than_acquisition=1)  # type: ignore[arg-type]
-
-    # Valid criteria
-    criteria = RecurringFeatureGateCriteria()
-    assert criteria.minimum_seeds == 30
+        RecurringFeatureGateCriteria(
+            require_recurrence_faster_than_acquisition=1
+        ).validate()
 
 
-def test_run_recurring_feature_gate_rejects_boolean_seeds() -> None:
-    protocol = RecurringFeatureProtocol(steps_per_phase=10, recovery_window=5, heldout_samples=16)
-    with pytest.raises(ValueError, match="seed"):
-        run_recurring_feature_gate((True,), protocol=protocol)  # type: ignore[arg-type]
+def test_run_rejects_boolean_seed_before_allocation() -> None:
+    protocol = replace(
+        RecurringFeatureProtocol(),
+        steps_per_phase=1,
+        recovery_window=1,
+        heldout_samples=1,
+    )
+    with pytest.raises(ValueError, match="seeds"):
+        run_recurring_feature_gate((True,), protocol=protocol)
 
-    with pytest.raises(ValueError, match="seed"):
-        run_recurring_feature_gate((False,), protocol=protocol)  # type: ignore[arg-type]
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"steps_per_phase": 2**24},
+        {"heldout_samples": 2**27},
+        {"feature_dim": 2**27},
+    ],
+)
+def test_protocol_rejects_oversized_seed_arrays_before_allocation(
+    overrides: dict[str, int],
+) -> None:
+    protocol = replace(RecurringFeatureProtocol(), **overrides)
+    with pytest.raises(ValueError, match="resource"):
+        protocol.validate()


### PR DESCRIPTION
Supersedes #959 and #964 while preserving the stronger #959 contributor commit. Protocol and criteria integers/booleans now require exact identities; all float32-consumed controls use shared exact host/sink validation and canonical storage; seeds use the shared unique JAX-seed boundary. The repair additionally preflights exact per-seed observation, target, task-index, and held-out array scalars/bytes against signed-int32 and 256 MiB before allocation. Verification on current main: 140 protocol/gate tests, scoped Ruff, strict source mypy, and diff-check pass. This source is registered for recurring_pair_features, so current pinned evidence remains fail-closed invalid until its frozen protocol is rerun; no outputs or hashes are modified.