### PR TITLE
fix(recurrent-latent): bind exact resource formulas

### DIFF
--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -647,12 +647,27 @@ class RecurrentLatentWorldModelResourceBudget:
     replay_capacity: int
 
     def __post_init__(self) -> None:
+        if type(self) is not RecurrentLatentWorldModelResourceBudget:
+            raise ValueError(
+                "resource budget must be an exact RecurrentLatentWorldModelResourceBudget"
+            )
+        for name, minimum in (
+            ("ensemble_size", 2),
+            ("observation_dim", 1),
+            ("latent_dim", 1),
+            ("target_dim", 1),
+            ("trainable_scalars_per_member", 1),
+            ("max_event_count", 1),
+            ("max_member_update_count", 1),
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_int(getattr(self, name), name=name, maximum=_INT32_MAX),
+            )
+            if getattr(self, name) < minimum:
+                raise ValueError(f"{name} must be at least {minimum}")
         for name in (
-            "ensemble_size",
-            "observation_dim",
-            "latent_dim",
-            "target_dim",
-            "trainable_scalars_per_member",
             "total_trainable_scalars",
             "persistent_float32_scalars",
             "persistent_int32_scalars",
@@ -671,8 +686,6 @@ class RecurrentLatentWorldModelResourceBudget:
             "member_gradient_candidates_per_event",
             "max_member_parameter_updates_per_event",
             "recurrent_advances_per_accepted_event",
-            "max_event_count",
-            "max_member_update_count",
             "replay_capacity",
         ):
             object.__setattr__(
@@ -680,6 +693,101 @@ class RecurrentLatentWorldModelResourceBudget:
                 name,
                 _nonnegative_int(getattr(self, name), name=name, maximum=_INT32_MAX),
             )
