### PR TITLE
fix(step5): reject leftover smoke-record identities

### DIFF
--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -30,6 +30,7 @@ from typing import Any, cast
 import jax.numpy as jnp
 import jax.random as jr
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialTDArrayResult,
     DifferentialTDConfig,
@@ -69,6 +70,12 @@ def _require_int(
     if maximum is not None and number > maximum:
         raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
     return number
+
+
+def _require_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean, got {value!r}")
+    return value
 
 
 def _finite_float32_scalar(name: str, value: object) -> tuple[int, int, float]:
@@ -175,6 +182,13 @@ class Step5SmokeResult:
     average_rewards_shape: tuple[int, ...]
     finite: bool
     learner_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step5_production.py
+++ b/tests/test_step5_production.py
@@ -1,0 +1,53 @@
+"""Tests for leftover identities on public Step 5 smoke records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.steps.step5 import Step5AverageRewardTDConfig, Step5SmokeResult
+
+
+def _legal_step5_smoke_result(**overrides: object) -> Step5SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step5AverageRewardTDConfig(),
+        "steps": 8,
+        "seed": 0,
+        "predictions_shape": (8,),
+        "td_errors_shape": (8,),
+        "average_rewards_shape": (8,),
+        "finite": True,
+        "learner_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step5SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step5_smoke_result_rejects_leftover_identities() -> None:
+    """Public Step 5 smoke records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step5_smoke_result(steps=True)
+    with pytest.raises(ValueError, match="steps"):
+        _legal_step5_smoke_result(steps=float("nan"))
+    with pytest.raises(ValueError, match="seed"):
+        _legal_step5_smoke_result(seed=True)
+    with pytest.raises(ValueError, match="finite"):
+        _legal_step5_smoke_result(finite=1)
+
+    legal = _legal_step5_smoke_result()
+    dumped = json.dumps(
+        {
+            "steps": legal.steps,
+            "seed": legal.seed,
+            "finite": legal.finite,
+        },
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+    assert '"steps": true' not in dumped
+    assert '"seed": true' not in dumped
+    assert '"finite": 1' not in dumped


### PR DESCRIPTION
Closes #1146.

## What changed

Step 5 smoke records now fail closed on leftover bool-as-int, leftover int-as-bool, bool-as-seed, and non-finite identities.

On origin/main `bb3c300`, `Step5AverageRewardTDConfig` already gated leftover scientific scalars. The public `Step5SmokeResult` constructor itself had no `__post_init__` and accepted `steps=True` / `NaN`, `seed=True`, and `finite=1`. Direct construction kept them, so `json.dumps(result.to_dict(), allow_nan=False)` emitted `"steps": true` or `"finite": 1`, and a leftover `NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `step5.py` smoke records, not a republish of Step 5 config leftover, and not `#1138`/`#1139`/`#1132`/`#1133`/`#1127`/`#1128`/`#1123`/`#1124`. Tests are in a new `tests/test_step5_production.py` so this does not stack on `#1133`'s `test_step5_step6_production.py`.

## Scope

- `alberta_framework/steps/step5.py`
- `tests/test_step5_production.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs after `#1133` = foreign `#1143` only (`bayes_predict`). These files were FREE. Archaeology `asi-step5-avg-reward-scalar-config` is a different stale config-scalar hole and was not adopted. Sibling leftover-smoke work on step11/step12 was mid-post and was not twinned.

## Verification

Exact candidate head: `a390ebabde0fccffc1262468b2c0a6750eea090f`
Base: `bb3c300`

- Red on base: `Step5SmokeResult(steps=True, ...)` accepted; dump emitted `"steps": true`
- Focused pytest `tests/test_step5_production.py` + `tests/test_step5_step6_production.py`: 191 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/steps/step5.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a390ebabde0fccffc1262468b2c0a6750eea090f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
