### PR TITLE
fix(streams): complete feature-discovery trust boundaries

### DIFF
--- a/alberta_framework/streams/feature_discovery.py
+++ b/alberta_framework/streams/feature_discovery.py
@@ -18,6 +18,7 @@ from numbers import Integral, Real
 from typing import Any, cast
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -114,6 +115,58 @@ def _require_int(
     if maximum is not None and number > maximum:
         raise ValueError(f"{name} must be <= {maximum}")
     return number
+
+
+def _checked_product(name: str, *factors: int) -> int:
+    product = 1
+    for factor in factors:
+        if factor < 0 or (factor != 0 and product > _INT32_MAX // factor):
+            raise ValueError(f"{name} must fit signed int32")
+        product *= factor
+    return product
+
+
+def _checked_sum(name: str, *terms: int) -> int:
+    total = 0
+    for term in terms:
+        if term < 0 or term > _INT32_MAX - total:
+            raise ValueError(f"{name} must fit signed int32")
+        total += term
+    return total
+
+
+def _require_array(
+    value: object,
+    *,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: jnp.dtype,
+) -> Array:
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array) or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted JAX array")
+    trusted = cast(Array, value)
+    if trusted.shape != shape or trusted.dtype != dtype:
+        raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
+    return trusted
+
+
+def _require_key(value: object, *, name: str) -> Array:
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array) or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    trusted = cast(Array, value)
+    try:
+        words = jr.key_data(trusted)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key") from error
+    if trusted.shape != () or words.shape != (2,) or words.dtype != jnp.dtype(jnp.uint32):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    return trusted
 
 
 @chex.dataclass(frozen=True)
@@ -214,6 +267,25 @@ class NonlinearFeatureDiscoveryStream:
         linear_scale_val = _require_nonnegative_real("linear_scale", linear_scale)
         noise_std_val = _require_nonnegative_real("noise_std", noise_std)
 
+        latent_weight_cells = _checked_product(
+            "nonlinear latent weight count", n_latents_val, feature_dim_val
+        )
+        context_cells = _checked_product(
+            "nonlinear context weight count", n_contexts_val, n_tasks_val, n_latents_val
+        )
+        linear_cells = _checked_product(
+            "nonlinear linear weight count", n_tasks_val, feature_dim_val
+        )
+        _checked_sum(
+            "nonlinear initialization byte count",
+            12,
+            _checked_product("nonlinear latent weight bytes", 4, latent_weight_cells),
+            _checked_product("nonlinear latent bias bytes", 4, n_latents_val),
+            # Persistent context weights plus dense, mask, and result temporaries.
+            _checked_product("nonlinear context initialization bytes", 13, context_cells),
+            _checked_product("nonlinear linear weight bytes", 4, linear_cells),
+        )
+
         self._feature_dim = feature_dim_val
         self._n_tasks = n_tasks_val
         self._n_latents = n_latents_val
@@ -282,6 +354,7 @@ class NonlinearFeatureDiscoveryStream:
 
     def init(self, key: Array) -> NonlinearFeatureDiscoveryState:
         """Initialize stream state."""
+        key = _require_key(key, name="key")
         key, k_latent, k_bias, k_ctx, k_mask, k_linear = jr.split(key, 6)
 
         # LeCun-style 1/sqrt(feature_dim) scaling gives each latent a roughly
@@ -332,7 +405,40 @@ class NonlinearFeatureDiscoveryStream:
         idx: Array,
     ) -> tuple[TimeStep, NonlinearFeatureDiscoveryState]:
         """Generate one multitask supervised sample."""
