### PR TITLE
fix(benchmarks): reject invalid progress_every before learner setup

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -496,6 +496,10 @@ def run_label_emnist(
     Returns:
         Host-side result arrays; see :class:`LabelEMNISTRunResult`.
     """
+    if progress_every is not None and (
+        type(progress_every) is not int or progress_every <= 0
+    ):
+        raise ValueError("progress_every must be a positive integer or None")
     seed_tuple = require_unique_jax_seeds(seeds, name="seeds")
     if config is None:
         config = LabelEMNISTConfig()

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -457,6 +457,27 @@ def debug_run():
 
 class TestTinySmokeRun:
 
+    @pytest.mark.parametrize("progress_every", [0, -1, True, np.int64(1)])
+    def test_rejects_invalid_progress_interval_before_learner_setup(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        progress_every: object,
+    ) -> None:
+        def unexpected_setup(*args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise AssertionError("invalid progress interval reached learner setup")
+
+        monkeypatch.setattr(upgd_label_emnist, "resolve_hyperparameters", unexpected_setup)
+        with pytest.raises(ValueError, match="progress_every must be a positive integer"):
+            run_label_emnist(
+                np.empty((TINY.task_length, TINY.input_dim), dtype=np.float32),
+                np.zeros(TINY.task_length, dtype=np.int32),
+                "adamw",
+                seeds=[0],
+                config=TINY,
+                progress_every=progress_every,  # type: ignore[arg-type]
+            )
+
     def test_shapes_and_bounds(self, debug_run):
         assert debug_run.per_task_accuracy.shape == (2, TINY.n_tasks)
         assert debug_run.per_step_accuracy.shape == (2, TINY.n_tasks, TINY.task_length)


### PR DESCRIPTION
Closes #1040.

## What changed

`run_label_emnist` accepted invalid `progress_every` values. In particular, `progress_every=0` completed learner/data setup and then crashed at the first task with `ZeroDivisionError` from `(task + 1) % progress_every`. Negative intervals silently disabled logging, and `True`/`np.int64` also passed through despite the public annotation requiring a canonical `int | None`.

## Fix

Validate `progress_every` up front, before seed, data, or learner setup: accept only `None` or an exact positive builtin `int`.

## Reachability

`run_label_emnist` is in the module's public `__all__`. The `shard` CLI subcommand parses `--progress-every` as a plain `int` and passes it straight to `run_label_emnist` via `_cmd_shard`, so arbitrary CLI integer input reaches the faulty modulo.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
REPRODUCED ZeroDivisionError: division by zero
```

- new test `test_rejects_invalid_progress_interval_before_learner_setup`, parametrized over `0`, `-1`, `True`, `np.int64(1)`, monkeypatching learner setup to prove rejection happens before any setup work.
- mutation check: reverted just the source guard, reran the new test -> all 4 parametrizations fail with `AssertionError: invalid progress interval reached learner setup` (setup was reached). restored -> all 4 pass.
- full file: `85 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the `ZeroDivisionError` myself against the unpatched code, ran the full mutation check myself (including catching and correcting a `git checkout --` mistake that briefly reverted the fix entirely rather than just my mutation), reran the full test file/lint/mypy, and re-traced reachability against `__all__` and the CLI argument parser before committing and pushing.

Attribution status: self-reported.
