### PR TITLE
fix(benchmarks): close post-sweep identity hook residuals

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -214,8 +214,13 @@ def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
 
 
 def _freeze_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return MappingProxyType({str(key): _freeze_json(item) for key, item in value.items()})
+    if type(value) in (dict, MappingProxyType):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ForagerMatchedCampaignError("canonical mappings require string keys")
+            result[key] = _freeze_json(item)
+        return MappingProxyType(result)
     if type(value) is list:
         return tuple(_freeze_json(item) for item in value)
     if type(value) is tuple:
@@ -224,17 +229,28 @@ def _freeze_json(value: Any) -> Any:
 
 
 def _plain(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _plain(item) for key, item in value.items()}
-    if isinstance(value, tuple):
+    if type(value) in (dict, MappingProxyType):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ForagerMatchedCampaignError("canonical mappings require string keys")
+            result[key] = _plain(item)
+        return result
+    if type(value) is tuple:
         return [_plain(item) for item in value]
-    if isinstance(value, list):
+    if type(value) is list:
         return [_plain(item) for item in value]
-    if type(value) is float and not math.isfinite(value):
-        raise ForagerMatchedCampaignError(
-            "canonical content contains a non-finite JSON number"
-        )
-    return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ForagerMatchedCampaignError(
+                "canonical content contains a non-finite JSON number"
+            )
+        return value
+    if value is None or type(value) in (str, bool, int):
+        return value
+    raise ForagerMatchedCampaignError(
+        f"canonical content contains unsupported {type(value).__name__}"
+    )
 
 
 def _canonical_sha256(value: Mapping[str, Any]) -> str:

--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -522,14 +522,14 @@ def _plain_json(value: Any, path: str = "value") -> Any:
         return value
     if value is None or type(value) in {str, bool, int}:
         return value
-    if isinstance(value, Mapping):
+    if type(value) in (dict, MappingProxyType):
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
                 raise ForagerMatchedQualificationError(f"{path} has a non-string key")
             result[key] = _plain_json(item, f"{path}.{key}")
         return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if type(value) in (list, tuple):
         return [_plain_json(item, f"{path}[]") for item in value]
     raise ForagerMatchedQualificationError(f"{path} contains unsupported {type(value).__name__}")
 

--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -25,7 +25,7 @@ import os
 import re
 import secrets
 import stat
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -117,14 +117,14 @@ class _OpenDirectory:
 
 
 def _plain(value: Any) -> Any:
-    if isinstance(value, Mapping):
+    if type(value) in (dict, MappingProxyType):
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
                 raise ForagerMatchedSealError("canonical mappings require string keys")
             result[key] = _plain(item)
         return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if type(value) in (list, tuple):
         return [_plain(item) for item in value]
     if type(value) is float:
         if not math.isfinite(value):

--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1612,17 +1612,32 @@ def load_forager_matrix_manifest(path: str | Path) -> ForagerMatrixManifest:
 def _json_safe(value: Any) -> Any:
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _json_safe(dataclasses.asdict(value))
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
+    if type(value) in (dict, MappingProxyType):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ForagerMatrixError("matrix artifact mappings require string keys")
+            result[key] = _json_safe(item)
+        return result
+    if type(value) in (list, tuple):
         return [_json_safe(item) for item in value]
-    if isinstance(value, float) and not math.isfinite(value):
-        raise ForagerMatrixError("matrix artifact identity is not finite JSON")
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ForagerMatrixError("matrix artifact identity is not finite JSON")
+        return value
+    if type(value) in (np.float16, np.float32, np.float64, np.longdouble):
+        if not bool(np.isfinite(value)):
+            raise ForagerMatrixError("matrix artifact identity is not finite JSON")
+        return float(value)
     if isinstance(value, Path):
         if value.is_absolute():
             raise ForagerMatrixError("absolute host paths are forbidden in matrix artifacts")
         return value.as_posix()
