### PR TITLE
fix(micro-continual): reject leftover result-record identities

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -951,6 +951,11 @@ class MicroRunResult:
     wall_clock_seconds: float
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "family",
+            _require_nonempty_string(self.family, context="MicroRunResult.family"),
+        )
         _require_nonempty_string(self.arm_name, context="MicroRunResult.arm_name")
         _require_nonempty_string(self.mechanism, context="MicroRunResult.mechanism")
         object.__setattr__(
@@ -958,6 +963,31 @@ class MicroRunResult:
             "hyperparameters",
             _freeze_micro_hyperparameters(
                 self.hyperparameters, context="MicroRunResult.hyperparameters"
+            ),
+        )
+        object.__setattr__(
+            self, "seed", require_jax_seed(self.seed, name="MicroRunResult.seed")
+        )
+        object.__setattr__(
+            self,
+            "hidden1",
+            _require_positive_int32(self.hidden1, name="MicroRunResult.hidden1"),
+        )
+        object.__setattr__(
+            self,
+            "hidden2",
+            _require_positive_int32(self.hidden2, name="MicroRunResult.hidden2"),
+        )
+        object.__setattr__(
+            self,
+            "overall_accuracy",
+            _require_finite_real(self.overall_accuracy, "MicroRunResult.overall_accuracy"),
+        )
+        object.__setattr__(
+            self,
+            "wall_clock_seconds",
+            _require_finite_real(
+                self.wall_clock_seconds, "MicroRunResult.wall_clock_seconds"
             ),
         )
 

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -45,6 +45,7 @@ from alberta_framework.benchmarks.micro_continual import (
     NONPROMOTING_POLICY,
     SEARCH_TASKS,
     BayesReference,
+    MicroRunResult,
     MicroStream,
     MicroStreamConfig,
     MicroTaskConfig,
@@ -1919,3 +1920,61 @@ def test_m3_applies_per_task_affine_transform() -> None:
     # two steps in the same task sharing an example agree exactly; across
     # tasks the transform differs.
     assert not np.array_equal(stream.xs[0], x_base[idx0])
+
+
+def _legal_micro_run_result(**overrides: object) -> MicroRunResult:
+    payload: dict[str, object] = {
+        "family": "input_permutation",
+        "arm_name": "sgd_raw",
+        "mechanism": "sgd",
+        "hyperparameters": {"step_size": 0.01, "weight_decay": 0.0},
+        "seed": 0,
+        "hidden1": 8,
+        "hidden2": 6,
+        "stream_config": TINY,
+        "per_regime_accuracy": np.zeros((TINY.n_regimes,)),
+        "per_regime_loss": np.zeros((TINY.n_regimes,)),
+        "per_regime_plasticity": np.zeros((TINY.n_regimes,)),
+        "overall_accuracy": 0.5,
+        "wall_clock_seconds": 1.0,
+    }
+    payload.update(overrides)
+    return MicroRunResult(**payload)  # type: ignore[arg-type]
+
+
+def test_micro_run_result_rejects_leftover_identities() -> None:
+    """Public micro result records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_micro_run_result(wall_clock_seconds=True)
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_micro_run_result(wall_clock_seconds=float("nan"))
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_micro_run_result(wall_clock_seconds=float("inf"))
+    with pytest.raises(ValueError, match="overall_accuracy"):
+        _legal_micro_run_result(overall_accuracy=True)
+    with pytest.raises(ValueError, match="family"):
+        _legal_micro_run_result(family=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal_micro_run_result(seed=True)
+    with pytest.raises(ValueError, match="hidden1"):
+        _legal_micro_run_result(hidden1=True)
+
+    legal = _legal_micro_run_result()
+    dumped = json.dumps(
+        {
+            "family": legal.family,
+            "seed": legal.seed,
+            "hidden1": legal.hidden1,
+            "overall_accuracy": legal.overall_accuracy,
+            "wall_clock_seconds": legal.wall_clock_seconds,
+        },
+        allow_nan=False,
+    )
+    assert '"wall_clock_seconds": 1.0' in dumped
+    assert '"overall_accuracy": 0.5' in dumped
+    assert '"wall_clock_seconds": true' not in dumped
+    assert '"overall_accuracy": true' not in dumped
+    assert '"family": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"hidden1": true' not in dumped


### PR DESCRIPTION
Closes #1116.

## What changed

Micro-continual result records now fail closed on leftover bool-as-float, bool-as-string, bool-as-seed, bool-as-width, and non-finite identities.

On origin/main `e8cea0e`, `MicroStreamConfig` already gated leftover bool/non-int protocol fields. The public `MicroRunResult` constructor itself accepted `wall_clock_seconds=True` / `NaN` / `Inf`, `overall_accuracy=True`, `family=True`, `seed=True`, and `hidden1=True`. Direct construction kept them, so `json.dumps({"wall_clock_seconds": result.wall_clock_seconds}, allow_nan=False)` emitted `"wall_clock_seconds": true`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `micro_continual.py` result records, not a republish of shard-JSON / persisted-config leftover, and not `#1113`/`#1114`/`#1107`/`#1108`/`#1100`/`#1099` or foreign `#1110`.

## Scope

- `alberta_framework/benchmarks/micro_continual.py`
- `tests/test_micro_continual.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = none. Recently merged `#1113` (IPMNIST result-record), `#1114` (label-EMNIST result-record), `#1110` (swift-td). These files were FREE.

## Verification

Exact candidate head: `e568730306a3bd2db72fe07238d9a4591ad3c991`
Base: `e8cea0e`

- Red on base: `MicroRunResult(wall_clock_seconds=True, ...)` accepted; dump emitted `"wall_clock_seconds": true`
- Focused pytest `tests/test_micro_continual.py`: 221 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/benchmarks/micro_continual.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.



<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e568730306a3bd2db72fe07238d9a4591ad3c991 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
