### PR TITLE
fix(streams): sanitize Step 1 scalar errors

### DIFF
--- a/alberta_framework/streams/alberta_plan_step1.py
+++ b/alberta_framework/streams/alberta_plan_step1.py
@@ -36,20 +36,35 @@ from alberta_framework._float32 import round_real_to_float32_with_ratio
 from alberta_framework.core.types import TimeStep
 
 _INT32_MAX = 2**31 - 1
+_ACTUAL_INT_TYPES = frozenset(
+    {
+        int,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    }
+)
 
 
 def _finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
     """Return the original real, exact ratio, and finite binary32 rounding."""
     actual_type = type(value)
     if issubclass(actual_type, bool) or not issubclass(actual_type, Real):
-        raise ValueError(f"{name} must be a real number, got {value!r}")
+        raise ValueError(f"{name} must be a real number")
     real = cast(Real, value)
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}") from None
+        raise ValueError(f"{name} must narrow to a finite float32") from None
     if not math.isfinite(narrowed):
-        raise ValueError(f"{name} must narrow to a finite float32, got {value!r}")
+        raise ValueError(f"{name} must narrow to a finite float32")
     return real, numerator, denominator, narrowed
 
 
@@ -72,14 +87,14 @@ def _canonical_float32_storage(value: Real, narrowed: float) -> float:
 def _require_nonnegative_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{name} must be non-negative, got {value!r}")
+        raise ValueError(f"{name} must be non-negative")
     return _canonical_float32_storage(real, narrowed)
 
 
 def _require_positive_real(name: str, value: object) -> float:
     real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{name} must be positive, got {value!r}")
+        raise ValueError(f"{name} must be positive")
     return _canonical_float32_storage(real, narrowed)
 
 
@@ -91,17 +106,17 @@ def _require_int(
     maximum: int | None = None,
 ) -> int:
     actual_type = type(value)
-    if issubclass(actual_type, bool) or not issubclass(actual_type, Integral):
-        raise ValueError(f"{name} must be an integer, got {value!r}")
+    if actual_type not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer")
     number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{name} must be positive, got {value!r}")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{name} must be non-negative, got {value!r}")
