### PR TITLE
fix(steps): totalize Step 11 trust boundaries

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="attr-defined,call-arg"
+# mypy: disable-error-code="attr-defined,call-arg,comparison-overlap,redundant-cast,unused-ignore"
 """Production-facing Step 11 OaK facade.
 
 Step 11 of the Alberta Plan introduces the OaK (Options and Knowledge)
@@ -33,6 +33,7 @@ from fractions import Fraction
 from numbers import Integral
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -137,11 +138,38 @@ class Step11OaKConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> Step11OaKConfig:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
-        specs_raw = data.pop("subtask_specs", [])
-        specs = tuple(SubtaskSpec(**s) for s in specs_raw)
-        return cls(subtask_specs=specs, **data)
+        if cls is not Step11OaKConfig:
+            raise ValueError("cls must be Step11OaKConfig")
+        if type(payload) is not dict:
+            raise ValueError("payload must be an actual dict")
+        if any(type(key) is not str for key in payload):
+            raise ValueError("payload keys must be exact strings")
+        if payload.keys() != _STEP11_CONFIG_FIELDS:
+            raise ValueError("payload must contain the exact Step11OaKConfig fields")
+        if type(payload["type"]) is not str or payload["type"] != "Step11OaKConfig":
+            raise ValueError("payload type must be Step11OaKConfig")
+        specs_raw = payload["subtask_specs"]
+        if type(specs_raw) is not list:
+            raise ValueError("subtask_specs must be an actual list")
+        if len(specs_raw) > _MAX_CONFIG_SEQUENCE_LENGTH:
+            raise ValueError(
+                f"subtask_specs must contain at most {_MAX_CONFIG_SEQUENCE_LENGTH} elements"
+            )
+        specs: list[SubtaskSpec] = []
+        for raw in specs_raw:
+            if type(raw) is not dict:
+                raise ValueError("subtask_specs entries must be actual dicts")
+            if any(type(key) is not str for key in raw):
+                raise ValueError("subtask_specs entry keys must be exact strings")
+            if raw.keys() != _SUBTASK_SPEC_FIELDS:
+                raise ValueError("subtask_specs entries must contain the exact fields")
+            specs.append(SubtaskSpec(**raw))
+        data = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"type", "subtask_specs"}
+        }
+        return cls(subtask_specs=tuple(specs), **data)
 
     def to_oak_config(self) -> OaKConfig:
         """Convert to the core :class:`OaKConfig`."""
@@ -170,6 +198,32 @@ class Step11OaKConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_CONFIG_SEQUENCE_LENGTH = 4096
+_STEP11_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "subtask_specs",
+        "observation_dim",
+        "n_primitive_actions",
+        "base_step_size",
+        "base_avg_reward_step_size",
+        "base_trace_decay",
+        "option_step_size",
+        "option_avg_reward_step_size",
+        "option_trace_decay",
+        "option_gamma",
+        "option_model_decay",
+        "option_model_step_size",
+        "option_planning_backups_per_step",
+        "epsilon_base",
+        "epsilon_option",
+        "utility_ema_decay",
+        "curation_threshold",
+    }
+)
+_SUBTASK_SPEC_FIELDS = frozenset(
+    {"feature_index", "threshold", "pseudo_reward_scale", "max_option_steps"}
+)
 _ACTUAL_INT_TYPES = (
     int,
     np.int8,
@@ -267,7 +321,65 @@ def _require_bool(name: str, value: object) -> bool:
     return value
 
 
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    actual_type = type(value)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        actual_shape = tuple(value.shape)  # type: ignore[attr-defined]
+        actual_dtype = jnp.dtype(value.dtype)  # type: ignore[attr-defined]
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != jnp.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
+    return cast(Array, value)
+
+
+def _require_typed_key(name: str, value: object) -> Array:
+    actual_type = type(value)
+    if not (issubclass(actual_type, jax.Array) or issubclass(actual_type, jax.core.Tracer)):
+        raise TypeError(f"{name} must be a scalar typed JAX PRNG key")
+    try:
+        shape = tuple(value.shape)  # type: ignore[attr-defined]
+        words = jr.key_data(cast(Array, value))
+        implementation = str(jr.key_impl(cast(Array, value)))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a scalar typed JAX PRNG key") from error
+    if shape != () or words.shape != (2,) or words.dtype != jnp.uint32:
+        raise TypeError(f"{name} must be a scalar typed JAX PRNG key")
+    if implementation != "threefry2x32":
+        raise ValueError(f"{name} must use Threefry2x32")
+    return cast(Array, value)
+
+
+def _require_agent(agent: object) -> OaKAgent:
+    if type(agent) is not OaKAgent:
+        raise TypeError("agent must be an actual OaKAgent")
+    return cast(OaKAgent, agent)
+
+
+def _require_state(state: object) -> OaKState:
+    if type(state) is not OaKState:
+        raise TypeError("state must be an actual OaKState")
+    return cast(OaKState, state)
+
+
 def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
+    if type(config) is not Step11OaKConfig:
+        raise ValueError("config must be an actual Step11OaKConfig")
     observation_dim = _require_int(
         "observation_dim",
         config.observation_dim,
@@ -288,6 +400,10 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
     )
     if type(config.subtask_specs) is not tuple:
         raise ValueError("subtask_specs must be a tuple of SubtaskSpec")
+    if len(config.subtask_specs) > _MAX_CONFIG_SEQUENCE_LENGTH:
+        raise ValueError(
+            f"subtask_specs must contain at most {_MAX_CONFIG_SEQUENCE_LENGTH} elements"
+        )
     canonical_specs: list[SubtaskSpec] = []
     for spec in config.subtask_specs:
         if type(spec) is not SubtaskSpec:
@@ -377,6 +493,10 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
     object.__setattr__(config, "epsilon_option", epsilon_option)
     object.__setattr__(config, "utility_ema_decay", utility_ema_decay)
     object.__setattr__(config, "curation_threshold", curation_threshold)
+    # Exercise the core constructor now, before the facade is accepted.  This
+    # carries the exact derived action-count and direct-array byte ceilings to
+    # direct records and JSON restores instead of deferring them to agent use.
+    config.to_oak_config()
 
 
 @dataclass(frozen=True)
@@ -395,6 +515,10 @@ class Step11SmokeResult:
     agent_config: dict[str, Any]
 
     def __post_init__(self) -> None:
+        if type(self) is not Step11SmokeResult:
+            raise ValueError("result must be an actual Step11SmokeResult")
+        if type(self.config) is not Step11OaKConfig:
+            raise ValueError("config must be an actual Step11OaKConfig")
         object.__setattr__(
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
@@ -421,6 +545,18 @@ class Step11SmokeResult:
                 maximum=_INT32_MAX,
             ),
         )
+        if self.td_errors_shape != (self.steps,):
+            raise ValueError("td_errors_shape must be exactly (steps,)")
+        if self.average_rewards_shape != (self.steps,):
+            raise ValueError("average_rewards_shape must be exactly (steps,)")
+        if self.primitive_actions_shape != (self.steps,):
+            raise ValueError("primitive_actions_shape must be exactly (steps,)")
+        if self.utility_emas_shape != (self.steps, len(self.config.subtask_specs)):
+            raise ValueError("utility_emas_shape must be exactly (steps, n_options)")
+        if self.option_termination_count > self.steps:
+            raise ValueError("option_termination_count must not exceed steps")
+        if type(self.agent_config) is not dict:
+            raise ValueError("agent_config must be an actual dict")
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -449,6 +585,8 @@ def make_step11_oak_agent(config: Step11OaKConfig | None = None) -> OaKAgent:
     """
     if config is None:
         config = Step11OaKConfig(subtask_specs=(SubtaskSpec(feature_index=0),))
