### PR TITLE
fix(records): enforce exact constructor-parser identity parity

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -107,10 +107,18 @@ class MatchedTask:
     environment_rng_schedule_sha256: str
 
     def __post_init__(self) -> None:
+        aperture_size = _require_int(
+            self.aperture_size,
+            "task.aperture_size",
+            minimum=1,
+            maximum=65_535,
+        )
+        if aperture_size % 2 != 1:
+            raise ForagerMatchedProtocolError("task.aperture_size must be odd")
         object.__setattr__(
             self,
             "aperture_size",
-            _require_int(self.aperture_size, "task.aperture_size", minimum=1, maximum=65_535),
+            aperture_size,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -392,10 +400,21 @@ class PairingEligibility:
     exclusion_reasons: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        eligible = _require_bool(self.eligible, "pairing.eligible")
+        if eligible and (self.analysis_role != "inferential" or self.exclusion_reasons):
+            raise ForagerMatchedProtocolError(
+                "pairing eligible candidates must be inferential with no exclusion reasons"
+            )
+        if not eligible and (
+            self.analysis_role != "descriptive_only" or not self.exclusion_reasons
+        ):
+            raise ForagerMatchedProtocolError(
+                "pairing ineligible candidates must be descriptive with exclusion reasons"
+            )
         object.__setattr__(
             self,
             "eligible",
-            _require_bool(self.eligible, "pairing.eligible"),
+            eligible,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -503,15 +522,20 @@ class SelectionGroup:
     advance_count: int
 
     def __post_init__(self) -> None:
+        advance_count = _require_int(
+            self.advance_count,
+            "selection_group.advance_count",
+            minimum=1,
+            maximum=_MAX_CANDIDATES,
+        )
+        if advance_count > len(self.candidate_ids):
+            raise ForagerMatchedProtocolError(
+                "selection_group.advance_count may not exceed the group candidate count"
+            )
         object.__setattr__(
             self,
             "advance_count",
-            _require_int(
-                self.advance_count,
-                "selection_group.advance_count",
-                minimum=1,
-                maximum=_MAX_CANDIDATES,
-            ),
+            advance_count,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -1135,7 +1159,7 @@ def _require_literal(value: Any, path: str, choices: tuple[str, ...]) -> str:
 
 
 def _require_bool(value: Any, path: str) -> bool:
-    if not isinstance(value, bool):
+    if type(value) is not bool:
         raise ForagerMatchedProtocolError(f"{path} must be a boolean")
     return value
 
@@ -1147,7 +1171,7 @@ def _require_int(
     minimum: int,
     maximum: int,
 ) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is not int:
         raise ForagerMatchedProtocolError(f"{path} must be an integer")
     if value < minimum or value > maximum:
         raise ForagerMatchedProtocolError(f"{path} must lie in [{minimum}, {maximum}]")
@@ -1293,8 +1317,6 @@ def _parse_task(value: Any) -> MatchedTask:
         minimum=1,
         maximum=65_535,
     )
-    if aperture % 2 != 1:
-        raise ForagerMatchedProtocolError(f"{path}.aperture_size must be odd")
     return MatchedTask(
         task_id=_require_identifier(payload["task_id"], f"{path}.task_id"),
         preset=preset,
@@ -1680,14 +1702,6 @@ def _parse_pairing(value: Any, path: str) -> PairingEligibility:
     reasons = _require_unique_identifiers(
         payload["exclusion_reasons"], f"{path}.exclusion_reasons", allow_empty=True
     )
-    if eligible and (role != "inferential" or reasons):
-        raise ForagerMatchedProtocolError(
-            f"{path} eligible candidates must be inferential with no exclusion reasons"
-        )
-    if not eligible and (role != "descriptive_only" or not reasons):
-        raise ForagerMatchedProtocolError(
-            f"{path} ineligible candidates must be descriptive with exclusion reasons"
-        )
     return PairingEligibility(
         analysis_role=cast(AnalysisRole, role),
         eligible=eligible,
@@ -1809,10 +1823,6 @@ def _parse_selection_plan(value: Any) -> SelectionPlan:
             minimum=1,
             maximum=_MAX_CANDIDATES,
         )
-        if advance_count > len(candidate_ids):
-            raise ForagerMatchedProtocolError(
-                f"{item_path}.advance_count may not exceed the group candidate count"
-            )
         groups.append(
             SelectionGroup(
                 selection_group=_require_identifier(

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -29,6 +29,7 @@ from typing import Any, cast
 
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
@@ -47,6 +48,18 @@ _STEP5_CONFIG_KEYS_ERROR = (
     "['average_reward_step_size', 'step_size', 'trace_decay']"
 )
 _INT32_MAX = 2**31 - 1
+_NUMPY_INTEGER_TYPES = (
+    np.byte,
+    np.short,
+    np.intc,
+    np.int_,
+    np.longlong,
+    np.ubyte,
+    np.ushort,
+    np.uintc,
+    np.uint,
+    np.ulonglong,
+)
 
 
 def _require_int(
@@ -58,9 +71,12 @@ def _require_int(
 ) -> int:
     """Reject non-integers (including bool and class-spoofed actual types)."""
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
+    if actual_type is int:
+        number = cast(int, value)
+    elif actual_type in _NUMPY_INTEGER_TYPES:
+        number = int(cast(Integral, value))
+    else:
         raise ValueError(f"{name} must be an integer, got {value!r}")
-    number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
             raise ValueError(f"{name} must be positive, got {value!r}")

--- a/tests/test_forager_matched_protocol.py
+++ b/tests/test_forager_matched_protocol.py
@@ -1454,3 +1454,87 @@ def test_matched_protocol_records_reject_leftover_identities() -> None:
     assert '"eligible": 1' not in dumped
     assert '"rank": true' not in dumped
     assert '"advance_count": true' not in dumped
+
+
+def test_matched_protocol_record_scalars_reject_hostile_exact_type_facades() -> None:
+    class IntFacade(int):
+        pass
+
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="aperture_size"):
+        matched.MatchedTask(
+            task_id="task",
+            preset="field_of_view",
+            environment_id="env",
+            foragax_distribution="dist",
+            foragax_version="0.1.0",
+            observation_type="rgb",
+            aperture_size=IntFacade(15),
+            task_identity_sha256=TASK_SHA,
+            environment_rng_schedule_sha256=SCHEDULE_SHA,
+        )
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="rank"):
+        matched.SelectionSlot(selection_group="alberta", rank=IntFacade(1))
+
+
+@pytest.mark.parametrize("aperture_size", (0, 2, 65_536))
+def test_matched_task_direct_construction_enforces_parser_aperture_bounds(
+    aperture_size: int,
+) -> None:
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="aperture_size"):
+        matched.MatchedTask(
+            task_id="task",
+            preset="field_of_view",
+            environment_id="env",
+            foragax_distribution="dist",
+            foragax_version="0.1.0",
+            observation_type="rgb",
+            aperture_size=aperture_size,
+            task_identity_sha256=TASK_SHA,
+            environment_rng_schedule_sha256=SCHEDULE_SHA,
+        )
+
+
+@pytest.mark.parametrize("rank", (0, 257))
+def test_selection_slot_direct_construction_enforces_rank_bounds(rank: int) -> None:
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="rank"):
+        matched.SelectionSlot(selection_group="alberta", rank=rank)
+
+
+@pytest.mark.parametrize("advance_count", (0, 2, 257))
+def test_selection_group_direct_construction_enforces_count_invariants(
+    advance_count: int,
+) -> None:
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="advance_count"):
+        matched.SelectionGroup(
+            selection_group="alberta",
+            candidate_ids=("candidate",),
+            advance_count=advance_count,
+        )
+
+
+@pytest.mark.parametrize(
+    ("analysis_role", "eligible", "exclusion_reasons"),
+    (
+        ("descriptive_only", True, ()),
+        ("inferential", True, ("reason",)),
+        ("inferential", False, ("reason",)),
+        ("descriptive_only", False, ()),
+    ),
+)
+def test_pairing_direct_construction_enforces_parser_cross_field_invariants(
+    analysis_role: matched.AnalysisRole,
+    eligible: bool,
+    exclusion_reasons: tuple[str, ...],
+) -> None:
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="pairing"):
+        matched.PairingEligibility(
+            analysis_role=analysis_role,
+            eligible=eligible,
+            exclusion_reasons=exclusion_reasons,
+        )
+
+
+@pytest.mark.parametrize("value", (-1, 2**63))
+def test_resource_record_direct_construction_enforces_exact_bounds(value: int) -> None:
+    with pytest.raises(matched.ForagerMatchedProtocolError, match="parameter_count"):
+        matched.ResourceAccounting(value, 0, 0, 0)

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1263,3 +1263,31 @@ def test_step11_smoke_result_rejects_leftover_identities() -> None:
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
     assert '"option_termination_count": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("steps", 0),
+        ("steps", 2**31),
+        ("steps", type("IntFacade", (int,), {})(8)),
+        ("seed", -1),
+        ("seed", 2**32),
+        ("finite", np.bool_(True)),
+        ("option_termination_count", -1),
+        ("option_termination_count", 2**31),
+    ),
+)
+def test_step11_smoke_result_rejects_hostile_and_boundary_scalars(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_step11_smoke_result(**{field: value})
+
+
+def test_step11_smoke_result_canonicalizes_supported_numpy_integer_identities() -> None:
+    result = _legal_step11_smoke_result(
+        steps=np.int64(8), option_termination_count=np.uint32(0)
+    )
+    assert type(result.steps) is int
+    assert type(result.option_termination_count) is int

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -1252,3 +1252,26 @@ def test_step12_smoke_result_rejects_leftover_identities() -> None:
     assert '"steps": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("steps", 0),
+        ("steps", 2**31),
+        ("steps", type("IntFacade", (int,), {})(8)),
+        ("seed", -1),
+        ("seed", 2**32),
+        ("finite", np.bool_(True)),
+    ),
+)
+def test_step12_smoke_result_rejects_hostile_and_boundary_scalars(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_step12_smoke_result(**{field: value})
+
+
+def test_step12_smoke_result_canonicalizes_supported_numpy_step_identity() -> None:
+    result = _legal_step12_smoke_result(steps=np.int64(8))
+    assert type(result.steps) is int

--- a/tests/test_step5_production.py
+++ b/tests/test_step5_production.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+import numpy as np
 import pytest
 
 from alberta_framework.steps.step5 import Step5AverageRewardTDConfig, Step5SmokeResult
@@ -51,3 +52,26 @@ def test_step5_smoke_result_rejects_leftover_identities() -> None:
     assert '"steps": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("steps", 0),
+        ("steps", 2**31),
+        ("steps", type("IntFacade", (int,), {})(8)),
+        ("seed", -1),
+        ("seed", 2**32),
+        ("finite", np.bool_(True)),
+    ),
+)
+def test_step5_smoke_result_rejects_hostile_and_boundary_scalars(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_step5_smoke_result(**{field: value})
+
+
+def test_step5_smoke_result_canonicalizes_supported_numpy_step_identity() -> None:
+    result = _legal_step5_smoke_result(steps=np.int64(8))
+    assert type(result.steps) is int


### PR DESCRIPTION
Follow-up deep review of #1147, #1149, #1150, and #1151 (issues #1144, #1145, #1146, #1148).\n\nThe merged narrow fixes correctly reject their reported bool/int leftovers, but the review found three deeper gaps: the shared matched-protocol validators still accepted int subclasses; direct constructors did not enforce the parser-only odd-aperture, pairing, and advancement cross-field invariants; and Step 5 accepted arbitrary Integral facades. This correction makes bool/int acceptance exact, retains canonical supported NumPy integer inputs for Step 5, and moves cross-field invariants into the record constructors so direct and parsed construction cannot drift.\n\nAdds hostile subclasses, NumPy booleans, lower/upper boundaries, parser-parity cases, and canonical-storage checks. No outputs or benchmark artifacts changed.\n\nVerification:\n- 707 focused Step 5/11/12 and matched-protocol tests passed\n- 38 new/deep tests passed after rebasing to current main\n- focused Ruff passed\n- strict mypy passed for all four source modules