### PR TITLE
fix(step11): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -231,6 +231,12 @@ def _require_int(
     return number
 
 
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
+
+
 def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
     observation_dim = _require_int(
         "observation_dim",
@@ -361,6 +367,23 @@ class Step11SmokeResult:
     finite: bool
     option_termination_count: int
     agent_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        object.__setattr__(
+            self,
+            "option_termination_count",
+            _require_int(
+                "option_termination_count",
+                self.option_termination_count,
+                minimum=0,
+                maximum=_INT32_MAX,
+            ),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1212,3 +1212,54 @@ def test_step11_oak_rejects_adversarial_ratio_floats(ratio: tuple[int, int]) -> 
             subtask_specs=(SubtaskSpec(feature_index=0),),
             option_gamma=HiddenBoundaryFloat(0.5),
         )
+
+
+def _legal_step11_smoke_result(**overrides: object) -> Step11SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step11OaKConfig(subtask_specs=(_SPEC0,)),
+        "steps": 8,
+        "seed": 0,
+        "td_errors_shape": (8,),
+        "average_rewards_shape": (8,),
+        "primitive_actions_shape": (8,),
+        "utility_emas_shape": (8,),
+        "finite": True,
+        "option_termination_count": 0,
+        "agent_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step11SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step11_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 11 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step11_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step11_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step11_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step11_smoke_result(finite=1)
+    with pytest.raises(ValueError, match="option_termination_count"):
+        _legal_step11_smoke_result(option_termination_count=True)
+
+    legal = _legal_step11_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+            "option_termination_count": legal.option_termination_count,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"option_termination_count": 0' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped
+    assert '"option_termination_count": true' not in dumped


### PR DESCRIPTION
Closes #1144.

## What changed

Step 11 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `bb3c300`, `Step11OaKConfig` already gated leftover bool/non-int facade fields. The public `Step11SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, `finite=1`, and `option_termination_count=True`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step11.py` smoke records, not a republish of Step 11 config leftover, and not `#1138`/`#1139`/`#1132`/`#1133`/`#1127`/`#1128`/`#1123`/`#1124`.

## Scope

- `alberta_framework/steps/step11.py`
- `tests/test_step11_production.py`

## Why this is unowned

Live occupancy at publish time: no open ss251 ASI PRs. Foreign `#1143` owns `micro_continual.py` only. Archaeology r4-epsilon dirt on `step11.py` is a different local-only epsilon-bounds hole and was not adopted.

## Verification

Exact candidate head: `93a318d749f6358305e7106745b248f6f8dee758`
Base: `bb3c300`

- Red on base: `Step11SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step11_production.py`: 207 passed (2 pre-existing longdouble platform asserts deselected; they fail on this host without our change)
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step11.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:93a318d749f6358305e7106745b248f6f8dee758 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
