### PR TITLE
fix(core): bind exact resource and action identities

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -88,12 +88,37 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.minimum(jnp.maximum(counter, 0), maximum - 1) + 1
 
 
-def _integer_action_ids(actions: Array) -> Array:
-    """Narrow integer action IDs without laundering floats or booleans."""
-    raw_actions = jnp.asarray(actions)
-    if not jnp.issubdtype(raw_actions.dtype, jnp.integer):
+def _integer_action_ids(
+    actions: object,
+    *,
+    n_actions: int,
+    expected_shape: tuple[int, ...],
+) -> tuple[Array, Bool[Array, " *shape"]]:
+    """Validate original-width action IDs before exposing safe int32 indices."""
+
+    if isinstance(actions, jax.core.Tracer):
+        raw_shape = tuple(actions.shape)
+        raw_dtype = np.dtype(actions.dtype)
+    else:
+        host_actions = np.asarray(actions)
+        raw_shape = tuple(host_actions.shape)
+        raw_dtype = host_actions.dtype
+        if not np.issubdtype(raw_dtype, np.integer):
+            raise ValueError("actions must have an integer dtype")
+        if not bool(np.all((host_actions >= 0) & (host_actions < n_actions))):
+            raise ValueError(f"actions must lie in [0, {n_actions})")
+    if not np.issubdtype(raw_dtype, np.integer):
         raise ValueError("actions must have an integer dtype")
