### PR TITLE
fix(steps): complete Step 9 facade boundaries

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -70,6 +70,8 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_CONFIG_SEQUENCE_LENGTH = 4_096
+_MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -173,13 +175,25 @@ class Step9DreamingConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step9DreamingConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        data = dict(payload)
-        data["control"] = Step6DifferentialSARSAConfig.from_dict(
-            cast(dict[str, object], data["control"])
+        data = _require_exact_payload(
+            payload,
+            name="Step9DreamingConfig payload",
+            fields=frozenset(cls.__dataclass_fields__),
         )
-        hs = data.get("model_hidden_sizes", (64,))
-        if isinstance(hs, list):
-            data["model_hidden_sizes"] = tuple(hs)
+        control_raw = _require_exact_payload(
+            data["control"],
+            name="control payload",
+            fields=frozenset(Step6DifferentialSARSAConfig.__dataclass_fields__),
+        )
+        data["control"] = Step6DifferentialSARSAConfig.from_dict(
+            control_raw
+        )
+        hs = data["model_hidden_sizes"]
+        if type(hs) is not list:
+            raise ValueError("model_hidden_sizes payload must be an exact list")
+        hidden = cast(list[object], hs)
+        _require_sequence_length("model_hidden_sizes", len(hidden))
+        data["model_hidden_sizes"] = tuple(hidden)
         return cls(**cast(Any, data))
 
     def to_world_model_config(self) -> ActionConditionedWorldModelConfig:
@@ -265,7 +279,92 @@ def _require_bool(name: str, value: object) -> bool:
     return value
 
 
+def _require_exact_payload(
+    value: object,
+    *,
+    name: str,
+    fields: frozenset[str],
+) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an exact dictionary")
+    raw = cast(dict[object, object], value)
+    if any(type(key) is not str for key in raw):
+        raise ValueError(f"{name} keys must be exact strings")
+    keys = cast(set[str], set(raw))
+    if keys != fields:
+        raise ValueError(f"{name} fields do not match the schema")
+    return cast(dict[str, object], dict(raw))
+
+
+def _require_sequence_length(name: str, count: int) -> None:
+    if count > _MAX_CONFIG_SEQUENCE_LENGTH:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_CONFIG_SEQUENCE_LENGTH} values"
+        )
+
+
+def _checked_product(name: str, *factors: int) -> int:
+    product = 1
+    for factor in factors:
+        if factor < 0 or (factor != 0 and product > _INT32_MAX // factor):
+            raise ValueError(f"derived {name} must fit signed int32")
+        product *= factor
+    return product
+
+
+def _checked_sum(name: str, *terms: int) -> int:
+    total = 0
+    for term in terms:
+        if term < 0 or term > _INT32_MAX - total:
+            raise ValueError(f"derived {name} must fit signed int32")
+        total += term
+    return total
+
+
+def _preflight_step9_resources(config: Step9DreamingConfig) -> None:
+    buffer_cells = _checked_product(
+        "Step 9 observation buffer count",
+        config.buffer_capacity,
+        config.observation_dim,
+    )
+    _checked_product("Step 9 observation buffer bytes", 4, buffer_cells)
+    dream_work = _checked_product(
+        "Step 9 dream work per real step",
+        config.planning_budget,
+        _checked_sum(
+            "Step 9 candidate and rollout work",
+            config.dream_candidate_count,
+            config.dream_rollout_horizon,
+        ),
+    )
+    if dream_work > _MAX_DREAM_WORK_PER_REAL_STEP:
+        raise ValueError(
+            "derived Step 9 dream work per real step must be at most "
+            f"{_MAX_DREAM_WORK_PER_REAL_STEP}"
+        )
+
+
+def _preflight_step9_smoke_resources(config: Step9DreamingConfig, steps: int) -> None:
+    rows = _checked_sum("Step 9 observation row count", steps, 1)
+    observations = _checked_product(
+        "Step 9 observation count", rows, config.observation_dim
+    )
+    dream_outputs = _checked_product(
+        "Step 9 dream output count", steps, config.planning_budget
+    )
+    _checked_sum(
+        "Step 9 smoke array bytes",
+        _checked_product("Step 9 observation bytes", 4, observations),
+        _checked_product("Step 9 scalar output bytes", 21, steps),
+        _checked_product("Step 9 dream output bytes", 5, dream_outputs),
+    )
+
+
 def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
+    if type(config) is not Step9DreamingConfig:
+        raise TypeError("config must be an exact Step9DreamingConfig")
+    if type(config.control) is not Step6DifferentialSARSAConfig:
+        raise TypeError("control must be an exact Step6DifferentialSARSAConfig")
     observation_dim = _require_int(
         "observation_dim", config.observation_dim, minimum=1, maximum=_INT32_MAX
     )
@@ -279,6 +378,7 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         )
     if type(config.model_hidden_sizes) is not tuple:
         raise ValueError("model_hidden_sizes must be a tuple of integers")
