### PR TITLE
fix(steps): complete Step 6 facade boundaries

### DIFF
--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -114,6 +114,8 @@ def _require_bool(name: str, value: object) -> bool:
 
 
 def _validate_step6_config(config: Step6DifferentialSARSAConfig) -> None:
+    if type(config) is not Step6DifferentialSARSAConfig:
+        raise TypeError("config must be an exact Step6DifferentialSARSAConfig")
     n_actions = _require_int(
         "n_actions",
         config.n_actions,
@@ -141,6 +143,7 @@ def _validate_step6_config(config: Step6DifferentialSARSAConfig) -> None:
     object.__setattr__(config, "epsilon_start", epsilon_start)
     object.__setattr__(config, "epsilon_end", epsilon_end)
     object.__setattr__(config, "epsilon_decay_steps", epsilon_decay_steps)
+    config.to_core_config()
 
 
 @dataclass(frozen=True)
@@ -174,7 +177,14 @@ class Step6DifferentialSARSAConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step6DifferentialSARSAConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        return cls(**cast(Any, payload))
+        if type(payload) is not dict:
+            raise ValueError("Step6DifferentialSARSAConfig payload must be an exact dictionary")
+        raw = cast(dict[object, object], payload)
+        if any(type(key) is not str for key in raw):
+            raise ValueError("Step6DifferentialSARSAConfig payload keys must be exact strings")
+        if cast(set[str], set(raw)) != frozenset(cls.__dataclass_fields__):
+            raise ValueError("Step6DifferentialSARSAConfig payload fields do not match the schema")
+        return cls(**cast(Any, dict(raw)))
 
     def to_core_config(self) -> DifferentialSARSAConfig:
         """Return the core differential SARSA config."""
@@ -204,6 +214,10 @@ class Step6SmokeResult:
     agent_config: dict[str, Any]
 
     def __post_init__(self) -> None:
+        if type(self.config) is not Step6DifferentialSARSAConfig:
+            raise TypeError("config must be an exact Step6DifferentialSARSAConfig")
+        if type(self.agent_config) is not dict:
+            raise TypeError("agent_config must be an exact dictionary")
         object.__setattr__(
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
@@ -236,8 +250,53 @@ def make_step6_differential_sarsa_agent(
     config: Step6DifferentialSARSAConfig | None = None,
 ) -> DifferentialSARSAAgent:
     """Create the production Step 6 differential SARSA agent."""
-    cfg = config or Step6DifferentialSARSAConfig()
+    if config is None:
+        cfg = Step6DifferentialSARSAConfig()
+    elif type(config) is Step6DifferentialSARSAConfig:
+        cfg = config
+    else:
+        raise TypeError("config must be an exact Step6DifferentialSARSAConfig")
     return DifferentialSARSAAgent(cfg.to_core_config())
+
+
+def _checked_product(name: str, *factors: int) -> int:
+    product = 1
+    for factor in factors:
+        if factor < 0 or (factor != 0 and product > _INT32_MAX // factor):
+            raise ValueError(f"derived {name} must fit signed int32")
+        product *= factor
+    return product
+
+
+def _checked_sum(name: str, *terms: int) -> int:
+    total = 0
+    for term in terms:
+        if term < 0 or term > _INT32_MAX - total:
+            raise ValueError(f"derived {name} must fit signed int32")
+        total += term
+    return total
+
+
+def _preflight_step6_smoke_resources(
+    config: Step6DifferentialSARSAConfig,
+    *,
+    steps: int,
+    feature_dim: int,
+) -> None:
+    state_parameters = _checked_product(
+        "Step 6 state parameter count", config.n_actions, feature_dim
+    )
+    _checked_product("Step 6 state parameter bytes", 8, state_parameters)
+    rows = _checked_sum("Step 6 observation row count", steps, 1)
+    observations = _checked_product("Step 6 observation count", rows, feature_dim)
+    q_values = _checked_product("Step 6 q-value count", steps, config.n_actions)
+    _checked_sum(
+        "Step 6 smoke array bytes",
+        _checked_product("Step 6 observation bytes", 4, observations),
+        _checked_product("Step 6 q-value bytes", 4, q_values),
+        # rewards, TD errors, average rewards, actions, and validity flags.
+        _checked_product("Step 6 scalar output bytes", 17, steps),
+    )
 
 
 def init_step6_state(
@@ -251,6 +310,9 @@ def init_step6_state(
     feature_dim = _require_int(
         "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
     )
+    if type(agent) is not DifferentialSARSAAgent:
+        raise TypeError("agent must be an exact DifferentialSARSAAgent")
+    _checked_product("Step 6 state parameter bytes", 8, agent.config.n_actions, feature_dim)
     state = agent.init(feature_dim, key)
     state, _action = agent.start(state, initial_features)
     return cast(DifferentialSARSAState, state)
@@ -290,7 +352,13 @@ def run_step6_smoke(
     )
     seed = require_jax_seed(seed, name="seed")
 
-    cfg = config or Step6DifferentialSARSAConfig()
+    if config is None:
+        cfg = Step6DifferentialSARSAConfig()
+    elif type(config) is Step6DifferentialSARSAConfig:
+        cfg = config
+    else:
+        raise TypeError("config must be an exact Step6DifferentialSARSAConfig")
+    _preflight_step6_smoke_resources(cfg, steps=steps, feature_dim=feature_dim)
     agent = make_step6_differential_sarsa_agent(cfg)
     data_key, state_key = jr.split(jr.key(seed))
     observations = jr.normal(data_key, (steps + 1, feature_dim), dtype=jnp.float32)

--- a/tests/test_step6_hostile_validation.py
+++ b/tests/test_step6_hostile_validation.py
@@ -6,7 +6,11 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
+from alberta_framework.steps.step6 import (
+    Step6DifferentialSARSAConfig,
+    make_step6_differential_sarsa_agent,
+    run_step6_smoke,
+)
 
 
 class _EvilStr(str):
@@ -172,3 +176,45 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step6DifferentialSARSAConfig(q_step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_from_dict_requires_exact_complete_schema_without_mapping_hooks() -> None:
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("mapping hook must not run")
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step6DifferentialSARSAConfig.from_dict(cast(Any, HostileDict()))
+    assert HostileDict.calls == 0
+    payload = Step6DifferentialSARSAConfig().to_dict()
+    payload["extra"] = 1
+    with pytest.raises(ValueError, match="schema"):
+        Step6DifferentialSARSAConfig.from_dict(payload)
+
+
+def test_runtime_entry_points_require_exact_config_without_truthiness_hooks() -> None:
+    calls = 0
+
+    class HostileConfig:
+        def __bool__(self) -> bool:  # pragma: no cover - must not run
+            nonlocal calls
+            calls += 1
+            raise AssertionError("truthiness hook must not run")
+
+    value = HostileConfig()
+    with pytest.raises(TypeError, match="exact Step6DifferentialSARSAConfig"):
+        make_step6_differential_sarsa_agent(cast(Any, value))
+    with pytest.raises(TypeError, match="exact Step6DifferentialSARSAConfig"):
+        run_step6_smoke(cast(Any, value), steps=1)
+    assert calls == 0
+
+
+def test_smoke_preflights_state_and_output_resources_before_allocation() -> None:
+    huge_actions = Step6DifferentialSARSAConfig(n_actions=536_870_912)
+    with pytest.raises(ValueError, match="state parameter bytes"):
+        run_step6_smoke(huge_actions, steps=1, feature_dim=1)
+    with pytest.raises(ValueError, match="observation row count"):
+        run_step6_smoke(steps=2**31 - 1, feature_dim=1)


### PR DESCRIPTION
Follow-up to #1239: require exact complete parser schema and runtime/record config identities, eagerly validate the core config, and preflight differential-SARSA state plus complete smoke arrays before any JAX allocation. Contributor scalar/hostile policy remains intact. No outputs or benchmarks. Verification: 206 Step6 focused tests passed; Ruff and strict mypy passed.