### PR TITLE
fix(world-model-ensemble): enforce exact resource identities

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -162,7 +162,7 @@ class LearningSignalEstimatorConfig:
         input_scalars = 2 * self.ensemble_size * self.target_dim + self.target_dim + 1
         if input_scalars > _INT32_MAX:
             raise ValueError(
-                "ensemble_size and target_dim produce an input resource budget above int32"
+                "ensemble_size and target_dim input resource budget must fit signed int32"
             )
         object.__setattr__(
             self,

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -400,6 +400,48 @@ class WorldModelEnsembleResourceBudget:
     max_replay_member_update_count: int
     replay_capacity: int
 
+    def __post_init__(self) -> None:
+        for name in (
+            "ensemble_size",
+            "observation_dim",
+            "target_dim",
+            "member_state_scalars_per_member",
+            "member_state_bytes_per_member",
+            "member_trainable_scalars",
+            "total_trainable_scalars",
+            "persistent_float32_scalars",
+            "persistent_float64_scalars",
+            "persistent_int32_scalars",
+            "persistent_int64_scalars",
+            "persistent_uint32_scalars",
+            "persistent_bool_scalars",
+            "persistent_state_scalars",
+            "persistent_state_bytes",
+            "bootstrap_prng_keys",
+            "bootstrap_prng_uint32_scalars",
+            "bootstrap_prng_bytes",
+            "prediction_output_logical_scalars",
+            "prediction_output_logical_bytes",
+            "update_result_output_logical_scalars",
+            "update_result_output_logical_bytes",
+            "replay_update_result_output_logical_scalars",
+            "replay_update_result_output_logical_bytes",
+            "member_update_candidates_per_valid_event",
+            "max_member_updates_per_event",
+            "replay_member_update_candidates_per_available_sample",
+            "max_replay_member_updates_per_available_sample",
+            "max_event_count",
+            "max_member_update_count",
+            "max_replay_event_count",
+            "max_replay_member_update_count",
+            "replay_capacity",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int(name, getattr(self, name), minimum=0, maximum=_INT32_MAX),
+            )
+
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible exact accounting record."""
         return dataclasses.asdict(self)

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -441,6 +441,112 @@ class WorldModelEnsembleResourceBudget:
                 name,
                 _require_int(name, getattr(self, name), minimum=0, maximum=_INT32_MAX),
             )
+        if self.ensemble_size < 2:
+            raise ValueError("ensemble_size must be at least two")
+        if self.observation_dim < 1:
+            raise ValueError("observation_dim must be positive")
+        if self.member_state_scalars_per_member <= 4 or self.member_trainable_scalars < 1:
+            raise ValueError("member state and trainable scalar counts must be positive")
+        if self.member_trainable_scalars > self.member_state_scalars_per_member - 4:
+            raise ValueError("member_trainable_scalars cannot exceed member state scalars")
+        expected = {
+            "target_dim": self.observation_dim + 2,
+            "member_state_bytes_per_member": 4 * self.member_state_scalars_per_member,
+            "total_trainable_scalars": self.ensemble_size * self.member_trainable_scalars,
+            "persistent_float32_scalars": (
+                self.ensemble_size * (self.member_state_scalars_per_member - 4)
+                + self.ensemble_size * self.target_dim
+                + 5
+            ),
+            "persistent_float64_scalars": 0,
+            "persistent_int32_scalars": 4 * self.ensemble_size + 6,
+            "persistent_int64_scalars": 0,
+            "persistent_uint32_scalars": 2 * self.ensemble_size + 4,
+            "persistent_bool_scalars": 2 * self.ensemble_size,
+            "persistent_state_scalars": (
+                self.ensemble_size * self.member_state_scalars_per_member
+                + self.ensemble_size * self.target_dim
+                + 4 * self.ensemble_size
+                + 15
+            ),
+            "persistent_state_bytes": (
+                self.ensemble_size * self.member_state_bytes_per_member
+                + 4 * self.ensemble_size * self.target_dim
+                + 10 * self.ensemble_size
+                + 60
+            ),
+            "bootstrap_prng_keys": 2,
+            "bootstrap_prng_uint32_scalars": 4,
+            "bootstrap_prng_bytes": 16,
+            "member_update_candidates_per_valid_event": self.ensemble_size,
+            "max_member_updates_per_event": self.ensemble_size,
+            "replay_member_update_candidates_per_available_sample": self.ensemble_size,
+            "max_replay_member_updates_per_available_sample": self.ensemble_size,
+            "max_event_count": _INT32_MAX,
+            "max_member_update_count": _INT32_MAX,
+            "max_replay_event_count": _INT32_MAX,
+            "max_replay_member_update_count": _INT32_MAX,
+            "replay_capacity": 0,
+        }
+        prediction_float_scalars = (
+            2 * self.ensemble_size * self.target_dim
+            + self.ensemble_size * self.observation_dim
+            + 2 * self.target_dim
+            + self.observation_dim
+            + 2 * self.ensemble_size
+            + 3
+        )
+        expected["prediction_output_logical_scalars"] = prediction_float_scalars + 2
+        expected["prediction_output_logical_bytes"] = 4 * prediction_float_scalars + 2
+        update_float_scalars = (
+            prediction_float_scalars
+            + self.target_dim
+            + self.ensemble_size
+            + self.observation_dim
+            + 10
+        )
+        update_bool_scalars = 2 * self.ensemble_size + 20
+        expected["update_result_output_logical_scalars"] = (
+            self.persistent_state_scalars + update_float_scalars + update_bool_scalars
+        )
+        expected["update_result_output_logical_bytes"] = (
+            self.persistent_state_bytes + 4 * update_float_scalars + update_bool_scalars
+        )
+        replay_float_scalars = (
+            prediction_float_scalars + self.target_dim + self.ensemble_size + 1
+        )
+        replay_bool_scalars = 2 * self.ensemble_size + 12
+        expected["replay_update_result_output_logical_scalars"] = (
+            self.persistent_state_scalars + replay_float_scalars + replay_bool_scalars
+        )
+        expected["replay_update_result_output_logical_bytes"] = (
+            self.persistent_state_bytes + 4 * replay_float_scalars + replay_bool_scalars
+        )
+        dtype_scalars = (
+            self.persistent_float32_scalars
+            + self.persistent_float64_scalars
+            + self.persistent_int32_scalars
+            + self.persistent_int64_scalars
+            + self.persistent_uint32_scalars
+            + self.persistent_bool_scalars
+        )
+        if dtype_scalars != self.persistent_state_scalars:
+            raise ValueError(
+                "persistent dtype scalar counts do not sum to persistent_state_scalars"
+            )
+        dtype_bytes = (
+            4 * self.persistent_float32_scalars
+            + 8 * self.persistent_float64_scalars
+            + 4 * self.persistent_int32_scalars
+            + 8 * self.persistent_int64_scalars
+            + 4 * self.persistent_uint32_scalars
+            + self.persistent_bool_scalars
+        )
+        if dtype_bytes != self.persistent_state_bytes:
+            raise ValueError("persistent dtype byte counts do not sum to persistent_state_bytes")
+        for name, value in expected.items():
+            if getattr(self, name) != value:
+                raise ValueError(f"{name} does not match the world-model ensemble implementation")
 
     def to_config(self) -> dict[str, int]:
         """Return a JSON-compatible exact accounting record."""

--- a/tests/test_world_model_ensemble_resource_budget.py
+++ b/tests/test_world_model_ensemble_resource_budget.py
@@ -1,0 +1,68 @@
+"""Leftover-identity gates for world-model-ensemble resource-budget records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from alberta_framework.core.world_model_ensemble import WorldModelEnsembleResourceBudget
+
+
+def _legal_budget() -> WorldModelEnsembleResourceBudget:
+    return WorldModelEnsembleResourceBudget(
+        ensemble_size=2,
+        observation_dim=3,
+        target_dim=4,
+        member_state_scalars_per_member=5,
+        member_state_bytes_per_member=20,
+        member_trainable_scalars=6,
+        total_trainable_scalars=12,
+        persistent_float32_scalars=8,
+        persistent_float64_scalars=0,
+        persistent_int32_scalars=4,
+        persistent_int64_scalars=0,
+        persistent_uint32_scalars=4,
+        persistent_bool_scalars=2,
+        persistent_state_scalars=18,
+        persistent_state_bytes=72,
+        bootstrap_prng_keys=2,
+        bootstrap_prng_uint32_scalars=4,
+        bootstrap_prng_bytes=16,
+        prediction_output_logical_scalars=10,
+        prediction_output_logical_bytes=40,
+        update_result_output_logical_scalars=20,
+        update_result_output_logical_bytes=80,
+        replay_update_result_output_logical_scalars=20,
+        replay_update_result_output_logical_bytes=80,
+        member_update_candidates_per_valid_event=2,
+        max_member_updates_per_event=2,
+        replay_member_update_candidates_per_available_sample=2,
+        max_replay_member_updates_per_available_sample=2,
+        max_event_count=100,
+        max_member_update_count=100,
+        max_replay_event_count=100,
+        max_replay_member_update_count=100,
+        replay_capacity=0,
+    )
+
+
+def test_world_model_ensemble_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="ensemble_size"):
+        replace(_legal_budget(), ensemble_size=True)
+    with pytest.raises(ValueError, match="replay_capacity"):
+        replace(_legal_budget(), replay_capacity=True)
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        replace(_legal_budget(), persistent_state_bytes=float("nan"))
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"ensemble_size": 2' in dumped
+    assert '"replay_capacity": 0' in dumped
+    assert '"persistent_state_bytes": 72' in dumped
+    assert '"ensemble_size": true' not in dumped
+    assert '"replay_capacity": true' not in dumped
+    assert '"persistent_state_bytes": true' not in dumped

