### PR TITLE
fix(steps): complete Step 12 facade boundaries

### DIFF
--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -126,11 +126,43 @@ class Step12IAConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> Step12IAConfig:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
-        specs_raw = data.pop("subtask_specs", [])
-        specs = tuple(SubtaskSpec(**s) for s in specs_raw)
-        return cls(subtask_specs=specs, **data)
+        data = _require_payload(
+            payload,
+            name="Step12IAConfig payload",
+            allowed=_STEP12_CONFIG_FIELDS,
+        )
+        if type(data["type"]) is not str or data["type"] != "Step12IAConfig":
+            raise ValueError("Step12IAConfig payload type must be 'Step12IAConfig'")
+        specs_raw = data.pop("subtask_specs")
+        if type(specs_raw) is not list:
+            raise ValueError("subtask_specs payload must be an exact list")
+        raw_specs = cast(list[object], specs_raw)
+        _require_subtask_count(len(raw_specs))
+        specs: list[SubtaskSpec] = []
+        for index in range(len(raw_specs)):
+            raw_spec = _require_payload(
+                raw_specs[index],
+                name=f"subtask_specs[{index}]",
+                allowed=_SUBTASK_SPEC_FIELDS,
+            )
+            specs.append(
+                SubtaskSpec(
+                    feature_index=_require_int(
+                        "feature_index", raw_spec["feature_index"], minimum=0,
+                        maximum=_INT32_MAX
+                    ),
+                    threshold=_require_positive_real("threshold", raw_spec["threshold"]),
+                    pseudo_reward_scale=_require_positive_real(
+                        "pseudo_reward_scale", raw_spec["pseudo_reward_scale"]
+                    ),
+                    max_option_steps=_require_int(
+                        "max_option_steps", raw_spec["max_option_steps"], minimum=1,
+                        maximum=_INT32_MAX
+                    ),
+                )
+            )
+        data.pop("type")
+        return cls(subtask_specs=tuple(specs), **data)
 
     def to_ia_config(self) -> IAConfig:
         """Convert to the core :class:`IAConfig`."""
