### PR TITLE
fix(ipmnist): reject leftover result-record identities

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -101,6 +101,7 @@ import tempfile
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from numbers import Real
 from pathlib import Path
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -290,6 +291,40 @@ def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
     if number < minimum or number > _INT32_MAX:
         raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
     return number
+
+
+def _require_finite_real(name: str, value: object) -> float:
+    actual_type = type(value)
+    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    try:
+        number = float(cast(Real, value))
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    return number
+
+
+def _require_nonempty_string(name: str, value: object) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
+    if type(values) is bool:
+        raise ValueError(f"{name} must not be a boolean")
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of integer seeds")
+    try:
+        raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a sequence of integer seeds") from exc
+    return tuple(
+        require_jax_seed(value, name=f"{name}[{index}]")
+        for index, value in enumerate(raw)
+    )
 
 
 @dataclass(frozen=True)
@@ -786,6 +821,20 @@ class IPMNISTRunResult:
     permutations: np.ndarray | None = None
     example_indices: np.ndarray | None = None
     noise_mode: str = "step"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "learner", _require_nonempty_string("learner", self.learner))
+        object.__setattr__(self, "seeds", _require_seed_identities(self.seeds, name="seeds"))
+        object.__setattr__(
+            self,
+            "wall_clock_seconds",
+            _require_finite_real("wall_clock_seconds", self.wall_clock_seconds),
+        )
+        object.__setattr__(
+            self,
+            "noise_mode",
+            _require_nonempty_string("noise_mode", self.noise_mode),
+        )
 
 
 def resolve_hyperparameters(

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -21,6 +21,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     PARTIAL_SCHEMA,
     UPGD_W_PROTOCOL_HYPERPARAMETERS,
     IPMNISTConfig,
+    IPMNISTRunResult,
     LeanUPGDState,
     LearnerUpdateResult,
     _make_adamw_learner,
@@ -1136,3 +1137,52 @@ class TestSummariesAndComparison:
         )
         assert not clean["learners"]["upgd_w"]["reproduction_gap_flagged"]
         assert clean["reference"] is PAPER_REFERENCE
+
+
+def _legal_ipmnist_run_result(**overrides: object) -> IPMNISTRunResult:
+    payload: dict[str, object] = {
+        "learner": "adamw",
+        "hyperparameters": dict(ADAMW_PROTOCOL_HYPERPARAMETERS),
+        "seeds": (0,),
+        "config": TINY,
+        "per_task_accuracy": np.zeros((1, TINY.n_tasks)),
+        "per_task_loss": np.zeros((1, TINY.n_tasks)),
+        "per_task_plasticity": np.zeros((1, TINY.n_tasks)),
+        "average_online_accuracy": np.zeros((1,)),
+        "wall_clock_seconds": 1.0,
+    }
+    payload.update(overrides)
+    return IPMNISTRunResult(**payload)  # type: ignore[arg-type]
+
+
+def test_ipmnist_run_result_rejects_leftover_identities() -> None:
+    """Public IPMNIST result records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_ipmnist_run_result(wall_clock_seconds=True)
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_ipmnist_run_result(wall_clock_seconds=float("nan"))
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_ipmnist_run_result(wall_clock_seconds=float("inf"))
+    with pytest.raises(ValueError, match="learner"):
+        _legal_ipmnist_run_result(learner=True)
+    with pytest.raises(ValueError, match="seeds"):
+        _legal_ipmnist_run_result(seeds=(True,))
+    with pytest.raises(ValueError, match="noise_mode"):
+        _legal_ipmnist_run_result(noise_mode=True)
+
+    legal = _legal_ipmnist_run_result()
+    dumped = json.dumps(
+        {
+            "learner": legal.learner,
+            "seeds": list(legal.seeds),
+            "wall_clock_seconds": legal.wall_clock_seconds,
+            "noise_mode": legal.noise_mode,
+        },
+        allow_nan=False,
+    )
+    assert '"wall_clock_seconds": 1.0' in dumped
+    assert '"wall_clock_seconds": true' not in dumped
+    assert '"learner": true' not in dumped
+    assert '"seeds": [true]' not in dumped
+    assert '"noise_mode": true' not in dumped


### PR DESCRIPTION
Closes #1111.

## What changed

IPMNIST result records now fail closed on leftover bool-as-float, bool-as-string, bool-as-seed, and non-finite identities.

On origin/main `e8cea0e`, `IPMNISTConfig` already gated leftover bool/non-int protocol fields. The public `IPMNISTRunResult` constructor itself accepted `wall_clock_seconds=True` / `NaN` / `Inf`, `learner=True`, `seeds=(True,)`, and `noise_mode=True`. Direct construction kept them, so `json.dumps({"wall_clock_seconds": result.wall_clock_seconds}, allow_nan=False)` emitted `"wall_clock_seconds": true`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `upgd_ipmnist.py`, not a republish of `#1107`/`#1108`/`#1100`/`#1099` or foreign `#1110`.

## Scope

- `alberta_framework/benchmarks/upgd_ipmnist.py`
- `tests/test_upgd_ipmnist.py`

## Why this is unowned

Live occupancy at publish time: ASI open = `#1110` (swift-td discount range). These files were FREE.

## Verification

Exact candidate head: `d4491251f1f32e2725a24dbbb6285e6825c6ca5b`
Base: `e8cea0e`

- Red on base: `IPMNISTRunResult(wall_clock_seconds=True, ...)` accepted; dump emitted `"wall_clock_seconds": true`
- Focused pytest `tests/test_upgd_ipmnist.py`: 116 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/benchmarks/upgd_ipmnist.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.



<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d4491251f1f32e2725a24dbbb6285e6825c6ca5b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
