### PR TITLE
fix(core): close post-tag validation residuals

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -162,10 +162,7 @@ def load_checkpoint(
         ) from e
 
     raw_metadata = loaded.metadata
-    if isinstance(raw_metadata, Mapping):
-        user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
-    else:
-        user_metadata = dict(cast(dict[str, Any], raw_metadata))
+    user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
     user_metadata.pop(_VERSION_KEY, None)
     _require_json_safe_metadata(user_metadata)
     return loaded.state, user_metadata
@@ -200,10 +197,7 @@ def load_checkpoint_metadata(path: str | Path) -> dict[str, Any]:
         )
 
     raw_metadata = loaded.metadata
-    if isinstance(raw_metadata, Mapping):
-        user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
-    else:
-        user_metadata = dict(cast(dict[str, Any], raw_metadata))
+    user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
     user_metadata.pop(_VERSION_KEY, None)
     _require_json_safe_metadata(user_metadata)
     return user_metadata

--- a/alberta_framework/core/delight.py
+++ b/alberta_framework/core/delight.py
@@ -277,7 +277,7 @@ class GradientJoyConfig:
         """Reconstruct from :meth:`to_config` output."""
         payload = _copy_mapping(config, name="GradientJoyConfig")
         type_value = payload.pop("type", None)
-        if type_value is not None and type_value != "GradientJoyConfig":
+        if type(type_value) is not str or type_value != "GradientJoyConfig":
             raise ValueError("GradientJoyConfig type is unsupported")
         allowed = {
             "candidate_semantics",
@@ -1915,7 +1915,7 @@ class DelightfulPolicyGradientConfig:
         """Reconstruct from :meth:`to_config` output."""
         payload = _copy_mapping(config, name="DelightfulPolicyGradientConfig")
         type_value = payload.pop("type", None)
-        if type_value is not None and type_value != "DelightfulPolicyGradientConfig":
+        if type(type_value) is not str or type_value != "DelightfulPolicyGradientConfig":
             raise ValueError("DelightfulPolicyGradientConfig type is unsupported")
         allowed = {
             "mode",

--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -1049,8 +1049,9 @@ def action_features(action: Array, n_actions: int | None = None) -> Array:
     action_array = jnp.asarray(action)
     if action_array.shape != () or not jnp.issubdtype(action_array.dtype, jnp.integer):
         raise ValueError("discrete action must be a scalar integer array")
-    action_index = action_array.astype(jnp.int32)
-    return jax.nn.one_hot(action_index, n_actions, dtype=jnp.float32)
+    valid = (action_array >= 0) & (action_array < n_actions)
+    action_index = jnp.where(valid, action_array, 0).astype(jnp.int32)
+    return jax.nn.one_hot(action_index, n_actions, dtype=jnp.float32) * valid
 
 
 def _neutralize_invalid(value: Array, valid: Array) -> Array:

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -619,7 +619,9 @@ class LearnedResourceManager:
             old_ema,
         )
         new_loss_ema = state.loss_ema.at[context].set(new_ema)
-        new_counts = state.action_counts.at[context].add(valid_actions.astype(jnp.int32))
+        old_counts = state.action_counts[context]
+        count_increments = valid_actions & (old_counts < _INT32_MAX)
+        new_counts = state.action_counts.at[context].add(count_increments.astype(jnp.int32))
 
         candidate_state = LearnedResourceManagerState(  # type: ignore[call-arg]
             log_weights=new_log_weights,
@@ -646,6 +648,7 @@ class LearnedResourceManager:
         update_applied = (
             context_valid
             & (state.step_count >= 0)
+            & jnp.all(state.action_counts >= 0)
             & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))
@@ -1244,7 +1247,9 @@ class GeneratorMetaResourceManager:
             old_ema,
         )
         new_reward_ema = state.reward_ema.at[context].set(new_ema)
-        new_counts = state.action_counts.at[context].add(finite.astype(jnp.int32))
+        old_counts = state.action_counts[context]
+        count_increments = finite & (old_counts < _INT32_MAX)
+        new_counts = state.action_counts.at[context].add(count_increments.astype(jnp.int32))
 
         candidate_state = GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
             log_weights=new_log_weights,
@@ -1272,6 +1277,7 @@ class GeneratorMetaResourceManager:
             context_valid
             & selection_input_valid
             & (state.step_count >= 0)
+            & jnp.all(state.action_counts >= 0)
             & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(candidate_state)
             & jnp.all(jnp.isfinite(weights))

--- a/tests/test_delight_validation.py
+++ b/tests/test_delight_validation.py
@@ -261,6 +261,10 @@ def test_delight_mapping_loaders_preserve_markers_and_exact_keys() -> None:
     assert restored == config
     with pytest.raises(ValueError, match="type"):
         GradientJoyConfig.from_config({**payload, "type": "wrong"})
