### PR TITLE
fix(matched-seal): reject non-finite canonical scalars

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -126,7 +126,13 @@ def _plain(value: Any) -> Any:
         return result
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return [_plain(item) for item in value]
-    if value is None or type(value) in {str, bool, int, float}:
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ForagerMatchedSealError(
+                "canonical content contains a non-finite JSON number"
+            )
+        return value
+    if value is None or type(value) in {str, bool, int}:
         return value
     raise ForagerMatchedSealError(
         f"canonical content contains unsupported {type(value).__name__}"

--- a/tests/test_forager_matched_seal.py
+++ b/tests/test_forager_matched_seal.py
@@ -44,6 +44,25 @@ def _sha(label: str) -> str:
 _QUALIFICATION_MANIFEST_SHA256 = _sha("matched-current-qualification-manifest")
 
 
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_plain_rejects_nonfinite_number_identities(invalid: float) -> None:
+    """Seal canonicalization must not keep NaN/Inf as trusted JSON scalars."""
+
+    with pytest.raises(seal.ForagerMatchedSealError, match="non-finite JSON number"):
+        seal._plain(invalid)
+    with pytest.raises(seal.ForagerMatchedSealError, match="non-finite JSON number"):
+        seal._plain({"score": invalid})
+
+
+def test_plain_keeps_finite_canonical_scalars() -> None:
+    assert seal._plain({"score": 1.25, "ok": True, "n": 2}) == {
+        "score": 1.25,
+        "ok": True,
+        "n": 2,
+    }
+    assert seal.canonical_json_bytes({"score": 1.25}) == b'{"score":1.25}'
+
+
 def _canonical_sha(value: dict[str, Any]) -> str:
     return hashlib.sha256(executor.canonical_json_bytes(value)).hexdigest()
 


### PR DESCRIPTION
Closes #1078.


## What changed

Matched-seal now fails closed on non-finite canonical scalar identities.

On origin/main `65ebb9f`, `canonical_json_bytes` already dumped with `allow_nan=False`, but `_plain` accepted `float` including `NaN`/`Inf`. In-memory canonicalization and equality could therefore keep non-finite identities.

This is leftover tax on `forager_matched_seal.py`, not a republish of open `#1074` (`forager_matched_qualification.py`) or merged `#1044`/`#1045`/`#1062`.

## Scope

- `alberta_framework/benchmarks/forager_matched_seal.py`
- `tests/test_forager_matched_seal.py`

## Why this is unowned

Live occupancy at publish time: `#1073` rule-discovery, `#1074` matched-qualification, foreign `#1076` dreaming. These files were FREE.

## Verification

Exact candidate head: `1ef1586c65275d2d7d5e244913be620fb3ba641d`
Base: `65ebb9f`

- Red on base: `_plain(nan/inf/-inf)` returns the float; dump already fail-closed
- Focused pytest on the new identities: 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:1ef1586c65275d2d7d5e244913be620fb3ba641d -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
