### PR TITLE
fix(learning-signals): reject non-canonical dtypes in estimator state

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -432,14 +432,14 @@ class LearningSignalEstimator:
             array = jnp.asarray(value)
             if array.shape != ():
                 raise ValueError(f"state.{name} must be scalar")
-            if not jnp.issubdtype(array.dtype, jnp.integer):
-                raise ValueError(f"state.{name} must have an integer dtype")
+            if array.dtype != jnp.dtype(jnp.int32):
+                raise ValueError(f"state.{name} must have dtype int32")
         for name, value in float_values.items():
             array = jnp.asarray(value)
             if array.shape != ():
                 raise ValueError(f"state.{name} must be scalar")
-            if not jnp.issubdtype(array.dtype, jnp.inexact):
-                raise ValueError(f"state.{name} must have a floating dtype")
+            if array.dtype != jnp.dtype(jnp.float32):
+                raise ValueError(f"state.{name} must have dtype float32")
 
     def observe(
         self,

--- a/tests/test_learning_signals.py
+++ b/tests/test_learning_signals.py
@@ -326,6 +326,25 @@ def test_lifetime_counters_saturate_without_wraparound() -> None:
     assert int(still_saturated.invalid_count) == 1
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "expected_dtype"),
+    [
+        ("step_count", jnp.asarray(0, dtype=jnp.int16), "int32"),
+        ("calibration_mean", jnp.asarray(0.0, dtype=jnp.float16), "float32"),
+    ],
+)
+def test_learning_signal_state_rejects_noncanonical_dtypes(
+    field: str,
+    value: jax.Array,
+    expected_dtype: str,
+) -> None:
+    estimator = _estimator()
+    state = replace(estimator.init(), **{field: value})
+
+    with pytest.raises(ValueError, match=rf"state\.{field} must have dtype {expected_dtype}"):
+        _observe_scalar(estimator, state)
+
+
 def test_shape_and_dtype_validation_is_strict() -> None:
     estimator = _estimator()
     state = estimator.init()


### PR DESCRIPTION
Closes #1119.

## What changed

`LearningSignalEstimator`'s state-contract check accepted any integer or floating dtype (via `jnp.issubdtype`) for state fields the class always constructs as canonical `int32`/`float32`. A narrower-precision dtype like `int16` or `float16` silently passed validation despite not matching the state the class actually produces internally.

## Fix

Require exact `int32`/`float32` dtypes on these state fields, matching the codebase's established state-contract pattern elsewhere in this session's work (e.g. `resource_manager.py`, `associative_memory.py`): exact dtype checks for internal state contracts (fully under the class's own control, always constructed by `init()`), broader subtype-aware `issubdtype` checks reserved for external caller-input validation (where accepting a legitimate `numpy.float64`, for example, matters).

## Reachability

`LearningSignalEstimator` is exported from both `alberta_framework/core/__init__.py`'s `__all__` and top-level `alberta_framework/__init__.py`'s `__all__` - fully public.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
canonical step_count dtype: int32
ACCEPTED (bug reproduced): int16 step_count silently passed validation
```

- new parametrized test `test_learning_signal_state_rejects_noncanonical_dtypes`, covering `step_count` (int16 vs int32) and `calibration_mean` (float16 vs float32).
- mutation check: reverted just the source fix, reran the new test -> both parametrizations fail with `DID NOT RAISE ValueError`. restored -> both pass.
- full file: `52 passed` - confirming no legitimate existing usage in this file relied on a non-canonical dtype being accepted.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter). The drafting session hit quota exhaustion partway through and never wrote its own report or committed - I recovered the real, uncommitted diff from the working tree and independently verified the entire thing from scratch with no report to lean on: reproduced the narrow-dtype acceptance myself against the unpatched code (confirming the class's own `init()` genuinely produces canonical int32/float32, so this is a real contract violation not a false positive), ran the full mutation check, full test file, lint, mypy, and reachability trace before committing and pushing.

Attribution status: self-reported.
