### PR TITLE
fix(step9): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -411,6 +411,23 @@ class Step9SmokeResult:
     control_config: dict[str, Any]
     world_model_config: dict[str, Any]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        object.__setattr__(
+            self,
+            "dream_acceptance_count",
+            _require_int(
+                "dream_acceptance_count",
+                self.dream_acceptance_count,
+                minimum=0,
+                maximum=_INT32_MAX,
+            ),
+        )
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -21,6 +21,7 @@ from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
 from alberta_framework.steps.step9 import (
     Step9DreamingConfig,
     Step9DreamingState,
+    Step9SmokeResult,
     init_step9_state,
     make_step9_components,
     run_step9_scan,
@@ -960,3 +961,54 @@ def test_step9_state_stays_finite_over_many_steps() -> None:
     )
     result = run_step9_smoke(cfg, steps=128, seed=7)
     assert result.finite
+
+
+def _legal_step9_smoke_result(**overrides: object) -> Step9SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step9DreamingConfig(),
+        "steps": 8,
+        "seed": 0,
+        "real_td_errors_shape": (8,),
+        "dream_td_errors_shape": (8,),
+        "actions_shape": (8,),
+        "finite": True,
+        "dream_acceptance_count": 1,
+        "control_config": {"ok": True},
+        "world_model_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step9SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step9_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 9 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step9_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step9_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step9_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step9_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="dream_acceptance_count"):
+        _legal_step9_smoke_result(dream_acceptance_count=True)
+
+    legal = _legal_step9_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "dream_acceptance_count": legal.dream_acceptance_count,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"dream_acceptance_count": 1' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"dream_acceptance_count": true' not in dumped


### PR DESCRIPTION
Closes #1126.

## What changed

Step 9 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, leftover bool-as-count, and non-finite identities.

On origin/main `869b584`, `run_step9_smoke` already gated leftover bool/non-int protocol fields. The public `Step9SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `dream_acceptance_count=True`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step9.py` smoke records, not a republish of Step 9 config leftover, and not `#1123`/`#1124`/`#1118`/`#1117`/`#1113`/`#1114`.

## Scope

- `alberta_framework/steps/step9.py`
- `tests/test_step9_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = `#1123` (step1 smoke-record), `#1124` (step8 smoke-record), `#1117` (micro-continual result-record), and `#1118` (pipeline smoke-record). These files were FREE.

## Verification

Exact candidate head: `ff5ed8d9e3b07f471995e752132c89b190b3ffe2`
Base: `869b584`

- Red on base: `Step9SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest leftover + `test_step9_smoke_defaults`: 2 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step9.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ff5ed8d9e3b07f471995e752132c89b190b3ffe2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
