### PR TITLE
fix(associative-memory): preserve row counts past float32 exact-integer limit

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -325,7 +325,7 @@ class AssociativeMemoryState:
     keys: Int[Array, "max_features key_width"]
     values: Float[Array, "max_features vocab_size"]
     utility: Float[Array, " max_features"]
-    counts: Float[Array, " max_features"]
+    counts: Int[Array, " max_features"]
     last_update: Int[Array, " max_features"]
     prior: Float[Array, " vocab_size"]
     family_logits: Float[Array, " family_count"]
@@ -648,7 +648,7 @@ class AssociativeMemoryLearner:
             ("state.keys", state.keys, (c.max_features, KEY_WIDTH), jnp.int32),
             ("state.values", state.values, (c.max_features, c.vocab_size), jnp.float32),
             ("state.utility", state.utility, (c.max_features,), jnp.float32),
-            ("state.counts", state.counts, (c.max_features,), jnp.float32),
+            ("state.counts", state.counts, (c.max_features,), jnp.int32),
             ("state.last_update", state.last_update, (c.max_features,), jnp.int32),
             ("state.prior", state.prior, (c.vocab_size,), jnp.float32),
             ("state.family_logits", state.family_logits, (FAMILY_COUNT,), jnp.float32),
@@ -694,7 +694,7 @@ class AssociativeMemoryLearner:
             ),
             values=jnp.zeros((c.max_features, c.vocab_size), dtype=jnp.float32),
             utility=jnp.zeros((c.max_features,), dtype=jnp.float32),
-            counts=jnp.zeros((c.max_features,), dtype=jnp.float32),
+            counts=jnp.zeros((c.max_features,), dtype=jnp.int32),
             last_update=jnp.zeros((c.max_features,), dtype=jnp.int32),
             prior=jnp.zeros((c.vocab_size,), dtype=jnp.float32),
             family_logits=jnp.zeros((FAMILY_COUNT,), dtype=jnp.float32),
@@ -1137,7 +1137,11 @@ class AssociativeMemoryLearner:
                 counts=jnp.where(
                     active_bool,
                     carry.counts.at[slot].set(
-                        jnp.where(found_scalar, carry.counts[slot] + 1.0, 1.0)
+                        jnp.where(
+                            found_scalar,
+                            _saturating_increment(carry.counts[slot]),
+                            jnp.asarray(1, dtype=jnp.int32),
+                        )
                     ),
                     carry.counts,
                 ),

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -229,7 +229,6 @@ def test_corrupted_active_family_logits_remain_fail_visible() -> None:
     [
         "values",
         "utility",
-        "counts",
         "prior",
         "family_logits",
         "window_logits",
@@ -254,8 +253,6 @@ def test_update_rejects_nonfinite_source_state_leaf(leaf: str) -> None:
         state = state.replace(values=state.values.at[0, 0].set(poison))
     elif leaf == "utility":
         state = state.replace(utility=state.utility.at[0].set(poison))
-    elif leaf == "counts":
-        state = state.replace(counts=state.counts.at[0].set(poison))
     elif leaf == "prior":
         state = state.replace(prior=state.prior.at[0].set(poison))
     elif leaf == "family_logits":
@@ -284,7 +281,7 @@ def test_array_runner_exposes_rejected_update_mask() -> None:
         AssociativeMemoryConfig(vocab_size=4, block_size=3, suffix_length=2, max_features=8)
     )
     state = learner.init().replace(
-        counts=learner.init().counts.at[0].set(jnp.asarray(jnp.inf, dtype=jnp.float32))
+        counts=learner.init().counts.at[0].set(jnp.asarray(-1, dtype=jnp.int32))
     )
     contexts = jnp.asarray([[1, 2, 3], [2, 3, 0]], dtype=jnp.int32)
     labels = jnp.asarray([1, 2], dtype=jnp.int32)
