### PR TITLE
fix(benchmarks): avoid catastrophic cancellation in bayes_predict

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -696,8 +696,10 @@ def bayes_predict(component_means: Array, dim_sigma: Array, x: Array) -> Array:
     ``(n, C, K, dim)`` difference tensor.
     """
     c, k, d = component_means.shape
-    whitened_x = x / dim_sigma[None, :]
     whitened_means = (component_means / dim_sigma[None, None, :]).reshape(c * k, d)
+    origin = whitened_means[0]
+    whitened_x = x / dim_sigma[None, :] - origin
+    whitened_means = whitened_means - origin
     cross = whitened_x @ whitened_means.T
     x_norms = jnp.sum(whitened_x * whitened_x, axis=1)
     mean_norms = jnp.sum(whitened_means * whitened_means, axis=1)

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -776,6 +776,21 @@ class TestBayesReference:
             np.asarray(base_predictions), np.asarray(transformed)
         )
 
+    def test_bayes_predict_avoids_common_offset_cancellation(self):
+        component_means = jnp.asarray(
+            [[[10_000.0, 10_000.0]], [[10_001.0, 10_001.0]]],
+            dtype=jnp.float32,
+        )
+        observations = jnp.asarray([[10_001.0, 10_001.0]], dtype=jnp.float32)
+
+        predictions = bayes_predict(
+            component_means,
+            jnp.ones((2,), dtype=jnp.float32),
+            observations,
+        )
+
+        np.testing.assert_array_equal(predictions, np.asarray([1], dtype=np.int32))
+
     def test_stream_geometry_matches_reference_geometry(self):
         stream = generate_stream(TINY, seed=5)
         means, dim_sigma = class_geometry(TINY, seed=5)


### PR DESCRIPTION
Closes #1142.

## What changed

`bayes_predict` computed squared Mahalanobis distances with the expanded identity `||x||^2 - 2 x.mu + ||mu||^2` directly on uncentered float32 values. Large common offsets catastrophically cancelled in that subtraction, changing class rankings despite every input remaining finite.

## Fix

Whiten the component means, choose the first whitened mean as a shared origin, then subtract that origin from both samples and means before applying the same expanded formula. Squared Euclidean/Mahalanobis distance is translation invariant - subtracting the same constant vector from both operands leaves `||x - mu||^2` exactly unchanged (the `origin` terms cancel in `x' - mu' = (x - origin) - (mu - origin) = x - mu`) - so this removes the large common offset without altering the result or the function's stated memory bound. No external numerical reference was needed: this is the standard shift-based recentering technique for numerically stable squared-distance computation, not a change to the benchmark's statistical model.

## Reachability

Corrupts the Monte Carlo Bayes reference used by `bayes_reference`, called from `merge_micro_shards`'s benchmark summary path. The module function is also directly importable. `micro_continual` is not re-exported from the package root (confirmed - no matches in `alberta_framework/__init__.py`, `alberta_framework/benchmarks/__init__.py`, or `pyproject.toml`), so reachability is through the benchmark module rather than the root package, with no console script entry.

## Verification

confirmed the bug live against the unpatched code before fixing (observation exactly matching one component mean, at a common offset of ~10000):
```text
predictions: [0]
```
(expected `[1]` - the observation exactly matches component 1's mean, distance 0.)

- new test `test_bayes_predict_avoids_common_offset_cancellation`.
- mutation check: reverted just the source fix, reran the new test -> fails with the exact misclassification (`[0]` vs expected `[1]`). restored -> passes.
- full file: `222 passed` (I ran this myself - the report's own attempt didn't complete within its execution budget and honestly disclosed that rather than fabricating a result).
- `ruff check` and `mypy` clean on both touched files.

## Provenance

AI-assisted: initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access (so it could not commit itself). The report honestly disclosed that its own full-file test run didn't complete within its execution budget rather than fabricating a result. I independently re-verified before shipping: reproduced the misclassification myself against the unpatched code, verified the translation-invariance math claim by hand, ran the full mutation check myself, ran the full test file myself to completion (`222 passed` in ~60s), reran lint/mypy, and re-traced reachability against the export lists and pyproject.toml.

Attribution status: self-reported.
