### PR TITLE
fix(core): reject leftover resource-budget identities in behavior-model and mixer

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -328,6 +328,69 @@ class BehaviorModelResourceBudget:
     learned_float32_scalars_touched_per_update: int
     replay_capacity: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "feature_dim",
+            _require_int32("feature_dim", self.feature_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "n_actions",
+            _require_int32("n_actions", self.n_actions, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "trainable_float32_scalars",
+            _require_int32(
+                "trainable_float32_scalars",
+                self.trainable_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "diagnostic_float32_scalars",
+            _require_int32(
+                "diagnostic_float32_scalars",
+                self.diagnostic_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "administrative_int32_scalars",
+            _require_int32(
+                "administrative_int32_scalars",
+                self.administrative_int32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "rng_uint32_scalars",
+            _require_int32("rng_uint32_scalars", self.rng_uint32_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "state_nbytes",
+            _require_int32("state_nbytes", self.state_nbytes, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "learned_float32_scalars_touched_per_update",
+            _require_int32(
+                "learned_float32_scalars_touched_per_update",
+                self.learned_float32_scalars_touched_per_update,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "replay_capacity",
+            _require_int32("replay_capacity", self.replay_capacity, minimum=0),
+        )
+
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""
         return dataclasses.asdict(self)

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -283,6 +283,43 @@ class RepresentationGradientMixerResourceBudget:
     output_scalars: int
     output_nbytes: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "representation_dim",
+            _require_int32("representation_dim", self.representation_dim, minimum=1),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_scalars",
+            _require_int32("persistent_state_scalars", self.persistent_state_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32("persistent_state_bytes", self.persistent_state_bytes, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_float32_scalars",
+            _require_int32("output_float32_scalars", self.output_float32_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_bool_scalars",
+            _require_int32("output_bool_scalars", self.output_bool_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_scalars",
+            _require_int32("output_scalars", self.output_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_nbytes",
+            _require_int32("output_nbytes", self.output_nbytes, minimum=0),
+        )
+
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,7 @@ try:
     from alberta_framework.core.behavior_model import (
         BehaviorModel,
         BehaviorModelConfig,
+        BehaviorModelResourceBudget,
         action_log_likelihoods,
         clipped_importance_ratios,
         epsilon_greedy_probabilities,
@@ -580,3 +582,62 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
     with pytest.raises(AssertionError, match="allocator reached"):
         model.init(max_feature_dim, jax.random.key(0))
     assert calls == 1
+
+
+def test_behavior_model_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+    with pytest.raises(ValueError, match="feature_dim"):
+        BehaviorModelResourceBudget(
+            feature_dim=True,  # type: ignore[arg-type]
+            n_actions=2,
+            trainable_float32_scalars=0,
+            diagnostic_float32_scalars=0,
+            administrative_int32_scalars=0,
+            rng_uint32_scalars=0,
+            state_nbytes=0,
+            learned_float32_scalars_touched_per_update=0,
+            replay_capacity=0,
+        )
+
+    with pytest.raises(ValueError, match="replay_capacity"):
+        BehaviorModelResourceBudget(
+            feature_dim=4,
+            n_actions=2,
+            trainable_float32_scalars=0,
+            diagnostic_float32_scalars=0,
+            administrative_int32_scalars=0,
+            rng_uint32_scalars=0,
+            state_nbytes=0,
+            learned_float32_scalars_touched_per_update=0,
+            replay_capacity=True,  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="state_nbytes"):
+        BehaviorModelResourceBudget(
+            feature_dim=4,
+            n_actions=2,
+            trainable_float32_scalars=0,
+            diagnostic_float32_scalars=0,
+            administrative_int32_scalars=0,
+            rng_uint32_scalars=0,
+            state_nbytes=float("nan"),  # type: ignore[arg-type]
+            learned_float32_scalars_touched_per_update=0,
+            replay_capacity=0,
+        )
+
+    legal = BehaviorModelResourceBudget(
+        feature_dim=4,
+        n_actions=2,
+        trainable_float32_scalars=8,
+        diagnostic_float32_scalars=0,
+        administrative_int32_scalars=0,
+        rng_uint32_scalars=2,
+        state_nbytes=40,
+        learned_float32_scalars_touched_per_update=4,
+        replay_capacity=0,
+    )
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"feature_dim": 4' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"feature_dim": true' not in dumped
+    assert '"replay_capacity": true' not in dumped

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -18,6 +18,7 @@ from jax import Array
 from alberta_framework.core.representation_gradient_mixer import (
     GradientMixMode,
     RepresentationGradientMixerConfig,
+    RepresentationGradientMixerResourceBudget,
     RepresentationGradientMixResult,
     mix_representation_gradients,
 )
@@ -728,3 +729,54 @@ def test_gradient_mixer_resource_budget_is_exported_from_public_packages() -> No
     budget = RepresentationGradientMixerConfig(representation_dim=3).resource_budget
     assert isinstance(budget, RootBudget)
     assert RootBudget is CoreBudget
+
+
+def test_representation_gradient_mixer_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=True,  # type: ignore[arg-type]
+            persistent_state_scalars=0,
+            persistent_state_bytes=0,
+            output_float32_scalars=0,
+            output_bool_scalars=0,
+            output_scalars=0,
+            output_nbytes=0,
+        )
+
+    with pytest.raises(ValueError, match="output_bool_scalars"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=4,
+            persistent_state_scalars=0,
+            persistent_state_bytes=0,
+            output_float32_scalars=0,
+            output_bool_scalars=True,  # type: ignore[arg-type]
+            output_scalars=0,
+            output_nbytes=0,
+        )
+
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        RepresentationGradientMixerResourceBudget(
+            representation_dim=4,
+            persistent_state_scalars=0,
+            persistent_state_bytes=float("nan"),  # type: ignore[arg-type]
+            output_float32_scalars=0,
+            output_bool_scalars=0,
+            output_scalars=0,
+            output_nbytes=0,
+        )
+
+    legal = RepresentationGradientMixerResourceBudget(
+        representation_dim=4,
+        persistent_state_scalars=0,
+        persistent_state_bytes=0,
+        output_float32_scalars=12,
+        output_bool_scalars=3,
+        output_scalars=15,
+        output_nbytes=60,
+    )
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"representation_dim": 4' in dumped
+    assert '"output_bool_scalars": 3' in dumped
+    assert '"representation_dim": true' not in dumped
+    assert '"output_bool_scalars": true' not in dumped


### PR DESCRIPTION
## Summary
- Resolves #1171 and resolves #1170.
- Adds `__post_init__` validation using existing `_require_int32` to `BehaviorModelResourceBudget` (`alberta_framework/core/behavior_model.py`) and `RepresentationGradientMixerResourceBudget` (`alberta_framework/core/representation_gradient_mixer.py`).
- Rejects leftover boolean identities (`True`/`False`), non-finite floats (`NaN`/`inf`), negative bounds, and float subclasses on integer fields upon construction.
- Ensures `to_dict()` outputs legal finite JSON without bool-as-int representations.
- Adds regression tests in `tests/test_behavior_model.py` and `tests/test_representation_gradient_mixer.py`.

## Verification
- `pytest tests/test_behavior_model.py tests/test_representation_gradient_mixer.py`: 110 passed
- `ruff check alberta_framework/core/behavior_model.py alberta_framework/core/representation_gradient_mixer.py tests/test_behavior_model.py tests/test_representation_gradient_mixer.py`: clean