### PR TITLE
fix(pipeline): enforce exact associative integer sinks

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -204,6 +204,20 @@ def _require_int(
     return number
 
 
+def _integer_associative_input(name: str, value: Array) -> Array:
+    """Narrow associative indices without laundering floats or booleans.
+
+    ``AssociativeMemoryLearner`` documents integer contexts and labels and
+    validates that contract itself. Narrowing a caller's array to ``int32``
+    before handing it over would defeat that validator and silently truncate
+    an invalid input into a valid-looking one, so reject it here instead.
+    """
+    array = jnp.asarray(value)
+    if not jnp.issubdtype(array.dtype, jnp.integer):
+        raise ValueError(f"{name} must have an integer dtype")
+    return array.astype(jnp.int32)
+
+
 @dataclass(frozen=True)
 class Step2FeatureConfig:
     """Config for the lightweight temporal-context Step 2 layer.
@@ -992,7 +1006,7 @@ class AlbertaPipeline:
             assert associative_state is not None
             prediction = associative.predict(
                 associative_state,
-                jnp.asarray(observation, dtype=jnp.int32),
+                _integer_associative_input("observation", observation),
             )
             return feature_state, upgd_state, associative_state, prediction.probabilities
         # identity
@@ -1028,7 +1042,7 @@ class AlbertaPipeline:
             associative_state = associative.init()
             initial_features = associative.predict(
                 associative_state,
-                jnp.asarray(initial_observation, dtype=jnp.int32),
+                _integer_associative_input("initial_observation", initial_observation),
             ).probabilities
         else:
             initial_features = initial_observation
@@ -1154,8 +1168,8 @@ class AlbertaPipeline:
             associative = cast(AssociativeMemoryLearner, self._associative)
             assoc_result = associative.update(
                 new_associative_state,
-                jnp.asarray(observation, dtype=jnp.int32),
-                jnp.asarray(associative_label, dtype=jnp.int32),
+                _integer_associative_input("observation", observation),
+                _integer_associative_input("associative_label", associative_label),
             )
             new_associative_state = assoc_result.state
             features = assoc_result.predictions
@@ -1269,7 +1283,7 @@ class AlbertaPipeline:
         else:
             upgd_targets_array = jnp.asarray(upgd_targets, dtype=jnp.float32)
         associative_labels_array = (
-            jnp.asarray(associative_labels, dtype=jnp.int32)
+            _integer_associative_input("associative_labels", associative_labels)
             if associative_labels is not None
             else jnp.zeros((observations.shape[0],), dtype=jnp.int32)
         )

--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -204,7 +204,12 @@ def _require_int(
     return number
 
 
-def _integer_associative_input(name: str, value: Array) -> Array:
+def _integer_associative_input(
+    name: str,
+    value: object,
+    *,
+    expected_shape: tuple[int, ...],
+) -> Array:
     """Narrow associative indices without laundering floats or booleans.
 
     ``AssociativeMemoryLearner`` documents integer contexts and labels and
@@ -212,10 +217,28 @@ def _integer_associative_input(name: str, value: Array) -> Array:
     before handing it over would defeat that validator and silently truncate
     an invalid input into a valid-looking one, so reject it here instead.
     """
-    array = jnp.asarray(value)
-    if not jnp.issubdtype(array.dtype, jnp.integer):
+    actual_type = type(value)
+    trusted = (
+        issubclass(actual_type, jax.core.Tracer)
+        or actual_type is np.ndarray
+        or isinstance(value, jax.Array)
+    )
+    if not trusted:
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        shape = tuple(value.shape)  # type: ignore[attr-defined]
+        dtype = np.dtype(value.dtype)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}")
+    if not np.issubdtype(dtype, np.integer):
         raise ValueError(f"{name} must have an integer dtype")
-    return array.astype(jnp.int32)
+    bounds = np.iinfo(cast(Any, dtype))
+    int32_bounds = np.iinfo(np.int32)
+    if bounds.min < int32_bounds.min or bounds.max > int32_bounds.max:
+        raise ValueError(f"{name} integer dtype must be wholly representable as int32")
+    return jnp.asarray(value, dtype=jnp.int32)
 
 
 @dataclass(frozen=True)
@@ -1006,7 +1029,11 @@ class AlbertaPipeline:
             assert associative_state is not None
             prediction = associative.predict(
                 associative_state,
-                _integer_associative_input("observation", observation),
+                _integer_associative_input(
+                    "observation",
+                    observation,
+                    expected_shape=(associative.config.block_size,),
+                ),
             )
             return feature_state, upgd_state, associative_state, prediction.probabilities
         # identity
@@ -1042,7 +1069,11 @@ class AlbertaPipeline:
             associative_state = associative.init()
             initial_features = associative.predict(
                 associative_state,
-                _integer_associative_input("initial_observation", initial_observation),
+                _integer_associative_input(
+                    "initial_observation",
+                    initial_observation,
+                    expected_shape=(associative.config.block_size,),
+                ),
             ).probabilities
         else:
             initial_features = initial_observation
@@ -1168,8 +1199,16 @@ class AlbertaPipeline:
             associative = cast(AssociativeMemoryLearner, self._associative)
             assoc_result = associative.update(
                 new_associative_state,
-                _integer_associative_input("observation", observation),
-                _integer_associative_input("associative_label", associative_label),
+                _integer_associative_input(
+                    "observation",
+                    observation,
+                    expected_shape=(associative.config.block_size,),
+                ),
+                _integer_associative_input(
+                    "associative_label",
+                    associative_label,
+                    expected_shape=(),
+                ),
             )
             new_associative_state = assoc_result.state
             features = assoc_result.predictions
@@ -1283,7 +1322,11 @@ class AlbertaPipeline:
         else:
             upgd_targets_array = jnp.asarray(upgd_targets, dtype=jnp.float32)
         associative_labels_array = (
-            _integer_associative_input("associative_labels", associative_labels)
+            _integer_associative_input(
+                "associative_labels",
+                associative_labels,
+                expected_shape=(observations.shape[0],),
+            )
             if associative_labels is not None
             else jnp.zeros((observations.shape[0],), dtype=jnp.int32)
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -986,5 +986,114 @@ def test_pipeline_smoke_result_rejects_leftover_identities() -> None:
     assert '"finite": 1' not in dumped
 
 
+@pytest.mark.parametrize(
+    "bad_context",
+    [
+        pytest.param(jnp.asarray([1.75, 2.25, 3.5, 4.5, 5.5], dtype=jnp.float32), id="float"),
+        pytest.param(jnp.asarray([True, False, True, False, True]), id="bool"),
+    ],
+)
+def test_associative_pipeline_rejects_non_integer_context(bad_context) -> None:
+    """Associative contexts must not be laundered into int32 by the pipeline.
+
+    ``AssociativeMemoryLearner`` documents ``Int[Array, " block_size"]`` and
+    rejects a non-integer context itself. The pipeline must not defeat that
+    validator by narrowing the caller's array first: a fractional or boolean
+    observation is an invalid input, not a truncated one.
+    """
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    good_context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.init(jr.key(0), bad_context)
+
+    state = pipeline.init(jr.key(0), good_context)
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.update(
+            state,
+            bad_context,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            associative_label=jnp.asarray(6, dtype=jnp.int32),
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_label",
+    [
+        pytest.param(jnp.asarray(6.9, dtype=jnp.float32), id="float"),
+        pytest.param(jnp.asarray(True), id="bool"),
+    ],
+)
+def test_associative_pipeline_rejects_non_integer_label(bad_label) -> None:
+    """A fractional or boolean associative label must raise, not truncate."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+    state = pipeline.init(jr.key(0), context)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.update(
+            state,
+            context,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray([1.0], dtype=jnp.float32),
+            associative_label=bad_label,
+        )
+
+
+def test_associative_run_arrays_rejects_non_integer_observations_and_labels() -> None:
+    """The array runner must reject non-integer contexts and label tables."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    state = pipeline.init(jr.key(0), jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32))
+    observations = jnp.asarray([[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]], dtype=jnp.int32)
+    steps = observations.shape[0]
+    zeros = jnp.zeros((steps,), dtype=jnp.float32)
+    cumulants = jnp.ones((steps, 1), dtype=jnp.float32)
+    labels = jnp.asarray([6, 7], dtype=jnp.int32)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        pipeline.run_arrays(
+            state,
+            observations.astype(jnp.float32) + 0.5,
+            zeros,
+            zeros,
+            cumulants,
+            associative_labels=labels,
+        )
+
+    for bad_labels in (
+        jnp.asarray([6.9, 7.1], dtype=jnp.float32),
+        jnp.asarray([True, False]),
+    ):
+        with pytest.raises(ValueError, match="integer dtype"):
+            pipeline.run_arrays(
+                state,
+                observations,
+                zeros,
+                zeros,
+                cumulants,
+                associative_labels=bad_labels,
+            )
+
+
+def test_associative_pipeline_accepts_documented_integer_contract() -> None:
+    """The guard must not reject the documented integer contract."""
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+    state = pipeline.init(jr.key(0), context)
+
+    result = pipeline.update(
+        state,
+        context,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+        associative_label=jnp.asarray(6, dtype=jnp.int32),
+    )
+    assert int(result.state.step_count) == 1
+
+
 # silence the import lint warnings used in the test runner
 _ = jax

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import pytest
+from jax import Array
 
 import alberta_framework as af
 from alberta_framework.pipeline import (
@@ -1091,6 +1092,111 @@ def test_associative_pipeline_accepts_documented_integer_contract() -> None:
         jnp.asarray(0.0, dtype=jnp.float32),
         jnp.asarray([1.0], dtype=jnp.float32),
         associative_label=jnp.asarray(6, dtype=jnp.int32),
+    )
+    assert int(result.state.step_count) == 1
+
+
+class _HostileAssociativeArray:
+    @property
+    def shape(self) -> tuple[int, ...]:
+        raise AssertionError("untrusted shape hook executed")
+
+    @property
+    def dtype(self) -> np.dtype:
+        raise AssertionError("untrusted dtype hook executed")
+
+    def __jax_array__(self) -> Array:
+        raise AssertionError("untrusted conversion hook executed")
+
+
+def test_associative_pipeline_rejects_untrusted_array_before_metadata_hooks() -> None:
+    pipeline = make_alberta_pipeline(_small_associative_config())
+
+    with pytest.raises(TypeError, match="trusted array"):
+        pipeline.init(jr.key(0), _HostileAssociativeArray())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "bad_context",
+    [
+        jnp.zeros((5, 1), dtype=jnp.int32),
+        jnp.zeros((4,), dtype=jnp.int32),
+    ],
+)
+def test_associative_pipeline_requires_exact_context_shape(bad_context: Array) -> None:
+    pipeline = make_alberta_pipeline(_small_associative_config())
+
+    with pytest.raises(ValueError, match="must have shape"):
+        pipeline.init(jr.key(0), bad_context)
+
+
+def test_associative_pipeline_requires_exact_label_shapes() -> None:
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+    state = pipeline.init(jr.key(0), context)
+    transition = (
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+    )
+
+    with pytest.raises(ValueError, match="must have shape"):
+        pipeline.update(
+            state,
+            context,
+            *transition,
+            associative_label=jnp.asarray([1], dtype=jnp.int32),
+        )
+    with pytest.raises(ValueError, match="must have shape"):
+        pipeline.run_arrays(
+            state,
+            context[None, :],
+            jnp.zeros((1,), dtype=jnp.float32),
+            jnp.zeros((1,), dtype=jnp.float32),
+            jnp.zeros((1, 1), dtype=jnp.float32),
+            associative_labels=jnp.asarray([[1]], dtype=jnp.int32),
+        )
+
+
+def test_associative_pipeline_rejects_wide_integer_dtypes_eager_and_jit() -> None:
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    with jax.enable_x64():
+        wide_context = jnp.asarray([1, 2, 3, 4, 2**32], dtype=jnp.uint64)
+        with pytest.raises(ValueError, match="representable as int32"):
+            pipeline.init(jr.key(0), wide_context)
+
+        compiled_init = jax.jit(lambda context: pipeline.init(jr.key(0), context))
+        with pytest.raises(ValueError, match="representable as int32"):
+            compiled_init(wide_context)
+
+        valid_context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int32)
+        state = pipeline.init(jr.key(0), valid_context)
+        compiled_update = jax.jit(
+            lambda label: pipeline.update(
+                state,
+                valid_context,
+                jnp.asarray(0.0, dtype=jnp.float32),
+                jnp.asarray(0.0, dtype=jnp.float32),
+                jnp.asarray([1.0], dtype=jnp.float32),
+                associative_label=label,
+            )
+        )
+        with pytest.raises(ValueError, match="representable as int32"):
+            compiled_update(jnp.asarray(2**32, dtype=jnp.uint64))
+
+
+def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> None:
+    pipeline = make_alberta_pipeline(_small_associative_config())
+    context = jnp.asarray([1, 2, 3, 4, 5], dtype=jnp.int16)
+    state = pipeline.init(jr.key(0), context)
+
+    result = pipeline.update(
+        state,
+        context,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+        associative_label=jnp.asarray(6, dtype=jnp.uint8),
     )
     assert int(result.state.step_count) == 1
 


### PR DESCRIPTION
Supersedes #1163 after deep review; preserves and builds on @techforky's failing-tests-first fix. Fixes #1162.

## Corrective design

The original helper rejected floats/bools, but still called `jnp.asarray` before establishing a trusted array type and narrowed every integer dtype to int32. That left hostile conversion hooks and wide signed/unsigned laundering open.

This successor:

- accepts only actual NumPy arrays, JAX arrays, or JAX tracers before touching metadata
- requires exact context/label/table shapes at each public sink
- rejects non-integer dtypes
- narrows only integer dtypes whose complete value range is representable in int32, making eager and JIT behavior identical without runtime wraparound
- adds hostile-hook, malformed-shape, uint64 eager/JIT, and safe int16/uint8 positive controls

## Verification

- `tests/test_pipeline.py`: 183 passed
- associative core suites: 239 passed
- Ruff: clean on changed files
- strict mypy: clean on `alberta_framework/pipeline.py`
- diff check: clean

No benchmark or `outputs/` artifacts touched.
