### PR TITLE
fix(foragax-open-screen): reject non-finite inspect JSON

### DIFF
--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -1040,7 +1040,13 @@ def _inspect_image(docker: str, image_id: str) -> dict[str, Any]:
         detail = capture.stderr.decode("utf-8", errors="replace").strip()
         raise ScreenError(f"cannot inspect exact OCI image {image_id}: {detail}")
     try:
-        value = json.loads(capture.stdout.decode("utf-8"))
+        value = json.loads(
+            capture.stdout.decode("utf-8"),
+            parse_constant=_reject_nonfinite_json_number,
+            parse_float=_parse_finite_json_float,
+        )
+    except ScreenError:
+        raise
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ScreenError("docker image inspect returned invalid JSON") from error
     if not isinstance(value, list) or len(value) != 1 or not isinstance(value[0], dict):

--- a/tests/test_foragax_open_screen.py
+++ b/tests/test_foragax_open_screen.py
@@ -1232,3 +1232,43 @@ def test_probe_ppo_schedule_rejects_bool_rollout_and_updates() -> None:
             probe._validate_ppo_schedule(rollout, updates, 32, "configs/demo.json")
     with pytest.raises(RuntimeError, match="PPO schedule does not equal the frozen horizon"):
         probe._validate_ppo_schedule(4, 4, 32, "configs/demo.json")
+
+
+@pytest.mark.parametrize("payload", ['[{"Id": NaN}]', '[{"Id": Infinity}]', '[{"Id": -Infinity}]'])
+def test_inspect_image_rejects_nonfinite_json(
+    monkeypatch: pytest.MonkeyPatch, payload: str
+) -> None:
+    """Docker inspect identities must not coerce NaN/Inf into trusted JSON."""
+
+    monkeypatch.setattr(
+        screen,
+        "_capture_process",
+        lambda command: screen.ProcessCapture(0, payload.encode("utf-8"), b""),
+    )
+    with pytest.raises(screen.ScreenError, match="non-finite"):
+        screen._inspect_image("docker", "sha256:" + ("ab" * 32))
+
+
+def test_inspect_image_accepts_finite_inspect_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    image_id = "sha256:" + ("ab" * 32)
+    payload = json.dumps(
+        [
+            {
+                "Id": image_id,
+                "Config": {
+                    "Entrypoint": screen._EXPECTED_IMAGE_ENTRYPOINT,
+                    "WorkingDir": screen._EXPECTED_IMAGE_WORKDIR,
+                },
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        screen,
+        "_capture_process",
+        lambda command: screen.ProcessCapture(0, payload.encode("utf-8"), b""),
+    )
+    assert screen._inspect_image("docker", image_id) == {
+        "id": image_id,
+        "entrypoint": screen._EXPECTED_IMAGE_ENTRYPOINT,
+        "working_dir": screen._EXPECTED_IMAGE_WORKDIR,
+    }


### PR DESCRIPTION
Closes #1060.


## What changed

Foragax open-screen docker inspect now rejects non-finite JSON numbers.

On origin/main `55a0800`, `_load_json_bytes` already used finite-number parse hooks, but `_inspect_image` used bare `json.loads`. A `[{"Id": NaN}]` inspect identity became a trusted inspect dict.

This is leftover tax on the inspect path, not a republish of forager-cli/matrix `#1044`/`#1045` or official-foragax package-freeze JSON.

## Scope

- `alberta_framework/benchmarks/foragax_open_screen.py`
- `tests/test_foragax_open_screen.py`

## Why this is unowned

No open ASI PRs at publish time. These files are not claimed by merged `#1056`/`#1057`/`#1058`.

## Verification

Exact candidate head: `184f939500d8f827ea73013dcd64574620f425b7`
Base: `55a0800`

- Red on base: `json.loads` accepts `[{"Id": NaN}]` / Infinity / -Infinity inspect payloads
- `PYTHONPATH=<worktree> pytest tests/test_foragax_open_screen.py::test_inspect_image_rejects_nonfinite_json tests/test_foragax_open_screen.py::test_inspect_image_accepts_finite_inspect_json tests/test_foragax_open_screen.py::test_probe_ppo_schedule_rejects_bool_rollout_and_updates -q -o addopts=""` → 5 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:184f939500d8f827ea73013dcd64574620f425b7 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