--- a/tests/test_world_model_ensemble_resource_budget.py
+++ b/tests/test_world_model_ensemble_resource_budget.py
@@ -13,37 +13,37 @@ from alberta_framework.core.world_model_ensemble import WorldModelEnsembleResour
 def _legal_budget() -> WorldModelEnsembleResourceBudget:
     return WorldModelEnsembleResourceBudget(
         ensemble_size=2,
-        observation_dim=3,
+        observation_dim=2,
         target_dim=4,
-        member_state_scalars_per_member=5,
-        member_state_bytes_per_member=20,
-        member_trainable_scalars=6,
-        total_trainable_scalars=12,
-        persistent_float32_scalars=8,
+        member_state_scalars_per_member=61,
+        member_state_bytes_per_member=244,
+        member_trainable_scalars=20,
+        total_trainable_scalars=40,
+        persistent_float32_scalars=127,
         persistent_float64_scalars=0,
-        persistent_int32_scalars=4,
+        persistent_int32_scalars=14,
         persistent_int64_scalars=0,
-        persistent_uint32_scalars=4,
-        persistent_bool_scalars=2,
-        persistent_state_scalars=18,
-        persistent_state_bytes=72,
+        persistent_uint32_scalars=8,
+        persistent_bool_scalars=4,
+        persistent_state_scalars=153,
+        persistent_state_bytes=600,
         bootstrap_prng_keys=2,
         bootstrap_prng_uint32_scalars=4,
         bootstrap_prng_bytes=16,
-        prediction_output_logical_scalars=10,
-        prediction_output_logical_bytes=40,
-        update_result_output_logical_scalars=20,
-        update_result_output_logical_bytes=80,
-        replay_update_result_output_logical_scalars=20,
-        replay_update_result_output_logical_bytes=80,
+        prediction_output_logical_scalars=39,
+        prediction_output_logical_bytes=150,
+        update_result_output_logical_scalars=232,
+        update_result_output_logical_bytes=844,
+        replay_update_result_output_logical_scalars=213,
+        replay_update_result_output_logical_bytes=792,
         member_update_candidates_per_valid_event=2,
         max_member_updates_per_event=2,
         replay_member_update_candidates_per_available_sample=2,
         max_replay_member_updates_per_available_sample=2,
-        max_event_count=100,
-        max_member_update_count=100,
-        max_replay_event_count=100,
-        max_replay_member_update_count=100,
+        max_event_count=2_147_483_647,
+        max_member_update_count=2_147_483_647,
+        max_replay_event_count=2_147_483_647,
+        max_replay_member_update_count=2_147_483_647,
         replay_capacity=0,
     )
 
