### PR TITLE
fix(actor-critic): reject invalid fixed actions before narrowing to int32

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -904,6 +904,15 @@ def run_actor_critic_from_arrays(
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
         use_fixed_actions = False
     else:
+        try:
+            actions_dtype = np.dtype(actions.dtype)
+        except (AttributeError, TypeError) as error:
+            raise ValueError("actions must expose an integer dtype") from error
+        if not np.issubdtype(actions_dtype, np.integer):
+            raise ValueError("actions must have an integer dtype")
+        action_values = np.asarray(actions)
+        if not bool(np.all((action_values >= 0) & (action_values < agent.config.n_actions))):
+            raise ValueError("actions must lie in [0, n_actions)")
         actions = jnp.asarray(actions, dtype=jnp.int32)
         use_fixed_actions = True
 

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -261,6 +261,34 @@ def test_scan_validates_all_host_metadata_before_any_jax_conversion(
         )
 
 
+@pytest.mark.parametrize(
+    "actions, message",
+    [
+        (jnp.asarray([0.75], dtype=jnp.float32), "integer dtype"),
+        (jnp.asarray([-1], dtype=jnp.int32), r"\[0, n_actions\)"),
+        (jnp.asarray([2], dtype=jnp.int32), r"\[0, n_actions\)"),
+        (np.asarray([2**32], dtype=np.uint64), r"\[0, n_actions\)"),
+    ],
+)
+def test_discrete_scan_rejects_actions_that_cannot_name_policy_entries(
+    actions: Array,
+    message: str,
+) -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+
+    with pytest.raises(ValueError, match=message):
+        run_actor_critic_from_arrays(
+            agent,
+            state,
+            jnp.asarray([[1.0, 0.0]], dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            jnp.asarray([False]),
+            jnp.asarray([[0.0, 1.0]], dtype=jnp.float32),
+            actions=actions,
+        )
+
+
 @pytest.mark.parametrize("continuous", [False, True])
 def test_scan_requires_transition_semantics_before_jax_conversion(
     continuous: bool,


### PR DESCRIPTION
Closes #1103.

## What changed

`run_actor_critic_from_arrays` accepted externally supplied fixed actions for pre-collected logs and immediately converted them with `jnp.asarray(actions, dtype=jnp.int32)`, without validating dtype or range first. A fractional action such as `0.75` was silently truncated to action `0`, and the transition was then accepted and changed the actor weights. Negative, out-of-range, and large unsigned values could likewise reach policy indexing after narrowing, including `uint64(2**32)` wrapping to `int32(0)` - a genuinely different, more dangerous failure mode than pure fractional truncation, since a huge out-of-range value can wrap to *any* valid-looking action index with no visible sign of invalidity.

## Fix

Validate every action in its original dtype (integer dtype required, value in `[0, n_actions)`) before narrowing to `int32`. The range check runs on the pre-narrowing value, so it correctly rejects `uint64(2**32)` on its own terms rather than relying on narrowing/wraparound semantics.

## Reachability

`run_actor_critic_from_arrays` is exported from both `alberta_framework/core/__init__.py`'s `__all__` and top-level `alberta_framework/__init__.py`'s `__all__`. Its public `actions` argument is explicitly intended for arbitrary pre-collected behavior logs, so the failing input is reachable through a public entry point.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
input action: 0.75 -> reported action: 0, update applied: True, actor weights changed: True
```

- new parametrized test `test_discrete_scan_rejects_actions_that_cannot_name_policy_entries`, covering fractional dtype, negative, upper-bound, and pre-narrowing unsigned-wraparound inputs (4 cases, `n_actions=2`).
- mutation check: reverted just the source validation, reran the new test -> all 4 fail with `DID NOT RAISE ValueError`. restored -> all 4 pass.
- full file: `24 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the fractional-action laundering myself against the unpatched code, ran the full mutation check myself (all 4 parametrizations), reran the full test file/lint/mypy, and re-traced reachability against both export lists.

Attribution status: self-reported.
