### PR TITLE
fix(step1): make public validation hook-free

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -66,8 +66,7 @@ _VALID_OPTIMIZERS: frozenset[str] = frozenset(
 _VALID_NORMALIZERS: frozenset[str] = frozenset({"none", "ema", "welford", "streaming_batch"})
 _VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
 _INT32_MAX: int = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
+_ACTUAL_INT_TYPES = (
         int,
         np.int8,
         np.int16,
@@ -79,40 +78,30 @@ _ACTUAL_INT_TYPES = frozenset(
         np.uint64,
         np.longlong,
         np.ulonglong,
-    }
 )
-_ACTUAL_FLOAT_TYPES = frozenset(
-    {
+_ACTUAL_FLOAT_TYPES = (
         float,
         Fraction,
         np.dtype("e").type,
         np.dtype("f").type,
         np.dtype("d").type,
         np.dtype("g").type,
-    }
 )
-_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES + _ACTUAL_FLOAT_TYPES
 
 
-def _require_exact_str(name: str, value: object) -> str:
-    if type(value) is not str:
-        raise ValueError(f"{name} must be an exact string")
-    return value
-
-
-def finite_real_and_float32(name: object, value: object) -> tuple[Real, int, int, float]:
+def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
     """Return the original real, exact ratio, and finite binary32 rounding."""
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
-    if actual_type not in _ALLOWED_REAL_TYPES:
-        raise ValueError(f"{host_name} must be a real number")
+    if not any(actual_type is candidate for candidate in _ALLOWED_REAL_TYPES):
+        raise ValueError(f"{name} must be a real number")
     real = cast(Real, value)
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(real)
     except (FloatingPointError, OverflowError, TypeError, ValueError):
-        raise ValueError(f"{host_name} must narrow to a finite float32") from None
+        raise ValueError(f"{name} must narrow to a finite float32") from None
     if not math.isfinite(narrowed):
-        raise ValueError(f"{host_name} must narrow to a finite float32")
+        raise ValueError(f"{name} must narrow to a finite float32")
     return real, numerator, denominator, narrowed
 
 
@@ -132,16 +121,14 @@ def canonical_float32_storage(value: Real, narrowed: float) -> float:
     return number
 
 
-def _require_real(name: object, value: object) -> tuple[float, float]:
+def _require_real(name: str, value: object) -> tuple[float, float]:
     """Return a JSON scalar and the value consumed by float32 JAX sinks."""
-    host_name = _require_exact_str("name", name)
-    real, _, _, narrowed = finite_real_and_float32(host_name, value)
+    real, _, _, narrowed = finite_real_and_float32(name, value)
     return canonical_float32_storage(real, narrowed), narrowed
 
 
-def _require_unit_interval(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, denominator, narrowed = finite_real_and_float32(host_name, value)
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = finite_real_and_float32(name, value)
     if (
         real < 0.0
         or not real <= 1.0
@@ -150,23 +137,21 @@ def _require_unit_interval(name: object, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{host_name} must be in [0, 1]")
+        raise ValueError(f"{name} must be in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_nonnegative_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{host_name} must be non-negative")
+        raise ValueError(f"{name} must be non-negative")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_positive_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{host_name} must remain positive in float32")
+        raise ValueError(f"{name} must remain positive in float32")
     return canonical_float32_storage(real, narrowed)
 
 
@@ -174,34 +159,32 @@ def _require_positive_real(name: object, value: object) -> float:
 _TRUSTED_INT_TYPES = _ACTUAL_INT_TYPES
 
 
-def _require_bool(name: object, value: object) -> bool:
+def _require_bool(name: str, value: object) -> bool:
     """Require an actual builtin bool (``__class__`` spoofing is ignored)."""
-    host_name = _require_exact_str("name", name)
     if type(value) is not bool:
-        raise ValueError(f"{host_name} must be a built-in bool")
+        raise ValueError(f"{name} must be a built-in bool")
     return value
 
 
 def _require_int(
-    name: object,
+    name: str,
     value: object,
     *,
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
-    if actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{host_name} must be an integer")
+    if not any(actual_type is candidate for candidate in _ACTUAL_INT_TYPES):
+        raise ValueError(f"{name} must be an integer")
     number: int = int(cast(Any, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{host_name} must be positive")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{host_name} must be non-negative")
-        raise ValueError(f"{host_name} must be >= {minimum}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{host_name} must be <= {maximum}")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
@@ -212,20 +195,20 @@ def _validate_step1_config(config: Step1KernelConfig) -> None:
         raise ValueError(
             f"num_relevant ({num_relevant}) must be <= feature_dim ({feature_dim})"
         )
-    if not isinstance(config.optimizer, str) or config.optimizer.lower() not in _VALID_OPTIMIZERS:
+    if type(config.optimizer) is not str or config.optimizer.lower() not in _VALID_OPTIMIZERS:
         raise ValueError(
             "unknown Step 1 optimizer; "
             f"expected one of {sorted(_VALID_OPTIMIZERS)}"
         )
     if (
-        not isinstance(config.normalizer, str)
+        type(config.normalizer) is not str
         or config.normalizer.lower() not in _VALID_NORMALIZERS
     ):
         raise ValueError(
             "unknown Step 1 normalizer; "
             f"expected one of {sorted(_VALID_NORMALIZERS)}"
         )
-    if not isinstance(config.stream, str) or config.stream.lower() not in _VALID_STREAMS:
+    if type(config.stream) is not str or config.stream.lower() not in _VALID_STREAMS:
         raise ValueError(
             "unknown Step 1 stream; "
             f"expected one of {sorted(_VALID_STREAMS)}"

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -503,7 +503,7 @@ def test_step1_rejects_spoofed_int_class_with_negative_ratio() -> None:
             type(self).ratio_calls += 1
             return (-1, 2**200)
 
-    with pytest.raises(ValueError, match="step_size must narrow to a finite float32"):
+    with pytest.raises(ValueError, match="step_size must be a real number"):
         Step1KernelConfig(step_size=SpoofedIntFloat(0.5))
     assert SpoofedIntFloat.class_calls == 0
     assert SpoofedIntFloat.ratio_calls == 0
@@ -525,7 +525,7 @@ def test_step1_rejects_spoofed_ratio_components() -> None:
             type(self).calls += 1
             return (SpoofedComponent(), 2)
 
-    with pytest.raises(ValueError, match="must narrow to a finite float32"):
+    with pytest.raises(ValueError, match="must be a real number"):
         Step1KernelConfig(step_size=BadRatioFloat(0.5))
     assert BadRatioFloat.calls == 0
 

--- a/tests/test_step1_hostile_validation.py
+++ b/tests/test_step1_hostile_validation.py
@@ -6,10 +6,16 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from alberta_framework.steps.step1 import Step1KernelConfig
+from alberta_framework.steps.step1 import Step1KernelConfig, Step1SmokeResult, run_step1_smoke
 
 
 class _EvilStr(str):
+    calls = 0
+
+    def lower(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("EvilStr.lower must not be called")
+
     def __str__(self) -> str:  # pragma: no cover
         raise AssertionError("EvilStr.__str__ must not be called")
 
@@ -28,9 +34,41 @@ class _HostileInt(int):
         type(self).calls += 1
         raise AssertionError("HostileInt.__index__ must not be called")
 
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("HostileInt.__int__ must not be called")
+
     def __repr__(self) -> str:
         type(self).calls += 1
         raise AssertionError("HostileInt.__repr__ must not be called")
+
+
+class _HostileMeta(type):
+    calls = 0
+
+    def __hash__(cls) -> int:
+        _HostileMeta.calls += 1
+        raise AssertionError("HostileMeta.__hash__ must not be called")
+
+
+class _HostileMetaclassInt(int, metaclass=_HostileMeta):
+    pass
+
+
+class _HostileMetaclassFloat(float, metaclass=_HostileMeta):
+    pass
+
+
+class _HostileTuple(tuple):
+    calls = 0
+
+    def __iter__(self):
+        type(self).calls += 1
+        raise AssertionError("HostileTuple.__iter__ must not be called")
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("HostileTuple.__repr__ must not be called")
 
 
 class _HostileFloat(float):
@@ -71,6 +109,11 @@ def test_rejects_bool_and_hostile_int() -> None:
     assert _HostileInt.calls == 0
     assert "HostileInt" not in str(exc.value)
 
+    _HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="must be an integer"):
+        Step1KernelConfig(feature_dim=_HostileMetaclassInt(4))
+    assert _HostileMeta.calls == 0
+
 
 def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     _HostileFloat.calls = 0
@@ -80,15 +123,10 @@ def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     assert "HostileFloat" not in str(exc.value)
     assert "!r" not in str(exc.value)
 
-
-def test_does_not_invoke_hostile_value_when_name_is_evil_via_sink() -> None:
-    from alberta_framework.steps.step1 import finite_real_and_float32
-
-    evil = _EvilStr("x")
-    _HostileFloat.calls = 0
-    with pytest.raises(ValueError, match="must be an exact string"):
-        finite_real_and_float32(evil, _HostileFloat(1.0))  # type: ignore[arg-type]
-    assert _HostileFloat.calls == 0
+    _HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="must be a real number"):
+        Step1KernelConfig(step_size=_HostileMetaclassFloat(0.01))
+    assert _HostileMeta.calls == 0
 
 
 def test_rejects_plain_string_for_step_size() -> None:
@@ -121,6 +159,30 @@ def test_rejects_unknown_optimizer_without_repr() -> None:
         Step1KernelConfig(optimizer="evil")  # type: ignore[arg-type]
     assert "evil" not in str(exc.value)
     assert "!r" not in str(exc.value)
+
+    _EvilStr.calls = 0
+    with pytest.raises(ValueError, match="unknown Step 1 optimizer"):
+        Step1KernelConfig(optimizer=_EvilStr("lms"))  # type: ignore[arg-type]
+    assert _EvilStr.calls == 0
+
+
+def test_smoke_result_rejects_hostile_shape_without_hooks() -> None:
+    _HostileTuple.calls = 0
+    with pytest.raises(ValueError, match="metrics_shape"):
+        Step1SmokeResult(
+            config=Step1KernelConfig(),
+            steps=2,
+            seed=0,
+            final_window_mse=0.0,
+            metrics_shape=_HostileTuple((2, 2)),
+            finite=True,
+        )
+    assert _HostileTuple.calls == 0
+
+
+@pytest.mark.parametrize("seed", [2**31, 2**32 - 1])
+def test_smoke_accepts_full_uint32_seed(seed: int) -> None:
+    assert run_step1_smoke(steps=2, final_window=1, seed=seed).seed == seed
 
 
 def test_valid_configs_still_pass() -> None:


### PR DESCRIPTION
Corrective successor to #1251, which raced and merged before review repairs could land. Preserves the original hardening while replacing hash-based allowlist membership with identity-only dispatch, removing internal helper-name widening, rejecting hostile string subclasses before lower(), preserving the full uint32 JAX seed contract, and adding zero-hook hostile int/metaclass/container coverage. Also updates two retained assertions to the intended exact-type rejection contract. Validation: exact 7-file Step1 consumer panel 522 passed; Ruff clean; strict mypy clean; diff clean.