### PR TITLE
fix(official-foragax): reject non-finite package-freeze JSON

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -3595,11 +3595,18 @@ def _sanitize_package_freeze_line(line: str) -> str:
         url = direct_url.get("url")
         if isinstance(url, str) and url.startswith("file:"):
             direct_url["url"] = "<LOCAL_PATH>"
-    return (
-        prefix
-        + " ; direct_url="
-        + json.dumps(direct_url, sort_keys=True, separators=(",", ":"))
-    )
+    try:
+        encoded = json.dumps(
+            direct_url,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise OfficialForagaxValidationError(
+            "package freeze direct_url is not finite JSON"
+        ) from exc
+    return prefix + " ; direct_url=" + encoded
 
 
 def _extract_probe_payload(stdout: bytes) -> Mapping[str, Any]:
@@ -3960,7 +3967,7 @@ payload = {{
         "class_source_sha256": class_source["sha256"],
     }},
 }}
-sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True) + "\\n")
+sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True, allow_nan=False) + "\\n")
 """
     result = _run_execution_python(
         repository=repository,
@@ -4623,7 +4630,7 @@ payload = {{
     }},
     "immutable_runtime": {immutable_runtime!r},
 }}
-sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True) + "\\n")
+sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True, allow_nan=False) + "\\n")
 """
     result = _run_execution_python(
         repository=repository,
@@ -5156,14 +5163,15 @@ for distribution in distributions():
                 json.loads(direct_url),
                 sort_keys=True,
                 separators=(",", ":"),
+                allow_nan=False,
             )
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError, ValueError):
             direct_url = direct_url.strip()
         line += f" ; direct_url={{direct_url}}"
     packages.append(line)
 sys.stdout.write(
     {_PROBE_PREFIX!r}
-    + json.dumps({{"packages": sorted(set(packages))}}, sort_keys=True)
+    + json.dumps({{"packages": sorted(set(packages))}}, sort_keys=True, allow_nan=False)
     + "\\n"
 )
 """

--- a/tests/test_official_foragax.py
+++ b/tests/test_official_foragax.py
@@ -375,6 +375,36 @@ def test_strict_json_and_archive_contracts_reject_lossy_inputs(
             label="test JSON",
         )
 
+    redacted = official_foragax_module._sanitize_package_freeze_line(
+        'pkg==1.0 ; direct_url={"url":"file:/tmp/local-wheel"}'
+    )
+    assert redacted == (
+        'pkg==1.0 ; direct_url={"url":"<LOCAL_PATH>"}'
+    )
+    malformed = official_foragax_module._sanitize_package_freeze_line(
+        "pkg==1.0 ; direct_url={not-json"
+    )
+    assert malformed.endswith(" ; direct_url=<REDACTED>")
+    with pytest.raises(
+        OfficialForagaxValidationError,
+        match="package freeze direct_url is not finite JSON",
+    ):
+        official_foragax_module._sanitize_package_freeze_line(
+            'pkg==1.0 ; direct_url={"url":NaN}'
+        )
+    with pytest.raises(
+        OfficialForagaxValidationError,
+        match="package freeze direct_url is not finite JSON",
+    ):
+        official_foragax_module._sanitize_package_freeze_line(
+            'pkg==1.0 ; direct_url={"url":Infinity}'
+        )
+    freeze_source = official_foragax_module._package_freeze.__code__.co_consts
+    assert any(
+        isinstance(constant, str) and "allow_nan=False" in constant
+        for constant in freeze_source
+    )
+
     contracts = [
         {
             "name": "rewards",


### PR DESCRIPTION
Closes #1036.

## What changed

Official Foragax package-freeze sanitization and guest probe dumps now use `allow_nan=False`.

On origin/main `9058c3a93736ef1b956dc31efb0696d3d0b1bc8a`, `_sanitize_package_freeze_line` decoded `direct_url` with `json.loads` (which accepts `NaN`) and re-emitted it with `json.dumps` without `allow_nan=False`. Guest `_package_freeze` had the same gap. A `direct_url={"url":NaN}` line became trusted OCI package inventory containing the token `NaN`, after `_strict_json_loads` already rejected non-finite constants on the probe line.

File-path redaction and malformed-JSON redaction are unchanged. Exact finite `direct_url` objects still sanitize.

## Scope

- `alberta_framework/benchmarks/official_foragax.py`
- `tests/test_official_foragax.py`

## Why this is unowned

Live occupancy at publish time: the only open ASI PR is `#1035` (`upgd.py` / `test_upgd_validation.py`). Neither target file is claimed. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`/`#1013`/`#1014`/`#1018`/`#1021`/`#1024`/`#1025`/`#1035`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on OaK planning bool, closed-loop config identities, CBP wrappers, future-utility half-life, dreaming action_features, RTU zero-state, stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `62406b69518d0f8fdf6bb622af766a4e8dcabaf5`
Base: `9058c3a93736ef1b956dc31efb0696d3d0b1bc8a`

- Red on base: `_sanitize_package_freeze_line('pkg==1.0 ; direct_url={"url":NaN}')` returns a line containing `NaN`
- `PYTHONPATH=<worktree> pytest tests/test_official_foragax.py::test_strict_json_and_archive_contracts_reject_lossy_inputs -q -o addopts=""` → 1 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:62406b69518d0f8fdf6bb622af766a4e8dcabaf5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
