### PR TITLE
fix(matched-protocol): reject leftover record identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -106,6 +106,13 @@ class MatchedTask:
     task_identity_sha256: str
     environment_rng_schedule_sha256: str
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "aperture_size",
+            _require_int(self.aperture_size, "task.aperture_size", minimum=1, maximum=65_535),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "task_id": self.task_id,
@@ -268,6 +275,13 @@ class AgentRNGContract:
     identity: str
     environment_key_shared: bool
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "environment_key_shared",
+            _require_bool(self.environment_key_shared, "agent_rng.environment_key_shared"),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "identity": self.identity,
@@ -318,6 +332,48 @@ class ResourceAccounting:
     replay_capacity_transitions: int
     recurrent_state_elements: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "parameter_count",
+            _require_int(
+                self.parameter_count,
+                "resources.parameter_count",
+                minimum=0,
+                maximum=_MAX_RESOURCE_COUNT,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "optimizer_update_count",
+            _require_int(
+                self.optimizer_update_count,
+                "resources.optimizer_update_count",
+                minimum=0,
+                maximum=_MAX_RESOURCE_COUNT,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity_transitions",
+            _require_int(
+                self.replay_capacity_transitions,
+                "resources.replay_capacity_transitions",
+                minimum=0,
+                maximum=_MAX_RESOURCE_COUNT,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "recurrent_state_elements",
+            _require_int(
+                self.recurrent_state_elements,
+                "resources.recurrent_state_elements",
+                minimum=0,
+                maximum=_MAX_RESOURCE_COUNT,
+            ),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "parameter_count": self.parameter_count,
@@ -334,6 +390,13 @@ class PairingEligibility:
     analysis_role: AnalysisRole
     eligible: bool
     exclusion_reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "eligible",
+            _require_bool(self.eligible, "pairing.eligible"),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -420,6 +483,13 @@ class SelectionSlot:
     selection_group: str
     rank: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "rank",
+            _require_int(self.rank, "selection_slot.rank", minimum=1, maximum=_MAX_CANDIDATES),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {"selection_group": self.selection_group, "rank": self.rank}
 
@@ -431,6 +501,18 @@ class SelectionGroup:
     selection_group: str
     candidate_ids: tuple[str, ...]
     advance_count: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "advance_count",
+            _require_int(
+                self.advance_count,
+                "selection_group.advance_count",
+                minimum=1,
+                maximum=_MAX_CANDIDATES,
+            ),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_matched_protocol.py
+++ b/tests/test_forager_matched_protocol.py
@@ -1376,3 +1376,81 @@ def test_loader_rejects_noncanonical_and_accepts_exact_canonical_json(tmp_path: 
     source.write_bytes(canonical)
     protocol = matched.load_forager_matched_protocol(source)
     assert protocol.canonical_bytes == source.read_bytes()
+
+
+def test_matched_protocol_records_reject_leftover_identities() -> None:
+    """Public protocol records must not keep leftover bool/int identities."""
+
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="aperture_size"):
+        matched.MatchedTask(
+            task_id="task",
+            preset="field_of_view",
+            environment_id="env",
+            foragax_distribution="dist",
+            foragax_version="0.1.0",
+            observation_type="rgb",
+            aperture_size=True,
+            task_identity_sha256=TASK_SHA,
+            environment_rng_schedule_sha256=SCHEDULE_SHA,
+        )
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="environment_key_shared"):
+        matched.AgentRNGContract(identity="threefry", environment_key_shared=1)
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="parameter_count"):
+        matched.ResourceAccounting(
+            parameter_count=True,
+            optimizer_update_count=0,
+            replay_capacity_transitions=0,
+            recurrent_state_elements=0,
+        )
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="eligible"):
+        matched.PairingEligibility(
+            analysis_role="inferential", eligible=1, exclusion_reasons=()
+        )
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="rank"):
+        matched.SelectionSlot(selection_group="alberta", rank=True)
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="advance_count"):
+        matched.SelectionGroup(selection_group="alberta", candidate_ids=("a",), advance_count=True)
+
+    legal_task = matched.MatchedTask(
+        task_id="task",
+        preset="field_of_view",
+        environment_id="env",
+        foragax_distribution="dist",
+        foragax_version="0.1.0",
+        observation_type="rgb",
+        aperture_size=15,
+        task_identity_sha256=TASK_SHA,
+        environment_rng_schedule_sha256=SCHEDULE_SHA,
+    )
+    legal_rng = matched.AgentRNGContract(identity="threefry", environment_key_shared=False)
+    legal_resources = matched.ResourceAccounting(0, 0, 0, 0)
+    legal_pairing = matched.PairingEligibility(
+        analysis_role="inferential", eligible=True, exclusion_reasons=()
+    )
+    legal_slot = matched.SelectionSlot(selection_group="alberta", rank=1)
+    legal_group = matched.SelectionGroup(
+        selection_group="alberta", candidate_ids=("a",), advance_count=1
+    )
+    dumped = json.dumps(
+        {
+            "aperture_size": legal_task.aperture_size,
+            "environment_key_shared": legal_rng.environment_key_shared,
+            "parameter_count": legal_resources.parameter_count,
+            "eligible": legal_pairing.eligible,
+            "rank": legal_slot.rank,
+            "advance_count": legal_group.advance_count,
+        },
+        allow_nan=False,
+    )
+    assert '"aperture_size": 15' in dumped
+    assert '"environment_key_shared": false' in dumped
+    assert '"parameter_count": 0' in dumped
+    assert '"eligible": true' in dumped
+    assert '"rank": 1' in dumped
+    assert '"advance_count": 1' in dumped
+    assert '"aperture_size": true' not in dumped
+    assert '"environment_key_shared": 1' not in dumped
+    assert '"parameter_count": true' not in dumped
+    assert '"eligible": 1' not in dumped
+    assert '"rank": true' not in dumped
+    assert '"advance_count": true' not in dumped


