### PR TITLE
fix(learning-signals): require attainable input budgets

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -324,6 +324,16 @@ class LearningSignalResourceBudget:
                 minimum=1,
             ),
         )
+        # Producer counts have the exact form D * (2E + 1) + 1 for
+        # ensemble size E >= 2 and target dimension D >= 1.  Removing all
+        # factors of two from count - 1 therefore leaves an odd factor >= 5.
+        odd_factor = self.input_float_scalars_per_step - 1
+        while odd_factor > 0 and odd_factor % 2 == 0:
+            odd_factor //= 2
+        if odd_factor < 5:
+            raise ValueError(
+                "input_float_scalars_per_step is not attainable by a legal estimator config"
+            )
         object.__setattr__(
             self,
             "persistent_float32_scalars",

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -106,6 +106,17 @@ def test_learning_signal_budget_rejects_hostile_integer_subclass_without_hook() 
         dataclasses.replace(_legal_budget(), input_float_scalars_per_step=_HostileInt(15))
 
 
+@pytest.mark.parametrize("count", [6, 8, 10, 11, 2_147_483_647])
+def test_learning_signal_budget_accepts_attainable_input_counts(count: int) -> None:
+    assert dataclasses.replace(_legal_budget(), input_float_scalars_per_step=count)
+
+
+@pytest.mark.parametrize("count", [1, 2, 3, 4, 5, 7, 9, 13, 17])
+def test_learning_signal_budget_rejects_unattainable_input_counts(count: int) -> None:
+    with pytest.raises(ValueError, match="not attainable"):
+        dataclasses.replace(_legal_budget(), input_float_scalars_per_step=count)
+
+
 def test_learning_signal_config_gates_exact_derived_input_budget_bound() -> None:
     largest = LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
     assert (


### PR DESCRIPTION
Require direct input resource counts to be attainable by some legal estimator config: for I = D*(2E+1)+1 with E>=2 and D>=1, the odd part of I-1 must be at least five. The loop is bounded by the int32 bit width.

Verification: 77 tests passed; ruff and mypy passed.