### PR TITLE
fix(model-replay): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -384,6 +384,32 @@ class ModelReplayRehearsalResourceBudget:
     max_real_event_count: int
     max_rehearsal_attempt_count: int
 
+    def __post_init__(self) -> None:
+        for name in (
+            "persistent_state_scalars",
+            "persistent_state_bytes",
+            "ensemble_state_bytes",
+            "replay_state_bytes",
+            "composer_accounting_bytes",
+            "replay_total_capacity",
+            "short_term_capacity",
+            "long_term_capacity",
+            "fixed_replay_quota",
+            "max_real_model_update_candidates_per_event",
+            "max_replay_model_update_candidates_per_event",
+            "max_total_model_update_candidates_per_event",
+            "max_actor_updates_per_event",
+            "max_critic_updates_per_event",
+            "max_state_builder_updates_per_event",
+            "max_real_event_count",
+            "max_rehearsal_attempt_count",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int(name, getattr(self, name), minimum=0),
+            )
+
     def to_config(self) -> dict[str, int]:
         """Return JSON-compatible exact accounting."""
         return dataclasses.asdict(self)

--- a/tests/test_model_replay_rehearsal_resource_budget.py
+++ b/tests/test_model_replay_rehearsal_resource_budget.py
@@ -1,0 +1,105 @@
+"""Leftover-identity gates for model-replay resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.model_replay_rehearsal import ModelReplayRehearsalResourceBudget
+
+
+def _legal_budget() -> ModelReplayRehearsalResourceBudget:
+    return ModelReplayRehearsalResourceBudget(
+        persistent_state_scalars=10,
+        persistent_state_bytes=40,
+        ensemble_state_bytes=20,
+        replay_state_bytes=12,
+        composer_accounting_bytes=8,
+        replay_total_capacity=4,
+        short_term_capacity=2,
+        long_term_capacity=2,
+        fixed_replay_quota=1,
+        max_real_model_update_candidates_per_event=2,
+        max_replay_model_update_candidates_per_event=2,
+        max_total_model_update_candidates_per_event=4,
+        max_actor_updates_per_event=0,
+        max_critic_updates_per_event=0,
+        max_state_builder_updates_per_event=0,
+        max_real_event_count=100,
+        max_rehearsal_attempt_count=100,
+    )
+
+
+def test_model_replay_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="persistent_state_scalars"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=True,
+            persistent_state_bytes=40,
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=0,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+    with pytest.raises(ValueError, match="max_actor_updates_per_event"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=10,
+            persistent_state_bytes=40,
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=True,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=10,
+            persistent_state_bytes=float("nan"),
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=0,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"persistent_state_scalars": 10' in dumped
+    assert '"max_actor_updates_per_event": 0' in dumped
+    assert '"persistent_state_bytes": 40' in dumped
+    assert '"persistent_state_scalars": true' not in dumped
+    assert '"max_actor_updates_per_event": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1188.

## What changed

The model-replay resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `b48715d`, rehearsal config scalars already reject leftover boolean identities. `ModelReplayRehearsalResourceBudget` had no `__post_init__` and accepted leftover identities (`persistent_state_scalars=True`, `max_actor_updates_per_event=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"persistent_state_scalars": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `model_replay_rehearsal.py` resource-budget records, not a republish of `#1057` (config/resource contracts), `#1181`/`#1182` (learning-signals/option-search, closed as superseded by `#1185`), `#1173` (mixer), or `#1174` (behavior-model).

## Scope

- `alberta_framework/core/model_replay_rehearsal.py`
- `tests/test_model_replay_rehearsal_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is empty. Shaw `#1185`/`#1186` occupy learning-signals/option-search only. `#1184` occupies `security.py`. These files were FREE.

## Verification

Exact candidate head: `d781533f7e4f432e0023b57ca2b4c0b3acc4861c`
Base: `b48715d`

- Red on base: `ModelReplayRehearsalResourceBudget(persistent_state_scalars=True, ...)` accepted; dump emitted `"persistent_state_scalars": true`
- Focused pytest `tests/test_model_replay_rehearsal_resource_budget.py`: 1 passed
- Existing model-replay validation tests: 24 passed
- Combined: 25 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d781533f7e4f432e0023b57ca2b4c0b3acc4861c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