### PR DESCRIPTION
Closes #1148.

## What changed

Public matched-current protocol records now fail closed on leftover bool-as-int and leftover int-as-bool identities.

On origin/main `bb3c300`, the JSON parser already used `_require_int` / `_require_bool`. Direct construction of `MatchedTask`, `AgentRNGContract`, `ResourceAccounting`, `PairingEligibility`, `SelectionSlot`, and `SelectionGroup` had no constructor gate and accepted leftover identities (`aperture_size=True`, `environment_key_shared=1`, `parameter_count=True`, `eligible=1`, `rank=True`, `advance_count=True`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"aperture_size": true` or `"environment_key_shared": 1`.

This is leftover tax on `forager_matched_protocol.py` public records, not a republish of `#1091`/`#1079`/`#1080`/`#1074` (different matched files).

## Scope

- `alberta_framework/benchmarks/forager_matched_protocol.py`
- `tests/test_forager_matched_protocol.py`

## Why this is unowned

Live occupancy at publish time: ASI open PRs after `#1133` = foreign `#1143` only (`bayes_predict`). These files were FREE. Pending factory queue twins of `#1091`/`#1090` were not released.

## Verification

Exact candidate head: `b0e25e2c3ed51f10f07323df4e857a131fe3e9c4`
Base: `bb3c300`

- Red on base: `AgentRNGContract(environment_key_shared=1)` accepted; dump emitted `"environment_key_shared": 1`
- Focused pytest `tests/test_forager_matched_protocol.py`: 53 passed
- Sibling `tests/test_forager_matched_open_protocol.py`: 22 passed
- `ruff check` on the two changed files: clean
- `mypy` on `alberta_framework/benchmarks/forager_matched_protocol.py`: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b0e25e2c3ed51f10f07323df4e857a131fe3e9c4 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
