### PR TITLE
fix(latent-world-model): saturate lifetime step counter

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -126,6 +126,11 @@ def _require_bool(name: str, value: object) -> bool:
     return value
 
 
+def _saturating_int32_increment(value: Array) -> Array:
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
+
+
 @dataclasses.dataclass(frozen=True)
 class LatentWorldModelConfig:
     """Configuration for :class:`LatentWorldModel`.
@@ -928,7 +933,7 @@ class LatentWorldModel:
             surprise_ema=next_surprise_ema,
             prediction_error_ema=next_prediction_error_ema,
             collapse_score_ema=next_collapse_score_ema,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_increment(state.step_count),
         )
         diagnostics_finite = (
             floating_tree_is_finite(prediction)

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -217,6 +217,31 @@ def test_latent_update_rejects_out_of_range_discounts(discount: float) -> None:
     )
 
 
+def test_latent_update_saturates_step_count_at_int32_max() -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=2,
+        hidden_sizes=(),
+    )
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(0)).replace(
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32)
+    )
+
+    result = model.update(
+        state,
+        jnp.asarray([0.1, -0.2], dtype=jnp.float32),
+        jnp.asarray(1, dtype=jnp.int32),
+        jnp.asarray(0.5, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        jnp.asarray([0.2, -0.1], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 2**31 - 1
+
+
 def test_latent_world_model_scan_loop_and_config_roundtrip() -> None:
     config = LatentWorldModelConfig(
         observation_dim=2,


### PR DESCRIPTION
Closes #1140.

## What changed

`LatentWorldModel.update` incremented its signed-int32 lifetime `step_count` with raw addition. At `2147483647`, a valid and otherwise finite update was accepted while the counter wrapped to `-2147483648`. The negative lifetime count corrupts persisted state and also changes first-step logic (`state.step_count == 0`) after a further full counter cycle.

## Fix

Add a local `_saturating_int32_increment` helper (same pattern already established elsewhere in this codebase for lifetime counters) and route `step_count` through it: once the counter reaches signed-int32 max, successful updates continue but the counter stays at the maximum instead of wrapping negative.

## Reachability

Independently reachable through public APIs, not delegated to a previously-fixed manager or counter implementation. `LatentWorldModel`, `LatentWorldModelConfig`, and `run_latent_world_model_learning_loop` are exported from both `alberta_framework.core`'s `__all__` and top-level `alberta_framework`'s `__all__`. `run_latent_world_model_learning_loop` calls `model.update` for each caller-provided transition; callers can also invoke the public `LatentWorldModel.update` directly with real observations, actions, rewards, discounts, and next observations.

## Verification

confirmed the bug live against the unpatched code before fixing:
```text
before: 2147483647
update_applied: True
after: -2147483648
```

- new test `test_latent_update_saturates_step_count_at_int32_max`.
- mutation check: reverted just the source fix, reran the new test -> fails with the exact wraparound value (`-2147483648` vs expected `2147483647`). restored -> passes.
- full file: `56 passed`.
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). I independently re-verified before shipping: reproduced the wraparound myself against the unpatched code, ran the full mutation check myself, reran the full test file/lint/mypy, and re-traced reachability against both export lists - confirming `_INT32_MAX` is a pre-existing constant in this file, not new to this fix.

Attribution status: self-reported.