-    return value
+    if value is None or type(value) in (str, bool, int):
+        return value
+    raise ForagerMatrixError(
+        f"matrix artifact contains unsupported {type(value).__name__} identity"
+    )
 
 
 def _assert_path_sanitized(value: Any, path: str = "artifact") -> None:

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -29,6 +29,7 @@ import sqlite3
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PureWindowsPath
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
@@ -133,13 +134,31 @@ def _canonical_json_sha256(value: Any) -> str:
 
 
 def _pairing_json(value: Any, *, name: str) -> str:
-    """Encode a pairing identity while rejecting non-finite JSON numbers."""
+    """Encode an exact pairing identity without invoking fallback hooks."""
+
+    def plain(item: Any) -> Any:
+        if type(item) in (dict, MappingProxyType):
+            result: dict[str, Any] = {}
+            for key, child in item.items():
+                if type(key) is not str:
+                    raise ValueError(f"{name} must have exact string keys")
+                result[key] = plain(child)
+            return result
+        if type(item) in (list, tuple):
+            return [plain(child) for child in item]
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError(f"{name} must contain finite numbers")
+            return item
+        if item is None or type(item) in (str, bool, int):
+            return item
+        raise ValueError(f"{name} contains a non-JSON identity")
+
     try:
         return json.dumps(
-            value,
+            plain(value),
             allow_nan=False,
             sort_keys=True,
-            default=str,
         )
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be finite JSON") from exc

--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -620,7 +620,7 @@ def _require_sha256(value: Any, path: str) -> str:
 
 
 def _require_int(value: Any, path: str, *, minimum: int, maximum: int) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is not int:
         raise ForagerRngParityError(f"{path} must be an integer")
     if not minimum <= value <= maximum:
         raise ForagerRngParityError(f"{path} must lie in [{minimum}, {maximum}]")

--- a/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
+++ b/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
@@ -20,7 +20,7 @@ import difflib
 import hashlib
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, Final, cast
 
@@ -234,21 +234,18 @@ def _plain_json(value: Any, *, path: str = "descriptor") -> Any:
                 f"{path} contains a non-finite JSON number"
             )
         return value
-    if value is None or isinstance(value, (str, bool, int)):
+    if value is None or type(value) in (str, bool, int):
         return value
-    if isinstance(value, Mapping):
+    if type(value) in (dict, MappingProxyType):
         result: dict[str, Any] = {}
         for key, item in value.items():
-            if not isinstance(key, str):
+            if type(key) is not str:
                 raise RTUPPORngIsolationError(
                     f"{path} contains a non-string object key"
                 )
             result[key] = _plain_json(item, path=f"{path}.{key}")
         return result
