### PR TITLE
fix(continual-metrics): reject leftover measurement-record identities

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -94,6 +94,10 @@ class StabilityGap:
     maximum: float
     per_step: NDArray[np.float64]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "mean", _require_finite_real("mean", self.mean))
+        object.__setattr__(self, "maximum", _require_finite_real("maximum", self.maximum))
+
 
 @dataclass(frozen=True)
 class ContinualLearningSummary:
@@ -115,6 +119,18 @@ class ContinualLearningSummary:
     per_task_final_performance: NDArray[np.float64]
     per_task_forgetting: NDArray[np.float64]
     per_task_backward_transfer: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        for name in (
+            "final_performance",
+            "prequential_performance",
+            "mean_forgetting",
+            "max_forgetting",
+            "backward_transfer",
+            "stability_gap_mean",
+            "stability_gap_max",
+        ):
+            object.__setattr__(self, name, _require_finite_real(name, getattr(self, name)))
 
 
 def _performance_matrix(

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
 from alberta_framework.utils.metrics import (
+    ContinualLearningSummary,
+    StabilityGap,
     compare_learners,
     compute_backward_transfer,
     compute_forward_transfer,
@@ -349,3 +353,53 @@ def test_stability_and_prequential_reject_boolean_identities() -> None:
     gap = compute_stability_gap([0.0, 1.0, 0.5], 1.0)
     np.testing.assert_allclose(gap.per_step, [1.0, 0.0, 0.5])
     assert compute_prequential_performance([0.0, 1.0]) == pytest.approx(0.5)
+
+
+def test_stability_gap_rejects_leftover_identities() -> None:
+    """Public gap records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="mean"):
+        StabilityGap(mean=True, maximum=0.0, per_step=np.array([0.0]))
+    with pytest.raises(ValueError, match="mean"):
+        StabilityGap(mean=float("nan"), maximum=0.0, per_step=np.array([0.0]))
+    with pytest.raises(ValueError, match="maximum"):
+        StabilityGap(mean=0.0, maximum=float("inf"), per_step=np.array([0.0]))
+
+    legal = StabilityGap(mean=0.1, maximum=0.2, per_step=np.array([0.1]))
+    dumped = json.dumps({"mean": legal.mean, "maximum": legal.maximum}, allow_nan=False)
+    assert '"mean": 0.1' in dumped
+    assert '"mean": true' not in dumped
+
+
+def _legal_continual_summary(**overrides: object) -> ContinualLearningSummary:
+    payload: dict[str, object] = {
+        "final_performance": 0.8,
+        "prequential_performance": 0.7,
+        "mean_forgetting": 0.1,
+        "max_forgetting": 0.2,
+        "backward_transfer": 0.0,
+        "stability_gap_mean": 0.05,
+        "stability_gap_max": 0.1,
+        "per_task_final_performance": np.array([0.8]),
+        "per_task_forgetting": np.array([0.1]),
+        "per_task_backward_transfer": np.array([0.0]),
+    }
+    payload.update(overrides)
+    return ContinualLearningSummary(**payload)  # type: ignore[arg-type]
+
+
+def test_continual_learning_summary_rejects_leftover_identities() -> None:
+    with pytest.raises(ValueError, match="final_performance"):
+        _legal_continual_summary(final_performance=True)
+    with pytest.raises(ValueError, match="mean_forgetting"):
+        _legal_continual_summary(mean_forgetting=float("nan"))
+    with pytest.raises(ValueError, match="stability_gap_max"):
+        _legal_continual_summary(stability_gap_max=float("inf"))
+
+    legal = _legal_continual_summary()
+    dumped = json.dumps(
+        {"final_performance": legal.final_performance},
+        allow_nan=False,
+    )
+    assert '"final_performance": 0.8' in dumped
+    assert '"final_performance": true' not in dumped


### PR DESCRIPTION
Closes #1105.

## What changed

Continual-learning measurement records now fail closed on leftover bool-as-float and non-finite identities.

On origin/main `0510754`, `compute_stability_gap` / `summarize_continual_learning` already gated leftover bool/NaN *inputs*. The public `StabilityGap` / `ContinualLearningSummary` constructors themselves accepted `True` / `NaN` / `Inf`. Direct construction kept them, so `json.dumps({"mean": gap.mean}, allow_nan=False)` emitted `"mean": true`, and a leftover `NaN` metric raised at dump time instead of failing closed at construction.

This is leftover tax on `utils/metrics.py`, not a republish of `#1099`/`#1095`/`#1086`/`#1087` or foreign `#1104`.

## Scope

- `alberta_framework/utils/metrics.py`
- `tests/test_continual_metrics.py`

## Why this is unowned

Live occupancy at publish time: ASI open = `#1104` (actor-critic fixed-action narrowing) + `#1096` (Deepanshu array-runner truncation). These files were FREE.

## Verification

Exact candidate head: `88313e0248e9b986f32df8acde7e09da9a7c2009`
Base: `0510754`

- Red on base: `StabilityGap(mean=True, ...)` accepted; dump emitted `"mean": true`
- Focused pytest `tests/test_continual_metrics.py`: 48 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/utils/metrics.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.



<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:88313e0248e9b986f32df8acde7e09da9a7c2009 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
