### PR TITLE
fix(average-reward): reject fractional external SARSA actions

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -2115,7 +2115,11 @@ class DifferentialSARSAAgent:
         in their own fail-closed diagnostics.
         """
         observation_f = jnp.asarray(observation, dtype=jnp.float32)
-        action_i = jnp.asarray(action, dtype=jnp.int32)
+        action_i = jnp.asarray(action)
+        if action_i.shape != ():
+            raise ValueError("differential SARSA action must be scalar")
+        if action_i.dtype != jnp.dtype(jnp.int32):
+            raise TypeError("differential SARSA action must have dtype int32")
         return (
             state.replace(
                 last_observation=observation_f,

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -707,6 +707,18 @@ def test_differential_sarsa_config_roundtrip_and_exact_td_error() -> None:
     chex.assert_trees_all_close(result.average_reward, state.average_reward)
 
 
+def test_differential_sarsa_start_with_action_rejects_fractional_action() -> None:
+    agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=3))
+    state = agent.init(2, jr.key(0))
+
+    with pytest.raises(TypeError, match="action must have dtype int32"):
+        agent.start_with_action(
+            state,
+            jnp.array([1.0, 0.0], dtype=jnp.float32),
+            jnp.array(1.75, dtype=jnp.float32),
+        )
+
+
 def test_differential_sarsa_update_and_scan_are_finite() -> None:
     agent = DifferentialSARSAAgent(
         DifferentialSARSAConfig(


### PR DESCRIPTION
Closes #1082.

## What changed

`DifferentialSARSAAgent.start_with_action` documents that it never reinterprets an externally selected action, but converted every input with `jnp.asarray(action, dtype=jnp.int32)` before validation - the same dtype-laundering class already fixed in `behavior_model.py` (#1049/#1051) and `dreaming.py` (#1075/#1076), independently present a third time here. A fractional action such as float32 `1.75` was silently stored as action `1`, and the next SARSA update treated that truncated action as valid, corrupting measurement rather than rejecting the invalid input.

## Fix

Require the supplied action to be a scalar `int32`. This deliberately matches the explicit-action contract `update()` already enforces on its own `next_action` parameter in this same class - identical shape check, identical exact-`int32`-equality check (not a broader `issubdtype` check, unlike the sibling fixes in other files), and matching error wording. Confirmed by reading `update()`'s own `next_action` validation directly: this brings `start_with_action` in line with an established local convention rather than introducing an inconsistent one.

## Reachability

`DifferentialSARSAAgent` is exported from `alberta_framework/core/__init__.py`'s `__all__` and top-level `alberta_framework/__init__.py`'s `__all__`. `start_with_action` is a public method accepting caller-provided actions, with no internal repo caller found (excluding the evaluation directory and tests) - directly reachable by external API consumers rather than through an in-tree benchmark path.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
supplied=1.75 stored_action: 1 state.last_action: 1
```

- new test `test_differential_sarsa_start_with_action_rejects_fractional_action`.
- mutation check: reverted just the source fix, reran the new test -> `Failed: DID NOT RAISE TypeError`. restored -> passes.
- full file: `98 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the truncation myself against the unpatched code (correcting my own first attempt's wrong assumption about `start_with_action`'s return type - it returns a `(state, action)` tuple, not a bare state), ran the full mutation check myself, reran the full test file/lint/mypy, re-traced reachability against both export lists, and specifically confirmed the fix's stricter exact-dtype check (vs. the `issubdtype`-based pattern used in the sibling `behavior_model.py`/`dreaming.py` fixes) by reading `update()`'s own `next_action` validation directly - it's not an inconsistency, it matches an already-established local convention in this exact class.

Attribution status: self-reported.
