### PR TITLE
fix(records): close Step and evaluation schema residuals

### DIFF
--- a/alberta_framework/evaluation/_measurement_validation.py
+++ b/alberta_framework/evaluation/_measurement_validation.py
@@ -1,0 +1,40 @@
+"""Shared exact validation for public evaluation measurement records."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+
+def finite_real(name: str, value: object) -> float:
+    """Return a finite builtin float without accepting facade identities."""
+
+    if type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    numeric = float(cast("int | float", value))
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be a finite real number")
+    return numeric
+
+
+def nonnegative_finite_real(name: str, value: object) -> float:
+    """Return one finite, non-negative measurement."""
+
+    numeric = finite_real(name, value)
+    if numeric < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return numeric
+
+
+def validate_interval_bounds(
+    *, lower: float, upper: float, confidence_level: float
+) -> None:
+    """Validate ordering and the open-unit confidence domain."""
+
+    if lower > upper:
+        raise ValueError("lower must not exceed upper")
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must lie in (0, 1)")
+
+
+__all__ = ["finite_real", "nonnegative_finite_real", "validate_interval_bounds"]

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -23,7 +23,6 @@ feature discovery, or completion of the Alberta Plan.
 from __future__ import annotations
 
 import functools
-import math
 import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -56,6 +55,11 @@ from alberta_framework.core.intelligence_amplification import (
 )
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.evaluation._measurement_validation import (
+    finite_real,
+    nonnegative_finite_real,
+    validate_interval_bounds,
+)
 from alberta_framework.streams.closed_loop import (
     SwitchingTwoStateConfig,
     SwitchingTwoStateMDP,
@@ -109,16 +113,6 @@ def _require_integer(
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
-
-
-def _finite_real(name: str, value: object) -> float:
-    """Reject leftover bool and non-finite identities without narrowing."""
-    if type(value) is bool or type(value) not in (int, float):
-        raise ValueError(f"{name} must be a finite real number")
-    numeric = float(cast("int | float", value))
-    if not math.isfinite(numeric):
-        raise ValueError(f"{name} must be a finite real number")
-    return numeric
 
 
 def _require_derived_int32(name: str, value: int) -> None:
@@ -334,13 +328,13 @@ class PairedBootstrapInterval:
     method: str = "paired-percentile-bootstrap"
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
-        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
-        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(self, "estimate", finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", finite_real("upper", self.upper))
         object.__setattr__(
             self,
             "confidence_level",
-            _finite_real("confidence_level", self.confidence_level),
+            finite_real("confidence_level", self.confidence_level),
         )
         object.__setattr__(
             self,
@@ -359,6 +353,11 @@ class PairedBootstrapInterval:
         )
         if type(self.method) is not str or not self.method:
             raise ValueError("method must be a non-empty string")
+        validate_interval_bounds(
+            lower=self.lower,
+            upper=self.upper,
+            confidence_level=self.confidence_level,
+        )
 
 
 @dataclass(frozen=True)
@@ -398,12 +397,14 @@ class ConditionTiming:
 
     def __post_init__(self) -> None:
         object.__setattr__(
-            self, "wall_seconds", _finite_real("wall_seconds", self.wall_seconds)
+            self,
+            "wall_seconds",
+            nonnegative_finite_real("wall_seconds", self.wall_seconds),
         )
         object.__setattr__(
             self,
             "mean_step_latency_ms",
-            _finite_real("mean_step_latency_ms", self.mean_step_latency_ms),
+            nonnegative_finite_real("mean_step_latency_ms", self.mean_step_latency_ms),
         )
 
 

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -32,7 +32,6 @@ solution.  All updates are predict-act-observe-update and use no replay.
 
 from __future__ import annotations
 
-import math
 import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -47,6 +46,11 @@ from jax import Array
 from numpy.typing import NDArray
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.evaluation._measurement_validation import (
+    finite_real,
+    nonnegative_finite_real,
+    validate_interval_bounds,
+)
 from alberta_framework.streams.recurring_multiagent import (
     AVOID_CONTEXT,
     AVOID_CONTEXT_INDEX,
@@ -105,16 +109,6 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
-
-
-def _finite_real(name: str, value: object) -> float:
-    """Reject leftover bool and non-finite identities without narrowing."""
-    if type(value) is bool or type(value) not in (int, float):
-        raise ValueError(f"{name} must be a finite real number")
-    numeric = float(cast("int | float", value))
-    if not math.isfinite(numeric):
-        raise ValueError(f"{name} must be a finite real number")
-    return numeric
 
 
 def _require_seed(value: object) -> int:
@@ -350,7 +344,11 @@ class TimingMetrics:
             "mean_update_latency_ms",
             "p95_update_latency_ms",
         ):
-            object.__setattr__(self, name, _finite_real(name, getattr(self, name)))
+            object.__setattr__(
+                self,
+                name,
+                nonnegative_finite_real(name, getattr(self, name)),
+            )
 
 
 @dataclass(frozen=True)
@@ -366,13 +364,13 @@ class BootstrapInterval:
     method: str = "paired-percentile-bootstrap"
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
-        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
-        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(self, "estimate", finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", finite_real("upper", self.upper))
         object.__setattr__(
             self,
             "confidence_level",
-            _finite_real("confidence_level", self.confidence_level),
+            finite_real("confidence_level", self.confidence_level),
         )
         object.__setattr__(
             self,
@@ -386,6 +384,11 @@ class BootstrapInterval:
         )
         if type(self.method) is not str or not self.method:
             raise ValueError("method must be a non-empty string")
+        validate_interval_bounds(
+            lower=self.lower,
+            upper=self.upper,
+            confidence_level=self.confidence_level,
+        )
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -53,6 +53,10 @@ from alberta_framework.core.ftl_world_model import (
     SparseFTLWorldModelState,
     run_sparse_ftl_world_model,
 )
+from alberta_framework.evaluation._measurement_validation import (
+    finite_real,
+    validate_interval_bounds,
+)
 
 CONDITION_NAMES = (
     "sparse_untrained",
@@ -104,16 +108,6 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
-
-
-def _finite_real(name: str, value: object) -> float:
-    """Reject leftover bool and non-finite identities without narrowing."""
-    if type(value) is bool or type(value) not in (int, float):
-        raise ValueError(f"{name} must be a finite real number")
-    numeric = float(cast("int | float", value))
-    if not math.isfinite(numeric):
-        raise ValueError(f"{name} must be a finite real number")
-    return numeric
 
 
 def _require_derived_int32(name: str, value: int) -> int:
@@ -333,7 +327,7 @@ class DecisionMetrics:
             "return_mae",
             "normalized_return_mae",
         ):
-            object.__setattr__(self, name, _finite_real(name, getattr(self, name)))
+            object.__setattr__(self, name, finite_real(name, getattr(self, name)))
 
 
 @dataclass(frozen=True)
@@ -360,13 +354,13 @@ class BootstrapEstimate:
     sample_size: int
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "estimate", _finite_real("estimate", self.estimate))
-        object.__setattr__(self, "lower", _finite_real("lower", self.lower))
-        object.__setattr__(self, "upper", _finite_real("upper", self.upper))
+        object.__setattr__(self, "estimate", finite_real("estimate", self.estimate))
+        object.__setattr__(self, "lower", finite_real("lower", self.lower))
+        object.__setattr__(self, "upper", finite_real("upper", self.upper))
         object.__setattr__(
             self,
             "confidence_level",
-            _finite_real("confidence_level", self.confidence_level),
+            finite_real("confidence_level", self.confidence_level),
         )
         object.__setattr__(
             self,
@@ -377,6 +371,11 @@ class BootstrapEstimate:
             self,
             "sample_size",
             _require_int32("sample_size", self.sample_size, minimum=1),
+        )
+        validate_interval_bounds(
+            lower=self.lower,
+            upper=self.upper,
+            confidence_level=self.confidence_level,
         )
 
 

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -24,7 +24,7 @@ import math
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -37,6 +37,7 @@ from alberta_framework._seed_validation import require_unique_jax_seeds
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
 )
+from alberta_framework.evaluation._measurement_validation import nonnegative_finite_real
 from alberta_framework.streams.gauntlet import (
     SEGMENT_NAMES,
     GauntletConfig,
@@ -218,21 +219,11 @@ def _nonnegative_int(value: object, *, name: str) -> int:
 def _optional_finite_float(value: object, *, name: str) -> float | None:
     if value is None:
         return None
-    if type(value) is bool or type(value) not in (int, float):
-        raise ValueError(f"{name} must be a finite real number or None")
-    numeric = float(cast("int | float", value))
-    if not math.isfinite(numeric):
-        raise ValueError(f"{name} must be a finite real number or None")
-    return numeric
+    return nonnegative_finite_real(name, value)
 
 
 def _finite_float(value: object, *, name: str) -> float:
-    if type(value) is bool or type(value) not in (int, float):
-        raise ValueError(f"{name} must be a finite real number")
-    numeric = float(cast("int | float", value))
-    if not math.isfinite(numeric):
-        raise ValueError(f"{name} must be a finite real number")
-    return numeric
+    return nonnegative_finite_real(name, value)
 
 
 def _integer_pairs(

--- a/alberta_framework/steps/_smoke_record_validation.py
+++ b/alberta_framework/steps/_smoke_record_validation.py
@@ -1,0 +1,25 @@
+"""Shared validation for public Step smoke-result array identities."""
+
+from __future__ import annotations
+
+_INT32_MAX = 2**31 - 1
+
+
+def require_step_shape(name: str, value: object, *, steps: int) -> tuple[int, ...]:
+    """Require one exact, bounded array shape whose leading axis is ``steps``."""
+
+    if type(value) is not tuple or not value:
+        raise ValueError(f"{name} must be a non-empty exact tuple")
+    dimensions: list[int] = []
+    for index, dimension in enumerate(value):
+        if type(dimension) is not int:
+            raise ValueError(f"{name}[{index}] must be an exact integer")
+        if not 0 <= dimension <= _INT32_MAX:
+            raise ValueError(f"{name}[{index}] must lie in [0, {_INT32_MAX}]")
+        dimensions.append(dimension)
+    if dimensions[0] != steps:
+        raise ValueError(f"{name}[0] must equal steps")
+    return tuple(dimensions)
+
+
+__all__ = ["require_step_shape"]

--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -40,6 +40,7 @@ from alberta_framework.core.optimizers import (
     Autostep,
     AutostepGTDLambda,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 from alberta_framework.streams.alberta_plan_step1 import (
     AlbertaPlanStep1Stream,
     XDistShiftStream,
@@ -278,6 +279,11 @@ class Step1SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "metrics_shape",
+            require_step_shape("metrics_shape", self.metrics_shape, steps=self.steps),
+        )
         object.__setattr__(
             self,
             "final_window_mse",

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -58,6 +58,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 
 @dataclass(frozen=True)
@@ -368,6 +369,18 @@ class Step10SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "td_errors_shape",
+            "average_rewards_shape",
+            "primitive_actions_shape",
+            "executing_options_shape",
+            "pseudo_rewards_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         object.__setattr__(
             self,

--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -57,6 +57,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 
 @dataclass(frozen=True)
@@ -373,6 +374,17 @@ class Step11SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "td_errors_shape",
+            "average_rewards_shape",
+            "primitive_actions_shape",
+            "utility_emas_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         object.__setattr__(
             self,

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -57,6 +57,7 @@ from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.steps._float32_validation import (
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 
 @dataclass(frozen=True)
@@ -341,6 +342,18 @@ class Step12SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "predictions_shape",
+            "cerebellum_errors_shape",
+            "recommendations_shape",
+            "augmented_obs_shape",
+            "cortex_td_errors_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:

--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -45,6 +45,7 @@ from alberta_framework.core.temporal_context import (
 )
 from alberta_framework.core.upgd import UPGDLearner, run_upgd_arrays
 from alberta_framework.core.upgd_memory import UPGDMemoryConfig, UPGDMemoryLearner
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 from alberta_framework.streams.out_of_class import (
     CompositionalStream,
     FrequencyMismatchStream,
@@ -669,6 +670,11 @@ class Step2SmokeResult:
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
         object.__setattr__(
             self,
+            "metrics_shape",
+            require_step_shape("metrics_shape", self.metrics_shape, steps=self.steps),
+        )
+        object.__setattr__(
+            self,
             "final_window_mse",
             _require_real("final_window_mse", self.final_window_mse),
         )
@@ -700,6 +706,11 @@ class Step2AssociativeSmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "metrics_shape",
+            require_step_shape("metrics_shape", self.metrics_shape, steps=self.steps),
+        )
         object.__setattr__(
             self,
             "initial_window_nll",

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -51,6 +51,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 Step4OptimizerName = Literal["lms", "idbd", "autostep"]
 Step4BounderName = Literal["none", "obgd"]
@@ -122,6 +123,12 @@ class Step4SmokeResult:
     def __post_init__(self) -> None:
         object.__setattr__(self, "steps", _require_positive_int("steps", self.steps))
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in ("q_values_shape", "td_errors_shape", "actions_shape"):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:

--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -39,6 +39,7 @@ from alberta_framework.core.average_reward import (
     run_differential_td_from_arrays,
 )
 from alberta_framework.steps._float32_validation import finite_real_and_float32
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 _STEP5_CONFIG_KEYS = frozenset(
     {"step_size", "average_reward_step_size", "trace_decay"}
@@ -204,6 +205,16 @@ class Step5SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "predictions_shape",
+            "td_errors_shape",
+            "average_rewards_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -37,6 +37,7 @@ from alberta_framework.core.average_reward import (
     run_differential_sarsa_from_arrays,
 )
 from alberta_framework.steps._float32_validation import finite_real_and_float32
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 _INT32_MAX = 2**31 - 1
 
@@ -194,6 +195,17 @@ class Step6SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "q_values_shape",
+            "td_errors_shape",
+            "average_rewards_shape",
+            "actions_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -72,6 +72,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 from alberta_framework.steps.step6 import (
     Step6DifferentialSARSAConfig,
     make_step6_differential_sarsa_agent,
@@ -359,6 +360,19 @@ class Step7SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "real_td_errors_shape",
+            "planning_td_errors_shape",
+            "planning_priorities_shape",
+            "planning_anchor_indices_shape",
+            "planning_importance_ratios_shape",
+            "actions_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         object.__setattr__(
             self,

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -47,6 +47,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 
 @dataclass(frozen=True)
@@ -234,6 +235,17 @@ class Step8SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in (
+            "reward_predictions_shape",
+            "next_observation_predictions_shape",
+            "reward_errors_shape",
+            "next_observation_errors_shape",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
 
     def to_dict(self) -> dict[str, object]:

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -62,6 +62,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 from alberta_framework.steps.step6 import (
     Step6DifferentialSARSAConfig,
     make_step6_differential_sarsa_agent,
@@ -416,6 +417,12 @@ class Step9SmokeResult:
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        for name in ("real_td_errors_shape", "dream_td_errors_shape", "actions_shape"):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         object.__setattr__(
             self,

--- a/tests/test_continual_ia_evidence.py
+++ b/tests/test_continual_ia_evidence.py
@@ -742,6 +742,29 @@ def test_condition_timing_rejects_leftover_identities() -> None:
     assert '"wall_seconds": true' not in dumped
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"lower": 0.3, "upper": 0.2},
+        {"confidence_level": 0.0},
+        {"confidence_level": 1.0},
+    ),
+)
+def test_paired_bootstrap_interval_enforces_schema_invariants(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _legal_interval(**overrides)
+
+
+@pytest.mark.parametrize("value", (-1.0, -0.001))
+def test_condition_timing_rejects_negative_measurements(value: float) -> None:
+    with pytest.raises(ValueError, match="wall_seconds"):
+        ConditionTiming(value, 0.0)
+    with pytest.raises(ValueError, match="mean_step_latency_ms"):
+        ConditionTiming(0.0, value)
+
+
 def test_bootstrap_and_run_work_preflights_fire_before_large_allocations() -> None:
     with pytest.raises(ValueError, match="bootstrap_draw_count"):
         paired_bootstrap_mean_interval(

--- a/tests/test_continual_multiagent_validation.py
+++ b/tests/test_continual_multiagent_validation.py
@@ -340,3 +340,26 @@ def test_timing_metrics_reject_leftover_identities() -> None:
     dumped = json.dumps({"wall_seconds": timing.wall_seconds}, allow_nan=False)
     assert '"wall_seconds": 1.25' in dumped
     assert '"wall_seconds": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"lower": 0.3, "upper": 0.2},
+        {"confidence_level": 0.0},
+        {"confidence_level": 1.0},
+    ),
+)
+def test_bootstrap_interval_enforces_schema_invariants(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _legal_interval(**overrides)
+
+
+@pytest.mark.parametrize("field", range(4))
+def test_timing_metrics_reject_negative_measurements(field: int) -> None:
+    values = [0.0, 0.0, 0.0, 0.0]
+    values[field] = -0.001
+    with pytest.raises(ValueError):
+        TimingMetrics(*values)

--- a/tests/test_ftl_decision_fidelity.py
+++ b/tests/test_ftl_decision_fidelity.py
@@ -498,3 +498,18 @@ def test_decision_metrics_reject_leftover_identities() -> None:
     dumped = json.dumps({"normalized_regret": metrics.normalized_regret}, allow_nan=False)
     assert '"normalized_regret": 0.1' in dumped
     assert '"normalized_regret": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"lower": 0.3, "upper": 0.2},
+        {"confidence_level": 0.0},
+        {"confidence_level": 1.0},
+    ),
+)
+def test_bootstrap_estimate_enforces_schema_invariants(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _legal_interval(**overrides)

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -212,3 +212,27 @@ def test_condition_seed_and_report_reject_leftover_identities() -> None:
     )
     assert report.seeds == (8,)
     assert report.wall_time_seconds_by_condition[CONDITION_PRIMARY] == 1.25
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "phase_squared_error_sum",
+        "early_squared_error_sum",
+        "tail_squared_error_sum",
+        "asymptotic_squared_error_sum",
+    ),
+)
+def test_phase_window_record_rejects_negative_squared_error_sums(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_phase(**{field: -0.001})
+
+
+def test_scale_report_rejects_negative_wall_time() -> None:
+    with pytest.raises(ValueError, match="wall_time_seconds_by_condition"):
+        ScaleRobustFeatureReport(
+            seeds=(8,),
+            records=(),
+            memory_by_condition={},
+            wall_time_seconds_by_condition={CONDITION_PRIMARY: -0.001},
+        )

--- a/tests/test_step_smoke_record_shapes.py
+++ b/tests/test_step_smoke_record_shapes.py
@@ -1,0 +1,172 @@
+"""Cross-Step smoke-result shape identity and consistency tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from alberta_framework.steps._smoke_record_validation import require_step_shape
+from alberta_framework.steps.step1 import Step1KernelConfig, Step1SmokeResult
+from alberta_framework.steps.step2 import (
+    Step2AssociativeConfig,
+    Step2AssociativeSmokeResult,
+    Step2KernelConfig,
+    Step2SmokeResult,
+)
+from alberta_framework.steps.step4 import Step4SARSAConfig, Step4SmokeResult
+from alberta_framework.steps.step5 import Step5AverageRewardTDConfig, Step5SmokeResult
+from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig, Step6SmokeResult
+from alberta_framework.steps.step7 import Step7DynaConfig, Step7SmokeResult
+from alberta_framework.steps.step8 import Step8SmokeResult, Step8WorldModelConfig
+from alberta_framework.steps.step9 import Step9DreamingConfig, Step9SmokeResult
+from alberta_framework.steps.step10 import Step10SmokeResult, Step10STOMPConfig
+from alberta_framework.steps.step11 import Step11OaKConfig, Step11SmokeResult
+from alberta_framework.steps.step12 import Step12IAConfig, Step12SmokeResult
+
+
+@pytest.mark.parametrize("value", ([], (), (True,), (-1,), (2**31,), (7,)))
+def test_shared_shape_gate_rejects_noncanonical_or_inconsistent_values(value: object) -> None:
+    with pytest.raises(ValueError):
+        require_step_shape("shape", value, steps=8)
+
+
+def _records_and_shape_fields() -> tuple[tuple[object, tuple[str, ...]], ...]:
+    return (
+        (Step1SmokeResult(Step1KernelConfig(), 8, 0, 0.0, (8,), True), ("metrics_shape",)),
+        (
+            Step2SmokeResult(Step2KernelConfig(), 8, 0, 0.0, (8,), True, {}),
+            ("metrics_shape",),
+        ),
+        (
+            Step2AssociativeSmokeResult(
+                Step2AssociativeConfig(), 8, 0, 1.0, 0.5, (8,), True, {}
+            ),
+            ("metrics_shape",),
+        ),
+        (
+            Step4SmokeResult(Step4SARSAConfig(), 8, 0, (8, 2), (8,), (8,), True, {}),
+            ("q_values_shape", "td_errors_shape", "actions_shape"),
+        ),
+        (
+            Step5SmokeResult(
+                Step5AverageRewardTDConfig(), 8, 0, (8,), (8,), (8,), True, {}
+            ),
+            ("predictions_shape", "td_errors_shape", "average_rewards_shape"),
+        ),
+        (
+            Step6SmokeResult(
+                Step6DifferentialSARSAConfig(),
+                8,
+                0,
+                (8, 2),
+                (8,),
+                (8,),
+                (8,),
+                True,
+                {},
+            ),
+            ("q_values_shape", "td_errors_shape", "average_rewards_shape", "actions_shape"),
+        ),
+        (
+            Step7SmokeResult(
+                Step7DynaConfig(),
+                8,
+                0,
+                (8,),
+                (8, 1),
+                (8, 1),
+                (8, 1),
+                (8, 1),
+                (8,),
+                True,
+                0,
+                {},
+                {},
+            ),
+            (
+                "real_td_errors_shape",
+                "planning_td_errors_shape",
+                "planning_priorities_shape",
+                "planning_anchor_indices_shape",
+                "planning_importance_ratios_shape",
+                "actions_shape",
+            ),
+        ),
+        (
+            Step8SmokeResult(
+                Step8WorldModelConfig(), 8, 0, (8,), (8, 4), (8,), (8, 4), True, {}
+            ),
+            (
+                "reward_predictions_shape",
+                "next_observation_predictions_shape",
+                "reward_errors_shape",
+                "next_observation_errors_shape",
+            ),
+        ),
+        (
+            Step9SmokeResult(
+                Step9DreamingConfig(), 8, 0, (8,), (8, 1), (8,), True, 0, {}, {}
+            ),
+            ("real_td_errors_shape", "dream_td_errors_shape", "actions_shape"),
+        ),
+        (
+            Step10SmokeResult(
+                Step10STOMPConfig(),
+                8,
+                0,
+                (8,),
+                (8,),
+                (8,),
+                (8,),
+                (8, 0),
+                True,
+                0,
+                {},
+            ),
+            (
+                "td_errors_shape",
+                "average_rewards_shape",
+                "primitive_actions_shape",
+                "executing_options_shape",
+                "pseudo_rewards_shape",
+            ),
+        ),
+        (
+            Step11SmokeResult(
+                Step11OaKConfig(), 8, 0, (8,), (8,), (8,), (8, 0), True, 0, {}
+            ),
+            (
+                "td_errors_shape",
+                "average_rewards_shape",
+                "primitive_actions_shape",
+                "utility_emas_shape",
+            ),
+        ),
+        (
+            Step12SmokeResult(
+                Step12IAConfig(), 8, 0, (8, 4), (8, 4), (8,), (8, 8), (8,), True, {}
+            ),
+            (
+                "predictions_shape",
+                "cerebellum_errors_shape",
+                "recommendations_shape",
+                "augmented_obs_shape",
+                "cortex_td_errors_shape",
+            ),
+        ),
+    )
+
+
+def test_every_changed_step_smoke_record_rejects_bool_shape_identities() -> None:
+    for record, fields in _records_and_shape_fields():
+        for field in fields:
+            with pytest.raises(ValueError, match=field):
+                replace(record, **{field: (True,)})
+
+
+def test_every_changed_step_smoke_record_rejects_step_shape_mismatch() -> None:
+    for record, fields in _records_and_shape_fields():
+        for field in fields:
+            with pytest.raises(ValueError, match="must equal steps"):
+                replace(record, **{field: (7,)})


### PR DESCRIPTION
Post-merge cross-PR audit of all `alberta_framework/steps/**` and `alberta_framework/evaluation/**` source changes since `ec299cff`.\n\nThe scalar hardening was correct but incomplete in composition:\n- every changed public Step smoke record still accepted bool dimensions and shape/step mismatches, so `to_dict()` could emit shape booleans or contradictory execution identities;\n- the three new bootstrap record validators duplicated finite-scalar logic while accepting reversed interval bounds and confidence levels outside `(0, 1)`;\n- timing and squared-error measurement records accepted finite negative values despite their artifact schemas requiring non-negative values.\n\nThis adds shared exact validators, wires every changed Step smoke result through a non-empty bounded exact shape gate with leading-axis/steps equality, consolidates evaluation scalar validation, and enforces interval/timing/error-sum semantics. No kernel math, benchmark execution, registered evidence source, or `outputs/**` artifact changes.\n\nVerification on current main:\n- 1,280 combined Step production/identity tests passed\n- 462 evaluation/record tests passed, 18 skipped\n- Ruff clean on all changed files\n- strict mypy clean on 17 changed source modules