-        raise ValueError(f"{name} must be >= {minimum}, got {value!r}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be <= {maximum}, got {value!r}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
@@ -401,9 +416,7 @@ class XDistShiftStream:
         if type(noise_in_target) is bool or type(noise_in_target) is np.bool_:
             noise_in_target_val = bool(noise_in_target)
         else:
-            raise TypeError(
-                f"noise_in_target must be a boolean, got {noise_in_target!r}"
-            )
+            raise TypeError("noise_in_target must be a boolean")
 
         self._feature_dim = feature_dim_val
         self._num_relevant = num_relevant_val

--- a/tests/test_alberta_plan_step1_streams.py
+++ b/tests/test_alberta_plan_step1_streams.py
@@ -424,6 +424,47 @@ class TestStep1StreamsValidation:
             AlbertaPlanStep1Stream(drift_rate_w=BadRatioFloat(0.5))
         assert BadRatioFloat.calls == 0
 
+    @pytest.mark.parametrize(
+        "field",
+        ["drift_rate_w", "drift_rate_b", "noise_std", "feature_std"],
+    )
+    def test_alberta_plan_step1_float_sinks_do_not_format_rejected_subclasses(
+        self, field: str
+    ) -> None:
+        class HostileFloat(float):
+            repr_calls = 0
+
+            def __repr__(self) -> str:  # pragma: no cover - must not run
+                type(self).repr_calls += 1
+                raise RuntimeError("repr hook must not run")
+
+        with pytest.raises(ValueError, match=field):
+            AlbertaPlanStep1Stream(**{field: HostileFloat(0.5)})
+        assert HostileFloat.repr_calls == 0
+
+    @pytest.mark.parametrize("field", ["feature_dim", "num_relevant"])
+    def test_alberta_plan_step1_int_sinks_do_not_run_subclass_hooks(
+        self, field: str
+    ) -> None:
+        class HostileInt(int):
+            hook_calls = 0
+
+            def __int__(self) -> int:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("int hook must not run")
+
+            def __index__(self) -> int:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("index hook must not run")
+
+            def __repr__(self) -> str:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("repr hook must not run")
+
+        with pytest.raises(ValueError, match=field):
+            AlbertaPlanStep1Stream(**{field: HostileInt(5)})
+        assert HostileInt.hook_calls == 0
+
     def test_xdist_shift_stream_properties_and_boundaries(self) -> None:
         stream = XDistShiftStream(
             feature_dim=10,
@@ -510,3 +551,60 @@ class TestStep1StreamsValidation:
                 num_relevant=3,
                 noise_std=Fraction(-1, 2**200),
             )
+
+    @pytest.mark.parametrize("field", ["noise_std", "scale_min", "scale_max"])
+    def test_xdist_float_sinks_do_not_format_rejected_subclasses(self, field: str) -> None:
+        class HostileFloat(float):
+            repr_calls = 0
+
+            def __repr__(self) -> str:  # pragma: no cover - must not run
+                type(self).repr_calls += 1
+                raise RuntimeError("repr hook must not run")
+
+        kwargs: dict[str, object] = {"feature_dim": 10, "num_relevant": 3}
+        kwargs[field] = HostileFloat(0.5)
+        with pytest.raises(ValueError, match=field):
+            XDistShiftStream(**kwargs)  # type: ignore[arg-type]
+        assert HostileFloat.repr_calls == 0
+
+    @pytest.mark.parametrize(
+        "field", ["feature_dim", "num_relevant", "scale_change_interval"]
+    )
+    def test_xdist_int_sinks_do_not_run_subclass_hooks(self, field: str) -> None:
+        class HostileInt(int):
+            hook_calls = 0
+
+            def __int__(self) -> int:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("int hook must not run")
+
+            def __index__(self) -> int:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("index hook must not run")
+
+            def __repr__(self) -> str:  # pragma: no cover - must not run
+                type(self).hook_calls += 1
+                raise RuntimeError("repr hook must not run")
+
+        kwargs: dict[str, object] = {"feature_dim": 10, "num_relevant": 3}
+        kwargs[field] = HostileInt(5)
+        with pytest.raises(ValueError, match=field):
+            XDistShiftStream(**kwargs)  # type: ignore[arg-type]
+        assert HostileInt.hook_calls == 0
+
+    def test_xdist_boolean_sink_does_not_format_rejected_value(self) -> None:
+        class HostileBoolLike:
+            repr_calls = 0
+
+            def __repr__(self) -> str:  # pragma: no cover - must not run
+                type(self).repr_calls += 1
+                raise RuntimeError("repr hook must not run")
+
+        value = HostileBoolLike()
+        with pytest.raises(TypeError, match="noise_in_target must be a boolean"):
+            XDistShiftStream(
+                feature_dim=10,
+                num_relevant=3,
+                noise_in_target=value,  # type: ignore[arg-type]
+            )
+        assert HostileBoolLike.repr_calls == 0


### PR DESCRIPTION
Follow-up to #1224: close the adjacent rejected-scalar formatting residual in both Step 1 streams.

- never interpolate rejected scalar or boolean values into validation errors
- exact-gate builtin and supported NumPy integer scalar types before canonical conversion
- reject integer subclasses before `__int__`, `__index__`, or `__repr__` hooks
- cover hostile float subclasses across all seven real-valued sinks and hostile integer subclasses across all five integer sinks
- cover the `noise_in_target` rejected-value path without invoking `__repr__`

Compatibility is retained for ordinary builtin/NumPy scalars and field-specific error messages. No output or benchmark artifacts changed.

Verification:
- `pytest -q tests/test_alberta_plan_step1_streams.py` (68 passed)
- `ruff check alberta_framework/streams/alberta_plan_step1.py tests/test_alberta_plan_step1_streams.py`
- `mypy alberta_framework/streams/alberta_plan_step1.py`