+    without_type = dict(payload)
+    without_type.pop("type")
+    with pytest.raises(ValueError, match="type"):
+        GradientJoyConfig.from_config(without_type)
     with pytest.raises(ValueError, match="unsupported fields"):
         GradientJoyConfig.from_config({**payload, "unknown": 1})
     # Delightful
@@ -270,6 +274,10 @@ def test_delight_mapping_loaders_preserve_markers_and_exact_keys() -> None:
     assert drestored == dconfig
     with pytest.raises(ValueError, match="type"):
         DelightfulPolicyGradientConfig.from_config({**dpayload, "type": "wrong"})
+    without_type = dict(dpayload)
+    without_type.pop("type")
+    with pytest.raises(ValueError, match="type"):
+        DelightfulPolicyGradientConfig.from_config(without_type)
     with pytest.raises(ValueError, match="unsupported fields"):
         DelightfulPolicyGradientConfig.from_config({**dpayload, "unknown": 1})
 
@@ -281,6 +289,14 @@ def test_delight_mapping_loaders_preserve_markers_and_exact_keys() -> None:
     with pytest.raises(ValueError, match="exact strings"):
         DelightfulPolicyGradientConfig.from_config(
             {StringSubclass("type"): "DelightfulPolicyGradientConfig", **dpayload}
+        )
+    class HostileStringValue(str):
+        def __eq__(self, other: object) -> bool:
+            raise AssertionError("hostile equality hook executed")
+
+    with pytest.raises(ValueError, match="type"):
+        GradientJoyConfig.from_config(
+            {**payload, "type": HostileStringValue("GradientJoyConfig")}
         )
 
     class HostileMapping(dict):  # type: ignore[type-arg]
@@ -317,5 +333,3 @@ def test_delight_min_objective_decrease_nonnegative() -> None:
     with pytest.raises(ValueError, match="must be nonnegative"):
         _grad_cfg(min_objective_decrease=-1e-8)
     _grad_cfg(min_objective_decrease=0.0)
-
-

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -618,3 +618,12 @@ def test_action_features_accepts_numpy_ints_and_omitted_width() -> None:
 def test_action_features_rejects_fractional_discrete_action() -> None:
     with pytest.raises(ValueError, match="scalar integer array"):
         action_features(jnp.asarray(1.75, dtype=jnp.float32), 3)
+
+
+@pytest.mark.unit
+def test_action_features_rejects_wide_action_before_narrowing_eager_and_jit() -> None:
+    with jax.enable_x64():
+        wide = jnp.asarray(2**32, dtype=jnp.uint64)
+        expected = jnp.zeros((3,), dtype=jnp.float32)
+        chex.assert_trees_all_equal(action_features(wide, 3), expected)
+        chex.assert_trees_all_equal(jax.jit(lambda x: action_features(x, 3))(wide), expected)

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -753,15 +753,36 @@ def test_resource_manager_state_contract_and_counter_saturation() -> None:
     with pytest.raises(ValueError, match="state.log_weights"):
         learned.weights(malformed)
 
-    saturated = state.replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
+    saturated = state.replace(
+        action_counts=jnp.full_like(state.action_counts, 2**31 - 1),
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32),
+    )
     result = learned.update(saturated, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
     assert bool(result.update_applied)
     assert int(result.state.step_count) == 2**31 - 1
+    assert bool(jnp.all(result.state.action_counts == 2**31 - 1))
 
     invalid = state.replace(step_count=jnp.asarray(-1, dtype=jnp.int32))
     result = learned.update(invalid, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
     assert not bool(result.update_applied)
     chex.assert_trees_all_equal(result.state, invalid)
+
+    invalid_counts = state.replace(action_counts=-jnp.ones_like(state.action_counts))
+    result = learned.update(invalid_counts, jnp.asarray([0.0, 1.0], dtype=jnp.float32))
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, invalid_counts)
+
+    generator = _minimal_generator_manager()
+    generator_state = generator.init()
+    generator_saturated = generator_state.replace(
+        action_counts=jnp.full_like(generator_state.action_counts, 2**31 - 1),
+        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32),
+    )
+    generator_result = generator.update(
+        generator_saturated, jnp.asarray([1.0, 0.5], dtype=jnp.float32)
+    )
+    assert bool(generator_result.update_applied)
+    assert bool(jnp.all(generator_result.state.action_counts == 2**31 - 1))
 
 
 def test_resource_manager_host_preflight_and_hostile_state_metadata() -> None:


### PR DESCRIPTION
## Summary
- saturate per-action resource counters and reject negative counter states
- validate discrete dream actions in original width before int32 narrowing, eager and JIT
- require exact config type markers and fail closed on non-mapping checkpoint metadata

## Verification
- 183 focused tests passed
- ruff passed
- mypy passed