@@ -158,6 +190,28 @@ class Step12IAConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_SUBTASK_SPECS = 4_096
+_MAX_PLANNING_BACKUPS_PER_STEP = 4_096
+_STEP12_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "n_demons",
+        "cerebellum_step_size",
+        "subtask_specs",
+        "observation_dim",
+        "n_primitive_actions",
+        "base_step_size",
+        "base_avg_reward_step_size",
+        "option_step_size",
+        "option_gamma",
+        "option_planning_backups_per_step",
+        "epsilon_base",
+        "utility_ema_decay",
+    }
+)
+_SUBTASK_SPEC_FIELDS = frozenset(
+    {"feature_index", "threshold", "pseudo_reward_scale", "max_option_steps"}
+)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -173,6 +227,101 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+
+
+def _require_payload(
+    value: object,
+    *,
+    name: str,
+    allowed: frozenset[str],
+) -> dict[str, Any]:
+    """Copy one exact record after checking its complete fixed schema."""
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an exact dictionary")
+    raw = cast(dict[object, object], value)
+    if any(type(key) is not str for key in raw):
+        raise ValueError(f"{name} keys must be exact strings")
+    keys = cast(set[str], set(raw))
+    if keys != allowed:
+        raise ValueError(f"{name} fields do not match the schema")
+    return cast(dict[str, Any], dict(raw))
+
+
+def _require_subtask_count(count: int) -> None:
+    if count > _MAX_SUBTASK_SPECS:
+        raise ValueError(
+            f"subtask_specs must contain at most {_MAX_SUBTASK_SPECS} values"
+        )
+
+
+def _checked_product(name: str, *factors: int) -> int:
+    product = 1
+    for factor in factors:
+        if factor < 0 or (factor != 0 and product > _INT32_MAX // factor):
+            raise ValueError(f"derived {name} must fit signed int32")
+        product *= factor
+    return product
+
+
+def _checked_sum(name: str, *terms: int) -> int:
+    total = 0
+    for term in terms:
+        if term < 0 or term > _INT32_MAX - total:
+            raise ValueError(f"derived {name} must fit signed int32")
+        total += term
+    return total
+
+
+def _preflight_step12_agent_resources(config: Step12IAConfig) -> None:
+    augmented_dim = _checked_sum(
+        "Step 12 augmented observation dimension",
+        config.observation_dim,
+        config.n_demons,
+    )
+    weights = _checked_product(
+        "Step 12 cerebellum weight count",
+        config.n_demons,
+        config.observation_dim,
+    )
+    _checked_sum(
+        "Step 12 direct agent bytes",
+        _checked_product("Step 12 cerebellum weight bytes", 4, weights),
+        _checked_product("Step 12 demon index bytes", 4, config.n_demons),
+        _checked_product("Step 12 augmented row bytes", 4, augmented_dim),
+    )
+
+
+def _preflight_step12_smoke_resources(
+    config: Step12IAConfig,
+    steps: int,
+) -> None:
+    observation_rows = _checked_sum("Step 12 observation row count", steps, 1)
+    observations = _checked_product(
+        "Step 12 observation count", observation_rows, config.observation_dim
+    )
+    demon_outputs = _checked_product(
+        "Step 12 demon output count", steps, config.n_demons
+    )
+    augmented_outputs = _checked_product(
+        "Step 12 augmented output count",
+        steps,
+        _checked_sum(
+            "Step 12 augmented observation dimension",
+            config.observation_dim,
+            config.n_demons,
+        ),
+    )
+    _checked_sum(
+        "Step 12 smoke array bytes",
+        _checked_product("Step 12 observation bytes", 4, observations),
+        _checked_product("Step 12 reward bytes", 4, steps),
+        _checked_product("Step 12 demon output bytes", 8, demon_outputs),
+        _checked_product("Step 12 augmented output bytes", 4, augmented_outputs),
+        # recommendation + TD error + two two-word clocks
+        _checked_product("Step 12 scalar and clock output bytes", 24, steps),
+        # Eight one-byte transaction-validity arrays.
+        _checked_product("Step 12 validity output bytes", 8, steps),
+    )
 
 
 def _require_unit_interval(name: str, value: object) -> float:
@@ -237,6 +386,8 @@ def _require_bool(name: str, value: object) -> bool:
 
 
 def _validate_ia_facade_config(config: Step12IAConfig) -> None:
+    if type(config) is not Step12IAConfig:
+        raise TypeError("config must be an exact Step12IAConfig")
     n_demons = _require_int("n_demons", config.n_demons, minimum=1, maximum=_INT32_MAX)
     observation_dim = _require_int(
         "observation_dim",
@@ -254,10 +405,11 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
         "option_planning_backups_per_step",
         config.option_planning_backups_per_step,
         minimum=0,
-        maximum=_INT32_MAX - 1,
+        maximum=_MAX_PLANNING_BACKUPS_PER_STEP,
     )
     if type(config.subtask_specs) is not tuple:
         raise ValueError("subtask_specs must be a tuple of SubtaskSpec")
+    _require_subtask_count(len(config.subtask_specs))
     canonical_specs: list[SubtaskSpec] = []
     for spec in config.subtask_specs:
         if type(spec) is not SubtaskSpec:
@@ -324,6 +476,10 @@ def _validate_ia_facade_config(config: Step12IAConfig) -> None:
     )
     object.__setattr__(config, "epsilon_base", epsilon_base)
     object.__setattr__(config, "utility_ema_decay", utility_ema_decay)
+    _preflight_step12_agent_resources(config)
+    # Constructing the nested configs is allocation-free and applies their
+    # exact derived STOMP/OaK resource formulas at this facade boundary.
+    config.to_ia_config()
 
 
 @dataclass(frozen=True)
@@ -342,6 +498,10 @@ class Step12SmokeResult:
     agent_config: dict[str, Any]
 
     def __post_init__(self) -> None:
