### PR TITLE
fix(prototype-agent): close merged resource and schema residuals

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -96,6 +96,7 @@ from alberta_framework.core.model_replay_rehearsal import (
     ModelReplayRehearsalConfig,
     RealModelReplayEvent,
 )
+from alberta_framework.core.multi_head_learner import _validate_direct_state_resources
 from alberta_framework.core.normalizers import _lifetime_counter_valid
 from alberta_framework.core.oak import (
     OaKAgent,
@@ -308,7 +309,9 @@ def _require_float32_resource(
     vector_scalars: int,
     fixed_scalars: int = 0,
 ) -> None:
-    total = int(vector_scalars) + int(fixed_scalars)
+    if vector_scalars < 0 or fixed_scalars < 0:
+        raise ValueError(f"{name} scalar counts must be non-negative")
+    total = vector_scalars + fixed_scalars
     if total > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
     if 4 * total > _INT32_MAX:
@@ -316,10 +319,10 @@ def _require_float32_resource(
 
 
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
-    if not isinstance(payload, Mapping):
+    if not issubclass(type(payload), Mapping):
         raise ValueError(f"{name} payload must be a mapping")
     try:
-        data = dict(payload)
+        data = dict(cast(Mapping[str, Any], payload))
     except Exception as error:
         raise ValueError(f"{name} payload could not be read") from error
     for key in data:
@@ -393,9 +396,11 @@ class GRUPerceptionConfig:
     def from_config(cls, payload: dict[str, Any]) -> GRUPerceptionConfig:
         """Reconstruct from :meth:`to_config` output."""
         data = _copy_mapping(payload, name="GRUPerceptionConfig")
-        data.pop("type", None)
-        if data.keys() - {"observation_dim", "hidden_dim"}:
-            raise ValueError("GRUPerceptionConfig payload has unknown fields")
+        type_name = data.pop("type", None)
+        if type(type_name) is not str or type_name != "GRUPerceptionConfig":
+            raise ValueError("GRUPerceptionConfig payload type is invalid")
+        if set(data) != {"observation_dim", "hidden_dim"}:
+            raise ValueError("GRUPerceptionConfig payload fields are invalid")
         return cls(**data)
 
 
@@ -705,26 +710,18 @@ class PrototypeAgentConfig:
                 maximum=_INT32_MAX,
             ),
         )
-        # Derived allocations must fit signed int32 without allocating JAX arrays
-        _require_float32_resource(
-            "PrototypeAgent buffer",
-            vector_scalars=int(self.buffer_capacity) * int(self.oak.observation_dim),
-            fixed_scalars=2,
-        )
-        # Horde trunk/head scalars: sum hidden + products with obs_dim
-        obs_dim = int(self.oak.observation_dim)
-        horde_vector = 0
-        prev = obs_dim
-        for hidden in self.horde_hidden_sizes:
-            horde_vector += prev * int(hidden) + int(hidden)
-            prev = int(hidden)
-        # Horde heads: n_options * prev * n_actions approximated as n_options*prev
-        # Use conservative bound including option policies from OaK
-        n_options = int(self.oak.n_options)
-        if self.horde_spec is not None and n_options > 0 and prev > 0:
-            horde_vector += n_options * prev
-        if horde_vector:
-            _require_float32_resource("PrototypeAgent horde", vector_scalars=horde_vector)
+        if self.world_model is not None:
+            _require_float32_resource(
+                "PrototypeAgent buffer",
+                vector_scalars=self.buffer_capacity * self.oak.observation_dim,
+                fixed_scalars=2,
+            )
+        if self.horde_spec is not None:
+            _validate_direct_state_resources(
+                len(self.horde_spec.demons),
+                self.horde_hidden_sizes,
+                self.oak.observation_dim,
+            )
         # GRU resource already validated via GRUPerceptionConfig.__post_init__
         if type(self.learn_state_builder_from_world_model) is not bool:
             raise ValueError("learn_state_builder_from_world_model must be boolean")
