### PR TITLE
fix(core): reject non-integer action dtypes in horde actor-critic and IA scan

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -1092,6 +1092,16 @@ def run_horde_actor_critic_from_arrays(
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
         use_fixed_actions = False
     else:
+        try:
+            actions_dtype = np.dtype(actions.dtype)
+        except (AttributeError, TypeError) as error:
+            raise ValueError("actions must expose an integer dtype") from error
+        if not np.issubdtype(actions_dtype, np.integer):
+            raise ValueError("actions must have an integer dtype")
+        action_values = np.asarray(actions)
+        if not bool(np.all((action_values >= 0) & (action_values < agent.config.n_actions))):
+            raise ValueError("actions must lie in [0, n_actions)")
+        actions = jnp.asarray(actions, dtype=jnp.int32)
         use_fixed_actions = True
     if auxiliary_cumulants is None:
         auxiliary_cumulants = jnp.zeros(

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -1350,11 +1350,16 @@ class IAAgent:
             )
 
         num_steps = jnp.asarray(partner_rewards).shape[0]
-        scan_actions = (
-            jnp.asarray(partner_actions, dtype=jnp.int32)
-            if partner_actions is not None
-            else jnp.zeros((num_steps,), dtype=jnp.int32)
-        )
+        if partner_actions is not None:
+            try:
+                partner_actions_dtype = np.dtype(partner_actions.dtype)
+            except (AttributeError, TypeError) as error:
+                raise ValueError("partner_actions must expose an integer dtype") from error
+            if not np.issubdtype(partner_actions_dtype, np.integer):
+                raise ValueError("partner_actions must have an integer dtype")
+            scan_actions = jnp.asarray(partner_actions, dtype=jnp.int32)
+        else:
+            scan_actions = jnp.zeros((num_steps,), dtype=jnp.int32)
         scan_discounts = (
             jnp.asarray(discounts, dtype=jnp.float32)
             if discounts is not None

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -1678,3 +1678,31 @@ def test_actor_resource_budgets_preflight_before_allocation(
     for feature_dim in (True, 2**31 - 1):
         with pytest.raises(ValueError):
             agent.init(feature_dim, jr.key(0))  # type: ignore[arg-type]
+
+
+def test_run_horde_actor_critic_from_arrays_rejects_non_integer_actions() -> None:
+    from alberta_framework.core.horde_actor_critic import run_horde_actor_critic_from_arrays
+
+    agent = _make_agent()
+    state = agent.init(feature_dim=4, key=jr.key(0))
+    obs = jnp.zeros((2, 4), dtype=jnp.float32)
+    rewards = jnp.zeros(2, dtype=jnp.float32)
+    next_obs = jnp.zeros((2, 4), dtype=jnp.float32)
+
+    # Fractional float actions rejected
+    with pytest.raises(ValueError, match="actions must have an integer dtype"):
+        run_horde_actor_critic_from_arrays(
+            agent, state, obs, rewards, next_obs, actions=jnp.array([1.75, 0.25], dtype=jnp.float32)
+        )
+
+    # Boolean actions rejected
+    with pytest.raises(ValueError, match="actions must have an integer dtype"):
+        run_horde_actor_critic_from_arrays(
+            agent, state, obs, rewards, next_obs, actions=jnp.array([True, False])
+        )
+
+    # Valid integer actions accepted
+    result = run_horde_actor_critic_from_arrays(
+        agent, state, obs, rewards, next_obs, actions=jnp.array([1, 0], dtype=jnp.int32)
+    )
+    assert result.actions.shape == (2,)

--- a/tests/test_ia_crediting.py
+++ b/tests/test_ia_crediting.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.intelligence_amplification import (
     ExoCerebellumConfig,
@@ -295,3 +296,41 @@ def test_scan_with_partner_actions_matches_loop() -> None:
     for wl, ws, bl, bs in zip(w_loop, w_scan, b_loop, b_scan):
         assert jnp.allclose(wl, ws, atol=1e-6)
         assert jnp.allclose(bl, bs, atol=1e-6)
+
+
+def test_ia_agent_scan_rejects_non_integer_partner_actions() -> None:
+    agent = IAAgent(_make_ia_config())
+    state = agent.start(agent.init(jr.key(2)), _OBS0)
+    num_steps = 4
+    obs = jnp.tile(_OBS0, (num_steps, 1))
+    rewards = jnp.zeros(num_steps, dtype=jnp.float32)
+
+    # Fractional float actions rejected
+    with pytest.raises(ValueError, match="partner_actions must have an integer dtype"):
+        agent.scan(
+            state,
+            obs,
+            rewards,
+            obs,
+            partner_actions=jnp.array([1.75, 0.25, 0.5, 1.0], dtype=jnp.float32),
+        )
+
+    # Boolean actions rejected
+    with pytest.raises(ValueError, match="partner_actions must have an integer dtype"):
+        agent.scan(
+            state,
+            obs,
+            rewards,
+            obs,
+            partner_actions=jnp.array([True, False, True, False]),
+        )
+
+    # Valid integer actions accepted
+    result = agent.scan(
+        state,
+        obs,
+        rewards,
+        obs,
+        partner_actions=jnp.array([1, 0, 1, 0], dtype=jnp.int32),
+    )
+    assert result.state is not None


### PR DESCRIPTION
## Summary
- Resolves #1096.
- Hardens `run_horde_actor_critic_from_arrays` in `alberta_framework/core/horde_actor_critic.py` and `IAAgent.scan` in `alberta_framework/core/intelligence_amplification.py` to require integer dtypes for caller-provided discrete actions (`actions` / `partner_actions`) and reject fractional float or boolean arrays.
- Adds unit tests in `tests/test_horde_actor_critic.py` and `tests/test_ia_crediting.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_horde_actor_critic.py`: 71 passed
- `PYTHONPATH=. pytest tests/test_ia_crediting.py`: 8 passed
- `ruff check .`: clean
- `mypy alberta_framework/core/horde_actor_critic.py alberta_framework/core/intelligence_amplification.py`: clean