### PR TITLE
fix(rule-discovery): reject invalid search identities

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -868,6 +868,12 @@ def _require_unique_task_names(task_names: Sequence[str], *, name: str) -> tuple
     return names
 
 
+def _require_search_int(name: str, value: object, *, minimum: int) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}, got {value!r}")
+    return value
+
+
 def evaluate_suite(
     genomes: Array,
     task_names: Sequence[str],
@@ -955,6 +961,10 @@ def _suite_geometry(config: EvalConfig) -> dict[str, Any]:
 def _resolved_suite(
     n_tasks: int | None, task_length: int | None, suite_kind: str = "digits"
 ) -> dict[str, EvalConfig]:
+    if n_tasks is not None:
+        n_tasks = _require_search_int("n_tasks", n_tasks, minimum=1)
+    if task_length is not None:
+        task_length = _require_search_int("task_length", task_length, minimum=1)
     suite: dict[str, EvalConfig]
     if suite_kind == "gauss":
         suite = dict(gauss_suite(n_tasks if n_tasks is not None else GAUSS_SEARCH_REGIMES))
@@ -1002,6 +1012,9 @@ def tune_champion_baseline(
     Returns ``(best_genome, best_accuracy, evaluated)`` where ``evaluated``
     holds every (genome, accuracy) pair for the archive.
     """
+    n_random = _require_search_int("n_random", n_random, minimum=0)
+    generations = _require_search_int("generations", generations, minimum=0)
+    children = _require_search_int("children", children, minimum=1)
     champion = champion_form_genome()
     flags = jnp.asarray(champion[:_N_FLAGS])
 
@@ -1066,6 +1079,12 @@ def run_search(
     :func:`tune_champion_baseline`). Never promotes anything by itself —
     promotion to the real protocol goes through ``ipmnist_screening`` arms.
     """
+    n_random = _require_search_int("n_random", n_random, minimum=0)
+    population = _require_search_int("population", population, minimum=1)
+    generations = _require_search_int("generations", generations, minimum=0)
+    elite = _require_search_int("elite", elite, minimum=1)
+    top_k = _require_search_int("top_k", top_k, minimum=1)
+    batch_size = _require_search_int("batch_size", batch_size, minimum=1)
     eval_seeds = require_unique_jax_seeds(eval_seeds, name="eval_seeds")
     holdout_seeds = require_unique_jax_seeds(holdout_seeds, name="holdout_seeds")
     search_seed = require_jax_seed(search_seed, name="search_seed")

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -49,8 +49,10 @@ from alberta_framework.benchmarks.rule_discovery import (
     penalized_fitness,
     random_genomes,
     rule_step,
+    run_search,
     run_stream,
     seed_genomes,
+    tune_champion_baseline,
 )
 from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig, init_mlp_params
 
@@ -408,6 +410,89 @@ def test_evaluate_population_rejects_nonfinite_genomes_before_materialization(
     genomes = jnp.zeros((2, GENOME_SIZE), dtype=jnp.float32).at[1, 0].set(invalid)
     with pytest.raises(ValueError, match="genomes must contain only finite values"):
         evaluate_population(genomes, MICRO_SUITE["M1"], seeds=(0,))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_random": True}, "n_random"),
+        ({"n_random": -1}, "n_random"),
+        ({"population": True}, "population"),
+        ({"population": 0}, "population"),
+        ({"generations": True}, "generations"),
+        ({"generations": -1}, "generations"),
+        ({"elite": True}, "elite"),
+        ({"elite": 0}, "elite"),
+        ({"top_k": True}, "top_k"),
+        ({"top_k": 0}, "top_k"),
+        ({"batch_size": True}, "batch_size"),
+        ({"batch_size": 0}, "batch_size"),
+    ],
+)
+def test_run_search_rejects_invalid_search_identities_before_genome_generation(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, object], match: str
+) -> None:
+    def unexpected_generation(*args: object, **kw: object) -> None:
+        del args, kw
+        raise AssertionError("invalid search identity reached genome generation")
+
+    monkeypatch.setattr(rule_discovery, "seed_genomes", unexpected_generation)
+    monkeypatch.setattr(rule_discovery, "random_genomes", unexpected_generation)
+    payload: dict[str, object] = {
+        "n_random": 2,
+        "population": 2,
+        "generations": 0,
+        "elite": 1,
+        "eval_seeds": (0,),
+        "holdout_seeds": (101,),
+        "top_k": 1,
+        "batch_size": 2,
+    }
+    payload.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        run_search(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("n_tasks", [True, 0, -1, 1.5])
+def test_resolved_suite_rejects_invalid_n_tasks_identities(n_tasks: object) -> None:
+    with pytest.raises(ValueError, match="n_tasks"):
+        rule_discovery._resolved_suite(n_tasks, None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("task_length", [True, 0, -1, 1.5])
+def test_resolved_suite_rejects_invalid_task_length_identities(
+    task_length: object,
+) -> None:
+    with pytest.raises(ValueError, match="task_length"):
+        rule_discovery._resolved_suite(None, task_length)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_random": True}, "n_random"),
+        ({"generations": True}, "generations"),
+        ({"children": True}, "children"),
+        ({"children": 0}, "children"),
+    ],
+)
+def test_tune_champion_baseline_rejects_invalid_search_identities(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, object], match: str
+) -> None:
+    def unexpected_generation(*args: object, **kw: object) -> None:
+        del args, kw
+        raise AssertionError("invalid search identity reached genome generation")
+
+    monkeypatch.setattr(rule_discovery, "random_genomes", unexpected_generation)
+    with pytest.raises(ValueError, match=match):
+        tune_champion_baseline(
+            jr.key(0),
+            task_names=("M1",),
+            eval_seeds=(0,),
+            batch_size=2,
+            suite=MICRO_SUITE,
+            **kwargs,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize("batch_size", [0, -4, True])


### PR DESCRIPTION
Closes #1071.

## What changed

Rule-discovery search now fails closed on invalid count identities.

On origin/main `65ebb9f`, `run_search` / `tune_champion_baseline` / `_resolved_suite` accepted `True` / `0` / negatives as ints (`True` is an `int` subclass), so a bool alias could change population, elite, or suite size before genomes ran.

This is leftover tax on `rule_discovery.py`, not a republish of merged `#1061` (`ipmnist_screening.py`) or `#1062` (`foragax_open_screen.py`).

## Scope

- `alberta_framework/benchmarks/rule_discovery.py`
- `tests/test_rule_discovery.py`

## Why this is unowned

No open ASI PRs at publish time. Occupancy scan reported these files FREE.

## Verification

Exact candidate head: `0c7d37bc111957055c55d5cf905b970efb1ce131`
Base: `65ebb9f`

- Red on base: `True` / `0` / negatives reach genome generation
- `PYTHONPATH=<worktree> pytest tests/test_rule_discovery.py -q -o addopts=""` → 76 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:0c7d37bc111957055c55d5cf905b970efb1ce131 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
