### PR TITLE
fix(canonical-upgd): reject leftover resource-record identities

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -1167,6 +1167,20 @@ class AlbertaAdaUPGDUpdate:
     metrics: dict[str, Array]
 
 
+def _require_exact_int(value: Any, path: str) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{path} must be an integer")
+    if value < 0 or value > _INT32_MAX:
+        raise ValueError(f"{path} must lie in [0, {_INT32_MAX}]")
+    return value
+
+
+def _require_exact_bool(value: Any, path: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{path} must be a boolean")
+    return value
+
+
 @dataclass(frozen=True)
 class AlbertaAdaUPGDResources:
     """Exact persistent-array accounting for one adaptive optimizer state."""
@@ -1176,6 +1190,28 @@ class AlbertaAdaUPGDResources:
     parameter_count: int
     persistent_array_count: int
     persistent_state_nbytes: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "official_reference_parity",
+            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+        )
+        object.__setattr__(
+            self,
+            "parameter_count",
+            _require_exact_int(self.parameter_count, "parameter_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_array_count",
+            _require_exact_int(self.persistent_array_count, "persistent_array_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_nbytes",
+            _require_exact_int(self.persistent_state_nbytes, "persistent_state_nbytes"),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-compatible resource record."""
@@ -1956,6 +1992,28 @@ class OfficialAdaUPGDResources:
     parameter_count: int
     persistent_array_count: int
     persistent_state_nbytes: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "official_reference_parity",
+            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+        )
+        object.__setattr__(
+            self,
+            "parameter_count",
+            _require_exact_int(self.parameter_count, "parameter_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_array_count",
+            _require_exact_int(self.persistent_array_count, "persistent_array_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_nbytes",
+            _require_exact_int(self.persistent_state_nbytes, "persistent_state_nbytes"),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-compatible resource record."""

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 from typing import Any
@@ -16,10 +17,12 @@ import pytest
 from alberta_framework.core.canonical_upgd import (
     AlbertaAdaUPGD,
     AlbertaAdaUPGDConfig,
+    AlbertaAdaUPGDResources,
     CanonicalUPGD,
     CanonicalUPGDConfig,
     OfficialAdaUPGD,
     OfficialAdaUPGDConfig,
+    OfficialAdaUPGDResources,
 )
 
 _INT32_MAX = 2_147_483_647
@@ -562,3 +565,73 @@ def test_official_counter_saturates_without_changing_source_equations() -> None:
     )
     result = optimizer.update(state, params, gradients, jr.key(13), noise=noise)
     assert int(result.state.step) == _INT32_MAX
+
+
+def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
+    """Public AdaUPGD resource records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="official_reference_parity"):
+        AlbertaAdaUPGDResources(
+            profile="safe_extended",
+            official_reference_parity=1,
+            parameter_count=1,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="parameter_count"):
+        AlbertaAdaUPGDResources(
+            profile="safe_extended",
+            official_reference_parity=True,
+            parameter_count=True,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="parameter_count"):
+        OfficialAdaUPGDResources(
+            profile="official_experiment_global",
+            source_commit="c",
+            source_path="path",
+            official_reference_parity=True,
+            parameter_count=True,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="persistent_state_nbytes"):
+        OfficialAdaUPGDResources(
+            profile="official_experiment_global",
+            source_commit="c",
+            source_path="path",
+            official_reference_parity=True,
+            parameter_count=1,
+            persistent_array_count=2,
+            persistent_state_nbytes=float("nan"),
+        )
+
+    legal_alberta = AlbertaAdaUPGDResources(
+        profile="safe_extended",
+        official_reference_parity=False,
+        parameter_count=1,
+        persistent_array_count=2,
+        persistent_state_nbytes=3,
+    )
+    legal_official = OfficialAdaUPGDResources(
+        profile="official_experiment_global",
+        source_commit="c",
+        source_path="path",
+        official_reference_parity=True,
+        parameter_count=1,
+        persistent_array_count=2,
+        persistent_state_nbytes=3,
+    )
+    dumped = json.dumps(
+        {
+            "alberta": legal_alberta.to_dict(),
+            "official": legal_official.to_dict(),
+        },
+        allow_nan=False,
+    )
+    assert '"official_reference_parity": false' in dumped
+    assert '"official_reference_parity": true' in dumped
+    assert '"parameter_count": 1' in dumped
+    assert '"parameter_count": true' not in dumped
+    assert '"official_reference_parity": 1' not in dumped


### PR DESCRIPTION
Closes #1165.

## What changed

Public AdaUPGD resource records now fail closed on leftover bool-as-int and leftover int-as-bool identities.

On origin/main `d35545f`, Canonical UPGD configs already reject leftover constructor scalars. `AlbertaAdaUPGDResources` and `OfficialAdaUPGDResources` had no `__post_init__` and accepted leftover identities (`official_reference_parity=1`, `parameter_count=True`, `persistent_state_nbytes=NaN`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"official_reference_parity": 1` or `"parameter_count": true`, or raised at dump time instead of failing closed at construction.

This is leftover tax on `canonical_upgd.py` resource records, not a republish of `#973` (closed `upgd.py` constructor scalars), `#677` (finite step sizes), or `#931` (multi-head constructor scalars).

## Scope

- `alberta_framework/core/canonical_upgd.py`
- `tests/test_canonical_upgd_validation.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1163` only (`pipeline.py` and `tests/test_pipeline.py`). These files were FREE. Merged leftover `#1158` (candidate-universe), `#1161` (recurring-multiagent resource-budget), and closed `#1159` do not occupy this pair.

## Verification

Exact candidate head: `fe11ef0c018cd14d50df933c6a9c0fd6e1ca6e5c`
Base: `d35545f`

- Red on base: `AlbertaAdaUPGDResources(..., official_reference_parity=1, ...)` accepted; dump emitted `"official_reference_parity": 1`
- Focused pytest `tests/test_canonical_upgd_validation.py`: 57 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fe11ef0c018cd14d50df933c6a9c0fd6e1ca6e5c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
