### PR TITLE
fix(learning-signals): bound derived input budget

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -159,6 +159,11 @@ class LearningSignalEstimatorConfig:
             "target_dim",
             _require_int32("target_dim", self.target_dim, minimum=1),
         )
+        input_scalars = 2 * self.ensemble_size * self.target_dim + self.target_dim + 1
+        if input_scalars > _INT32_MAX:
+            raise ValueError(
+                "ensemble_size and target_dim produce an input resource budget above int32"
+            )
         object.__setattr__(
             self,
             "progress_warmup_steps",

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -7,7 +7,11 @@ import json
 
 import pytest
 
-from alberta_framework.core.learning_signals import LearningSignalResourceBudget
+from alberta_framework.core.learning_signals import (
+    LearningSignalEstimator,
+    LearningSignalEstimatorConfig,
+    LearningSignalResourceBudget,
+)
 
 
 class _HostileInt(int):
@@ -100,3 +104,15 @@ def test_learning_signal_budget_requires_exact_derived_identity(field: str) -> N
 def test_learning_signal_budget_rejects_hostile_integer_subclass_without_hook() -> None:
     with pytest.raises(ValueError, match="input_float_scalars_per_step"):
         dataclasses.replace(_legal_budget(), input_float_scalars_per_step=_HostileInt(15))
+
+
+def test_learning_signal_config_gates_exact_derived_input_budget_bound() -> None:
+    largest = LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
+    assert (
+        LearningSignalEstimator(largest).resource_budget().input_float_scalars_per_step
+        == 2_147_483_646
+    )
+    with pytest.raises(ValueError, match="input resource budget"):
+        LearningSignalEstimatorConfig(ensemble_size=1_073_741_823, target_dim=1)
+    with pytest.raises(ValueError, match="input resource budget"):
+        LearningSignalEstimatorConfig(ensemble_size=50_000, target_dim=50_000)


### PR DESCRIPTION
Follow-up to #1185: gate the exact derived input-scalar formula during config construction so every accepted config can produce its int32 resource record. Includes largest-fitting, first-overflow, and product-overflow tests.

Verification: 63 tests passed; ruff passed.