### PR TITLE
fix(step4): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -31,6 +31,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.optimizers import (
     IDBD,
     LMS,
@@ -117,6 +118,11 @@ class Step4SmokeResult:
     actions_shape: tuple[int, ...]
     finite: bool
     agent_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "steps", _require_positive_int("steps", self.steps))
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -209,6 +215,12 @@ def _require_nonneg_int(name: str, value: object) -> int:
     if number > _INT32_MAX:
         raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
 
 
 def _validate_sarsa_config(config: Step4SARSAConfig) -> None:

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -17,6 +17,7 @@ import pytest
 from alberta_framework.core.optimizers import IDBD, LMS, Autostep, ObGDBounding
 from alberta_framework.steps import (
     Step4SARSAConfig,
+    Step4SmokeResult,
     init_step4_state,
     make_step4_bounder,
     make_step4_optimizer,
@@ -333,3 +334,47 @@ def test_step4_sarsa_dimensions_preserve_int32_maximum() -> None:
     assert type(config.n_actions) is int
     assert type(config.epsilon_decay_steps) is int
     assert type(config.hidden_sizes[0]) is int
+
+
+def _legal_step4_smoke_result(**overrides: object) -> Step4SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step4SARSAConfig(),
+        "steps": 8,
+        "seed": 0,
+        "q_values_shape": (8, 2),
+        "td_errors_shape": (8,),
+        "actions_shape": (8,),
+        "finite": True,
+        "agent_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step4SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step4_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 4 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step4_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step4_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step4_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step4_smoke_result(finite=1)
+
+    legal = _legal_step4_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped


### PR DESCRIPTION
Closes #1130.

## What changed

Step 4 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `bb0a6b3`, `Step4SARSAConfig` already gated leftover bool/non-int protocol fields. The public `Step4SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, and `finite=1`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step4.py` smoke records, not a republish of Step 4 config leftover, and not `#1127`/`#1128`/`#1123`/`#1124`/`#1118`/`#1117`.

## Scope

- `alberta_framework/steps/step4.py`
- `tests/test_step4_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs = `#1127` (step2 smoke-record) and `#1128` (step9 smoke-record). These files were FREE.

## Verification

Exact candidate head: `de622a260e59d9f28d55316cc20016217cdf7b9f`
Base: `bb0a6b3`

- Red on base: `Step4SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step4_production.py`: 65 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step4.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:de622a260e59d9f28d55316cc20016217cdf7b9f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
