### PR TITLE
fix(step12): scope hostile validation to public inputs

### DIFF
--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -173,18 +173,10 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
-_NUMPY_INTEGER_TYPES = _ACTUAL_INT_TYPES - {int}
 
 
-def _require_exact_str(name: str, value: object) -> str:
-    if type(value) is not str:
-        raise ValueError(f"{name} must be an exact string")
-    return value
-
-
-def _require_unit_interval(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, denominator, narrowed = finite_real_and_float32(host_name, value)
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
         real < 0.0
         or not real <= 1.0
@@ -193,59 +185,54 @@ def _require_unit_interval(name: object, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{host_name} must be in [0, 1]")
+        raise ValueError(f"{name} must be in [0, 1]")
     return float(narrowed)
 
 
-def _require_nonnegative_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{host_name} must be non-negative")
+        raise ValueError(f"{name} must be non-negative")
     return float(narrowed)
 
 
-def _require_positive_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{host_name} must be positive")
+        raise ValueError(f"{name} must be positive")
     return float(narrowed)
 
 
-def _require_real_scalar(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    _, _, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_real_scalar(name: str, value: object) -> float:
+    _, _, _, narrowed = finite_real_and_float32(name, value)
     return float(narrowed)
 
 
 def _require_int(
-    name: object,
+    name: str,
     value: object,
     *,
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
     if actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{host_name} must be an integer")
+        raise ValueError(f"{name} must be an integer")
     number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{host_name} must be positive")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{host_name} must be non-negative")
-        raise ValueError(f"{host_name} must be >= {minimum}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{host_name} must be <= {maximum}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
-def _require_bool(name: object, value: object) -> bool:
-    host_name = _require_exact_str("name", name)
+def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
-        raise ValueError(f"{host_name} must be a boolean")
+        raise ValueError(f"{name} must be a boolean")
     return value
 
 

--- a/tests/test_step12_hostile_validation.py
+++ b/tests/test_step12_hostile_validation.py
@@ -29,6 +29,10 @@ class _HostileInt(int):
         type(self).calls += 1
         raise AssertionError("HostileInt.__index__ must not be called")
 
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("HostileInt.__int__ must not be called")
+
     def __repr__(self) -> str:
         type(self).calls += 1
         raise AssertionError("HostileInt.__repr__ must not be called")
@@ -48,6 +52,28 @@ class _HostileFloat(float):
     def __repr__(self) -> str:
         type(self).calls += 1
         raise AssertionError("HostileFloat.__repr__ must not be called")
+
+
+class _HostileTypeName(type):
+    calls = 0
+
+    def __getattribute__(cls, name: str) -> Any:
+        if name == "__name__":
+            _HostileTypeName.calls += 1
+            raise AssertionError("metaclass __name__ hook must not be called")
+        return super().__getattribute__(name)
+
+
+class _HostileSpecsContainer(metaclass=_HostileTypeName):
+    calls = 0
+
+    def __iter__(self):
+        type(self).calls += 1
+        raise AssertionError("container iteration hook must not be called")
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("container repr hook must not be called")
 
 
 def test_rejects_string_subclass_for_n_demons() -> None:
@@ -82,16 +108,6 @@ def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     assert "!r" not in str(exc.value)
 
 
-def test_does_not_invoke_hostile_value_when_name_is_evil_via_sink() -> None:
-    from alberta_framework.steps._float32_validation import finite_real_and_float32
-
-    evil = _EvilStr("x")
-    _HostileFloat.calls = 0
-    with pytest.raises(ValueError, match="must be an exact string"):
-        finite_real_and_float32(evil, _HostileFloat(1.0))  # type: ignore[arg-type]
-    assert _HostileFloat.calls == 0
-
-
 def test_rejects_plain_string_for_option_gamma() -> None:
     with pytest.raises(ValueError, match="must be a real number"):
         Step12IAConfig(option_gamma="0.99")  # type: ignore[arg-type]
@@ -113,6 +129,15 @@ def test_rejects_subtask_specs_non_tuple_without_repr() -> None:
     with pytest.raises(ValueError, match="must be a tuple of SubtaskSpec") as exc:
         Step12IAConfig(subtask_specs=[SubtaskSpec(feature_index=0)])  # type: ignore[arg-type]
     assert "!r" not in str(exc.value)
+
+
+def test_rejects_hostile_subtask_container_without_metadata_hooks() -> None:
+    _HostileTypeName.calls = 0
+    _HostileSpecsContainer.calls = 0
+    with pytest.raises(ValueError, match="must be a tuple of SubtaskSpec"):
+        Step12IAConfig(subtask_specs=_HostileSpecsContainer())  # type: ignore[arg-type]
+    assert _HostileTypeName.calls == 0
+    assert _HostileSpecsContainer.calls == 0
 
 
 def test_rejects_feature_index_out_of_range_without_repr() -> None:


### PR DESCRIPTION
Post-merge corrective for #1233.

The Step 12 caller-controlled numeric, boolean, tuple, and SubtaskSpec metadata hardening is retained. This removes the unnecessary widening of private helper `name` parameters, which are fixed internal literals, and removes an unrelated duplicate test of the shared scalar sink. It adds the missing public-boundary adversarial coverage for `int.__int__` and hostile subtask containers/metaclasses, proving rejection occurs without conversion, iteration, repr, or type-name hooks.

Verification on the repaired tree:
- full Step12/shared float32 panel: 328 passed
- focused hostile Step12 panel: 13 passed
- Ruff: clean
- mypy Step12 facade: clean
- diff/worktree: clean