### PR TITLE
fix(step8): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -34,6 +34,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelConfig,
@@ -227,6 +228,13 @@ class Step8SmokeResult:
     next_observation_errors_shape: tuple[int, ...]
     finite: bool
     model_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from alberta_framework.steps.step8 import (
+    Step8SmokeResult,
     Step8WorldModelConfig,
     init_step8_state,
     make_step8_world_model,
@@ -424,3 +425,48 @@ def test_step8_world_model_rejects_spoofed_int_class_and_adversarial_ratios() ->
 
     with pytest.raises(ValueError, match="utility_decay"):
         Step8WorldModelConfig(utility_decay=SpoofedIntFloat(0.5))
+
+
+def _legal_step8_smoke_result(**overrides: object) -> Step8SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step8WorldModelConfig(),
+        "steps": 8,
+        "seed": 0,
+        "reward_predictions_shape": (8,),
+        "next_observation_predictions_shape": (8, 4),
+        "reward_errors_shape": (8,),
+        "next_observation_errors_shape": (8, 4),
+        "finite": True,
+        "model_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step8SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step8_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 8 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step8_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step8_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step8_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step8_smoke_result(finite=1)
+
+    legal = _legal_step8_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped


### PR DESCRIPTION
Closes #1122.

## What changed

Step 8 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `869b584`, `Step8WorldModelConfig` already gated leftover bool/non-int protocol fields. The public `Step8SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, and `finite=1`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step8.py` smoke records, not a republish of Step 8 config leftover, and not `#1118`/`#1117`/`#1113`/`#1114`/`#1107`/`#1108`.

## Scope

- `alberta_framework/steps/step8.py`
- `tests/test_step8_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = `#1117` (micro-continual result-record) and `#1118` (pipeline smoke-record). These files were FREE.

## Verification

Exact candidate head: `1dbc3c92ece0c4fc393fbe8c9e6a79c295cb7212`
Base: `869b584`

- Red on base: `Step8SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step8_production.py`: 84 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step8.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1dbc3c92ece0c4fc393fbe8c9e6a79c295cb7212 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