-    return raw_actions.astype(jnp.int32)
+    try:
+        broadcast_shape = np.broadcast_shapes(raw_shape, expected_shape)
+    except ValueError as error:
+        raise ValueError(f"actions must broadcast to shape {expected_shape}") from error
+    if broadcast_shape != expected_shape:
+        raise ValueError(f"actions must broadcast to shape {expected_shape}")
+    raw_actions = jnp.broadcast_to(jnp.asarray(actions), expected_shape)
+    valid = (raw_actions >= 0) & (raw_actions < n_actions)
+    safe = jnp.where(valid, raw_actions, 0).astype(jnp.int32)
+    return safe, valid
 
 
 def floor_and_renormalize_probabilities(
@@ -133,10 +158,15 @@ def selected_action_probabilities(
     broadcast to ``probabilities.shape[:-1]``.
     """
     probs = jnp.asarray(probabilities, dtype=jnp.float32)
-    action_ids = _integer_action_ids(actions)
+    action_ids, actions_valid = _integer_action_ids(
+        actions,
+        n_actions=probs.shape[-1],
+        expected_shape=tuple(probs.shape[:-1]),
+    )
     one_hot = jax.nn.one_hot(action_ids, probs.shape[-1], dtype=jnp.float32)
     selected = jnp.sum(probs * one_hot, axis=-1)
-    return jnp.maximum(selected, jnp.asarray(min_probability, dtype=jnp.float32))
+    floor = jnp.asarray(min_probability, dtype=jnp.float32)
+    return jnp.where(actions_valid, jnp.maximum(selected, floor), floor)
 
 
 def action_log_likelihoods(
@@ -332,12 +362,12 @@ class BehaviorModelResourceBudget:
         object.__setattr__(
             self,
             "feature_dim",
-            _require_int32("feature_dim", self.feature_dim, minimum=0),
+            _require_int32("feature_dim", self.feature_dim, minimum=1),
         )
         object.__setattr__(
             self,
             "n_actions",
-            _require_int32("n_actions", self.n_actions, minimum=0),
+            _require_int32("n_actions", self.n_actions, minimum=1),
         )
         object.__setattr__(
             self,
@@ -390,6 +420,22 @@ class BehaviorModelResourceBudget:
             "replay_capacity",
             _require_int32("replay_capacity", self.replay_capacity, minimum=0),
         )
+        trainable, state_nbytes = _resource_counts(self.n_actions, self.feature_dim)
+        expected = {
+            "trainable_float32_scalars": trainable,
+            "diagnostic_float32_scalars": 3,
+            "administrative_int32_scalars": 1,
+            "rng_uint32_scalars": 2,
+            "state_nbytes": state_nbytes,
+            "learned_float32_scalars_touched_per_update": trainable + 3,
+            "replay_capacity": 0,
+        }
+        for name, expected_value in expected.items():
+            if getattr(self, name) != expected_value:
+                raise ValueError(
+                    f"{name} must equal the exact behavior-model resource formula "
+                    f"({expected_value})"
+                )
 
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""
@@ -560,7 +606,6 @@ class BehaviorModel:
         logits = self.predict_logits(state, observation)
         return jax.nn.softmax(logits / self._config.temperature)
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def action_probability(
         self,
         state: BehaviorModelState,
@@ -575,7 +620,6 @@ class BehaviorModel:
             min_probability=self._config.min_probability,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def action_log_likelihood(
         self,
         state: BehaviorModelState,
@@ -585,7 +629,6 @@ class BehaviorModel:
         """Return the floor-clipped log-likelihood of ``action``."""
         return jnp.log(self.action_probability(state, observation, action))
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def input_loss_gradient(
         self,
         state: BehaviorModelState,
@@ -602,9 +645,32 @@ class BehaviorModel:
         mutation from this result must commit it only when ``result.valid`` is
         true.
         """
+        action_id, action_valid = _integer_action_ids(
+            action,
+            n_actions=self._config.n_actions,
+            expected_shape=(),
+        )
+        return cast(
+            BehaviorModelInputGradient,
+            self._input_loss_gradient_jit(
+                state,
+                observation,
+                action_id,
+                action_valid,
+            ),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _input_loss_gradient_jit(
+        self,
+        state: BehaviorModelState,
+        observation: Array,
+        action_id: Array,
+        action_valid: Array,
+    ) -> BehaviorModelInputGradient:
+        """Execute one already identity-checked input-gradient transaction."""
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
-        action_id = _integer_action_ids(action)
         logits = state.weights @ obs + state.bias
         scaled_logits = logits / cfg.temperature
         probabilities = jax.nn.softmax(scaled_logits)
@@ -619,8 +685,7 @@ class BehaviorModel:
         # NaN gradient to the state builder.
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
-            & (action_id >= 0)
-            & (action_id < cfg.n_actions)
+            & action_valid
         )
         source_finite = jnp.all(jnp.isfinite(state.weights)) & jnp.all(
             jnp.isfinite(state.bias)
@@ -645,7 +710,6 @@ class BehaviorModel:
             valid=valid,
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
         state: BehaviorModelState,
@@ -653,9 +717,32 @@ class BehaviorModel:
         action: Array,
     ) -> BehaviorModelUpdateResult:
         """Update the behavior model from one observed action."""
+        action_id, action_valid = _integer_action_ids(
+            action,
+            n_actions=self._config.n_actions,
+            expected_shape=(),
+        )
+        return cast(
+            BehaviorModelUpdateResult,
+            self._update_jit(
+                state,
+                observation,
+                action_id,
+                action_valid,
+            ),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _update_jit(
+        self,
+        state: BehaviorModelState,
+        observation: Array,
+        action_id: Array,
+        action_valid: Array,
+    ) -> BehaviorModelUpdateResult:
+        """Execute one already identity-checked atomic update."""
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
-        action_id = _integer_action_ids(action)
         logits = state.weights @ obs + state.bias
         probabilities = jax.nn.softmax(logits / cfg.temperature)
         one_hot = jax.nn.one_hot(action_id, cfg.n_actions, dtype=jnp.float32)
@@ -741,8 +828,7 @@ class BehaviorModel:
         )
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
-            & (action_id >= 0)
-            & (action_id < cfg.n_actions)
+            & action_valid
         )
         proposed_finite = (
             jnp.all(jnp.isfinite(new_state.weights))
@@ -807,7 +893,6 @@ class BehaviorModel:
             log_likelihood=jnp.log(action_prob),
         )
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def importance_ratio(
         self,
         state: BehaviorModelState,
@@ -834,6 +919,14 @@ def run_behavior_model_from_arrays(
     actions: Int[Array, " num_steps"],
 ) -> BehaviorModelArrayResult:
     """Run online behavior prediction over arrays with ``jax.lax.scan``."""
+
+    if len(observations.shape) != 2:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    _, _ = _integer_action_ids(
+        actions,
+        n_actions=model.config.n_actions,
+        expected_shape=(observations.shape[0],),
+    )
 
     def _scan_fn(
         carry: BehaviorModelState,

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -287,7 +287,12 @@ class RepresentationGradientMixerResourceBudget:
         object.__setattr__(
             self,
             "representation_dim",
-            _require_int32("representation_dim", self.representation_dim, minimum=0),
+            _require_int32(
+                "representation_dim",
+                self.representation_dim,
+                minimum=1,
+                maximum=_MAX_REPRESENTATION_DIM,
+            ),
         )
         object.__setattr__(
             self,
@@ -325,6 +330,24 @@ class RepresentationGradientMixerResourceBudget:
             "output_nbytes",
             _require_int32("output_nbytes", self.output_nbytes, minimum=0),
         )
+        expected = {
+            "persistent_state_scalars": 0,
+            "persistent_state_bytes": 0,
+            "output_float32_scalars": self.representation_dim
+            + _DIAGNOSTIC_FLOAT32_SCALARS,
+            "output_bool_scalars": _OUTPUT_BOOL_SCALARS,
+            "output_scalars": self.representation_dim
+            + _DIAGNOSTIC_FLOAT32_SCALARS
+            + _OUTPUT_BOOL_SCALARS,
+            "output_nbytes": 4
+            * (self.representation_dim + _DIAGNOSTIC_FLOAT32_SCALARS)
+            + _OUTPUT_BOOL_SCALARS,
+        }
+        for name, expected_value in expected.items():
+            if getattr(self, name) != expected_value:
+                raise ValueError(
+                    f"{name} must equal the exact mixer resource formula ({expected_value})"
+                )
 
     def to_dict(self) -> dict[str, int]:
         """Return a JSON-compatible resource record."""

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -386,6 +386,59 @@ def test_update_rejects_non_integer_action_dtypes(action: jax.Array) -> None:
         model.update(state, observation, action)
 
 
+@pytest.mark.parametrize(
+    "action",
+    (
+        np.int64(2**32),
+        np.uint64(2**32),
+        np.int64(-1),
+    ),
+)
+def test_behavior_model_rejects_original_width_action_before_jax_narrowing(
+    action: object,
+) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
+    probabilities = jnp.array([0.2, 0.3, 0.5], dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="actions must lie"):
+        model.update(state, observation, action)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="actions must lie"):
+        model.input_loss_gradient(state, observation, action)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="actions must lie"):
+        selected_action_probabilities(probabilities, action)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="actions must lie"):
+        run_behavior_model_from_arrays(
+            model,
+            state,
+            observations=observation[None, :],
+            actions=np.asarray([action]),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("action", (-1, 3, 2**31 - 1))
+def test_behavior_model_staged_invalid_actions_are_atomic_and_neutral(action: int) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
+
+    staged_update = jax.jit(lambda current, selected: model.update(current, observation, selected))
+    result = staged_update(state, jnp.asarray(action, dtype=jnp.int32))
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+    chex.assert_trees_all_equal(result.probabilities, jnp.zeros((3,), dtype=jnp.float32))
+    assert float(result.loss) == 0.0
+
+    staged_gradient = jax.jit(
+        lambda current, selected: model.input_loss_gradient(current, observation, selected)
+    )
+    gradient = staged_gradient(state, jnp.asarray(action, dtype=jnp.int32))
+    assert not bool(gradient.valid)
+    chex.assert_trees_all_equal(gradient.gradient, jnp.zeros((2,), dtype=jnp.float32))
+    assert float(gradient.loss) == 0.0
+
+
 def test_likelihood_improves_on_deterministic_policy_stream() -> None:
     model = BehaviorModel(BehaviorModelConfig(n_actions=2, step_size=0.2, diagnostic_decay=0.9))
     state = model.init(feature_dim=2, key=jax.random.key(2))

--- a/tests/test_behavior_model_resource_budget.py
+++ b/tests/test_behavior_model_resource_budget.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
+import numpy as np
 import pytest
 
 from alberta_framework.core.behavior_model import BehaviorModelResourceBudget
@@ -71,3 +73,40 @@ def test_behavior_model_resource_budget_rejects_leftover_identities() -> None:
     assert '"feature_dim": true' not in dumped
     assert '"replay_capacity": true' not in dumped
     assert '"state_nbytes": true' not in dumped
+
+
+def test_behavior_budget_rejects_hostile_integer_facades_without_hooks() -> None:
+    class HostileInt(int):
+        comparison_calls = 0
+
+        def __lt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        replace(_legal_budget(), feature_dim=HostileInt(5))
+    assert HostileInt.comparison_calls == 0
+
+
+@pytest.mark.parametrize("field", ("feature_dim", "n_actions"))
+@pytest.mark.parametrize("value", (0, 2**31, np.uint64(2**32)))
+def test_behavior_budget_rejects_dimension_boundaries(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(_legal_budget(), **{field: value})
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "trainable_float32_scalars",
+        "diagnostic_float32_scalars",
+        "administrative_int32_scalars",
+        "rng_uint32_scalars",
+        "state_nbytes",
+        "learned_float32_scalars_touched_per_update",
+        "replay_capacity",
+    ),
+)
+def test_behavior_budget_rejects_cross_field_formula_drift(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(_legal_budget(), **{field: getattr(_legal_budget(), field) + 1})

--- a/tests/test_representation_gradient_mixer_resource_budget.py
+++ b/tests/test_representation_gradient_mixer_resource_budget.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
+import numpy as np
 import pytest
 
 from alberta_framework.core.representation_gradient_mixer import (
@@ -65,3 +67,39 @@ def test_mixer_resource_budget_rejects_leftover_identities() -> None:
     assert '"representation_dim": true' not in dumped
     assert '"output_bool_scalars": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+def test_mixer_resource_budget_rejects_hostile_integer_facades_without_hooks() -> None:
+    class HostileInt(int):
+        comparison_calls = 0
+
+        def __lt__(self, other: object) -> bool:
+            type(self).comparison_calls += 1
+            raise RuntimeError("comparison hook")
+
+    for value in (HostileInt(3),):
+        with pytest.raises(ValueError, match="representation_dim"):
+            replace(_legal_budget(), representation_dim=value)
+    assert HostileInt.comparison_calls == 0
+
+
+@pytest.mark.parametrize("value", (0, 2**31, np.uint64(2**32)))
+def test_mixer_resource_budget_rejects_dimension_boundaries(value: object) -> None:
+    with pytest.raises(ValueError, match="representation_dim"):
+        replace(_legal_budget(), representation_dim=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "persistent_state_scalars",
+        "persistent_state_bytes",
+        "output_float32_scalars",
+        "output_bool_scalars",
+        "output_scalars",
+        "output_nbytes",
+    ),
+)
+def test_mixer_resource_budget_rejects_cross_field_formula_drift(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(_legal_budget(), **{field: getattr(_legal_budget(), field) + 1})


### PR DESCRIPTION
Deep-review successor to merged #1173/#1174 (issues #1170/#1171), and supersedes duplicate #1176. Original contributor authorship is preserved in the merged PRs.\n\nThe narrow field gates were necessary but insufficient:\n- both public budgets accepted internally contradictory counts that did not match their source allocation formulas;\n- representation/feature/action dimensions admitted zero even though the configured runtime cannot;\n- behavior action IDs were converted to int32 before range validation, so original-width `uint64(2**32)` / `int64(2**32)` could become action zero;\n- direct methods were JIT wrappers, which erased host width before the method body could reject it.\n\nThis enforces complete derived resource formulas and bounds; validates original action dtype/width/range before narrowing; retains safe indices plus validity masks under tracing; makes invalid staged gradient/update transactions atomic and neutral; and retains compiled inner gradient/update paths behind host-validation wrappers. Array runner inputs are preflighted before scan.\n\nVerification on current main:\n- 642 combined behavior/mixer/dreaming/Step 9 dependent tests passed\n- focused 140-test behavior/mixer panel passed after the inner-JIT refactor\n- Ruff clean\n- strict mypy clean\n\nNo benchmark run or `outputs/**` changes.