### PR TITLE
fix(causal-map): reject reward sum overflow

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -1793,6 +1793,11 @@ def causal_map_step(
     reward_sum = state.reward_sum.at[safe_channel].add(
         jnp.where(observed_reward, reward, 0.0)
     )
+    reward_sum = _runtime_require(
+        jnp.all(jnp.isfinite(reward_sum)),
+        reward_sum,
+        message="causal-map reward accumulation must remain finite",
+    )
     next_reward_count = _saturating_add_int32(
         state.reward_count[safe_channel],
         observed_reward.astype(jnp.int32),

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -515,6 +515,25 @@ def test_reward_sign_and_magnitude_are_learned_from_own_transition() -> None:
     assert int(state.cell_ready_step[1, 0]) == 11
 
 
+def test_reward_accumulation_overflow_is_rejected_eager_and_jit() -> None:
+    config = CausalMapForagerConfig()
+    observation = _observation((1, 0, 0), aperture=3, channels=1)
+    state, action = causal_map_start(observation, config, 0)
+    assert int(action) == 0
+    maximum = jnp.asarray(jnp.finfo(jnp.float32).max, dtype=jnp.float32)
+    state, _, _ = causal_map_step(state, maximum, observation, config)
+
+    with pytest.raises(Exception, match="reward accumulation must remain finite"):
+        jax.block_until_ready(  # type: ignore[no-untyped-call]
+            causal_map_step(state, maximum, observation, config)
+        )
+    compiled = jax.jit(
+        lambda current: causal_map_step(current, maximum, observation, config)
+    )
+    with pytest.raises(Exception, match="reward accumulation must remain finite"):
+        jax.block_until_ready(compiled(state))  # type: ignore[no-untyped-call]
+
+
 def test_zero_reward_without_collection_does_not_corrupt_channel_mean() -> None:
     config = CausalMapForagerConfig()
     state, action = causal_map_start(_observation((1, 0, 0)), config, 0)


### PR DESCRIPTION
Closes #1134.

## What changed

`causal_map_step` validated each incoming reward as a finite float32 scalar, but did not validate the result of adding it to the learned per-channel `reward_sum`. Two individually valid `float32.max` rewards overflowed that statistic to `inf`, corrupting the planner state and preventing later state validation/serialization.

## Fix

Route the updated `reward_sum` through the file's existing JAX-compatible `_runtime_require` helper (already used 6 times elsewhere in this file, works via `jax.debug.callback` under both eager execution and `jax.jit`) to reject a non-finite accumulated statistic.

## Reachability

`causal_map_step` is re-exported from `alberta_framework.benchmarks.__init__`'s `__all__`, along with `CausalMapForagerAgent`, `run_causal_map_forager`, and `run_causal_map_forager_seeds`. `CausalMapForagerAgent.step` (public) accepts any finite float32-compatible reward from the ordinary Forager environment transition, with no internal sanitizer between caller input and this accumulator.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
sum_after_1: 3.4028234663852886e+38 finite: True
sum_after_2: inf finite: False
```

- new test `test_reward_accumulation_overflow_is_rejected_eager_and_jit`, exercising both the eager path and a `jax.jit`-compiled path.
- mutation check: reverted just the source guard, reran the new test -> `Failed: DID NOT RAISE Exception` on the eager-path assertion. restored -> passes both paths.
- full file: `141 passed, 4 skipped`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the overflow myself against the unpatched code, ran the full mutation check myself, reran the full test file/lint/mypy, and re-traced reachability against the export list - also confirming `_runtime_require` is a pre-existing, already-established helper in this file (not new validation logic introduced by this fix).

Attribution status: self-reported.