@@ -2421,6 +2418,8 @@ class PrototypeAgent:
     """
 
     def __init__(self, config: PrototypeAgentConfig) -> None:
+        if type(config) is not PrototypeAgentConfig:
+            raise ValueError("config must be an exact PrototypeAgentConfig")
         self._config = config
         self._oak = OaKAgent(config.oak)
         self._option_search_control: OptionSearchControl | None = None

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -13,9 +13,12 @@ from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
     GRUPerceptionConfig,
+    PrototypeAgent,
     PrototypeAgentConfig,
     _require_float32_resource,
 )
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 
 _INT32_MAX = 2**31 - 1
 
@@ -66,6 +69,14 @@ def _cfg(**overrides: Any) -> PrototypeAgentConfig:
     base: dict[str, Any] = {"oak": _oak()}
     base.update(overrides)
     return PrototypeAgentConfig(**base)  # type: ignore[arg-type]
+
+
+def _world_model(observation_dim: int) -> ActionConditionedWorldModelConfig:
+    return ActionConditionedWorldModelConfig(
+        observation_dim=observation_dim,
+        n_actions=2,
+        hidden_sizes=(),
+    )
 
 
 def test_prototype_int_validators_reject_hostile_without_hook() -> None:
@@ -159,6 +170,8 @@ def test_prototype_require_float32_resource_boundaries() -> None:
         _require_float32_resource("x", vector_scalars=legal + 1)
     with pytest.raises(ValueError, match="scalar count"):
         _require_float32_resource("x", vector_scalars=_INT32_MAX + 1)
+    with pytest.raises(ValueError, match="non-negative"):
+        _require_float32_resource("x", vector_scalars=-1)
 
 
 def test_prototype_buffer_resource_preflight_without_allocation() -> None:
@@ -166,12 +179,15 @@ def test_prototype_buffer_resource_preflight_without_allocation() -> None:
     obs_dim = 2
     oak = _oak(obs_dim=obs_dim)
     legal = (_INT32_MAX // 4 - 2) // obs_dim  # byte boundary
-    cfg = _cfg(oak=oak, buffer_capacity=legal)
+    cfg = _cfg(oak=oak, world_model=_world_model(obs_dim), buffer_capacity=legal)
     assert cfg.buffer_capacity == legal
     with pytest.raises(ValueError, match="byte count|scalar count"):
-        _cfg(oak=oak, buffer_capacity=legal + 1)
+        _cfg(oak=oak, world_model=_world_model(obs_dim), buffer_capacity=legal + 1)
     with pytest.raises(ValueError, match="fit signed int32"):
-        _cfg(oak=oak, buffer_capacity=600_000_000)
+        _cfg(oak=oak, world_model=_world_model(obs_dim), buffer_capacity=600_000_000)
+
+    dormant = _cfg(oak=oak, buffer_capacity=600_000_000)
+    assert dormant.world_model is None
 
     # GRU: 3*h*obs +3*h*h +4*h byte overflow
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
@@ -181,6 +197,26 @@ def test_prototype_buffer_resource_preflight_without_allocation() -> None:
 def test_prototype_gru_resource_overflow_without_allocation() -> None:
     with pytest.raises(ValueError, match="fit signed int32"):
         GRUPerceptionConfig(observation_dim=1_000_000, hidden_dim=1_000_000)
+
+
+def test_prototype_horde_uses_exact_learner_resource_formula() -> None:
+    horde = create_horde_spec(
+        (
+            GVFSpec(
+                name="prediction",
+                demon_type=DemonType.PREDICTION,
+                cumulant_index=0,
+                gamma=0.0,
+                lamda=0.0,
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="direct_state_bytes"):
+        _cfg(
+            oak=_oak(obs_dim=2),
+            horde_spec=horde,
+            horde_hidden_sizes=(70_000_000,),
+        )
 
 
 def test_prototype_mapping_loaders_preserve_markers_and_exact_keys() -> None:
@@ -200,8 +236,14 @@ def test_prototype_mapping_loaders_preserve_markers_and_exact_keys() -> None:
         PrototypeAgentConfig.from_config({**payload, "extra": 1})
 
     gru_payload = GRUPerceptionConfig(observation_dim=4, hidden_dim=8).to_config()
-    with pytest.raises(ValueError, match="unknown fields"):
+    with pytest.raises(ValueError, match="fields"):
         GRUPerceptionConfig.from_config({**gru_payload, "extra": 1})
+    with pytest.raises(ValueError, match="type"):
+        GRUPerceptionConfig.from_config({**gru_payload, "type": "Wrong"})
+    with pytest.raises(ValueError, match="fields"):
+        GRUPerceptionConfig.from_config(
+            {"type": "GRUPerceptionConfig", "hidden_dim": 8}
+        )
 
 
 def test_prototype_config_rejects_hostile_mapping() -> None:
@@ -219,6 +261,30 @@ def test_prototype_config_rejects_hostile_mapping() -> None:
         PrototypeAgentConfig.from_config(HostileMapping())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="could not be read"):
         GRUPerceptionConfig.from_config(HostileMapping())  # type: ignore[arg-type]
+
+    class MappingSpoof:
+        calls = 0
+
+        @property
+        def __class__(self) -> type:
+            return dict
+
+        def __iter__(self) -> Iterator[str]:
+            type(self).calls += 1
+            raise AssertionError("mapping hook executed")
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        PrototypeAgentConfig.from_config(MappingSpoof())  # type: ignore[arg-type]
+    assert MappingSpoof.calls == 0
+
+
+def test_prototype_agent_requires_exact_config_type() -> None:
+    class DerivedConfig(PrototypeAgentConfig):
+        pass
+
+    derived = DerivedConfig(oak=_oak())
+    with pytest.raises(ValueError, match="exact PrototypeAgentConfig"):
+        PrototypeAgent(derived)
 
 
 def test_prototype_valid_construction() -> None:


### PR DESCRIPTION
Post-#1024 corrective. Scope buffer accounting to the only lane that allocates it; replace approximate Horde sizing (which used option count) with the exact MultiHead state formula keyed by demon count; reject negative resource-helper counts; require exact PrototypeAgentConfig at runtime; make GRU schema markers/fields exact; and reject mapping class spoofing before hooks. Focused residual panel: 23 passed. Broad Prototype/config/transition/Step3 panel: over 100 tests passed with no failures and continuing. Ruff and diff-check clean.