### PR TITLE
fix(continual-multiagent): reject leftover measurement-record identities

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -32,6 +32,7 @@ solution.  All updates are predict-act-observe-update and use no replay.
 
 from __future__ import annotations
 
+import math
 import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -104,6 +105,16 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
+
+
+def _finite_real(name: str, value: object) -> float:
+    """Reject leftover bool and non-finite identities without narrowing."""
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number")
+    return numeric
 
 
 def _require_seed(value: object) -> int:
@@ -310,6 +321,18 @@ class ControllerBudget:
     state_bytes: int
     action_scalars_per_step: int
 
+    def __post_init__(self) -> None:
+        for name, minimum in (
+            ("state_scalars", 0),
+            ("state_bytes", 0),
+            ("action_scalars_per_step", 1),
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int32(name, getattr(self, name), minimum=minimum),
+            )
+
 
 @dataclass(frozen=True)
 class TimingMetrics:
@@ -319,6 +342,15 @@ class TimingMetrics:
     mean_step_latency_ms: float
     mean_update_latency_ms: float
     p95_update_latency_ms: float
+
+    def __post_init__(self) -> None:
+        for name in (
+            "wall_seconds",
+            "mean_step_latency_ms",
+            "mean_update_latency_ms",
+            "p95_update_latency_ms",
+        ):
+            object.__setattr__(self, name, _finite_real(name, getattr(self, name)))
 
 
 @dataclass(frozen=True)
@@ -332,6 +364,28 @@ class BootstrapInterval:
     resamples: int
     sample_size: int
     method: str = "paired-percentile-bootstrap"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(
+            self,
+            "confidence_level",
+            _finite_real("confidence_level", self.confidence_level),
+        )
+        object.__setattr__(
+            self,
+            "resamples",
+            _require_int32("resamples", self.resamples, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "sample_size",
+            _require_int32("sample_size", self.sample_size, minimum=1),
+        )
+        if type(self.method) is not str or not self.method:
+            raise ValueError("method must be a non-empty string")
 
 
 @dataclass(frozen=True)

--- a/tests/test_continual_multiagent_validation.py
+++ b/tests/test_continual_multiagent_validation.py
@@ -11,13 +11,19 @@ import pytest
 from alberta_framework.evaluation.continual_multiagent import (
     _MAX_CONFIGURED_ARRAY_NBYTES,
     AcceptanceThresholds,
+    BootstrapInterval,
     ContinualMultiAgentConfig,
+    ControllerBudget,
+    TimingMetrics,
     _bootstrap_working_nbytes,
     _condition_result_array_nbytes,
     _condition_working_nbytes,
     _world_array_nbytes,
     paired_bootstrap_mean_interval,
     run_continual_multiagent_benchmark,
+)
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    _interval_payload,
 )
 
 _INT32_MAX = 2**31 - 1
@@ -269,3 +275,68 @@ def test_default_configuration_and_thresholds_round_trip_through_canonical_json(
     threshold_payload = json.loads(json.dumps(asdict(AcceptanceThresholds()), sort_keys=True))
     assert ContinualMultiAgentConfig(**config_payload) == ContinualMultiAgentConfig()
     assert AcceptanceThresholds(**threshold_payload) == AcceptanceThresholds()
+
+
+def _legal_interval(**overrides: object) -> BootstrapInterval:
+    payload: dict[str, object] = {
+        "estimate": 0.1,
+        "lower": 0.0,
+        "upper": 0.2,
+        "confidence_level": 0.95,
+        "resamples": 1_000,
+        "sample_size": 30,
+    }
+    payload.update(overrides)
+    return BootstrapInterval(**payload)  # type: ignore[arg-type]
+
+
+def test_controller_budget_rejects_leftover_identities() -> None:
+    """Public resource records must not keep leftover bool-as-int identities."""
+
+    with pytest.raises(ValueError, match="state_scalars"):
+        ControllerBudget(True, 1, 1)
+    with pytest.raises(ValueError, match="state_bytes"):
+        ControllerBudget(1, False, 1)
+    with pytest.raises(ValueError, match="action_scalars_per_step"):
+        ControllerBudget(1, 1, True)
+    budget = ControllerBudget(8, 64, 2)
+    dumped = json.dumps(
+        {
+            "state_scalars": budget.state_scalars,
+            "state_bytes": budget.state_bytes,
+            "action_scalars_per_step": budget.action_scalars_per_step,
+        },
+        allow_nan=False,
+    )
+    assert '"state_scalars": 8' in dumped
+    assert '"state_scalars": true' not in dumped
+
+
+def test_bootstrap_interval_rejects_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="resamples"):
+        _legal_interval(resamples=True)
+    with pytest.raises(ValueError, match="sample_size"):
+        _legal_interval(sample_size=False)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=True)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=float("nan"))
+    with pytest.raises(ValueError, match="upper"):
+        _legal_interval(upper=float("inf"))
+
+    legal = _legal_interval()
+    dumped = json.dumps(_interval_payload(legal), allow_nan=False)
+    assert '"resamples": 1000' in dumped
+    assert '"resamples": true' not in dumped
+    assert '"estimate": 0.1' in dumped
+
+
+def test_timing_metrics_reject_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="wall_seconds"):
+        TimingMetrics(True, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError, match="mean_update_latency_ms"):
+        TimingMetrics(0.0, 0.0, float("nan"), 0.0)
+    timing = TimingMetrics(1.25, 0.5, 0.25, 0.75)
+    dumped = json.dumps({"wall_seconds": timing.wall_seconds}, allow_nan=False)
+    assert '"wall_seconds": 1.25' in dumped
+    assert '"wall_seconds": true' not in dumped


### PR DESCRIPTION
Closes #1093.


## What changed

Continual-multiagent measurement records now fail closed on leftover bool-as-int and non-finite identities.

On origin/main `5842ac3`, `ContinualMultiAgentConfig` already gated ints via `_require_int32`. The public `ControllerBudget` / `BootstrapInterval` / `TimingMetrics` constructors themselves accepted `True` / `NaN` / `Inf`. Artifact payloads preserved them, so `json.dumps(..., allow_nan=False)` emitted `"state_scalars": true` / `"resamples": true`, and `_finite_float(NaN)` silently wrote `null`.

This is leftover tax on `continual_multiagent.py`, not a republish of `#1086`/`#1087`/`#1090`/`#1091` or foreign `#1083`.

## Scope

- `alberta_framework/evaluation/continual_multiagent.py`
- `tests/test_continual_multiagent_validation.py`

## Why this is unowned

Live occupancy at publish time: `#1086` scale-robust, `#1087` recurring-ipmnist, `#1090` rtu-ppo, `#1091` matched-campaign, foreign `#1083` average-reward. These files were FREE.

## Verification

Exact candidate head: `b4ccb6c544bdb2d3a69f37791d2e548623ca7ade`
Base: `5842ac3`

- Red on base: `ControllerBudget(True, 1, 1)` accepted; JSON dumped `"state_scalars": true`
- Focused pytest on the new identities + existing config round-trip: 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:b4ccb6c544bdb2d3a69f37791d2e548623ca7ade -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b4ccb6c544bdb2d3a69f37791d2e548623ca7ade -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
