### PR TITLE
fix(forager-rng-parity): reject leftover key and digest identities

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -197,6 +197,15 @@ class KeyFrame:
     next_key: tuple[int, int]
     environment_key: tuple[int, int]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "input_key", _require_key_words(self.input_key, "input_key"))
+        object.__setattr__(self, "next_key", _require_key_words(self.next_key, "next_key"))
+        object.__setattr__(
+            self,
+            "environment_key",
+            _require_key_words(self.environment_key, "environment_key"),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "input_key": list(self.input_key),
@@ -212,6 +221,23 @@ class TreeDigest:
     leaf_count: int
     structure_sha256: str
     content_sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "leaf_count",
+            _require_int(self.leaf_count, "leaf_count", minimum=1, maximum=100_000),
+        )
+        object.__setattr__(
+            self,
+            "structure_sha256",
+            _require_sha256(self.structure_sha256, "structure_sha256"),
+        )
+        object.__setattr__(
+            self,
+            "content_sha256",
+            _require_sha256(self.content_sha256, "content_sha256"),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -599,6 +625,15 @@ def _require_int(value: Any, path: str, *, minimum: int, maximum: int) -> int:
     if not minimum <= value <= maximum:
         raise ForagerRngParityError(f"{path} must lie in [{minimum}, {maximum}]")
     return value
+
+
+def _require_key_words(value: Any, path: str) -> tuple[int, int]:
+    if type(value) is not tuple or len(value) != 2:
+        raise ForagerRngParityError(f"{path} must contain exactly two words")
+    return (
+        _require_int(value[0], f"{path}[0]", minimum=0, maximum=_KEY_WORD_MAX),
+        _require_int(value[1], f"{path}[1]", minimum=0, maximum=_KEY_WORD_MAX),
+    )
 
 
 def _key_words(key: Any) -> tuple[int, int]:

--- a/tests/test_forager_rng_parity.py
+++ b/tests/test_forager_rng_parity.py
@@ -574,3 +574,31 @@ def test_result_round_trip_is_canonical_and_order_independent() -> None:
     parsed = parity.validate_parity_result(shuffled)
     assert parsed.canonical_bytes == parity.canonical_json_bytes(payload)
     assert parsed.payload_sha256 == payload["payload_sha256"]
+
+
+def test_key_frame_rejects_leftover_bool_identities() -> None:
+    """Public key-split records must not keep leftover bool-as-uint32 identities."""
+
+    with pytest.raises(parity.ForagerRngParityError, match="input_key"):
+        parity.KeyFrame((True, False), (0, 1), (2, 3))
+    with pytest.raises(parity.ForagerRngParityError, match="next_key"):
+        parity.KeyFrame((0, 1), (True, 0), (2, 3))
+    frame = parity.KeyFrame((0, 1), (2, 3), (4, 5))
+    dumped = json.dumps(frame.to_dict(), allow_nan=False)
+    assert '"input_key": [0, 1]' in dumped
+    assert "true" not in dumped
+
+
+def test_tree_digest_rejects_leftover_identities() -> None:
+    digest_a = hashlib.sha256(b"structure").hexdigest()
+    digest_b = hashlib.sha256(b"content").hexdigest()
+    with pytest.raises(parity.ForagerRngParityError, match="leaf_count"):
+        parity.TreeDigest(True, digest_a, digest_b)
+    with pytest.raises(parity.ForagerRngParityError, match="structure_sha256"):
+        parity.TreeDigest(1, "not-a-digest", digest_b)
+    with pytest.raises(parity.ForagerRngParityError, match="content_sha256"):
+        parity.TreeDigest(1, digest_a, float("nan"))  # type: ignore[arg-type]
+    digest = parity.TreeDigest(3, digest_a, digest_b)
+    dumped = json.dumps(digest.to_dict(), allow_nan=False)
+    assert '"leaf_count": 3' in dumped
+    assert '"leaf_count": true' not in dumped


### PR DESCRIPTION
Closes #1098.

## What changed

Forager RNG-parity key and digest records now fail closed on leftover bool-as-uint32 and leftover digest identities.

On origin/main `4f77b27`, the load path already gated key words and SHA-256 digests via `_require_int` / `_require_sha256`. The public `KeyFrame` / `TreeDigest` constructors themselves accepted `True` as a key word or `leaf_count`, and accepted a non-digest hash. `to_dict()` preserved them, so `json.dumps(..., allow_nan=False)` emitted `"leaf_count": true`.

This is leftover tax on `forager_rng_parity.py`, not a republish of `#1094`/`#1095`/`#1090`/`#1091`/`#1086`/`#1087` or foreign `#1083`.

## Scope

- `alberta_framework/benchmarks/forager_rng_parity.py`
- `tests/test_forager_rng_parity.py`

## Why this is unowned

Live occupancy at publish time: ASI open = 0. `#1096` is Deepanshu array-runner truncation (actor_critic / horde / IA scan) — disjoint. These files were FREE.

## Verification

Exact candidate head: `0296d3d4690c1e8921e8694873ca7c979d2084ce`
Base: `4f77b27`

- Red on base: `KeyFrame((True, False), ...)` and `TreeDigest(True, ...)` accepted
- Focused pytest `tests/test_forager_rng_parity.py`: 40 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-head:0296d3d4690c1e8921e8694873ca7c979d2084ce -->
<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
