### PR TITLE
fix(historical-forager): reject leftover result-record identities

### DIFF
--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -872,6 +872,24 @@ class HistoricalForagerRunResult:
     runtime: Mapping[str, Any]
     kernel: Mapping[str, Any]
 
+    def __post_init__(self) -> None:
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise HistoricalForagerContractError("seed must be an integer")
+        if not 0 <= self.seed <= _MAX_SEED:
+            raise HistoricalForagerContractError(f"seed must lie in [0, {_MAX_SEED}]")
+        if isinstance(self.steps, bool) or not isinstance(self.steps, int):
+            raise HistoricalForagerContractError("steps must be an integer")
+        if not 1 <= self.steps <= _MAX_STEPS:
+            raise HistoricalForagerContractError(f"steps must lie in [1, {_MAX_STEPS}]")
+        if (
+            isinstance(self.aperture_size, bool)
+            or not isinstance(self.aperture_size, int)
+            or self.aperture_size not in range(1, 16, 2)
+        ):
+            raise HistoricalForagerContractError(
+                "aperture_size must be one of 1, 3, 5, 7, 9, 11, 13, 15"
+            )
+
     def to_dict(self) -> dict[str, Any]:
         """Return the canonical manifest payload."""
         provenance = historical_forager_provenance()

--- a/tests/test_historical_forager_reconstructed.py
+++ b/tests/test_historical_forager_reconstructed.py
@@ -22,6 +22,7 @@ from alberta_framework.benchmarks.historical_forager import (
     HistoricalForagerContractError,
     HistoricalForagerPairingIdentity,
     HistoricalForagerRunConfig,
+    HistoricalForagerRunResult,
     HistoricalUpdateKernel,
     assert_historical_artifacts_pairable,
     development_historical_environment_adapter,
@@ -593,3 +594,36 @@ def test_metric_rejects_nonfinite_or_unbounded_shapes() -> None:
         historical_fov_metrics(np.asarray([[1.0]]))
     with pytest.raises(HistoricalForagerContractError):
         historical_fov_metrics(np.asarray([math.nan]))
+
+
+def _legal_run_result(**overrides: object) -> HistoricalForagerRunResult:
+    payload: dict[str, object] = {
+        "seed": 0,
+        "aperture_size": 9,
+        "steps": 10,
+        "metrics": {"fov_last_10pct_ema_auc": 0.1},
+        "reward_sidecar": {"sha256": "a" * 64},
+        "environment_adapter": {"kind": "development"},
+        "runtime": {"python": "3.12"},
+        "kernel": {"name": "random"},
+    }
+    payload.update(overrides)
+    return HistoricalForagerRunResult(**payload)  # type: ignore[arg-type]
+
+
+def test_run_result_rejects_leftover_identities() -> None:
+    """Public historical result records must not keep leftover bool identities."""
+
+    with pytest.raises(HistoricalForagerContractError, match="seed"):
+        _legal_run_result(seed=True)
+    with pytest.raises(HistoricalForagerContractError, match="steps"):
+        _legal_run_result(steps=True)
+    with pytest.raises(HistoricalForagerContractError, match="aperture_size"):
+        _legal_run_result(aperture_size=True)
+
+    legal = _legal_run_result()
+    dumped = json.dumps(legal.to_dict()["run"], allow_nan=False)
+    assert '"seed": 0' in dumped
+    assert '"seed": true' not in dumped
+    assert '"steps": 10' in dumped
+    assert '"aperture_size": 9' in dumped


### PR DESCRIPTION
Closes #1106.

## What changed

Historical Forager result records now fail closed on leftover bool-as-int identities.

On origin/main `0510754`, `HistoricalForagerRunConfig` already rejected leftover bool seed/steps/aperture identities. The public `HistoricalForagerRunResult` constructor itself accepted `seed=True` / `steps=True` / `aperture_size=True`. `to_dict()["run"]` then emitted `"seed": true` into the historical manifest.

This is leftover tax on `historical_forager.py`, not a republish of `#1100`/`#1091`/`#1090` or foreign `#1104`.

## Scope

- `alberta_framework/benchmarks/historical_forager.py`
- `tests/test_historical_forager_reconstructed.py`

## Why this is unowned

Live occupancy at publish time: ASI open = `#1104` (actor-critic fixed-action narrowing) + `#1096` (Deepanshu array-runner truncation). These files were FREE.

## Verification

Exact candidate head: `ada84e0a6d75c960eb23be644de950a5683194bf`
Base: `0510754`

- Red on base: `HistoricalForagerRunResult(seed=True, ...)` accepted; dump emitted `"seed": true`
- Focused pytest `tests/test_historical_forager_reconstructed.py`: 36 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/benchmarks/historical_forager.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.



<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ada84e0a6d75c960eb23be644de950a5683194bf -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
