### PR TITLE
fix(recurring-multiagent): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -77,6 +77,20 @@ RECURRING_TWO_AGENT_CLOCK_DELTA_NBYTES = 8
 type PartnerPolicy = Callable[[Array, Array], Array]
 
 
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int = 0,
+    maximum: int = _INT32_MAX,
+) -> int:
+    if type(value) is bool or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
+    return value
+
+
 def _require_array(
     value: Any,
     *,
@@ -257,6 +271,29 @@ class RecurringTwoAgentResourceBudget:
     exact_clock_delta_nbytes: int
     trainable_scalars: int = 0
     replay_capacity: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "state_nbytes", _require_int("state_nbytes", self.state_nbytes))
+        object.__setattr__(
+            self,
+            "exact_clock_nbytes",
+            _require_int("exact_clock_nbytes", self.exact_clock_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "exact_clock_delta_nbytes",
+            _require_int("exact_clock_delta_nbytes", self.exact_clock_delta_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int("trainable_scalars", self.trainable_scalars),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity",
+            _require_int("replay_capacity", self.replay_capacity),
+        )
 
     def to_dict(self) -> dict[str, int | str]:
         return {

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import FrozenInstanceError
 
 import chex
@@ -21,6 +22,7 @@ from alberta_framework.streams import (
     RecurringTwoAgentTransition,
     RecurringTwoAgentWorld,
 )
+from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentResourceBudget
 
 
 def _with_step_count(
@@ -553,3 +555,48 @@ def test_recurring_two_agent_world_initial_positions_reject_booleans() -> None:
     # Valid initial positions
     world = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
     assert world.to_config()["initial_positions"] == [-0.5, 0.5]
+
+
+def test_recurring_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="state_nbytes"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=True,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+    with pytest.raises(ValueError, match="trainable_scalars"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            trainable_scalars=True,
+        )
+    with pytest.raises(ValueError, match="replay_capacity"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            replay_capacity=True,
+        )
+    with pytest.raises(ValueError, match="state_nbytes"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=float("nan"),
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+
+    legal = RecurringTwoAgentResourceBudget(
+        state_nbytes=1,
+        exact_clock_nbytes=12,
+        exact_clock_delta_nbytes=8,
+    )
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"state_nbytes": 1' in dumped
+    assert '"exact_clock_nbytes": 12' in dumped
+    assert '"trainable_scalars": 0' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"state_nbytes": true' not in dumped
+    assert '"trainable_scalars": true' not in dumped
+    assert '"replay_capacity": true' not in dumped


### PR DESCRIPTION
Closes #1156.

## What changed

The recurring two-agent resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `bb3c300` (files unchanged through `4217225`), `RecurringTwoAgentWorld` already rejected leftover boolean identities on constructor scalars such as `initial_positions`. `RecurringTwoAgentResourceBudget` had no `__post_init__` and accepted leftover identities (`state_nbytes=True`, `trainable_scalars=True`, `replay_capacity=True`, `state_nbytes=NaN`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"state_nbytes": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `recurring_multiagent.py` resource-budget records, not a republish of `#946` (recurring start positions), `#1014` (closed-loop config), or `#1095` (continual-multiagent measurement records).

## Scope

- `alberta_framework/streams/recurring_multiagent.py`
- `tests/test_recurring_multiagent_stream.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1157` only (`forager_matched_protocol.py`, `step5.py`, and those tests). These files were FREE. Closed `#1154`/`#1153`/`#1143` (bayes / micro_continual), `#1152` (horde/IA), and merged leftover `#1151`/`#1150`/`#1149`/`#1147` do not occupy this pair.

## Verification

Exact candidate head: `844a3e191b7566792a6109d97abf9a7b76613ca3`
Base: `bb3c300`

- Red on base: `RecurringTwoAgentResourceBudget(state_nbytes=True, ...)` accepted; dump emitted `"state_nbytes": true`
- Focused pytest `tests/test_recurring_multiagent_stream.py`: 29 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:844a3e191b7566792a6109d97abf9a7b76613ca3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
