### PR TITLE
fix(continual-ia): reject leftover interval and timing identities

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -23,6 +23,7 @@ feature discovery, or completion of the Alberta Plan.
 from __future__ import annotations
 
 import functools
+import math
 import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -108,6 +109,16 @@ def _require_integer(
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _finite_real(name: str, value: object) -> float:
+    """Reject leftover bool and non-finite identities without narrowing."""
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number")
+    return numeric
 
 
 def _require_derived_int32(name: str, value: int) -> None:
@@ -322,6 +333,33 @@ class PairedBootstrapInterval:
     sample_size: int
     method: str = "paired-percentile-bootstrap"
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(
+            self,
+            "confidence_level",
+            _finite_real("confidence_level", self.confidence_level),
+        )
+        object.__setattr__(
+            self,
+            "resamples",
+            _require_integer(
+                "resamples",
+                self.resamples,
+                minimum=1,
+                maximum=_MAX_BOOTSTRAP_RESAMPLES,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "sample_size",
+            _require_integer("sample_size", self.sample_size, minimum=1),
+        )
+        if type(self.method) is not str or not self.method:
+            raise ValueError("method must be a non-empty string")
+
 
 @dataclass(frozen=True)
 class ControllerBudget:
@@ -357,6 +395,16 @@ class ConditionTiming:
 
     wall_seconds: float
     mean_step_latency_ms: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "wall_seconds", _finite_real("wall_seconds", self.wall_seconds)
+        )
+        object.__setattr__(
+            self,
+            "mean_step_latency_ms",
+            _finite_real("mean_step_latency_ms", self.mean_step_latency_ms),
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_continual_ia_evidence.py
+++ b/tests/test_continual_ia_evidence.py
@@ -22,6 +22,7 @@ from alberta_framework.evaluation.continual_ia import (
     IAAcceptanceThresholds,
     IAConditionName,
     IAConditionResult,
+    PairedBootstrapInterval,
     aggregate_ia_evidence,
     condition_controller_budgets,
     evaluate_ia_acceptance,
@@ -31,6 +32,7 @@ from alberta_framework.evaluation.continual_ia import (
 from alberta_framework.evaluation.continual_ia_artifact import (
     PROTOCOL_VERSION,
     SCHEMA_VERSION,
+    _interval_payload,
     build_ia_evidence_artifact,
     ia_artifact_json,
     load_ia_evidence_artifact,
@@ -687,6 +689,57 @@ def test_controller_budget_rejects_hostile_or_out_of_domain_payloads() -> None:
         ControllerBudget(0, True, 1, 1, 1, False)
     with pytest.raises(ValueError, match="ia_attached"):
         ControllerBudget(0, 0, 1, 1, 1, 1)
+
+
+def _legal_interval(**overrides: object) -> PairedBootstrapInterval:
+    payload: dict[str, object] = {
+        "estimate": 0.1,
+        "lower": 0.0,
+        "upper": 0.2,
+        "confidence_level": 0.95,
+        "resamples": 1_000,
+        "sample_size": 30,
+    }
+    payload.update(overrides)
+    return PairedBootstrapInterval(**payload)  # type: ignore[arg-type]
+
+
+def test_paired_bootstrap_interval_rejects_leftover_identities() -> None:
+    """Public interval records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="resamples"):
+        _legal_interval(resamples=True)
+    with pytest.raises(ValueError, match="sample_size"):
+        _legal_interval(sample_size=False)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=True)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=float("nan"))
+    with pytest.raises(ValueError, match="lower"):
+        _legal_interval(lower=float("inf"))
+
+    legal = _legal_interval()
+    dumped = json.dumps(_interval_payload(legal), allow_nan=False)
+    assert '"resamples": 1000' in dumped
+    assert '"resamples": true' not in dumped
+    assert '"estimate": 0.1' in dumped
+
+
+def test_condition_timing_rejects_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="wall_seconds"):
+        ConditionTiming(wall_seconds=True, mean_step_latency_ms=0.0)
+    with pytest.raises(ValueError, match="mean_step_latency_ms"):
+        ConditionTiming(wall_seconds=0.0, mean_step_latency_ms=float("nan"))
+    timing = ConditionTiming(wall_seconds=1.25, mean_step_latency_ms=0.5)
+    dumped = json.dumps(
+        {
+            "wall_seconds": timing.wall_seconds,
+            "mean_step_latency_ms": timing.mean_step_latency_ms,
+        },
+        allow_nan=False,
+    )
+    assert '"wall_seconds": 1.25' in dumped
+    assert '"wall_seconds": true' not in dumped
 
 
 def test_bootstrap_and_run_work_preflights_fire_before_large_allocations() -> None:


### PR DESCRIPTION
Closes #1092.


## What changed

Continual-IA interval and timing records now fail closed on leftover bool-as-int and non-finite identities.

On origin/main `5842ac3`, `ContinualIAConfig` and `ControllerBudget` already gated ints via `_require_integer`. The public `PairedBootstrapInterval` / `ConditionTiming` constructors themselves accepted `True` / `NaN` / `Inf`. `_interval_payload` preserved them, so `json.dumps(..., allow_nan=False)` emitted `"resamples": true`, and `_finite_float(NaN)` silently wrote `null`. `estimate=True` became JSON `1.0`.

This is leftover tax on `continual_ia.py`, not a republish of `#1086`/`#1087`/`#1090`/`#1091` or foreign `#1083`.

## Scope

- `alberta_framework/evaluation/continual_ia.py`
- `tests/test_continual_ia_evidence.py`

## Why this is unowned

Live occupancy at publish time: `#1086` scale-robust, `#1087` recurring-ipmnist, `#1090` rtu-ppo, `#1091` matched-campaign, foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `62497539e3f28c7c0b4e6ab59d77ed364b15fe91`
Base: `5842ac3`

- Red on base: `PairedBootstrapInterval(resamples=True, ...)` accepted; `_interval_payload` dumped `"resamples": true`
- Focused pytest on the new identities + existing controller-budget test: 3 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:62497539e3f28c7c0b4e6ab59d77ed364b15fe91 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:62497539e3f28c7c0b4e6ab59d77ed364b15fe91 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
