### PR TITLE
fix(benchmarks): reject non-finite micro stream geometry

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -530,6 +530,14 @@ def class_geometry(config: MicroStreamConfig, seed: int) -> tuple[Array, Array]:
     return component_means.astype(jnp.float32), dim_sigma
 
 
+def _require_finite_geometry(component_means: Array, dim_sigma: Array) -> None:
+    if not bool(
+        jnp.all(jnp.isfinite(component_means))
+        & jnp.all(jnp.isfinite(dim_sigma))
+    ):
+        raise ValueError("micro stream geometry must remain finite in float32")
+
+
 @dataclass(frozen=True)
 class GaussianMicroStream:
     """A materialized micro stream plus its generating ground truth.
@@ -591,6 +599,7 @@ def generate_stream(config: MicroStreamConfig, seed: int) -> GaussianMicroStream
         key_regime, 5
     )
     component_means, dim_sigma = class_geometry(config, seed)
+    _require_finite_geometry(component_means, dim_sigma)
 
     n_steps = config.n_steps
     base_y = jr.randint(key_labels, (n_steps,), 0, config.n_classes).astype(jnp.int32)
@@ -740,6 +749,7 @@ def bayes_reference(
         bayes_work_scalars,
     )
     component_means, dim_sigma = class_geometry(config, seed)
+    _require_finite_geometry(component_means, dim_sigma)
     key = jr.fold_in(jr.key(seed), _BAYES_DOMAIN)
     n_correct = 0
     drawn = 0

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -553,6 +553,21 @@ class TestSpectrum:
 
 
 class TestGenerator:
+    def test_geometry_overflow_fails_before_materializing_nonfinite_stream(self):
+        config = tiny(
+            "input_permutation",
+            dim=8,
+            n_classes=2,
+            n_components=1,
+            component_sparsity=1,
+            offset_scale=float(np.finfo(np.float32).max),
+        )
+
+        with pytest.raises(ValueError, match="geometry must remain finite"):
+            generate_stream(config, seed=2)
+        with pytest.raises(ValueError, match="geometry must remain finite"):
+            bayes_reference(config, seed=2, n_samples=1)
+
     def test_deterministic_per_seed(self):
         a = generate_stream(TINY, seed=0)
         b = generate_stream(TINY, seed=0)


### PR DESCRIPTION
Closes #1069.

## What changed

`MicroStreamConfig` accepted individually finite `float32` geometry scales whose combined random geometry arithmetic overflows in float32. With a deterministic config near `offset_scale=float32.max`, `class_geometry` produced `-inf` in the generating component means, which propagated silently into `generate_stream`'s learner-visible observations and `bayes_reference`'s Monte Carlo metric.

## Fix

Add a shared `_require_finite_geometry` check invoked immediately after `class_geometry` in both measurement consumers (`generate_stream`, `bayes_reference`). Kept outside `class_geometry` itself so that function stays JIT-compatible.

## Reachability

Reachable with caller-controlled, non-hardcoded-safe configuration values through `python -m alberta_framework.benchmarks.micro_continual -> main -> _config_from_args -> _run_or_skip_shard -> run_micro_arm -> generate_stream -> class_geometry`, and via the ladder merge's `bayes_reference -> class_geometry`. `micro_continual` is not re-exported by `alberta_framework.__init__` or `alberta_framework.benchmarks.__init__`, and has no installed `[project.scripts]` entry - confirmed independently (no matches for the module in either `__init__.py` or `pyproject.toml`).

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
generate_stream: NO ERROR
component_means finite: False
x finite: False
```

- new test `test_geometry_overflow_fails_before_materializing_nonfinite_stream`, covering both `generate_stream` and `bayes_reference`.
- mutation check: reverted just the source guard calls, reran the new test -> `Failed: DID NOT RAISE ValueError`. restored -> passes.
- full file: `220 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the non-finite propagation myself against the unpatched code, ran the full mutation check myself, reran the full test file/lint/mypy, and re-confirmed the no-export/no-console-script reachability claim directly against `__init__.py` and `pyproject.toml`.

Attribution status: self-reported.
