### PR TITLE
fix(dreaming): reject fractional discrete actions

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -1046,7 +1046,10 @@ def action_features(action: Array, n_actions: int | None = None) -> Array:
     if n_actions is None:
         return jnp.ravel(jnp.asarray(action, dtype=jnp.float32))
     n_actions = _require_int("n_actions", n_actions, minimum=1)
-    action_index = jnp.squeeze(jnp.asarray(action, dtype=jnp.int32))
+    action_array = jnp.asarray(action)
+    if action_array.shape != () or not jnp.issubdtype(action_array.dtype, jnp.integer):
+        raise ValueError("discrete action must be a scalar integer array")
+    action_index = action_array.astype(jnp.int32)
     return jax.nn.one_hot(action_index, n_actions, dtype=jnp.float32)
 
 

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -612,3 +612,9 @@ def test_action_features_accepts_numpy_ints_and_omitted_width() -> None:
     chex.assert_trees_all_close(one_hot, jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32))
     raw = action_features(action)
     chex.assert_trees_all_close(raw, jnp.array([1.0], dtype=jnp.float32))
+
+
+@pytest.mark.unit
+def test_action_features_rejects_fractional_discrete_action() -> None:
+    with pytest.raises(ValueError, match="scalar integer array"):
+        action_features(jnp.asarray(1.75, dtype=jnp.float32), 3)


### PR DESCRIPTION
Closes #1075.

## What changed

`action_features` silently converted a fractional discrete action to `int32` before one-hot encoding it - the same dtype-laundering bug class already fixed in `behavior_model.py`'s `_integer_action_ids` (#1049/#1051), independently present here too. `imagined_transition_to_supervised_item` calls this with `n_actions` set, so a malformed dream action could corrupt the action features used for supervised world-model training.

## Fix

Require the action to be a scalar integer-typed array before converting to `int32`, when discrete encoding is selected via `n_actions`. Continuous/raw action features (`n_actions` omitted) are unchanged. Dropping the prior `jnp.squeeze` in favor of an explicit `shape != ()` check is intentional, not incidental: the only real production caller (`ImaginedTransition.action`, one action per transition, alongside sibling scalar fields like `reward`/`discount`) and the existing `test_action_features_accepts_numpy_ints_and_omitted_width` test both already only ever pass a scalar - nothing relied on squeeze reducing a non-scalar shape.

## Reachability

`action_features` and `imagined_transition_to_supervised_item` are both exported from `alberta_framework/core/__init__.py`'s `__all__` and top-level `alberta_framework/__init__.py`'s `__all__`, callable directly as `from alberta_framework import action_features` with non-hardcoded input.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
action_features(1.75, 3) = [0.0, 1.0, 0.0]
```

- new test `test_action_features_rejects_fractional_discrete_action`.
- mutation check: reverted just the source fix, reran the new test -> `Failed: DID NOT RAISE ValueError`. restored -> passes.
- full file: `78 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the laundering myself against the unpatched code, ran the full mutation check myself, reran the full test file/lint/mypy, re-traced reachability against both export lists, and specifically checked whether dropping `jnp.squeeze` for a strict scalar-shape check could regress any real caller (traced `ImaginedTransition`'s field shapes and the existing numpy-int test - confirmed scalar-only usage throughout, no regression).

Attribution status: self-reported.