+        if type(self.config) is not Step12IAConfig:
+            raise TypeError("config must be an exact Step12IAConfig")
+        if type(self.agent_config) is not dict:
+            raise TypeError("agent_config must be an exact dictionary")
         object.__setattr__(
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
@@ -388,6 +548,9 @@ def make_step12_ia_agent(config: Step12IAConfig | None = None) -> IAAgent:
     """
     if config is None:
         config = Step12IAConfig()
+    elif type(config) is not Step12IAConfig:
+        raise TypeError("config must be an exact Step12IAConfig")
+    _preflight_step12_agent_resources(config)
     return IAAgent(config.to_ia_config())
 
 
@@ -478,7 +641,14 @@ def run_step12_smoke(
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
     seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
 
-    cfg = config or Step12IAConfig()
+    if config is None:
+        cfg = Step12IAConfig()
+    elif type(config) is Step12IAConfig:
+        cfg = config
+    else:
+        raise TypeError("config must be an exact Step12IAConfig")
+    _preflight_step12_agent_resources(cfg)
+    _preflight_step12_smoke_resources(cfg, steps)
     agent = make_step12_ia_agent(cfg)
     obs_dim = cfg.observation_dim
 

--- a/tests/test_step12_hostile_validation.py
+++ b/tests/test_step12_hostile_validation.py
@@ -7,7 +7,12 @@ import numpy as np
 import pytest
 
 from alberta_framework.core.options import SubtaskSpec
-from alberta_framework.steps.step12 import Step12IAConfig
+from alberta_framework.steps.step12 import (
+    Step12IAConfig,
+    Step12SmokeResult,
+    make_step12_ia_agent,
+    run_step12_smoke,
+)
 
 
 class _EvilStr(str):
@@ -182,3 +187,122 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step12IAConfig(cerebellum_step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_from_config_requires_complete_exact_schema_without_mapping_hooks() -> None:
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("mapping hook must not run")
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step12IAConfig.from_config(cast(Any, HostileDict()))
+    assert HostileDict.calls == 0
+
+    payload = Step12IAConfig().to_config()
+    for mutation in (
+        lambda value: value.pop("type"),
+        lambda value: value.__setitem__("extra", 1),
+        lambda value: value.__setitem__("type", "wrong"),
+    ):
+        malformed = dict(payload)
+        mutation(malformed)
+        with pytest.raises(ValueError, match="(schema|payload type)"):
+            Step12IAConfig.from_config(malformed)
+
+
+def test_from_config_requires_exact_nested_records_before_hooks() -> None:
+    class HostileRecord(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("record hook must not run")
+
+    payload = Step12IAConfig().to_config()
+    payload["subtask_specs"] = [HostileRecord()]
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step12IAConfig.from_config(payload)
+    assert HostileRecord.calls == 0
+
+
+def test_from_config_and_direct_paths_have_matching_canonical_values() -> None:
+    direct = Step12IAConfig(
+        n_demons=np.int32(3),  # type: ignore[arg-type]
+        cerebellum_step_size=np.float64(0.05),  # type: ignore[arg-type]
+        subtask_specs=(SubtaskSpec(feature_index=0, threshold=Fraction(1, 2)),),
+    )
+    parsed = Step12IAConfig.from_config(direct.to_config())
+    assert parsed == direct
+    assert parsed.to_config() == direct.to_config()
+
+
+def test_subtask_validation_work_is_bounded_before_iteration() -> None:
+    spec = SubtaskSpec(feature_index=0)
+    with pytest.raises(ValueError, match="at most 4096"):
+        Step12IAConfig(subtask_specs=(spec,) * 4_097)
+
+    payload = Step12IAConfig().to_config()
+    raw_spec = {
+        "feature_index": 0,
+        "threshold": 0.5,
+        "pseudo_reward_scale": 1.0,
+        "max_option_steps": 8,
+    }
+    payload["subtask_specs"] = [raw_spec] * 4_097
+    with pytest.raises(ValueError, match="at most 4096"):
+        Step12IAConfig.from_config(payload)
+
+
+def test_runtime_entry_points_require_exact_config_without_hooks() -> None:
+    calls = 0
+
+    class HostileConfig:
+        def __bool__(self) -> bool:  # pragma: no cover - must not run
+            nonlocal calls
+            calls += 1
+            raise AssertionError("truthiness hook must not run")
+
+        def to_ia_config(self) -> object:  # pragma: no cover - must not run
+            nonlocal calls
+            calls += 1
+            raise AssertionError("config hook must not run")
+
+    value = HostileConfig()
+    with pytest.raises(TypeError, match="exact Step12IAConfig"):
+        make_step12_ia_agent(cast(Any, value))
+    with pytest.raises(TypeError, match="exact Step12IAConfig"):
+        run_step12_smoke(cast(Any, value), steps=1)
+    assert calls == 0
+
+
+def test_runtime_preflights_derived_resources_before_jax_allocation() -> None:
+    with pytest.raises(ValueError, match="augmented observation dimension"):
+        Step12IAConfig(n_demons=2**31 - 1, observation_dim=1)
+    with pytest.raises(ValueError, match="cerebellum weight bytes"):
+        Step12IAConfig(n_demons=536_870_912, observation_dim=1)
+    with pytest.raises(ValueError, match="cerebellum weight count"):
+        Step12IAConfig(n_demons=50_000, observation_dim=50_000)
+    with pytest.raises(ValueError, match="observation row count"):
+        run_step12_smoke(steps=2**31 - 1)
+
+
+def test_smoke_record_requires_exact_config_and_agent_config_identities() -> None:
+    legal: dict[str, object] = {
+        "config": Step12IAConfig(),
+        "steps": 1,
+        "seed": 0,
+        "predictions_shape": (1, 4),
+        "cerebellum_errors_shape": (1, 4),
+        "recommendations_shape": (1,),
+        "augmented_obs_shape": (1, 8),
+        "cortex_td_errors_shape": (1,),
+        "finite": True,
+        "agent_config": {},
+    }
+    with pytest.raises(TypeError, match="config must be an exact"):
+        Step12SmokeResult(**{**legal, "config": object()})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="agent_config must be an exact"):
+        Step12SmokeResult(**{**legal, "agent_config": {"x": 1}.keys()})  # type: ignore[arg-type]

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -406,13 +406,13 @@ def test_step12_ia_fields_preserve_legal_endpoints() -> None:
         option_gamma=1.0,
         epsilon_base=1.0,
         utility_ema_decay=1.0,
-        option_planning_backups_per_step=2**31 - 2,
+        option_planning_backups_per_step=4_096,
     )
     make_step12_ia_agent(upper)
     assert upper.option_gamma == 1.0
     assert upper.epsilon_base == 1.0
     assert upper.utility_ema_decay == 1.0
-    assert upper.option_planning_backups_per_step == 2**31 - 2
+    assert upper.option_planning_backups_per_step == 4_096
 
 
 def test_step12_ia_fields_canonicalize_nonbuiltin_numbers() -> None:
@@ -550,14 +550,14 @@ def test_step12_float32_underflow_and_finite_boundaries_are_canonical() -> None:
     assert maximum.subtask_specs[0].pseudo_reward_scale == _FLOAT32_MAX
 
 
-def test_step12_int32_counter_boundaries_match_core_sinks() -> None:
+def test_step12_counter_and_planning_work_boundaries() -> None:
     config = _config_with(
         subtask_specs=(SubtaskSpec(feature_index=0, max_option_steps=_INT32_MAX),),
-        option_planning_backups_per_step=_INT32_MAX - 1,
+        option_planning_backups_per_step=4_096,
     )
     make_step12_ia_agent(config)
     assert config.subtask_specs[0].max_option_steps == _INT32_MAX
-    assert config.option_planning_backups_per_step == _INT32_MAX - 1
+    assert config.option_planning_backups_per_step == 4_096
 
     with pytest.raises(ValueError, match="max_option_steps"):
         _config_with(
@@ -566,7 +566,7 @@ def test_step12_int32_counter_boundaries_match_core_sinks() -> None:
             )
         )
     with pytest.raises(ValueError, match="option_planning_backups_per_step"):
-        _config_with(option_planning_backups_per_step=_INT32_MAX)
+        _config_with(option_planning_backups_per_step=4_097)
 
 
 def test_step12_builtin_json_roundtrip_preserves_canonical_config() -> None:
@@ -1092,28 +1092,28 @@ def test_step12_state_stays_finite_200_steps() -> None:
 def test_step12_config_preserves_float32_boundaries() -> None:
     f32_max = float(np.finfo(np.float32).max)
     spec = SubtaskSpec(
-        feature_index=2**31 - 2,
+        feature_index=0,
         threshold=f32_max,
         pseudo_reward_scale=f32_max,
         max_option_steps=2**31 - 1,
     )
     config = Step12IAConfig(
-        n_demons=2**31 - 1,
+        n_demons=1,
         cerebellum_step_size=f32_max,
         subtask_specs=(spec,),
-        observation_dim=2**31 - 1,
-        n_primitive_actions=2**31 - 1,
+        observation_dim=1,
+        n_primitive_actions=1,
         base_step_size=f32_max,
         base_avg_reward_step_size=f32_max,
         option_step_size=f32_max,
         option_gamma=1.0,
-        option_planning_backups_per_step=2**31 - 2,
+        option_planning_backups_per_step=4_096,
         epsilon_base=1.0,
         utility_ema_decay=1.0,
     )
-    assert config.n_demons == 2**31 - 1
-    assert config.observation_dim == 2**31 - 1
-    assert config.option_planning_backups_per_step == 2**31 - 2
+    assert config.n_demons == 1
+    assert config.observation_dim == 1
+    assert config.option_planning_backups_per_step == 4_096
     assert config.cerebellum_step_size == f32_max
 
 


### PR DESCRIPTION
Follow-up to #1233, preserving contributor authorship while closing the residual Step 12 schema, resource, and runtime boundaries.

- require the complete exact `Step12IAConfig` payload schema and type discriminator
- exact-gate every nested subtask record before construction or hooks
- bound direct/parser subtask validation to 4096 records
- require exact Step 12 config identities at facade/runtime/record entry points
- preflight cerebellum weights, demon indices, augmented width, and complete smoke output arrays before JAX allocation
- eagerly apply nested STOMP/OaK resource formulas at config construction
- cap per-step planning work at 4096 backups while preserving exact counter domains

No output or benchmark artifacts changed.

Verification: `pytest -q tests/test_step12_hostile_validation.py tests/test_step12_production.py -k ...` (155 passed, 66 deselected); scoped Ruff passed; strict mypy passed.