+    elif type(config) is not Step11OaKConfig:
+        raise TypeError("config must be an actual Step11OaKConfig")
     return OaKAgent(config.to_oak_config())
 
 
@@ -468,11 +606,18 @@ def init_step11_state(
     Returns:
         Primed :class:`OaKState`.
     """
-    init_key, start_key = jr.split(key)
+    checked_agent = _require_agent(agent)
+    checked_key = _require_typed_key("key", key)
+    observation = _trusted_array(
+        "initial_observation",
+        initial_observation,
+        shape=(checked_agent.config.observation_dim,),
+        dtype=jnp.float32,
+    )
+    init_key, start_key = jr.split(checked_key)
     del start_key
-    state = agent.init(init_key)
-    obs = jnp.asarray(initial_observation, dtype=jnp.float32)
-    return agent.start(state, obs)
+    state = checked_agent.init(init_key)
+    return checked_agent.start(state, observation)
 
 
 def step11_update(
@@ -492,7 +637,16 @@ def step11_update(
     Returns:
         :class:`OaKUpdateResult` with new state and diagnostics.
     """
-    return agent.update(state, env_reward, next_observation)
+    checked_agent = _require_agent(agent)
+    checked_state = _require_state(state)
+    reward = _trusted_array("env_reward", env_reward, shape=(), dtype=jnp.float32)
+    observation = _trusted_array(
+        "next_observation",
+        next_observation,
+        shape=(checked_agent.config.observation_dim,),
+        dtype=jnp.float32,
+    )
+    return checked_agent.update(checked_state, reward, observation)
 
 
 def run_step11_scan(
@@ -512,7 +666,29 @@ def run_step11_scan(
     Returns:
         :class:`OaKArrayResult` with per-step diagnostics.
     """
-    return agent.scan(state, rewards, next_observations)
+    checked_agent = _require_agent(agent)
+    checked_state = _require_state(state)
+    actual_type = type(rewards)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError("rewards must be a trusted array")
+    try:
+        steps = int(rewards.shape[0])  # type: ignore[attr-defined]
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("rewards must expose trusted shape metadata") from error
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("rewards must contain between 1 and signed-int32 steps")
+    checked_rewards = _trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
+    checked_observations = _trusted_array(
+        "next_observations",
+        next_observations,
+        shape=(steps, checked_agent.config.observation_dim),
+        dtype=jnp.float32,
+    )
+    return checked_agent.scan(checked_state, checked_rewards, checked_observations)
 
 
 def run_step11_smoke(
@@ -537,6 +713,8 @@ def run_step11_smoke(
     cfg = config
     if cfg is None:
         cfg = Step11OaKConfig(subtask_specs=(SubtaskSpec(feature_index=0),))
+    elif type(cfg) is not Step11OaKConfig:
+        raise TypeError("config must be an actual Step11OaKConfig")
 
     agent = make_step11_oak_agent(cfg)
     obs_dim = cfg.observation_dim

--- a/tests/test_step11_hostile_validation.py
+++ b/tests/test_step11_hostile_validation.py
@@ -3,11 +3,19 @@
 from fractions import Fraction
 from typing import Any, cast
 
+import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.core.options import SubtaskSpec
-from alberta_framework.steps.step11 import Step11OaKConfig
+from alberta_framework.steps.step11 import (
+    Step11OaKConfig,
+    init_step11_state,
+    make_step11_oak_agent,
+    run_step11_scan,
+    step11_update,
+)
 
 
 class _EvilStr(str):
@@ -213,3 +221,100 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step11OaKConfig(base_step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_config_subclass_is_rejected_before_attribute_hooks() -> None:
+    class HostileConfig(Step11OaKConfig):
+        calls = 0
+
+        def __getattribute__(self, name: str) -> object:
+            if name not in {"calls", "__class__"}:
+                type(self).calls += 1
+                raise AssertionError("attribute hook must not run")
+            return super().__getattribute__(name)
+
+    hostile = object.__new__(HostileConfig)
+    with pytest.raises(ValueError, match="actual Step11OaKConfig"):
+        Step11OaKConfig.__post_init__(hostile)
+    assert HostileConfig.calls == 0
+
+
+def test_from_config_requires_exact_closed_json_schema() -> None:
+    payload = Step11OaKConfig().to_config()
+    for altered in (
+        {key: value for key, value in payload.items() if key != "type"},
+        {**payload, "type": "Wrong"},
+        {**payload, "extra": 1},
+    ):
+        with pytest.raises(ValueError):
+            Step11OaKConfig.from_config(altered)
+
+    class DictSubclass(dict[str, Any]):
+        pass
+
+    with pytest.raises(ValueError, match="actual dict"):
+        Step11OaKConfig.from_config(DictSubclass(payload))
+
+
+def test_from_config_rejects_hostile_or_open_subtask_entries() -> None:
+    payload = Step11OaKConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),)
+    ).to_config()
+    payload["subtask_specs"] = [{**payload["subtask_specs"][0], "extra": 1}]
+    with pytest.raises(ValueError, match="exact fields"):
+        Step11OaKConfig.from_config(payload)
+
+
+class _HostileArray:
+    calls = 0
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        type(self).calls += 1
+        raise AssertionError("shape hook must not run")
+
+    @property
+    def dtype(self) -> np.dtype[Any]:
+        type(self).calls += 1
+        raise AssertionError("dtype hook must not run")
+
+
+def test_runtime_rejects_hostile_arrays_without_hooks() -> None:
+    agent = make_step11_oak_agent()
+    _HostileArray.calls = 0
+    with pytest.raises(TypeError, match="trusted array"):
+        init_step11_state(
+            agent,
+            key=jr.key(0),
+            initial_observation=cast(Any, _HostileArray()),
+        )
+    assert _HostileArray.calls == 0
+
+
+def test_runtime_requires_typed_key_and_exact_float32_arrays() -> None:
+    agent = make_step11_oak_agent()
+    with pytest.raises(TypeError, match="typed JAX PRNG key"):
+        init_step11_state(
+            agent,
+            key=cast(Any, jr.PRNGKey(0)),
+            initial_observation=jnp.zeros(4, dtype=jnp.float32),
+        )
+    state = init_step11_state(
+        agent,
+        key=jr.key(0),
+        initial_observation=jnp.zeros(4, dtype=jnp.float32),
+    )
+    with pytest.raises(TypeError, match="env_reward.*float32"):
+        step11_update(
+            agent,
+            state,
+            jnp.asarray(0, dtype=jnp.int32),
+            jnp.zeros(4, dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_step11_scan(
+            agent,
+            state,
+            jnp.zeros(2, dtype=jnp.float32),
+            jnp.zeros((3, 4), dtype=jnp.float32),
+        )

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -1164,15 +1164,15 @@ def test_step11_state_stays_finite_200_steps() -> None:
 def test_step11_config_preserves_float32_boundaries() -> None:
     f32_max = float(np.finfo(np.float32).max)
     spec = SubtaskSpec(
-        feature_index=2**31 - 2,
+        feature_index=3,
         threshold=f32_max,
         pseudo_reward_scale=f32_max,
         max_option_steps=2**31 - 1,
     )
     config = Step11OaKConfig(
         subtask_specs=(spec,),
-        observation_dim=2**31 - 1,
-        n_primitive_actions=2**31 - 1,
+        observation_dim=4,
+        n_primitive_actions=2,
         base_step_size=f32_max,
         base_avg_reward_step_size=f32_max,
         base_trace_decay=1.0,
@@ -1188,9 +1188,18 @@ def test_step11_config_preserves_float32_boundaries() -> None:
         utility_ema_decay=1.0,
         curation_threshold=f32_max,
     )
-    assert config.observation_dim == 2**31 - 1
+    assert config.observation_dim == 4
     assert config.option_planning_backups_per_step == 2**31 - 2
     assert config.base_step_size == f32_max
+
+
+def test_step11_config_rejects_derived_core_resource_overflow() -> None:
+    with pytest.raises(ValueError, match="derived n_total_actions"):
+        Step11OaKConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0),),
+            observation_dim=1,
+            n_primitive_actions=2**31 - 1,
+        )
 
 
 def test_step11_oak_normalizes_conversion_hook_failures() -> None:
@@ -1270,7 +1279,7 @@ def _legal_step11_smoke_result(**overrides: object) -> Step11SmokeResult:
         "td_errors_shape": (8,),
         "average_rewards_shape": (8,),
         "primitive_actions_shape": (8,),
-        "utility_emas_shape": (8,),
+        "utility_emas_shape": (8, 1),
         "finite": True,
         "option_termination_count": 0,
         "agent_config": {"ok": True},


### PR DESCRIPTION
## Summary\n- enforce exact bounded Step 11 records and closed JSON schema\n- preflight nested STOMP/OaK resource identities during facade construction\n- reject hostile runtime containers before array/key coercion and validate exact smoke identities\n\n## Verification\n- 241 focused Step 11 tests passed\n- Ruff passed\n- mypy passed\n\nFollow-up to #1235.