-    if isinstance(value, Sequence) and not isinstance(
-        value,
-        (str, bytes, bytearray),
-    ):
+    if type(value) in (list, tuple):
         return [
             _plain_json(item, path=f"{path}[{index}]")
             for index, item in enumerate(value)

--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -660,17 +660,16 @@ class HistoricalForagerRunConfig:
     allow_unverified_development_adapter: bool = False
 
     def __post_init__(self) -> None:
-        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+        if type(self.seed) is not int:
             raise HistoricalForagerContractError("seed must be an integer")
         if not 0 <= self.seed <= _MAX_SEED:
             raise HistoricalForagerContractError(f"seed must lie in [0, {_MAX_SEED}]")
-        if isinstance(self.steps, bool) or not isinstance(self.steps, int):
+        if type(self.steps) is not int:
             raise HistoricalForagerContractError("steps must be an integer")
         if not 1 <= self.steps <= _MAX_STEPS:
             raise HistoricalForagerContractError(f"steps must lie in [1, {_MAX_STEPS}]")
         if (
-            isinstance(self.aperture_size, bool)
-            or not isinstance(self.aperture_size, int)
+            type(self.aperture_size) is not int
             or self.aperture_size not in range(1, 16, 2)
         ):
             raise HistoricalForagerContractError(
@@ -873,17 +872,16 @@ class HistoricalForagerRunResult:
     kernel: Mapping[str, Any]
 
     def __post_init__(self) -> None:
-        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+        if type(self.seed) is not int:
             raise HistoricalForagerContractError("seed must be an integer")
         if not 0 <= self.seed <= _MAX_SEED:
             raise HistoricalForagerContractError(f"seed must lie in [0, {_MAX_SEED}]")
-        if isinstance(self.steps, bool) or not isinstance(self.steps, int):
+        if type(self.steps) is not int:
             raise HistoricalForagerContractError("steps must be an integer")
         if not 1 <= self.steps <= _MAX_STEPS:
             raise HistoricalForagerContractError(f"steps must lie in [1, {_MAX_STEPS}]")
         if (
-            isinstance(self.aperture_size, bool)
-            or not isinstance(self.aperture_size, int)
+            type(self.aperture_size) is not int
             or self.aperture_size not in range(1, 16, 2)
         ):
             raise HistoricalForagerContractError(

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -202,6 +202,16 @@ def _require_nonempty_string(value: object, *, context: str) -> str:
     return value
 
 
+def _require_builtin_finite_real(value: object, *, context: str) -> float:
+    """Canonicalize a result scalar without invoking numeric subclass hooks."""
+    if type(value) not in (int, float):
+        raise ValueError(f"{context} must be a finite built-in real number")
+    number = float(cast("int | float", value))
+    if not math.isfinite(number):
+        raise ValueError(f"{context} must be a finite built-in real number")
+    return number
+
+
 # =============================================================================
 # Configuration
 # =============================================================================
@@ -988,13 +998,17 @@ class MicroRunResult:
         object.__setattr__(
             self,
             "overall_accuracy",
-            _require_finite_real(self.overall_accuracy, "MicroRunResult.overall_accuracy"),
+            _require_builtin_finite_real(
+                self.overall_accuracy,
+                context="MicroRunResult.overall_accuracy",
+            ),
         )
         object.__setattr__(
             self,
             "wall_clock_seconds",
-            _require_finite_real(
-                self.wall_clock_seconds, "MicroRunResult.wall_clock_seconds"
+            _require_builtin_finite_real(
+                self.wall_clock_seconds,
+                context="MicroRunResult.wall_clock_seconds",
             ),
         )
 

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -101,7 +101,6 @@ import tempfile
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from numbers import Real
 from pathlib import Path
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -294,13 +293,9 @@ def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    if type(value) not in (int, float):
         raise ValueError(f"{name} must be a finite real number")
-    try:
-        number = float(cast(Real, value))
-    except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite real number") from exc
+    number = float(cast("int | float", value))
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number
@@ -313,18 +308,9 @@ def _require_nonempty_string(name: str, value: object) -> str:
 
 
 def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
-    if type(values) is bool:
-        raise ValueError(f"{name} must not be a boolean")
-    if isinstance(values, (str, bytes)):
-        raise ValueError(f"{name} must be a sequence of integer seeds")
-    try:
-        raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
-    except TypeError as exc:
-        raise ValueError(f"{name} must be a sequence of integer seeds") from exc
-    return tuple(
-        require_jax_seed(value, name=f"{name}[{index}]")
-        for index, value in enumerate(raw)
-    )
+    if type(values) is not tuple:
+        raise ValueError(f"{name} must be an exact tuple of unique integer seeds")
+    return require_unique_jax_seeds(values, name=name)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -97,7 +97,6 @@ import platform
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from numbers import Real
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -424,13 +423,9 @@ def build_schedule(key: Array, config: LabelEMNISTConfig, n_train: int) -> Label
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
+    if type(value) not in (int, float):
         raise ValueError(f"{name} must be a finite real number")
-    try:
-        number = float(cast(Real, value))
-    except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite real number") from exc
+    number = float(cast("int | float", value))
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number
@@ -443,18 +438,9 @@ def _require_nonempty_string(name: str, value: object) -> str:
 
 
 def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
-    if type(values) is bool:
-        raise ValueError(f"{name} must not be a boolean")
-    if isinstance(values, (str, bytes)):
-        raise ValueError(f"{name} must be a sequence of integer seeds")
-    try:
-        raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
-    except TypeError as exc:
-        raise ValueError(f"{name} must be a sequence of integer seeds") from exc
-    return tuple(
-        require_jax_seed(value, name=f"{name}[{index}]")
-        for index, value in enumerate(raw)
-    )
+    if type(values) is not tuple:
+        raise ValueError(f"{name} must be an exact tuple of unique integer seeds")
+    return require_unique_jax_seeds(values, name=name)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -33,7 +33,7 @@ import numpy as np
 from jax import Array
 from numpy.typing import NDArray
 
-from alberta_framework._seed_validation import require_unique_jax_seeds
+from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
 )
@@ -242,6 +242,32 @@ def _integer_pairs(
     return tuple(pairs)
 
 
+def _resource_accounting_map(value: object) -> dict[str, dict[str, int | bool]]:
+    if type(value) is not dict:
+        raise TypeError("memory_by_condition must be an exact dictionary")
+    result: dict[str, dict[str, int | bool]] = {}
+    for condition, accounting in value.items():
+        if type(condition) is not str or not condition:
+            raise ValueError("memory_by_condition keys must be non-empty strings")
+        if type(accounting) is not dict:
+            raise TypeError(f"memory_by_condition[{condition}] must be an exact dictionary")
+        normalized: dict[str, int | bool] = {}
+        for name, count in accounting.items():
+            if type(name) is not str or not name:
+                raise ValueError("resource-accounting keys must be non-empty strings")
+            if type(count) is bool:
+                normalized[name] = count
+            elif type(count) is int and count >= 0:
+                normalized[name] = count
+            else:
+                raise ValueError(
+                    f"memory_by_condition[{condition}][{name}] must be a non-negative "
+                    "integer or boolean"
+                )
+        result[condition] = normalized
+    return result
+
+
 @dataclass(frozen=True)
 class PhaseWindowRecord:
     """Sufficient prequential-error statistics for one 3,000-step phase."""
@@ -337,9 +363,9 @@ class ConditionSeedRecord:
     final_active_pairs: tuple[tuple[int, int], ...]
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "seed", _nonnegative_int(self.seed, name="seed"))
-        if type(self.condition) is not str:
-            raise ValueError("condition must be a string")
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        if type(self.condition) is not str or not self.condition:
+            raise ValueError("condition must be a non-empty string")
         if type(self.phases) is not tuple:
             raise TypeError("phases must be an exact tuple")
         if any(type(phase) is not PhaseWindowRecord for phase in self.phases):
@@ -379,28 +405,26 @@ class ScaleRobustFeatureReport:
     def __post_init__(self) -> None:
         if type(self.seeds) is not tuple:
             raise TypeError("seeds must be an exact tuple")
-        object.__setattr__(
-            self,
-            "seeds",
-            tuple(
-                _nonnegative_int(seed, name=f"seeds[{index}]")
-                for index, seed in enumerate(self.seeds)
-            ),
-        )
+        object.__setattr__(self, "seeds", require_unique_jax_seeds(self.seeds, name="seeds"))
         if type(self.records) is not tuple:
             raise TypeError("records must be an exact tuple")
         if any(type(record) is not ConditionSeedRecord for record in self.records):
             raise TypeError("records must contain ConditionSeedRecord values")
-        if not isinstance(self.wall_time_seconds_by_condition, Mapping):
-            raise TypeError("wall_time_seconds_by_condition must be a mapping")
+        object.__setattr__(
+            self,
+            "memory_by_condition",
+            _resource_accounting_map(self.memory_by_condition),
+        )
+        if type(self.wall_time_seconds_by_condition) is not dict:
+            raise TypeError("wall_time_seconds_by_condition must be an exact dictionary")
+        for name in self.wall_time_seconds_by_condition:
+            if type(name) is not str or not name:
+                raise ValueError("wall_time_seconds_by_condition keys must be non-empty strings")
         object.__setattr__(
             self,
             "wall_time_seconds_by_condition",
             {
-                name: _finite_float(
-                    value,
-                    name=f"wall_time_seconds_by_condition[{name}]",
-                )
+                name: _finite_float(value, name=f"wall_time_seconds_by_condition[{name}]")
                 for name, value in self.wall_time_seconds_by_condition.items()
             },
         )

--- a/tests/test_forager_matched_campaign.py
+++ b/tests/test_forager_matched_campaign.py
@@ -43,6 +43,22 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # canonical bytes with a self-consistent digest triple exercise the binding.
 _QUALIFICATION_MANIFEST = {"schema_version": "test.matched_current_qualification.v1"}
 _QUALIFICATION_MANIFEST_BYTES = campaign.canonical_json_bytes(_QUALIFICATION_MANIFEST)
+
+
+def test_canonical_json_rejects_nonstring_keys_without_string_hooks() -> None:
+    class HostileKey:
+        def __str__(self) -> str:
+            raise AssertionError("canonicalization must not stringify keys")
+
+    with pytest.raises(campaign.ForagerMatchedCampaignError, match="canonical JSON"):
+        campaign.canonical_json_bytes({HostileKey(): 1})  # type: ignore[dict-item]
+
+    class HostileMapping(dict[str, object]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("canonicalization must not invoke mapping hooks")
+
+    with pytest.raises(campaign.ForagerMatchedCampaignError, match="canonical JSON"):
+        campaign.canonical_json_bytes(HostileMapping(value=1))
 _QUALIFICATION_MANIFEST_SHA256 = hashlib.sha256(_QUALIFICATION_MANIFEST_BYTES).hexdigest()
 
 

--- a/tests/test_forager_matched_qualification.py
+++ b/tests/test_forager_matched_qualification.py
@@ -57,6 +57,23 @@ def test_canonical_json_rejects_nonfinite_number_identities(invalid: float) -> N
         qualification._canonical_json_bytes({"score": invalid})  # noqa: SLF001
 
 
+def test_canonical_json_rejects_hostile_container_subclasses_without_hooks() -> None:
+    class HostileMapping(dict[str, object]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("canonicalization must not invoke mapping hooks")
+
+    class HostileSequence(list[object]):
+        def __iter__(self):
+            raise AssertionError("canonicalization must not invoke sequence hooks")
+
+    for value in (HostileMapping(value=1), HostileSequence()):
+        with pytest.raises(
+            qualification.ForagerMatchedQualificationError,
+            match="unsupported",
+        ):
+            qualification._plain_json(value)  # noqa: SLF001
+
+
 def test_replace_integer_literals_keeps_finite_configuration_copy() -> None:
     raw = b'{"total_steps": 1}'
     transform = SimpleNamespace(

--- a/tests/test_forager_matched_seal.py
+++ b/tests/test_forager_matched_seal.py
@@ -63,6 +63,20 @@ def test_plain_keeps_finite_canonical_scalars() -> None:
     assert seal.canonical_json_bytes({"score": 1.25}) == b'{"score":1.25}'
 
 
+def test_plain_rejects_hostile_container_subclasses_without_hooks() -> None:
+    class HostileMapping(dict[str, object]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("canonicalization must not invoke mapping hooks")
+
+    class HostileSequence(list[object]):
+        def __iter__(self):
+            raise AssertionError("canonicalization must not invoke sequence hooks")
+
+    for value in (HostileMapping(value=1), HostileSequence()):
+        with pytest.raises(seal.ForagerMatchedSealError, match="unsupported"):
+            seal._plain(value)  # noqa: SLF001
+
+
 def _canonical_sha(value: dict[str, Any]) -> str:
     return hashlib.sha256(executor.canonical_json_bytes(value)).hexdigest()
 

--- a/tests/test_forager_matrix.py
+++ b/tests/test_forager_matrix.py
@@ -1230,6 +1230,22 @@ def test_json_safe_rejects_nonfinite_artifact_identities() -> None:
         matrix._canonical_json_bytes({"scale": float("nan")})
 
 
+def test_json_safe_rejects_nonstring_keys_without_string_hooks() -> None:
+    class HostileKey:
+        def __str__(self) -> str:
+            raise AssertionError("artifact normalization must not stringify keys")
+
+    with pytest.raises(matrix.ForagerMatrixError, match="string keys"):
+        matrix._json_safe({HostileKey(): 1})
+
+    class HostileMapping(dict[str, object]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("artifact normalization must not invoke mapping hooks")
+
+    with pytest.raises(matrix.ForagerMatrixError, match="unsupported HostileMapping"):
+        matrix._json_safe(HostileMapping(value=1))
+
+
 def test_source_snapshot_is_reproducible_canonical_and_path_independent(
     _isolated_source_tree: Path,
 ) -> None:

--- a/tests/test_forager_results.py
+++ b/tests/test_forager_results.py
@@ -43,6 +43,24 @@ def test_non_foragax_pairing_identity_rejects_nonfinite_environment() -> None:
     finite = _environment_signature(_run(environment={"kind": "toy", "scale": 1.0}))
     assert '"scale": 1.0' in finite[0]
 
+
+def test_pairing_identity_rejects_unsupported_values_without_string_hooks() -> None:
+    class HostileStringFallback:
+        def __str__(self) -> str:
+            raise AssertionError("pairing identity must not invoke __str__")
+
+    with pytest.raises(ValueError, match="finite JSON"):
+        _environment_signature(
+            _run(environment={"kind": "toy", "hostile": HostileStringFallback()})
+        )
+
+    class HostileMapping(dict[str, object]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("pairing identity must not invoke mapping hooks")
+
+    with pytest.raises(ValueError, match="finite JSON"):
+        _environment_signature(_run(environment=HostileMapping(kind="toy")))
+
     with pytest.raises(ValueError, match="environment pairing identity"):
         _environment_signature(_run(environment={"kind": "toy", "scale": math.nan}))
     with pytest.raises(ValueError, match="environment pairing identity"):

--- a/tests/test_forager_rng_parity.py
+++ b/tests/test_forager_rng_parity.py
@@ -15,6 +15,22 @@ import pytest
 from alberta_framework.benchmarks import forager_rng_parity as parity
 
 
+def test_key_frame_rejects_integer_subclasses_before_comparison_hooks() -> None:
+    class HostileInt(int):
+        def __lt__(self, other: object) -> bool:
+            raise AssertionError("hostile comparison must not run")
+
+        def __gt__(self, other: object) -> bool:
+            raise AssertionError("hostile comparison must not run")
+
+    with pytest.raises(parity.ForagerRngParityError, match=r"input_key\[0\]"):
+        parity.KeyFrame(
+            input_key=(HostileInt(0), 0),
+            next_key=(0, 0),
+            environment_key=(0, 0),
+        )
+
+
 def _runtime_identity() -> parity.VerifiedRuntimeIdentity:
     return parity.VerifiedRuntimeIdentity(
         required_oci_image_id=parity.REQUIRED_OCI_IMAGE_ID,

--- a/tests/test_forager_rtu_ppo_rng_isolation.py
+++ b/tests/test_forager_rtu_ppo_rng_isolation.py
@@ -551,3 +551,19 @@ def test_plain_json_keeps_finite_canonical_scalars() -> None:
         "n": 2,
     }
     assert isolation._canonical_json({"score": 1.25}) == b'{"score":1.25}'
+
+
+def test_plain_json_rejects_scalar_subclasses_without_conversion_hooks() -> None:
+    class HostileInt(int):
+        def __int__(self) -> int:
+            raise AssertionError("hostile integer conversion must not run")
+
+    with pytest.raises(isolation.RTUPPORngIsolationError, match="non-JSON value"):
+        isolation._plain_json({"count": HostileInt(1)})
+
+    class HostileSequence(list[object]):
+        def __iter__(self):
+            raise AssertionError("hostile iteration must not run")
+
+    with pytest.raises(isolation.RTUPPORngIsolationError, match="non-JSON value"):
+        isolation._plain_json(HostileSequence())

--- a/tests/test_historical_forager_reconstructed.py
+++ b/tests/test_historical_forager_reconstructed.py
@@ -627,3 +627,16 @@ def test_run_result_rejects_leftover_identities() -> None:
     assert '"seed": true' not in dumped
     assert '"steps": 10' in dumped
     assert '"aperture_size": 9' in dumped
+
+
+def test_run_result_rejects_integer_subclasses_before_comparison_hooks() -> None:
+    class HostileInt(int):
+        def __le__(self, other: object) -> bool:
+            raise AssertionError("hostile comparison must not run")
+
+        def __ge__(self, other: object) -> bool:
+            raise AssertionError("hostile comparison must not run")
+
+    for field in ("seed", "steps", "aperture_size"):
+        with pytest.raises(HistoricalForagerContractError, match=field):
+            _legal_run_result(**{field: HostileInt(1)})

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -2008,3 +2008,14 @@ def test_micro_run_result_rejects_leftover_identities() -> None:
     assert '"family": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"hidden1": true' not in dumped
+
+
+def test_micro_run_result_rejects_numeric_subclasses_without_conversion_hooks() -> None:
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("result validation must not invoke __float__")
+
+    with pytest.raises(ValueError, match="overall_accuracy"):
+        _legal_micro_run_result(overall_accuracy=HostileFloat(0.5))
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_micro_run_result(wall_clock_seconds=HostileFloat(1.0))

--- a/tests/test_scale_robust_feature.py
+++ b/tests/test_scale_robust_feature.py
@@ -236,3 +236,50 @@ def test_scale_report_rejects_negative_wall_time() -> None:
             memory_by_condition={},
             wall_time_seconds_by_condition={CONDITION_PRIMARY: -0.001},
         )
+
+
+def test_seed_and_timing_maps_reject_aliases_before_container_hooks() -> None:
+    with pytest.raises(ValueError, match="uint32 JAX key domain"):
+        ConditionSeedRecord(
+            seed=2**32,
+            condition=CONDITION_PRIMARY,
+            phases=(),
+            end_segment_5_active_pairs=(),
+            end_segment_7_active_pairs=(),
+            final_active_pairs=(),
+        )
+    with pytest.raises(ValueError, match="unique"):
+        ScaleRobustFeatureReport(
+            seeds=(8, 8),
+            records=(),
+            memory_by_condition={},
+            wall_time_seconds_by_condition={},
+        )
+
+    class HostileTimingMap(dict[str, float]):
+        def items(self):  # type: ignore[no-untyped-def, override]
+            raise AssertionError("timing mapping hooks must not run")
+
+    with pytest.raises(TypeError, match="exact dictionary"):
+        ScaleRobustFeatureReport(
+            seeds=(8,),
+            records=(),
+            memory_by_condition={},
+            wall_time_seconds_by_condition=HostileTimingMap(),
+        )
+
+    class HostileResourceInt(int):
+        def __ge__(self, other: object) -> bool:
+            raise AssertionError("resource comparison hooks must not run")
+
+    with pytest.raises(ValueError, match="non-negative integer or boolean"):
+        ScaleRobustFeatureReport(
+            seeds=(8,),
+            records=(),
+            memory_by_condition={
+                CONDITION_PRIMARY: {
+                    "persistent_array_bytes": HostileResourceInt(1),
+                }
+            },
+            wall_time_seconds_by_condition={},
+        )

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -1186,3 +1186,22 @@ def test_ipmnist_run_result_rejects_leftover_identities() -> None:
     assert '"learner": true' not in dumped
     assert '"seeds": [true]' not in dumped
     assert '"noise_mode": true' not in dumped
+
+
+def test_ipmnist_run_result_rejects_hostile_scalar_and_seed_containers() -> None:
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("hostile float conversion must not run")
+
+    class HostileSeeds:
+        def __iter__(self):
+            raise AssertionError("hostile seed iteration must not run")
+
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_ipmnist_run_result(wall_clock_seconds=HostileFloat(1.0))
+    with pytest.raises(ValueError, match="exact tuple"):
+        _legal_ipmnist_run_result(seeds=HostileSeeds())
+    with pytest.raises(ValueError, match="non-empty"):
+        _legal_ipmnist_run_result(seeds=())
+    with pytest.raises(ValueError, match="unique"):
+        _legal_ipmnist_run_result(seeds=(0, 0))

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -743,8 +743,8 @@ class TestPlanShardMergeAccounting:
     def test_summarize_result_refuses_vacuous_single_seed_stderr(self):
         with pytest.raises(ValueError, match="fewer than two observations"):
             summarize_result(self._synthetic_result(np.asarray([0.5])))
-        with pytest.raises(ValueError, match="fewer than two observations"):
-            summarize_result(self._synthetic_result(np.asarray([], dtype=np.float64)))
+        with pytest.raises(ValueError, match="seeds must be non-empty"):
+            self._synthetic_result(np.asarray([], dtype=np.float64))
 
     def test_summarize_result_two_seed_stderr_is_sample_se(self):
         values = np.asarray([0.25, 0.75], dtype=np.float64)
@@ -915,3 +915,22 @@ def test_label_emnist_run_result_rejects_leftover_identities() -> None:
     assert '"wall_clock_seconds": true' not in dumped
     assert '"learner": true' not in dumped
     assert '"seeds": [true]' not in dumped
+
+
+def test_label_emnist_result_rejects_hostile_scalar_and_seed_containers() -> None:
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            raise AssertionError("hostile float conversion must not run")
+
+    class HostileSeeds:
+        def __iter__(self):
+            raise AssertionError("hostile seed iteration must not run")
+
+    with pytest.raises(ValueError, match="wall_clock_seconds"):
+        _legal_label_emnist_run_result(wall_clock_seconds=HostileFloat(1.0))
+    with pytest.raises(ValueError, match="exact tuple"):
+        _legal_label_emnist_run_result(seeds=HostileSeeds())
+    with pytest.raises(ValueError, match="non-empty"):
+        _legal_label_emnist_run_result(seeds=())
+    with pytest.raises(ValueError, match="unique"):
+        _legal_label_emnist_run_result(seeds=(0, 0))


### PR DESCRIPTION
## Summary

- Fail closed on hostile scalar and container subclasses across post-tag benchmark/evaluation record surfaces.
- Require canonical, unique JAX-domain seed tuples and exact JSON/resource-accounting identities.
- Remove permissive stringification/coercion paths that could execute user hooks or alias distinct records.
- Add adversarial regressions across affected benchmark and scale-robust evaluation records.

Source/test-only corrective audit: no benchmark runs, output writes, or evidence-artifact changes.

## Verification

- 890 passed, 2 warnings: combined post-tag benchmark/evaluation focused panel
- 225 passed, 2 warnings: amended micro-continual and scale-robust panel
- 21 passed: post-rebase scale-robust suite
- Ruff passed all 24 touched files
- mypy passed all 12 touched source files under strict project configuration
- git diff --check passed