### PR TITLE
fix(micro-continual): center whitened means to prevent catastrophic cancellation in bayes_predict

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -698,9 +698,12 @@ def bayes_predict(component_means: Array, dim_sigma: Array, x: Array) -> Array:
     c, k, d = component_means.shape
     whitened_x = x / dim_sigma[None, :]
     whitened_means = (component_means / dim_sigma[None, None, :]).reshape(c * k, d)
-    cross = whitened_x @ whitened_means.T
-    x_norms = jnp.sum(whitened_x * whitened_x, axis=1)
-    mean_norms = jnp.sum(whitened_means * whitened_means, axis=1)
+    origin = whitened_means[0:1]
+    centered_x = whitened_x - origin
+    centered_means = whitened_means - origin
+    cross = centered_x @ centered_means.T
+    x_norms = jnp.sum(centered_x * centered_x, axis=1)
+    mean_norms = jnp.sum(centered_means * centered_means, axis=1)
     d2 = (x_norms[:, None] - 2.0 * cross + mean_norms[None, :]).reshape(-1, c, k)
     scores = jax.scipy.special.logsumexp(-0.5 * d2, axis=2)
     return jnp.argmax(scores, axis=1).astype(jnp.int32)

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1978,3 +1978,20 @@ def test_micro_run_result_rejects_leftover_identities() -> None:
     assert '"family": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"hidden1": true' not in dumped
+
+
+def test_bayes_predict_large_offset_catastrophic_cancellation() -> None:
+    from alberta_framework.benchmarks.micro_continual import bayes_predict
+
+    # Component means with a large common offset:
+    # Class 0: mean [10000.0, 10000.0]
+    # Class 1: mean [10002.0, 10000.0]
+    component_means = jnp.array([[[10000.0, 10000.0]], [[10002.0, 10000.0]]], dtype=jnp.float32)
+    dim_sigma = jnp.array([1.0, 1.0], dtype=jnp.float32)
+
+    # Observation exactly matches class 1 mean
+    x = jnp.array([[10002.0, 10000.0]], dtype=jnp.float32)
+    predictions = bayes_predict(component_means, dim_sigma, x)
+
+    # Must predict class 1, not class 0
+    assert int(predictions[0]) == 1


### PR DESCRIPTION
## Summary
- Resolves #1142.
- In `alberta_framework/benchmarks/micro_continual.py`, centers `whitened_x` and `whitened_means` around `origin = whitened_means[0:1]` before calculating squared Euclidean distances in expanded form. This preserves translation invariance while eliminating catastrophic cancellation when component means and observations share a large common offset.
- Adds unit tests in `tests/test_micro_continual.py`.

## Verification
- `PYTHONPATH=. pytest tests/test_micro_continual.py`: 222 passed
- `ruff check .`: clean
- `mypy alberta_framework/benchmarks/micro_continual.py`: clean