### PR TITLE
fix(swift-td): reject out-of-range TD discount factors

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -560,6 +560,8 @@ class SwiftTD:
             & jnp.all(jnp.isfinite(observation))
             & (next_observation_finite | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
+            & (gamma_scalar >= 0.0)
+            & (gamma_scalar <= 1.0)
         )
         update_applied = (
             self._state_is_valid(state)

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -724,3 +724,24 @@ def test_swift_td_invalid_adopted_scalar_domain_rolls_back() -> None:
     )
     assert not bool(result.update_applied)
     chex.assert_trees_all_equal(result.new_state, state)
+
+
+@pytest.mark.parametrize("gamma", (-0.5, 1.5))
+def test_swift_td_out_of_range_discount_rolls_back(gamma: float) -> None:
+    optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.9)
+    state = optimizer.init(3)
+    observation = jnp.ones((3,), dtype=jnp.float32)
+    result = jax.jit(optimizer.update)(
+        state,
+        jnp.asarray(1.0, dtype=jnp.float32),
+        observation,
+        observation,
+        jnp.asarray(gamma, dtype=jnp.float32),
+    )
+
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.new_state, state)
+    chex.assert_trees_all_equal(result.weight_delta, jnp.zeros_like(result.weight_delta))
+    chex.assert_trees_all_equal(result.bias_delta, jnp.zeros_like(result.bias_delta))
+    for value in result.metrics.values():
+        chex.assert_trees_all_equal(value, jnp.zeros_like(value))


### PR DESCRIPTION
Closes #1109.

## What changed

`SwiftTD.update` documents `gamma` as a TD discount factor but accepted every finite float32 value. A negative discount multiplied eligibility-side traces by a negative decay factor, flipping their sign while the update still reported `update_applied=True`; discounts above one could amplify traces beyond the configured lambda decay.

## Fix

Add the missing domain check (`0.0 <= gamma <= 1.0`) to the existing transactional `inputs_valid` predicate - the same gate already used for the file's other finite/domain checks (isfinite td_error/observation/gamma, the next_observation-finite-or-gamma-zero relationship). Out-of-range discounts now fail closed through the same existing rollback path (`select_transaction`/`neutralize_metrics`), exposing no state, weight, bias, or metric mutation.

## Reachability

`SwiftTD`, `SwiftTDState`, and `SwiftTDUpdate` are publicly exported from `alberta_framework/core/__init__.py`'s `__all__` (not re-exported from the top-level `alberta_framework/__init__.py`). `TDLinearLearner.update` calls its optimizer's `update` method with the transition's runtime `gamma`, so arbitrary caller-provided discounts reach the fixed code through the public `alberta_framework.core.SwiftTD` plus `TDLinearLearner` surface.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
gamma=-0.5 update_applied=True
gamma=1.5 update_applied=True
```

- new parametrized test `test_swift_td_out_of_range_discount_rolls_back`, covering both sides of the interval under JIT and asserting full transactional rollback (state, weight_delta, bias_delta, and every metric all unchanged/zeroed).
- mutation check: reverted just the two new domain-check clauses, reran the new test -> both parametrizations fail (`assert not True`). restored -> both pass.
- full file: `62 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the out-of-range acceptance myself against the unpatched code, ran the full mutation check myself (both parametrizations), reran the full test file/lint/mypy, and re-traced reachability against the export lists - confirming the report's precise claim that `SwiftTD` is core-only, not top-level-exported.

Attribution status: self-reported.
