### PR TITLE
fix(core): saturate keyboard-chord learner step_count at int32 max

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -1015,7 +1015,7 @@ def update_keyboard_chord_learner(
     proposed_state = KeyboardChordLearnerState(
         chord_vector=proposed_vector * scale,
         reward_baseline=baseline,
-        step_count=state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(state.step_count),
     )
     # Inf reward * a zero chord coordinate is 0*inf = NaN, then the
     # max-norm rescaling is nan/inf and the whole vector stays poisoned.

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -21,6 +21,7 @@ import pytest
 
 from alberta_framework.core.oak import (
     KeyboardChordLearnerConfig,
+    KeyboardChordLearnerState,
     OaKAgent,
     OaKArrayResult,
     OaKConfig,
@@ -995,6 +996,32 @@ def test_keyboard_chord_learner_step_count_saturates(use_jit: bool) -> None:
     )
 
     assert int(updated.step_count) == jnp.iinfo(jnp.int32).max
+
+
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_keyboard_chord_learner_step_count_stays_saturated_through_scan(
+    use_jit: bool,
+) -> None:
+    cfg = KeyboardChordLearnerConfig(n_options=2)
+    maximum = jnp.iinfo(jnp.int32).max
+    state = init_keyboard_chord_learner(cfg).replace(
+        step_count=jnp.asarray(maximum - 1, dtype=jnp.int32)
+    )
+    selected = jnp.array([1.0, 0.0], dtype=jnp.float32)
+    reward = jnp.array(1.0, dtype=jnp.float32)
+
+    def run_scan(initial: KeyboardChordLearnerState):
+        def body(carry: KeyboardChordLearnerState, _: None):
+            updated = update_keyboard_chord_learner(cfg, carry, selected, reward)
+            return updated, updated.step_count
+
+        return jax.lax.scan(body, initial, xs=None, length=3)
+
+    scan = jax.jit(run_scan) if use_jit else run_scan
+    final, counts = scan(state)
+
+    np.testing.assert_array_equal(np.asarray(counts), np.asarray([maximum] * 3, dtype=np.int32))
+    assert int(final.step_count) == maximum
 
 
 def test_keyboard_chord_learner_max_norm_bounds_vector() -> None:

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -13,6 +13,7 @@ from fractions import Fraction
 from typing import Any
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -974,6 +975,26 @@ def test_keyboard_chord_learner_positive_reward_moves_toward_chord() -> None:
     after = float(jnp.dot(updated.chord_vector, selected))
     assert after > before
     assert int(updated.step_count) == 1
+
+
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_keyboard_chord_learner_step_count_saturates(use_jit: bool) -> None:
+    cfg = KeyboardChordLearnerConfig(n_options=2)
+    state = init_keyboard_chord_learner(cfg).replace(
+        step_count=jnp.asarray(jnp.iinfo(jnp.int32).max, dtype=jnp.int32)
+    )
+    update = update_keyboard_chord_learner
+    if use_jit:
+        update = jax.jit(update, static_argnums=0)
+
+    updated = update(
+        cfg,
+        state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array(1.0, dtype=jnp.float32),
+    )
+
+    assert int(updated.step_count) == jnp.iinfo(jnp.int32).max
 
 
 def test_keyboard_chord_learner_max_norm_bounds_vector() -> None:


### PR DESCRIPTION
Closes #1234.

## What changed

`update_keyboard_chord_learner` incremented its lifetime `step_count` with raw `state.step_count + 1` instead of the shared `_saturating_int32_counter_increment` helper already used by every other counter in this same module.

## Fix

Switch this one call site to the existing `_saturating_int32_counter_increment` helper — no new code, matching the pattern already established at `execution_counts` (two other call sites in the same file) and the drift test's expected-step-count check.

## Reachability

`update_keyboard_chord_learner` is imported by `alberta_framework/steps/step11.py` and listed in that module's `__all__`, so the Step 11 production facade is reachable from the publicly exported Step 11 API with ordinary finite chord/reward inputs — not dead code.

## Verification

Live reproduction against the unpatched tree (`step_count` initialized at `INT32_MAX`):

```text
eager: step_count=-2147483648 dtype=int32
jit: step_count=-2147483648 dtype=int32
```

After the fix, same initial state:

```text
eager: step_count=2147483647 dtype=int32
jit: step_count=2147483647 dtype=int32
```

Added `test_keyboard_chord_learner_step_count_saturates`, parametrized over eager and JIT execution.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_step11_production.py::test_keyboard_chord_learner_step_count_saturates[False]
FAILED tests/test_step11_production.py::test_keyboard_chord_learner_step_count_saturates[True]
AssertionError: assert -2147483648 == 2147483647
2 failed, 218 deselected
```

Fix restored: `2 passed, 218 deselected`.

Full `tests/test_step11_production.py`: `218 passed, 2 failed`. The two failures (`test_step11_oak_validates_original_real_domain_before_narrowing`, `test_step11_oak_narrows_the_original_real_once`) are pre-existing and unrelated — a platform-specific `np.longdouble`/float32 precision quirk in unrelated real-domain-narrowing tests, not touched by this change.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), full test file, lint, mypy, and the reachability trace above were all re-run and re-confirmed by hand, not taken from the draft's own report.

Attribution status: self-reported.
