### PR TITLE
fix(timing): validate monotonic telemetry samples

### DIFF
--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -21,12 +21,63 @@ print(f"Took {t.duration:.2f} seconds")
 ```
 """
 
+import math
 import time
 from collections.abc import Callable
+from fractions import Fraction
 from types import TracebackType
 
+import numpy as np
 
-def format_duration(seconds: float) -> str:
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
+_ACTUAL_FLOAT_TYPES = frozenset(
+    {
+        float,
+        Fraction,
+        np.dtype("e").type,
+        np.dtype("f").type,
+        np.dtype("d").type,
+        np.dtype("g").type,
+    }
+)
+_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+
+
+def _require_exact_str(name: str, value: object) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{name} must be an exact string")
+    return value
+
+
+def _require_finite_real(name: str, value: object) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite real number, not a boolean")
+    if type(value) not in _ALLOWED_REAL_TYPES:
+        raise ValueError(f"{name} must be a finite real number")
+    try:
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    return number
+
+
+def format_duration(seconds: object) -> str:
     """Format a duration in seconds as a human-readable string.
 
     Args:
@@ -43,7 +94,10 @@ def format_duration(seconds: float) -> str:
     format_duration(3665)  # Returns: '1h 1m 5.00s'
     ```
     """
-    rounded_seconds = round(seconds, 2)
+    sec = _require_finite_real("seconds", seconds)
+    if sec < 0:
+        raise ValueError("seconds must be a finite real number")
+    rounded_seconds = round(sec, 2)
     if rounded_seconds < 60:
         return f"{rounded_seconds:.2f}s"
     elif rounded_seconds < 3600:
@@ -93,8 +147,8 @@ class Timer:
 
     def __init__(
         self,
-        name: str = "Operation",
-        verbose: bool = True,
+        name: object = "Operation",
+        verbose: object = True,
         print_fn: Callable[[str], None] | None = None,
     ):
         """Initialize the timer.
@@ -104,6 +158,11 @@ class Timer:
             verbose: Whether to print the duration when done
             print_fn: Custom print function (defaults to built-in print)
         """
+        _require_exact_str("name", name)
+        if type(verbose) is not bool:
+            raise ValueError("verbose must be a built-in bool")
+        if print_fn is not None and not callable(print_fn):
+            raise ValueError("print_fn must be callable")
         self.name = name
         self.verbose = verbose
         self.print_fn = print_fn or print
@@ -144,5 +203,5 @@ class Timer:
     def __repr__(self) -> str:
         """Return string representation."""
         if self.duration > 0:
-            return f"Timer(name={self.name!r}, duration={self.duration:.2f}s)"
-        return f"Timer(name={self.name!r})"
+            return f"Timer(name={self.name}, duration={self.duration:.2f}s)"
+        return f"Timer(name={self.name})"

--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -55,6 +55,8 @@ _ACTUAL_FLOAT_TYPES = frozenset(
     }
 )
 _ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+_MAX_DURATION_SECONDS = 1.0e12
+_MAX_TIMER_SAMPLES = 2_147_483_647
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -70,11 +72,18 @@ def _require_finite_real(name: str, value: object) -> float:
         raise ValueError(f"{name} must be a finite real number")
     try:
         number = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a finite real number") from exc
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number
+
+
+def _read_perf_counter() -> float:
+    sample = time.perf_counter()
+    if type(sample) is not float or not math.isfinite(sample) or sample < 0.0:
+        raise ValueError("perf_counter must return a non-negative finite built-in float")
+    return sample
 
 
 def format_duration(seconds: object) -> str:
@@ -97,6 +106,8 @@ def format_duration(seconds: object) -> str:
     sec = _require_finite_real("seconds", seconds)
     if sec < 0:
         raise ValueError("seconds must be a finite real number")
+    if sec > _MAX_DURATION_SECONDS:
+        raise ValueError("seconds exceeds the telemetry formatting bound")
     rounded_seconds = round(sec, 2)
     if rounded_seconds < 60:
         return f"{rounded_seconds:.2f}s"
@@ -115,8 +126,9 @@ def format_duration(seconds: object) -> str:
 class Timer:
     """Context manager for timing code execution.
 
-    Measures wall-clock time for a block of code and optionally prints
-    the duration when the block completes.
+    Measures monotonic process-local telemetry for a block and optionally
+    prints it. Timing is telemetry-only: this utility does not qualify timing
+    protocols or create performance/scientific evidence.
 
     Attributes:
         name: Description of what is being timed
