### PR TITLE
fix(scale-robust-feature): reject leftover measurement-record identities

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -209,6 +209,48 @@ EXPECTED_MEMORY: dict[str, dict[str, int | bool]] = {
 }
 
 
+def _nonnegative_int(value: object, *, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _optional_finite_float(value: object, *, name: str) -> float | None:
+    if value is None:
+        return None
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number or None")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number or None")
+    return numeric
+
+
+def _finite_float(value: object, *, name: str) -> float:
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number")
+    return numeric
+
+
+def _integer_pairs(
+    value: object, *, name: str
+) -> tuple[tuple[int, int], ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be an exact tuple")
+    pairs: list[tuple[int, int]] = []
+    for index, pair in enumerate(value):
+        if type(pair) is not tuple or len(pair) != 2:
+            raise ValueError(f"{name}[{index}] must be an exact integer pair")
+        left, right = pair
+        if type(left) is not int or type(right) is not int:
+            raise ValueError(f"{name}[{index}] must contain integers")
+        pairs.append((left, right))
+    return tuple(pairs)
+
+
 @dataclass(frozen=True)
 class PhaseWindowRecord:
     """Sufficient prequential-error statistics for one 3,000-step phase."""
@@ -225,6 +267,72 @@ class PhaseWindowRecord:
     asymptotic_squared_error_sum: float | None
     asymptotic_count: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        if type(self.phase_name) is not str:
+            raise ValueError("phase_name must be a string")
+        object.__setattr__(
+            self,
+            "step_count",
+            _nonnegative_int(self.step_count, name="step_count"),
+        )
+        object.__setattr__(
+            self,
+            "nonfinite_steps",
+            _nonnegative_int(self.nonfinite_steps, name="nonfinite_steps"),
+        )
+        object.__setattr__(
+            self,
+            "phase_squared_error_sum",
+            _optional_finite_float(
+                self.phase_squared_error_sum,
+                name="phase_squared_error_sum",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "early_squared_error_sum",
+            _optional_finite_float(
+                self.early_squared_error_sum,
+                name="early_squared_error_sum",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "early_count",
+            _nonnegative_int(self.early_count, name="early_count"),
+        )
+        object.__setattr__(
+            self,
+            "tail_squared_error_sum",
+            _optional_finite_float(
+                self.tail_squared_error_sum,
+                name="tail_squared_error_sum",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "tail_count",
+            _nonnegative_int(self.tail_count, name="tail_count"),
+        )
+        object.__setattr__(
+            self,
+            "asymptotic_squared_error_sum",
+            _optional_finite_float(
+                self.asymptotic_squared_error_sum,
+                name="asymptotic_squared_error_sum",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "asymptotic_count",
+            _nonnegative_int(self.asymptotic_count, name="asymptotic_count"),
+        )
+
 
 @dataclass(frozen=True)
 class ConditionSeedRecord:
@@ -237,6 +345,36 @@ class ConditionSeedRecord:
     end_segment_7_active_pairs: tuple[tuple[int, int], ...]
     final_active_pairs: tuple[tuple[int, int], ...]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "seed", _nonnegative_int(self.seed, name="seed"))
+        if type(self.condition) is not str:
+            raise ValueError("condition must be a string")
+        if type(self.phases) is not tuple:
+            raise TypeError("phases must be an exact tuple")
+        if any(type(phase) is not PhaseWindowRecord for phase in self.phases):
+            raise TypeError("phases must contain PhaseWindowRecord values")
+        object.__setattr__(
+            self,
+            "end_segment_5_active_pairs",
+            _integer_pairs(
+                self.end_segment_5_active_pairs,
+                name="end_segment_5_active_pairs",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "end_segment_7_active_pairs",
+            _integer_pairs(
+                self.end_segment_7_active_pairs,
+                name="end_segment_7_active_pairs",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "final_active_pairs",
+            _integer_pairs(self.final_active_pairs, name="final_active_pairs"),
+        )
+
 
 @dataclass(frozen=True)
 class ScaleRobustFeatureReport:
@@ -246,6 +384,35 @@ class ScaleRobustFeatureReport:
     records: tuple[ConditionSeedRecord, ...]
     memory_by_condition: Mapping[str, Mapping[str, int | bool]]
     wall_time_seconds_by_condition: Mapping[str, float]
+
+    def __post_init__(self) -> None:
+        if type(self.seeds) is not tuple:
+            raise TypeError("seeds must be an exact tuple")
+        object.__setattr__(
+            self,
+            "seeds",
+            tuple(
+                _nonnegative_int(seed, name=f"seeds[{index}]")
+                for index, seed in enumerate(self.seeds)
+            ),
+        )
+        if type(self.records) is not tuple:
+            raise TypeError("records must be an exact tuple")
+        if any(type(record) is not ConditionSeedRecord for record in self.records):
+            raise TypeError("records must contain ConditionSeedRecord values")
+        if not isinstance(self.wall_time_seconds_by_condition, Mapping):
+            raise TypeError("wall_time_seconds_by_condition must be a mapping")
+        object.__setattr__(
+            self,
+            "wall_time_seconds_by_condition",
+            {
+                name: _finite_float(
+                    value,
+                    name=f"wall_time_seconds_by_condition[{name}]",
+                )
+                for name, value in self.wall_time_seconds_by_condition.items()
+            },
+        )
 
 
 def frozen_stream_config() -> GauntletConfig:

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -17,14 +17,21 @@ computation starts, so they stay fast: a rejection must be raised before the
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from alberta_framework._seed_validation import JAX_KEY_SEED_MAX
 from alberta_framework.evaluation.scale_robust_feature import (
+    CONDITION_PRIMARY,
     DEVELOPMENT_SEEDS,
     EVIDENCE_SEEDS,
+    ConditionSeedRecord,
+    PhaseWindowRecord,
+    ScaleRobustFeatureReport,
     run_scale_robust_feature_evaluation,
 )
+from alberta_framework.evaluation.scale_robust_feature_artifact import _phase_payload
 
 
 class _ProtocolStartedError(Exception):
@@ -124,3 +131,84 @@ def test_canonical_evidence_and_development_seeds_pass_validation() -> None:
         run_scale_robust_feature_evaluation(seeds=EVIDENCE_SEEDS)
     with pytest.raises(_ProtocolStartedError):
         run_scale_robust_feature_evaluation(seeds=DEVELOPMENT_SEEDS)
+
+
+def _legal_phase(**overrides: object) -> PhaseWindowRecord:
+    payload: dict[str, object] = {
+        "phase_index": 0,
+        "phase_name": "scale",
+        "step_count": 1,
+        "nonfinite_steps": 0,
+        "phase_squared_error_sum": 1.0,
+        "early_squared_error_sum": 1.0,
+        "early_count": 1,
+        "tail_squared_error_sum": 1.0,
+        "tail_count": 1,
+        "asymptotic_squared_error_sum": 1.0,
+        "asymptotic_count": 1,
+    }
+    payload.update(overrides)
+    return PhaseWindowRecord(**payload)  # type: ignore[arg-type]
+
+
+def test_phase_window_record_rejects_bool_and_nonfinite_identities() -> None:
+    """Public measurement records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="phase_index"):
+        _legal_phase(phase_index=True)
+    with pytest.raises(ValueError, match="step_count"):
+        _legal_phase(step_count=False)
+    with pytest.raises(ValueError, match="phase_squared_error_sum"):
+        _legal_phase(phase_squared_error_sum=float("nan"))
+    with pytest.raises(ValueError, match="early_squared_error_sum"):
+        _legal_phase(early_squared_error_sum=float("inf"))
+
+    legal = _legal_phase()
+    dumped = json.dumps(_phase_payload(legal), allow_nan=False)
+    assert '"phase_index": 0' in dumped
+    assert '"phase_index": true' not in dumped
+    assert _legal_phase(phase_squared_error_sum=None).phase_squared_error_sum is None
+
+
+def test_condition_seed_and_report_reject_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="seed"):
+        ConditionSeedRecord(
+            seed=True,  # type: ignore[arg-type]
+            condition=CONDITION_PRIMARY,
+            phases=(),
+            end_segment_5_active_pairs=(),
+            end_segment_7_active_pairs=(),
+            final_active_pairs=(),
+        )
+    with pytest.raises(ValueError, match="end_segment_5_active_pairs"):
+        ConditionSeedRecord(
+            seed=8,
+            condition=CONDITION_PRIMARY,
+            phases=(),
+            end_segment_5_active_pairs=((True, 1),),  # type: ignore[arg-type]
+            end_segment_7_active_pairs=(),
+            final_active_pairs=(),
+        )
+    with pytest.raises(ValueError, match="seeds"):
+        ScaleRobustFeatureReport(
+            seeds=(True,),  # type: ignore[arg-type]
+            records=(),
+            memory_by_condition={},
+            wall_time_seconds_by_condition={CONDITION_PRIMARY: 1.0},
+        )
+    with pytest.raises(ValueError, match="wall_time_seconds_by_condition"):
+        ScaleRobustFeatureReport(
+            seeds=(8,),
+            records=(),
+            memory_by_condition={},
+            wall_time_seconds_by_condition={CONDITION_PRIMARY: float("nan")},
+        )
+
+    report = ScaleRobustFeatureReport(
+        seeds=(8,),
+        records=(),
+        memory_by_condition={},
+        wall_time_seconds_by_condition={CONDITION_PRIMARY: 1.25},
+    )
+    assert report.seeds == (8,)
+    assert report.wall_time_seconds_by_condition[CONDITION_PRIMARY] == 1.25


### PR DESCRIPTION
Closes #1084.


## What changed

Scale-robust measurement records now fail closed on leftover bool-as-int and non-finite identities.

On origin/main `5842ac3`, `run_scale_robust_feature_evaluation` already gated `seeds` via `require_unique_jax_seeds`, and the artifact validator later treated bools as missing via `_strict_int`. The public `PhaseWindowRecord` / `ConditionSeedRecord` / `ScaleRobustFeatureReport` constructors themselves accepted `True` / `NaN` / `Inf`. `_phase_payload` preserved them, so `json.dumps(..., allow_nan=False)` emitted `"phase_index": true` for a finite-float record.

This is leftover tax on `scale_robust_feature.py`, not a republish of merged `#1061`/`#1062`/`#1079`/`#1080` or foreign `#1064`.

## Scope

- `alberta_framework/evaluation/scale_robust_feature.py`
- `tests/test_scale_robust_feature.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `745f19598dc6c4d8edaf10c03bad7d334da4781a`
Base: `5842ac3`

- Red on base: `PhaseWindowRecord(phase_index=True, ...finite floats...)` accepted; `_phase_payload` dumped `"phase_index": true`
- Focused pytest on the new identities + existing seed-domain tests: 15 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:745f19598dc6c4d8edaf10c03bad7d334da4781a -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
