### PR TITLE
fix(model-replay): enforce exact resource identities

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -384,6 +384,32 @@ class ModelReplayRehearsalResourceBudget:
     max_real_event_count: int
     max_rehearsal_attempt_count: int
 
+    def __post_init__(self) -> None:
+        for name in (
+            "persistent_state_scalars",
+            "persistent_state_bytes",
+            "ensemble_state_bytes",
+            "replay_state_bytes",
+            "composer_accounting_bytes",
+            "replay_total_capacity",
+            "short_term_capacity",
+            "long_term_capacity",
+            "fixed_replay_quota",
+            "max_real_model_update_candidates_per_event",
+            "max_replay_model_update_candidates_per_event",
+            "max_total_model_update_candidates_per_event",
+            "max_actor_updates_per_event",
+            "max_critic_updates_per_event",
+            "max_state_builder_updates_per_event",
+            "max_real_event_count",
+            "max_rehearsal_attempt_count",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int(name, getattr(self, name), minimum=0),
+            )
+
     def to_config(self) -> dict[str, int]:
         """Return JSON-compatible exact accounting."""
         return dataclasses.asdict(self)

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -188,6 +188,8 @@ class ModelReplayRehearsalConfig:
                 raise ValueError("one_hot requires replay.action_dim == model.n_actions")
         else:
             raise ValueError("action_encoding must be 'scalar_index' or 'one_hot'")
+        if self.ensemble.ensemble_size * (self.replay_quota + 1) > _INT32_MAX:
+            raise ValueError("derived per-event model update candidates must fit signed int32")
 
     @property
     def replay_quota(self) -> int:
@@ -409,6 +411,45 @@ class ModelReplayRehearsalResourceBudget:
                 name,
                 _require_int(name, getattr(self, name), minimum=0),
             )
+        if self.persistent_state_scalars <= 0:
+            raise ValueError("persistent_state_scalars must be positive")
+        if self.ensemble_state_bytes <= 0:
+            raise ValueError("ensemble_state_bytes must be positive")
+        if self.replay_state_bytes <= 0:
+            raise ValueError("replay_state_bytes must be positive")
+        if self.fixed_replay_quota < 1:
+            raise ValueError("fixed_replay_quota must be positive")
+        if self.short_term_capacity < 1 or self.long_term_capacity < 1:
+            raise ValueError("replay tier capacities must be positive")
+        if self.fixed_replay_quota > self.replay_total_capacity:
+            raise ValueError("fixed_replay_quota cannot exceed replay_total_capacity")
+        if self.max_real_model_update_candidates_per_event < 2:
+            raise ValueError("max_real_model_update_candidates_per_event must be at least two")
+        expected = {
+            "composer_accounting_bytes": 28,
+            "persistent_state_bytes": (
+                self.ensemble_state_bytes + self.replay_state_bytes + 28
+            ),
+            "replay_total_capacity": self.short_term_capacity + self.long_term_capacity,
+            "max_replay_model_update_candidates_per_event": (
+                self.fixed_replay_quota
+                * self.max_real_model_update_candidates_per_event
+            ),
+            "max_total_model_update_candidates_per_event": (
+                (self.fixed_replay_quota + 1)
+                * self.max_real_model_update_candidates_per_event
+            ),
+            "max_actor_updates_per_event": 0,
+            "max_critic_updates_per_event": 0,
+            "max_state_builder_updates_per_event": 0,
+            "max_real_event_count": _INT32_MAX // self.fixed_replay_quota,
+            "max_rehearsal_attempt_count": (
+                (_INT32_MAX // self.fixed_replay_quota) * self.fixed_replay_quota
+            ),
+        }
+        for name, value in expected.items():
+            if getattr(self, name) != value:
+                raise ValueError(f"{name} does not match the model-replay implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return JSON-compatible exact accounting."""

--- a/tests/test_model_replay_rehearsal_resource_budget.py
+++ b/tests/test_model_replay_rehearsal_resource_budget.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 import pytest
@@ -11,11 +12,11 @@ from alberta_framework.core.model_replay_rehearsal import ModelReplayRehearsalRe
 
 def _legal_budget() -> ModelReplayRehearsalResourceBudget:
     return ModelReplayRehearsalResourceBudget(
-        persistent_state_scalars=10,
-        persistent_state_bytes=40,
+        persistent_state_scalars=15,
+        persistent_state_bytes=60,
         ensemble_state_bytes=20,
         replay_state_bytes=12,
-        composer_accounting_bytes=8,
+        composer_accounting_bytes=28,
         replay_total_capacity=4,
         short_term_capacity=2,
         long_term_capacity=2,
@@ -26,8 +27,8 @@ def _legal_budget() -> ModelReplayRehearsalResourceBudget:
         max_actor_updates_per_event=0,
         max_critic_updates_per_event=0,
         max_state_builder_updates_per_event=0,
-        max_real_event_count=100,
-        max_rehearsal_attempt_count=100,
+        max_real_event_count=2_147_483_647,
+        max_rehearsal_attempt_count=2_147_483_647,
     )
 
 
@@ -97,9 +98,46 @@ def test_model_replay_resource_budget_rejects_leftover_identities() -> None:
 
     legal = _legal_budget()
     dumped = json.dumps(legal.to_config(), allow_nan=False)
-    assert '"persistent_state_scalars": 10' in dumped
+    assert '"persistent_state_scalars": 15' in dumped
     assert '"max_actor_updates_per_event": 0' in dumped
-    assert '"persistent_state_bytes": 40' in dumped
+    assert '"persistent_state_bytes": 60' in dumped
     assert '"persistent_state_scalars": true' not in dumped
     assert '"max_actor_updates_per_event": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "persistent_state_bytes",
+        "ensemble_state_bytes",
+        "replay_state_bytes",
+        "composer_accounting_bytes",
+        "replay_total_capacity",
+        "short_term_capacity",
+        "long_term_capacity",
+        "fixed_replay_quota",
+        "max_real_model_update_candidates_per_event",
+        "max_replay_model_update_candidates_per_event",
+        "max_total_model_update_candidates_per_event",
+        "max_actor_updates_per_event",
+        "max_critic_updates_per_event",
+        "max_state_builder_updates_per_event",
+        "max_real_event_count",
+        "max_rehearsal_attempt_count",
+    ],
+)
+def test_model_replay_budget_rejects_false_exact_identities(field: str) -> None:
+    legal = _legal_budget()
+    with pytest.raises(ValueError):
+        dataclasses.replace(legal, **{field: getattr(legal, field) + 1})
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
+
+
+def test_model_replay_budget_rejects_hostile_integer_without_hook() -> None:
+    with pytest.raises(ValueError, match="persistent_state_scalars"):
+        dataclasses.replace(_legal_budget(), persistent_state_scalars=_HostileInt(15))