@@ -158,21 +170,49 @@ class Timer:
             verbose: Whether to print the duration when done
             print_fn: Custom print function (defaults to built-in print)
         """
-        _require_exact_str("name", name)
+        validated_name = _require_exact_str("name", name)
         if type(verbose) is not bool:
             raise ValueError("verbose must be a built-in bool")
         if print_fn is not None and not callable(print_fn):
             raise ValueError("print_fn must be callable")
-        self.name = name
-        self.verbose = verbose
-        self.print_fn = print_fn or print
+        self.name: str = validated_name
+        self.verbose: bool = verbose
+        self.print_fn = print if print_fn is None else print_fn
         self.start_time: float = 0.0
         self.end_time: float = 0.0
         self.duration: float = 0.0
+        self._last_sample: float = 0.0
+        self._sample_count: int = 0
+        self._active: bool = False
+
+    def _validate_static_contract(self) -> None:
+        _require_exact_str("name", self.name)
+        if type(self.verbose) is not bool:
+            raise ValueError("verbose must be a built-in bool")
+        if not callable(self.print_fn):
+            raise ValueError("print_fn must be callable")
+
+    def _record_sample(self) -> float:
+        if type(self._sample_count) is not int or not 0 <= self._sample_count < _MAX_TIMER_SAMPLES:
+            raise ValueError("timer sample count is outside the signed-int32 bound")
+        sample = _read_perf_counter()
+        if sample < self._last_sample:
+            raise ValueError("perf_counter samples must be monotonic")
+        self._last_sample = sample
+        self._sample_count += 1
+        return sample
 
     def __enter__(self) -> "Timer":
         """Start the timer."""
-        self.start_time = time.perf_counter()
+        self._validate_static_contract()
+        if self._active:
+            raise RuntimeError("Timer cannot be entered while already active")
+        self._last_sample = 0.0
+        self._sample_count = 0
+        self.start_time = self._record_sample()
+        self.end_time = 0.0
+        self.duration = 0.0
+        self._active = True
         return self
 
     def __exit__(
@@ -182,8 +222,18 @@ class Timer:
         exc_tb: TracebackType | None,
     ) -> None:
         """Stop the timer and report completion or failure, never both."""
-        self.end_time = time.perf_counter()
-        self.duration = self.end_time - self.start_time
+        self._validate_static_contract()
+        if not self._active:
+            raise RuntimeError("Timer cannot exit before it is entered")
+        try:
+            end_time = self._record_sample()
+            duration = end_time - self.start_time
+            if not math.isfinite(duration) or not 0.0 <= duration <= _MAX_DURATION_SECONDS:
+                raise ValueError("timer duration is outside the finite telemetry bound")
+            self.end_time = end_time
+            self.duration = duration
+        finally:
+            self._active = False
 
         if self.verbose:
             formatted = format_duration(self.duration)
@@ -198,10 +248,23 @@ class Timer:
         Returns:
             Elapsed time in seconds
         """
-        return time.perf_counter() - self.start_time
+        self._validate_static_contract()
+        if not self._active:
+            raise RuntimeError("elapsed requires an active Timer")
+        start_time = _require_finite_real("start_time", self.start_time)
+        if start_time < 0.0:
+            raise ValueError("start_time must be non-negative")
+        elapsed = self._record_sample() - start_time
+        if not 0.0 <= elapsed <= _MAX_DURATION_SECONDS:
+            raise ValueError("elapsed timing is outside the finite telemetry bound")
+        return elapsed
 
     def __repr__(self) -> str:
         """Return string representation."""
-        if self.duration > 0:
-            return f"Timer(name={self.name}, duration={self.duration:.2f}s)"
-        return f"Timer(name={self.name})"
+        self._validate_static_contract()
+        duration = _require_finite_real("duration", self.duration)
+        if not 0.0 <= duration <= _MAX_DURATION_SECONDS:
+            raise ValueError("duration is outside the finite telemetry bound")
+        if duration > 0:
+            return f"Timer(name={self.name!r}, duration={duration:.2f}s)"
+        return f"Timer(name={self.name!r})"

--- a/tests/test_timing_hostile_validation.py
+++ b/tests/test_timing_hostile_validation.py
@@ -7,6 +7,7 @@ from fractions import Fraction
 import numpy as np
 import pytest
 
+import alberta_framework.utils.timing as timing
 from alberta_framework.utils.timing import Timer, format_duration
 
 
@@ -55,6 +56,10 @@ def test_format_rejects_nonfinite() -> None:
 def test_format_rejects_negative() -> None:
     with pytest.raises(ValueError, match="finite real number"):
         format_duration(-1.0)
+    with pytest.raises(ValueError, match="formatting bound"):
+        format_duration(1.0e13)
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(Fraction(10**10_000, 1))
 
 
 def test_format_valid_cases() -> None:
@@ -122,3 +127,68 @@ def test_format_rejects_hostile_int() -> None:
 
     with pytest.raises(ValueError, match="finite real number"):
         format_duration(HostileInt(1))
