### PR TITLE
test(float32): align retained exact-scalar fixtures

### DIFF
--- a/tests/test_alberta_plan_step1_streams.py
+++ b/tests/test_alberta_plan_step1_streams.py
@@ -7,6 +7,7 @@ eta_t`` with non-stationarity in either the target functions or the input
 distribution.
 """
 
+from fractions import Fraction
 from typing import Any
 
 import chex
@@ -378,27 +379,30 @@ class TestStep1StreamsValidation:
             pytest.param((-1, 2**200), id="negative-subnormal-ratio"),
         ],
     )
-    def test_alberta_plan_step1_rejects_adversarial_ratio_drift(
+    def test_alberta_plan_step1_rejects_exact_fraction_drift(
         self, ratio: tuple[int, int]
     ) -> None:
-        class HiddenBoundaryFloat(float):
-            def as_integer_ratio(self) -> tuple[int, int]:
-                return ratio
-
-        with pytest.raises(ValueError, match="drift_rate_w must narrow to a finite float32"):
-            AlbertaPlanStep1Stream(drift_rate_w=HiddenBoundaryFloat(0.5))
+        with pytest.raises(ValueError, match="drift_rate_w must be non-negative"):
+            AlbertaPlanStep1Stream(drift_rate_w=Fraction(*ratio))
 
     def test_alberta_plan_step1_rejects_spoofed_int_class(self) -> None:
         class SpoofedIntFloat(float):
+            class_calls = 0
+            ratio_calls = 0
+
             @property
             def __class__(self) -> type[int]:
+                type(self).class_calls += 1
                 return int
 
             def as_integer_ratio(self) -> tuple[int, int]:
+                type(self).ratio_calls += 1
                 return (-1, 2**200)
 
         with pytest.raises(ValueError, match="drift_rate_w must narrow to a finite float32"):
             AlbertaPlanStep1Stream(drift_rate_w=SpoofedIntFloat(0.5))
+        assert SpoofedIntFloat.class_calls == 0
+        assert SpoofedIntFloat.ratio_calls == 0
 
     def test_alberta_plan_step1_rejects_spoofed_ratio_components(self) -> None:
         class SpoofedComponent:
@@ -410,11 +414,15 @@ class TestStep1StreamsValidation:
                 return 1
 
         class BadRatioFloat(float):
+            calls = 0
+
             def as_integer_ratio(self) -> tuple[Any, Any]:
+                type(self).calls += 1
                 return (SpoofedComponent(), 2)
 
         with pytest.raises(ValueError, match="must narrow to a finite float32"):
             AlbertaPlanStep1Stream(drift_rate_w=BadRatioFloat(0.5))
+        assert BadRatioFloat.calls == 0
 
     def test_xdist_shift_stream_properties_and_boundaries(self) -> None:
         stream = XDistShiftStream(
@@ -495,10 +503,10 @@ class TestStep1StreamsValidation:
                 scale_max=1.00000002,
             )
 
-    def test_xdist_shift_rejects_adversarial_ratio(self) -> None:
-        class HiddenBoundaryFloat(float):
-            def as_integer_ratio(self) -> tuple[int, int]:
-                return (-1, 2**200)
-
-        with pytest.raises(ValueError, match="noise_std must narrow to a finite float32"):
-            XDistShiftStream(feature_dim=10, num_relevant=3, noise_std=HiddenBoundaryFloat(0.5))
+    def test_xdist_shift_rejects_exact_negative_fraction(self) -> None:
+        with pytest.raises(ValueError, match="noise_std must be non-negative"):
+            XDistShiftStream(
+                feature_dim=10,
+                num_relevant=3,
+                noise_std=Fraction(-1, 2**200),
+            )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 """Production Step 1-4 pipeline tests."""
 
 import json
+from fractions import Fraction
 
 import chex
 import jax
@@ -805,24 +806,16 @@ def test_pipeline_associative_requires_ordered_weight_bounds() -> None:
         pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
     ],
 )
-def test_pipeline_unit_interval_rejects_adversarial_ratio_floats(
+def test_pipeline_unit_interval_rejects_exact_fraction_boundaries(
     ratio: tuple[int, int]
 ) -> None:
-    class HiddenBoundaryFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=r"sparsity must be in \[0, 1\]"):
-        Step2UPGDConfig(sparsity=HiddenBoundaryFloat(0.5))
+        Step2UPGDConfig(sparsity=Fraction(*ratio))
 
 
-def test_pipeline_nonnegative_rejects_adversarial_negative_ratio() -> None:
-    class HiddenNegativeFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return (-1, 1)
-
+def test_pipeline_nonnegative_rejects_exact_negative_fraction() -> None:
     with pytest.raises(ValueError, match=r"step_size must be non-negative"):
-        Step2UPGDConfig(step_size=HiddenNegativeFloat(0.5))
+        Step2UPGDConfig(step_size=Fraction(-1, 1))
 
 
 def test_pipeline_rejects_class_property_spoofing_float() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -453,15 +453,11 @@ def test_step1_smoke_accepts_full_uint32_seed_domain(seed: int) -> None:
         pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
     ],
 )
-def test_step1_unit_interval_rejects_adversarial_ratio_floats(
+def test_step1_unit_interval_rejects_exact_fraction_boundaries(
     field: str, ratio: tuple[int, int]
 ) -> None:
-    class HiddenBoundaryFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=rf"{field} must be in \[0, 1\]"):
-        Step1KernelConfig(**{field: HiddenBoundaryFloat(0.5)})
+        Step1KernelConfig(**{field: Fraction(*ratio)})
 
 
 @pytest.mark.parametrize(
@@ -474,13 +470,9 @@ def test_step1_unit_interval_rejects_adversarial_ratio_floats(
         "noise_std",
     ],
 )
-def test_step1_nonnegative_rejects_adversarial_negative_ratio(field: str) -> None:
-    class HiddenNegativeFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return (-1, 1)
-
+def test_step1_nonnegative_rejects_exact_negative_fraction(field: str) -> None:
     with pytest.raises(ValueError, match=rf"{field} must be non-negative"):
-        Step1KernelConfig(**{field: HiddenNegativeFloat(0.5)})
+        Step1KernelConfig(**{field: Fraction(-1, 1)})
 
 
 def test_step1_rejects_class_property_spoofing_float() -> None:
@@ -499,15 +491,22 @@ def test_step1_rejects_class_property_spoofing_float() -> None:
 
 def test_step1_rejects_spoofed_int_class_with_negative_ratio() -> None:
     class SpoofedIntFloat(float):
+        class_calls = 0
+        ratio_calls = 0
+
         @property
         def __class__(self) -> type[int]:
+            type(self).class_calls += 1
             return int
 
         def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).ratio_calls += 1
             return (-1, 2**200)
 
-    with pytest.raises(ValueError, match="step_size must be non-negative"):
+    with pytest.raises(ValueError, match="step_size must narrow to a finite float32"):
         Step1KernelConfig(step_size=SpoofedIntFloat(0.5))
+    assert SpoofedIntFloat.class_calls == 0
+    assert SpoofedIntFloat.ratio_calls == 0
 
 
 def test_step1_rejects_spoofed_ratio_components() -> None:
@@ -520,11 +519,15 @@ def test_step1_rejects_spoofed_ratio_components() -> None:
             return 1
 
     class BadRatioFloat(float):
+        calls = 0
+
         def as_integer_ratio(self) -> tuple[Any, Any]:
+            type(self).calls += 1
             return (SpoofedComponent(), 2)
 
     with pytest.raises(ValueError, match="must narrow to a finite float32"):
         Step1KernelConfig(step_size=BadRatioFloat(0.5))
+    assert BadRatioFloat.calls == 0
 
 
 
@@ -785,15 +788,22 @@ def test_step2_configs_enforce_exact_scientific_domains(
 
 def test_step2_rejects_spoofed_int_class_with_negative_ratio() -> None:
     class SpoofedIntFloat(float):
+        class_calls = 0
+        ratio_calls = 0
+
         @property
         def __class__(self) -> type[int]:
+            type(self).class_calls += 1
             return int
 
         def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).ratio_calls += 1
             return (-1, 2**200)
 
-    with pytest.raises(ValueError, match="step_size must be non-negative"):
+    with pytest.raises(ValueError, match="step_size must narrow to a finite float32"):
         Step2KernelConfig(step_size=SpoofedIntFloat(0.5))
+    assert SpoofedIntFloat.class_calls == 0
+    assert SpoofedIntFloat.ratio_calls == 0
 
 
 def test_step2_rejects_spoofed_ratio_components() -> None:
@@ -806,11 +816,15 @@ def test_step2_rejects_spoofed_ratio_components() -> None:
             return 1
 
     class BadRatioFloat(float):
+        calls = 0
+
         def as_integer_ratio(self) -> tuple[Any, Any]:
+            type(self).calls += 1
             return (SpoofedComponent(), 2)
 
     with pytest.raises(ValueError, match="must narrow to a finite float32"):
         Step2KernelConfig(step_size=BadRatioFloat(0.5))
+    assert BadRatioFloat.calls == 0
 
 
 
@@ -1271,15 +1285,11 @@ def test_step2_associative_smoke_rejects_invalid_inputs(
         pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
     ],
 )
-def test_step2_unit_interval_rejects_adversarial_ratio_floats(
+def test_step2_unit_interval_rejects_exact_fraction_boundaries(
     ratio: tuple[int, int]
 ) -> None:
-    class HiddenBoundaryFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=r"update_rate must be in \(0, 1\]"):
-        Step2MemoryConfig(update_rate=HiddenBoundaryFloat(0.5))
+        Step2MemoryConfig(update_rate=Fraction(*ratio))
 
 
 @pytest.mark.parametrize(
@@ -1291,15 +1301,11 @@ def test_step2_unit_interval_rejects_adversarial_ratio_floats(
         (Step2MemoryConfig, "novelty_threshold"),
     ],
 )
-def test_step2_nonnegative_rejects_adversarial_negative_ratio(
+def test_step2_nonnegative_rejects_exact_negative_fraction(
     config_type: type[Any], field: str
 ) -> None:
-    class HiddenNegativeFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return (-1, 1)
-
     with pytest.raises(ValueError, match=rf"{field} must be non-negative"):
-        config_type(**{field: HiddenNegativeFloat(0.5)})
+        config_type(**{field: Fraction(-1, 1)})
 
 
 def test_step2_rejects_class_property_spoofing_float() -> None:

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -1144,15 +1144,11 @@ def test_step12_smoke_rejects_invalid_inputs(kwargs: dict[str, Any], match: str)
         pytest.param((2**200 + 1, 2**200), id="above-one-rounds-to-one"),
     ],
 )
-def test_step12_rejects_adversarial_ratio_floats(
+def test_step12_rejects_exact_fraction_boundaries(
     ratio: tuple[int, int]
 ) -> None:
-    class HiddenBoundaryFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=r"option_gamma must be in \[0, 1\]"):
-        Step12IAConfig(option_gamma=HiddenBoundaryFloat(0.5))
+        Step12IAConfig(option_gamma=Fraction(*ratio))
 
 
 def test_step12_rejects_class_property_spoofing_float() -> None:
@@ -1171,15 +1167,22 @@ def test_step12_rejects_class_property_spoofing_float() -> None:
 
 def test_step12_rejects_spoofed_int_class_with_negative_ratio() -> None:
     class SpoofedIntFloat(float):
+        class_calls = 0
+        ratio_calls = 0
+
         @property
         def __class__(self) -> type[int]:
+            type(self).class_calls += 1
             return int
 
         def as_integer_ratio(self) -> tuple[int, int]:
+            type(self).ratio_calls += 1
             return (-1, 2**200)
 
-    with pytest.raises(ValueError, match="base_step_size must be non-negative"):
+    with pytest.raises(ValueError, match="base_step_size must be finite"):
         Step12IAConfig(base_step_size=SpoofedIntFloat(0.5))
+    assert SpoofedIntFloat.class_calls == 0
+    assert SpoofedIntFloat.ratio_calls == 0
 
 
 def test_step12_rejects_integer_subclass_conversion_hooks() -> None:
@@ -1201,11 +1204,15 @@ def test_step12_rejects_spoofed_ratio_components() -> None:
             return 1
 
     class BadRatioFloat(float):
+        calls = 0
+
         def as_integer_ratio(self) -> tuple[Any, Any]:
+            type(self).calls += 1
             return (SpoofedComponent(), 2)
 
     with pytest.raises(ValueError, match="must be finite"):
         Step12IAConfig(option_gamma=BadRatioFloat(0.5))
+    assert BadRatioFloat.calls == 0
 
 
 def _legal_step12_smoke_result(**overrides: object) -> Step12SmokeResult:

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -580,19 +580,15 @@ def test_step6_fields_enforce_exact_scientific_domains(
         ("epsilon_end", (2**200 + 1, 2**200)),
     ],
 )
-def test_step6_fields_reject_hostile_exact_ratio_domains(
+def test_step6_fields_reject_exact_fraction_domains(
     field: str,
     ratio: tuple[int, int],
 ) -> None:
-    class HostileRatioFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return ratio
-
     with pytest.raises(ValueError, match=field):
-        Step6DifferentialSARSAConfig(**{field: HostileRatioFloat(0.5)})
+        Step6DifferentialSARSAConfig(**{field: Fraction(*ratio)})
 
 
-def test_step6_exact_ratio_is_read_once() -> None:
+def test_step6_rejects_float_subclass_before_ratio_hook() -> None:
     class StatefulRatioFloat(float):
         calls = 0
 
@@ -602,10 +598,9 @@ def test_step6_exact_ratio_is_read_once() -> None:
                 return (1, 2)
             return (-1, 1)
 
-    config = Step6DifferentialSARSAConfig(q_step_size=StatefulRatioFloat(0.5))
-
-    assert StatefulRatioFloat.calls == 1
-    assert config.q_step_size == 0.5
+    with pytest.raises(ValueError, match="q_step_size must be finite"):
+        Step6DifferentialSARSAConfig(q_step_size=StatefulRatioFloat(0.5))
+    assert StatefulRatioFloat.calls == 0
 
 
 def test_step6_class_spoof_cannot_bypass_exact_ratio_dispatch() -> None:
@@ -622,7 +617,7 @@ def test_step6_class_spoof_cannot_bypass_exact_ratio_dispatch() -> None:
 
     with pytest.raises(ValueError, match="q_step_size"):
         Step6DifferentialSARSAConfig(q_step_size=IntegralSpoofFloat(0.5))
-    assert IntegralSpoofFloat.calls == 1
+    assert IntegralSpoofFloat.calls == 0
 
 
 @pytest.mark.parametrize("field", ["n_actions", "epsilon_decay_steps"])
@@ -667,7 +662,7 @@ def test_nested_step6_payload_refuses_integral_class_spoof(
 
     with pytest.raises(ValueError, match="q_step_size"):
         config_type.from_dict(payload)
-    assert IntegralSpoofFloat.calls == 1
+    assert IntegralSpoofFloat.calls == 0
 
 
 def test_step6_builtin_float_serialization_and_signed_zero_are_preserved() -> None:
@@ -700,13 +695,9 @@ def test_step6_builtin_float_serialization_and_signed_zero_are_preserved() -> No
         pytest.param(lambda control: Step9DreamingConfig(control=control), id="step9"),
     ],
 )
-def test_nested_step7_and_step9_refuse_hostile_step6_ratio(wrap: Any) -> None:
-    class HiddenNegativeFloat(float):
-        def as_integer_ratio(self) -> tuple[int, int]:
-            return (-1, 2**200)
-
+def test_nested_step7_and_step9_refuse_exact_negative_step6_fraction(wrap: Any) -> None:
     with pytest.raises(ValueError, match="q_step_size"):
-        wrap(Step6DifferentialSARSAConfig(q_step_size=HiddenNegativeFloat(0.5)))
+        wrap(Step6DifferentialSARSAConfig(q_step_size=Fraction(-1, 2**200)))
 
 
 def test_step6_float32_narrowing_avoids_longdouble_double_rounding() -> None:


### PR DESCRIPTION
Finishes the retained-test migration after #1207 changed the shared float32 trust boundary to reject scalar subclasses before conversion hooks.

- exact domain/binary32 boundary checks now use safe `Fraction` fixtures
- hostile float subclasses remain rejection probes and assert `as_integer_ratio` / spoofed `__class__` hooks are never invoked
- updates only stale tests; runtime code is unchanged

Verification on rebased head:
- `tests/test_production_steps.py`: 385 passed
- consolidated changed-contract selection across all five files: 56 passed, 958 deselected
- pre-repair consolidated search run identified exactly the stale assertions (829 peers passed)
- Ruff: clean
- diff check/status: clean