### PR TITLE
fix(timing): preserve authoritative block failures

### DIFF
--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -66,7 +66,7 @@ def _require_exact_str(name: str, value: object) -> str:
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    if isinstance(value, (bool, np.bool_)):
+    if type(value) in (bool, np.bool_):
         raise ValueError(f"{name} must be a finite real number, not a boolean")
     if type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a finite real number")
@@ -222,25 +222,33 @@ class Timer:
         exc_tb: TracebackType | None,
     ) -> None:
         """Stop the timer and report completion or failure, never both."""
-        self._validate_static_contract()
-        if not self._active:
-            raise RuntimeError("Timer cannot exit before it is entered")
         try:
+            self._validate_static_contract()
+            if not self._active:
+                raise RuntimeError("Timer cannot exit before it is entered")
             end_time = self._record_sample()
             duration = end_time - self.start_time
             if not math.isfinite(duration) or not 0.0 <= duration <= _MAX_DURATION_SECONDS:
                 raise ValueError("timer duration is outside the finite telemetry bound")
             self.end_time = end_time
             self.duration = duration
+        except BaseException:
+            if exc_type is None:
+                raise
+            return
         finally:
             self._active = False
 
         if self.verbose:
-            formatted = format_duration(self.duration)
-            if exc_type is None:
-                self.print_fn(f"{self.name} completed in {formatted}")
-            else:
-                self.print_fn(f"{self.name} failed after {formatted}")
+            try:
+                formatted = format_duration(self.duration)
+                if exc_type is None:
+                    self.print_fn(f"{self.name} completed in {formatted}")
+                else:
+                    self.print_fn(f"{self.name} failed after {formatted}")
+            except BaseException:
+                if exc_type is None:
+                    raise
 
     def elapsed(self) -> float:
         """Get elapsed time since timer started (can be called during execution).

--- a/tests/test_timing_hostile_validation.py
+++ b/tests/test_timing_hostile_validation.py
@@ -129,6 +129,16 @@ def test_format_rejects_hostile_int() -> None:
         format_duration(HostileInt(1))
 
 
+def test_format_rejects_hostile_class_spoof_without_hook() -> None:
+    class HostileClass:
+        @property
+        def __class__(self) -> type:
+            raise AssertionError("class hook executed")
+
+    with pytest.raises(ValueError, match="finite real number"):
+        format_duration(HostileClass())
+
+
 def test_timer_rejects_nonfinite_and_hostile_clock_samples_without_hooks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -155,6 +165,51 @@ def test_timer_rejects_decreasing_clock_and_closes_transaction(
         timer.__exit__(None, None, None)
     with pytest.raises(RuntimeError, match="active"):
         timer.elapsed()
+
+
+def test_timer_invalid_exit_sample_preserves_block_exception_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    samples = iter([10.0, 9.0])
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: next(samples))
+    timer = Timer(verbose=False)
+    with pytest.raises(KeyError, match="authoritative"):
+        with timer:
+            raise KeyError("authoritative")
+    assert timer._active is False
+
+
+def test_timer_static_validation_failure_cleans_up_and_preserves_block_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: 10.0)
+    timer = Timer(verbose=False)
+    with pytest.raises(KeyError, match="authoritative"):
+        with timer:
+            timer.name = _StringSubclass("mutated")  # type: ignore[assignment]
+            raise KeyError("authoritative")
+    assert timer._active is False
+
+    timer = Timer(verbose=False)
+    with pytest.raises(ValueError, match="exact string"):
+        with timer:
+            timer.name = _StringSubclass("mutated")  # type: ignore[assignment]
+    assert timer._active is False
+
+
+def test_timer_reporting_failure_does_not_mask_block_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    samples = iter([1.0, 2.0])
+    monkeypatch.setattr(timing.time, "perf_counter", lambda: next(samples))
+
+    def broken_reporter(message: str) -> None:
+        del message
+        raise RuntimeError("report failed")
+
+    with pytest.raises(KeyError, match="authoritative"):
+        with Timer(print_fn=broken_reporter):
+            raise KeyError("authoritative")
 
 
 def test_timer_rejects_reentry_and_sample_counter_overflow(


### PR DESCRIPTION
Follow-up to #1211.

- replaces hostile-hook-capable bool isinstance checks with exact types
- covers all exit validation with unconditional inactive cleanup
- prevents invalid clock/static/reporting telemetry from replacing the authoritative timed-block exception
- still surfaces telemetry failures when the block itself succeeded

Verification: 52 timing and smoke tests passed; ruff and mypy passed.