@@ -533,7 +530,35 @@ def test_evicted_row_is_reset_before_a_new_key_writes_into_it() -> None:
     chex.assert_trees_all_close(rows[:, 3], jnp.zeros((rows.shape[0],), dtype=jnp.float32))
     assert bool(jnp.all(rows[:, 1] > 0.0))
     assert int(jnp.argmax(prediction.logits)) == 1
-    chex.assert_trees_all_close(state.counts[slots], jnp.ones((rows.shape[0],), dtype=jnp.float32))
+    chex.assert_trees_all_equal(state.counts[slots], jnp.ones((rows.shape[0],), dtype=jnp.int32))
+
+
+def test_associative_row_counts_advance_past_float32_integer_limit() -> None:
+    learner = AssociativeMemoryLearner(
+        AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=2,
+            suffix_length=2,
+            feature_family="position_token",
+            max_features=2,
+        )
+    )
+    context = jnp.asarray([0, 1], dtype=jnp.int32)
+    label = jnp.asarray(2, dtype=jnp.int32)
+    state = learner.update(learner.init(), context, label).state
+    prediction = learner.predict(state, context)
+    active_slots = prediction.indices[prediction.feature_mask > 0]
+    state = state.replace(
+        counts=state.counts.at[active_slots].set(jnp.asarray(2**24, dtype=jnp.int32))
+    )
+
+    result = learner.update(state, context, label)
+
+    assert bool(result.update_applied)
+    chex.assert_trees_all_equal(
+        result.state.counts[active_slots],
+        jnp.full(active_slots.shape, 2**24 + 1, dtype=jnp.int32),
+    )
 
 
 def test_associative_adaptive_family_scope_prefers_useful_pairs() -> None:


### PR DESCRIPTION
Closes #1101.

## What changed

`AssociativeMemoryState.counts` was stored and incremented as `float32` - the same bug class already fixed this cycle in `reward_model.py` (#1018), `resource_manager.py` (#1066), and `compositional_features.py` (#1068), independently present in a fourth class here. At `2**24`, incrementing a float32 value no longer necessarily changes it, silently freezing per-row usage counts while the update still reports success.

## Fix

Move `counts` to `int32` throughout: the state dtype contract, zero-init, and the update increment, routed through the file's existing `_saturating_increment` helper (already used for `step_count` in this same class - clamps to `INT32_MAX - 1` before adding 1) rather than introducing a new one.

Two existing tests were adjusted for the dtype change: `test_update_rejects_nonfinite_source_state_leaf` no longer parametrizes over `counts` (NaN-poisoning doesn't apply to an int32 field), and `test_array_runner_exposes_rejected_update_mask` now poisons `counts` with an invalid negative int (`-1`) instead of `jnp.inf`, preserving the same "rejected update" coverage through a value shape that's actually meaningful for the new dtype.

## Reachability

`AssociativeMemoryLearner` is exported from both `alberta_framework/core/__init__.py`'s `__all__` and top-level `alberta_framework/__init__.py`'s `__all__` - fully public.

## Verification

confirmed the bug live against the unpatched code before fixing, via a real learner update flow (not synthetic state construction):
```text
before: [16777216.0, 16777216.0]
after:  [16777216.0, 16777216.0]
```

- new test `test_associative_row_counts_advance_past_float32_integer_limit`, driving a real `init` -> `update` -> `predict` -> forced-count -> `update` sequence and asserting the count becomes `2**24 + 1`.
- mutation check: reverted just the source fix, reran the new test -> fails with the exact stalled value (`16777216.0` vs expected `16777217`). restored -> passes.
- full file: `186 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter). The drafting session hit a transient AgentRouter transport failure (`stream disconnected before completion`, 5 failed reconnects) partway through and never wrote its own report or committed - I recovered the real, uncommitted diff from the working tree and independently verified the entire thing from scratch with no report to lean on: re-reproduced the stall myself against the unpatched code, ran the full mutation check, full test file, lint, mypy, reachability trace, and confirmed the two adjusted pre-existing tests are sound (not silently dropped coverage) before committing and pushing.

Attribution status: self-reported.
