### PR TITLE
fix(matched-executor): reject non-finite configuration copies

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -2229,7 +2229,15 @@ def _replay_configuration_transforms(candidate: MatchedCandidate, original: byte
     if not transforms:
         return original
     decoded = _object(decode_strict_json(original), "original candidate configuration")
-    expected_configuration = cast(dict[str, Any], json.loads(json.dumps(decoded)))
+    try:
+        expected_configuration = cast(
+            dict[str, Any],
+            json.loads(json.dumps(decoded, allow_nan=False)),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ForagerMatchedExecutorError(
+            "original configuration is not finite canonical JSON"
+        ) from exc
     transformed = original
     for transform in transforms:
         if (

--- a/tests/test_forager_matched_executor.py
+++ b/tests/test_forager_matched_executor.py
@@ -36,7 +36,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
 from io import BytesIO
 from pathlib import Path, PurePosixPath
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from typing import Any, NoReturn, cast
 
 import pytest
@@ -1039,6 +1039,53 @@ def test_replay_uses_frozen_open_builder_transforms_including_search_oracle() ->
             original,
         )
         assert hashlib.sha256(replayed).hexdigest() == derived_sha256
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_replay_configuration_transforms_rejects_nonfinite_copy(
+    monkeypatch: pytest.MonkeyPatch, invalid: float
+) -> None:
+    """Host-boundary transform copies must not launder NaN/Inf through json.dumps."""
+
+    candidate = SimpleNamespace(
+        configuration=SimpleNamespace(
+            allowed_transforms=(
+                SimpleNamespace(
+                    transform_type="byte_preserving_unique_literal_replacement",
+                    value_type="integer",
+                    value=2,
+                    target="total_steps",
+                ),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        executor, "decode_strict_json", lambda raw: {"total_steps": invalid}
+    )
+    with pytest.raises(
+        executor.ForagerMatchedExecutorError,
+        match="finite canonical JSON",
+    ):
+        executor._replay_configuration_transforms(candidate, b'{"total_steps": 1}')
+
+
+def test_replay_configuration_transforms_keeps_finite_configuration_copy() -> None:
+    candidate = SimpleNamespace(
+        configuration=SimpleNamespace(
+            allowed_transforms=(
+                SimpleNamespace(
+                    transform_type="byte_preserving_unique_literal_replacement",
+                    value_type="integer",
+                    value=2,
+                    target="total_steps",
+                ),
+            )
+        )
+    )
+    rewritten = executor._replay_configuration_transforms(
+        candidate, b'{"total_steps": 1}'
+    )
+    assert b'"total_steps": 2' in rewritten or b'"total_steps":2' in rewritten
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1077.


## What changed

Matched-executor now fails closed on non-finite configuration-copy identities.

On origin/main `65ebb9f`, `decode_strict_json` already rejected `NaN`/`Infinity` tokens, but `_replay_configuration_transforms` copied the decoded host object via `json.dumps` without `allow_nan=False`. A Python object carrying non-finite floats therefore laundered through the integer-literal transform replay.

This is leftover tax on `forager_matched_executor.py`, not a republish of open `#1074` (`forager_matched_qualification.py`) or merged `#1044`/`#1045`/`#1062`.

## Scope

- `alberta_framework/benchmarks/forager_matched_executor.py`
- `tests/test_forager_matched_executor.py`

## Why this is unowned

Live occupancy at publish time: `#1073` rule-discovery, `#1074` matched-qualification, foreign `#1076` dreaming. These files were FREE.

## Verification

Exact candidate head: `62d6c404947e095325ab08510b19ec0de4ab96ec`
Base: `65ebb9f`

- Red on base: `json.dumps({"score": nan})` copies `nan`; `allow_nan=False` raises
- Focused pytest on the new identities + existing frozen-transform replay: 5 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:62d6c404947e095325ab08510b19ec0de4ab96ec -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
