### PR TITLE
fix(partner-fusion): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -95,6 +95,15 @@ def _strict_positive_int(value: object, *, name: str, maximum: int = _INT32_MAX)
     return canonical
 
 
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
 def _strict_float32(
     value: object,
     *,
@@ -471,6 +480,39 @@ class PartnerPolicyFusionResourceBudget:
     rng_state_bytes: int
     replay_capacity: int
     dynamic_partner_capacity: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_partners",
+            "context_dim",
+            "n_actions",
+            "model_feature_dim",
+            "trainable_float32_scalars",
+            "persistent_float32_scalars",
+            "persistent_int32_scalars",
+            "persistent_bool_scalars",
+            "persistent_state_scalars",
+            "persistent_state_bytes",
+            "max_messages_per_decision",
+            "max_model_scores_per_decision",
+            "partner_id_pairwise_equality_comparisons_per_decision",
+            "max_trainable_scalars_touched_per_feedback",
+            "decision_input_float32_scalars",
+            "decision_input_int32_scalars",
+            "decision_input_bool_scalars",
+            "feedback_input_float32_scalars",
+            "feedback_input_int32_scalars",
+            "feedback_input_bool_scalars",
+            "max_parameter_updates_per_feedback",
+            "rng_state_bytes",
+            "replay_capacity",
+            "dynamic_partner_capacity",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int32(name, getattr(self, name), minimum=0),
+            )
 
     def to_config(self) -> dict[str, int]:
         """Return the fixed JSON-compatible resource record."""

--- a/tests/test_partner_policy_fusion_resource_budget.py
+++ b/tests/test_partner_policy_fusion_resource_budget.py
@@ -1,0 +1,133 @@
+"""Leftover-identity gates for partner-fusion resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.partner_policy_fusion import PartnerPolicyFusionResourceBudget
+
+
+def _legal_budget() -> PartnerPolicyFusionResourceBudget:
+    return PartnerPolicyFusionResourceBudget(
+        max_partners=3,
+        context_dim=2,
+        n_actions=3,
+        model_feature_dim=4,
+        trainable_float32_scalars=12,
+        persistent_float32_scalars=17,
+        persistent_int32_scalars=15,
+        persistent_bool_scalars=2,
+        persistent_state_scalars=34,
+        persistent_state_bytes=130,
+        max_messages_per_decision=3,
+        max_model_scores_per_decision=3,
+        partner_id_pairwise_equality_comparisons_per_decision=9,
+        max_trainable_scalars_touched_per_feedback=4,
+        decision_input_float32_scalars=10,
+        decision_input_int32_scalars=33,
+        decision_input_bool_scalars=7,
+        feedback_input_float32_scalars=1,
+        feedback_input_int32_scalars=4,
+        feedback_input_bool_scalars=4,
+        max_parameter_updates_per_feedback=1,
+        rng_state_bytes=0,
+        replay_capacity=0,
+        dynamic_partner_capacity=0,
+    )
+
+
+def test_partner_fusion_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="max_partners"):
+        PartnerPolicyFusionResourceBudget(
+            max_partners=True,
+            context_dim=2,
+            n_actions=3,
+            model_feature_dim=4,
+            trainable_float32_scalars=12,
+            persistent_float32_scalars=17,
+            persistent_int32_scalars=15,
+            persistent_bool_scalars=2,
+            persistent_state_scalars=34,
+            persistent_state_bytes=130,
+            max_messages_per_decision=3,
+            max_model_scores_per_decision=3,
+            partner_id_pairwise_equality_comparisons_per_decision=9,
+            max_trainable_scalars_touched_per_feedback=4,
+            decision_input_float32_scalars=10,
+            decision_input_int32_scalars=33,
+            decision_input_bool_scalars=7,
+            feedback_input_float32_scalars=1,
+            feedback_input_int32_scalars=4,
+            feedback_input_bool_scalars=4,
+            max_parameter_updates_per_feedback=1,
+            rng_state_bytes=0,
+            replay_capacity=0,
+            dynamic_partner_capacity=0,
+        )
+    with pytest.raises(ValueError, match="replay_capacity"):
+        PartnerPolicyFusionResourceBudget(
+            max_partners=3,
+            context_dim=2,
+            n_actions=3,
+            model_feature_dim=4,
+            trainable_float32_scalars=12,
+            persistent_float32_scalars=17,
+            persistent_int32_scalars=15,
+            persistent_bool_scalars=2,
+            persistent_state_scalars=34,
+            persistent_state_bytes=130,
+            max_messages_per_decision=3,
+            max_model_scores_per_decision=3,
+            partner_id_pairwise_equality_comparisons_per_decision=9,
+            max_trainable_scalars_touched_per_feedback=4,
+            decision_input_float32_scalars=10,
+            decision_input_int32_scalars=33,
+            decision_input_bool_scalars=7,
+            feedback_input_float32_scalars=1,
+            feedback_input_int32_scalars=4,
+            feedback_input_bool_scalars=4,
+            max_parameter_updates_per_feedback=1,
+            rng_state_bytes=0,
+            replay_capacity=True,
+            dynamic_partner_capacity=0,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        PartnerPolicyFusionResourceBudget(
+            max_partners=3,
+            context_dim=2,
+            n_actions=3,
+            model_feature_dim=4,
+            trainable_float32_scalars=12,
+            persistent_float32_scalars=17,
+            persistent_int32_scalars=15,
+            persistent_bool_scalars=2,
+            persistent_state_scalars=34,
+            persistent_state_bytes=float("nan"),
+            max_messages_per_decision=3,
+            max_model_scores_per_decision=3,
+            partner_id_pairwise_equality_comparisons_per_decision=9,
+            max_trainable_scalars_touched_per_feedback=4,
+            decision_input_float32_scalars=10,
+            decision_input_int32_scalars=33,
+            decision_input_bool_scalars=7,
+            feedback_input_float32_scalars=1,
+            feedback_input_int32_scalars=4,
+            feedback_input_bool_scalars=4,
+            max_parameter_updates_per_feedback=1,
+            rng_state_bytes=0,
+            replay_capacity=0,
+            dynamic_partner_capacity=0,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"max_partners": 3' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"persistent_state_bytes": 130' in dumped
+    assert '"max_partners": true' not in dumped
+    assert '"replay_capacity": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1189.

## What changed

The partner-fusion resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `b48715d`, fusion config scalars already reject leftover boolean identities. `PartnerPolicyFusionResourceBudget` had no `__post_init__` and accepted leftover identities (`max_partners=True`, `replay_capacity=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"max_partners": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `partner_policy_fusion.py` resource-budget records, not a republish of `#730` (closed fusion integer contracts), `#1181`/`#1182` (learning-signals/option-search, closed as superseded by `#1185`), `#1173` (mixer), or `#1174` (behavior-model).

## Scope

- `alberta_framework/core/partner_policy_fusion.py`
- `tests/test_partner_policy_fusion_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is empty. Shaw `#1185`/`#1186` occupy learning-signals/option-search only. `#1184` occupies `security.py`. These files were FREE.

## Verification

Exact candidate head: `9dc324e3f28b1c9941c76e112f5400fb2dab1bf8`
Base: `b48715d`

- Red on base: `PartnerPolicyFusionResourceBudget(max_partners=True, ...)` accepted; dump emitted `"max_partners": true`
- Focused pytest `tests/test_partner_policy_fusion_resource_budget.py`: 1 passed
- Existing partner-fusion tests: 65 passed
- Combined: 66 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9dc324e3f28b1c9941c76e112f5400fb2dab1bf8 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
