### PR TITLE
fix(core): preserve discrete action contracts under JIT

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -38,6 +38,9 @@ from alberta_framework._float32 import round_real_to_float32
 from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.optimizers import Bounder, bounder_from_config
 from alberta_framework.core.update_safety import (
+    checked_integer_action_array,
+)
+from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
 
@@ -902,25 +905,23 @@ def run_actor_critic_from_arrays(
         discounts = jnp.where(terminated, 0.0, agent.config.gamma).astype(jnp.float32)
     if actions is None:
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
+        actions_valid = jnp.ones((num_steps,), dtype=jnp.bool_)
         use_fixed_actions = False
     else:
-        try:
-            actions_dtype = np.dtype(actions.dtype)
-        except (AttributeError, TypeError) as error:
-            raise ValueError("actions must expose an integer dtype") from error
-        if not np.issubdtype(actions_dtype, np.integer):
-            raise ValueError("actions must have an integer dtype")
-        action_values = np.asarray(actions)
-        if not bool(np.all((action_values >= 0) & (action_values < agent.config.n_actions))):
-            raise ValueError("actions must lie in [0, n_actions)")
-        actions = jnp.asarray(actions, dtype=jnp.int32)
+        actions, actions_valid = checked_integer_action_array(
+            actions,
+            agent.config.n_actions,
+            name="actions",
+            expected_shape=(num_steps,),
+            range_message="actions must lie in [0, n_actions)",
+        )
         use_fixed_actions = True
 
     def _scan_fn(
         carry: ActorCriticState,
-        inputs: tuple[Array, Array, Array, Array, Array],
+        inputs: tuple[Array, Array, Array, Array, Array, Array],
     ) -> tuple[ActorCriticState, tuple[Array, Array, Array, Array, Array]]:
-        obs, reward, term_discount, next_obs, fixed_action = inputs
+        obs, reward, term_discount, next_obs, fixed_action, fixed_action_valid = inputs
         if use_fixed_actions:
             started_state = carry.replace(  # type: ignore[attr-defined]
                 last_observation=obs,
@@ -936,27 +937,28 @@ def run_actor_critic_from_arrays(
             next_obs,
             discount=term_discount,
         )
+        update_applied = result.update_applied & fixed_action_valid
         next_carry = jax.lax.cond(
-            result.update_applied,
+            update_applied,
             lambda: result.state,
             lambda: carry,
         )
         return next_carry, (
             jnp.where(
-                result.update_applied,
+                update_applied,
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            jnp.where(result.update_applied, current_policy, jnp.zeros_like(current_policy)),
-            result.value,
-            result.td_error,
-            result.update_applied,
+            jnp.where(update_applied, current_policy, jnp.zeros_like(current_policy)),
+            jnp.where(update_applied, result.value, 0.0),
+            jnp.where(update_applied, result.td_error, 0.0),
+            update_applied,
         )
 
     final_state, (actions, policies, values, td_errors, updates_applied) = jax.lax.scan(
         _scan_fn,
         state,
-        (observations, rewards, discounts, next_observations, actions),
+        (observations, rewards, discounts, next_observations, actions, actions_valid),
     )
     return ActorCriticArrayResult(  # type: ignore[call-arg]
         state=final_state,

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -57,6 +57,9 @@ from alberta_framework.core.optimizers import (
 )
 from alberta_framework.core.types import AutostepParamState, DemonType, MLPParams
 from alberta_framework.core.update_safety import (
+    checked_integer_action_array,
+)
+from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
 
@@ -1088,20 +1091,22 @@ def run_horde_actor_critic_from_arrays(
     fixed per-head ``gamma`` values; variable per-transition discounts remain a
     future extension to ``HordeLearner.update`` itself.
     """
+    rewards_shape = tuple(rewards.shape)
+    if len(rewards_shape) != 1 or rewards_shape[0] < 1:
+        raise ValueError("rewards must have shape (num_steps,)")
+    num_steps = rewards_shape[0]
     if actions is None:
         actions = jnp.full_like(rewards, -1, dtype=jnp.int32)
+        actions_valid = jnp.ones((num_steps,), dtype=jnp.bool_)
         use_fixed_actions = False
     else:
-        try:
-            actions_dtype = np.dtype(actions.dtype)
-        except (AttributeError, TypeError) as error:
-            raise ValueError("actions must expose an integer dtype") from error
-        if not np.issubdtype(actions_dtype, np.integer):
-            raise ValueError("actions must have an integer dtype")
-        action_values = np.asarray(actions)
-        if not bool(np.all((action_values >= 0) & (action_values < agent.config.n_actions))):
-            raise ValueError("actions must lie in [0, n_actions)")
-        actions = jnp.asarray(actions, dtype=jnp.int32)
+        actions, actions_valid = checked_integer_action_array(
+            actions,
+            agent.config.n_actions,
+            name="actions",
+            expected_shape=(num_steps,),
+            range_message="actions must lie in [0, n_actions)",
+        )
         use_fixed_actions = True
     if auxiliary_cumulants is None:
         auxiliary_cumulants = jnp.zeros(
@@ -1117,12 +1122,20 @@ def run_horde_actor_critic_from_arrays(
 
     def _scan_fn(
         carry: HordeActorCriticState,
-        inputs: tuple[Array, Array, Array, Array, Array, Array],
+        inputs: tuple[Array, Array, Array, Array, Array, Array, Array],
     ) -> tuple[
         HordeActorCriticState,
         tuple[Array, Array, Array, Array, Array, Array],
     ]:
-        obs, reward, next_obs, fixed_action, aux, transition_discount = inputs
+        (
+            obs,
+            reward,
+            next_obs,
+            fixed_action,
+            fixed_action_valid,
+            aux,
+            transition_discount,
+        ) = inputs
         if use_fixed_actions:
             started_state = carry.replace(  # type: ignore[attr-defined]
                 last_observation=obs,
@@ -1138,22 +1151,27 @@ def run_horde_actor_critic_from_arrays(
             aux,
             transition_discount,
         )
+        update_applied = result.update_applied & fixed_action_valid
         committed_state = jax.lax.cond(
-            result.update_applied,
+            update_applied,
             lambda: result.state,
             lambda: carry,
         )
         return committed_state, (
             jnp.where(
-                result.update_applied,
+                update_applied,
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            result.policy,
-            result.value,
-            result.td_error,
-            result.critic_result.td_errors,
-            result.update_applied,
+            jnp.where(update_applied, result.policy, jnp.zeros_like(result.policy)),
+            jnp.where(update_applied, result.value, 0.0),
+            jnp.where(update_applied, result.td_error, 0.0),
+            jnp.where(
+                update_applied,
+                result.critic_result.td_errors,
+                jnp.zeros_like(result.critic_result.td_errors),
+            ),
+            update_applied,
         )
 
     (
@@ -1174,6 +1192,7 @@ def run_horde_actor_critic_from_arrays(
             rewards,
             next_observations,
             actions,
+            actions_valid,
             auxiliary_cumulants,
             discounts,
         ),

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -69,6 +69,7 @@ from alberta_framework.core.oak import (
     migrate_legacy_oak_state,
     oak_total_lifetime_counter_nbytes,
 )
+from alberta_framework.core.update_safety import checked_integer_action_array
 
 EXO_CEREBELLUM_STATE_SCHEMA = "alberta.exo-cerebellum-state.v2"
 IA_STATE_SCHEMA = "alberta.intelligence-amplification-state.v2"
@@ -402,12 +403,12 @@ def _checked_partner_action(
         raise ValueError("partner_action must be scalar")
     if not jnp.issubdtype(raw.dtype, jnp.integer):
         raise ValueError("partner_action must have an integer dtype")
-    executed = jnp.asarray(raw, dtype=jnp.int32)
-    valid = (executed >= 0) & (executed < n_primitive_actions)
+    valid = (raw >= 0) & (raw < n_primitive_actions)
     if not isinstance(valid, jax.core.Tracer) and not bool(valid):
         raise ValueError(f"partner_action must be in [0, {n_primitive_actions})")
+    executed = jnp.where(valid, raw, 0).astype(jnp.int32)
     return (
-        jnp.where(valid, executed, jnp.array(0, dtype=jnp.int32)),
+        executed,
         valid,
     )
 
@@ -1349,15 +1350,22 @@ class IAAgent:
                 result.update_applied,
             )
 
-        num_steps = jnp.asarray(partner_rewards).shape[0]
+        partner_rewards_shape = tuple(partner_rewards.shape)
+        if len(partner_rewards_shape) != 1 or partner_rewards_shape[0] < 1:
+            raise ValueError("partner_rewards must have shape (num_steps,)")
+        num_steps = partner_rewards_shape[0]
         if partner_actions is not None:
-            try:
-                partner_actions_dtype = np.dtype(partner_actions.dtype)
-            except (AttributeError, TypeError) as error:
-                raise ValueError("partner_actions must expose an integer dtype") from error
-            if not np.issubdtype(partner_actions_dtype, np.integer):
-                raise ValueError("partner_actions must have an integer dtype")
-            scan_actions = jnp.asarray(partner_actions, dtype=jnp.int32)
+            _, _ = checked_integer_action_array(
+                partner_actions,
+                self._config.cortex.n_primitive_actions,
+                name="partner_actions",
+                expected_shape=(num_steps,),
+                range_message="partner_actions must lie in the primitive action range",
+            )
+            # Preserve the original integer dtype until each scalar reaches
+            # ``_checked_partner_action``; narrowing here would erase wide
+            # invalid values such as uint64(2**32).
+            scan_actions = jnp.asarray(partner_actions)
         else:
             scan_actions = jnp.zeros((num_steps,), dtype=jnp.int32)
         scan_discounts = (

--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from jaxtyping import Bool
+from jaxtyping import Bool, Int
 
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -77,6 +77,48 @@ def safe_discrete_action(
     fallback = -1 if allow_unset else 0
     safe = jnp.where(valid, raw, jnp.asarray(fallback, dtype=jnp.float32))
     return safe.astype(jnp.int32), valid
+
+
+def checked_integer_action_array(
+    actions: object,
+    n_actions: int,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+    range_message: str,
+) -> tuple[Int[Array, " *shape"], Bool[Array, " *shape"]]:
+    """Validate an integer action array without narrowing away invalid values.
+
+    Shape and dtype are static contracts, so they fail identically in eager
+    and staged/JIT calls. Concrete out-of-domain values raise before work is
+    staged. Traced values cannot synchronously raise from ordinary ``jax.jit``;
+    they instead produce a safe index plus a validity mask that callers must
+    include in their transaction commit predicate.
+    """
+
+    n_actions = _require_non_negative_int("n_actions", n_actions)
+    try:
+        shape = tuple(actions.shape)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError) as error:
+        raise ValueError(f"{name} must expose an exact shape") from error
+    if shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}")
+    try:
+        dtype = np.dtype(actions.dtype)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError) as error:
+        raise ValueError(f"{name} must expose an integer dtype") from error
+    if not np.issubdtype(dtype, np.integer):
+        raise ValueError(f"{name} must have an integer dtype")
+
+    if not isinstance(actions, jax.core.Tracer):
+        host_actions = np.asarray(actions)
+        if not bool(np.all((host_actions >= 0) & (host_actions < n_actions))):
+            raise ValueError(range_message)
+
+    raw = jnp.asarray(actions)
+    valid = (raw >= 0) & (raw < n_actions)
+    safe = jnp.where(valid, raw, 0).astype(jnp.int32)
+    return safe, valid
 
 
 def floating_tree_is_finite(tree: object) -> Bool[Array, ""]:

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -287,6 +288,48 @@ def test_discrete_scan_rejects_actions_that_cannot_name_policy_entries(
             jnp.asarray([[0.0, 1.0]], dtype=jnp.float32),
             actions=actions,
         )
+
+
+def test_discrete_scan_action_contract_is_jittable_and_invalid_values_are_atomic() -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.asarray([[1.0, 0.0]], dtype=jnp.float32)
+    rewards = jnp.asarray([1.0], dtype=jnp.float32)
+    terminated = jnp.asarray([False])
+    next_observations = jnp.asarray([[0.0, 1.0]], dtype=jnp.float32)
+
+    compiled = jax.jit(
+        lambda initial_state, fixed_actions: run_actor_critic_from_arrays(
+            agent,
+            initial_state,
+            observations,
+            rewards,
+            terminated,
+            next_observations,
+            actions=fixed_actions,
+        )
+    )
+    valid = compiled(state, jnp.asarray([1], dtype=jnp.int32))
+    assert bool(valid.updates_applied[0])
+
+    invalid = compiled(state, jnp.asarray([2], dtype=jnp.int32))
+    chex.assert_trees_all_equal(
+        invalid.state.replace(rng_key=jr.key_data(invalid.state.rng_key)),
+        state.replace(rng_key=jr.key_data(state.rng_key)),
+    )
+    assert not bool(jnp.any(invalid.updates_applied))
+    assert not bool(jnp.any(invalid.actions))
+    assert not bool(jnp.any(invalid.policies))
+    assert not bool(jnp.any(invalid.values))
+    assert not bool(jnp.any(invalid.td_errors))
+
+    for bad_actions in (
+        jnp.asarray([0.5], dtype=jnp.float32),
+        jnp.asarray([True], dtype=jnp.bool_),
+        jnp.asarray([[0]], dtype=jnp.int32),
+    ):
+        with pytest.raises(ValueError):
+            compiled(state, bad_actions)
 
 
 @pytest.mark.parametrize("continuous", [False, True])

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -1706,3 +1706,40 @@ def test_run_horde_actor_critic_from_arrays_rejects_non_integer_actions() -> Non
         agent, state, obs, rewards, next_obs, actions=jnp.array([1, 0], dtype=jnp.int32)
     )
     assert result.actions.shape == (2,)
+
+
+def test_horde_array_action_contract_is_jittable_and_invalid_values_are_atomic() -> None:
+    agent = _make_agent()
+    state = agent.init(feature_dim=4, key=jr.key(0))
+    obs = jnp.zeros((1, 4), dtype=jnp.float32)
+    rewards = jnp.ones(1, dtype=jnp.float32)
+
+    compiled = jax.jit(
+        lambda initial_state, fixed_actions: run_horde_actor_critic_from_arrays(
+            agent,
+            initial_state,
+            obs,
+            rewards,
+            obs,
+            actions=fixed_actions,
+        )
+    )
+    valid = compiled(state, jnp.asarray([1], dtype=jnp.int32))
+    assert bool(valid.updates_applied[0])
+
+    invalid = compiled(state, jnp.asarray([2], dtype=jnp.int32))
+    _assert_state_unchanged(invalid.state, state)
+    assert not bool(jnp.any(invalid.updates_applied))
+    assert not bool(jnp.any(invalid.actions))
+    assert not bool(jnp.any(invalid.policies))
+    assert not bool(jnp.any(invalid.values))
+    assert not bool(jnp.any(invalid.td_errors))
+    assert not bool(jnp.any(invalid.critic_td_errors))
+
+    for bad_actions in (
+        jnp.asarray([0.5], dtype=jnp.float32),
+        jnp.asarray([True], dtype=jnp.bool_),
+        jnp.asarray([[0]], dtype=jnp.int32),
+    ):
+        with pytest.raises(ValueError):
+            compiled(state, bad_actions)

--- a/tests/test_ia_crediting.py
+++ b/tests/test_ia_crediting.py
@@ -8,6 +8,8 @@ epsilon-greedy selection happened to pick.
 
 from __future__ import annotations
 
+import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -20,6 +22,7 @@ from alberta_framework.core.intelligence_amplification import (
     IAConfig,
     IAState,
     RecommendationProtocolConfig,
+    _checked_partner_action,
     init_recommendation_protocol_state,
     update_recommendation_protocol,
 )
@@ -334,3 +337,59 @@ def test_ia_agent_scan_rejects_non_integer_partner_actions() -> None:
         partner_actions=jnp.array([1, 0, 1, 0], dtype=jnp.int32),
     )
     assert result.state is not None
+
+
+def test_ia_scan_action_contract_is_jittable_and_invalid_values_are_atomic() -> None:
+    agent = IAAgent(_make_ia_config())
+    state = agent.start(agent.init(jr.key(2)), _OBS0)
+    obs = jnp.tile(_OBS0, (1, 1))
+    rewards = jnp.ones((1,), dtype=jnp.float32)
+
+    compiled = jax.jit(
+        lambda initial_state, executed_actions: agent.scan(
+            initial_state,
+            obs,
+            rewards,
+            obs,
+            partner_actions=executed_actions,
+        )
+    )
+    valid = compiled(state, jnp.asarray([1], dtype=jnp.int32))
+    assert bool(valid.updates_applied[0])
+
+    invalid = compiled(state, jnp.asarray([_N_PRIM], dtype=jnp.int32))
+    # JIT canonicalizes legacy Python-float lifecycle metadata to a device
+    # scalar; compare with that no-op boundary rather than the host object.
+    compiled_input_state = jax.jit(lambda value: value)(state)
+    chex.assert_trees_all_equal(invalid.state, compiled_input_state)
+    assert not bool(jnp.any(invalid.updates_applied))
+
+    for bad_actions in (
+        jnp.asarray([0.5], dtype=jnp.float32),
+        jnp.asarray([True], dtype=jnp.bool_),
+        jnp.asarray([[0]], dtype=jnp.int32),
+    ):
+        with pytest.raises(ValueError):
+            compiled(state, bad_actions)
+
+
+def test_ia_scan_preserves_wide_action_values_until_range_validation() -> None:
+    agent = IAAgent(_make_ia_config())
+    state = agent.start(agent.init(jr.key(2)), _OBS0)
+    obs = jnp.tile(_OBS0, (1, 1))
+    rewards = jnp.ones((1,), dtype=jnp.float32)
+
+    with jax.enable_x64():
+        wide = jnp.asarray([2**32], dtype=jnp.uint64)
+        with pytest.raises(ValueError, match="partner_actions must lie"):
+            agent.scan(state, obs, rewards, obs, partner_actions=wide)
+
+        checked = jax.jit(
+            lambda action: _checked_partner_action(
+                action,
+                n_primitive_actions=_N_PRIM,
+            )
+        )
+        safe_action, action_valid = checked(wide[0])
+        assert int(safe_action) == 0
+        assert not bool(action_valid)


### PR DESCRIPTION
## Summary

Follow-up corrective to #1152 / #1096 after deep review.

- centralize exact integer action-array validation without narrowing before bounds checks
- preserve static dtype and shape failures under eager and `jax.jit`
- keep original-width comparisons for wide unsigned action IDs
- carry traced range validity into actor-critic and Horde scan commit predicates so invalid steps cannot mutate state or emit accepted diagnostics
- preserve IA action width until its scalar transaction gate, preventing `uint64(2**32)` from becoming action zero
- cover eager and compiled float, bool, malformed-shape, out-of-range, and wide-unsigned cases

## Why the merged fix needed correction

The Horde/actor host range check called `np.asarray` on a JAX tracer, so otherwise-valid compiled scan calls failed during tracing. IA narrowed the full action array to int32 before its scalar gate, leaving wide-integer laundering possible. The merged tests exercised only eager float/bool inputs.

## Verification

- 8 focused adversarial tests passed
- broader actor/Horde/IA panel: 162 passed, one pre-existing wide-unsigned assertion exposed the shared-helper ordering defect; after correcting host validation-before-device conversion, that assertion and all 7 adversarial tests passed
- Ruff passed on all changed files
- strict mypy passed on all four changed source modules
- diff check clean
