### PR TITLE
fix(matched-qualification): reject non-finite probe JSON

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -514,7 +514,13 @@ def _decode_json(raw: bytes, label: str) -> Any:
 
 
 def _plain_json(value: Any, path: str = "value") -> Any:
-    if value is None or type(value) in {str, bool, int, float}:
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ForagerMatchedQualificationError(
+                f"{path} contains a non-finite JSON number"
+            )
+        return value
+    if value is None or type(value) in {str, bool, int}:
         return value
     if isinstance(value, Mapping):
         result: dict[str, Any] = {}
@@ -1829,7 +1835,15 @@ def _replace_integer_literals(raw: bytes, transforms: Sequence[Any]) -> bytes:
     parsed = _decode_json(raw, "original configuration")
     if type(parsed) is not dict:
         raise ForagerMatchedQualificationError("original configuration must be an object")
-    expected = cast(dict[str, Any], json.loads(json.dumps(parsed)))
+    try:
+        expected = cast(
+            dict[str, Any],
+            json.loads(json.dumps(parsed, allow_nan=False)),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ForagerMatchedQualificationError(
+            "original configuration is not finite canonical JSON"
+        ) from exc
     transformed = raw
     for transform in transforms:
         if (

--- a/tests/test_forager_matched_qualification.py
+++ b/tests/test_forager_matched_qualification.py
@@ -48,6 +48,27 @@ def _sha(label: str) -> str:
     return hashlib.sha256(label.encode("ascii")).hexdigest()
 
 
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_canonical_json_rejects_nonfinite_number_identities(invalid: float) -> None:
+    with pytest.raises(
+        qualification.ForagerMatchedQualificationError,
+        match="non-finite JSON number",
+    ):
+        qualification._canonical_json_bytes({"score": invalid})  # noqa: SLF001
+
+
+def test_replace_integer_literals_keeps_finite_configuration_copy() -> None:
+    raw = b'{"total_steps": 1}'
+    transform = SimpleNamespace(
+        transform_type="byte_preserving_unique_literal_replacement",
+        value_type="integer",
+        value=2,
+        target="total_steps",
+    )
+    rewritten = qualification._replace_integer_literals(raw, (transform,))  # noqa: SLF001
+    assert b'"total_steps": 2' in rewritten or b'"total_steps":2' in rewritten
+
+
 def _fresh_replay_fixture(
     tmp_path: Path,
 ) -> tuple[Path, Any, str, dict[str, Any]]:
@@ -2195,7 +2216,7 @@ def test_bundle_preserves_exact_manifest_bytes_and_threads_one_digest(
 
     with pytest.raises(
         qualification.ForagerMatchedQualificationError,
-        match="bounded canonical JSON",
+        match="non-finite JSON number",
     ):
         replace(
             bundle,


### PR DESCRIPTION
Closes #1072.

## What changed

Matched-qualification now fails closed on non-finite JSON number identities.

On origin/main `65ebb9f`, `_canonical_json_bytes` already dumped with `allow_nan=False`, but `_plain_json` accepted `NaN`/`Inf` and `_replace_integer_literals` copied via `json.dumps` without `allow_nan=False`. Equality and transform copies could therefore launder non-finite numbers.

This is leftover tax on `forager_matched_qualification.py`, not a republish of merged `#1062` (`foragax_open_screen.py`) or `#1044`/`#1045`.

## Scope

- `alberta_framework/benchmarks/forager_matched_qualification.py`
- `tests/test_forager_matched_qualification.py`

## Why this is unowned

No open ASI PRs at publish time. Occupancy scan reported these files FREE.

## Verification

Exact candidate head: `3f31edffa20d4317236b2f2bb38b1ecda8bc20dc`
Base: `65ebb9f`

- Red on base: `_plain_json(float("nan"))` returns the float; integer-literal copies use `json.dumps` without `allow_nan=False`
- Focused pytest on the new identities + existing bundle digest test: 5 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- evidence-head:3f31edffa20d4317236b2f2bb38b1ecda8bc20dc -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
