### PR TITLE
fix(forager-cli): reject non-finite protocol/baseline JSON

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -149,7 +149,7 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     if isinstance(value, float) and not math.isfinite(value):
-        return None
+        raise ValueError("forager CLI payload is not finite JSON")
     if isinstance(value, Path):
         return str(value)
     return value
@@ -578,10 +578,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                 target.to_dict() for target in paper_reference_targets(preset)
             ],
         }
-        LOGGER.info(json.dumps(_json_safe(baseline_payload), indent=2, sort_keys=True))
+        LOGGER.info(
+            json.dumps(
+                _json_safe(baseline_payload),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
         return 0
     if args.protocol_only:
-        LOGGER.info(json.dumps(_json_safe(protocol.to_dict()), indent=2, sort_keys=True))
+        LOGGER.info(
+            json.dumps(
+                _json_safe(protocol.to_dict()),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
         return 0
 
     reference_names = {name for name, _seed, _path in args.reference_npz}

--- a/tests/test_forager_cli.py
+++ b/tests/test_forager_cli.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from alberta_framework import forager_cli
@@ -93,6 +95,25 @@ def test_final_window_zero_is_not_replaced_by_protocol_default() -> None:
     assert (args.final_window or 100_000) == 100_000
     resolved = forager_cli._explicit_int_or_default(args.final_window, 100_000)
     assert resolved == 0
+
+
+def test_json_safe_rejects_nonfinite_protocol_identities() -> None:
+    """Protocol/baseline dumps must not coerce NaN/Inf into JSON null."""
+    finite = forager_cli._json_safe({"preset": "toy", "scale": 1.0})
+    assert finite == {"preset": "toy", "scale": 1.0}
+    encoded = json.dumps(finite, indent=2, sort_keys=True, allow_nan=False)
+    assert '"scale": 1.0' in encoded
+
+    for bad in (float("nan"), float("inf"), float("-inf"), np.float64("nan")):
+        with pytest.raises(ValueError, match="forager CLI payload is not finite JSON"):
+            forager_cli._json_safe({"scale": bad})
+
+
+def test_protocol_and_baseline_dumps_refuse_nonfinite_json() -> None:
+    source = __import__("inspect").getsource(forager_cli.main)
+    assert "allow_nan=False" in source
+    assert "json.dumps(_json_safe(baseline_payload), indent=2, sort_keys=True)" not in source
+    assert "json.dumps(_json_safe(protocol.to_dict()), indent=2, sort_keys=True)" not in source
 
 
 def test_main_passes_explicit_final_window_to_config() -> None:


### PR DESCRIPTION
Closes #1042.

## What changed

Forager CLI protocol/baseline dumps now fail closed on non-finite JSON numbers.

On origin/main `2df4018`, `_json_safe` coerced `NaN`/`Infinity` to `None`, and `--list-paper-baselines` / `--protocol-only` dumped the result without `allow_nan=False`. A `{"scale": NaN}` identity became trusted CLI JSON containing `null`.

`--final-window 0` fail-closed behavior from #924 is unchanged. Exact finite protocol and baseline payloads still dump.

## Scope

- `alberta_framework/forager_cli.py`
- `tests/test_forager_cli.py`

## Why this is unowned

Live occupancy at publish time: open ASI PRs do not claim these files (`#1041` is `upgd_label_emnist.py`). This is leftover tax after `#924`, not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`/`#1013`/`#1014`/`#1035`/`#1038`/`#1039`, or leftover tax on official-foragax package-freeze JSON, forager-results pairing identities, or forager-matrix artifact identities.

## Verification

Exact candidate head: `3decfb98b7363c271004fef5713503f1dc74c91d`
Base: `2df4018`

- Red on base: `_json_safe({"scale": float("nan")})` returns `{"scale": None}`
- `PYTHONPATH=<worktree> pytest tests/test_forager_cli.py -q -o addopts=""` → 10 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:3decfb98b7363c271004fef5713503f1dc74c91d -->
<!-- evidence-row:logs -->
- [ ] logs: <attachment URL or N/A - reason>
<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: <attachment URL or N/A - reason>
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: <attachment URL or N/A - reason>

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
