### PR TITLE
fix(forager-results): reject non-finite pairing identities

### DIFF
--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -132,6 +132,19 @@ def _canonical_json_sha256(value: Any) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _pairing_json(value: Any, *, name: str) -> str:
+    """Encode a pairing identity while rejecting non-finite JSON numbers."""
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            sort_keys=True,
+            default=str,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be finite JSON") from exc
+
+
 def _json_mapping_copy(value: Mapping[str, Any], *, name: str) -> dict[str, Any]:
     """Return a detached JSON mapping while rejecting non-finite/unsafe values."""
     try:
@@ -2161,10 +2174,9 @@ def _environment_signature(run: ForagerRunResult) -> tuple[Any, ...]:
     semantic = _foragax_semantic_signature(run)
     environment_signature: str | tuple[str, str]
     if semantic is None:
-        environment_signature = json.dumps(
+        environment_signature = _pairing_json(
             run.environment,
-            sort_keys=True,
-            default=str,
+            name="environment pairing identity",
         )
     else:
         implementation = _foragax_implementation_signature(run)
@@ -2175,7 +2187,10 @@ def _environment_signature(run: ForagerRunResult) -> tuple[Any, ...]:
         environment_signature = (semantic, implementation)
     return (
         environment_signature,
-        json.dumps(run.metric_contract, sort_keys=True, default=str),
+        _pairing_json(
+            run.metric_contract,
+            name="metric_contract pairing identity",
+        ),
         run.steps,
     )
 

--- a/tests/test_forager_results.py
+++ b/tests/test_forager_results.py
@@ -1,0 +1,66 @@
+"""Pairing identities must be finite JSON."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.benchmarks.forager import ForagerRunResult
+from alberta_framework.benchmarks.forager_results import _environment_signature
+
+
+def _run(
+    *,
+    environment: dict[str, object],
+    metric_contract: dict[str, object] | None = None,
+) -> ForagerRunResult:
+    return ForagerRunResult(
+        agent="toy",
+        privileged=False,
+        seed=0,
+        steps=1,
+        total_reward=0.0,
+        mean_reward=0.0,
+        final_window_mean_reward=0.0,
+        final_ewm_reward=0.0,
+        mean_ewm_reward=0.0,
+        fov_last_10pct_ema_auc=0.0,
+        mean_biome_regret=0.0,
+        final_biome_regret=0.0,
+        curve_steps=(1,),
+        curve_ewm_reward=(0.0,),
+        curve_window_reward=(0.0,),
+        duration_s=1.0,
+        frames_per_second=1.0,
+        environment=environment,
+        metric_contract=metric_contract or {"metric": "mean_reward"},
+        agent_metadata={"name": "toy", "privileged": False},
+    )
+
+
+def test_non_foragax_pairing_identity_rejects_nonfinite_environment() -> None:
+    finite = _environment_signature(_run(environment={"kind": "toy", "scale": 1.0}))
+    assert '"scale": 1.0' in finite[0]
+
+    with pytest.raises(ValueError, match="environment pairing identity"):
+        _environment_signature(_run(environment={"kind": "toy", "scale": math.nan}))
+    with pytest.raises(ValueError, match="environment pairing identity"):
+        _environment_signature(_run(environment={"kind": "toy", "scale": math.inf}))
+
+
+def test_non_foragax_pairing_identity_rejects_nonfinite_metric_contract() -> None:
+    with pytest.raises(ValueError, match="metric_contract pairing identity"):
+        _environment_signature(
+            _run(
+                environment={"kind": "toy", "scale": 1.0},
+                metric_contract={"metric": "mean_reward", "ewm_decay": math.nan},
+            )
+        )
+    with pytest.raises(ValueError, match="metric_contract pairing identity"):
+        _environment_signature(
+            _run(
+                environment={"kind": "toy", "scale": 1.0},
+                metric_contract={"metric": "mean_reward", "ewm_decay": math.inf},
+            )
+        )


### PR DESCRIPTION
Closes #1037.

## What changed

Non-Foragax Forager pairing identities now fail closed on non-finite JSON numbers.

On origin/main `9058c3a93736ef1b956dc31efb0696d3d0b1bc8a`, `_environment_signature` used `json.dumps(..., default=str)` without `allow_nan=False` when `_foragax_semantic_signature` was `None`. A toy environment `{"scale": NaN}` became a pairing key containing the token `NaN`. The same module already hashes Foragax semantics with `allow_nan=False`.

`default=str` is preserved for historical non-JSON leaves. Exact finite environments and metric contracts still pair.

## Scope

- `alberta_framework/benchmarks/forager_results.py`
- `tests/test_forager_results.py`

## Why this is unowned

Live occupancy at publish time: the only open ASI PR is `#1035` (`upgd.py` / `test_upgd_validation.py`). Neither target file is claimed. This is not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`/`#1013`/`#1014`/`#1018`/`#1021`/`#1024`/`#1025`/`#1035`, Shaw `#890`–`#892`, byt61 `#895`–`#897`, or leftover tax on OaK planning bool, closed-loop config identities, CBP wrappers, future-utility half-life, dreaming action_features, RTU zero-state, stream/cumulant dimensions, delight `kondo_enabled`, Step2AssociativeConfig, visualization best/CI, checkpoint metadata, HordeLearner/MixedHorde/IndependentDemonHorde constructors, log_spaced, safe_discrete_action, off-policy horde ratio-clip, UPGDLearner constructors, recurring-feature gate, gauntlet windows, recurring start positions, interaction constructor scalars, micro-continual shard JSON, export bool identities, GVFSpec, multi-head, forager-cli, timing, label-emnist, smoke CLI, average-reward, upgd-ipmnist, metrics, nexting, experiments, security, IDBD, true-online-td, baseline-optimizers, or partial-observation.

## Verification

Exact candidate head: `30d266b7df76560aa37c83b2e7fad08d03cb50c5`
Base: `9058c3a93736ef1b956dc31efb0696d3d0b1bc8a`

- Red on base: `_environment_signature` of a non-Foragax run with `environment={"scale": NaN}` returns a pairing key containing `NaN`
- `PYTHONPATH=<worktree> pytest tests/test_forager_results.py tests/test_forager_benchmark.py::test_summary_and_paired_comparison_fail_closed tests/test_forager_benchmark.py::test_pairing_requires_matching_foragax_rng_schedule -q -o addopts=""` → 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:30d266b7df76560aa37c83b2e7fad08d03cb50c5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
