### PR TITLE
fix(core): saturate temporal_context lifetime step_count at int32 max

### DIFF
--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -317,7 +317,11 @@ class TemporalContextFeaturizer:
         )
         proposed = TemporalContextState(
             observation_ema=decayed_ema + (1.0 - decay) * obs,
-            step_count=state.step_count + 1,
+            step_count=jnp.minimum(
+                state.step_count,
+                jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32),
+            )
+            + jnp.asarray(1, dtype=jnp.int32),
         )
         return cast(
             TemporalContextState,

--- a/tests/test_temporal_context.py
+++ b/tests/test_temporal_context.py
@@ -172,6 +172,20 @@ def test_finite_temporal_context_path_is_bitwise_unchanged() -> None:
     assert int(next_state.step_count) == 18
 
 
+def test_temporal_context_step_count_saturates_at_int32_max() -> None:
+    featurizer = TemporalContextFeaturizer(
+        TemporalContextConfig(input_dim=1, periods=())
+    )
+    state = TemporalContextState(
+        observation_ema=jnp.zeros((1,), dtype=jnp.float32),
+        step_count=jnp.asarray(np.iinfo(np.int32).max, dtype=jnp.int32),
+    )
+
+    next_state = featurizer.update(state, jnp.ones((1,), dtype=jnp.float32))
+
+    assert int(next_state.step_count) == np.iinfo(np.int32).max
+
+
 _INVALID_TEMPORAL_CONTEXT_CONFIGS: tuple[dict[str, object], ...] = (
     {"input_dim": 0},
     {"input_dim": -1},


### PR DESCRIPTION
Closes #1226.

## What changed

`TemporalContextFeaturizer.update` incremented its lifetime `step_count` with ordinary `int32` addition. At `2147483647` (`INT32_MAX`), the next observation wrapped the counter to `-2147483648`.

## Fix

Clamp the pre-increment counter to `INT32_MAX - 1` before adding one, so the counter saturates at `INT32_MAX` instead of wrapping negative. No change to ordinary finite-run behavior.

Same bug class as `latent_world_model.py::LatentWorldModel.update` (#1141) and `reward_model.py` (#1018): a lifetime int32 counter wrapping instead of saturating, found here in a sibling module.

## Reachability

`TemporalContextFeaturizer` is exported from the package root in `alberta_framework/__init__.py`. `alberta_framework/steps/step2.py::make_step2_temporal_context` constructs it from public `Step2TemporalContextConfig`, so normal Step 2 observations advance the affected counter with non-hardcoded inputs. The phase code uses `step_count` as absolute time, so a long-running featurizer silently jumping its temporal coordinates backward is a real correctness issue, not just a display artifact.

## Verification

Live reproduction against the unpatched tree (`step_count` initialized at `INT32_MAX`):

```text
step -2147483648 features [ 0.         -0.98677     0.16212673]
```

After the fix, same initial state:

```text
step 2147483647 features [ 0.         -0.98677     0.16212673]
```

Added `test_temporal_context_step_count_saturates_at_int32_max` to `tests/test_temporal_context.py`.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_temporal_context.py::test_temporal_context_step_count_saturates_at_int32_max
AssertionError: assert -2147483648 == 2147483647
1 failed, 37 passed
```

Fix restored: `38 passed`.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), full test file, lint, mypy, and the reachability trace above were all re-run and re-confirmed by hand, not taken from the draft's own report.

Attribution status: self-reported.
