### PR TITLE
fix(candidate-universe): reject leftover record identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -28,6 +28,8 @@ FORAGER_MATCHED_CANDIDATE_UNIVERSE_SCHEMA_VERSION: Final = (
 )
 
 _MAX_JSON_BYTES: Final = 2 * 1024 * 1024
+_MAX_INT32: Final = 2**31 - 1
+_MAX_JAX_SEED: Final = 2**32 - 1
 _OPEN_DEVELOPMENT_SEEDS: Final = (2_000_001, 2_000_002)
 
 ScreenId = Literal[
@@ -59,6 +61,21 @@ def _require_exact_int(value: Any, path: str) -> int:
     return value
 
 
+def _require_bounded_int(
+    value: Any,
+    path: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    number = _require_exact_int(value, path)
+    if not minimum <= number <= maximum:
+        raise ForagerMatchedCandidateUniverseError(
+            f"{path} must lie in [{minimum}, {maximum}]"
+        )
+    return number
+
+
 def _require_exact_bool(value: Any, path: str) -> bool:
     if type(value) is not bool:
         raise ForagerMatchedCandidateUniverseError(f"{path} must be a boolean")
@@ -66,29 +83,31 @@ def _require_exact_bool(value: Any, path: str) -> bool:
 
 
 def _require_finite_real(value: Any, path: str) -> float:
-    if type(value) is bool or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number")
-    try:
-        number = float(value)
-    except (OverflowError, ValueError) as exc:
-        raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number") from exc
+    number = float(cast("int | float", value))
     if not math.isfinite(number):
         raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number")
     return number
 
 
 def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
-    if type(values) is bool:
-        raise ForagerMatchedCandidateUniverseError(f"{name} must not be a boolean")
-    if isinstance(values, (str, bytes)):
-        raise ForagerMatchedCandidateUniverseError(f"{name} must be a sequence of integer seeds")
-    try:
-        raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
-    except TypeError as exc:
+    if type(values) is not tuple or not values:
         raise ForagerMatchedCandidateUniverseError(
-            f"{name} must be a sequence of integer seeds"
-        ) from exc
-    return tuple(_require_exact_int(item, f"{name}[{index}]") for index, item in enumerate(raw))
+            f"{name} must be a non-empty exact tuple of unique JAX seeds"
+        )
+    seeds = tuple(
+        _require_bounded_int(
+            item,
+            f"{name}[{index}]",
+            minimum=0,
+            maximum=_MAX_JAX_SEED,
+        )
+        for index, item in enumerate(values)
+    )
+    if len(set(seeds)) != len(seeds):
+        raise ForagerMatchedCandidateUniverseError(f"{name} must contain unique seeds")
+    return seeds
 
 
 @dataclass(frozen=True)
@@ -111,12 +130,22 @@ class ScreeningArtifactBinding:
         object.__setattr__(
             self,
             "horizon_per_seed",
-            _require_exact_int(self.horizon_per_seed, "horizon_per_seed"),
+            _require_bounded_int(
+                self.horizon_per_seed,
+                "horizon_per_seed",
+                minimum=1,
+                maximum=_MAX_INT32,
+            ),
         )
         object.__setattr__(
             self,
             "candidate_count",
-            _require_exact_int(self.candidate_count, "candidate_count"),
+            _require_bounded_int(
+                self.candidate_count,
+                "candidate_count",
+                minimum=1,
+                maximum=_MAX_INT32,
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -183,12 +212,22 @@ class LocalCandidateGenerationBinding:
         object.__setattr__(
             self,
             "horizon_per_seed",
-            _require_exact_int(self.horizon_per_seed, "horizon_per_seed"),
+            _require_bounded_int(
+                self.horizon_per_seed,
+                "horizon_per_seed",
+                minimum=1,
+                maximum=_MAX_INT32,
+            ),
         )
         object.__setattr__(
             self,
             "candidate_count",
-            _require_exact_int(self.candidate_count, "candidate_count"),
+            _require_bounded_int(
+                self.candidate_count,
+                "candidate_count",
+                minimum=1,
+                maximum=_MAX_INT32,
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -233,7 +272,12 @@ class ScreenedArmDecision:
         object.__setattr__(
             self,
             "open_development_rank",
-            _require_exact_int(self.open_development_rank, "open_development_rank"),
+            _require_bounded_int(
+                self.open_development_rank,
+                "open_development_rank",
+                minimum=1,
+                maximum=_MAX_INT32,
+            ),
         )
         object.__setattr__(
             self,

--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -53,6 +53,44 @@ class ForagerMatchedCandidateUniverseError(ValueError):
     """The candidate-universe artifact or one of its bindings is invalid."""
 
 
+def _require_exact_int(value: Any, path: str) -> int:
+    if type(value) is not int:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be an integer")
+    return value
+
+
+def _require_exact_bool(value: Any, path: str) -> bool:
+    if type(value) is not bool:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a boolean")
+    return value
+
+
+def _require_finite_real(value: Any, path: str) -> float:
+    if type(value) is bool or not isinstance(value, (int, float)):
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number")
+    try:
+        number = float(value)
+    except (OverflowError, ValueError) as exc:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number") from exc
+    if not math.isfinite(number):
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number")
+    return number
+
+
+def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
+    if type(values) is bool:
+        raise ForagerMatchedCandidateUniverseError(f"{name} must not be a boolean")
+    if isinstance(values, (str, bytes)):
+        raise ForagerMatchedCandidateUniverseError(f"{name} must be a sequence of integer seeds")
+    try:
+        raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise ForagerMatchedCandidateUniverseError(
+            f"{name} must be a sequence of integer seeds"
+        ) from exc
+    return tuple(_require_exact_int(item, f"{name}[{index}]") for index, item in enumerate(raw))
+
+
 @dataclass(frozen=True)
 class ScreeningArtifactBinding:
     """Exact JSON bindings for one historical open-development screen."""
@@ -68,6 +106,18 @@ class ScreeningArtifactBinding:
     protocol_schema_version: str
     horizon_per_seed: int
     candidate_count: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "horizon_per_seed",
+            _require_exact_int(self.horizon_per_seed, "horizon_per_seed"),
+        )
+        object.__setattr__(
+            self,
+            "candidate_count",
+            _require_exact_int(self.candidate_count, "candidate_count"),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -124,6 +174,23 @@ class LocalCandidateGenerationBinding:
     source_inventory_sha256: str
     artifacts: tuple[BoundJsonArtifact, ...]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "seeds",
+            _require_seed_identities(self.seeds, name="seeds"),
+        )
+        object.__setattr__(
+            self,
+            "horizon_per_seed",
+            _require_exact_int(self.horizon_per_seed, "horizon_per_seed"),
+        )
+        object.__setattr__(
+            self,
+            "candidate_count",
+            _require_exact_int(self.candidate_count, "candidate_count"),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "screen_id": self.screen_id,
@@ -162,6 +229,21 @@ class ScreenedArmDecision:
     worker_configuration_sha256: str | None = None
     historical_descriptor_sha256: str | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "open_development_rank",
+            _require_exact_int(self.open_development_rank, "open_development_rank"),
+        )
+        object.__setattr__(
+            self,
+            "open_development_aggregate_mean",
+            _require_finite_real(
+                self.open_development_aggregate_mean,
+                "open_development_aggregate_mean",
+            ),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "screen_id": self.screen_id,
@@ -193,6 +275,13 @@ class RegisteredCandidateDecision:
     rng_relationship: str
     observation_access: str
     rationale: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "pairing_eligible",
+            _require_exact_bool(self.pairing_eligible, "pairing_eligible"),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -1399,12 +1488,6 @@ def _read_bound_json(
 def _require_false(value: Mapping[str, Any], key: str, context: str) -> None:
     if value.get(key) is not False:
         raise ForagerMatchedCandidateUniverseError(f"{context}.{key} must be false")
-
-
-def _require_exact_int(value: Any, path: str) -> int:
-    if type(value) is not int:
-        raise ForagerMatchedCandidateUniverseError(f"{path} must be an integer")
-    return value
 
 
 def _require_exact_int_list(value: Any, path: str) -> list[int]:

--- a/tests/test_forager_matched_candidate_universe.py
+++ b/tests/test_forager_matched_candidate_universe.py
@@ -832,3 +832,65 @@ def test_candidate_universe_records_reject_leftover_identities() -> None:
     assert '"open_development_rank": true' not in dumped
     assert '"open_development_aggregate_mean": true' not in dumped
     assert '"pairing_eligible": 1' not in dumped
+
+
+def test_candidate_universe_records_reject_hostile_and_aliased_numbers() -> None:
+    class HostileInt(int):
+        def __lt__(self, other: object) -> bool:
+            raise AssertionError("hostile integer comparison must not run")
+
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("hostile float conversion must not run")
+
+    class HostileSeeds:
+        def __iter__(self):
+            raise AssertionError("hostile seed iteration must not run")
+
+    for field, value in (
+        ("horizon_per_seed", 0),
+        ("candidate_count", 0),
+        ("horizon_per_seed", HostileInt(1)),
+    ):
+        with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match=field):
+            _legal_screening_binding(**{field: value})
+
+    binding_arguments: dict[str, object] = {
+        "screen_id": "horde_fov_tuning_v2",
+        "family": "alberta_horde_actor_critic",
+        "horizon_per_seed": 10,
+        "candidate_count": 4,
+        "normalized_matrix_sha256": "a" * 64,
+        "source_tree_sha256": "a" * 64,
+        "source_archive_sha256": "a" * 64,
+        "source_inventory_sha256": "a" * 64,
+        "artifacts": (universe.BoundJsonArtifact("role", "p.json", "a" * 64),),
+    }
+    for seeds, message in (
+        (HostileSeeds(), "non-empty exact tuple"),
+        ((), "non-empty"),
+        ((0, 0), "unique"),
+        ((-1,), r"\[0, 4294967295\]"),
+        ((2**32,), r"\[0, 4294967295\]"),
+        ((HostileInt(0),), r"seeds\[0\]"),
+    ):
+        with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match=message):
+            universe.LocalCandidateGenerationBinding(  # type: ignore[arg-type]
+                seeds=seeds,
+                **binding_arguments,
+            )
+
+    with pytest.raises(
+        universe.ForagerMatchedCandidateUniverseError,
+        match="open_development_aggregate_mean",
+    ):
+        universe.ScreenedArmDecision(
+            screen_id="dqn_common_control_v3",
+            configuration="configs/x",
+            configuration_sha256="a" * 64,
+            open_development_rank=1,
+            open_development_aggregate_mean=HostileFloat(0.5),
+            disposition="registered_horizon_transform",
+            registered_candidate_ids=("a",),
+            rationale="r",
+        )

--- a/tests/test_forager_matched_candidate_universe.py
+++ b/tests/test_forager_matched_candidate_universe.py
@@ -708,3 +708,127 @@ def test_internal_descriptor_validator_rejects_external_group_role_drift(
 
     with pytest.raises(AssertionError, match="selection group|role/pairing"):
         universe._validate_internal_descriptor(descriptor)
+
+
+def _legal_screening_binding(**overrides: object) -> universe.ScreeningArtifactBinding:
+    payload: dict[str, object] = {
+        "screen_id": "dqn_common_control_v3",
+        "family": "common_control_dqn",
+        "protocol_path": "p.json",
+        "protocol_sha256": "a" * 64,
+        "screen_plan_path": "s.json",
+        "screen_plan_sha256": "a" * 64,
+        "aggregate_path": "a.json",
+        "aggregate_sha256": "a" * 64,
+        "protocol_schema_version": "v1",
+        "horizon_per_seed": 100,
+        "candidate_count": 2,
+    }
+    payload.update(overrides)
+    return universe.ScreeningArtifactBinding(**payload)  # type: ignore[arg-type]
+
+
+def test_candidate_universe_records_reject_leftover_identities() -> None:
+    """Public candidate-universe records must not keep leftover bool/int identities."""
+
+    with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match="horizon_per_seed"):
+        _legal_screening_binding(horizon_per_seed=True)
+    with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match="candidate_count"):
+        _legal_screening_binding(candidate_count=True)
+    with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match="seeds"):
+        universe.LocalCandidateGenerationBinding(
+            screen_id="horde_fov_tuning_v2",
+            family="alberta_horde_actor_critic",
+            seeds=(True,),
+            horizon_per_seed=10,
+            candidate_count=4,
+            normalized_matrix_sha256="a" * 64,
+            source_tree_sha256="a" * 64,
+            source_archive_sha256="a" * 64,
+            source_inventory_sha256="a" * 64,
+            artifacts=(universe.BoundJsonArtifact("role", "p.json", "a" * 64),),
+        )
+    with pytest.raises(
+        universe.ForagerMatchedCandidateUniverseError, match="open_development_rank"
+    ):
+        universe.ScreenedArmDecision(
+            screen_id="dqn_common_control_v3",
+            configuration="configs/x",
+            configuration_sha256="a" * 64,
+            open_development_rank=True,
+            open_development_aggregate_mean=0.5,
+            disposition="registered_horizon_transform",
+            registered_candidate_ids=("a",),
+            rationale="r",
+        )
+    with pytest.raises(
+        universe.ForagerMatchedCandidateUniverseError,
+        match="open_development_aggregate_mean",
+    ):
+        universe.ScreenedArmDecision(
+            screen_id="dqn_common_control_v3",
+            configuration="configs/x",
+            configuration_sha256="a" * 64,
+            open_development_rank=1,
+            open_development_aggregate_mean=True,
+            disposition="registered_horizon_transform",
+            registered_candidate_ids=("a",),
+            rationale="r",
+        )
+    with pytest.raises(universe.ForagerMatchedCandidateUniverseError, match="pairing_eligible"):
+        universe.RegisteredCandidateDecision(
+            candidate_id="c",
+            selection_group="alberta",
+            analysis_role="inferential",
+            pairing_eligible=1,
+            source_screen_id=None,
+            source_configuration=None,
+            implementation_relationship="independent_alberta_tuning_arm",
+            rng_relationship="isolated_agent_and_environment_streams",
+            observation_access="matched_partial_color_aperture_9",
+            rationale="r",
+        )
+
+    legal_screen = _legal_screening_binding()
+    legal_arm = universe.ScreenedArmDecision(
+        screen_id="dqn_common_control_v3",
+        configuration="configs/x",
+        configuration_sha256="a" * 64,
+        open_development_rank=1,
+        open_development_aggregate_mean=0.5,
+        disposition="registered_horizon_transform",
+        registered_candidate_ids=("a",),
+        rationale="r",
+    )
+    legal_reg = universe.RegisteredCandidateDecision(
+        candidate_id="c",
+        selection_group="alberta",
+        analysis_role="inferential",
+        pairing_eligible=True,
+        source_screen_id=None,
+        source_configuration=None,
+        implementation_relationship="independent_alberta_tuning_arm",
+        rng_relationship="isolated_agent_and_environment_streams",
+        observation_access="matched_partial_color_aperture_9",
+        rationale="r",
+    )
+    dumped = json.dumps(
+        {
+            "horizon_per_seed": legal_screen.horizon_per_seed,
+            "candidate_count": legal_screen.candidate_count,
+            "open_development_rank": legal_arm.open_development_rank,
+            "open_development_aggregate_mean": legal_arm.open_development_aggregate_mean,
+            "pairing_eligible": legal_reg.pairing_eligible,
+        },
+        allow_nan=False,
+    )
+    assert '"horizon_per_seed": 100' in dumped
+    assert '"candidate_count": 2' in dumped
+    assert '"open_development_rank": 1' in dumped
+    assert '"open_development_aggregate_mean": 0.5' in dumped
+    assert '"pairing_eligible": true' in dumped
+    assert '"horizon_per_seed": true' not in dumped
+    assert '"candidate_count": true' not in dumped
+    assert '"open_development_rank": true' not in dumped
+    assert '"open_development_aggregate_mean": true' not in dumped
+    assert '"pairing_eligible": 1' not in dumped


### PR DESCRIPTION
Closes #1155.

## What changed

Public matched-current candidate-universe records now fail closed on leftover bool-as-int and leftover int-as-bool identities.

On origin/main `bb3c300` (files unchanged through `4217225`), the JSON parser already used `_require_exact_int`. Direct construction of `ScreeningArtifactBinding`, `LocalCandidateGenerationBinding`, `ScreenedArmDecision`, and `RegisteredCandidateDecision` had no constructor gate and accepted leftover identities (`horizon_per_seed=True`, `seeds=(True,)`, `open_development_rank=True`, `pairing_eligible=1`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"horizon_per_seed": true`, `"seeds": [true]`, or `"pairing_eligible": 1`.

This is leftover tax on `forager_matched_candidate_universe.py` public records, not a republish of `#1151` (matched-protocol) or `#1108` (historical-forager).

## Scope

- `alberta_framework/benchmarks/forager_matched_candidate_universe.py`
- `tests/test_forager_matched_candidate_universe.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1157` only (`forager_matched_protocol.py`, `step5.py`, and those tests). These files were FREE. Closed `#1154`/`#1153`/`#1143` (bayes / micro_continual), `#1152` (horde/IA), and merged leftover `#1151`/`#1150`/`#1149`/`#1147` do not occupy this pair.

## Verification

Exact candidate head: `51302d2cf11746c58d7f35d551a4ab3a5959372e`
Base: `bb3c300`

- Red on base: `ScreeningArtifactBinding(horizon_per_seed=True)` accepted; dump emitted `"horizon_per_seed": true`
- Focused pytest `tests/test_forager_matched_candidate_universe.py`: 32 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:51302d2cf11746c58d7f35d551a4ab3a5959372e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