@@ -62,7 +62,61 @@ def test_world_model_ensemble_resource_budget_rejects_leftover_identities() -> N
     dumped = json.dumps(legal.to_config(), allow_nan=False)
     assert '"ensemble_size": 2' in dumped
     assert '"replay_capacity": 0' in dumped
-    assert '"persistent_state_bytes": 72' in dumped
+    assert '"persistent_state_bytes": 600' in dumped
     assert '"ensemble_size": true' not in dumped
     assert '"replay_capacity": true' not in dumped
     assert '"persistent_state_bytes": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "ensemble_size",
+        "observation_dim",
+        "target_dim",
+        "member_state_scalars_per_member",
+        "member_state_bytes_per_member",
+        "member_trainable_scalars",
+        "total_trainable_scalars",
+        "persistent_float32_scalars",
+        "persistent_float64_scalars",
+        "persistent_int32_scalars",
+        "persistent_int64_scalars",
+        "persistent_uint32_scalars",
+        "persistent_bool_scalars",
+        "persistent_state_scalars",
+        "persistent_state_bytes",
+        "bootstrap_prng_keys",
+        "bootstrap_prng_uint32_scalars",
+        "bootstrap_prng_bytes",
+        "prediction_output_logical_scalars",
+        "prediction_output_logical_bytes",
+        "update_result_output_logical_scalars",
+        "update_result_output_logical_bytes",
+        "replay_update_result_output_logical_scalars",
+        "replay_update_result_output_logical_bytes",
+        "member_update_candidates_per_valid_event",
+        "max_member_updates_per_event",
+        "replay_member_update_candidates_per_available_sample",
+        "max_replay_member_updates_per_available_sample",
+        "max_event_count",
+        "max_member_update_count",
+        "max_replay_event_count",
+        "max_replay_member_update_count",
+        "replay_capacity",
+    ],
+)
+def test_world_model_ensemble_budget_rejects_false_exact_identity(field: str) -> None:
+    legal = _legal_budget()
+    with pytest.raises(ValueError):
+        replace(legal, **{field: getattr(legal, field) + 1})
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:
+        raise AssertionError("hostile index hook executed")
+
+
+def test_world_model_ensemble_budget_rejects_hostile_integer_without_hook() -> None:
+    with pytest.raises(ValueError, match="ensemble_size"):
+        replace(_legal_budget(), ensemble_size=_HostileInt(2))


### PR DESCRIPTION
Supersedes #1198 while preserving its contributor commit.

- validates all primitive record identities without hostile hooks
- binds architecture, target, per-member trainable/state, dtype-aware persistent, PRNG, output-result, candidate, lifetime, and replay formulas
- replaces the original internally impossible fixture with a measured coherent record
- repairs the adjacent learning-signal overflow diagnostic regression exposed by the broad panel

Verification: full ensemble panel 110 passed after two message-only failures were repaired; focused rerun 37 passed; ruff and mypy passed.