### PR TITLE
fix(behavior-model): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -328,6 +328,69 @@ class BehaviorModelResourceBudget:
     learned_float32_scalars_touched_per_update: int
     replay_capacity: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "feature_dim",
+            _require_int32("feature_dim", self.feature_dim, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "trainable_float32_scalars",
+            _require_int32(
+                "trainable_float32_scalars",
+                self.trainable_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "diagnostic_float32_scalars",
+            _require_int32(
+                "diagnostic_float32_scalars",
+                self.diagnostic_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "administrative_int32_scalars",
+            _require_int32(
+                "administrative_int32_scalars",
+                self.administrative_int32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "rng_uint32_scalars",
+            _require_int32("rng_uint32_scalars", self.rng_uint32_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "state_nbytes",
+            _require_int32("state_nbytes", self.state_nbytes, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "learned_float32_scalars_touched_per_update",
+            _require_int32(
+                "learned_float32_scalars_touched_per_update",
+                self.learned_float32_scalars_touched_per_update,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity",
+            _require_int32("replay_capacity", self.replay_capacity, minimum=0),
+        )
+
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""
         return dataclasses.asdict(self)

--- a/tests/test_behavior_model_resource_budget.py
+++ b/tests/test_behavior_model_resource_budget.py
@@ -1,0 +1,73 @@
+"""Leftover-identity gates for behavior-model resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.behavior_model import BehaviorModelResourceBudget
+
+
+def _legal_budget() -> BehaviorModelResourceBudget:
+    return BehaviorModelResourceBudget(
+        feature_dim=5,
+        n_actions=3,
+        trainable_float32_scalars=18,
+        diagnostic_float32_scalars=3,
+        administrative_int32_scalars=1,
+        rng_uint32_scalars=2,
+        state_nbytes=96,
+        learned_float32_scalars_touched_per_update=21,
+        replay_capacity=0,
+    )
+
+
+def test_behavior_model_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        BehaviorModelResourceBudget(
+            feature_dim=True,
+            n_actions=3,
+            trainable_float32_scalars=18,
+            diagnostic_float32_scalars=3,
+            administrative_int32_scalars=1,
+            rng_uint32_scalars=2,
+            state_nbytes=96,
+            learned_float32_scalars_touched_per_update=21,
+            replay_capacity=0,
+        )
+    with pytest.raises(ValueError, match="replay_capacity"):
+        BehaviorModelResourceBudget(
+            feature_dim=5,
+            n_actions=3,
+            trainable_float32_scalars=18,
+            diagnostic_float32_scalars=3,
+            administrative_int32_scalars=1,
+            rng_uint32_scalars=2,
+            state_nbytes=96,
+            learned_float32_scalars_touched_per_update=21,
+            replay_capacity=True,
+        )
+    with pytest.raises(ValueError, match="state_nbytes"):
+        BehaviorModelResourceBudget(
+            feature_dim=5,
+            n_actions=3,
+            trainable_float32_scalars=18,
+            diagnostic_float32_scalars=3,
+            administrative_int32_scalars=1,
+            rng_uint32_scalars=2,
+            state_nbytes=float("nan"),
+            learned_float32_scalars_touched_per_update=21,
+            replay_capacity=0,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"feature_dim": 5' in dumped
+    assert '"n_actions": 3' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"feature_dim": true' not in dumped
+    assert '"replay_capacity": true' not in dumped
+    assert '"state_nbytes": true' not in dumped


### PR DESCRIPTION
Closes #1171.

## What changed

The behavior-model resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `d35545f`, the factory already rejects leftover boolean identities on `feature_dim` / `n_actions` when building a budget. `BehaviorModelResourceBudget` had no `__post_init__` and accepted leftover identities (`feature_dim=True`, `replay_capacity=True`, `state_nbytes=NaN`). `json.dumps(record.to_dict(), allow_nan=False)` then emitted `"feature_dim": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `behavior_model.py` resource-budget records, not a republish of `#1166` (gauntlet resource-budget), `#1167` (canonical UPGD resource records), or `#606` (reward-model scalar config).

## Scope

- `alberta_framework/core/behavior_model.py`
- `tests/test_behavior_model_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ss251 `#1166`/`#1167` only (`gauntlet.py`, `canonical_upgd.py`). Foreign `#1163` is closed. These files were FREE. Merged leftover `#1158` (candidate-universe) and `#1161` (recurring-multiagent resource-budget) do not occupy this pair.

## Verification

Exact candidate head: `c647980eb915a839d103c9cd4bfbb05b15881935`
Base: `d35545f`

- Red on base: `BehaviorModelResourceBudget(feature_dim=True, ...)` accepted; dump emitted `"feature_dim": true`
- Focused pytest `tests/test_behavior_model_resource_budget.py`: 1 passed
- Existing behavior-model resource tests: 2 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c647980eb915a839d103c9cd4bfbb05b15881935 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
