### PR TITLE
fix(core): make keyboard-chord updates total

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -977,10 +977,63 @@ class KeyboardChordLearnerState:
     step_count: Int[Array, ""]
 
 
+def _keyboard_array_operand(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: object,
+) -> Array:
+    """Require trusted JAX metadata before keyboard arithmetic or coercion."""
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise ValueError(f"{name} must be a JAX array")
+    array = cast(Array, value)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if array.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}")
+    return array
+
+
+def _keyboard_state_operand(
+    config: KeyboardChordLearnerConfig,
+    state: object,
+) -> KeyboardChordLearnerState:
+    """Require the exact keyboard learner state schema without hostile hooks."""
+    if type(state) is not KeyboardChordLearnerState:
+        raise ValueError("state must be an exact KeyboardChordLearnerState")
+    trusted = state
+    _keyboard_array_operand(
+        "state.chord_vector",
+        trusted.chord_vector,
+        shape=(config.n_options,),
+        dtype=jnp.float32,
+    )
+    _keyboard_array_operand(
+        "state.reward_baseline",
+        trusted.reward_baseline,
+        shape=(),
+        dtype=jnp.float32,
+    )
+    _keyboard_array_operand(
+        "state.step_count",
+        trusted.step_count,
+        shape=(),
+        dtype=jnp.int32,
+    )
+    return trusted
+
+
 def init_keyboard_chord_learner(
     config: KeyboardChordLearnerConfig,
 ) -> KeyboardChordLearnerState:
     """Initialize keyboard-chord learner state."""
