### PR TITLE
fix(behavior-model): reject non-integer action dtypes

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -88,6 +88,14 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.minimum(jnp.maximum(counter, 0), maximum - 1) + 1
 
 
+def _integer_action_ids(actions: Array) -> Array:
+    """Narrow integer action IDs without laundering floats or booleans."""
+    raw_actions = jnp.asarray(actions)
+    if not jnp.issubdtype(raw_actions.dtype, jnp.integer):
+        raise ValueError("actions must have an integer dtype")
+    return raw_actions.astype(jnp.int32)
+
+
 def floor_and_renormalize_probabilities(
     probabilities: Array,
     min_probability: float = 1e-6,
@@ -125,7 +133,7 @@ def selected_action_probabilities(
     broadcast to ``probabilities.shape[:-1]``.
     """
     probs = jnp.asarray(probabilities, dtype=jnp.float32)
-    action_ids = jnp.asarray(actions, dtype=jnp.int32)
+    action_ids = _integer_action_ids(actions)
     one_hot = jax.nn.one_hot(action_ids, probs.shape[-1], dtype=jnp.float32)
     selected = jnp.sum(probs * one_hot, axis=-1)
     return jnp.maximum(selected, jnp.asarray(min_probability, dtype=jnp.float32))
@@ -533,7 +541,7 @@ class BehaviorModel:
         """
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
-        action_id = jnp.asarray(action, dtype=jnp.int32)
+        action_id = _integer_action_ids(action)
         logits = state.weights @ obs + state.bias
         scaled_logits = logits / cfg.temperature
         probabilities = jax.nn.softmax(scaled_logits)
@@ -584,7 +592,7 @@ class BehaviorModel:
         """Update the behavior model from one observed action."""
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
-        action_id = jnp.asarray(action, dtype=jnp.int32)
+        action_id = _integer_action_ids(action)
         logits = state.weights @ obs + state.bias
         probabilities = jax.nn.softmax(logits / cfg.temperature)
         one_hot = jax.nn.one_hot(action_id, cfg.n_actions, dtype=jnp.float32)

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -370,6 +370,22 @@ def test_probability_simplex_and_helper_invariants() -> None:
     chex.assert_trees_all_close(logs, jnp.log(selected))
 
 
+@pytest.mark.parametrize(
+    "action",
+    [
+        jnp.array(1.9, dtype=jnp.float32),
+        jnp.array(True, dtype=jnp.bool_),
+    ],
+)
+def test_update_rejects_non_integer_action_dtypes(action: jax.Array) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="actions must have an integer dtype"):
+        model.update(state, observation, action)
+
+
 def test_likelihood_improves_on_deterministic_policy_stream() -> None:
     model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.2, diagnostic_decay=0.9))
     state = model.init(feature_dim=2, key=jax.random.key(2))


### PR DESCRIPTION
Closes #1049.

## What changed

`BehaviorModel.update`, `input_loss_gradient`, and the shared `selected_action_probabilities` helper converted actions to `int32` via `jnp.asarray(actions, dtype=jnp.int32)` before checking their domain, so fractional and boolean action arrays were silently laundered into discrete action IDs instead of being rejected.

## Fix

Add `_integer_action_ids`, which inspects the raw JAX dtype via `jnp.issubdtype(dtype, jnp.integer)` before narrowing to `int32` and rejects non-integer dtypes. `jnp.bool_` is not a `jnp.integer` subdtype, so booleans are rejected too, alongside floats. All three call sites route through this shared helper.

## Reachability

`BehaviorModel`, `BehaviorModelConfig`, and `selected_action_probabilities` are exported from both `alberta_framework/core/__init__.py`'s `__all__` and re-exported from top-level `alberta_framework/__init__.py`'s `__all__`. `BehaviorModel.update` also consumes action arrays supplied to the public `run_behavior_model_from_arrays` scan - real caller-provided inputs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
fractional: action=1.9 ACCEPTED, step_count now 1, weights changed: True
boolean: action=True ACCEPTED, step_count now 1, weights changed: True
```

- new parametrized test `test_update_rejects_non_integer_action_dtypes`, covering fractional float and boolean action arrays.
- mutation check: reverted just the source fix, reran the new test -> both parametrizations fail with `Failed: DID NOT RAISE ValueError`. restored -> both pass.
- full file: `41 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the dtype-laundering myself against the unpatched code (correcting a wrong assumption in my own first attempt about `update`'s return signature - it returns a single `BehaviorModelUpdateResult`, not a tuple), ran the full mutation check myself, reran the full test file/lint/mypy, and re-traced reachability against both `__all__` export lists.

Attribution status: self-reported.