-        del idx
+        if type(state) is not NonlinearFeatureDiscoveryState:
+            raise TypeError("state must be an exact NonlinearFeatureDiscoveryState")
+        _require_key(state.key, name="state.key")
+        _require_array(
+            state.latent_weights,
+            name="state.latent_weights",
+            shape=(self._n_latents, self._feature_dim),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.latent_biases,
+            name="state.latent_biases",
+            shape=(self._n_latents,),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.context_weights,
+            name="state.context_weights",
+            shape=(self._n_contexts, self._n_tasks, self._n_latents),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.linear_weights,
+            name="state.linear_weights",
+            shape=(self._n_tasks, self._feature_dim),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.step_count,
+            name="state.step_count",
+            shape=(),
+            dtype=jnp.dtype(jnp.int32),
+        )
+        _require_array(idx, name="idx", shape=(), dtype=jnp.dtype(jnp.int32))
         key, k_x, k_noise = jr.split(state.key, 3)
 
         x = self._feature_std * jr.normal(
@@ -362,13 +468,18 @@ def collect_feature_discovery_stream(
     see the exact same stream.  It still uses the one-step stream interface and
     ``jax.lax.scan``; it does not imply experience replay inside a learner.
     """
-    import jax
-
     num_steps = _require_int("num_steps", num_steps, minimum=1, maximum=_INT32_MAX)
-    if not hasattr(stream, "init") or not callable(stream.init):
-        raise TypeError("stream must provide a callable init method")
-    if not hasattr(stream, "step") or not callable(stream.step):
-        raise TypeError("stream must provide a callable step method")
+    if type(stream) not in (NonlinearFeatureDiscoveryStream, InteractionFeatureDiscoveryStream):
+        raise TypeError(
+            "stream must be an exact feature-discovery stream with init and step"
+        )
+    key = _require_key(key, name="key")
+    output_cells = _checked_product(
+        "collected feature-discovery output count",
+        num_steps,
+        _checked_sum("collected row width", stream.feature_dim, stream.target_dim),
+    )
+    _checked_product("collected feature-discovery output bytes", 4, output_cells)
 
     state = stream.init(key)
 
@@ -380,7 +491,7 @@ def collect_feature_discovery_stream(
         return new_state, (timestep.observation, timestep.target)
 
     _, (observations, targets) = jax.lax.scan(
-        step_fn, state, jnp.arange(num_steps)
+        step_fn, state, jnp.arange(num_steps, dtype=jnp.int32)
     )
     return observations, targets
 
@@ -445,6 +556,31 @@ class InteractionFeatureDiscoveryStream:
         else:
             raise TypeError("include_squares must be a boolean")
 
+        pair_count = (
+            feature_dim_val * (feature_dim_val + 1) // 2
+            if include_squares_val
+            else feature_dim_val * (feature_dim_val - 1) // 2
+        )
+        if pair_count > _INT32_MAX:
+            raise ValueError("interaction pair count must fit signed int32")
+        context_cells = _checked_product(
+            "interaction context weight count",
+            n_contexts_val,
+            n_tasks_val,
+            pair_count,
+        )
+        linear_cells = _checked_product(
+            "interaction linear weight count", n_tasks_val, feature_dim_val
+        )
+        _checked_sum(
+            "interaction initialization byte count",
+            12,
+            _checked_product("interaction pair bytes", 8, pair_count),
+            # Persistent context weights plus scores, mask, and result temporaries.
+            _checked_product("interaction context initialization bytes", 13, context_cells),
+            _checked_product("interaction linear weight bytes", 4, linear_cells),
+        )
+
         self._feature_dim = feature_dim_val
         self._n_tasks = n_tasks_val
         self._n_contexts = n_contexts_val
@@ -454,6 +590,7 @@ class InteractionFeatureDiscoveryStream:
         self._linear_scale = linear_scale_val
         self._noise_std = noise_std_val
         self._include_squares = include_squares_val
+        self._n_pairs = pair_count
 
     @property
     def feature_dim(self) -> int:
@@ -516,6 +653,7 @@ class InteractionFeatureDiscoveryStream:
 
     def init(self, key: Array) -> InteractionFeatureDiscoveryState:
         """Initialize stream state."""
+        key = _require_key(key, name="key")
         key, k_ctx, k_mask, k_linear = jr.split(key, 4)
         pair_left, pair_right = self._pairs()
         n_pairs = pair_left.shape[0]
@@ -557,7 +695,40 @@ class InteractionFeatureDiscoveryStream:
         idx: Array,
     ) -> tuple[TimeStep, InteractionFeatureDiscoveryState]:
         """Generate one multitask interaction sample."""
-        del idx
+        if type(state) is not InteractionFeatureDiscoveryState:
+            raise TypeError("state must be an exact InteractionFeatureDiscoveryState")
+        _require_key(state.key, name="state.key")
+        _require_array(
+            state.pair_left,
+            name="state.pair_left",
+            shape=(self._n_pairs,),
+            dtype=jnp.dtype(jnp.int32),
+        )
+        _require_array(
+            state.pair_right,
+            name="state.pair_right",
+            shape=(self._n_pairs,),
+            dtype=jnp.dtype(jnp.int32),
+        )
+        _require_array(
+            state.context_weights,
+            name="state.context_weights",
+            shape=(self._n_contexts, self._n_tasks, self._n_pairs),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.linear_weights,
+            name="state.linear_weights",
+            shape=(self._n_tasks, self._feature_dim),
+            dtype=jnp.dtype(jnp.float32),
+        )
+        _require_array(
+            state.step_count,
+            name="state.step_count",
+            shape=(),
+            dtype=jnp.dtype(jnp.int32),
+        )
+        _require_array(idx, name="idx", shape=(), dtype=jnp.dtype(jnp.int32))
         key, k_x, k_noise = jr.split(state.key, 3)
         x = self._feature_std * jr.normal(
             k_x, (self._feature_dim,), dtype=jnp.float32

--- a/tests/test_feature_discovery_hostile_validation.py
+++ b/tests/test_feature_discovery_hostile_validation.py
@@ -1,5 +1,8 @@
 """Hostile validation for streams/feature_discovery sink gates."""
 
+import jax
+import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
@@ -7,6 +10,8 @@ from alberta_framework.streams.feature_discovery import (
     InteractionFeatureDiscoveryStream,
     NonlinearFeatureDiscoveryStream,
 )
+
+_INT32_MAX = 2**31 - 1
 
 
 class _EvilStr(str):
@@ -27,6 +32,27 @@ class _HostileFloat(float):
     def as_integer_ratio(self):  # type: ignore[override]
         type(self).calls += 1
         raise AssertionError("HostileFloat hook must not leak via !r")
+
+
+class _HostileInt(int):
+    calls = 0
+
+    @property
+    def __class__(self) -> type[int]:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("class hook")
+
+    def __int__(self) -> int:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("int hook")
+
+    def __index__(self) -> int:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("index hook")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("repr hook")
 
     def __float__(self) -> float:  # type: ignore[override]
         type(self).calls += 1
@@ -65,6 +91,35 @@ def test_rejects_bool_and_hostile_int_for_feature_dim() -> None:
     _HostileInt.calls = 0
     with pytest.raises(ValueError, match="must be an integer"):
         NonlinearFeatureDiscoveryStream(feature_dim=_HostileInt(4))
+    assert _HostileInt.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("factory", "field"),
+    [
+        (NonlinearFeatureDiscoveryStream, "feature_dim"),
+        (NonlinearFeatureDiscoveryStream, "n_tasks"),
+        (NonlinearFeatureDiscoveryStream, "n_latents"),
+        (NonlinearFeatureDiscoveryStream, "n_contexts"),
+        (NonlinearFeatureDiscoveryStream, "context_length"),
+        (NonlinearFeatureDiscoveryStream, "active_latents_per_context"),
+        (InteractionFeatureDiscoveryStream, "feature_dim"),
+        (InteractionFeatureDiscoveryStream, "n_tasks"),
+        (InteractionFeatureDiscoveryStream, "n_contexts"),
+        (InteractionFeatureDiscoveryStream, "context_length"),
+        (InteractionFeatureDiscoveryStream, "active_pairs_per_context"),
+    ],
+)
+def test_every_integer_field_rejects_subclass_without_hooks(
+    factory: type[NonlinearFeatureDiscoveryStream] | type[InteractionFeatureDiscoveryStream],
+    field: str,
+) -> None:
+    _HostileInt.calls = 0
+    kwargs: dict[str, object] = {field: _HostileInt(4)}
+    if field != "feature_dim":
+        kwargs["feature_dim"] = 4
+    with pytest.raises(ValueError, match=field):
+        factory(**kwargs)  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
 
 
@@ -126,3 +181,115 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="must narrow to a finite float32"):
         NonlinearFeatureDiscoveryStream(feature_dim=4, feature_std=RatioFloat(0.5))  # type: ignore[arg-type]
+
+
+def test_derived_nonlinear_resources_fail_before_allocation() -> None:
+    with pytest.raises(ValueError, match="context weight count"):
+        NonlinearFeatureDiscoveryStream(
+            feature_dim=2,
+            n_tasks=50_000,
+            n_latents=50_000,
+            n_contexts=2,
+        )
+    with pytest.raises(ValueError, match="latent weight bytes"):
+        NonlinearFeatureDiscoveryStream(
+            feature_dim=20_000,
+            n_tasks=1,
+            n_latents=50_000,
+            n_contexts=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("feature_dim", "include_squares"),
+    [(65_536, True), (65_537, False)],
+)
+def test_interaction_pair_count_fails_before_python_pair_construction(
+    feature_dim: int, include_squares: bool
+) -> None:
+    with pytest.raises(ValueError, match="pair count"):
+        InteractionFeatureDiscoveryStream(
+            feature_dim=feature_dim,
+            include_squares=include_squares,
+        )
+
+
+def test_interaction_derived_context_resources_fail_before_allocation() -> None:
+    with pytest.raises(ValueError, match="context weight count"):
+        InteractionFeatureDiscoveryStream(
+            feature_dim=100,
+            n_tasks=50_000,
+            n_contexts=50_000,
+        )
+
+
+def test_collect_rejects_hostile_duck_stream_without_attribute_hooks() -> None:
+    calls = 0
+
+    class HostileStream:
+        @property
+        def __class__(self) -> type[NonlinearFeatureDiscoveryStream]:  # pragma: no cover
+            nonlocal calls
+            calls += 1
+            raise AssertionError("class hook")
+
+        def __getattribute__(self, name: str) -> object:  # pragma: no cover
+            if name != "__class__":
+                nonlocal calls
+                calls += 1
+                raise AssertionError("attribute hook")
+            return super().__getattribute__(name)
+
+    from alberta_framework.streams.feature_discovery import collect_feature_discovery_stream
+
+    with pytest.raises(TypeError, match="exact feature-discovery stream"):
+        collect_feature_discovery_stream(HostileStream(), 1, jr.key(0))
+    assert calls == 0
+
+
+def test_collect_preflights_output_resource_total() -> None:
+    from alberta_framework.streams.feature_discovery import collect_feature_discovery_stream
+
+    stream = NonlinearFeatureDiscoveryStream(feature_dim=4, n_tasks=1)
+    with pytest.raises(ValueError, match="output (count|bytes)"):
+        collect_feature_discovery_stream(stream, _INT32_MAX, jr.key(0))
+
+
+@pytest.mark.parametrize(
+    "factory", [NonlinearFeatureDiscoveryStream, InteractionFeatureDiscoveryStream]
+)
+def test_init_requires_scalar_typed_threefry_key(
+    factory: type[NonlinearFeatureDiscoveryStream] | type[InteractionFeatureDiscoveryStream],
+) -> None:
+    stream = factory(feature_dim=4)
+    for bad in (jnp.asarray([0, 1], dtype=jnp.uint32), jnp.asarray(0, dtype=jnp.int32)):
+        with pytest.raises(TypeError, match="Threefry"):
+            stream.init(bad)
+
+
+@pytest.mark.parametrize(
+    "factory", [NonlinearFeatureDiscoveryStream, InteractionFeatureDiscoveryStream]
+)
+def test_eager_and_jit_transactions_match_and_validate_static_contracts(
+    factory: type[NonlinearFeatureDiscoveryStream] | type[InteractionFeatureDiscoveryStream],
+) -> None:
+    stream = factory(feature_dim=4, n_tasks=2, n_contexts=2)
+    state = stream.init(jr.key(7))
+    idx = jnp.asarray(0, dtype=jnp.int32)
+    eager_timestep, eager_state = stream.step(state, idx)
+    jit_timestep, jit_state = jax.jit(stream.step)(state, idx)
+    np.testing.assert_array_equal(eager_timestep.observation, jit_timestep.observation)
+    np.testing.assert_array_equal(eager_timestep.target, jit_timestep.target)
+    np.testing.assert_array_equal(eager_state.step_count, jit_state.step_count)
+
+    with pytest.raises(ValueError, match="idx"):
+        stream.step(state, jnp.asarray(0.0, dtype=jnp.float32))
+
+
+def test_step_rejects_wrong_state_array_before_jax_computation() -> None:
+    stream = NonlinearFeatureDiscoveryStream(feature_dim=4, n_latents=3)
+    state = stream.init(jr.key(0)).replace(
+        latent_weights=jnp.zeros((3, 4), dtype=jnp.int32)
+    )
+    with pytest.raises(ValueError, match="latent_weights"):
+        stream.step(state, jnp.asarray(0, dtype=jnp.int32))


### PR DESCRIPTION
Follow-up to #1221, preserving the contributor's merged authorship while closing the residual trust-boundary and derived-resource gaps found in deep review.

- preflight exact nonlinear, interaction-pair, context, initialization, and collected-output resource products before allocation
- reject hostile integer subclasses without invoking `__class__`, `__int__`, `__index__`, or `__repr__` hooks
- require scalar typed Threefry keys and exact state/array shape/dtype contracts before eager or JIT computation
- reject arbitrary duck streams before attribute lookup and retain the two supported concrete stream types
- preserve exact NumPy integer and boolean compatibility plus the merged float32 narrowing policy

Verification:
- `pytest -q tests/test_feature_discovery_hostile_validation.py` (33 passed, post-rebase)
- focused existing stream classes + hostile contract (84 passed before rebase; merge only removed duplicate contributor tests)
- `ruff check alberta_framework/streams/feature_discovery.py tests/test_feature_discovery_hostile_validation.py`
- `mypy alberta_framework/streams/feature_discovery.py`