+        ensemble = self.ensemble_size
+        observation = self.observation_dim
+        latent = self.latent_dim
+        target = observation + 2
+        trainable = self.trainable_scalars_per_member
+
+        # The action count is not carried in this record, but the architecture
+        # formula is linear in that positive dimension.  Require the stored
+        # per-member count to identify one attainable configured architecture.
+        fixed_trainable = (
+            3 * latent * (observation + latent)
+            + 3 * latent
+            + 2 * target * (latent + 1)
+        )
+        action_contribution = trainable - fixed_trainable
+        if action_contribution < 3 * latent or action_contribution % (3 * latent) != 0:
+            raise ValueError(
+                "trainable_scalars_per_member does not identify a positive action dimension"
+            )
+
+        persistent_f32 = ensemble * (trainable + latent)
+        persistent_i32 = ensemble + 3
+        persistent_u32 = 2
+        persistent_bool = ensemble
+        persistent_scalars = persistent_f32 + persistent_i32 + persistent_u32 + persistent_bool
+
+        prediction_f32 = (
+            4 * ensemble * target
+            + 5 * target
+            + ensemble * observation
+            + observation
+            + 2 * ensemble
+            + 4
+            + ensemble * latent
+        )
+        prediction_bool = 5
+        start_f32 = ensemble * latent + observation
+        start_scalars = start_f32 + 2
+        start_bytes = 4 * (start_f32 + 1) + 1
+        decision_f32 = start_f32 + prediction_f32
+        decision_i32 = 2
+        decision_bool = prediction_bool + 1
+        decision_scalars = decision_f32 + decision_i32 + decision_bool
+        decision_bytes = 4 * (decision_f32 + decision_i32) + decision_bool
+
+        update_extra_f32 = target + ensemble + observation + 2
+        update_extra_bool = 1 + 2 * ensemble
+        diagnostics_bool = 15 + 2 * ensemble
+        update_scalars = (
+            persistent_scalars
+            + prediction_f32
+            + prediction_bool
+            + update_extra_f32
+            + update_extra_bool
+            + start_scalars
+            + diagnostics_bool
+        )
+        update_bytes = (
+            4 * (persistent_f32 + persistent_i32 + persistent_u32)
+            + persistent_bool
+            + 4 * prediction_f32
+            + prediction_bool
+            + 4 * update_extra_f32
+            + update_extra_bool
+            + start_bytes
+            + diagnostics_bool
+        )
+        expected = {
+            "target_dim": target,
+            "total_trainable_scalars": ensemble * trainable,
+            "persistent_float32_scalars": persistent_f32,
+            "persistent_int32_scalars": persistent_i32,
+            "persistent_uint32_scalars": persistent_u32,
+            "persistent_bool_scalars": persistent_bool,
+            "persistent_state_scalars": persistent_scalars,
+            "persistent_state_bytes": 4
+            * (persistent_f32 + persistent_i32 + persistent_u32)
+            + persistent_bool,
+            "bootstrap_prng_keys": 1,
+            "bootstrap_prng_uint32_scalars": 2,
+            "start_cache_logical_scalars": start_scalars,
+            "start_cache_logical_bytes": start_bytes,
+            "decision_cache_logical_scalars": decision_scalars,
+            "decision_cache_logical_bytes": decision_bytes,
+            "update_result_logical_scalars": update_scalars,
+            "update_result_logical_bytes": update_bytes,
+            "member_gradient_candidates_per_event": ensemble,
+            "max_member_parameter_updates_per_event": ensemble,
+            "recurrent_advances_per_accepted_event": 1,
+            "max_member_update_count": self.max_event_count,
+            "replay_capacity": 0,
+        }
+        for name, expected_value in expected.items():
+            if getattr(self, name) != expected_value:
+                raise ValueError(f"{name} does not match the recurrent-latent implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return exact JSON-compatible accounting."""

--- a/tests/test_recurrent_latent_world_model_resource_budget.py
+++ b/tests/test_recurrent_latent_world_model_resource_budget.py
@@ -3,37 +3,45 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
+from dataclasses import fields, replace
 
+import numpy as np
 import pytest
 
 from alberta_framework.core.recurrent_latent_world_model_ensemble import (
+    RecurrentLatentWorldModelEnsemble,
+    RecurrentLatentWorldModelEnsembleConfig,
     RecurrentLatentWorldModelResourceBudget,
 )
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
 
 
 def _legal_budget() -> RecurrentLatentWorldModelResourceBudget:
     return RecurrentLatentWorldModelResourceBudget(
         ensemble_size=2,
-        observation_dim=3,
-        latent_dim=4,
-        target_dim=5,
-        trainable_scalars_per_member=6,
-        total_trainable_scalars=12,
-        persistent_float32_scalars=8,
-        persistent_int32_scalars=4,
-        persistent_uint32_scalars=4,
+        observation_dim=2,
+        latent_dim=3,
+        target_dim=4,
+        trainable_scalars_per_member=104,
+        total_trainable_scalars=208,
+        persistent_float32_scalars=214,
+        persistent_int32_scalars=5,
+        persistent_uint32_scalars=2,
         persistent_bool_scalars=2,
-        persistent_state_scalars=18,
-        persistent_state_bytes=72,
+        persistent_state_scalars=223,
+        persistent_state_bytes=886,
         bootstrap_prng_keys=1,
         bootstrap_prng_uint32_scalars=2,
-        start_cache_logical_scalars=3,
-        start_cache_logical_bytes=12,
-        decision_cache_logical_scalars=4,
-        decision_cache_logical_bytes=16,
-        update_result_logical_scalars=10,
-        update_result_logical_bytes=40,
+        start_cache_logical_scalars=10,
+        start_cache_logical_bytes=37,
+        decision_cache_logical_scalars=88,
+        decision_cache_logical_bytes=334,
+        update_result_logical_scalars=344,
+        update_result_logical_bytes=1280,
         member_gradient_candidates_per_event=2,
         max_member_parameter_updates_per_event=2,
         recurrent_advances_per_accepted_event=1,
@@ -57,7 +65,98 @@ def test_recurrent_latent_resource_budget_rejects_leftover_identities() -> None:
     dumped = json.dumps(legal.to_config(), allow_nan=False)
     assert '"ensemble_size": 2' in dumped
     assert '"replay_capacity": 0' in dumped
-    assert '"persistent_state_bytes": 72' in dumped
+    assert '"persistent_state_bytes": 886' in dumped
     assert '"ensemble_size": true' not in dumped
     assert '"replay_capacity": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        field.name
+        for field in fields(RecurrentLatentWorldModelResourceBudget)
+        if field.name
+        not in {
+            "ensemble_size",
+            "observation_dim",
+            "latent_dim",
+            "trainable_scalars_per_member",
+            "max_event_count",
+        }
+    ],
+)
+def test_recurrent_latent_budget_rejects_every_derived_field_mutation(field: str) -> None:
+    budget = _legal_budget()
+    with pytest.raises(ValueError, match=field):
+        replace(budget, **{field: getattr(budget, field) + 1})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("ensemble_size", 1),
+        ("observation_dim", 0),
+        ("latent_dim", 0),
+        ("trainable_scalars_per_member", 0),
+        ("max_event_count", 0),
+    ],
+)
+def test_recurrent_latent_budget_requires_positive_provenance(
+    field: str, value: int
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        replace(_legal_budget(), **{field: value})
+
+
+@pytest.mark.parametrize("field", ["ensemble_size", "observation_dim", "latent_dim"])
+def test_recurrent_latent_budget_binds_provenance_dimensions(field: str) -> None:
+    budget = _legal_budget()
+    with pytest.raises(ValueError):
+        replace(budget, **{field: getattr(budget, field) + 1})
+
+
+def test_recurrent_latent_budget_requires_attainable_action_dimension() -> None:
+    with pytest.raises(ValueError, match="positive action dimension"):
+        replace(_legal_budget(), trainable_scalars_per_member=103)
+
+
+@pytest.mark.parametrize("value", [_HostileInt(2), 2**31, -1])
+def test_recurrent_latent_budget_rejects_hostile_wide_or_negative_dimensions(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="ensemble_size"):
+        replace(_legal_budget(), ensemble_size=value)  # type: ignore[arg-type]
+
+
+def test_recurrent_latent_budget_canonicalizes_numpy_integer_dimensions() -> None:
+    budget = replace(
+        _legal_budget(),
+        ensemble_size=np.int32(2),
+        observation_dim=np.uint16(2),
+        latent_dim=np.int64(3),
+    )
+    assert type(budget.ensemble_size) is int
+    assert type(budget.observation_dim) is int
+    assert type(budget.latent_dim) is int
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        RecurrentLatentWorldModelEnsembleConfig(
+            ensemble_size=2, observation_dim=2, n_actions=2, latent_dim=3, max_updates=17
+        ),
+        RecurrentLatentWorldModelEnsembleConfig(
+            ensemble_size=3, observation_dim=4, n_actions=2, latent_dim=5, max_updates=31
+        ),
+        RecurrentLatentWorldModelEnsembleConfig(
+            ensemble_size=4, observation_dim=1, n_actions=3, latent_dim=2, max_updates=1
+        ),
+    ],
+)
+def test_recurrent_latent_producer_matches_all_exact_formulas(
+    config: RecurrentLatentWorldModelEnsembleConfig,
+) -> None:
+    budget = RecurrentLatentWorldModelEnsemble(config).resource_budget()
+    assert budget == RecurrentLatentWorldModelResourceBudget(**budget.to_config())


### PR DESCRIPTION
Corrective follow-up to #1199 and closes #1197. Preserves the merged contributor patch while binding direct records to an attainable recurrent architecture and every exact persistent/cache/result/work/lifetime formula. Adds positive, hostile, wide, provenance-mutation, every-derived-field, and multi-architecture producer tests.\n\nVerification: 38 focused tests passed; 4 representative existing construction/accounting/checkpoint/overflow tests passed; Ruff and strict mypy passed. The monolithic existing JAX file was externally killed under concurrent load without an assertion failure. No benchmark or outputs were produced.