+    if type(config) is not KeyboardChordLearnerConfig:
+        raise ValueError("config must be an exact KeyboardChordLearnerConfig")
     return KeyboardChordLearnerState(
         chord_vector=jnp.ones(config.n_options, dtype=jnp.float32) / config.n_options,
         reward_baseline=jnp.array(0.0, dtype=jnp.float32),
@@ -998,10 +1051,34 @@ def update_keyboard_chord_learner(
 
     Positive advantage moves the learned chord vector toward the selected
     chord; negative advantage moves it away.  The reward baseline is an EMA.
+    The int32 step count is saturating telemetry: learning continues after
+    exhaustion while the counter remains at its final representable value.
+    Invalid source state, inputs, or proposed values commit no state field.
     """
-    chord = jnp.asarray(selected_chord, dtype=jnp.float32).reshape((config.n_options,))
-    chord_norm = chord / (jnp.linalg.norm(chord) + 1.0e-8)
-    reward_arr = jnp.asarray(reward, dtype=jnp.float32)
+    if type(config) is not KeyboardChordLearnerConfig:
+        raise ValueError("config must be an exact KeyboardChordLearnerConfig")
+    state = _keyboard_state_operand(config, state)
+    chord = _keyboard_array_operand(
+        "selected_chord",
+        selected_chord,
+        shape=(config.n_options,),
+        dtype=jnp.float32,
+    )
+    reward_arr = _keyboard_array_operand(
+        "reward",
+        reward,
+        shape=(),
+        dtype=jnp.float32,
+    )
+    chord_max = jnp.max(jnp.abs(chord))
+    _, chord_exponent = jnp.frexp(chord_max)
+    scaled_chord = jnp.ldexp(chord, -chord_exponent)
+    scaled_chord_norm = jnp.linalg.norm(scaled_chord)
+    chord_norm = jnp.where(
+        chord_max > 0.0,
+        scaled_chord / scaled_chord_norm,
+        jnp.zeros_like(chord),
+    )
     baseline = (
         config.baseline_decay * state.reward_baseline + (1.0 - config.baseline_decay) * reward_arr
     )
@@ -1010,21 +1087,35 @@ def update_keyboard_chord_learner(
         state.chord_vector * (1.0 - config.step_size * config.l2_penalty)
         + config.step_size * advantage * chord_norm
     )
-    norm = jnp.linalg.norm(proposed_vector)
-    scale = jnp.minimum(1.0, jnp.asarray(config.max_norm, dtype=jnp.float32) / (norm + 1.0e-8))
+    vector_max = jnp.max(jnp.abs(proposed_vector))
+    _, vector_exponent = jnp.frexp(vector_max)
+    scaled_vector = jnp.ldexp(proposed_vector, -vector_exponent)
+    scaled_vector_norm = jnp.linalg.norm(scaled_vector)
+    max_norm = jnp.asarray(config.max_norm, dtype=jnp.float32)
+    exceeds_max_norm = vector_max > max_norm / scaled_vector_norm
+    bounded_vector = jnp.where(
+        exceeds_max_norm,
+        (scaled_vector / scaled_vector_norm) * max_norm,
+        proposed_vector,
+    )
     proposed_state = KeyboardChordLearnerState(
-        chord_vector=proposed_vector * scale,
+        chord_vector=bounded_vector,
         reward_baseline=baseline,
         step_count=_saturating_int32_counter_increment(state.step_count),
     )
     # Inf reward * a zero chord coordinate is 0*inf = NaN, then the
     # max-norm rescaling is nan/inf and the whole vector stays poisoned.
+    source_valid = (
+        jnp.all(jnp.isfinite(state.chord_vector))
+        & jnp.isfinite(state.reward_baseline)
+        & (state.step_count >= jnp.asarray(0, dtype=jnp.int32))
+    )
     inputs_valid = jnp.all(jnp.isfinite(chord)) & jnp.isfinite(reward_arr)
     proposed_finite = jnp.all(jnp.isfinite(proposed_state.chord_vector)) & jnp.isfinite(
         proposed_state.reward_baseline
     )
     return jax.lax.cond(
-        inputs_valid & proposed_finite,
+        source_valid & inputs_valid & proposed_finite,
         lambda: proposed_state,
         lambda: state,
     )

--- a/tests/test_keyboard_chord_learner_validation.py
+++ b/tests/test_keyboard_chord_learner_validation.py
@@ -1,0 +1,218 @@
+"""Strict transaction tests for the keyboard-chord learner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.oak import (
+    KeyboardChordLearnerConfig,
+    KeyboardChordLearnerState,
+    init_keyboard_chord_learner,
+    update_keyboard_chord_learner,
+)
+
+
+@pytest.mark.parametrize("disable_jit", [True, False])
+def test_saturation_continues_learning_atomically(disable_jit: bool) -> None:
+    config = KeyboardChordLearnerConfig(
+        n_options=2,
+        step_size=0.5,
+        baseline_decay=0.5,
+    )
+    state = init_keyboard_chord_learner(config).replace(
+        step_count=jnp.asarray(np.iinfo(np.int32).max - 1, dtype=jnp.int32)
+    )
+    chord = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+
+    with jax.disable_jit(disable_jit):
+        at_max = update_keyboard_chord_learner(
+            config,
+            state,
+            chord,
+            jnp.asarray(1.0, dtype=jnp.float32),
+        )
+        after_max = update_keyboard_chord_learner(
+            config,
+            at_max,
+            chord,
+            jnp.asarray(2.0, dtype=jnp.float32),
+        )
+        rejected = update_keyboard_chord_learner(
+            config,
+            after_max,
+            chord,
+            jnp.asarray(jnp.inf, dtype=jnp.float32),
+        )
+
+    assert int(at_max.step_count) == np.iinfo(np.int32).max
+    assert int(after_max.step_count) == np.iinfo(np.int32).max
+    assert not bool(jnp.array_equal(at_max.chord_vector, after_max.chord_vector))
+    assert float(after_max.reward_baseline) > float(at_max.reward_baseline)
+    chex.assert_trees_all_equal(rejected, after_max)
+
+
+def test_scan_saturates_and_rejects_invalid_rows_atomically() -> None:
+    config = KeyboardChordLearnerConfig(
+        n_options=2,
+        step_size=0.5,
+        baseline_decay=0.5,
+    )
+    initial = init_keyboard_chord_learner(config).replace(
+        step_count=jnp.asarray(np.iinfo(np.int32).max - 1, dtype=jnp.int32)
+    )
+    chords = jnp.asarray([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]], dtype=jnp.float32)
+    rewards = jnp.asarray([1.0, jnp.nan, 2.0], dtype=jnp.float32)
+
+    @jax.jit
+    def run(
+        state: KeyboardChordLearnerState,
+        chord_rows: jax.Array,
+        reward_rows: jax.Array,
+    ) -> KeyboardChordLearnerState:
+        def update(
+            carry: KeyboardChordLearnerState,
+            row: tuple[jax.Array, jax.Array],
+        ) -> tuple[KeyboardChordLearnerState, None]:
+            next_state = update_keyboard_chord_learner(config, carry, row[0], row[1])
+            return next_state, None
+
+        return jax.lax.scan(update, state, (chord_rows, reward_rows))[0]
+
+    final = run(initial, chords, rewards)
+    expected = update_keyboard_chord_learner(
+        config,
+        update_keyboard_chord_learner(config, initial, chords[0], rewards[0]),
+        chords[2],
+        rewards[2],
+    )
+
+    chex.assert_trees_all_equal(final, expected)
+    assert int(final.step_count) == np.iinfo(np.int32).max
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("chord_vector", jnp.zeros((2,), dtype=jnp.int32)),
+        ("chord_vector", jnp.zeros((1,), dtype=jnp.float32)),
+        ("reward_baseline", jnp.zeros((1,), dtype=jnp.float32)),
+        ("reward_baseline", jnp.asarray(0, dtype=jnp.int32)),
+        ("step_count", jnp.zeros((1,), dtype=jnp.int32)),
+        ("step_count", jnp.asarray(0.0, dtype=jnp.float32)),
+        ("step_count", jnp.asarray(False, dtype=jnp.bool_)),
+    ],
+)
+def test_state_metadata_is_exact(field: str, value: jax.Array) -> None:
+    config = KeyboardChordLearnerConfig(n_options=2)
+    state = init_keyboard_chord_learner(config).replace(**{field: value})
+
+    with pytest.raises(ValueError, match=f"state.{field}"):
+        update_keyboard_chord_learner(
+            config,
+            state,
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+        )
+
+
+@pytest.mark.parametrize(
+    ("chord", "reward", "match"),
+    [
+        (jnp.ones((2,), dtype=jnp.int32), jnp.asarray(1.0, dtype=jnp.float32), "selected_chord"),
+        (
+            jnp.ones((1, 2), dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+            "selected_chord",
+        ),
+        (jnp.ones((2,), dtype=jnp.float32), jnp.asarray(1, dtype=jnp.int32), "reward"),
+        (jnp.ones((2,), dtype=jnp.float32), jnp.ones((1,), dtype=jnp.float32), "reward"),
+    ],
+)
+def test_inputs_are_not_reshaped_or_narrowed(
+    chord: jax.Array,
+    reward: jax.Array,
+    match: str,
+) -> None:
+    config = KeyboardChordLearnerConfig(n_options=2)
+    with pytest.raises(ValueError, match=match):
+        update_keyboard_chord_learner(
+            config,
+            init_keyboard_chord_learner(config),
+            chord,
+            reward,
+        )
+
+
+def test_hostile_objects_are_rejected_without_hooks() -> None:
+    class Hostile:
+        calls = 0
+
+        def __getattribute__(self, name: str) -> Any:
+            if name == "calls":
+                return object.__getattribute__(self, name)
+            type(self).calls += 1
+            raise AssertionError("hostile attribute hook executed")
+
+        def __jax_array__(self) -> jax.Array:
+            type(self).calls += 1
+            raise AssertionError("hostile JAX hook executed")
+
+    config = KeyboardChordLearnerConfig(n_options=2)
+    state = init_keyboard_chord_learner(config)
+    hostile = Hostile()
+
+    with pytest.raises(ValueError, match="state must be"):
+        update_keyboard_chord_learner(  # type: ignore[arg-type]
+            config, hostile, jnp.ones((2,), dtype=jnp.float32), jnp.asarray(1.0)
+        )
+    with pytest.raises(ValueError, match="selected_chord"):
+        update_keyboard_chord_learner(  # type: ignore[arg-type]
+            config, state, hostile, jnp.asarray(1.0, dtype=jnp.float32)
+        )
+    assert Hostile.calls == 0
+
+
+def test_invalid_source_values_hold_the_complete_state() -> None:
+    config = KeyboardChordLearnerConfig(n_options=2)
+    base = init_keyboard_chord_learner(config)
+    invalid_states = (
+        base.replace(step_count=jnp.asarray(-1, dtype=jnp.int32)),
+        base.replace(chord_vector=jnp.asarray([jnp.inf, 0.0], dtype=jnp.float32)),
+        base.replace(reward_baseline=jnp.asarray(jnp.nan, dtype=jnp.float32)),
+    )
+    for state in invalid_states:
+        result = update_keyboard_chord_learner(
+            config,
+            state,
+            jnp.ones((2,), dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+        )
+        chex.assert_trees_all_equal(result, state)
+
+
+def test_wide_finite_chord_preserves_direction_and_bounds_update() -> None:
+    config = KeyboardChordLearnerConfig(
+        n_options=2,
+        step_size=1.0,
+        baseline_decay=0.0,
+        max_norm=0.75,
+    )
+    state = init_keyboard_chord_learner(config)
+    largest = jnp.finfo(jnp.float32).max
+    result = update_keyboard_chord_learner(
+        config,
+        state,
+        jnp.asarray([largest, largest], dtype=jnp.float32),
+        jnp.asarray(largest, dtype=jnp.float32),
+    )
+
+    chex.assert_tree_all_finite(result)
+    assert float(jnp.linalg.norm(result.chord_vector)) == pytest.approx(0.75)
+    assert bool(jnp.all(result.chord_vector > 0.0))
+    assert int(result.step_count) == 1


### PR DESCRIPTION
Closes #1234.

Supersedes #1236 while preserving svector-anu's authored saturation commit. Retains the shared saturating int32 increment, then closes the complete public transaction: exact config/state/JAX float32 chord and reward metadata gates run before coercion, malformed or nonfinite source state holds every field, and invalid inputs or nonfinite candidates remain atomic. The counter is explicitly telemetry-only: chord/baseline learning continues after it reaches INT32_MAX.

Finite-wide chord and proposed-vector norms use exponent scaling so valid float32 extremes preserve direction and max-norm behavior rather than overflowing into a silent zero update. Tests cover eager/JIT MAX-1 -> MAX -> MAX, invalid-at-MAX rollback, mixed scan atomicity, exact state/input shape and dtype, hostile no-hook rejection, invalid source state, and float32-max inputs.

Verification: 17 focused strict tests passed; the Step11 production + OaK prototype panel passed; Ruff and strict mypy passed.