+
+
+def test_timer_rejects_nonfinite_and_hostile_clock_samples_without_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: float("nan"))
+    with pytest.raises(ValueError, match="perf_counter"):
+        Timer(verbose=False).__enter__()
+
+    _HostileFloat.calls = 0
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: _HostileFloat(1.0))
+    with pytest.raises(ValueError, match="perf_counter"):
+        Timer(verbose=False).__enter__()
+    assert _HostileFloat.calls == 0
+
+
+def test_timer_rejects_decreasing_clock_and_closes_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    samples = iter([10.0, 11.0, 10.5])
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: next(samples))
+    timer = Timer(verbose=False)
+    timer.__enter__()
+    assert timer.elapsed() == 1.0
+    with pytest.raises(ValueError, match="monotonic"):
+        timer.__exit__(None, None, None)
+    with pytest.raises(RuntimeError, match="active"):
+        timer.elapsed()
+
+
+def test_timer_rejects_reentry_and_sample_counter_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: 1.0)
+    timer = Timer(verbose=False)
+    timer.__enter__()
+    with pytest.raises(RuntimeError, match="already active"):
+        timer.__enter__()
+    timer._sample_count = 2_147_483_647
+    with pytest.raises(ValueError, match="sample count"):
+        timer.elapsed()
+
+
+def test_timer_does_not_probe_falsey_callback_truthiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages: list[str] = []
+
+    class Callback:
+        def __bool__(self) -> bool:
+            raise AssertionError("truthiness hook executed")
+
+        def __call__(self, message: str) -> None:
+            messages.append(message)
+
+    samples = iter([1.0, 2.0])
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: next(samples))
+    with Timer("op", print_fn=Callback()):
+        pass
+    assert messages == ["op completed in 1.00s"]
+
+
+def test_timer_declares_telemetry_only_semantics() -> None:
+    assert "telemetry-only" in (Timer.__doc__ or "")
+    assert "scientific evidence" in (Timer.__doc__ or "")

--- a/tests/test_timing_hostile_validation.py
+++ b/tests/test_timing_hostile_validation.py
@@ -1,0 +1,124 @@
+"""Hostile-safe validation for timing utilities."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from alberta_framework.utils.timing import Timer, format_duration
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def as_integer_ratio(self) -> tuple[int, int]:
+        type(self).calls += 1
+        raise RuntimeError("ratio hook")
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise RuntimeError("float hook")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_format_rejects_bool() -> None:
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(True)
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(np.bool_(True))
+
+
+def test_format_rejects_hostile_float_without_hook() -> None:
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(_HostileFloat(1.0))
+    assert _HostileFloat.calls == 0
+
+
+def test_format_rejects_string_subclass() -> None:
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(_StringSubclass("1.0"))
+
+
+def test_format_rejects_nonfinite() -> None:
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(float("nan"))
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(float("inf"))
+
+
+def test_format_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(-1.0)
+
+
+def test_format_valid_cases() -> None:
+    assert format_duration(0.5) == "0.50s"
+    assert format_duration(90.5) == "1m 30.50s"
+    assert format_duration(3665) == "1h 1m 5.00s"
+    assert format_duration(Fraction(1, 2)) == "0.50s"
+    assert format_duration(np.float64(1.0)) == "1.00s"
+
+
+def test_timer_rejects_string_subclass_name() -> None:
+    with pytest.raises(ValueError, match="exact string"):
+        Timer(name=_StringSubclass("op"))
+
+
+def test_timer_does_not_invoke_hostile_name_repr() -> None:
+    class EvilStr(str):
+        def __repr__(self) -> str:  # pragma: no cover
+            raise RuntimeError("repr hook")
+
+        def __str__(self) -> str:  # pragma: no cover
+            raise RuntimeError("str hook")
+
+    with pytest.raises(ValueError, match="exact string"):
+        Timer(name=EvilStr("op"))
+
+
+def test_timer_rejects_verbose_not_bool() -> None:
+    with pytest.raises(ValueError, match="built-in bool"):
+        Timer(name="op", verbose=1)
+    with pytest.raises(ValueError, match="built-in bool"):
+        Timer(name="op", verbose=_StringSubclass("true"))
+
+
+def test_timer_repr_does_not_invoke_hostile_repr() -> None:
+    class EvilStr(str):
+        def __repr__(self) -> str:  # pragma: no cover
+            raise RuntimeError("repr hook")
+
+    evil = EvilStr("op")
+    # Timer should reject EvilStr at construction, so repr not needed
+    with pytest.raises(ValueError, match="exact string"):
+        Timer(name=evil)
+    # Valid timer repr should not use !r
+    t = Timer(name="good")
+    t.duration = 1.23
+    r = repr(t)
+    assert "good" in r
+    assert "duration" in r
+
+
+def test_timer_valid() -> None:
+    t = Timer(name="ok", verbose=False)
+    assert t.name == "ok"
+    assert t.verbose is False
+    with t:
+        pass
+    assert t.duration >= 0
+
+
+def test_format_rejects_hostile_int() -> None:
+    class HostileInt(int):
+        def __repr__(self) -> str:  # pragma: no cover
+            raise AssertionError("repr hook")
+
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(HostileInt(1))


### PR DESCRIPTION
Supersedes #1209 while preserving its contributor commit.

- validates exact hostile-safe names, flags, callbacks, and duration inputs
- accepts only built-in finite nonnegative perf-counter floats
- enforces monotonic samples, active/reentry/exit state, signed-int32 sample count, and bounded duration
- closes timer state atomically on invalid exit samples
- preserves repr compatibility and avoids callback truthiness hooks
- explicitly documents telemetry-only, non-evidence semantics

Verification: 48 timing and utility smoke tests passed; ruff and mypy passed.