### PR TITLE
fix(float32): preserve exact Fraction zero

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -142,8 +142,11 @@ def _real_ratio(value: object) -> tuple[int, int, bool]:
         denominator = -denominator
     if denominator == 0:
         raise ValueError("ratio denominator must be nonzero")
-    negative_zero = numerator == 0 and actual_type in _ACTUAL_FLOAT_TYPES and bool(
-        np.signbit(cast(Any, value))
+    negative_zero = (
+        numerator == 0
+        and actual_type in _ACTUAL_FLOAT_TYPES
+        and actual_type is not Fraction
+        and bool(np.signbit(cast(Any, value)))
     )
     return numerator, denominator, negative_zero
 

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -2,6 +2,7 @@
 """Tests for the Step 2 fixed-budget associative memory."""
 
 import math
+from fractions import Fraction
 
 import chex
 import jax.numpy as jnp
@@ -788,18 +789,14 @@ def test_step2_associative_from_dict_rejects_unknown_and_partial_keys() -> None:
         pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
     ],
 )
-def test_associative_memory_rejects_adversarial_ratio_floats(
-    ratio: tuple[int, int]
+def test_associative_memory_rejects_exact_fraction_boundaries(
+    ratio: tuple[int, int],
 ) -> None:
-    class HiddenBoundaryFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=r"retention must be in \[0, 1\]"):
         AssociativeMemoryConfig(
             vocab_size=4,
             block_size=8,
-            retention=HiddenBoundaryFloat(0.5),
+            retention=Fraction(*ratio),
         )
 
 

--- a/tests/test_associative_memory_validation.py
+++ b/tests/test_associative_memory_validation.py
@@ -180,7 +180,7 @@ def test_associative_float_validators_reject_hostile_ratio() -> None:
 
     with pytest.raises(ValueError, match="write_lr"):
         _base_cfg(write_lr=HostileFloat(1.0))  # type: ignore[arg-type]
-    assert HostileFloat.calls == 1
+    assert HostileFloat.calls == 0
 
 
 def test_associative_dimensions_preflight_without_allocation() -> None:

--- a/tests/test_dual_replay.py
+++ b/tests/test_dual_replay.py
@@ -793,13 +793,9 @@ def test_config_rejects_objects_that_only_spoof_float_through_class(field: str) 
         _strict_memory(**{field: _FloatSpoof()})
 
 
-def test_config_accepts_honest_float_subclasses_as_canonical_floats() -> None:
-    memory = _strict_memory(surprise_weight=_LyingFloat(0.5, (1, 2)))
-    assert type(memory.config.surprise_weight) is float
-    assert memory.config.surprise_weight == 0.5
-    payload = memory.to_config()
-    json.dumps(payload, allow_nan=False)
-    assert DualReplayMemory.from_config(payload).config == memory.config
+def test_config_rejects_float_subclass_even_with_honest_ratio() -> None:
+    with pytest.raises(ValueError, match="surprise_weight"):
+        _strict_memory(surprise_weight=_LyingFloat(0.5, (1, 2)))
 
 
 @pytest.mark.parametrize("field", _FLOAT32_SCALARS)

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -1,5 +1,6 @@
 """Tests for Step 2 fixed-budget feature discovery."""
 
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -3142,25 +3143,28 @@ class TestFeatureDiscoveryStreamsValidation:
         with pytest.raises(ValueError, match=match):
             NonlinearFeatureDiscoveryStream(**base)
 
-    def test_nonlinear_rejects_adversarial_ratio(self) -> None:
-        class HiddenBoundaryFloat(float):
-            def as_integer_ratio(self) -> tuple[int, int]:
-                return (-1, 2**200)
-
+    def test_nonlinear_rejects_exact_negative_fraction(self) -> None:
         with pytest.raises(ValueError, match="linear_scale must be non-negative"):
-            NonlinearFeatureDiscoveryStream(feature_dim=8, linear_scale=HiddenBoundaryFloat(0.5))
+            NonlinearFeatureDiscoveryStream(
+                feature_dim=8,
+                linear_scale=Fraction(-1, 2**200),
+            )
 
     def test_nonlinear_rejects_spoofed_int_class(self) -> None:
         class SpoofedIntFloat(float):
+            calls = 0
+
             @property
             def __class__(self) -> type[int]:
+                type(self).calls += 1
                 return int
 
             def as_integer_ratio(self) -> tuple[int, int]:
                 return (-1, 2**200)
 
-        with pytest.raises(ValueError, match="noise_std must be non-negative"):
+        with pytest.raises(ValueError, match="noise_std must narrow to a finite float32"):
             NonlinearFeatureDiscoveryStream(feature_dim=8, noise_std=SpoofedIntFloat(0.5))
+        assert SpoofedIntFloat.calls == 0
 
     def test_nonlinear_rejects_spoofed_ratio_components(self) -> None:
         class SpoofedComponent:
@@ -3250,13 +3254,12 @@ class TestFeatureDiscoveryStreamsValidation:
         )
         assert stream.include_squares is True
 
-    def test_interaction_rejects_adversarial_ratio(self) -> None:
-        class HiddenBoundaryFloat(float):
-            def as_integer_ratio(self) -> tuple[int, int]:
-                return (-1, 2**200)
-
+    def test_interaction_rejects_exact_negative_fraction(self) -> None:
         with pytest.raises(ValueError, match="linear_scale must be non-negative"):
-            InteractionFeatureDiscoveryStream(feature_dim=6, linear_scale=HiddenBoundaryFloat(0.5))
+            InteractionFeatureDiscoveryStream(
+                feature_dim=6,
+                linear_scale=Fraction(-1, 2**200),
+            )
 
     def test_collect_feature_discovery_stream_validation(self) -> None:
         stream = NonlinearFeatureDiscoveryStream(feature_dim=4)

--- a/tests/test_float32.py
+++ b/tests/test_float32.py
@@ -32,6 +32,10 @@ def test_rounds_fraction_midpoint_exactly(offset: Fraction, expected: np.float32
     )
 
 
+def test_rounds_fraction_zero_without_numpy_conversion() -> None:
+    assert _raw_float32(round_real_to_float32(Fraction(0))) == 0
+
+
 def test_rounds_overflow_midpoint_outward() -> None:
     float32_max = (2**24 - 1) * 2**104
     midpoint = Fraction(float32_max + 2**103)


### PR DESCRIPTION
Post-merge corrective for #1207.

`Fraction` is an explicitly supported exact scalar type, but the merged negative-zero path passed `Fraction(0)` to `numpy.signbit`, which raises `TypeError`. Fractions cannot encode signed zero, so this excludes only `Fraction` from sign-bit probing while retaining signed-zero preservation for built-in and NumPy floating types.

The retained tests that intentionally exercised float-subclass ratio hooks are updated to the new exact-type trust contract: exact boundary behavior is still tested with safe `Fraction` values, while hostile subclass hooks are asserted not to run.

Verification on rebased head:
- targeted changed-contract panel: 25 passed
- helper/scalar hostile panel: 75 passed
- additional consumer panel: 507 passed before intentional stop at 98%, no failures
- Ruff: clean
- mypy `_float32.py`: clean
- diff check: clean