### PR TITLE
fix(pipeline): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -771,6 +771,13 @@ class AlbertaPipelineSmokeResult:
     actions_shape: tuple[int, ...]
     finite: bool
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,6 +14,7 @@ import alberta_framework as af
 from alberta_framework.pipeline import (
     AlbertaPipeline,
     AlbertaPipelineConfig,
+    AlbertaPipelineSmokeResult,
     HordeActorCriticPipelineConfig,
     Step2AssociativePipelineConfig,
     Step2FeatureConfig,
@@ -939,6 +940,50 @@ def test_pipeline_full_config_json_roundtrip() -> None:
     )
     payload = json.loads(json.dumps(config.to_dict()))
     assert AlbertaPipelineConfig.from_dict(payload) == config
+
+
+def _legal_pipeline_smoke_result(**overrides: object) -> AlbertaPipelineSmokeResult:
+    payload: dict[str, object] = {
+        "config": _small_pipeline_config(),
+        "steps": 8,
+        "seed": 0,
+        "feature_shape": (8, 3),
+        "horde_predictions_shape": (8, 2),
+        "q_values_shape": (8, 2),
+        "actions_shape": (8,),
+        "finite": True,
+    }
+    payload.update(overrides)
+    return AlbertaPipelineSmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_pipeline_smoke_result_rejects_leftover_identities() -> None:
+    """Public pipeline smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_pipeline_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_pipeline_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_pipeline_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_pipeline_smoke_result(finite=1)
+
+    legal = _legal_pipeline_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
 
 
 # silence the import lint warnings used in the test runner


### PR DESCRIPTION
Closes #1115.

## What changed

Pipeline smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `e8cea0e`, `run_pipeline_smoke` already gated leftover bool/non-int protocol fields. The public `AlbertaPipelineSmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, and `finite=1`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `pipeline.py` smoke records, not a republish of cumulant-dimension leftover, and not `#1113`/`#1114`/`#1107`/`#1108`/`#1100`/`#1099` or foreign `#1110`.

## Scope

- `alberta_framework/pipeline.py`
- `tests/test_pipeline.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = none. Recently merged `#1113` (IPMNIST result-record), `#1114` (label-EMNIST result-record), `#1110` (swift-td). These files were FREE.

## Verification

Exact candidate head: `4897a5d4c28a166a329eed4a88247e6bf08fd02c`
Base: `e8cea0e`

- Red on base: `AlbertaPipelineSmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_pipeline.py`: 171 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/pipeline.py`: pre-existing 7 errors unchanged (chex untyped + horde union types); no new errors in the smoke-result constructor
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.



<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4897a5d4c28a166a329eed4a88247e6bf08fd02c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
