### PR TITLE
fix(seed-validation): bound canonical seed schedules

### DIFF
--- a/alberta_framework/_seed_validation.py
+++ b/alberta_framework/_seed_validation.py
@@ -8,9 +8,10 @@ same random stream while being recorded as different identities.
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, cast
 
 JAX_KEY_SEED_MAX: Final[int] = (1 << 32) - 1
+JAX_SEED_SEQUENCE_MAX_LENGTH: Final[int] = 4_096
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -40,23 +41,43 @@ def require_jax_seed(value: object, *, name: str = "seed") -> int:
 def require_unique_jax_seeds(
     values: object, *, name: str = "seeds"
 ) -> tuple[int, ...]:
-    """Validate a non-empty, ordered sequence of unique canonical JAX seeds."""
+    """Validate one bounded ordered list/tuple of unique canonical JAX seeds."""
 
     _require_exact_str("name", name)
-    if isinstance(values, (str, bytes, bytearray)):
-        raise ValueError(f"{name} must be a non-string sequence")
     if type(values) not in (list, tuple):
-        raise ValueError(f"{name} must be a list or tuple of seeds")
-    raw: tuple[object, ...] = tuple(values)  # type: ignore[arg-type]
-    if not raw:
+        raise ValueError(f"{name} must be an exact list or tuple of seeds")
+    raw = cast(list[object] | tuple[object, ...], values)
+    count = len(raw)
+    if count == 0:
         raise ValueError(f"{name} must be non-empty")
-    seeds = tuple(
-        require_jax_seed(value, name=f"{name}[{index}]")
-        for index, value in enumerate(raw)
-    )
-    if len(set(seeds)) != len(seeds):
-        raise ValueError(f"{name} must contain unique seeds")
-    return seeds
+    if count > JAX_SEED_SEQUENCE_MAX_LENGTH:
+        raise ValueError(
+            f"{name} must contain at most {JAX_SEED_SEQUENCE_MAX_LENGTH} seeds"
+        )
+
+    seen: set[int] = set()
+    checked: list[int] = []
+    for index in range(count):
+        value = raw[index]
+        if type(value) is not int or not 0 <= value <= JAX_KEY_SEED_MAX:
+            raise ValueError(
+                f"{name}[{index}] must be a built-in integer in "
+                f"[0, {JAX_KEY_SEED_MAX}] (the uint32 JAX key domain)"
+            )
+        seed = value
+        if seed in seen:
+            raise ValueError(f"{name} must contain unique seeds")
+        seen.add(seed)
+        checked.append(seed)
+
+    if type(raw) is tuple:
+        return cast(tuple[int, ...], raw)
+    return tuple(checked)
 
 
-__all__ = ["JAX_KEY_SEED_MAX", "require_jax_seed", "require_unique_jax_seeds"]
+__all__ = [
+    "JAX_KEY_SEED_MAX",
+    "JAX_SEED_SEQUENCE_MAX_LENGTH",
+    "require_jax_seed",
+    "require_unique_jax_seeds",
+]

--- a/tests/test_seed_validation_hostile_validation.py
+++ b/tests/test_seed_validation_hostile_validation.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 
+import numpy as np
 import pytest
 
 from alberta_framework._seed_validation import (
     JAX_KEY_SEED_MAX,
+    JAX_SEED_SEQUENCE_MAX_LENGTH,
     require_jax_seed,
     require_unique_jax_seeds,
 )
@@ -53,6 +56,22 @@ def test_require_jax_seed_rejects_hostile_int() -> None:
         require_jax_seed(_HostileInt(0))
 
 
+@pytest.mark.parametrize(
+    "value",
+    [np.int64(0), np.uint32(0), np.bool_(False), 0.0, "0", None, -1, 2**32],
+)
+def test_require_jax_seed_rejects_every_non_builtin_or_out_of_domain_family(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="built-in integer.*uint32"):
+        require_jax_seed(value)
+
+
+def test_require_jax_seed_accepts_exact_uint32_endpoints() -> None:
+    assert require_jax_seed(0) == 0
+    assert require_jax_seed(JAX_KEY_SEED_MAX) == JAX_KEY_SEED_MAX
+
+
 def test_require_jax_seed_rejects_string_subclass_name() -> None:
     with pytest.raises(ValueError, match="exact string"):
         require_jax_seed(0, name=_StringSubclass("seed"))
