### PR TITLE
fix(recurring-ipmnist): reject leftover sentinel-requirement identities

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -270,6 +270,32 @@ class SentinelProbeRequirement:
     sentinel_set_sha256: str
     sentinel_case_count: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        object.__setattr__(
+            self,
+            "checkpoint_step",
+            _positive_int(self.checkpoint_step, name="checkpoint_step"),
+        )
+        _identifier(self.permutation_id, name="permutation_id", versioned=True)
+        _sha256(self.permutation_sha256, name="permutation_sha256")
+        object.__setattr__(
+            self,
+            "exposure_index",
+            _nonnegative_int(self.exposure_index, name="exposure_index"),
+        )
+        _identifier(self.sentinel_set_id, name="sentinel_set_id", versioned=True)
+        _sha256(self.sentinel_set_sha256, name="sentinel_set_sha256")
+        object.__setattr__(
+            self,
+            "sentinel_case_count",
+            _positive_int(self.sentinel_case_count, name="sentinel_case_count"),
+        )
+
     @property
     def ordering_key(self) -> tuple[int, int, str, int]:
         return (

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -12,6 +12,7 @@ from alberta_framework.evaluation.recurring_ipmnist_retention import (
     RecurringIPMNISTProtocol,
     RecurringIPMNISTTrace,
     SentinelProbeBinding,
+    SentinelProbeRequirement,
     SentinelProbeSnapshot,
     build_recurring_ipmnist_retention_report,
 )
@@ -337,6 +338,28 @@ def test_recurring_ipmnist_dataclasses_reject_booleans_and_non_integers() -> Non
             sentinel_set_sha256=_sha("2"),
             sentinel_case_count=2.5,  # type: ignore[arg-type]
         )
+    with pytest.raises(ValueError, match="phase_index"):
+        SentinelProbeRequirement(
+            phase_index=True,  # type: ignore[arg-type]
+            checkpoint_step=4,
+            permutation_id="permutation-a.v1",
+            permutation_sha256=_sha("a"),
+            exposure_index=0,
+            sentinel_set_id="sentinel-a.v1",
+            sentinel_set_sha256=_sha("2"),
+            sentinel_case_count=1,
+        )
+    with pytest.raises(ValueError, match="sentinel_case_count"):
+        SentinelProbeRequirement(
+            phase_index=0,
+            checkpoint_step=4,
+            permutation_id="permutation-a.v1",
+            permutation_sha256=_sha("a"),
+            exposure_index=0,
+            sentinel_set_id="sentinel-a.v1",
+            sentinel_set_sha256=_sha("2"),
+            sentinel_case_count=True,  # type: ignore[arg-type]
+        )
 
     class HostileInt(int):
         def __index__(self) -> int:
@@ -395,6 +418,23 @@ def test_recurring_ipmnist_dataclasses_accept_and_canonicalize_numpy_integers() 
     assert type(snapshot.checkpoint_step) is int
     assert type(snapshot.exposure_index) is int
     assert type(snapshot.to_config()["checkpoint_step"]) is int
+
+    requirement = SentinelProbeRequirement(
+        phase_index=np.int32(0),
+        checkpoint_step=np.uint16(4),
+        permutation_id="permutation-a.v1",
+        permutation_sha256=_sha("a"),
+        exposure_index=np.uint8(0),
+        sentinel_set_id="sentinel-a.v1",
+        sentinel_set_sha256=_sha("2"),
+        sentinel_case_count=np.int32(1),
+    )
+    assert type(requirement.phase_index) is int
+    assert type(requirement.checkpoint_step) is int
+    assert type(requirement.exposure_index) is int
+    assert type(requirement.sentinel_case_count) is int
+    assert type(requirement.to_config()["phase_index"]) is int
+    assert requirement.to_config()["phase_index"] is not True
 
 
 def test_recurring_ipmnist_phase_preflights_derived_stop_step() -> None:


### PR DESCRIPTION
Closes #1085.


## What changed

`SentinelProbeRequirement` now fails closed on leftover bool-as-int identities.

On origin/main `5842ac3`, `RecurringIPMNISTPhase`, `SentinelProbeBinding`, and `SentinelProbeSnapshot` already rejected `True` via `_nonnegative_int` / `_positive_int`. `SentinelProbeRequirement` was leftover: it accepted `phase_index=True` and `sentinel_case_count=True`, and `to_config()` dumped those bools as JSON `true`.

This is leftover tax on `recurring_ipmnist_retention.py`, not a republish of merged `#1061`/`#1062`/`#1079`/`#1080` or foreign `#1064`.

## Scope

- `alberta_framework/evaluation/recurring_ipmnist_retention.py`
- `tests/test_recurring_ipmnist_retention.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `9b2f268965983514a69e74d3a5417a73e1c64b88`
Base: `5842ac3`

- Red on base: `SentinelProbeRequirement(phase_index=True, ...)` accepted; `to_config()` dumped `"phase_index": true`
- Focused pytest on the new identities + existing leftover-tax tests: 16 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Summary

## Expected behavior

## Scope

## Verification

<!-- evidence-head:9b2f268965983514a69e74d3a5417a73e1c64b88 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
