### PR TITLE
fix(step2): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -253,6 +253,13 @@ def _require_int(
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    """Require an actual builtin bool (``__class__`` spoofing is ignored)."""
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a bool, got {value!r}")
+    return value
+
+
 def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
     feature_dim = _require_int(
         "feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX
@@ -655,6 +662,18 @@ class Step2SmokeResult:
     finite: bool
     learner_config: dict[str, Any]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "final_window_mse",
+            _require_real("final_window_mse", self.final_window_mse),
+        )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
@@ -675,6 +694,23 @@ class Step2AssociativeSmokeResult:
     metrics_shape: tuple[int, ...]
     finite: bool
     learner_config: dict[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "initial_window_nll",
+            _require_real("initial_window_nll", self.initial_window_nll),
+        )
+        object.__setattr__(
+            self,
+            "final_window_nll",
+            _require_real("final_window_nll", self.final_window_nll),
+        )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step2_int_validation.py
+++ b/tests/test_step2_int_validation.py
@@ -1,0 +1,114 @@
+"""Host-boundary leftover-identity gates for public Step 2 smoke records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.steps.step2 import (
+    Step2AssociativeConfig,
+    Step2AssociativeSmokeResult,
+    Step2KernelConfig,
+    Step2SmokeResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _legal_step2_smoke_result(**overrides: object) -> Step2SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step2KernelConfig(),
+        "steps": 8,
+        "seed": 0,
+        "final_window_mse": 0.25,
+        "metrics_shape": (8, 2),
+        "finite": True,
+        "learner_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step2SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def _legal_step2_associative_smoke_result(
+    **overrides: object,
+) -> Step2AssociativeSmokeResult:
+    payload: dict[str, object] = {
+        "config": Step2AssociativeConfig(),
+        "steps": 8,
+        "seed": 0,
+        "initial_window_nll": 1.5,
+        "final_window_nll": 0.75,
+        "metrics_shape": (8,),
+        "finite": True,
+        "learner_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step2AssociativeSmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step2_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 2 smoke records must not keep leftover bool/NaN identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step2_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step2_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step2_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step2_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal_step2_smoke_result(final_window_mse=True)
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal_step2_smoke_result(final_window_mse=float("nan"))
+
+    legal = _legal_step2_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "final_window_mse": legal.final_window_mse,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"final_window_mse": 0.25' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"final_window_mse": true' not in dumped
+
+
+def test_step2_associative_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 2 associative smoke records must not keep leftover identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step2_associative_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step2_associative_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step2_associative_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="initial_window_nll"):
+        _legal_step2_associative_smoke_result(initial_window_nll=True)
+    with pytest.raises(ValueError, match="final_window_nll"):
+        _legal_step2_associative_smoke_result(final_window_nll=float("nan"))
+
+    legal = _legal_step2_associative_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "initial_window_nll": legal.initial_window_nll,
+            "final_window_nll": legal.final_window_nll,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"finite": true' in dumped
+    assert '"steps": true' not in dumped
+    assert '"finite": 1' not in dumped


### PR DESCRIPTION
Closes #1125.

## What changed

Step 2 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, leftover bool-as-float, and non-finite identities.

On origin/main `869b584`, `run_step2_smoke` already gated leftover bool/non-int protocol fields. The public `Step2SmokeResult` and `Step2AssociativeSmokeResult` constructors themselves had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `final_window_mse=True` / `NaN` (plus associative NLL leftovers). Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step2.py` smoke records, not a republish of Step 2 config leftover (`#995`), and not `#1123`/`#1124`/`#1118`/`#1117`/`#1113`/`#1114`.

## Scope

- `alberta_framework/steps/step2.py`
- `tests/test_step2_int_validation.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = `#1123` (step1 smoke-record), `#1124` (step8 smoke-record), `#1117` (micro-continual result-record), and `#1118` (pipeline smoke-record). These files were FREE.

## Verification

Exact candidate head: `1f2ba8a1381fe30621d0ac6fd8abfdbe043d84fc`
Base: `869b584`

- Red on base: `Step2SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step2_int_validation.py`: 2 passed
- Legal `run_step2_smoke` / `run_step2_associative_smoke` still construct
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step2.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1f2ba8a1381fe30621d0ac6fd8abfdbe043d84fc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
