### PR TITLE
fix(off-policy-td): validate exact host discount domain

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -144,14 +144,17 @@ def _zero_if_unused(scale: Array, value: Array) -> Array:
 
 def _array_metadata(name: str, value: object, shape: tuple[int, ...]) -> Array:
     """Require exact float32 host metadata before a value reaches JAX."""
+    actual_type = type(value)
     if not (
-        type(value) is np.ndarray
-        or isinstance(value, jax.Array)
-        or type(value) is jax.ShapeDtypeStruct
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+        or actual_type is jax.ShapeDtypeStruct
     ):
         raise ValueError(f"{name} must expose trusted array metadata")
-    actual_shape = tuple(value.shape)
-    actual_dtype = np.dtype(value.dtype)
+    trusted_value = cast(Any, value)
+    actual_shape = tuple(trusted_value.shape)
+    actual_dtype = np.dtype(trusted_value.dtype)
     if actual_shape != shape or actual_dtype != np.dtype(np.float32):
         raise ValueError(f"{name} must have shape {shape} and dtype float32")
     return cast(Array, value)
@@ -162,6 +165,14 @@ def _scalar_operand(name: str, value: object) -> Array:
         canonical = validated_float32_scalar(name, value)
         return jnp.asarray(canonical, dtype=jnp.float32)
     return _array_metadata(name, value, ())
+
+
+def _discount_operand(value: object) -> Array:
+    """Validate a discount in its exact host and consumed float32 domains."""
+    if type(value) in _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES:
+        canonical = validated_float32_scalar("gamma", value, lower=0.0, upper=1.0)
+        return jnp.asarray(canonical, dtype=jnp.float32)
+    return _array_metadata("gamma", value, ())
 
 
 def _stable_rms(values: Array) -> Array:
@@ -523,7 +534,7 @@ class OffPolicyTDLinearLearner:
         observation = _array_metadata("observation", observation, (feature_dim,))
         next_observation = _array_metadata("next_observation", next_observation, (feature_dim,))
         reward = _scalar_operand("reward", reward)
