### PR TITLE
fix(mixer): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -283,6 +283,49 @@ class RepresentationGradientMixerResourceBudget:
     output_scalars: int
     output_nbytes: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "representation_dim",
+            _require_int32("representation_dim", self.representation_dim, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_scalars",
+            _require_int32(
+                "persistent_state_scalars", self.persistent_state_scalars, minimum=0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32(
+                "persistent_state_bytes", self.persistent_state_bytes, minimum=0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_float32_scalars",
+            _require_int32(
+                "output_float32_scalars", self.output_float32_scalars, minimum=0
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_bool_scalars",
+            _require_int32("output_bool_scalars", self.output_bool_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_scalars",
+            _require_int32("output_scalars", self.output_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_nbytes",
+            _require_int32("output_nbytes", self.output_nbytes, minimum=0),
+        )
+
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""
 

--- a/tests/test_representation_gradient_mixer_resource_budget.py
+++ b/tests/test_representation_gradient_mixer_resource_budget.py
@@ -1,0 +1,67 @@
+"""Leftover-identity gates for mixer resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.representation_gradient_mixer import (
+    RepresentationGradientMixerResourceBudget,
+)
+
+
+def _legal_budget() -> RepresentationGradientMixerResourceBudget:
+    return RepresentationGradientMixerResourceBudget(
+        representation_dim=3,
+        persistent_state_scalars=0,
+        persistent_state_bytes=0,
+        output_float32_scalars=15,
+        output_bool_scalars=12,
+        output_scalars=27,
+        output_nbytes=72,
+    )
+
+
+def test_mixer_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=True,
+            persistent_state_scalars=0,
+            persistent_state_bytes=0,
+            output_float32_scalars=15,
+            output_bool_scalars=12,
+            output_scalars=27,
+            output_nbytes=72,
+        )
+    with pytest.raises(ValueError, match="output_bool_scalars"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=3,
+            persistent_state_scalars=0,
+            persistent_state_bytes=0,
+            output_float32_scalars=15,
+            output_bool_scalars=True,
+            output_scalars=27,
+            output_nbytes=72,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=3,
+            persistent_state_scalars=0,
+            persistent_state_bytes=float("nan"),
+            output_float32_scalars=15,
+            output_bool_scalars=12,
+            output_scalars=27,
+            output_nbytes=72,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"representation_dim": 3' in dumped
+    assert '"persistent_state_scalars": 0' in dumped
+    assert '"output_bool_scalars": 12' in dumped
+    assert '"representation_dim": true' not in dumped
+    assert '"output_bool_scalars": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1170.

## What changed

The representation-gradient mixer resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `d35545f`, mixer config scalars already reject leftover boolean identities. `RepresentationGradientMixerResourceBudget` had no `__post_init__` and accepted leftover identities (`representation_dim=True`, `output_bool_scalars=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"representation_dim": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `representation_gradient_mixer.py` resource-budget records, not a republish of `#1166` (gauntlet resource-budget), `#1167` (canonical UPGD resource records), or `#1161` (recurring-multiagent resource-budget).

## Scope

- `alberta_framework/core/representation_gradient_mixer.py`
- `tests/test_representation_gradient_mixer_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ss251 `#1166`/`#1167` only (`gauntlet.py`, `canonical_upgd.py`). Foreign `#1163` is closed. These files were FREE. Merged leftover `#1158` (candidate-universe) and `#1161` (recurring-multiagent resource-budget) do not occupy this pair.

## Verification

Exact candidate head: `02e692c7313dddbdb9ce4c697445638292dcfaf3`
Base: `d35545f`

- Red on base: `RepresentationGradientMixerResourceBudget(representation_dim=True, ...)` accepted; dump emitted `"representation_dim": true`
- Focused pytest `tests/test_representation_gradient_mixer_resource_budget.py`: 1 passed
- Existing mixer allocation/export tests: 2 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:02e692c7313dddbdb9ce4c697445638292dcfaf3 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
