### PR TITLE
fix(fixed-count): make selection boundary total

### DIFF
--- a/alberta_framework/_fixed_count_selection.py
+++ b/alberta_framework/_fixed_count_selection.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Final
+
+import jax
 import jax.numpy as jnp
 from jax import Array
+
+_INT32_MAX: Final[int] = (1 << 31) - 1
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -13,11 +18,13 @@ def _require_exact_str(name: str, value: object) -> str:
 
 
 def require_positive_builtin_int(value: object, *, name: str) -> int:
-    """Return an exact built-in positive integer or fail before JAX tracing."""
+    """Return an exact positive built-in integer in the JAX int32 domain."""
 
     _require_exact_str("name", name)
-    if type(value) is not int or value < 1:
-        raise ValueError(f"{name} must be a positive built-in integer")
+    if type(value) is not int or not 1 <= value <= _INT32_MAX:
+        raise ValueError(
+            f"{name} must be a positive built-in integer at most int32 max ({_INT32_MAX})"
+        )
     return value
 
 
@@ -31,7 +38,19 @@ def stable_smallest_mask(scores: Array, count: int) -> Array:
     public stream constructors impose their stricter positive-count contract.
     """
 
-    if type(count) is not int or not 0 <= count <= scores.shape[-1]:
+    if type(count) is not int or count < 0:
+        raise ValueError("count must be a built-in integer within the candidate axis")
+    score_type = type(scores)
+    if not (
+        issubclass(score_type, jax.Array)
+        or issubclass(score_type, jax.core.Tracer)
+    ):
+        raise ValueError("scores must be a JAX array")
+    if scores.ndim < 1:
+        raise ValueError("scores must have a candidate axis")
+    if not jnp.issubdtype(scores.dtype, jnp.floating):
+        raise ValueError("scores must have a floating dtype")
+    if count > scores.shape[-1]:
         raise ValueError("count must be a built-in integer within the candidate axis")
     finite_scores = jnp.where(jnp.isfinite(scores), scores, jnp.inf)
     order = jnp.argsort(finite_scores, axis=-1, stable=True)

--- a/tests/test_fixed_count_selection_hostile_validation.py
+++ b/tests/test_fixed_count_selection_hostile_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework._fixed_count_selection import (
@@ -63,6 +64,16 @@ def test_require_positive_valid() -> None:
     assert require_positive_builtin_int(3, name="n") == 3
 
 
+@pytest.mark.parametrize("value", [np.int64(1), np.uint32(1), 1.0, "1", 2**31])
+def test_require_positive_rejects_nonbuiltin_or_out_of_int32_values(value: object) -> None:
+    with pytest.raises(ValueError, match="positive built-in integer"):
+        require_positive_builtin_int(value, name="n")
+
+
+def test_require_positive_accepts_exact_int32_endpoint() -> None:
+    assert require_positive_builtin_int(2**31 - 1, name="n") == 2**31 - 1
+
+
 def test_stable_smallest_rejects_bool_count() -> None:
     scores = jnp.array([[0.1, 0.2, 0.3]])
     with pytest.raises(ValueError, match="built-in integer"):
@@ -107,3 +118,40 @@ def test_stable_smallest_does_not_invoke_hostile_name_repr_via_require() -> None
 
     with pytest.raises(ValueError, match="exact string"):
         require_positive_builtin_int(1, name=EvilStr("count"))
+
+
+def test_stable_smallest_rejects_hostile_scores_before_attribute_access() -> None:
+    class HostileScores:
+        def __getattribute__(self, name: str) -> object:  # pragma: no cover
+            raise AssertionError(f"attribute hook executed: {name}")
+
+    with pytest.raises(ValueError, match="JAX array"):
+        stable_smallest_mask(HostileScores(), 0)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "scores",
+    [
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.asarray([1, 2], dtype=jnp.int32),
+        jnp.asarray([True, False], dtype=jnp.bool_),
+        jnp.asarray([1.0 + 1.0j], dtype=jnp.complex64),
+    ],
+)
+def test_stable_smallest_rejects_missing_axis_or_nonfloating_scores(scores: object) -> None:
+    with pytest.raises(ValueError, match="candidate axis|floating dtype"):
+        stable_smallest_mask(scores, 0)  # type: ignore[arg-type]
+
+
+def test_stable_smallest_output_formula_is_exact_across_leading_axes() -> None:
+    scores = jnp.asarray(
+        [
+            [[0.3, 0.1, 0.2], [0.5, 0.4, 0.6]],
+            [[0.0, -1.0, 2.0], [3.0, 1.0, 2.0]],
+        ],
+        dtype=jnp.float32,
+    )
+    mask = stable_smallest_mask(scores, 2)
+    assert mask.shape == scores.shape
+    assert mask.dtype == jnp.bool_
+    assert bool(jnp.all(jnp.sum(mask, axis=-1) == 2))


### PR DESCRIPTION
Corrective follow-up to #1205. Preserves the merged contributor name/identity gates while bounding positive host counts to int32 and making the score boundary total: count identity is checked first, hostile/non-JAX values are rejected before attribute access, rank and floating dtype are explicit, and the candidate-axis bound remains exact under eager/JIT.\n\nVerification: 32 focused tests and 11 representative stream/micro compatibility tests passed; an additional combined caller run passed 162+ tests before an external concurrent-JAX kill with no assertion failure. Ruff and strict mypy passed. No benchmark or outputs were produced.