### PR TITLE
fix(gauntlet): reject hostile resource identities

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -90,7 +90,10 @@ def _require_int(
     minimum: int = 0,
     maximum: int = _INT32_MAX,
 ) -> int:
-    if type(value) is bool or not isinstance(value, int):
+    # This is a JSON/checkpoint identity boundary. Reject by exact type before
+    # comparisons so hostile ``int`` subclasses cannot execute hooks and
+    # NumPy scalar identities cannot leak into persisted metadata.
+    if type(value) is not int:
         raise ValueError(f"{name} must be an integer")
     if value < minimum or value > maximum:
         raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")

--- a/tests/test_gauntlet_resource_budget.py
+++ b/tests/test_gauntlet_resource_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+import numpy as np
 import pytest
 
 from alberta_framework.streams.gauntlet import LifetimeGauntletResourceBudget
@@ -52,3 +53,51 @@ def test_gauntlet_resource_budget_rejects_leftover_identities() -> None:
     assert '"state_nbytes": true' not in dumped
     assert '"trainable_scalars": true' not in dumped
     assert '"replay_capacity": true' not in dumped
+
+
+def test_gauntlet_resource_budget_rejects_noncanonical_ints_without_hooks() -> None:
+    class HostileInt(int):
+        comparison_calls = 0
+
+        def __lt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+        def __gt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+    for value in (HostileInt(1), np.int64(1), np.uint64(1)):
+        with pytest.raises(ValueError, match="state_nbytes"):
+            LifetimeGauntletResourceBudget(
+                state_nbytes=value,  # type: ignore[arg-type]
+                exact_clock_nbytes=12,
+                exact_clock_delta_nbytes=8,
+            )
+    assert HostileInt.comparison_calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "state_nbytes",
+        "exact_clock_nbytes",
+        "exact_clock_delta_nbytes",
+        "trainable_scalars",
+        "replay_capacity",
+    ),
+)
+@pytest.mark.parametrize("value", (-1, 2**31))
+def test_gauntlet_resource_budget_rejects_out_of_int32_domain(
+    field: str, value: int
+) -> None:
+    payload = {
+        "state_nbytes": 1,
+        "exact_clock_nbytes": 12,
+        "exact_clock_delta_nbytes": 8,
+        "trainable_scalars": 0,
+        "replay_capacity": 0,
+    }
+    payload[field] = value
+    with pytest.raises(ValueError, match=field):
+        LifetimeGauntletResourceBudget(**payload)


### PR DESCRIPTION
Deep-review correction for #1166 / issue #1164.\n\nThe merged bool/non-finite gate still used `isinstance(value, int)`, retained arbitrary `int` subclasses in checkpoint JSON, and invoked hostile comparison hooks before rejection. This requires the exact built-in integer identity before range checks and adds all-field lower/upper boundary coverage plus hostile subclass and NumPy scalar cases.\n\nVerification on current main:\n- 50 gauntlet/resource/scale interaction tests passed\n- focused Ruff passed\n- strict mypy passed\n\nNo benchmark run or `outputs/**` change.