### PR TITLE
fix(benchmarks): compute Bayes distances without cancellation

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -691,19 +691,24 @@ def bayes_predict(component_means: Array, dim_sigma: Array, x: Array) -> Array:
 
     Equal class priors, equal component weights, shared diagonal covariance:
     the Bayes rule is ``argmax_c logsumexp_k(-0.5 * mahalanobis²(x, mu_ck))``.
-    Distances are computed in expanded (GEMM) form so memory stays
-    ``O(n * n_classes * n_components)`` instead of materializing the
-    ``(n, C, K, dim)`` difference tensor.
+    Components are visited sequentially so memory stays
+    ``O(n * n_classes * n_components + n * dim)`` instead of materializing
+    the ``(n, C, K, dim)`` difference tensor.  Computing each coordinate
+    difference before squaring also avoids the catastrophic cancellation in
+    the expanded ``||x||² - 2 x·mu + ||mu||²`` identity.
     """
     c, k, d = component_means.shape
     whitened_means = (component_means / dim_sigma[None, None, :]).reshape(c * k, d)
-    origin = whitened_means[0]
-    whitened_x = x / dim_sigma[None, :] - origin
-    whitened_means = whitened_means - origin
-    cross = whitened_x @ whitened_means.T
-    x_norms = jnp.sum(whitened_x * whitened_x, axis=1)
-    mean_norms = jnp.sum(whitened_means * whitened_means, axis=1)
-    d2 = (x_norms[:, None] - 2.0 * cross + mean_norms[None, :]).reshape(-1, c, k)
+    whitened_x = x / dim_sigma[None, :]
+
+    def squared_distances(mean: Array) -> Array:
+        delta = whitened_x - mean[None, :]
+        return jnp.sum(delta * delta, axis=1)
+
+    # lax.map evaluates one component at a time.  Unlike vmap/broadcasting,
+    # this makes the bounded-memory contract explicit while retaining a
+    # vectorized reduction across samples and dimensions for each component.
+    d2 = jax.lax.map(squared_distances, whitened_means).T.reshape(-1, c, k)
     scores = jax.scipy.special.logsumexp(-0.5 * d2, axis=2)
     return jnp.argmax(scores, axis=1).astype(jnp.int32)
 
@@ -734,14 +739,14 @@ def bayes_reference(
     chunk_size = min(20_000, n_samples)
     class_components = config.n_classes * config.n_components
     # Exact named host-visible arrays retained at the peak of bayes_predict:
-    # geometry + whitened geometry, y/z/eps/x, whitened x, cross/d2,
-    # their norms, scores, and predictions. Expression/compiler temporaries
+    # geometry + whitened geometry, y/z/eps/x, whitened x, d2, scores, and
+    # predictions. The one-component delta and expression/compiler temporaries
     # are intentionally outside this explicitly named work contract.
     bayes_work_scalars = (
         2 * class_components * config.dim
         + config.dim
         + 3 * chunk_size * config.dim
-        + 2 * chunk_size * class_components
+        + chunk_size * class_components
         + chunk_size * config.n_classes
         + class_components
         + 4 * chunk_size

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -791,6 +791,21 @@ class TestBayesReference:
 
         np.testing.assert_array_equal(predictions, np.asarray([1], dtype=np.int32))
 
+    def test_bayes_predict_avoids_cancellation_away_from_shared_origin(self):
+        component_means = jnp.asarray(
+            [[[0.0, 0.0]], [[10_000.0, 10_000.0]], [[10_001.0, 10_001.0]]],
+            dtype=jnp.float32,
+        )
+        observations = jnp.asarray([[10_001.0, 10_001.0]], dtype=jnp.float32)
+
+        predictions = bayes_predict(
+            component_means,
+            jnp.ones((2,), dtype=jnp.float32),
+            observations,
+        )
+
+        np.testing.assert_array_equal(predictions, np.asarray([2], dtype=np.int32))
+
     def test_stream_geometry_matches_reference_geometry(self):
         stream = generate_stream(TINY, seed=5)
         means, dim_sigma = class_geometry(TINY, seed=5)


### PR DESCRIPTION
Closes #1142.

## What changed

Both existing proposals (#1143 and #1153) subtract one shared mean before retaining the expanded `||x||² - 2x·mu + ||mu||²` identity. That fixes the reported two-class/common-offset reproducer, but it still cancels for any pair of far-away means not equal to the chosen origin. For example, with exact means `0`, `10000`, and `10001`, an observation exactly at `10001` is still assigned to `10000`.

This replacement keeps the bounded-memory requirement while removing the unstable identity entirely:

- whiten observations and component means once;
- visit components sequentially with `jax.lax.map`;
- subtract coordinates before squaring and reducing;
- retain only the `(n, C*K)` distance result plus one `(n, dim)` component delta, never `(n, C, K, dim)`;
- update the exact named-array resource estimate from two `(n, C*K)` matrices (`cross` and `d2`) to one (`d2`).

The first commit preserves the original reporter/contributor's authorship and common-offset regression. The follow-up adds the deeper counterexample and refactors the implementation.

## Verification

- `.venv/bin/python -m pytest tests/test_micro_continual.py -q` — 223 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/micro_continual.py tests/test_micro_continual.py` — passed
- `.venv/bin/python -m mypy alberta_framework/benchmarks/micro_continual.py` — passed
- mutation/depth check: both #1143 and #1153 misclassify the new three-class exact-mean case; this branch predicts class 2
