### PR TITLE
fix(option-search): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -170,6 +170,109 @@ class OptionSearchControlResourceBudget:
     stomp_self_audits_per_call: int
     max_diagnostic_payload_bytes_per_call: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_options",
+            _require_int32("n_options", self.n_options, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "backup_budget",
+            _require_int32("backup_budget", self.backup_budget, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32(
+                "persistent_state_bytes",
+                self.persistent_state_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "rng_draws_per_call",
+            _require_int32("rng_draws_per_call", self.rng_draws_per_call, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "candidate_values_per_evaluation",
+            _require_int32(
+                "candidate_values_per_evaluation",
+                self.candidate_values_per_evaluation,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_candidate_evaluations_per_call",
+            _require_int32(
+                "max_candidate_evaluations_per_call",
+                self.max_candidate_evaluations_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_learner_updates_per_call",
+            _require_int32(
+                "max_base_learner_updates_per_call",
+                self.max_base_learner_updates_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_model_matrix_vector_products_per_call",
+            _require_int32(
+                "max_model_matrix_vector_products_per_call",
+                self.max_model_matrix_vector_products_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_value_forward_calls_per_call",
+            _require_int32(
+                "max_base_value_forward_calls_per_call",
+                self.max_base_value_forward_calls_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_value_backward_calls_per_call",
+            _require_int32(
+                "max_base_value_backward_calls_per_call",
+                self.max_base_value_backward_calls_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "stomp_self_audits_per_call",
+            _require_int32(
+                "stomp_self_audits_per_call",
+                self.stomp_self_audits_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_diagnostic_payload_bytes_per_call",
+            _require_int32(
+                "max_diagnostic_payload_bytes_per_call",
+                self.max_diagnostic_payload_bytes_per_call,
+                minimum=0,
+            ),
+        )
+
     def to_config(self) -> dict[str, int]:
         """Return the exact JSON-compatible logical resource record."""
 

--- a/tests/test_option_search_control_resource_budget.py
+++ b/tests/test_option_search_control_resource_budget.py
@@ -1,0 +1,89 @@
+"""Leftover-identity gates for option-search resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.option_search_control import OptionSearchControlResourceBudget
+
+
+def _legal_budget() -> OptionSearchControlResourceBudget:
+    return OptionSearchControlResourceBudget(
+        n_options=2,
+        observation_dim=4,
+        backup_budget=3,
+        persistent_state_bytes=0,
+        rng_draws_per_call=0,
+        candidate_values_per_evaluation=2,
+        max_candidate_evaluations_per_call=6,
+        max_base_learner_updates_per_call=3,
+        max_model_matrix_vector_products_per_call=6,
+        max_base_value_forward_calls_per_call=12,
+        max_base_value_backward_calls_per_call=3,
+        stomp_self_audits_per_call=1,
+        max_diagnostic_payload_bytes_per_call=191,
+    )
+
+
+def test_option_search_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="n_options"):
+        OptionSearchControlResourceBudget(
+            n_options=True,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=0,
+            rng_draws_per_call=0,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+    with pytest.raises(ValueError, match="rng_draws_per_call"):
+        OptionSearchControlResourceBudget(
+            n_options=2,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=0,
+            rng_draws_per_call=True,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        OptionSearchControlResourceBudget(
+            n_options=2,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=float("nan"),
+            rng_draws_per_call=0,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"n_options": 2' in dumped
+    assert '"backup_budget": 3' in dumped
+    assert '"persistent_state_bytes": 0' in dumped
+    assert '"n_options": true' not in dumped
+    assert '"rng_draws_per_call": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1180.

## What changed

The option-search resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `715d059`, option-search config already rejects leftover boolean identities on `backup_budget`. `OptionSearchControlResourceBudget` had no `__post_init__` and accepted leftover identities (`n_options=True`, `rng_draws_per_call=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"n_options": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `option_search_control.py` resource-budget records, not a republish of `#1173` (mixer resource-budget), `#1174` (behavior-model resource-budget), `#1175` (gauntlet hostile), or `#1166` (gauntlet resource-budget).

## Scope

- `alberta_framework/core/option_search_control.py`
- `tests/test_option_search_control_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: foreign `#1176` (mixer/behavior-model twin) and `#1178` (Shaw post-tag residuals on checkpoints/delight/dreaming/resource_manager). These files were FREE. Merged leftover `#1173`/`#1174` do not occupy this pair.

## Verification

Exact candidate head: `26faa684dbd9943d906662eca499d4f1e6016e2d`
Base: `715d059`

- Red on base: `OptionSearchControlResourceBudget(n_options=True, ...)` accepted; dump emitted `"n_options": true`
- Focused pytest `tests/test_option_search_control_resource_budget.py`: 1 passed
- Existing option-search tests: 28 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:26faa684dbd9943d906662eca499d4f1e6016e2d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
