### PR TITLE
fix(resource-manager): preserve long-lived action counters past float32 exact-integer limit

### DIFF
--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -39,7 +39,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 from jax import Array
-from jaxtyping import Bool, Float
+from jaxtyping import Bool, Float, Int
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.update_safety import (
@@ -297,7 +297,7 @@ class LearnedResourceManagerState:
 
     log_weights: Float[Array, " n_contexts n_actions"]
     loss_ema: Float[Array, " n_contexts n_actions"]
-    action_counts: Float[Array, " n_contexts n_actions"]
+    action_counts: Int[Array, " n_contexts n_actions"]
     step_count: Array
 
 
@@ -491,7 +491,7 @@ class LearnedResourceManager:
         return LearnedResourceManagerState(  # type: ignore[call-arg]
             log_weights=jnp.zeros(shape, dtype=jnp.float32),
             loss_ema=jnp.zeros(shape, dtype=jnp.float32),
-            action_counts=jnp.zeros(shape, dtype=jnp.float32),
+            action_counts=jnp.zeros(shape, dtype=jnp.int32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
@@ -499,9 +499,12 @@ class LearnedResourceManager:
         if type(state) is not LearnedResourceManagerState:
             raise ValueError("state must be a LearnedResourceManagerState")
         shape = (self._n_contexts, self._n_actions)
-        for name in ("log_weights", "loss_ema", "action_counts"):
+        for name in ("log_weights", "loss_ema"):
             leaf = getattr(state, name)
             _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
+        _require_array_metadata(
+            "state.action_counts", state.action_counts, shape, jnp.int32
+        )
         _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
     def weights(
@@ -616,7 +619,7 @@ class LearnedResourceManager:
             old_ema,
         )
         new_loss_ema = state.loss_ema.at[context].set(new_ema)
-        new_counts = state.action_counts.at[context].add(valid_actions.astype(jnp.float32))
+        new_counts = state.action_counts.at[context].add(valid_actions.astype(jnp.int32))
 
         candidate_state = LearnedResourceManagerState(  # type: ignore[call-arg]
             log_weights=new_log_weights,
@@ -672,7 +675,7 @@ class GeneratorMetaResourceManagerState:
 
     log_weights: Float[Array, " n_contexts n_policies"]
     reward_ema: Float[Array, " n_contexts n_policies"]
-    action_counts: Float[Array, " n_contexts n_policies"]
+    action_counts: Int[Array, " n_contexts n_policies"]
     step_count: Array
 
 
@@ -995,7 +998,7 @@ class GeneratorMetaResourceManager:
         return GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
             log_weights=log_weights,
             reward_ema=jnp.zeros(shape, dtype=jnp.float32),
-            action_counts=jnp.zeros(shape, dtype=jnp.float32),
+            action_counts=jnp.zeros(shape, dtype=jnp.int32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
@@ -1003,9 +1006,12 @@ class GeneratorMetaResourceManager:
         if type(state) is not GeneratorMetaResourceManagerState:
             raise ValueError("state must be a GeneratorMetaResourceManagerState")
         shape = (self._n_contexts, self.n_policies)
-        for name in ("log_weights", "reward_ema", "action_counts"):
+        for name in ("log_weights", "reward_ema"):
             leaf = getattr(state, name)
             _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
+        _require_array_metadata(
+            "state.action_counts", state.action_counts, shape, jnp.int32
+        )
         _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
     def weights(
@@ -1238,7 +1244,7 @@ class GeneratorMetaResourceManager:
             old_ema,
         )
         new_reward_ema = state.reward_ema.at[context].set(new_ema)
-        new_counts = state.action_counts.at[context].add(finite.astype(jnp.float32))
+        new_counts = state.action_counts.at[context].add(finite.astype(jnp.int32))
 
         candidate_state = GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
             log_weights=new_log_weights,

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -111,6 +111,16 @@ class TestLearnedResourceManager:
         assert result.state.action_counts[0, 0] == pytest.approx(1.0)
         assert result.state.action_counts[0, 1] == pytest.approx(0.0)
 
+    def test_action_counts_increment_past_float32_exact_integer_limit(self) -> None:
+        manager = LearnedResourceManager(n_actions=2)
+        state = manager.init().replace(
+            action_counts=manager.init().action_counts.at[0, 0].set(2**24)
+        )
+
+        result = manager.update(state, jnp.asarray([0.0, jnp.nan], dtype=jnp.float32))
+
+        assert int(result.state.action_counts[0, 0]) == 2**24 + 1
+
     def test_zero_discount_recovers_nonfinite_logits(self) -> None:
         manager = LearnedResourceManager(
             n_actions=2,
@@ -328,6 +338,19 @@ class TestGeneratorMetaResourceManager:
             exploration=0.0,
             reward_decay=reward_decay,
         )
+
+    def test_action_counts_increment_past_float32_exact_integer_limit(self) -> None:
+        manager = self._manager()
+        state = manager.init().replace(  # type: ignore[attr-defined]
+            action_counts=manager.init().action_counts.at[0, 0].set(2**24)
+        )
+
+        result = manager.update(
+            state,
+            jnp.asarray([1.0, jnp.nan], dtype=jnp.float32),
+        )
+
+        assert int(result.state.action_counts[0, 0]) == 2**24 + 1
 
     def test_zero_discount_recovers_nonfinite_logits(self) -> None:
         manager = self._manager(discount=0.0)


### PR DESCRIPTION
Closes #1065.

## What changed

`LearnedResourceManagerState.action_counts` and `GeneratorMetaResourceManagerState.action_counts` are documented and used as counts, but were stored and incremented as `float32`. IEEE-754 binary32 cannot represent every integer above `2**24`, so a valid update at count `16777216` left the count unchanged while `step_count` continued to advance - silently corrupting long-run resource-allocation accounting.

## Fix

Both action-count arrays now use `int32` throughout: zero-init, state validation, and the increment cast. Applied symmetrically to both classes.

## Reachability

`LearnedResourceManager` and `GeneratorMetaResourceManager` are exported from top-level `alberta_framework/__init__.py`'s `__all__` (not re-exported from `alberta_framework/core/__init__.py` - correcting an overstated claim in the initial draft). `GeneratorMetaResourceManager` is also instantiated inside `alberta_framework/core/compositional_features.py` (`self._generator_resource_manager = GeneratorMetaResourceManager(...)`) and driven with runtime rewards, not hardcoded-safe values. `LearnedResourceManager.update` is directly reachable from the public package API with caller-supplied losses and context IDs.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
before: 16777216
after:  16777216
```

- two new regression tests (`test_action_counts_increment_past_float32_exact_integer_limit`, one per manager class), each initializing state at `2**24` and asserting the count becomes `2**24 + 1` after a valid update.
- mutation check: reverted just the source fix, reran both tests -> both fail with `assert 16777216 == ((2 ** 24) + 1)`. restored -> both pass.
- full file: `66 passed`.
- caller integration test `test_compositional_features.py`: `50 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the float32-precision-loss myself against the unpatched code, ran the full mutation check myself, reran both the touched test file and the caller integration test, reran lint/mypy, and re-traced reachability - catching and correcting an overstated export-surface claim in the report (the classes are exported from the top-level package only, not `alberta_framework/core/__init__.py`). I also spotted a separate, similarly-shaped `float32` counter bug in a sibling class (`FiniteCandidateSelectorState.action_counts` in `compositional_features.py`) while checking for downstream `action_counts` usages - out of scope for this fix, correctly left untouched, flagged in the issue for a future look.

Attribution status: self-reported.
