### PR TITLE
fix(ftl-decision-fidelity): reject leftover measurement-record identities

### DIFF
--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -106,6 +106,16 @@ def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
 
 
+def _finite_real(name: str, value: object) -> float:
+    """Reject leftover bool and non-finite identities without narrowing."""
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number")
+    return numeric
+
+
 def _require_derived_int32(name: str, value: int) -> int:
     if value > _INT32_MAX:
         raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
@@ -311,6 +321,20 @@ class DecisionMetrics:
     return_mae: float
     normalized_return_mae: float
 
+    def __post_init__(self) -> None:
+        if type(self.condition) is not str or not self.condition:
+            raise ValueError("condition must be a non-empty string")
+        for name in (
+            "normalized_regret",
+            "domain_a_normalized_regret",
+            "domain_b_normalized_regret",
+            "oracle_pick_rate",
+            "reward_mae",
+            "return_mae",
+            "normalized_return_mae",
+        ):
+            object.__setattr__(self, name, _finite_real(name, getattr(self, name)))
+
 
 @dataclass(frozen=True)
 class SeedDecisionResult:
@@ -334,6 +358,26 @@ class BootstrapEstimate:
     confidence_level: float
     resamples: int
     sample_size: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(
+            self,
+            "confidence_level",
+            _finite_real("confidence_level", self.confidence_level),
+        )
+        object.__setattr__(
+            self,
+            "resamples",
+            _require_int32("resamples", self.resamples, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "sample_size",
+            _require_int32("sample_size", self.sample_size, minimum=1),
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -19,7 +19,9 @@ from alberta_framework.evaluation.ftl_decision_fidelity import (
     CONDITION_NAMES,
     DEVELOPMENT_SEEDS,
     EVIDENCE_SEEDS,
+    BootstrapEstimate,
     DecisionFidelityConfig,
+    DecisionMetrics,
     evaluate_sparse_snapshot,
     precompute_decision_probes,
     run_ftl_decision_fidelity_evaluation,
@@ -451,3 +453,48 @@ def test_menu_resource_preflight_runs_before_element_hooks() -> None:
             horizon=2**31 - 1,
             menu_amplitudes=(hostile, hostile, hostile),  # type: ignore[arg-type]
         )
+
+
+def _legal_interval(**overrides: object) -> BootstrapEstimate:
+    payload: dict[str, object] = {
+        "estimate": 0.1,
+        "lower": 0.0,
+        "upper": 0.2,
+        "confidence_level": 0.95,
+        "resamples": 1_000,
+        "sample_size": 30,
+    }
+    payload.update(overrides)
+    return BootstrapEstimate(**payload)  # type: ignore[arg-type]
+
+
+def test_bootstrap_estimate_rejects_leftover_identities() -> None:
+    """Public interval records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="resamples"):
+        _legal_interval(resamples=True)
+    with pytest.raises(ValueError, match="sample_size"):
+        _legal_interval(sample_size=False)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=True)
+    with pytest.raises(ValueError, match="estimate"):
+        _legal_interval(estimate=float("nan"))
+    with pytest.raises(ValueError, match="upper"):
+        _legal_interval(upper=float("inf"))
+
+    legal = _legal_interval()
+    dumped = json.dumps(dataclasses.asdict(legal), allow_nan=False)
+    assert '"resamples": 1000' in dumped
+    assert '"resamples": true' not in dumped
+    assert '"estimate": 0.1' in dumped
+
+
+def test_decision_metrics_reject_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="normalized_regret"):
+        DecisionMetrics("sparse_after_b", True, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError, match="reward_mae"):
+        DecisionMetrics("sparse_after_b", 0.0, 0.0, 0.0, 0.0, float("nan"), 0.0, 0.0)
+    metrics = DecisionMetrics("sparse_after_b", 0.1, 0.0, 0.2, 0.5, 0.25, 0.3, 0.05)
+    dumped = json.dumps({"normalized_regret": metrics.normalized_regret}, allow_nan=False)
+    assert '"normalized_regret": 0.1' in dumped
+    assert '"normalized_regret": true' not in dumped


### PR DESCRIPTION
Closes #1097.

## What changed

FTL decision-fidelity measurement records now fail closed on leftover bool-as-int and non-finite identities.

On origin/main `4f77b27`, `DecisionFidelityConfig` already gated ints via `_require_int32`. The public `DecisionMetrics` / `BootstrapEstimate` constructors themselves accepted `True` / `NaN` / `Inf`. `dataclasses.asdict` preserved them, so `json.dumps(..., allow_nan=False)` emitted `"resamples": true` / `"estimate": true`, and a leftover `NaN` metric raised instead of failing closed at construction.

This is leftover tax on `ftl_decision_fidelity.py`, not a republish of `#1094`/`#1095`/`#1090`/`#1091`/`#1086`/`#1087` or foreign `#1083`.

## Scope

- `alberta_framework/evaluation/ftl_decision_fidelity.py`
- `tests/test_ftl_decision_fidelity.py`

## Why this is unowned

Live occupancy at publish time: ASI open = 0. `#1096` is Deepanshu array-runner truncation (actor_critic / horde / IA scan) — disjoint. These files were FREE.

## Verification

Exact candidate head: `8d8c55e4e478bfbd4f07d36ded425ceac09b6030`
Base: `4f77b27`

- Red on base: `BootstrapEstimate(resamples=True, ...)` accepted; dump emitted `"resamples": true`
- Focused pytest on the new identities (deselected: `thirty_seed`, `multi_step_sparse`, `recurring_visitation`, `raw_online_ridge`): 103 passed, 7 skipped, 4 deselected
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:8d8c55e4e478bfbd4f07d36ded425ceac09b6030 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
