### PR TITLE
fix(matched-campaign): reject non-finite canonical scalars

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -230,6 +230,10 @@ def _plain(value: Any) -> Any:
         return [_plain(item) for item in value]
     if isinstance(value, list):
         return [_plain(item) for item in value]
+    if type(value) is float and not math.isfinite(value):
+        raise ForagerMatchedCampaignError(
+            "canonical content contains a non-finite JSON number"
+        )
     return value
 
 

--- a/tests/test_forager_matched_campaign.py
+++ b/tests/test_forager_matched_campaign.py
@@ -1427,3 +1427,28 @@ def test_campaign_and_qualification_console_scripts_are_registered() -> None:
     assert scripts["alberta-forager-matched-qualification"] == (
         "alberta_framework.benchmarks.forager_matched_qualification:main"
     )
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf")])
+def test_plain_rejects_nonfinite_number_identities(invalid: float) -> None:
+    """Campaign canonicalization must not keep NaN/Inf as trusted JSON scalars."""
+
+    with pytest.raises(
+        campaign.ForagerMatchedCampaignError,
+        match="non-finite JSON number",
+    ):
+        campaign._plain(invalid)
+    with pytest.raises(
+        campaign.ForagerMatchedCampaignError,
+        match="non-finite JSON number",
+    ):
+        campaign._plain({"score": invalid})
+
+
+def test_plain_keeps_finite_canonical_scalars() -> None:
+    assert campaign._plain({"score": 1.25, "ok": True, "n": 2}) == {
+        "score": 1.25,
+        "ok": True,
+        "n": 2,
+    }
+    assert campaign.canonical_json_bytes({"score": 1.25}) == b'{"score":1.25}'


### PR DESCRIPTION
Closes #1089.

## What changed

Matched-campaign now fails closed on non-finite canonical scalar identities.

On origin/main `5842ac3`, `canonical_json_bytes` already dumped with `allow_nan=False`, but `_plain` accepted `float` including `NaN`/`Inf`. In-memory canonicalization and equality could therefore keep non-finite identities.

This is leftover tax on `forager_matched_campaign.py`, not a republish of merged `#1079`/`#1080` or open `#1086`/`#1087`.

## Scope

- `alberta_framework/benchmarks/forager_matched_campaign.py`
- `tests/test_forager_matched_campaign.py`

## Why this is unowned

Live occupancy at publish time: `#1086` scale-robust-feature, `#1087` recurring-ipmnist, foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `e92218bb57789b37c6d4684fa4cc493921a33bf1`
Base: `5842ac3`

- Red on base: `_plain(nan/inf/-inf)` returns the float; dump already fail-closed
- Focused pytest on the new identities: 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e92218bb57789b37c6d4684fa4cc493921a33bf1 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
