### PR TITLE
fix(step6): complete facade trust boundaries

### DIFF
--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -40,27 +40,19 @@ from alberta_framework.steps._float32_validation import finite_real_and_float32
 from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 _INT32_MAX = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+_ACTUAL_INT_TYPES = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
 )
-
-
-def _require_exact_str(name: str, value: object) -> str:
-    if type(value) is not str:
-        raise ValueError(f"{name} must be an exact string")
-    return value
 
 
 def _compatible_float32_storage(value: object, narrowed: float) -> float:
@@ -72,9 +64,8 @@ def _compatible_float32_storage(value: object, narrowed: float) -> float:
     return narrowed
 
 
-def _require_unit_interval(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, denominator, narrowed = finite_real_and_float32(host_name, value)
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
         real < 0.0
         or not real <= 1.0
@@ -83,45 +74,42 @@ def _require_unit_interval(name: object, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{host_name} must be in [0, 1]")
+        raise ValueError(f"{name} must be in [0, 1]")
     return _compatible_float32_storage(real, narrowed)
 
 
-def _require_nonnegative_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{host_name} must be non-negative")
+        raise ValueError(f"{name} must be non-negative")
     return _compatible_float32_storage(real, narrowed)
 
 
 def _require_int(
-    name: object,
+    name: str,
     value: object,
     *,
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
-    if actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{host_name} must be an integer")
+    if all(actual_type is not allowed for allowed in _ACTUAL_INT_TYPES):
+        raise ValueError(f"{name} must be an integer")
     number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{host_name} must be positive")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{host_name} must be non-negative")
-        raise ValueError(f"{host_name} must be >= {minimum}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{host_name} must be at most int32 max")
+        raise ValueError(f"{name} must be at most int32 max")
     return number
 
 
-def _require_bool(name: object, value: object) -> bool:
-    host_name = _require_exact_str("name", name)
+def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
-        raise ValueError(f"{host_name} must be a built-in bool")
+        raise ValueError(f"{name} must be a built-in bool")
     return value
 
 
@@ -300,7 +288,7 @@ def run_step6_smoke(
     feature_dim = _require_int(
         "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
     )
-    seed = _require_int("seed", seed, minimum=0, maximum=_INT32_MAX)
+    seed = require_jax_seed(seed, name="seed")
 
     cfg = config or Step6DifferentialSARSAConfig()
     agent = make_step6_differential_sarsa_agent(cfg)

--- a/tests/test_step5_step6_production.py
+++ b/tests/test_step5_step6_production.py
@@ -308,11 +308,11 @@ def test_step6_smoke_rejects_non_integral_dimensions(field: str, value: Any) -> 
         ("feature_dim", 0),
         ("feature_dim", 2**31),
         ("seed", -1),
-        ("seed", 2**31),
+        ("seed", 2**32),
         ("seed", True),
         ("steps", np.int64(2**31)),
         ("feature_dim", np.int64(2**31)),
-        ("seed", np.int64(2**31)),
+        ("seed", np.uint64(2**32)),
         ("seed", np.int64(-1)),
     ],
 )

--- a/tests/test_step6_hostile_validation.py
+++ b/tests/test_step6_hostile_validation.py
@@ -28,6 +28,10 @@ class _HostileInt(int):
         type(self).calls += 1
         raise AssertionError("HostileInt.__index__ must not be called")
 
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("HostileInt.__int__ must not be called")
+
     def __repr__(self) -> str:
         type(self).calls += 1
         raise AssertionError("HostileInt.__repr__ must not be called")
@@ -72,6 +76,29 @@ def test_rejects_bool_and_hostile_int() -> None:
     assert "HostileInt" not in str(exc.value)
 
 
+def test_rejects_hostile_integer_metaclass_without_hash_hook() -> None:
+    class HostileMeta(type):
+        calls = 0
+
+        def __hash__(cls) -> int:
+            HostileMeta.calls += 1
+            raise AssertionError("HostileMeta.__hash__ must not be called")
+
+    class HostileMetaInt(int, metaclass=HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        Step6DifferentialSARSAConfig(n_actions=HostileMetaInt(2))  # type: ignore[arg-type]
+    assert HostileMeta.calls == 0
+
+
+def test_smoke_accepts_full_uint32_seed_contract() -> None:
+    from alberta_framework.steps.step6 import run_step6_smoke
+
+    result = run_step6_smoke(steps=1, feature_dim=1, seed=2**32 - 1)
+    assert result.seed == 2**32 - 1
+
+
 def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be finite") as exc:
@@ -79,16 +106,6 @@ def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     assert _HostileFloat.calls == 0
     assert "HostileFloat" not in str(exc.value)
     assert "!r" not in str(exc.value)
-
-
-def test_does_not_invoke_hostile_value_when_name_is_evil_via_sink() -> None:
-    from alberta_framework.steps._float32_validation import finite_real_and_float32
-
-    evil = _EvilStr("x")
-    _HostileFloat.calls = 0
-    with pytest.raises(ValueError, match="must be an exact string"):
-        finite_real_and_float32(evil, _HostileFloat(1.0))  # type: ignore[arg-type]
-    assert _HostileFloat.calls == 0
 
 
 def test_rejects_plain_string_for_q_step_size() -> None:
@@ -117,9 +134,6 @@ def test_rejects_negative_q_step_size_without_repr() -> None:
 def test_rejects_bool_gate_without_repr() -> None:
     from alberta_framework.steps.step6 import _require_bool
 
-    with pytest.raises(ValueError, match="must be an exact string") as exc:
-        _require_bool(_EvilStr("finite"), True)  # type: ignore[arg-type]
-    assert "EvilStr" not in str(exc.value)
     with pytest.raises(ValueError, match="must be a built-in bool") as exc2:
         _require_bool("finite", _StringSubclass("true"))  # type: ignore[arg-type]
     assert "StringSubclass" not in str(exc2.value)


### PR DESCRIPTION
Corrective follow-up to merged #1239 after deep review found two live residuals. The original frozenset allowlist executed hostile integer-metaclass `__hash__`, and the smoke facade incorrectly capped JAX seeds at signed int32 instead of the established full uint32 contract. This repair uses identity-only exact integer admission, adds `__int__` and metaclass zero-hook regressions, restores full `require_jax_seed` semantics, removes the unrelated private helper-name expansion/shared-helper test, and preserves builtin/all NumPy scalar compatibility. Failing-test-first reproduced both defects. Verification on the rebased exact-main lineage: 319 Step5/6/shared-float32 tests passed; scoped Ruff, strict Step6 mypy, and diff check clean. No pinned outputs or registered evidence sources changed.