### PR TITLE
fix(forager-matrix): reject non-finite artifact identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1617,7 +1617,7 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     if isinstance(value, float) and not math.isfinite(value):
-        return None
+        raise ForagerMatrixError("matrix artifact identity is not finite JSON")
     if isinstance(value, Path):
         if value.is_absolute():
             raise ForagerMatrixError("absolute host paths are forbidden in matrix artifacts")

--- a/tests/test_forager_matrix.py
+++ b/tests/test_forager_matrix.py
@@ -1213,6 +1213,23 @@ def test_strict_loader_rejects_duplicate_ids_nonfinite_and_unsafe_reference(
         matrix.parse_forager_matrix_manifest(unsafe)
 
 
+def test_json_safe_rejects_nonfinite_artifact_identities() -> None:
+    """Artifact identities must not coerce NaN/Inf into JSON null."""
+    finite = matrix._json_safe({"scale": 1.0})
+    assert finite == {"scale": 1.0}
+    assert matrix._canonical_json_bytes(finite) == b'{"scale":1.0}'
+
+    for bad in (float("nan"), float("inf"), float("-inf"), np.float64("nan")):
+        with pytest.raises(
+            matrix.ForagerMatrixError,
+            match="matrix artifact identity is not finite JSON",
+        ):
+            matrix._json_safe({"scale": bad})
+
+    with pytest.raises(matrix.ForagerMatrixError, match="not canonical JSON"):
+        matrix._canonical_json_bytes({"scale": float("nan")})
+
+
 def test_source_snapshot_is_reproducible_canonical_and_path_independent(
     _isolated_source_tree: Path,
 ) -> None:


### PR DESCRIPTION
Closes #1043.

## What changed

Forager matrix artifact identities now fail closed on non-finite JSON numbers.

On origin/main `2df4018`, `_json_safe` coerced `NaN`/`Infinity` to `None` before `_canonical_json_bytes`. A `{"scale": NaN}` extra-kwargs / run / environment identity became `{"scale":null}` and hashed as if it were missing, even though the canonical dumper already uses `allow_nan=False`.

Exact finite artifact identities still canonicalize. Manifest-loader rejection of `NaN` tokens is unchanged.

## Scope

- `alberta_framework/benchmarks/forager_matrix.py`
- `tests/test_forager_matrix.py`

## Why this is unowned

Live occupancy at publish time: open ASI PRs do not claim these files (`#1041` is `upgd_label_emnist.py`). This is leftover tax after `#1039`, not a republish of `#893`/`#894`/`#898`/`#899`/`#901`/`#903`/`#904`/`#905`/`#908`/`#909`/`#912`/`#913`/`#916`/`#917`/`#924`/`#925`/`#930`/`#931`/`#934`/`#935`/`#946`/`#947`/`#959`/`#960`/`#972`/`#973`/`#982`/`#983`/`#986`/`#987`/`#990`/`#991`/`#994`/`#995`/`#999`/`#1000`/`#1003`/`#1004`/`#1008`/`#1010`/`#1013`/`#1014`/`#1035`/`#1038`/`#1039`, or leftover tax on official-foragax package-freeze JSON, forager-results pairing identities, or forager-cli protocol/baseline dumps.

## Verification

Exact candidate head: `c7e6e91ad8327a2f50c6b01969f382009d4d1b36`
Base: `2df4018`

- Red on base: `_json_safe({"scale": float("nan")})` returns `{"scale": None}` and `_canonical_json_bytes` of that coerced mapping is `b'{"scale":null}'`
- `PYTHONPATH=<worktree> pytest tests/test_forager_matrix.py::test_json_safe_rejects_nonfinite_artifact_identities tests/test_forager_matrix.py::test_strict_loader_rejects_duplicate_ids_nonfinite_and_unsafe_reference -q -o addopts=""` → 2 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:c7e6e91ad8327a2f50c6b01969f382009d4d1b36 -->
<!-- evidence-row:logs -->
- [ ] logs: <attachment URL or N/A - reason>
<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: <attachment URL or N/A - reason>
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: <attachment URL or N/A - reason>

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
