### PR TITLE
fix(world-model-ensemble): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -400,6 +400,48 @@ class WorldModelEnsembleResourceBudget:
     max_replay_member_update_count: int
     replay_capacity: int
 
+    def __post_init__(self) -> None:
+        for name in (
+            "ensemble_size",
+            "observation_dim",
+            "target_dim",
+            "member_state_scalars_per_member",
+            "member_state_bytes_per_member",
+            "member_trainable_scalars",
+            "total_trainable_scalars",
+            "persistent_float32_scalars",
+            "persistent_float64_scalars",
+            "persistent_int32_scalars",
+            "persistent_int64_scalars",
+            "persistent_uint32_scalars",
+            "persistent_bool_scalars",
+            "persistent_state_scalars",
+            "persistent_state_bytes",
+            "bootstrap_prng_keys",
+            "bootstrap_prng_uint32_scalars",
+            "bootstrap_prng_bytes",
+            "prediction_output_logical_scalars",
+            "prediction_output_logical_bytes",
+            "update_result_output_logical_scalars",
+            "update_result_output_logical_bytes",
+            "replay_update_result_output_logical_scalars",
+            "replay_update_result_output_logical_bytes",
+            "member_update_candidates_per_valid_event",
+            "max_member_updates_per_event",
+            "replay_member_update_candidates_per_available_sample",
+            "max_replay_member_updates_per_available_sample",
+            "max_event_count",
+            "max_member_update_count",
+            "max_replay_event_count",
+            "max_replay_member_update_count",
+            "replay_capacity",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int(name, getattr(self, name), minimum=0, maximum=_INT32_MAX),
+            )
+
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible exact accounting record."""
         return dataclasses.asdict(self)

--- a/tests/test_world_model_ensemble_resource_budget.py
+++ b/tests/test_world_model_ensemble_resource_budget.py
@@ -1,0 +1,68 @@
+"""Leftover-identity gates for world-model-ensemble resource-budget records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from alberta_framework.core.world_model_ensemble import WorldModelEnsembleResourceBudget
+
+
+def _legal_budget() -> WorldModelEnsembleResourceBudget:
+    return WorldModelEnsembleResourceBudget(
+        ensemble_size=2,
+        observation_dim=3,
+        target_dim=4,
+        member_state_scalars_per_member=5,
+        member_state_bytes_per_member=20,
+        member_trainable_scalars=6,
+        total_trainable_scalars=12,
+        persistent_float32_scalars=8,
+        persistent_float64_scalars=0,
+        persistent_int32_scalars=4,
+        persistent_int64_scalars=0,
+        persistent_uint32_scalars=4,
+        persistent_bool_scalars=2,
+        persistent_state_scalars=18,
+        persistent_state_bytes=72,
+        bootstrap_prng_keys=2,
+        bootstrap_prng_uint32_scalars=4,
+        bootstrap_prng_bytes=16,
+        prediction_output_logical_scalars=10,
+        prediction_output_logical_bytes=40,
+        update_result_output_logical_scalars=20,
+        update_result_output_logical_bytes=80,
+        replay_update_result_output_logical_scalars=20,
+        replay_update_result_output_logical_bytes=80,
+        member_update_candidates_per_valid_event=2,
+        max_member_updates_per_event=2,
+        replay_member_update_candidates_per_available_sample=2,
+        max_replay_member_updates_per_available_sample=2,
+        max_event_count=100,
+        max_member_update_count=100,
+        max_replay_event_count=100,
+        max_replay_member_update_count=100,
+        replay_capacity=0,
+    )
+
+
+def test_world_model_ensemble_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="ensemble_size"):
+        replace(_legal_budget(), ensemble_size=True)
+    with pytest.raises(ValueError, match="replay_capacity"):
+        replace(_legal_budget(), replay_capacity=True)
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        replace(_legal_budget(), persistent_state_bytes=float("nan"))
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"ensemble_size": 2' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"persistent_state_bytes": 72' in dumped
+    assert '"ensemble_size": true' not in dumped
+    assert '"replay_capacity": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped


### PR DESCRIPTION
Closes #1196.

## What changed

The world-model-ensemble resource-budget record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `e9a3eb6`, ensemble config scalars already reject leftover boolean identities. `WorldModelEnsembleResourceBudget` had no `__post_init__` and accepted leftover identities (`ensemble_size=True`, `replay_capacity=True`, `persistent_state_bytes=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"ensemble_size": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `world_model_ensemble.py` resource-budget records, not a republish of `#1190` (model-replay), `#1191` (partner-fusion), `#1181`/`#1182` (learning-signals/option-search, closed as superseded by `#1185`), `#1173` (mixer), or `#1174` (behavior-model). Not `world_model.py` step_size.

## Scope

- `alberta_framework/core/world_model_ensemble.py`
- `tests/test_world_model_ensemble_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is `#1190` (model-replay only). These files were FREE.

## Verification

Exact candidate head: `3a3545a02738d819c37295e2863c9f6e68be3b12`
Base: `e9a3eb6`

- Red on base: `WorldModelEnsembleResourceBudget(..., ensemble_size=True)` accepted; dump emitted `"ensemble_size": true`
- Focused pytest `tests/test_world_model_ensemble_resource_budget.py`: 1 passed
- Existing world-model-ensemble tests: 38 passed
- Combined: 39 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3a3545a02738d819c37295e2863c9f6e68be3b12 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
