### PR TITLE
fix(ipmnist-screening): reject invalid progress intervals

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -7700,6 +7700,10 @@ def run_screening_config(
     ``noise_pool_steps`` and never merge with exact shards nor pass proxy
     validation.
     """
+    if progress_every is not None and (
+        type(progress_every) is not int or progress_every <= 0
+    ):
+        raise ValueError("progress_every must be a positive integer or None")
     resolved_seed = require_jax_seed(seed, name="seed")
     noise_mode = _validated_screening_noise_mode(noise_mode, spec)
     effective_noise_pool_steps = _validated_screening_noise_pool_steps(

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -410,6 +410,23 @@ class TestScreeningInputDomain:
                 x, y, spec, seed=0, config=SMALL, noise_mode=noise_mode
             )
 
+    @pytest.mark.parametrize("progress_every", [0, -1, True, 1.5])
+    def test_rejects_invalid_progress_interval_before_learner_factory(
+        self, small_data, progress_every: object
+    ) -> None:
+        """Host-boundary progress identities must not reach the learner factory."""
+        x, y = small_data
+        spec = replace(screening_spec("upgd_w_control"), factory=self._boom_factory)
+        with pytest.raises(ValueError, match="progress_every"):
+            run_screening_config(
+                x,
+                y,
+                spec,
+                seed=0,
+                config=SMALL,
+                progress_every=progress_every,  # type: ignore[arg-type]
+            )
+
 
 class TestIDBDCombo:
     def test_meta_zero_reduces_to_lean_upgd(self):


### PR DESCRIPTION
Closes #1059.


## What changed

IPMNIST screening now fails closed on invalid `progress_every` identities.

On origin/main `55a0800`, `run_screening_config(..., progress_every=)` accepted `True` / `0` / `-1` / `1.5` and reached the learner factory. `True` is an `int` subclass, so a bool alias could change logging cadence.

This is leftover tax on `ipmnist_screening.py`, not a republish of merged `#1056` (`upgd_ipmnist.py`) or forager-cli/matrix `#1044`/`#1045`.

## Scope

- `alberta_framework/benchmarks/ipmnist_screening.py`
- `tests/test_ipmnist_screening.py`

## Why this is unowned

No open ASI PRs at publish time. Occupancy on `upgd_ipmnist.py` (`#1056`) and `model_replay_rehearsal.py` (`#1057`) has already merged and does not claim these files.

## Verification

Exact candidate head: `06a0e2f4155026d95a46a5258e74c8fdbb4dcdac`
Base: `55a0800`

- Red on base: `progress_every=True|0|-1|1.5` reaches the learner factory
- `PYTHONPATH=<worktree> pytest tests/test_ipmnist_screening.py::TestScreeningInputDomain -q -o addopts=""` → 18 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:06a0e2f4155026d95a46a5258e74c8fdbb4dcdac -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
