### PR TITLE
fix(step1): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -140,6 +140,13 @@ _TRUSTED_INT_TYPES: tuple[type, ...] = (
 )
 
 
+def _require_bool(name: str, value: object) -> bool:
+    """Require an actual builtin bool (``__class__`` spoofing is ignored)."""
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a bool, got {value!r}")
+    return value
+
+
 def _require_int(
     name: str,
     value: object,
@@ -265,6 +272,18 @@ class Step1SmokeResult:
     final_window_mse: float
     metrics_shape: tuple[int, ...]
     finite: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "final_window_mse",
+            _require_real("final_window_mse", self.final_window_mse)[0],
+        )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step1_int_validation.py
+++ b/tests/test_step1_int_validation.py
@@ -8,10 +8,12 @@ conversion runs, and the invalid-type error never interpolates the value.
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
-from alberta_framework.steps import Step1KernelConfig, run_step1_smoke
+from alberta_framework.steps import Step1KernelConfig, Step1SmokeResult, run_step1_smoke
 
 pytestmark = pytest.mark.unit
 
@@ -131,3 +133,52 @@ def test_step1_config_still_rejects_non_integer_scalars(field: str, value: objec
 def test_step1_smoke_bounds_errors_still_name_the_field(field: str) -> None:
     with pytest.raises(ValueError, match=f"{field} must be positive"):
         run_step1_smoke(**_smoke_kwargs(field, 0))  # type: ignore[arg-type]
+
+
+def _legal_step1_smoke_result(**overrides: object) -> Step1SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step1KernelConfig(),
+        "steps": 8,
+        "seed": 0,
+        "final_window_mse": 0.25,
+        "metrics_shape": (8, 2),
+        "finite": True,
+    }
+    payload.update(overrides)
+    return Step1SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step1_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 1 smoke records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step1_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step1_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step1_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step1_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal_step1_smoke_result(final_window_mse=True)
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal_step1_smoke_result(final_window_mse=float("nan"))
+
+    legal = _legal_step1_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "final_window_mse": legal.final_window_mse,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"final_window_mse": 0.25' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"final_window_mse": true' not in dumped


### PR DESCRIPTION
Closes #1121.

## What changed

Step 1 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, leftover bool-as-float, and non-finite identities.

On origin/main `869b584`, `run_step1_smoke` already gated leftover bool/non-int protocol fields. The public `Step1SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `final_window_mse=True` / `NaN`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step1.py` smoke records, not a republish of Step 1 integer-trust leftover, and not `#1118`/`#1117`/`#1113`/`#1114`/`#1107`/`#1108`.

## Scope

- `alberta_framework/steps/step1.py`
- `tests/test_step1_int_validation.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = `#1117` (micro-continual result-record) and `#1118` (pipeline smoke-record). These files were FREE.

## Verification

Exact candidate head: `2fff16c620199e20ceb399e20df6c4ccd5d2baeb`
Base: `869b584`

- Red on base: `Step1SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step1_int_validation.py`: 37 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step1.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2fff16c620199e20ceb399e20df6c4ccd5d2baeb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
