### PR TITLE
fix(pipeline): reject non-integer associative contexts and labels

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -204,6 +204,20 @@ def _require_int(
     return number
 
 
+def _integer_associative_input(name: str, value: Array) -> Array:
+    """Narrow associative indices without laundering floats or booleans.
+
+    ``AssociativeMemoryLearner`` documents integer contexts and labels and
+    validates that contract itself. Narrowing a caller's array to ``int32``
+    before handing it over would defeat that validator and silently truncate
+    an invalid input into a valid-looking one, so reject it here instead.
+    """
+    array = jnp.asarray(value)
+    if not jnp.issubdtype(array.dtype, jnp.integer):
+        raise ValueError(f"{name} must have an integer dtype")
+    return array.astype(jnp.int32)
+
+
 @dataclass(frozen=True)
 class Step2FeatureConfig:
     """Config for the lightweight temporal-context Step 2 layer.
@@ -992,7 +1006,7 @@ class AlbertaPipeline:
             assert associative_state is not None
             prediction = associative.predict(
                 associative_state,
-                jnp.asarray(observation, dtype=jnp.int32),
+                _integer_associative_input("observation", observation),
             )
             return feature_state, upgd_state, associative_state, prediction.probabilities
         # identity
@@ -1028,7 +1042,7 @@ class AlbertaPipeline:
             associative_state = associative.init()
             initial_features = associative.predict(
                 associative_state,
-                jnp.asarray(initial_observation, dtype=jnp.int32),
+                _integer_associative_input("initial_observation", initial_observation),
             ).probabilities
         else:
             initial_features = initial_observation
@@ -1154,8 +1168,8 @@ class AlbertaPipeline:
             associative = cast(AssociativeMemoryLearner, self._associative)
             assoc_result = associative.update(
                 new_associative_state,
-                jnp.asarray(observation, dtype=jnp.int32),
-                jnp.asarray(associative_label, dtype=jnp.int32),
+                _integer_associative_input("observation", observation),
+                _integer_associative_input("associative_label", associative_label),
             )
             new_associative_state = assoc_result.state
             features = assoc_result.predictions
@@ -1269,7 +1283,7 @@ class AlbertaPipeline:
         else:
             upgd_targets_array = jnp.asarray(upgd_targets, dtype=jnp.float32)
         associative_labels_array = (
-            jnp.asarray(associative_labels, dtype=jnp.int32)
+            _integer_associative_input("associative_labels", associative_labels)
             if associative_labels is not None
             else jnp.zeros((observations.shape[0],), dtype=jnp.int32)
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -986,5 +986,114 @@ def test_pipeline_smoke_result_rejects_leftover_identities() -> None:
     assert '"finite": 1' not in dumped
 
 
+@pytest.mark.parametrize(
+    "bad_context",
+    [
+        pytest.param(jnp.asarray([1.75, 2.25, 3.5, 4.5, 5.5], dtype=jnp.float32), id="float"),
+        pytest.param(jnp.asarray([True, False, True, False, True]), id="bool"),
+    ],
+)
+def test_associative_pipeline_rejects_non_integer_context(bad_context) -> None:
+    """Associative contexts must not be laundered into int32 by the pipeline.
+
+    ``AssociativeMemoryLearner`` documents ``Int[Array, " block_size"]`` and
+    rejects a non-integer context itself. The pipeline must not defeat that
+    validator by narrowing the caller's array first: a fractional or boolean
+    observation is an invalid input, not a truncated one.
+    """
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    good_context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.init(jr.key(0), bad_context)
+
+    state = pipeline.init(jr.key(0), good_context)
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.update(
+            state,
+            bad_context,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            associative_label=jnp.asarray(6, dtype=jnp.int32),
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_label",
+    [
+        pytest.param(jnp.asarray(6.9, dtype=jnp.float32), id="float"),
+        pytest.param(jnp.asarray(True), id="bool"),
+    ],
+)
+def test_associative_pipeline_rejects_non_integer_label(bad_label) -> None:
+    """A fractional or boolean associative label must raise, not truncate."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+    state = pipeline.init(jr.key(0), context)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.update(
+            state,
+            context,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            associative_label=bad_label,
+        )
+
+
+def test_associative_run_arrays_rejects_non_integer_observations_and_labels() -> None:
+    """The array runner must reject non-integer contexts and label tables."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    state = pipeline.init(jr.key(0), jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32))
+    observations = jnp.asarray([[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]], dtype=jnp.int32)
+    steps = observations.shape[0]
+    zeros = jnp.zeros((steps,), dtype=jnp.float32)
+    cumulants = jnp.ones((steps, 1), dtype=jnp.float32)
+    labels = jnp.asarray([6, 7], dtype=jnp.int32)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.run_arrays(
+            state,
+            observations.astype(jnp.float32) + 0.5,
+            zeros,
+            zeros,
+            cumulants,
+            associative_labels=labels,
+        )
+
+    for bad_labels in (
+        jnp.asarray([6.9, 7.1], dtype=jnp.float32),
+        jnp.asarray([True, False]),
+    ):
+        with pytest.raises(ValueError, match="integer dtype"):
+            pipeline.run_arrays(
+                state,
+                observations,
+                zeros,
+                zeros,
+                cumulants,
+                associative_labels=bad_labels,
+            )
+
+
+def test_associative_pipeline_accepts_documented_integer_contract() -> None:
+    """The guard must not reject the documented integer contract."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+    state = pipeline.init(jr.key(0), context)
+
+    result = pipeline.update(
+        state,
+        context,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+        associative_label=jnp.asarray(6, dtype=jnp.int32),
+    )
+    assert int(result.state.step_count) == 1
+
+
 # silence the import lint warnings used in the test runner
 _ = jax