+    _require_sequence_length("model_hidden_sizes", len(config.model_hidden_sizes))
     model_hidden_sizes = tuple(
         _require_int("model_hidden_sizes", size, minimum=1, maximum=_INT32_MAX)
         for size in config.model_hidden_sizes
@@ -372,6 +472,9 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
     object.__setattr__(config, "dream_utility_weight", dream_utility_weight)
     object.__setattr__(config, "buffer_capacity", buffer_capacity)
     object.__setattr__(config, "dreams_update_average_reward", dreams_update_average_reward)
+    _preflight_step9_resources(config)
+    config.to_world_model_config()
+    config.control.to_core_config()
 
 
 @chex.dataclass(frozen=True)
@@ -426,6 +529,12 @@ class Step9SmokeResult:
     world_model_config: dict[str, Any]
 
     def __post_init__(self) -> None:
+        if type(self.config) is not Step9DreamingConfig:
+            raise TypeError("config must be an exact Step9DreamingConfig")
+        if type(self.control_config) is not dict:
+            raise TypeError("control_config must be an exact dictionary")
+        if type(self.world_model_config) is not dict:
+            raise TypeError("world_model_config must be an exact dictionary")
         object.__setattr__(
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
@@ -462,7 +571,13 @@ def make_step9_components(
     config: Step9DreamingConfig | None = None,
 ) -> tuple[DifferentialSARSAAgent, ActionConditionedWorldModel, RecentObservationBuffer]:
     """Create the Step 9 control agent, world model, and observation buffer."""
-    cfg = config or Step9DreamingConfig()
+    if config is None:
+        cfg = Step9DreamingConfig()
+    elif type(config) is Step9DreamingConfig:
+        cfg = config
+    else:
+        raise TypeError("config must be an exact Step9DreamingConfig")
+    _preflight_step9_resources(cfg)
     agent = make_step6_differential_sarsa_agent(cfg.control)
     model = ActionConditionedWorldModel(cfg.to_world_model_config())
     buffer = RecentObservationBuffer(cfg.buffer_capacity, cfg.observation_dim)
@@ -858,7 +973,14 @@ def run_step9_smoke(
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
     seed = require_jax_seed(seed, name="seed")
 
-    cfg = config or Step9DreamingConfig()
+    if config is None:
+        cfg = Step9DreamingConfig()
+    elif type(config) is Step9DreamingConfig:
+        cfg = config
+    else:
+        raise TypeError("config must be an exact Step9DreamingConfig")
+    _preflight_step9_resources(cfg)
+    _preflight_step9_smoke_resources(cfg, steps)
     agent, model, buffer = make_step9_components(cfg)
     data_key, state_key = jr.split(jr.key(seed))
     observations = jr.normal(

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -6,7 +6,11 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from alberta_framework.steps.step9 import Step9DreamingConfig
+from alberta_framework.steps.step9 import (
+    Step9DreamingConfig,
+    make_step9_components,
+    run_step9_smoke,
+)
 
 
 class _EvilStr(str):
@@ -175,3 +179,68 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step9DreamingConfig(model_step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_from_dict_requires_exact_complete_and_nested_schema_without_hooks() -> None:
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("mapping hook must not run")
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step9DreamingConfig.from_dict(cast(Any, HostileDict()))
+    assert HostileDict.calls == 0
+
+    payload = Step9DreamingConfig().to_dict()
+    malformed = dict(payload)
+    malformed["extra"] = 1
+    with pytest.raises(ValueError, match="schema"):
+        Step9DreamingConfig.from_dict(malformed)
+    payload["control"] = HostileDict()
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step9DreamingConfig.from_dict(payload)
+    assert HostileDict.calls == 0
+
+
+def test_hidden_size_validation_is_bounded_before_iteration() -> None:
+    with pytest.raises(ValueError, match="at most 4096"):
+        Step9DreamingConfig(model_hidden_sizes=(1,) * 4_097)
+    payload = Step9DreamingConfig().to_dict()
+    payload["model_hidden_sizes"] = [1] * 4_097
+    with pytest.raises(ValueError, match="at most 4096"):
+        Step9DreamingConfig.from_dict(payload)
+
+
+def test_derived_allocation_and_runtime_work_fail_at_config_boundary() -> None:
+    with pytest.raises(ValueError, match="observation buffer bytes"):
+        Step9DreamingConfig(buffer_capacity=536_870_912, observation_dim=1)
+    with pytest.raises(ValueError, match="dream work per real step"):
+        Step9DreamingConfig(
+            planning_budget=65,
+            dream_candidate_count=64,
+            dream_rollout_horizon=1,
+        )
+
+
+def test_runtime_entry_points_require_exact_config_without_truthiness_hooks() -> None:
+    calls = 0
+
+    class HostileConfig:
+        def __bool__(self) -> bool:  # pragma: no cover - must not run
+            nonlocal calls
+            calls += 1
+            raise AssertionError("truthiness hook must not run")
+
+    value = HostileConfig()
+    with pytest.raises(TypeError, match="exact Step9DreamingConfig"):
+        make_step9_components(cast(Any, value))
+    with pytest.raises(TypeError, match="exact Step9DreamingConfig"):
+        run_step9_smoke(cast(Any, value), steps=1)
+    assert calls == 0
+
+
+def test_smoke_preflights_complete_output_shape_before_allocation() -> None:
+    with pytest.raises(ValueError, match="observation row count"):
+        run_step9_smoke(steps=2**31 - 1)

--- a/tests/test_step9_production.py
+++ b/tests/test_step9_production.py
@@ -414,15 +414,15 @@ def test_step9_count_fields_reject_values_outside_int32_contract(
         _config_with(**{field: value})
 
 
-def test_step9_count_fields_preserve_int32_upper_endpoints() -> None:
+def test_step9_count_fields_preserve_counter_and_work_endpoints() -> None:
     config = _config_with(
         dreaming_warmup_steps=2**31 - 1,
-        dream_candidate_count=2**31 - 1,
-        buffer_capacity=2**31 - 2,
+        dream_candidate_count=4_095,
+        buffer_capacity=1_024,
     )
     assert config.dreaming_warmup_steps == 2**31 - 1
-    assert config.dream_candidate_count == 2**31 - 1
-    assert config.buffer_capacity == 2**31 - 2
+    assert config.dream_candidate_count == 4_095
+    assert config.buffer_capacity == 1_024
     json.dumps(config.to_dict(), allow_nan=False)
 
 


### PR DESCRIPTION
Follow-up to #1237: exact-gate Step 9 full/nested parser schemas and runtime config identities, bound hidden-size validation, preflight world-model/buffer/smoke allocation totals, and cap combined candidate/rollout planning work at 4096 operations per real step. Contributor scalar and hostile-hook coverage remains intact. No outputs or benchmarks. Verification: 165 focused tests passed; Ruff and strict mypy passed.