### PR TITLE
fix(step10): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -44,6 +44,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jax import Array
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.options import (
     STOMPAgent,
     STOMPArrayResult,
@@ -225,6 +226,12 @@ def _require_int(
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
+
+
 def _validate_stomp_facade_config(config: Step10STOMPConfig) -> None:
     # Observation dimensions and action indices flow into int32 JAX sinks;
     # bounding both keeps every feature_index (< observation_dim) in range.
@@ -355,6 +362,23 @@ class Step10SmokeResult:
     finite: bool
     option_termination_count: int
     agent_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        object.__setattr__(
+            self,
+            "option_termination_count",
+            _require_int(
+                "option_termination_count",
+                self.option_termination_count,
+                minimum=0,
+                maximum=_INT32_MAX,
+            ),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -984,3 +984,55 @@ def test_subtasks_from_feature_scores_integrates_with_stomp() -> None:
     state = init_step10_state(agent, key=jr.key(0), initial_observation=jnp.zeros(4))
     result = step10_update(agent, state, jnp.array(0.0), jnp.ones(4))
     assert bool(jnp.isfinite(result.td_error))
+
+
+def _legal_step10_smoke_result(**overrides: object) -> Step10SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step10STOMPConfig(subtask_specs=(_SPEC1,)),
+        "steps": 8,
+        "seed": 0,
+        "td_errors_shape": (8,),
+        "average_rewards_shape": (8,),
+        "primitive_actions_shape": (8,),
+        "executing_options_shape": (8,),
+        "pseudo_rewards_shape": (8,),
+        "finite": True,
+        "option_termination_count": 0,
+        "agent_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step10SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step10_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 10 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step10_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step10_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step10_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step10_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="option_termination_count"):
+        _legal_step10_smoke_result(option_termination_count=True)
+
+    legal = _legal_step10_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "option_termination_count": legal.option_termination_count,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"option_termination_count": 0' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"option_termination_count": true' not in dumped


### PR DESCRIPTION
Closes #1137.

## What changed

Step 10 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `bb0a6b3`, `Step10STOMPConfig` already gated leftover bool/non-int facade fields. The public `Step10SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `option_termination_count=True`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step10.py` smoke records, not a republish of Step 10 config leftover, and not `#1132`/`#1133`/`#1127`/`#1128`/`#1123`/`#1124`/`#1118`/`#1117`.

## Scope

- `alberta_framework/steps/step10.py`
- `tests/test_step10_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open ss251 PRs = `#1132` (step4 smoke-record), `#1133` (step6 smoke-record), `#1127` (step2), `#1128` (step9). These files were FREE. Archaeology r4-epsilon dirt on `step10.py` is a different local-only epsilon-bounds hole and was not adopted.

## Verification

Exact candidate head: `7cdda8b2d21f3935dc5e95e2f638735d2421ba92`
Base: `bb0a6b3`

- Red on base: `Step10SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step10_production.py`: 166 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step10.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7cdda8b2d21f3935dc5e95e2f638735d2421ba92 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
