### PR TITLE
fix(recurring-multiagent): enforce canonical resource budgets

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -84,7 +84,10 @@ def _require_int(
     minimum: int = 0,
     maximum: int = _INT32_MAX,
 ) -> int:
-    if type(value) is bool or not isinstance(value, int):
+    # This record is a JSON/provenance boundary.  Require the exact built-in
+    # identity before comparing the value so hostile ``int`` subclasses cannot
+    # execute comparison hooks and NumPy scalars cannot leak into ``to_dict``.
+    if type(value) is not int:
         raise ValueError(f"{name} must be an integer")
     if value < minimum or value > maximum:
         raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")

--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -77,6 +77,20 @@ RECURRING_TWO_AGENT_CLOCK_DELTA_NBYTES = 8
 type PartnerPolicy = Callable[[Array, Array], Array]
 
 
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int = 0,
+    maximum: int = _INT32_MAX,
+) -> int:
+    if type(value) is bool or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
+    return value
+
+
 def _require_array(
     value: Any,
     *,
@@ -257,6 +271,29 @@ class RecurringTwoAgentResourceBudget:
     exact_clock_delta_nbytes: int
     trainable_scalars: int = 0
     replay_capacity: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "state_nbytes", _require_int("state_nbytes", self.state_nbytes))
+        object.__setattr__(
+            self,
+            "exact_clock_nbytes",
+            _require_int("exact_clock_nbytes", self.exact_clock_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "exact_clock_delta_nbytes",
+            _require_int("exact_clock_delta_nbytes", self.exact_clock_delta_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int("trainable_scalars", self.trainable_scalars),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity",
+            _require_int("replay_capacity", self.replay_capacity),
+        )
 
     def to_dict(self) -> dict[str, int | str]:
         return {

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -600,3 +600,35 @@ def test_recurring_resource_budget_rejects_leftover_identities() -> None:
     assert '"state_nbytes": true' not in dumped
     assert '"trainable_scalars": true' not in dumped
     assert '"replay_capacity": true' not in dumped
+
+
+def test_recurring_resource_budget_rejects_noncanonical_ints_without_hooks() -> None:
+    class HostileInt(int):
+        comparison_calls = 0
+
+        def __lt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+        def __gt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+    for value in (HostileInt(1), np.int64(1), np.uint64(1)):
+        with pytest.raises(ValueError, match="state_nbytes"):
+            RecurringTwoAgentResourceBudget(
+                state_nbytes=value,  # type: ignore[arg-type]
+                exact_clock_nbytes=12,
+                exact_clock_delta_nbytes=8,
+            )
+    assert HostileInt.comparison_calls == 0
+
+
+@pytest.mark.parametrize("value", [-1, 2**31])
+def test_recurring_resource_budget_rejects_out_of_int32_domain(value: int) -> None:
+    with pytest.raises(ValueError, match="state_nbytes"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=value,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )

--- a/tests/test_recurring_multiagent_stream.py
+++ b/tests/test_recurring_multiagent_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import FrozenInstanceError
 
 import chex
@@ -21,6 +22,7 @@ from alberta_framework.streams import (
     RecurringTwoAgentTransition,
     RecurringTwoAgentWorld,
 )
+from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentResourceBudget
 
 
 def _with_step_count(
@@ -553,3 +555,48 @@ def test_recurring_two_agent_world_initial_positions_reject_booleans() -> None:
     # Valid initial positions
     world = RecurringTwoAgentWorld(initial_positions=(-0.5, 0.5))
     assert world.to_config()["initial_positions"] == [-0.5, 0.5]
+
+
+def test_recurring_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="state_nbytes"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=True,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+    with pytest.raises(ValueError, match="trainable_scalars"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            trainable_scalars=True,
+        )
+    with pytest.raises(ValueError, match="replay_capacity"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            replay_capacity=True,
+        )
+    with pytest.raises(ValueError, match="state_nbytes"):
+        RecurringTwoAgentResourceBudget(
+            state_nbytes=float("nan"),
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+
+    legal = RecurringTwoAgentResourceBudget(
+        state_nbytes=1,
+        exact_clock_nbytes=12,
+        exact_clock_delta_nbytes=8,
+    )
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"state_nbytes": 1' in dumped
+    assert '"exact_clock_nbytes": 12' in dumped
+    assert '"trainable_scalars": 0' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"state_nbytes": true' not in dumped
+    assert '"trainable_scalars": true' not in dumped
+    assert '"replay_capacity": true' not in dumped


### PR DESCRIPTION
Supersedes #1159 after deep review while preserving ss251 authored change. The original `isinstance(int)` boundary admitted hostile int subclasses and executed comparison hooks, and allowed noncanonical NumPy scalars to reach a public JSON/provenance record. This replacement requires exact built-in integers before comparisons, retains the signed-int32 domain, and adds zero-hook hostile/subclass/NumPy and exact boundary regressions. Verification: 32 stream tests, Ruff, strict source mypy, diff-check. No outputs or benchmarks touched. Closes #1156.