### PR TITLE
fix(partner-fusion): bind exact resource formulas

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -482,11 +482,13 @@ class PartnerPolicyFusionResourceBudget:
     dynamic_partner_capacity: int
 
     def __post_init__(self) -> None:
+        for name in ("max_partners", "context_dim", "n_actions", "model_feature_dim"):
+            object.__setattr__(
+                self,
+                name,
+                _require_int32(name, getattr(self, name), minimum=1),
+            )
         for name in (
-            "max_partners",
-            "context_dim",
-            "n_actions",
-            "model_feature_dim",
             "trainable_float32_scalars",
             "persistent_float32_scalars",
             "persistent_int32_scalars",
@@ -513,6 +515,37 @@ class PartnerPolicyFusionResourceBudget:
                 name,
                 _require_int32(name, getattr(self, name), minimum=0),
             )
+        partners = self.max_partners
+        features = self.context_dim + 2
+        persistent_f32 = partners * features + features + 1
+        persistent_i32 = 2 * partners + 9
+        persistent_bool = 2
+        expected = {
+            "model_feature_dim": features,
+            "trainable_float32_scalars": partners * features,
+            "persistent_float32_scalars": persistent_f32,
+            "persistent_int32_scalars": persistent_i32,
+            "persistent_bool_scalars": persistent_bool,
+            "persistent_state_scalars": persistent_f32 + persistent_i32 + persistent_bool,
+            "persistent_state_bytes": 4 * (persistent_f32 + persistent_i32) + persistent_bool,
+            "max_messages_per_decision": partners,
+            "max_model_scores_per_decision": partners,
+            "partner_id_pairwise_equality_comparisons_per_decision": partners * partners,
+            "max_trainable_scalars_touched_per_feedback": features,
+            "decision_input_float32_scalars": self.context_dim + 2 + 2 * partners,
+            "decision_input_int32_scalars": 6 + 9 * partners,
+            "decision_input_bool_scalars": self.n_actions + 1 + partners,
+            "feedback_input_float32_scalars": 1,
+            "feedback_input_int32_scalars": 4,
+            "feedback_input_bool_scalars": 4,
+            "max_parameter_updates_per_feedback": 1,
+            "rng_state_bytes": 0,
+            "replay_capacity": 0,
+            "dynamic_partner_capacity": 0,
+        }
+        for name, expected_value in expected.items():
+            if getattr(self, name) != expected_value:
+                raise ValueError(f"{name} does not match the partner-fusion implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return the fixed JSON-compatible resource record."""

--- a/tests/test_partner_policy_fusion_resource_budget.py
+++ b/tests/test_partner_policy_fusion_resource_budget.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
+import numpy as np
 import pytest
 
-from alberta_framework.core.partner_policy_fusion import PartnerPolicyFusionResourceBudget
+from alberta_framework.core.partner_policy_fusion import (
+    PartnerPolicyFusion,
+    PartnerPolicyFusionConfig,
+    PartnerPolicyFusionResourceBudget,
+)
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
 
 
 def _legal_budget() -> PartnerPolicyFusionResourceBudget:
@@ -131,3 +142,84 @@ def test_partner_fusion_resource_budget_rejects_leftover_identities() -> None:
     assert '"max_partners": true' not in dumped
     assert '"replay_capacity": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "model_feature_dim",
+        "trainable_float32_scalars",
+        "persistent_float32_scalars",
+        "persistent_int32_scalars",
+        "persistent_bool_scalars",
+        "persistent_state_scalars",
+        "persistent_state_bytes",
+        "max_messages_per_decision",
+        "max_model_scores_per_decision",
+        "partner_id_pairwise_equality_comparisons_per_decision",
+        "max_trainable_scalars_touched_per_feedback",
+        "decision_input_float32_scalars",
+        "decision_input_int32_scalars",
+        "decision_input_bool_scalars",
+        "feedback_input_float32_scalars",
+        "feedback_input_int32_scalars",
+        "feedback_input_bool_scalars",
+        "max_parameter_updates_per_feedback",
+        "rng_state_bytes",
+        "replay_capacity",
+        "dynamic_partner_capacity",
+    ],
+)
+def test_partner_fusion_resource_budget_requires_exact_formulas(field: str) -> None:
+    budget = _legal_budget()
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(budget, **{field: getattr(budget, field) + 1})
+
+
+@pytest.mark.parametrize("field", ["max_partners", "context_dim", "n_actions"])
+def test_partner_fusion_resource_budget_requires_positive_dimensions(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        dataclasses.replace(_legal_budget(), **{field: 0})
+
+
+@pytest.mark.parametrize("field", ["max_partners", "context_dim", "n_actions"])
+def test_partner_fusion_resource_budget_binds_provenance_dimensions(field: str) -> None:
+    budget = _legal_budget()
+    with pytest.raises(ValueError, match="partner-fusion implementation"):
+        dataclasses.replace(budget, **{field: getattr(budget, field) + 1})
+
+
+@pytest.mark.parametrize("value", [_HostileInt(3), 2**31, -1])
+def test_partner_fusion_resource_budget_rejects_hostile_or_wide_dimensions(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="max_partners"):
+        dataclasses.replace(_legal_budget(), max_partners=value)  # type: ignore[arg-type]
+
+
+def test_partner_fusion_resource_budget_canonicalizes_numpy_integer_dimensions() -> None:
+    budget = dataclasses.replace(
+        _legal_budget(),
+        max_partners=np.int32(3),
+        context_dim=np.uint16(2),
+        n_actions=np.int64(3),
+    )
+    assert type(budget.max_partners) is int
+    assert type(budget.context_dim) is int
+    assert type(budget.n_actions) is int
+
+
+def test_partner_fusion_producer_budget_is_total_at_configured_maxima() -> None:
+    fusion = PartnerPolicyFusion(
+        PartnerPolicyFusionConfig(
+            max_partners=1024,
+            context_dim=65_536,
+            n_actions=65_536,
+        )
+    )
+    budget = fusion.resource_budget
+    assert budget == PartnerPolicyFusionResourceBudget(**budget.to_config())
+    assert all(
+        type(value) is int and 0 <= value <= 2**31 - 1
+        for value in budget.to_config().values()
+    )


### PR DESCRIPTION
Corrective follow-up to #1191 and closes #1189. Preserves the merged contributor patch while binding every resource field to the partner-fusion provenance dimensions and implementation formulas. Rejects zero, hostile-subclass, wide, and cross-field-forged records; proves the maximum accepted config always produces an int32-total budget.\n\nVerification: 98 focused tests passed; Ruff passed; strict mypy passed. No benchmark or outputs were produced.