### PR TITLE
fix(canonical-upgd): bind exact resource identities

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -1167,6 +1167,20 @@ class AlbertaAdaUPGDUpdate:
     metrics: dict[str, Array]
 
 
+def _require_exact_int(value: Any, path: str) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{path} must be an integer")
+    if value < 0 or value > _INT32_MAX:
+        raise ValueError(f"{path} must lie in [0, {_INT32_MAX}]")
+    return value
+
+
+def _require_exact_bool(value: Any, path: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{path} must be a boolean")
+    return value
+
+
 @dataclass(frozen=True)
 class AlbertaAdaUPGDResources:
     """Exact persistent-array accounting for one adaptive optimizer state."""
@@ -1176,6 +1190,28 @@ class AlbertaAdaUPGDResources:
     parameter_count: int
     persistent_array_count: int
     persistent_state_nbytes: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "official_reference_parity",
+            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+        )
+        object.__setattr__(
+            self,
+            "parameter_count",
+            _require_exact_int(self.parameter_count, "parameter_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_array_count",
+            _require_exact_int(self.persistent_array_count, "persistent_array_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_nbytes",
+            _require_exact_int(self.persistent_state_nbytes, "persistent_state_nbytes"),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-compatible resource record."""
@@ -1956,6 +1992,28 @@ class OfficialAdaUPGDResources:
     parameter_count: int
     persistent_array_count: int
     persistent_state_nbytes: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "official_reference_parity",
+            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+        )
+        object.__setattr__(
+            self,
+            "parameter_count",
+            _require_exact_int(self.parameter_count, "parameter_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_array_count",
+            _require_exact_int(self.persistent_array_count, "persistent_array_count"),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_nbytes",
+            _require_exact_int(self.persistent_state_nbytes, "persistent_state_nbytes"),
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-compatible resource record."""

--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -1181,6 +1181,19 @@ def _require_exact_bool(value: Any, path: str) -> bool:
     return value
 
 
+def _require_exact_identity(value: Any, path: str, expected: str) -> str:
+    if type(value) is not str or value != expected:
+        raise ValueError(f"{path} must equal the canonical identity {expected!r}")
+    return value
+
+
+def _require_exact_parity(value: Any, path: str, expected: bool) -> bool:
+    parity = _require_exact_bool(value, path)
+    if parity is not expected:
+        raise ValueError(f"{path} must be {expected}")
+    return parity
+
+
 @dataclass(frozen=True)
 class AlbertaAdaUPGDResources:
     """Exact persistent-array accounting for one adaptive optimizer state."""
@@ -1194,8 +1207,17 @@ class AlbertaAdaUPGDResources:
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
+            "profile",
+            _require_exact_identity(self.profile, "profile", ALBERTA_ADAUPGD_PROFILE),
+        )
+        object.__setattr__(
+            self,
             "official_reference_parity",
-            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+            _require_exact_parity(
+                self.official_reference_parity,
+                "official_reference_parity",
+                False,
+            ),
         )
         object.__setattr__(
             self,
@@ -1994,10 +2016,24 @@ class OfficialAdaUPGDResources:
     persistent_state_nbytes: int
 
     def __post_init__(self) -> None:
+        for field_name, value, expected in (
+            ("profile", self.profile, OFFICIAL_ADAUPGD_PROFILE),
+            ("source_commit", self.source_commit, OFFICIAL_ADAUPGD_COMMIT),
+            ("source_path", self.source_path, OFFICIAL_ADAUPGD_PATH),
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_exact_identity(value, field_name, expected),
+            )
         object.__setattr__(
             self,
             "official_reference_parity",
-            _require_exact_bool(self.official_reference_parity, "official_reference_parity"),
+            _require_exact_parity(
+                self.official_reference_parity,
+                "official_reference_parity",
+                True,
+            ),
         )
         object.__setattr__(
             self,

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -15,6 +15,10 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.canonical_upgd import (
+    ALBERTA_ADAUPGD_PROFILE,
+    OFFICIAL_ADAUPGD_COMMIT,
+    OFFICIAL_ADAUPGD_PATH,
+    OFFICIAL_ADAUPGD_PROFILE,
     AlbertaAdaUPGD,
     AlbertaAdaUPGDConfig,
     AlbertaAdaUPGDResources,
@@ -572,7 +576,7 @@ def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
 
     with pytest.raises(ValueError, match="official_reference_parity"):
         AlbertaAdaUPGDResources(
-            profile="safe_extended",
+            profile=ALBERTA_ADAUPGD_PROFILE,
             official_reference_parity=1,
             parameter_count=1,
             persistent_array_count=2,
@@ -580,17 +584,17 @@ def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
         )
     with pytest.raises(ValueError, match="parameter_count"):
         AlbertaAdaUPGDResources(
-            profile="safe_extended",
-            official_reference_parity=True,
+            profile=ALBERTA_ADAUPGD_PROFILE,
+            official_reference_parity=False,
             parameter_count=True,
             persistent_array_count=2,
             persistent_state_nbytes=3,
         )
     with pytest.raises(ValueError, match="parameter_count"):
         OfficialAdaUPGDResources(
-            profile="official_experiment_global",
-            source_commit="c",
-            source_path="path",
+            profile=OFFICIAL_ADAUPGD_PROFILE,
+            source_commit=OFFICIAL_ADAUPGD_COMMIT,
+            source_path=OFFICIAL_ADAUPGD_PATH,
             official_reference_parity=True,
             parameter_count=True,
             persistent_array_count=2,
@@ -598,9 +602,9 @@ def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
         )
     with pytest.raises(ValueError, match="persistent_state_nbytes"):
         OfficialAdaUPGDResources(
-            profile="official_experiment_global",
-            source_commit="c",
-            source_path="path",
+            profile=OFFICIAL_ADAUPGD_PROFILE,
+            source_commit=OFFICIAL_ADAUPGD_COMMIT,
+            source_path=OFFICIAL_ADAUPGD_PATH,
             official_reference_parity=True,
             parameter_count=1,
             persistent_array_count=2,
@@ -608,16 +612,16 @@ def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
         )
 
     legal_alberta = AlbertaAdaUPGDResources(
-        profile="safe_extended",
+        profile=ALBERTA_ADAUPGD_PROFILE,
         official_reference_parity=False,
         parameter_count=1,
         persistent_array_count=2,
         persistent_state_nbytes=3,
     )
     legal_official = OfficialAdaUPGDResources(
-        profile="official_experiment_global",
-        source_commit="c",
-        source_path="path",
+        profile=OFFICIAL_ADAUPGD_PROFILE,
+        source_commit=OFFICIAL_ADAUPGD_COMMIT,
+        source_path=OFFICIAL_ADAUPGD_PATH,
         official_reference_parity=True,
         parameter_count=1,
         persistent_array_count=2,
@@ -635,3 +639,96 @@ def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
     assert '"parameter_count": 1' in dumped
     assert '"parameter_count": true' not in dumped
     assert '"official_reference_parity": 1' not in dumped
+
+
+class _HostileRecordIdentity:
+    def __eq__(self, other: object) -> bool:
+        del other
+        raise AssertionError("untrusted equality hook executed")
+
+    def __index__(self) -> int:
+        raise AssertionError("untrusted index hook executed")
+
+    def __int__(self) -> int:
+        raise AssertionError("untrusted integer hook executed")
+
+
+class _HostileStringIdentity(str):
+    def __eq__(self, other: object) -> bool:
+        del other
+        raise AssertionError("untrusted string equality hook executed")
+
+
+def _legal_alberta_resources(**overrides: object) -> AlbertaAdaUPGDResources:
+    values: dict[str, object] = {
+        "profile": ALBERTA_ADAUPGD_PROFILE,
+        "official_reference_parity": False,
+        "parameter_count": 1,
+        "persistent_array_count": 2,
+        "persistent_state_nbytes": 3,
+    }
+    values.update(overrides)
+    return AlbertaAdaUPGDResources(**values)  # type: ignore[arg-type]
+
+
+def _legal_official_resources(**overrides: object) -> OfficialAdaUPGDResources:
+    values: dict[str, object] = {
+        "profile": OFFICIAL_ADAUPGD_PROFILE,
+        "source_commit": OFFICIAL_ADAUPGD_COMMIT,
+        "source_path": OFFICIAL_ADAUPGD_PATH,
+        "official_reference_parity": True,
+        "parameter_count": 1,
+        "persistent_array_count": 2,
+        "persistent_state_nbytes": 3,
+    }
+    values.update(overrides)
+    return OfficialAdaUPGDResources(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("factory", "field", "value"),
+    [
+        (_legal_alberta_resources, "profile", "safe_extended"),
+        (_legal_alberta_resources, "profile", _HostileStringIdentity(ALBERTA_ADAUPGD_PROFILE)),
+        (_legal_alberta_resources, "official_reference_parity", True),
+        (_legal_official_resources, "profile", ALBERTA_ADAUPGD_PROFILE),
+        (_legal_official_resources, "source_commit", "main"),
+        (
+            _legal_official_resources,
+            "source_path",
+            _HostileStringIdentity(OFFICIAL_ADAUPGD_PATH),
+        ),
+        (_legal_official_resources, "official_reference_parity", False),
+        (_legal_official_resources, "parameter_count", _HostileRecordIdentity()),
+        (_legal_official_resources, "persistent_array_count", np.int32(2)),
+        (_legal_official_resources, "persistent_state_nbytes", -1),
+        (_legal_official_resources, "persistent_state_nbytes", _INT32_MAX + 1),
+    ],
+)
+def test_adaupgd_resource_records_bind_exact_hostile_safe_identities(
+    factory: Any,
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        factory(**{field: value})
+
+
+def test_adaupgd_resource_records_dump_only_bound_json_primitives() -> None:
+    records = {
+        "alberta": _legal_alberta_resources(
+            parameter_count=_INT32_MAX,
+            persistent_array_count=0,
+            persistent_state_nbytes=_INT32_MAX,
+        ).to_dict(),
+        "official": _legal_official_resources().to_dict(),
+    }
+    dumped = json.dumps(records, allow_nan=False, sort_keys=True)
+    decoded = json.loads(dumped)
+
+    assert decoded["alberta"]["profile"] == ALBERTA_ADAUPGD_PROFILE
+    assert decoded["alberta"]["official_reference_parity"] is False
+    assert decoded["official"]["profile"] == OFFICIAL_ADAUPGD_PROFILE
+    assert decoded["official"]["source_commit"] == OFFICIAL_ADAUPGD_COMMIT
+    assert decoded["official"]["source_path"] == OFFICIAL_ADAUPGD_PATH
+    assert decoded["official"]["official_reference_parity"] is True

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 from typing import Any
@@ -16,10 +17,12 @@ import pytest
 from alberta_framework.core.canonical_upgd import (
     AlbertaAdaUPGD,
     AlbertaAdaUPGDConfig,
+    AlbertaAdaUPGDResources,
     CanonicalUPGD,
     CanonicalUPGDConfig,
     OfficialAdaUPGD,
     OfficialAdaUPGDConfig,
+    OfficialAdaUPGDResources,
 )
 
 _INT32_MAX = 2_147_483_647
@@ -562,3 +565,73 @@ def test_official_counter_saturates_without_changing_source_equations() -> None:
     )
     result = optimizer.update(state, params, gradients, jr.key(13), noise=noise)
     assert int(result.state.step) == _INT32_MAX
+
+
+def test_canonical_upgd_resource_records_reject_leftover_identities() -> None:
+    """Public AdaUPGD resource records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="official_reference_parity"):
+        AlbertaAdaUPGDResources(
+            profile="safe_extended",
+            official_reference_parity=1,
+            parameter_count=1,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="parameter_count"):
+        AlbertaAdaUPGDResources(
+            profile="safe_extended",
+            official_reference_parity=True,
+            parameter_count=True,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="parameter_count"):
+        OfficialAdaUPGDResources(
+            profile="official_experiment_global",
+            source_commit="c",
+            source_path="path",
+            official_reference_parity=True,
+            parameter_count=True,
+            persistent_array_count=2,
+            persistent_state_nbytes=3,
+        )
+    with pytest.raises(ValueError, match="persistent_state_nbytes"):
+        OfficialAdaUPGDResources(
+            profile="official_experiment_global",
+            source_commit="c",
+            source_path="path",
+            official_reference_parity=True,
+            parameter_count=1,
+            persistent_array_count=2,
+            persistent_state_nbytes=float("nan"),
+        )
+
+    legal_alberta = AlbertaAdaUPGDResources(
+        profile="safe_extended",
+        official_reference_parity=False,
+        parameter_count=1,
+        persistent_array_count=2,
+        persistent_state_nbytes=3,
+    )
+    legal_official = OfficialAdaUPGDResources(
+        profile="official_experiment_global",
+        source_commit="c",
+        source_path="path",
+        official_reference_parity=True,
+        parameter_count=1,
+        persistent_array_count=2,
+        persistent_state_nbytes=3,
+    )
+    dumped = json.dumps(
+        {
+            "alberta": legal_alberta.to_dict(),
+            "official": legal_official.to_dict(),
+        },
+        allow_nan=False,
+    )
+    assert '"official_reference_parity": false' in dumped
+    assert '"official_reference_parity": true' in dumped
+    assert '"parameter_count": 1' in dumped
+    assert '"parameter_count": true' not in dumped
+    assert '"official_reference_parity": 1' not in dumped


### PR DESCRIPTION
Supersedes #1167 after deep review; preserves @ss251's original failing-tests-first commit. Fixes #1165.

The original patch rejected bool/int scalar identity leftovers, but still allowed semantically false resource records: an Alberta record could claim official parity, an official record could deny parity, and profile/source provenance strings could be arbitrary while serializing as valid JSON.

This successor binds:

- the exact Alberta profile and `official_reference_parity=False`
- the exact official profile, pinned source commit/path, and `official_reference_parity=True`
- exact built-in nonnegative int counts bounded by signed int32
- hostile string/numeric subclasses without invoking equality or conversion hooks
- JSON output to the bound primitive identities

Verification:

- canonical UPGD/AdaUPGD combined panel: 163 passed
- focused validation: 69 passed
- Ruff clean on changed files
- strict mypy clean on `canonical_upgd.py`
- diff check clean

No kernels, benchmarks, or outputs changed.