### PR DESCRIPTION
Fixes #1162.

## What moved

`AlbertaPipeline.init`, `.update`, and `.run_arrays` narrowed caller-supplied associative contexts and labels with `jnp.asarray(..., dtype=jnp.int32)` before calling `AssociativeMemoryLearner`. That defeated the learner's own `_validate_context_static_contract` (`core/associative_memory.py:676`, which requires `dtype=jnp.int32`): a fractional float or boolean array was truncated into a valid-looking int32 array and written into associative state, rather than rejected.

The learner rejects the exact array the pipeline accepted:

```text
1) associative memory called DIRECTLY with fractional array:
   -> REJECTED: TypeError: context has an invalid dtype
2) same array through AlbertaPipeline.update():
   -> ACCEPTED, step_count=1
      supplied [1.75, 2.25, 3.5, 4.5, 5.5] -> used [1, 2, 3, 4, 5]
      supplied label 6.9 -> used 6
```

This is the dtype-laundering class already fixed in `behavior_model.py` (#1049/#1051), `dreaming.py` (#1075/#1076), and `DifferentialSARSAAgent.start_with_action` (#1082), and reported for the three array runners in #1096. The `AlbertaPipeline` associative path is independent of all of those.

## The change

One helper, following the established `_integer_action_ids` pattern from `core/behavior_model.py:91` — reject non-integer dtype, then narrow:

```python
def _integer_associative_input(name: str, value: Array) -> Array:
    array = jnp.asarray(value)
    if not jnp.issubdtype(array.dtype, jnp.integer):
        raise ValueError(f"{name} must have an integer dtype")
    return array.astype(jnp.int32)
```

Applied at all five laundering sites: the `predict` path, `init`, both `update` sites (context and label), and the `run_arrays` label table. Booleans are rejected because `jnp.issubdtype(bool, jnp.integer)` is `False`, matching the existing guards.

No behavior change for the documented contract — integer contexts and labels narrow to `int32` exactly as before.

## Tests

Failing-tests-first. Added to `tests/test_pipeline.py`:

- `test_associative_pipeline_rejects_non_integer_context[float|bool]` — `init` and `update`
- `test_associative_pipeline_rejects_non_integer_label[float|bool]` — scalar label
- `test_associative_run_arrays_rejects_non_integer_observations_and_labels` — array runner, both observations and label table
- `test_associative_pipeline_accepts_documented_integer_contract` — positive control

Before the fix, on `f1ef8f0`: **5 failed, 1 passed** (all five with `DID NOT RAISE ValueError`; the positive control passed, confirming the tests target only the laundering).

## Verification

Commit `c178be8b45ca0075f2c1f1d998fe6e23e9843986`, based on `f1ef8f0d1954bf70173cbd55a3b2a0dbc733f46f`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_pipeline.py
# 177 passed in 24.88s

python -m pytest -q -p no:randomly -o addopts= \
  tests/test_associative_memory.py tests/test_associative_memory_validation.py
# 239 passed in 17.75s

python -m ruff check .
# All checks passed!

python -m mypy
# Success: no issues found in 168 source files
```

Environment: Python 3.12.14, jax 0.11.0, numpy 2.5.2, CPU, network-isolated container built from `pyproject.toml` with `.[dev,gymnasium,forager]`.

## What remains open

- I did not audit the other 570-odd `int32` casts in the tree; this PR is scoped to the `AlbertaPipeline` associative path that #1162 documents. The repeat discovery of this class across five modules suggests a systematic sweep would be worth someone's time, but that is a separate change.
- No benchmark lane is touched and no `outputs/` artifact is read or written, so no evidence-package rows apply here.

<!-- evidence-head:c178be8b45ca0075f2c1f1d998fe6e23e9843986 -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported. No Slop receipt attached — the receipt pipeline's terms preflight is currently failing closed for all registry projects.