@@ -71,12 +90,12 @@ def test_require_jax_seed_does_not_invoke_hostile_name_repr() -> None:
 
 
 def test_require_unique_rejects_string_values() -> None:
-    with pytest.raises(ValueError, match="non-string sequence"):
+    with pytest.raises(ValueError, match="exact list or tuple"):
         require_unique_jax_seeds("abc")
 
 
 def test_require_unique_rejects_string_subclass_values() -> None:
-    with pytest.raises(ValueError, match="non-string sequence"):
+    with pytest.raises(ValueError, match="exact list or tuple"):
         require_unique_jax_seeds(_StringSubclass("abc"))
 
 
@@ -105,7 +124,7 @@ def test_require_unique_rejects_bytes_subclass() -> None:
     class BytesSubclass(bytes):
         pass
 
-    with pytest.raises(ValueError, match="non-string sequence"):
+    with pytest.raises(ValueError, match="exact list or tuple"):
         require_unique_jax_seeds(BytesSubclass(b"ab"))
 
 
@@ -138,3 +157,43 @@ def test_require_unique_rejects_hostile_int_element() -> None:
     _HostileInt(1)  # ensure class works
     with pytest.raises(ValueError, match="built-in integer"):
         require_unique_jax_seeds([0, _HostileInt(1)])
+
+
+def test_require_unique_preserves_order_and_canonical_tuple_identity() -> None:
+    raw = (JAX_KEY_SEED_MAX, 0, 17)
+    result = require_unique_jax_seeds(raw)
+    assert result is raw
+    assert result == (JAX_KEY_SEED_MAX, 0, 17)
+
+
+def test_require_unique_canonicalizes_exact_list_without_mutating_it() -> None:
+    raw = [7, 3, 11]
+    result = require_unique_jax_seeds(raw)
+    assert raw == [7, 3, 11]
+    assert result == (7, 3, 11)
+    assert all(type(seed) is int for seed in result)
+
+
+def test_require_unique_json_roundtrip_preserves_seed_identities() -> None:
+    seeds = require_unique_jax_seeds([0, 17, JAX_KEY_SEED_MAX])
+    encoded = json.dumps(seeds, allow_nan=False)
+    assert json.loads(encoded) == [0, 17, JAX_KEY_SEED_MAX]
+
+
+def test_require_unique_rejects_oversized_exact_list_before_reading_elements() -> None:
+    values: list[object] = [_HostileInt(0)] * (JAX_SEED_SEQUENCE_MAX_LENGTH + 1)
+    with pytest.raises(ValueError, match="at most 4096"):
+        require_unique_jax_seeds(values)
+
+
+def test_require_unique_accepts_exact_ceiling_without_sorting() -> None:
+    values = list(range(JAX_SEED_SEQUENCE_MAX_LENGTH - 1, -1, -1))
+    result = require_unique_jax_seeds(values)
+    assert len(result) == JAX_SEED_SEQUENCE_MAX_LENGTH
+    assert result[0] == JAX_SEED_SEQUENCE_MAX_LENGTH - 1
+    assert result[-1] == 0
+
+
+def test_require_unique_rejects_first_duplicate_without_touching_later_hostile() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        require_unique_jax_seeds([5, 5, _HostileInt(1)])


### PR DESCRIPTION
Corrective follow-up to #1201. Preserves the merged contributor trust-boundary gates while removing unbounded pre-validation copying and repeated full passes. Requires exact list/tuple containers, caps schedules at the project-standard 4,096 seeds before element access, validates scalar/domain/duplicates in one indexed pass, preserves order and exact tuples, and verifies canonical JSON identity.\n\nVerification: 30 focused hostile/boundary tests and 276 seed-facing compatibility tests passed; Ruff and strict mypy passed. No benchmark or outputs were produced.