### PR TITLE
fix(gauntlet): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -83,6 +83,20 @@ LIFETIME_GAUNTLET_CLOCK_NBYTES = 12
 LIFETIME_GAUNTLET_CLOCK_DELTA_NBYTES = 8
 
 
+def _require_int(
+    name: str,
+    value: object,
+    *,
+    minimum: int = 0,
+    maximum: int = _INT32_MAX,
+) -> int:
+    if type(value) is bool or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
+    return value
+
+
 def _require_array(
     value: Any,
     *,
@@ -558,6 +572,29 @@ class LifetimeGauntletResourceBudget:
     exact_clock_delta_nbytes: int
     trainable_scalars: int = 0
     replay_capacity: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "state_nbytes", _require_int("state_nbytes", self.state_nbytes))
+        object.__setattr__(
+            self,
+            "exact_clock_nbytes",
+            _require_int("exact_clock_nbytes", self.exact_clock_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "exact_clock_delta_nbytes",
+            _require_int("exact_clock_delta_nbytes", self.exact_clock_delta_nbytes),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int("trainable_scalars", self.trainable_scalars),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity",
+            _require_int("replay_capacity", self.replay_capacity),
+        )
 
     def to_dict(self) -> dict[str, int | str]:
         return {

--- a/tests/test_gauntlet_resource_budget.py
+++ b/tests/test_gauntlet_resource_budget.py
@@ -1,0 +1,54 @@
+"""Leftover-identity gates for lifetime gauntlet resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.streams.gauntlet import LifetimeGauntletResourceBudget
+
+
+def test_gauntlet_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="state_nbytes"):
+        LifetimeGauntletResourceBudget(
+            state_nbytes=True,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+    with pytest.raises(ValueError, match="trainable_scalars"):
+        LifetimeGauntletResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            trainable_scalars=True,
+        )
+    with pytest.raises(ValueError, match="replay_capacity"):
+        LifetimeGauntletResourceBudget(
+            state_nbytes=1,
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+            replay_capacity=True,
+        )
+    with pytest.raises(ValueError, match="state_nbytes"):
+        LifetimeGauntletResourceBudget(
+            state_nbytes=float("nan"),
+            exact_clock_nbytes=12,
+            exact_clock_delta_nbytes=8,
+        )
+
+    legal = LifetimeGauntletResourceBudget(
+        state_nbytes=1,
+        exact_clock_nbytes=12,
+        exact_clock_delta_nbytes=8,
+    )
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"state_nbytes": 1' in dumped
+    assert '"exact_clock_nbytes": 12' in dumped
+    assert '"trainable_scalars": 0' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"state_nbytes": true' not in dumped
+    assert '"trainable_scalars": true' not in dumped
+    assert '"replay_capacity": true' not in dumped


### PR DESCRIPTION
Closes #1164.

## What changed

The lifetime-gauntlet resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `d35545f`, scorecard window scalars already reject leftover boolean identities. `LifetimeGauntletResourceBudget` had no `__post_init__` and accepted leftover identities (`state_nbytes=True`, `trainable_scalars=True`, `replay_capacity=True`, `state_nbytes=NaN`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"state_nbytes": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `gauntlet.py` resource-budget records, not a republish of `#960` (closed scorecard window), `#1159`/`#1161` (recurring-multiagent resource-budget), or `#982` (log-spaced spacing).

## Scope

- `alberta_framework/streams/gauntlet.py`
- `tests/test_gauntlet_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1163` only (`pipeline.py` and `tests/test_pipeline.py`). These files were FREE. Merged leftover `#1158` (candidate-universe), `#1161` (recurring-multiagent resource-budget), and closed `#1159` do not occupy this pair.

## Verification

Exact candidate head: `760b417f59ca98ed0a45667bb76a92328b590f0e`
Base: `d35545f`

- Red on base: `LifetimeGauntletResourceBudget(state_nbytes=True, ...)` accepted; dump emitted `"state_nbytes": true`
- Focused pytest `tests/test_gauntlet_resource_budget.py`: 1 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:760b417f59ca98ed0a45667bb76a92328b590f0e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
