### PR TITLE
fix(strict-json): bound adversarial payload validation

### DIFF
--- a/alberta_framework/_strict_json.py
+++ b/alberta_framework/_strict_json.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 
+def _require_path(value: object, *, name: str = "path") -> Path:
+    if type(value) is str:
+        return Path(value)
+    if isinstance(value, Path) and type(value).__module__.startswith("pathlib"):
+        return Path(value)
+    raise ValueError(f"{name} must be an exact str or Path")
+
+
 def _reject_nonstandard_constant(value: str) -> NoReturn:
     raise ValueError(f"non-standard JSON numeric constant: {value}")
 
@@ -25,7 +33,7 @@ def _reject_duplicate_object_keys(
     parsed: dict[str, Any] = {}
     for key, value in pairs:
         if key in parsed:
-            raise ValueError(f"duplicate JSON object key: {key!r}")
+            raise ValueError(f"duplicate JSON object key: {key}")
         parsed[key] = value
     return parsed
 
@@ -33,7 +41,7 @@ def _reject_duplicate_object_keys(
 def load_strict_json_object(path: Path | str) -> dict[str, Any]:
     """Load one finite UTF-8 JSON object, rejecting duplicate keys at every depth."""
 
-    resolved = Path(path)
+    resolved = _require_path(path, name="path")
     parsed = json.loads(
         resolved.read_text(encoding="utf-8"),
         parse_constant=_reject_nonstandard_constant,

--- a/alberta_framework/_strict_json.py
+++ b/alberta_framework/_strict_json.py
@@ -7,47 +7,128 @@ import math
 from pathlib import Path
 from typing import Any, NoReturn
 
+_CONCRETE_PATH_TYPE = type(Path())
+_MAX_JSON_BYTES = 16 * 1024 * 1024
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_VALUES = 1_000_000
+
 
 def _require_path(value: object, *, name: str = "path") -> Path:
     if type(value) is str:
         return Path(value)
-    if isinstance(value, Path) and type(value).__module__.startswith("pathlib"):
+    if type(value) is _CONCRETE_PATH_TYPE:
         return Path(value)
     raise ValueError(f"{name} must be an exact str or Path")
 
 
 def _reject_nonstandard_constant(value: str) -> NoReturn:
-    raise ValueError(f"non-standard JSON numeric constant: {value}")
+    if type(value) is not str:
+        raise ValueError("non-standard JSON numeric constant must be an exact string")
+    raise ValueError("non-standard JSON numeric constant is forbidden")
 
 
 def _parse_finite_float(value: str) -> float:
+    if type(value) is not str:
+        raise ValueError("JSON float token must be an exact string")
     parsed = float(value)
     if not math.isfinite(parsed):
-        raise ValueError(f"non-finite JSON number is forbidden: {value}")
+        raise ValueError("non-finite JSON number is forbidden")
     return parsed
 
 
 def _reject_duplicate_object_keys(
     pairs: list[tuple[str, Any]],
 ) -> dict[str, Any]:
+    if type(pairs) is not list:
+        raise ValueError("JSON object pairs must be an exact list")
     parsed: dict[str, Any] = {}
-    for key, value in pairs:
+    for pair in pairs:
+        if type(pair) is not tuple or len(pair) != 2:
+            raise ValueError("JSON object entries must be exact key-value pairs")
+        key, value = pair
+        if type(key) is not str:
+            raise ValueError("JSON object keys must be exact strings")
         if key in parsed:
-            raise ValueError(f"duplicate JSON object key: {key}")
+            raise ValueError("duplicate JSON object key")
         parsed[key] = value
     return parsed
+
+
+def _decode_bounded_utf8_json(path: Path) -> str:
+    try:
+        with path.open("rb") as stream:
+            raw = stream.read(_MAX_JSON_BYTES + 1)
+    except OSError:
+        raise
+    if len(raw) > _MAX_JSON_BYTES:
+        raise ValueError("JSON payload exceeds the byte limit")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ValueError("JSON payload must be valid UTF-8") from error
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_JSON_DEPTH:
+                raise ValueError("JSON payload exceeds the nesting-depth limit")
+        elif character in "]}":
+            depth -= 1
+    return text
+
+
+def _validate_exact_json_tree(root: object) -> None:
+    stack: list[tuple[object, int]] = [(root, 1)]
+    values_seen = 0
+    while stack:
+        value, depth = stack.pop()
+        values_seen += 1
+        if values_seen > _MAX_JSON_VALUES:
+            raise ValueError("JSON payload exceeds the value-count limit")
+        if depth > _MAX_JSON_DEPTH:
+            raise ValueError("JSON payload exceeds the nesting-depth limit")
+        if type(value) is dict:
+            for key, child in value.items():
+                if type(key) is not str:
+                    raise ValueError("JSON object keys must be exact strings")
+                stack.append((child, depth + 1))
+        elif type(value) is list:
+            stack.extend((child, depth + 1) for child in value)
+        elif type(value) is float:
+            if not math.isfinite(value):
+                raise ValueError("non-finite JSON number is forbidden")
+        elif type(value) not in (str, int, bool, type(None)):
+            raise ValueError("JSON payload contains a non-JSON value")
 
 
 def load_strict_json_object(path: Path | str) -> dict[str, Any]:
     """Load one finite UTF-8 JSON object, rejecting duplicate keys at every depth."""
 
     resolved = _require_path(path, name="path")
-    parsed = json.loads(
-        resolved.read_text(encoding="utf-8"),
-        parse_constant=_reject_nonstandard_constant,
-        parse_float=_parse_finite_float,
-        object_pairs_hook=_reject_duplicate_object_keys,
-    )
-    if not isinstance(parsed, dict):
+    text = _decode_bounded_utf8_json(resolved)
+    try:
+        parsed = json.loads(
+            text,
+            parse_constant=_reject_nonstandard_constant,
+            parse_float=_parse_finite_float,
+            object_pairs_hook=_reject_duplicate_object_keys,
+        )
+    except RecursionError as error:
+        raise ValueError("JSON payload exceeds the parser recursion limit") from error
+    _validate_exact_json_tree(parsed)
+    if type(parsed) is not dict:
         raise ValueError(f"{resolved}: payload must contain one JSON object")
     return parsed

--- a/tests/test_strict_json_hostile_validation.py
+++ b/tests/test_strict_json_hostile_validation.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from alberta_framework._strict_json import _reject_duplicate_object_keys, load_strict_json_object
+import alberta_framework._strict_json as strict_json
+from alberta_framework._strict_json import (
+    _reject_duplicate_object_keys,
+    _validate_exact_json_tree,
+    load_strict_json_object,
+)
 
 
 class _StringSubclass(str):
@@ -66,15 +71,17 @@ def test_reject_duplicate_does_not_invoke_repr() -> None:
         def __repr__(self) -> str:  # pragma: no cover
             raise RuntimeError("repr hook")
 
+        def __hash__(self) -> int:  # pragma: no cover
+            raise RuntimeError("hash hook")
+
     evil = EvilStr("dup")
-    with pytest.raises(ValueError, match="duplicate JSON object key"):
+    with pytest.raises(ValueError, match="exact strings"):
         _reject_duplicate_object_keys([(evil, 1), (evil, 2)])
 
 
 def test_reject_duplicate_rejects_string_subclass_key() -> None:
     key = _StringSubclass("dup")
-    # JSON loads produces plain str, direct call with subclass still duplicate
-    with pytest.raises(ValueError, match="duplicate JSON object key"):
+    with pytest.raises(ValueError, match="exact strings"):
         _reject_duplicate_object_keys([(key, 1), (key, 2)])
 
 
@@ -107,3 +114,41 @@ def test_hostile_path_not_invoke_fspath_on_error() -> None:
 def test_load_rejects_bytes_path() -> None:
     with pytest.raises(ValueError, match="exact str or Path"):
         load_strict_json_object(b"/tmp/x.json")  # type: ignore[arg-type]
+
+
+def test_load_rejects_excessive_depth_before_parser_recursion(tmp_path: Path) -> None:
+    path = tmp_path / "deep.json"
+    path.write_text('{"x":' * 65 + "0" + "}" * 65, encoding="utf-8")
+    with pytest.raises(ValueError, match="nesting-depth"):
+        load_strict_json_object(path)
+
+
+def test_load_rejects_oversized_payload_with_bounded_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(strict_json, "_MAX_JSON_BYTES", 16)
+    path = tmp_path / "large.json"
+    path.write_bytes(b'{"value":"' + b"x" * 32 + b'"}')
+    with pytest.raises(ValueError, match="byte limit"):
+        load_strict_json_object(path)
+
+
+def test_exact_tree_validator_rejects_non_json_containers_and_values() -> None:
+    with pytest.raises(ValueError, match="non-JSON value"):
+        _validate_exact_json_tree({"value": (1, 2)})
+    with pytest.raises(ValueError, match="exact strings"):
+        _validate_exact_json_tree({_StringSubclass("key"): 1})
+    with pytest.raises(ValueError, match="non-finite"):
+        _validate_exact_json_tree({"value": float("inf")})
+
+
+def test_duplicate_hook_rejects_non_string_key_before_hostile_hooks() -> None:
+    class HostileKey:
+        def __hash__(self) -> int:
+            raise AssertionError("hash hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("repr hook executed")
+
+    with pytest.raises(ValueError, match="exact strings"):
+        _reject_duplicate_object_keys([(HostileKey(), 1)])  # type: ignore[list-item]

--- a/tests/test_strict_json_hostile_validation.py
+++ b/tests/test_strict_json_hostile_validation.py
@@ -1,0 +1,109 @@
+"""Hostile-safe validation for strict JSON loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from alberta_framework._strict_json import _reject_duplicate_object_keys, load_strict_json_object
+
+
+class _StringSubclass(str):
+    pass
+
+
+class _HostilePath(Path):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("str hook")
+
+    def __fspath__(self) -> str:  # pragma: no cover
+        raise AssertionError("fspath hook")
+
+
+def test_load_rejects_string_subclass_path(tmp_path: Path) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"a": 1}), encoding="utf-8")
+    with pytest.raises(ValueError, match="exact str or Path"):
+        load_strict_json_object(_StringSubclass(str(good)))
+
+
+def test_load_rejects_hostile_path() -> None:
+    hostile = object.__new__(_HostilePath)
+    with pytest.raises(ValueError, match="exact str or Path"):
+        load_strict_json_object(hostile)
+
+
+def test_load_rejects_hostile_path_via_str_subclass() -> None:
+    with pytest.raises(ValueError, match="exact str or Path"):
+        load_strict_json_object(_StringSubclass("/tmp/x.json"))
+
+
+def test_load_with_exact_str_path(tmp_path: Path) -> None:
+    payload = {"a": 1, "b": 2}
+    path = tmp_path / "ok.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert load_strict_json_object(str(path)) == payload
+
+
+def test_load_with_posix_path(tmp_path: Path) -> None:
+    payload = {"a": 1}
+    path = tmp_path / "ok2.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert load_strict_json_object(path) == payload
+
+
+def test_load_rejects_non_object_payload(tmp_path: Path) -> None:
+    path = tmp_path / "arr.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError, match="payload must contain one JSON object"):
+        load_strict_json_object(path)
+
+
+def test_reject_duplicate_does_not_invoke_repr() -> None:
+    class EvilStr(str):
+        def __repr__(self) -> str:  # pragma: no cover
+            raise RuntimeError("repr hook")
+
+    evil = EvilStr("dup")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        _reject_duplicate_object_keys([(evil, 1), (evil, 2)])
+
+
+def test_reject_duplicate_rejects_string_subclass_key() -> None:
+    key = _StringSubclass("dup")
+    # JSON loads produces plain str, direct call with subclass still duplicate
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        _reject_duplicate_object_keys([(key, 1), (key, 2)])
+
+
+def test_load_rejects_duplicate_keys_in_file(tmp_path: Path) -> None:
+    path = tmp_path / "dup.json"
+    # duplicate key "a" at object level
+    path.write_text('{"a": 1, "a": 2}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_strict_json_object(path)
+
+
+def test_load_rejects_nonfinite_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"a": NaN}', encoding="utf-8")
+    with pytest.raises(ValueError, match="non-standard JSON numeric constant"):
+        load_strict_json_object(path)
+
+
+def test_hostile_path_not_invoke_fspath_on_error() -> None:
+    hostile = object.__new__(_HostilePath)
+    try:
+        load_strict_json_object(hostile)
+    except ValueError as exc:
+        assert "exact str or Path" in str(exc)
+        # ensure hook not invoked — would have raised AssertionError
+    else:
+        raise AssertionError("should have raised")
+
+
+def test_load_rejects_bytes_path() -> None:
+    with pytest.raises(ValueError, match="exact str or Path"):
+        load_strict_json_object(b"/tmp/x.json")  # type: ignore[arg-type]


### PR DESCRIPTION
Supersedes #1204 while preserving its contributor commit.

- accepts only exact trusted path types before filesystem access
- bounds input reads to 16 MiB, nesting to 64, and decoded values to 1,000,000
- validates strict UTF-8 and exact JSON containers/primitives with finite floats
- rejects non-string/duplicate keys and hostile subclasses before hash/equality/repr/conversion hooks
- converts parser recursion failures to the stable validation boundary

Verification: 61 strict-JSON and consumer compatibility tests passed; ruff and mypy passed.