### PR TITLE
test(streams): align hostile float rejection contract

### DIFF
--- a/tests/test_alberta_plan_step1_streams.py
+++ b/tests/test_alberta_plan_step1_streams.py
@@ -385,7 +385,7 @@ class TestStep1StreamsValidation:
             def as_integer_ratio(self) -> tuple[int, int]:
                 return ratio
 
-        with pytest.raises(ValueError, match="drift_rate_w must be non-negative"):
+        with pytest.raises(ValueError, match="drift_rate_w must narrow to a finite float32"):
             AlbertaPlanStep1Stream(drift_rate_w=HiddenBoundaryFloat(0.5))
 
     def test_alberta_plan_step1_rejects_spoofed_int_class(self) -> None:
@@ -397,7 +397,7 @@ class TestStep1StreamsValidation:
             def as_integer_ratio(self) -> tuple[int, int]:
                 return (-1, 2**200)
 
-        with pytest.raises(ValueError, match="drift_rate_w must be non-negative"):
+        with pytest.raises(ValueError, match="drift_rate_w must narrow to a finite float32"):
             AlbertaPlanStep1Stream(drift_rate_w=SpoofedIntFloat(0.5))
 
     def test_alberta_plan_step1_rejects_spoofed_ratio_components(self) -> None:
@@ -500,5 +500,5 @@ class TestStep1StreamsValidation:
             def as_integer_ratio(self) -> tuple[int, int]:
                 return (-1, 2**200)
 
-        with pytest.raises(ValueError, match="noise_std must be non-negative"):
+        with pytest.raises(ValueError, match="noise_std must narrow to a finite float32"):
             XDistShiftStream(feature_dim=10, num_relevant=3, noise_std=HiddenBoundaryFloat(0.5))


### PR DESCRIPTION
Closes four retained test failures exposed by the post-merge exact-main audit. PR #1220 intentionally made `_float32` reject float subclasses before invoking their overridable `as_integer_ratio` hooks. The Step 1 stream correctly translates that exact-type rejection to `must narrow to a finite float32`; these four assertions still expected the obsolete downstream sign-validation message from when hostile ratios were interpreted. This tests-only change aligns them with the hardened trust-boundary contract. No source or pinned output changes. Verification: affected Step 1 stream plus core/hostile float32 tests, 118 passed; scoped Ruff passed.