--- a/tests/test_model_replay_rehearsal_resource_budget.py
+++ b/tests/test_model_replay_rehearsal_resource_budget.py
@@ -1,0 +1,105 @@
+"""Leftover-identity gates for model-replay resource-budget records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.core.model_replay_rehearsal import ModelReplayRehearsalResourceBudget
+
+
+def _legal_budget() -> ModelReplayRehearsalResourceBudget:
+    return ModelReplayRehearsalResourceBudget(
+        persistent_state_scalars=10,
+        persistent_state_bytes=40,
+        ensemble_state_bytes=20,
+        replay_state_bytes=12,
+        composer_accounting_bytes=8,
+        replay_total_capacity=4,
+        short_term_capacity=2,
+        long_term_capacity=2,
+        fixed_replay_quota=1,
+        max_real_model_update_candidates_per_event=2,
+        max_replay_model_update_candidates_per_event=2,
+        max_total_model_update_candidates_per_event=4,
+        max_actor_updates_per_event=0,
+        max_critic_updates_per_event=0,
+        max_state_builder_updates_per_event=0,
+        max_real_event_count=100,
+        max_rehearsal_attempt_count=100,
+    )
+
+
+def test_model_replay_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="persistent_state_scalars"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=True,
+            persistent_state_bytes=40,
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=0,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+    with pytest.raises(ValueError, match="max_actor_updates_per_event"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=10,
+            persistent_state_bytes=40,
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=True,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        ModelReplayRehearsalResourceBudget(
+            persistent_state_scalars=10,
+            persistent_state_bytes=float("nan"),
+            ensemble_state_bytes=20,
+            replay_state_bytes=12,
+            composer_accounting_bytes=8,
+            replay_total_capacity=4,
+            short_term_capacity=2,
+            long_term_capacity=2,
+            fixed_replay_quota=1,
+            max_real_model_update_candidates_per_event=2,
+            max_replay_model_update_candidates_per_event=2,
+            max_total_model_update_candidates_per_event=4,
+            max_actor_updates_per_event=0,
+            max_critic_updates_per_event=0,
+            max_state_builder_updates_per_event=0,
+            max_real_event_count=100,
+            max_rehearsal_attempt_count=100,
+        )
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"persistent_state_scalars": 10' in dumped
+    assert '"max_actor_updates_per_event": 0' in dumped
+    assert '"persistent_state_bytes": 40' in dumped
+    assert '"persistent_state_scalars": true' not in dumped
+    assert '"max_actor_updates_per_event": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped

--- a/tests/test_model_replay_rehearsal_validation.py
+++ b/tests/test_model_replay_rehearsal_validation.py
@@ -299,6 +299,22 @@ def test_composer_persistent_bytes_preflight_without_allocation() -> None:
     )
 
 
+def test_config_rejects_derived_per_event_candidate_overflow_before_allocation() -> None:
+    ensemble = _ensemble(ensemble_size=50_000)
+    replay = _replay(
+        total_capacity=100_000,
+        short_term_capacity=50_000,
+        short_term_sample_size=50_000,
+        long_term_sample_size=50_000,
+    )
+    with pytest.raises(ValueError, match="per-event model update candidates"):
+        ModelReplayRehearsalConfig(
+            ensemble=ensemble,
+            replay=replay,
+            action_encoding="one_hot",
+        )
+
+
 def test_from_config_requires_exact_schema() -> None:
     cfg = _composer()
     payload = cfg.to_config()


### PR DESCRIPTION
Supersedes #1190 while preserving its contributor commit.

- rejects hostile and non-integer resource identities
- enforces exact byte decomposition, capacities, update formulas, zero non-model updates, and lifetime bounds
- rejects derived per-event candidate overflow in config construction before allocation/compilation
- covers the concrete 50,000 x 100,000 overflow case and every derivable field mutation

Verification: 43 focused tests passed; ruff and mypy passed.