### PR TITLE
Reject unsupported actor optimizers at construction in nonlinear horde actor-critics

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -1517,6 +1517,11 @@ class NonlinearHordeActorCriticAgent:
         self._actor_optimizer = (
             actor_optimizer if actor_optimizer is not None else Autostep(initial_step_size=0.01)
         )
+        if not self._actor_optimizer.supported_for_mlp():
+            raise ValueError(
+                f"actor_optimizer {type(self._actor_optimizer).__name__} does not support "
+                "the MLP shape-generic update API"
+            )
         self._actor_bounder = actor_bounder
 
     @property
@@ -2184,6 +2189,11 @@ class NonlinearQHordeActorCriticAgent:
         self._actor_optimizer = (
             actor_optimizer if actor_optimizer is not None else Autostep(initial_step_size=0.01)
         )
+        if not self._actor_optimizer.supported_for_mlp():
+            raise ValueError(
+                f"actor_optimizer {type(self._actor_optimizer).__name__} does not support "
+                "the MLP shape-generic update API"
+            )
         self._actor_bounder = actor_bounder
 
     @property

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -18,7 +18,7 @@ from alberta_framework.core.horde_actor_critic import (
     QHordeActorCriticState,
     run_horde_actor_critic_from_arrays,
 )
-from alberta_framework.core.optimizers import Autostep, ObGDBounding
+from alberta_framework.core.optimizers import Autostep, ObGD, ObGDBounding
 from alberta_framework.core.types import (
     DemonType,
     GVFSpec,
@@ -803,6 +803,17 @@ class TestNonlinearHordeActorCriticConfig:
                 self._simple_critic(),
             )
 
+    def test_actor_optimizer_must_support_mlp(self) -> None:
+        # An optimizer without the shape-generic MLP hooks (init_for_shape /
+        # update_from_gradient) must be rejected at construction time rather
+        # than raising NotImplementedError deep inside a jitted update.
+        with pytest.raises(ValueError, match="does not support the MLP"):
+            NonlinearHordeActorCriticAgent(
+                NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=(16,)),
+                self._simple_critic(),
+                actor_optimizer=ObGD(),  # type: ignore[arg-type]
+            )
+
     def test_config_roundtrip(self) -> None:
         cfg = NonlinearHordeActorCriticConfig(
             n_actions=4,
@@ -1253,6 +1264,29 @@ class TestNonlinearQHordeActorCritic:
             critic,
             actor_optimizer=Autostep(initial_step_size=0.01),
         )
+
+    def test_actor_optimizer_must_support_mlp(self) -> None:
+        demons = [
+            GVFSpec(  # type: ignore[call-arg]
+                name=f"q_{action}",
+                demon_type=DemonType.CONTROL,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=-1,
+            )
+            for action in range(N_ACTIONS)
+        ]
+        critic = HordeLearner(
+            create_horde_spec(demons),
+            hidden_sizes=(16,),
+            step_size=0.03,
+        )
+        with pytest.raises(ValueError, match="does not support the MLP"):
+            NonlinearQHordeActorCriticAgent(
+                NonlinearQHordeActorCriticConfig(n_actions=N_ACTIONS, hidden_sizes=(16,)),
+                critic,
+                actor_optimizer=ObGD(),  # type: ignore[arg-type]
+            )
 
     def test_update_returns_finite_q_values(self) -> None:
         agent = self._agent()


### PR DESCRIPTION
`NonlinearHordeActorCriticAgent` and `NonlinearQHordeActorCriticAgent` drive the
MLP shape-generic optimizer path (`init_for_shape` / `update_from_gradient`),
but — unlike `MLPLearner` (`learners.py`) and `MultiHeadMLPLearner` — neither
validated `supported_for_mlp()` at construction.

As a result, passing an optimizer that does not implement the MLP hooks (e.g.
`ObGD`) constructs fine and only fails later with a `NotImplementedError` raised
deep inside the jitted update — exactly the failure mode that
`Optimizer.supported_for_mlp()`'s own docstring says these construction sites
should prevent:

> MLP, multi-head, and head-optimizer construction sites should call this before
> accepting an optimizer, so an unsupported choice fails at construction time
> instead of raising `NotImplementedError` deep inside a jitted update.

This adds the same construction-time guard already used by the other MLP-path
constructors to both nonlinear horde actor-critics, covered by
failing-test-first tests.

**Checks (project config):**
- `python -m pytest tests/test_horde_actor_critic.py` → 70 passed
- `python -m ruff check .` → clean
- `python -m mypy` → `Success: no issues found in 168 source files`
