### PR TITLE
fix(step7): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -57,6 +57,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAState,
@@ -194,6 +195,12 @@ def _require_int(
     if maximum is not None and number > maximum:
         raise ValueError(f"{name} must be at most int32 max, got {value!r}")
     return number
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
 
 
 def _validate_planning_config(config: Step7DynaConfig) -> None:
@@ -346,6 +353,23 @@ class Step7SmokeResult:
     planning_acceptance_count: int
     control_config: dict[str, Any]
     world_model_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        object.__setattr__(
+            self,
+            "planning_acceptance_count",
+            _require_int(
+                "planning_acceptance_count",
+                self.planning_acceptance_count,
+                minimum=0,
+                maximum=_INT32_MAX,
+            ),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -760,3 +760,57 @@ def test_step7_dyna_json_roundtrip() -> None:
     )
     assert restored.planning_priority_propagation == config.planning_priority_propagation
     assert restored.planning_utility_step_size == config.planning_utility_step_size
+
+
+def _legal_step7_smoke_result(**overrides: object) -> Step7SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step7DynaConfig(),
+        "steps": 8,
+        "seed": 0,
+        "real_td_errors_shape": (8,),
+        "planning_td_errors_shape": (8, 1),
+        "planning_priorities_shape": (8, 1),
+        "planning_anchor_indices_shape": (8, 1),
+        "planning_importance_ratios_shape": (8, 1),
+        "actions_shape": (8,),
+        "finite": True,
+        "planning_acceptance_count": 0,
+        "control_config": {"ok": True},
+        "world_model_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step7SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step7_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 7 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step7_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step7_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step7_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step7_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="planning_acceptance_count"):
+        _legal_step7_smoke_result(planning_acceptance_count=True)
+
+    legal = _legal_step7_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "planning_acceptance_count": legal.planning_acceptance_count,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"planning_acceptance_count": 0' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"planning_acceptance_count": true' not in dumped


### PR DESCRIPTION
Closes #1136.

## What changed

Step 7 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `bb0a6b3`, `Step7DynaConfig` already gated leftover bool/non-int planning fields. The public `Step7SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `planning_acceptance_count=True`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step7.py` smoke records, not a republish of Step 7 config leftover, and not `#1132`/`#1133`/`#1127`/`#1128`/`#1123`/`#1124`/`#1118`/`#1117`.

## Scope

- `alberta_framework/steps/step7.py`
- `tests/test_step7_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open ss251 PRs = `#1132` (step4 smoke-record), `#1133` (step6 smoke-record), `#1127` (step2), `#1128` (step9). These files were FREE. Archaeology r6-config dirt on `step7.py` is a different local-only config-scalar hole and was not adopted.

## Verification

Exact candidate head: `491e15330ed007a0b857c694bbb0a2a8baf27619`
Base: `bb0a6b3`

- Red on base: `Step7SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step7_production.py`: 120 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step7.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:491e15330ed007a0b857c694bbb0a2a8baf27619 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