-        gamma = _scalar_operand("gamma", gamma)
+        gamma = _discount_operand(gamma)
         rho = _scalar_operand("rho", rho)
         result = self._update_jit(state, observation, reward, next_observation, gamma, rho)
         return cast(
@@ -740,7 +751,7 @@ class ETDLinearLearner:
         observation = _array_metadata("observation", observation, (feature_dim,))
         next_observation = _array_metadata("next_observation", next_observation, (feature_dim,))
         reward = _scalar_operand("reward", reward)
-        gamma = _scalar_operand("gamma", gamma)
+        gamma = _discount_operand(gamma)
         rho = _scalar_operand("rho", rho)
         interest = _scalar_operand("interest", interest)
         result = self._update_jit(
@@ -961,7 +972,7 @@ class GradientTDLinearLearner:
         observation = _array_metadata("observation", observation, (feature_dim,))
         next_observation = _array_metadata("next_observation", next_observation, (feature_dim,))
         reward = _scalar_operand("reward", reward)
-        gamma = _scalar_operand("gamma", gamma)
+        gamma = _discount_operand(gamma)
         rho = _scalar_operand("rho", rho)
         result = self._update_jit(state, observation, reward, next_observation, gamma, rho)
         return cast(

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import math
 from fractions import Fraction
 
 import chex
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -71,6 +73,150 @@ def test_update_rejects_discount_outside_unit_interval(learner, gamma: float) ->
     chex.assert_trees_all_equal(result.state, state)
     assert not bool(result.update_applied)
     assert float(result.td_error) == 0.0
+
+
+@pytest.mark.parametrize(
+    "learner",
+    [
+        OffPolicyTDLinearLearner(step_size=0.1),
+        ETDLinearLearner(step_size=0.1),
+        GradientTDLinearLearner(step_size=0.1),
+    ],
+)
+@pytest.mark.parametrize(
+    "gamma",
+    [
+        -math.nextafter(0.0, 1.0),
+        -Fraction(1, 2**200),
+        math.nextafter(1.0, 2.0),
+        Fraction(1, 1) + Fraction(1, 2**100),
+    ],
+)
+def test_update_rejects_exact_host_gamma_before_float32_narrowing(learner, gamma: object) -> None:
+    state = learner.init(1)
+    with pytest.raises(ValueError, match="gamma"):
+        learner.update(
+            state,
+            jnp.asarray([1.0], dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+            jnp.asarray([jnp.inf], dtype=jnp.float32),
+            gamma,
+            jnp.asarray(1.0, dtype=jnp.float32),
+        )
+
+
+def test_gamma_operand_rejects_hostile_metadata_without_hooks() -> None:
+    class HostileGamma:
+        @property
+        def __class__(self) -> type:
+            raise AssertionError("class hook executed")
+
+        @property
+        def shape(self):
+            raise AssertionError("shape hook executed")
+
+        @property
+        def dtype(self):
+            raise AssertionError("dtype hook executed")
+
+    learner = OffPolicyTDLinearLearner()
+    with pytest.raises(ValueError, match="gamma"):
+        learner.update(
+            learner.init(1),
+            jnp.ones((1,), dtype=jnp.float32),
+            jnp.float32(1.0),
+            jnp.ones((1,), dtype=jnp.float32),
+            HostileGamma(),
+            jnp.float32(1.0),
+        )
+
+    with pytest.raises(ValueError, match="dtype float32"):
+        learner.update(
+            learner.init(1),
+            jnp.ones((1,), dtype=jnp.float32),
+            jnp.float32(1.0),
+            jnp.ones((1,), dtype=jnp.float32),
+            np.asarray(0.5, dtype=np.float64),
+            jnp.float32(1.0),
+        )
+
+
+@pytest.mark.parametrize(
+    "learner",
+    [
+        OffPolicyTDLinearLearner(step_size=0.1),
+        ETDLinearLearner(step_size=0.1),
+        GradientTDLinearLearner(step_size=0.1),
+    ],
+)
+@pytest.mark.parametrize("gamma", [0.0, 1.0])
+def test_update_accepts_gamma_endpoints_eager_and_explicit_jit(learner, gamma: float) -> None:
+    state = learner.init(1)
+    observation = jnp.asarray([1.0], dtype=jnp.float32)
+    next_observation = jnp.asarray([2.0], dtype=jnp.float32)
+    reward = jnp.asarray(1.0, dtype=jnp.float32)
+    rho = jnp.asarray(1.0, dtype=jnp.float32)
+    gamma_array = jnp.asarray(gamma, dtype=jnp.float32)
+
+    eager = learner.update(state, observation, reward, next_observation, gamma_array, rho)
+    compiled = jax.jit(
+        lambda current, discount: learner.update(
+            current, observation, reward, next_observation, discount, rho
+        )
+    )(state, gamma_array)
+    assert bool(eager.update_applied)
+    assert bool(compiled.update_applied)
+    compiled_learning_state = compiled.state.replace(
+        birth_timestamp=eager.state.birth_timestamp,
+        uptime_s=eager.state.uptime_s,
+    )
+    chex.assert_trees_all_equal(eager.state, compiled_learning_state)
+
+
+@pytest.mark.parametrize(
+    "learner",
+    [
+        OffPolicyTDLinearLearner(step_size=0.1),
+        ETDLinearLearner(step_size=0.1),
+        GradientTDLinearLearner(step_size=0.1),
+    ],
+)
+def test_runtime_gamma_rejection_is_atomic_and_neutral(learner) -> None:
+    state = learner.init(1)
+    result = learner.update(
+        state,
+        jnp.asarray([1.0], dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.asarray([2.0], dtype=jnp.float32),
+        jnp.asarray(1.25, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    chex.assert_trees_all_equal(result.state, state)
+    assert not bool(result.update_applied)
+    for name in ("prediction", "td_error", "metrics"):
+        assert bool(jnp.all(jnp.asarray(getattr(result, name)) == 0))
+    for name in ("rho_clipped", "follow_on_trace", "emphasis"):
+        if hasattr(result, name):
+            assert bool(jnp.all(jnp.asarray(getattr(result, name)) == 0))
+
+
+def test_gradient_td_scan_rejects_only_invalid_gamma_rows_atomically() -> None:
+    learner = GradientTDLinearLearner(step_size=0.01)
+    state = learner.init(1)
+    result = run_gradient_td_learning_loop(
+        learner,
+        state,
+        jnp.ones((3, 1), dtype=jnp.float32),
+        jnp.ones((3,), dtype=jnp.float32),
+        jnp.ones((3, 1), dtype=jnp.float32),
+        jnp.asarray([0.0, 1.25, 1.0], dtype=jnp.float32),
+        jnp.ones((3,), dtype=jnp.float32),
+    )
+    assert result.updates_applied.tolist() == [True, False, True]
+    assert int(result.state.step_count) == 2
+    assert float(result.predictions[1]) == 0.0
+    assert float(result.td_errors[1]) == 0.0
+    assert bool(jnp.all(result.metrics[1] == 0))
 
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to merged #1216.

- validates exact host gamma before float32 narrowing, preventing negative-underflow terminal bypass and >1 round-to-one laundering
- keeps exact float32 array/tracer metadata gates hostile-safe
- covers legal 0/1 endpoints eager and outer-JIT, full atomic output neutralization, and mixed valid/invalid Gradient-TD scan rows

Verification: 99 off-policy TD tests passed; ruff and mypy passed.