### PR TITLE
fix(rtu-ppo): reject non-finite descriptor scalars

### DIFF
--- a/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
+++ b/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
@@ -19,6 +19,7 @@ import dataclasses
 import difflib
 import hashlib
 import json
+import math
 from collections.abc import Mapping, Sequence
 from types import MappingProxyType
 from typing import Any, Final, cast
@@ -227,7 +228,13 @@ def _unified_diff(upstream: bytes, derived: bytes) -> bytes:
 
 def _plain_json(value: Any, *, path: str = "descriptor") -> Any:
     """Return a detached JSON value from mutable or frozen containers."""
-    if value is None or isinstance(value, (str, bool, int, float)):
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise RTUPPORngIsolationError(
+                f"{path} contains a non-finite JSON number"
+            )
+        return value
+    if value is None or isinstance(value, (str, bool, int)):
         return value
     if isinstance(value, Mapping):
         result: dict[str, Any] = {}

--- a/tests/test_forager_rtu_ppo_rng_isolation.py
+++ b/tests/test_forager_rtu_ppo_rng_isolation.py
@@ -526,3 +526,28 @@ def test_public_runtime_probe_rejects_frozen_schedule_drift(
         match="public environment key trace differs",
     ):
         isolation.run_public_rng_isolation_probe(source)
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_plain_json_rejects_nonfinite_number_identities(invalid: float) -> None:
+    """RNG-isolation descriptors must not keep NaN/Inf as trusted JSON scalars."""
+
+    with pytest.raises(
+        isolation.RTUPPORngIsolationError,
+        match="non-finite JSON number",
+    ):
+        isolation._plain_json(invalid)
+    with pytest.raises(
+        isolation.RTUPPORngIsolationError,
+        match="non-finite JSON number",
+    ):
+        isolation._plain_json({"score": invalid})
+
+
+def test_plain_json_keeps_finite_canonical_scalars() -> None:
+    assert isolation._plain_json({"score": 1.25, "ok": True, "n": 2}) == {
+        "score": 1.25,
+        "ok": True,
+        "n": 2,
+    }
+    assert isolation._canonical_json({"score": 1.25}) == b'{"score":1.25}'


### PR DESCRIPTION
Closes #1088.

## What changed

RTU/PPO RNG-isolation now fails closed on non-finite descriptor scalar identities.

On origin/main `5842ac3`, `_canonical_json` already dumped with `allow_nan=False`, but `_plain_json` accepted `float` including `NaN`/`Inf`. In-memory canonicalization and equality could therefore keep non-finite identities.

This is leftover tax on `forager_rtu_ppo_rng_isolation.py`, not a republish of merged `#1079`/`#1080` or open `#1086`/`#1087`.

## Scope

- `alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py`
- `tests/test_forager_rtu_ppo_rng_isolation.py`

## Why this is unowned

Live occupancy at publish time: `#1086` scale-robust-feature, `#1087` recurring-ipmnist, foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `61b1fd412a32da1032a9227fadc4b54904f7112d`
Base: `5842ac3`

- Red on base: `_plain_json(nan/inf/-inf)` returns the float; dump already fail-closed
- Focused pytest on the new identities: 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:61b1fd412a32da1032a9227fadc4b54904f7112d -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
