### PR TITLE
fix(benchmarks): validate registered arm contract on micro shard load

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1129,6 +1129,7 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         )
     if payload.get("arm_name") not in MICRO_ARM_REGISTRY:
         raise ValueError(f"{path}: unknown arm {payload.get('arm_name')!r}")
+    arm_spec = MICRO_ARM_REGISTRY[payload["arm_name"]]
     if not isinstance(payload.get("mechanism"), str) or not payload["mechanism"]:
         raise ValueError(f"{path}: mechanism must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):
@@ -1138,6 +1139,14 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
             payload["hyperparameters"], context=f"{path}: hyperparameters"
         )
     )
+    if payload["mechanism"] != arm_spec.mechanism:
+        raise ValueError(
+            f"{path}: mechanism does not match registered arm {arm_spec.name!r}"
+        )
+    if payload["hyperparameters"] != dict(arm_spec.hyperparameters):
+        raise ValueError(
+            f"{path}: hyperparameters do not match registered arm {arm_spec.name!r}"
+        )
     environment = payload.get("environment")
     required_environment_fields = ("jax", "numpy", "python", "platform")
     if not isinstance(environment, dict) or any(

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1142,6 +1142,26 @@ class TestShards:
         with pytest.raises(ValueError, match="hyperparameters"):
             load_micro_shard(path)
 
+    @pytest.mark.parametrize(
+        ("fieldname", "value"),
+        [
+            ("mechanism", "forged-mechanism"),
+            ("hyperparameters", {"step_size": 999.0, "weight_decay": 0.0}),
+        ],
+    )
+    def test_load_rejects_registered_arm_contract_mismatch(
+        self, tmp_path: Path, fieldname: str, value: object
+    ) -> None:
+        payload = micro_shard_payload(self._result())
+        payload[fieldname] = value
+        path = self._write_payload(tmp_path, payload)
+
+        verb = "does" if fieldname == "mechanism" else "do"
+        with pytest.raises(
+            ValueError, match=rf"{fieldname} {verb} not match registered arm"
+        ):
+            load_micro_shard(path)
+
     def test_payload_roundtrip(self, tmp_path: Path):
         result = self._result()
         payload = micro_shard_payload(result)
@@ -1499,7 +1519,7 @@ class TestShards:
 
         with pytest.raises(
             ValueError,
-            match=rf"arm 'sgd_raw' has inconsistent {fieldname} across seeds",
+            match=rf"{fieldname} (does|do) not match registered arm 'sgd_raw'",
         ):
             merge_micro_shards([path_a, path_b], bayes_samples=1_000)
 
@@ -1677,7 +1697,7 @@ class TestTransferValidation:
 
         with pytest.raises(
             ValueError,
-            match="arm 'sgd_raw' has inconsistent mechanism across seeds",
+            match="mechanism does not match registered arm 'sgd_raw'",
         ):
             transfer_validation_from_shards([*paths, drifted_path])
 


### PR DESCRIPTION
Closes #1047.

## What changed

`load_micro_shard` accepted a shard whose `arm_name` named a registered canonical arm while its `mechanism` or `hyperparameters` described a different implementation. Cross-seed validation only checked that altered shards agreed with each other, so a consistently altered batch could be merged and ranked under the canonical arm name, corrupting benchmark attribution.

## Fix

After resolving the registered `MicroArmSpec`, compare the shard's already-canonicalized mechanism and hyperparameters against the registered spec's (canonicalized via the same `_freeze_micro_hyperparameters` helper both sides use) and reject mismatches at load time. Existing merge and transfer-validation tests were updated to expect rejection at this earlier load boundary instead of the later cross-seed-consistency check.

## Reachability

`load_micro_shard` is called from `merge_micro_shards`, `transfer_validation_from_shards`, and `_run_or_skip_shard`. The module's `main()` is executed via `python -m alberta_framework.benchmarks.micro_continual`; its `ladder` command loads existing shards through `_run_or_skip_shard` and merges through `merge_micro_shards`, so real shard JSON files from user-selected output directories reach this validator. No console-script entry point is registered, and the module is not re-exported from any `__init__.py`.

## Verification

confirmed the bug live against the unpatched code before fixing, forging only the hyperparameters of an otherwise-real `sgd_raw` shard:
```text
sgd_raw {'step_size': 999.0, 'weight_decay': 0.0}
```
(registered `sgd_raw` hyperparameters are `{'step_size': 0.01, 'weight_decay': 0.0}`.)

- new parametrized test `test_load_rejects_registered_arm_contract_mismatch`, covering both `mechanism` and `hyperparameters` forgery.
- mutation check: reverted just the source fix, reran -> both parametrizations fail with `Failed: DID NOT RAISE ValueError`. restored -> both pass.
- full file: `219 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the forged-shard acceptance myself, ran the full mutation check myself, reran the full test file/lint/mypy, and re-traced reachability against the module's callers and `pyproject.toml`'s console-script list. Along the way I also chased down and resolved a confusing false alarm in my own verification: invoking the report's reproduction script as a bare file (`python script.py`) resolved `alberta_framework` to a stale, unpatched sibling checkout via this worktree's shared editable-install `.pth` entry (script-file execution sets `sys.path[0]` to the script's own directory, not cwd) — an artifact of how I invoked it, not a flaw in the fix. The authoritative check throughout, `pytest -m`/`python -c` run from the worktree's own directory, correctly resolved this worktree's code and is what the mutation-resistance transcript above reflects.

Attribution status: self-reported.
