### PR TITLE
fix(ipmnist): reject invalid progress intervals

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -853,6 +853,8 @@ def run_ipmnist(
         Host-side result arrays; see :class:`IPMNISTRunResult`.
     """
     seed_tuple = require_unique_jax_seeds(seeds, name="seeds")
+    if progress_every is not None:
+        progress_every = _require_int32("progress_every", progress_every)
     if config is None:
         config = IPMNISTConfig()
     if noise_mode not in ("step", "pool"):

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -356,6 +356,26 @@ class TestInputDomain:
         with pytest.raises(ValueError, match=message):
             run_ipmnist(x, y, "adamw", seeds=[0], config=TINY)
 
+    @pytest.mark.parametrize("progress_every", [0, -1, True, 1.5])
+    def test_run_rejects_invalid_progress_interval_before_setup(
+        self, monkeypatch: pytest.MonkeyPatch, progress_every: object
+    ) -> None:
+        def unexpected_setup(*args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise AssertionError("invalid progress interval reached learner setup")
+
+        x, y = _synthetic_dataset(0, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        monkeypatch.setattr(upgd_ipmnist, "resolve_hyperparameters", unexpected_setup)
+        with pytest.raises(ValueError, match="progress_every"):
+            run_ipmnist(
+                x,
+                y,
+                "adamw",
+                seeds=[0],
+                config=TINY,
+                progress_every=progress_every,  # type: ignore[arg-type]
+            )
+
 
 @pytest.mark.unit
 class TestInputDomainBoundary:


### PR DESCRIPTION
Closes #1055.

## What changed

`run_ipmnist` accepted invalid `progress_every` values and used them directly as a modulo divisor after completing a task - the same bug class already fixed in the sibling `upgd_label_emnist.py::run_label_emnist` (#1040/#1041), independently present here too. `progress_every=0` performed benchmark setup and computation, then crashed with `ZeroDivisionError`. Negative values, booleans, and fractional values had unintended logging semantics instead of being rejected.

## Fix

Validate and canonicalize `progress_every` with the module's existing `_require_int32` helper (an explicit whitelist of `int` plus every concrete numpy integer scalar type - already used elsewhere in this file, so no new validation logic) before configuration, data validation, or learner setup.

## Reachability

`run_ipmnist` is public: imported and listed in `alberta_framework/benchmarks/__init__.py`'s `__all__` (not re-exported from the package-root `alberta_framework/__init__.py`). The production CLI parses `--progress-every` with `type=int` and passes `args.progress_every` directly to `run_ipmnist`, so `--progress-every 0` reaches the public runner with a real unsafe value.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
REPRODUCED ZeroDivisionError: division by zero
```

- new parametrized test `test_run_rejects_invalid_progress_interval_before_setup`, covering `0`, `-1`, `True`, `1.5`, monkeypatching learner setup to prove rejection happens before any setup work.
- mutation check: reverted just the source guard, reran the new test -> all 4 fail with `AssertionError: invalid progress interval reached learner setup` (setup was reached). restored -> all 4 pass.
- full file: `115 passed` (I ran this myself - the report's own attempt didn't complete within its execution budget and honestly disclosed that rather than fabricating a result).
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). The report honestly disclosed that its own full-file test run didn't complete within its execution budget rather than fabricating a result. I independently re-verified before shipping: reproduced the `ZeroDivisionError` myself against the unpatched code, ran the full mutation check myself, ran the full test file myself to completion (`115 passed` in ~53s), reran lint/mypy, and re-traced reachability against the export list and CLI argument parser.

Attribution status: self-reported.
