### PR TITLE
fix(core): enforce exact resource budget formulas

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -309,6 +309,81 @@ class LearningSignalResourceBudget:
     output_logical_bytes: int
     trainable_scalars: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "input_float_scalars_per_step",
+            _require_int32(
+                "input_float_scalars_per_step",
+                self.input_float_scalars_per_step,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_float32_scalars",
+            _require_int32(
+                "persistent_float32_scalars",
+                self.persistent_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_int32_scalars",
+            _require_int32(
+                "persistent_int32_scalars",
+                self.persistent_int32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_scalars",
+            _require_int32(
+                "persistent_state_scalars",
+                self.persistent_state_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32(
+                "persistent_state_bytes",
+                self.persistent_state_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_float32_scalars",
+            _require_int32(
+                "output_float32_scalars",
+                self.output_float32_scalars,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "output_bool_scalars",
+            _require_int32("output_bool_scalars", self.output_bool_scalars, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "output_logical_bytes",
+            _require_int32(
+                "output_logical_bytes",
+                self.output_logical_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "trainable_scalars",
+            _require_int32("trainable_scalars", self.trainable_scalars, minimum=0),
+        )
+
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible budget description."""
         return dataclasses.asdict(self)

--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -316,7 +316,7 @@ class LearningSignalResourceBudget:
             _require_int32(
                 "input_float_scalars_per_step",
                 self.input_float_scalars_per_step,
-                minimum=0,
+                minimum=1,
             ),
         )
         object.__setattr__(
@@ -383,6 +383,19 @@ class LearningSignalResourceBudget:
             "trainable_scalars",
             _require_int32("trainable_scalars", self.trainable_scalars, minimum=0),
         )
+        expected = {
+            "persistent_float32_scalars": 5,
+            "persistent_int32_scalars": 4,
+            "persistent_state_scalars": 9,
+            "persistent_state_bytes": 36,
+            "output_float32_scalars": 8,
+            "output_bool_scalars": 6,
+            "output_logical_bytes": 38,
+            "trainable_scalars": 0,
+        }
+        for name, value in expected.items():
+            if getattr(self, name) != value:
+                raise ValueError(f"{name} does not match the learning-signal implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible budget description."""

--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -170,6 +170,109 @@ class OptionSearchControlResourceBudget:
     stomp_self_audits_per_call: int
     max_diagnostic_payload_bytes_per_call: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "n_options",
+            _require_int32("n_options", self.n_options, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "observation_dim",
+            _require_int32("observation_dim", self.observation_dim, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "backup_budget",
+            _require_int32("backup_budget", self.backup_budget, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "persistent_state_bytes",
+            _require_int32(
+                "persistent_state_bytes",
+                self.persistent_state_bytes,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "rng_draws_per_call",
+            _require_int32("rng_draws_per_call", self.rng_draws_per_call, minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "candidate_values_per_evaluation",
+            _require_int32(
+                "candidate_values_per_evaluation",
+                self.candidate_values_per_evaluation,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_candidate_evaluations_per_call",
+            _require_int32(
+                "max_candidate_evaluations_per_call",
+                self.max_candidate_evaluations_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_learner_updates_per_call",
+            _require_int32(
+                "max_base_learner_updates_per_call",
+                self.max_base_learner_updates_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_model_matrix_vector_products_per_call",
+            _require_int32(
+                "max_model_matrix_vector_products_per_call",
+                self.max_model_matrix_vector_products_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_value_forward_calls_per_call",
+            _require_int32(
+                "max_base_value_forward_calls_per_call",
+                self.max_base_value_forward_calls_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_base_value_backward_calls_per_call",
+            _require_int32(
+                "max_base_value_backward_calls_per_call",
+                self.max_base_value_backward_calls_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "stomp_self_audits_per_call",
+            _require_int32(
+                "stomp_self_audits_per_call",
+                self.stomp_self_audits_per_call,
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_diagnostic_payload_bytes_per_call",
+            _require_int32(
+                "max_diagnostic_payload_bytes_per_call",
+                self.max_diagnostic_payload_bytes_per_call,
+                minimum=0,
+            ),
+        )
+
     def to_config(self) -> dict[str, int]:
         """Return the exact JSON-compatible logical resource record."""
 

--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -174,17 +174,17 @@ class OptionSearchControlResourceBudget:
         object.__setattr__(
             self,
             "n_options",
-            _require_int32("n_options", self.n_options, minimum=0),
+            _require_int32("n_options", self.n_options, minimum=1),
         )
         object.__setattr__(
             self,
             "observation_dim",
-            _require_int32("observation_dim", self.observation_dim, minimum=0),
+            _require_int32("observation_dim", self.observation_dim, minimum=1),
         )
         object.__setattr__(
             self,
             "backup_budget",
-            _require_int32("backup_budget", self.backup_budget, minimum=0),
+            _require_int32("backup_budget", self.backup_budget, minimum=1),
         )
         object.__setattr__(
             self,
@@ -272,6 +272,32 @@ class OptionSearchControlResourceBudget:
                 minimum=0,
             ),
         )
+        candidate_slots = self.n_options * self.backup_budget
+        diagnostic_bytes = (
+            4 * self.observation_dim
+            + 18
+            + 4 * self.n_options
+            + 16 * candidate_slots
+            + 19 * self.backup_budget
+            + 4
+        )
+        expected = {
+            "persistent_state_bytes": 0,
+            "rng_draws_per_call": 0,
+            "candidate_values_per_evaluation": self.n_options,
+            "max_candidate_evaluations_per_call": candidate_slots,
+            "max_base_learner_updates_per_call": self.backup_budget,
+            "max_model_matrix_vector_products_per_call": candidate_slots,
+            "max_base_value_forward_calls_per_call": (
+                self.n_options + 2
+            ) * self.backup_budget,
+            "max_base_value_backward_calls_per_call": self.backup_budget,
+            "stomp_self_audits_per_call": 1,
+            "max_diagnostic_payload_bytes_per_call": diagnostic_bytes,
+        }
+        for name, value in expected.items():
+            if getattr(self, name) != value:
+                raise ValueError(f"{name} does not match the option-search implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return the exact JSON-compatible logical resource record."""
@@ -397,6 +423,8 @@ class OptionSearchControl:
     ) -> None:
         self._agent = stomp_agent
         self._config = config or OptionSearchControlConfig()
+        if self._agent.config.n_options < 1:
+            raise ValueError("option search control requires at least one option")
         candidate_slots = self._agent.config.n_options * self._config.backup_budget
         if candidate_slots > _MAX_CANDIDATE_DIAGNOSTIC_SLOTS:
             raise ValueError(

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -1,0 +1,73 @@
+"""Leftover-identity gates for learning-signal resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.learning_signals import LearningSignalResourceBudget
+
+
+def _legal_budget() -> LearningSignalResourceBudget:
+    return LearningSignalResourceBudget(
+        input_float_scalars_per_step=15,
+        persistent_float32_scalars=5,
+        persistent_int32_scalars=4,
+        persistent_state_scalars=9,
+        persistent_state_bytes=36,
+        output_float32_scalars=8,
+        output_bool_scalars=6,
+        output_logical_bytes=38,
+        trainable_scalars=0,
+    )
+
+
+def test_learning_signals_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="input_float_scalars_per_step"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=True,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=36,
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=0,
+        )
+    with pytest.raises(ValueError, match="trainable_scalars"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=15,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=36,
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=True,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        LearningSignalResourceBudget(
+            input_float_scalars_per_step=15,
+            persistent_float32_scalars=5,
+            persistent_int32_scalars=4,
+            persistent_state_scalars=9,
+            persistent_state_bytes=float("nan"),
+            output_float32_scalars=8,
+            output_bool_scalars=6,
+            output_logical_bytes=38,
+            trainable_scalars=0,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"input_float_scalars_per_step": 15' in dumped
+    assert '"output_bool_scalars": 6' in dumped
+    assert '"trainable_scalars": 0' in dumped
+    assert '"input_float_scalars_per_step": true' not in dumped
+    assert '"trainable_scalars": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 import pytest
 
 from alberta_framework.core.learning_signals import LearningSignalResourceBudget
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
 
 
 def _legal_budget() -> LearningSignalResourceBudget:
@@ -71,3 +77,26 @@ def test_learning_signals_resource_budget_rejects_leftover_identities() -> None:
     assert '"input_float_scalars_per_step": true' not in dumped
     assert '"trainable_scalars": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "persistent_float32_scalars",
+        "persistent_int32_scalars",
+        "persistent_state_scalars",
+        "persistent_state_bytes",
+        "output_float32_scalars",
+        "output_bool_scalars",
+        "output_logical_bytes",
+        "trainable_scalars",
+    ],
+)
+def test_learning_signal_budget_requires_exact_derived_identity(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(_legal_budget(), **{field: getattr(_legal_budget(), field) + 1})
+
+
+def test_learning_signal_budget_rejects_hostile_integer_subclass_without_hook() -> None:
+    with pytest.raises(ValueError, match="input_float_scalars_per_step"):
+        dataclasses.replace(_legal_budget(), input_float_scalars_per_step=_HostileInt(15))

--- a/tests/test_option_search_control.py
+++ b/tests/test_option_search_control.py
@@ -136,6 +136,10 @@ def test_config_is_strict_and_resource_budget_is_explicit() -> None:
             OptionSearchControlConfig(backup_budget=4_096),
         )
 
+    empty_agent = STOMPAgent(_stomp_config(n_options=0))
+    with pytest.raises(ValueError, match="at least one option"):
+        OptionSearchControl(empty_agent)
+
 
 def test_option_search_control_is_exported_from_public_namespaces() -> None:
     assert alberta_framework.OptionSearchControl is OptionSearchControl

--- a/tests/test_option_search_control_resource_budget.py
+++ b/tests/test_option_search_control_resource_budget.py
@@ -1,0 +1,89 @@
+"""Leftover-identity gates for option-search resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.option_search_control import OptionSearchControlResourceBudget
+
+
+def _legal_budget() -> OptionSearchControlResourceBudget:
+    return OptionSearchControlResourceBudget(
+        n_options=2,
+        observation_dim=4,
+        backup_budget=3,
+        persistent_state_bytes=0,
+        rng_draws_per_call=0,
+        candidate_values_per_evaluation=2,
+        max_candidate_evaluations_per_call=6,
+        max_base_learner_updates_per_call=3,
+        max_model_matrix_vector_products_per_call=6,
+        max_base_value_forward_calls_per_call=12,
+        max_base_value_backward_calls_per_call=3,
+        stomp_self_audits_per_call=1,
+        max_diagnostic_payload_bytes_per_call=191,
+    )
+
+
+def test_option_search_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="n_options"):
+        OptionSearchControlResourceBudget(
+            n_options=True,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=0,
+            rng_draws_per_call=0,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+    with pytest.raises(ValueError, match="rng_draws_per_call"):
+        OptionSearchControlResourceBudget(
+            n_options=2,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=0,
+            rng_draws_per_call=True,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        OptionSearchControlResourceBudget(
+            n_options=2,
+            observation_dim=4,
+            backup_budget=3,
+            persistent_state_bytes=float("nan"),
+            rng_draws_per_call=0,
+            candidate_values_per_evaluation=2,
+            max_candidate_evaluations_per_call=6,
+            max_base_learner_updates_per_call=3,
+            max_model_matrix_vector_products_per_call=6,
+            max_base_value_forward_calls_per_call=12,
+            max_base_value_backward_calls_per_call=3,
+            stomp_self_audits_per_call=1,
+            max_diagnostic_payload_bytes_per_call=191,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"n_options": 2' in dumped
+    assert '"backup_budget": 3' in dumped
+    assert '"persistent_state_bytes": 0' in dumped
+    assert '"n_options": true' not in dumped
+    assert '"rng_draws_per_call": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped

--- a/tests/test_option_search_control_resource_budget.py
+++ b/tests/test_option_search_control_resource_budget.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 import pytest
 
 from alberta_framework.core.option_search_control import OptionSearchControlResourceBudget
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
 
 
 def _legal_budget() -> OptionSearchControlResourceBudget:
@@ -23,7 +29,7 @@ def _legal_budget() -> OptionSearchControlResourceBudget:
         max_base_value_forward_calls_per_call=12,
         max_base_value_backward_calls_per_call=3,
         stomp_self_audits_per_call=1,
-        max_diagnostic_payload_bytes_per_call=191,
+        max_diagnostic_payload_bytes_per_call=199,
     )
 
 
@@ -87,3 +93,34 @@ def test_option_search_resource_budget_rejects_leftover_identities() -> None:
     assert '"n_options": true' not in dumped
     assert '"rng_draws_per_call": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "persistent_state_bytes",
+        "rng_draws_per_call",
+        "candidate_values_per_evaluation",
+        "max_candidate_evaluations_per_call",
+        "max_base_learner_updates_per_call",
+        "max_model_matrix_vector_products_per_call",
+        "max_base_value_forward_calls_per_call",
+        "max_base_value_backward_calls_per_call",
+        "stomp_self_audits_per_call",
+        "max_diagnostic_payload_bytes_per_call",
+    ],
+)
+def test_option_search_budget_requires_exact_derived_identity(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(_legal_budget(), **{field: getattr(_legal_budget(), field) + 1})
+
+
+def test_option_search_budget_rejects_hostile_integer_subclass_without_hook() -> None:
+    with pytest.raises(ValueError, match="n_options"):
+        dataclasses.replace(_legal_budget(), n_options=_HostileInt(2))
+
+
+@pytest.mark.parametrize("field", ["n_options", "observation_dim", "backup_budget"])
+def test_option_search_budget_requires_positive_dimensions(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(_legal_budget(), **{field: 0})


### PR DESCRIPTION
Supersedes #1181 and #1182 while preserving both contributor commits.

- validates primitive integer identities without hostile hooks
- enforces every fixed and cross-field derived resource formula
- rejects zero-option controllers before runtime indexing
- adds hostile, mutation, positive-dimension, and producer-path coverage

Verification: 105 combined tests passed; ruff and mypy passed.