### PR TITLE
fix(learning-signals): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -309,6 +309,81 @@ class LearningSignalResourceBudget:
     output_logical_bytes: int
     trainable_scalars: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "input_float_scalars_per_step",
+            _require_int32(
+                "input_float_scalars_per_step",
+                self.input_float_scalars_per_step,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_float32_scalars",
+            _require_int32(
+                "persistent_float32_scalars",
+                self.persistent_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_int32_scalars",
+            _require_int32(
+                "persistent_int32_scalars",
+                self.persistent_int32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_scalars",
+            _require_int32(
+                "persistent_state_scalars",
+                self.persistent_state_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32(
+                "persistent_state_bytes",
+                self.persistent_state_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_float32_scalars",
+            _require_int32(
+                "output_float32_scalars",
+                self.output_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_bool_scalars",
+            _require_int32("output_bool_scalars", self.output_bool_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_logical_bytes",
+            _require_int32(
+                "output_logical_bytes",
+                self.output_logical_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int32("trainable_scalars", self.trainable_scalars, minimum=0),
+        )
+
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible budget description."""
         return dataclasses.asdict(self)

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -1,0 +1,73 @@
+"""Leftover-identity gates for learning-signal resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.learning_signals import LearningSignalResourceBudget
+
+
+def _legal_budget() -> LearningSignalResourceBudget:
+    return LearningSignalResourceBudget(
+        input_float_scalars_per_step=15,
+        persistent_float32_scalars=5,
+        persistent_int32_scalars=4,
+        persistent_state_scalars=9,
+        persistent_state_bytes=36,
+        output_float32_scalars=8,
+        output_bool_scalars=6,
+        output_logical_bytes=38,
+        trainable_scalars=0,
+    )
+
+
+def test_learning_signals_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="input_float_scalars_per_step"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=True,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=36,
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=0,
+        )
+    with pytest.raises(ValueError, match="trainable_scalars"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=15,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=36,
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=True,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=15,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=float("nan"),
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=0,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"input_float_scalars_per_step": 15' in dumped
+    assert '"output_bool_scalars": 6' in dumped
+    assert '"trainable_scalars": 0' in dumped
+    assert '"input_float_scalars_per_step": true' not in dumped
+    assert '"trainable_scalars": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1179.

## What changed

The learning-signal resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `715d059`, estimator config scalars already reject leftover boolean identities. `LearningSignalResourceBudget` had no `__post_init__` and accepted leftover identities (`input_float_scalars_per_step=True`, `trainable_scalars=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"input_float_scalars_per_step": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `learning_signals.py` resource-budget records, not a republish of `#1173` (mixer resource-budget), `#1174` (behavior-model resource-budget), `#1175` (gauntlet hostile), or `#1166` (gauntlet resource-budget).

## Scope

- `alberta_framework/core/learning_signals.py`
- `tests/test_learning_signals_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1176` (mixer/behavior-model twin) and `#1178` (Shaw post-tag residuals on checkpoints/delight/dreaming/resource_manager). These files were FREE. Merged leftover `#1173`/`#1174` do not occupy this pair.

## Verification

Exact candidate head: `99774b2e8237e58d1a5e7fdfd7499c6d8d587b6b`
Base: `715d059`

- Red on base: `LearningSignalResourceBudget(input_float_scalars_per_step=True, ...)` accepted; dump emitted `"input_float_scalars_per_step": true`
- Focused pytest `tests/test_learning_signals_resource_budget.py`: 1 passed
- Existing learning-signal tests: 52 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:99774b2e8237e58d1a5e7fdfd7499c6d8d587b6b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
