### PR TITLE
fix(compositional-features): preserve selector action counts past float32 limit

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -382,7 +382,7 @@ class CompositionalFeatureState:
     candidate_ages: Int[Array, " n_candidates"]
     candidate_selector_log_weights: Float[Array, " n_candidates"]
     candidate_selector_cumulative_loss: Float[Array, " n_candidates"]
-    candidate_selector_action_counts: Float[Array, " n_candidates"]
+    candidate_selector_action_counts: Int[Array, " n_candidates"]
     feature_generator_policy: Int[Array, " n_features"]
     candidate_generator_policy: Int[Array, " n_candidates"]
     generator_resource_state: GeneratorMetaResourceManagerState
@@ -509,7 +509,7 @@ class FiniteCandidateSelectorState:
 
     log_weights: Float[Array, " n_candidates"]
     cumulative_loss: Float[Array, " n_candidates"]
-    action_counts: Float[Array, " n_candidates"]
+    action_counts: Int[Array, " n_candidates"]
     step_count: Int[Array, ""]
 
 
@@ -642,7 +642,7 @@ class FiniteCandidateSelector:
         return FiniteCandidateSelectorState(
             log_weights=jnp.zeros(self._n_candidates, dtype=jnp.float32),
             cumulative_loss=jnp.zeros(self._n_candidates, dtype=jnp.float32),
-            action_counts=jnp.zeros(self._n_candidates, dtype=jnp.float32),
+            action_counts=jnp.zeros(self._n_candidates, dtype=jnp.int32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
 
@@ -739,7 +739,7 @@ class FiniteCandidateSelector:
             jnp.nan_to_num(bounded_losses, nan=0.0),
             0.0,
         )
-        action_counts = state.action_counts + update_finite.astype(jnp.float32)
+        action_counts = state.action_counts + update_finite.astype(jnp.int32)
         next_state = FiniteCandidateSelectorState(
             log_weights=log_weights,
             cumulative_loss=cumulative_loss,
@@ -752,7 +752,7 @@ class FiniteCandidateSelector:
             & jnp.all(state.cumulative_loss >= 0.0)
             & jnp.all(state.action_counts >= 0.0)
             & jnp.all(state.cumulative_loss <= state.action_counts)
-            & jnp.all(state.action_counts <= state.step_count.astype(jnp.float32))
+            & jnp.all(state.action_counts <= state.step_count)
         )
         update_available = (
             source_state_valid
@@ -773,7 +773,7 @@ class FiniteCandidateSelector:
         expected = (
             (state.log_weights, (self._n_candidates,), jnp.float32),
             (state.cumulative_loss, (self._n_candidates,), jnp.float32),
-            (state.action_counts, (self._n_candidates,), jnp.float32),
+            (state.action_counts, (self._n_candidates,), jnp.int32),
             (state.step_count, (), jnp.int32),
         )
         for value, shape, dtype in expected:
@@ -2021,7 +2021,7 @@ class CompositionalFeatureLearner:
             candidate_ages=jnp.zeros(cand_count, dtype=jnp.int32),
             candidate_selector_log_weights=jnp.zeros(cand_count, dtype=jnp.float32),
             candidate_selector_cumulative_loss=jnp.zeros(cand_count, dtype=jnp.float32),
-            candidate_selector_action_counts=jnp.zeros(cand_count, dtype=jnp.float32),
+            candidate_selector_action_counts=jnp.zeros(cand_count, dtype=jnp.int32),
             feature_generator_policy=jnp.zeros(n_features, dtype=jnp.int32),
             candidate_generator_policy=jnp.zeros(cand_count, dtype=jnp.int32),
             generator_resource_state=self._generator_resource_manager.init(),
@@ -4420,7 +4420,7 @@ class CompositionalFeatureLearner:
             reset_candidate_traces, 0.0, candidate_selector_cumulative_loss
         )
         candidate_selector_action_counts = jnp.where(
-            reset_candidate_traces, 0.0, candidate_selector_action_counts
+            reset_candidate_traces, 0, candidate_selector_action_counts
         )
 
         ranking_utilities = self._ranking_utility(

--- a/tests/test_compositional_feature_scalar_residuals.py
+++ b/tests/test_compositional_feature_scalar_residuals.py
@@ -253,13 +253,30 @@ def test_selector_rejects_semantically_corrupt_state_atomically() -> None:
     losses = jnp.asarray([0.25, 0.75], dtype=jnp.float32)
     corruptions = (
         state.replace(cumulative_loss=state.cumulative_loss.at[0].set(-1.0)),
-        state.replace(action_counts=state.action_counts.at[0].set(-1.0)),
-        state.replace(action_counts=state.action_counts.at[0].set(1.0)),
+        state.replace(action_counts=state.action_counts.at[0].set(-1)),
+        state.replace(action_counts=state.action_counts.at[0].set(1)),
         state.replace(cumulative_loss=state.cumulative_loss.at[0].set(1.0)),
     )
     for corrupt in corruptions:
         result = selector.update(corrupt, losses)
         chex.assert_trees_all_equal(result.state, corrupt)
+
+
+def test_selector_action_counts_advance_past_float32_exact_integer_limit() -> None:
+    selector = FiniteCandidateSelector(2)
+    exact_integer_limit = 2**24
+    initial_state = selector.init()
+    state = initial_state.replace(
+        action_counts=jnp.full(2, exact_integer_limit, dtype=initial_state.action_counts.dtype),
+        step_count=jnp.asarray(exact_integer_limit, dtype=jnp.int32),
+    )
+
+    result = selector.update(state, jnp.asarray([0.0, 0.0], dtype=jnp.float32))
+
+    np.testing.assert_array_equal(
+        np.asarray(result.state.action_counts),
+        np.asarray([exact_integer_limit + 1, exact_integer_limit + 1]),
+    )
 
 
 @pytest.mark.parametrize("horizon", [True, 1.5, np.float32(1.0), 0, 2**31])


### PR DESCRIPTION
Closes #1067.

## What changed

`FiniteCandidateSelectorState.action_counts` and the embedded `CompositionalFeatureState.candidate_selector_action_counts` were stored as `float32` event counters - the same bug class just fixed in `resource_manager.py`'s two managers (#1065/#1066), independently present here too. At `2**24`, adding one to a float32 value no longer necessarily changes it, so the selector kept advancing `step_count` while silently freezing action-count measurement.

## Fix

Move both the standalone and embedded selector action-count arrays to `int32`: init, update accumulation, the `cumulative_loss <= action_counts <= step_count` invariant check (dropping the now-unnecessary `.astype(jnp.float32)` cast on `step_count`), the state dtype contract, and the candidate-reset branch (`jnp.where(..., 0.0, ...)` -> `jnp.where(..., 0, ...)`, matching the now-int32 array).

## Reachability

`FiniteCandidateSelector` is independently reachable/constructible directly from `alberta_framework.core.compositional_features` (module-public, not re-exported from the root package). It's also exercised internally by `CompositionalFeatureLearner`: non-legacy `candidate_selector` configuration constructs a `FiniteCandidateSelector`, `update()` builds its state from `candidate_selector_action_counts`, and writes the returned counts back into `CompositionalFeatureState`. `CompositionalFeatureLearner` is exported from top-level `alberta_framework.__init__.__all__`.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
before counts: [16777216.0, 16777216.0]
after counts:  [16777216.0, 16777216.0]
counts advanced: [False, False]
```

- new test `test_selector_action_counts_advance_past_float32_exact_integer_limit`, initializing state at `2**24` and asserting counts become `2**24 + 1` after a valid update.
- mutation check: reverted just the source fix, reran the new test -> fails with the exact stalled value (`16777216.0` vs expected `16777217`). restored -> passes.
- touched file: `37 passed`.
- broader caller file `test_compositional_features.py`: `50 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). This specific sibling instance was pre-scouted by me while independently verifying #1066 (I spotted `FiniteCandidateSelectorState.action_counts` had the same shape while checking downstream `action_counts` usages) and handed to this round as a lead. I independently re-verified before shipping: reproduced the float32-precision-loss myself against the unpatched code, ran the full mutation check myself, reran both the touched file and the broader caller test file, reran lint/mypy, and re-traced reachability against both export lists.

Attribution status: self-reported.
