### PR TITLE
fix(prereg): invoke the exact setup-uv binary

### DIFF
--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -161,6 +161,7 @@ jobs:
             --output "$RUNNER_TEMP/prereg-metadata/owner-authorization.json"
 
       - name: Set up exact uv 0.9.24
+        id: uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           version: 0.9.24
@@ -170,9 +171,15 @@ jobs:
       - name: Install exact uv-managed CPython 3.12.12
         id: python
         shell: bash
+        env:
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
-          if [[ "$(uv --version)" != "uv 0.9.24" ]]; then
+          if [[ "$UV_PATH" != /* || ! -x "$UV_PATH" ]]; then
+            echo "setup-uv did not return an absolute executable uv path" >&2
+            exit 1
+          fi
+          if [[ "$("$UV_PATH" --version)" != "uv 0.9.24" ]]; then
             echo "setup-uv did not install exact uv 0.9.24" >&2
             exit 1
           fi
@@ -180,8 +187,8 @@ jobs:
             echo "PYTHONOPTIMIZE must be exactly zero" >&2
             exit 1
           fi
-          uv python install --managed-python 3.12.12
-          python_path="$(uv python find --managed-python --no-project 3.12.12)"
+          "$UV_PATH" python install --managed-python 3.12.12
+          python_path="$("$UV_PATH" python find --managed-python --no-project 3.12.12)"
           identity="$("$python_path" -c \
             'import platform; print(platform.python_implementation(), platform.python_version(), platform.machine())')"
           if [[ "$identity" != "CPython 3.12.12 arm64" ]]; then
@@ -198,6 +205,7 @@ jobs:
         shell: bash
         env:
           PYTHON_PATH: ${{ steps.python.outputs.path }}
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
           cpu_brand="$(sysctl -n machdep.cpu.brand_string)"
@@ -205,11 +213,12 @@ jobs:
             echo "macos-14 runner is not an Apple M1 family host: $cpu_brand" >&2
             exit 1
           fi
-          uv sync \
+          "$UV_PATH" sync \
             --locked \
             --python "$PYTHON_PATH" \
             --extra research
-          uv run --no-sync python - "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
+          "$UV_PATH" run --no-sync python - \
+            "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
           import importlib.metadata
           import json
           import os
@@ -334,10 +343,11 @@ jobs:
           UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
           WORKFLOW_BLOB_SHA1: ${{ steps.identity.outputs.workflow_blob_sha1 }}
           DRIVER_BLOB_SHA1: ${{ steps.identity.outputs.driver_blob_sha1 }}
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
           metadata="$RUNNER_TEMP/prereg-metadata/launch-preflight.json"
-          uv run --no-sync python .github/scripts/ipmnist_prereg.py preflight \
+          "$UV_PATH" run --no-sync python .github/scripts/ipmnist_prereg.py preflight \
             --protocol "$PROTOCOL" \
             --repository "$GITHUB_REPOSITORY" \
             --source "$SOURCE" \
@@ -355,9 +365,11 @@ jobs:
 
       - name: Run code-only preregistration preflight tests
         shell: bash
+        env:
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
-          uv run --no-sync python -m pytest \
+          "$UV_PATH" run --no-sync python -m pytest \
             tests/test_ipmnist_prereg_workflow.py \
             tests/test_ipmnist_screening.py \
             -q \
@@ -368,10 +380,12 @@ jobs:
 
       - name: Materialize and hash the canonical MNIST cache
         shell: bash
+        env:
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
           data_home="$RUNNER_TEMP/openml-cache"
-          uv run --no-sync python - "$data_home" <<'PY'
+          "$UV_PATH" run --no-sync python - "$data_home" <<'PY'
           import hashlib
           import os
           import sys
@@ -402,6 +416,7 @@ jobs:
         shell: bash
         env:
           PROTOCOL: ${{ inputs.protocol }}
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
           case "$PROTOCOL" in
@@ -438,7 +453,7 @@ jobs:
             for arm in "$control" "$candidate"; do
               shard="$shards_dir/${arm}_seed${seed}.json"
               log="$logs_dir/${arm}_seed${seed}.log"
-              uv run --no-sync python -m \
+              "$UV_PATH" run --no-sync python -m \
                 alberta_framework.benchmarks.ipmnist_screening run \
                 --config-name "$arm" \
                 --seed "$seed" \
@@ -452,7 +467,7 @@ jobs:
               shard_args+=("$shard")
             done
           done
-          uv run --no-sync python -m \
+          "$UV_PATH" run --no-sync python -m \
             alberta_framework.benchmarks.ipmnist_screening merge \
             --shards "${shard_args[@]}" \
             --control-name "$control" \
@@ -471,10 +486,11 @@ jobs:
           SOURCE: ${{ inputs.launch_sha }}
           TREE: ${{ steps.identity.outputs.tree }}
           UV_LOCK_SHA256: ${{ steps.identity.outputs.uv_lock_sha256 }}
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
           result="$RUNNER_TEMP/prereg-metadata/result-validation.json"
-          uv run --no-sync python .github/scripts/ipmnist_prereg.py validate \
+          "$UV_PATH" run --no-sync python .github/scripts/ipmnist_prereg.py validate \
             --protocol "$PROTOCOL" \
             --root "$GITHUB_WORKSPACE" \
             --runner-receipt "$RUNNER_TEMP/prereg-metadata/runner.json" \
@@ -487,7 +503,7 @@ jobs:
             echo
             echo "- Protocol: $PROTOCOL"
             echo "- Source: $SOURCE"
-            echo "- Outcome: $(uv run --no-sync python -c 'import json,sys; print(json.load(open(sys.argv[1]))["outcome"])' "$result")"
+            echo "- Outcome: $("$UV_PATH" run --no-sync python -c 'import json,sys; print(json.load(open(sys.argv[1]))["outcome"])' "$result")"
             echo "- Validation metadata: result-validation.json"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -495,9 +511,10 @@ jobs:
         shell: bash
         env:
           PROTOCOL: ${{ inputs.protocol }}
+          UV_PATH: ${{ steps.uv.outputs.uv-path }}
         run: |
           set -euo pipefail
-          uv run --no-sync python .github/scripts/ipmnist_prereg.py seal \
+          "$UV_PATH" run --no-sync python .github/scripts/ipmnist_prereg.py seal \
             --protocol "$PROTOCOL" \
             --root "$GITHUB_WORKSPACE" \
             --launch-preflight "$RUNNER_TEMP/prereg-metadata/launch-preflight.json" \

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -97,13 +97,25 @@ def test_issue184_workflow_pins_every_shell_mapping() -> None:
         < measurement_index
     )
     assert "python3 .github/scripts/ipmnist_prereg.py authorize" in workflow
-    assert "uv run --no-sync python .github/scripts/ipmnist_prereg.py preflight" in workflow
+    assert '"$UV_PATH" run --no-sync python .github/scripts/ipmnist_prereg.py preflight' in workflow
     upload = workflow[workflow.index("- name: Upload 90-day result or partial recovery bundle") :]
     assert "${{ steps.protocol.outputs.output_root }}" in upload
     assert "outputs/ipmnist_screening/replication_r1" not in upload
     assert "outputs/ipmnist_screening/rls_preset_ablation_r1" not in upload
     assert "outputs/ipmnist_screening/gate_ablation_r3" not in upload
     assert "retention-days: 90" in upload
+
+
+def test_prereg_workflow_invokes_only_setup_uv_pinned_binary() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "ipmnist-prereg.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "      - name: Set up exact uv 0.9.24\n        id: uv\n" in workflow
+    assert 'UV_PATH: ${{ steps.uv.outputs.uv-path }}' in workflow
+    assert '[[ "$UV_PATH" != /* || ! -x "$UV_PATH" ]]' in workflow
+    shell_lines = [line.strip() for line in workflow.splitlines()]
+    assert not any(line.startswith("uv ") or "$(uv " in line for line in shell_lines)
+    assert sum('"$UV_PATH" ' in line for line in shell_lines) >= 13
 
 
 def test_issue184_github_and_local_protocols_cannot_drift() -> None:
@@ -877,8 +889,8 @@ def test_workflow_installs_exact_uv_managed_python() -> None:
         encoding="utf-8"
     )
     assert "actions/setup-python@" not in workflow
-    assert "uv python install --managed-python 3.12.12" in workflow
-    assert 'uv python find --managed-python --no-project 3.12.12' in workflow
+    assert '"$UV_PATH" python install --managed-python 3.12.12' in workflow
+    assert '"$UV_PATH" python find --managed-python --no-project 3.12.12' in workflow
     assert "CPython 3.12.12 arm64" in workflow
     assert '--python "$PYTHON_PATH"' in workflow
     assert '"jax_disable_jit": False' in workflow


### PR DESCRIPTION
## Outcome

Repairs the fail-closed pre-measurement stop in #51 run 32066770249. `setup-uv` installed uv 0.9.24 successfully, but the next step called bare `uv`; the hosted runner PATH resolved a different preinstalled binary, so the exact-version gate stopped before Python setup, dataset materialization, or any shard.

## Fix

- bind the pinned action step as `id: uv`
- require its documented `uv-path` output to be absolute and executable
- invoke that exact path at every one of the workflow uv call sites, including Python installation, sync, preflight, tests, dataset materialization, all shards/merge, validation, outcome display, and sealing
- add a workflow contract test that rejects all bare `uv` execution and pins the action output

## Failing-test-first evidence

On the unmodified base, the new path-binding test failed because the setup step had no id/output binding. After the repair: 126 workflow-driver tests passed; actionlint, Ruff, strict driver mypy, and diff check passed.

No benchmark, seed, dataset, or result artifact was created. The failed run uploaded only a 1,086-byte partial preflight artifact. A future run requires a new source/tag, a new exact owner authorization, and one new dispatch; rerunning attempt 1 is forbidden.

Refs #51