### PR TITLE
fix(prototype-lifecycle): reject leftover resource-budget identities

### DIFF
--- a/alberta_framework/core/prototype_feature_lifecycle.py
+++ b/alberta_framework/core/prototype_feature_lifecycle.py
@@ -108,6 +108,12 @@ def _strict_int(
     return canonical
 
 
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an actual bool")
+    return value
+
+
 def _strict_float(
     value: object,
     *,
@@ -583,6 +589,47 @@ class PrototypeFeatureLifecycleResourceBudget:
     max_active_pair_products_per_observe: int
     max_candidate_pair_products_per_observe: int
     max_observations: int
+
+    def __post_init__(self) -> None:
+        if type(self.mechanism_status) is not str:
+            raise ValueError("mechanism_status must be an actual str")
+        object.__setattr__(
+            self,
+            "scientific_promotion_allowed",
+            _require_exact_bool(
+                "scientific_promotion_allowed",
+                self.scientific_promotion_allowed,
+            ),
+        )
+        for name in (
+            "base_feature_slots",
+            "active_pair_slots",
+            "candidate_pair_slots",
+            "managed_oak_feature_width",
+            "learner_persistent_state_nbytes",
+            "router_persistent_state_nbytes",
+            "lifecycle_counter_nbytes",
+            "lifecycle_state_nbytes",
+            "consumer_binding_persistent_nbytes",
+            "internal_learner_template_nbytes",
+            "internal_oak_template_nbytes",
+            "internal_template_nbytes",
+            "owned_persistent_state_nbytes",
+            "managed_oak_consumer_nbytes",
+            "rebuilt_base_cache_nbytes",
+            "input_route_feature_groups",
+            "output_route_feature_groups",
+            "router_calls_per_observe",
+            "router_calls_per_committed_curation",
+            "max_active_pair_products_per_observe",
+            "max_candidate_pair_products_per_observe",
+            "max_observations",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _strict_int(getattr(self, name), name=name, minimum=0),
+            )
 
     def to_config(self) -> dict[str, str | int | bool]:
         """Return an exact JSON-compatible resource record."""

--- a/tests/test_prototype_feature_lifecycle_resource_budget.py
+++ b/tests/test_prototype_feature_lifecycle_resource_budget.py
@@ -1,0 +1,67 @@
+"""Leftover-identity gates for prototype-lifecycle resource-budget records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from alberta_framework.core.prototype_feature_lifecycle import (
+    PrototypeFeatureLifecycleResourceBudget,
+)
+
+
+def _legal_budget() -> PrototypeFeatureLifecycleResourceBudget:
+    return PrototypeFeatureLifecycleResourceBudget(
+        mechanism_status="development_mechanism_only",
+        scientific_promotion_allowed=False,
+        base_feature_slots=4,
+        active_pair_slots=1,
+        candidate_pair_slots=1,
+        managed_oak_feature_width=5,
+        learner_persistent_state_nbytes=8,
+        router_persistent_state_nbytes=8,
+        lifecycle_counter_nbytes=16,
+        lifecycle_state_nbytes=32,
+        consumer_binding_persistent_nbytes=8,
+        internal_learner_template_nbytes=8,
+        internal_oak_template_nbytes=8,
+        internal_template_nbytes=16,
+        owned_persistent_state_nbytes=48,
+        managed_oak_consumer_nbytes=24,
+        rebuilt_base_cache_nbytes=20,
+        input_route_feature_groups=2,
+        output_route_feature_groups=1,
+        router_calls_per_observe=2,
+        router_calls_per_committed_curation=2,
+        max_active_pair_products_per_observe=5,
+        max_candidate_pair_products_per_observe=1,
+        max_observations=10,
+    )
+
+
+def test_prototype_lifecycle_resource_budget_rejects_leftover_identities() -> None:
+    """Public resource-budget records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="base_feature_slots"):
+        replace(_legal_budget(), base_feature_slots=True)
+    with pytest.raises(ValueError, match="max_observations"):
+        replace(_legal_budget(), max_observations=True)
+    with pytest.raises(ValueError, match="lifecycle_state_nbytes"):
+        replace(_legal_budget(), lifecycle_state_nbytes=float("nan"))
+    with pytest.raises(ValueError, match="scientific_promotion_allowed"):
+        replace(_legal_budget(), scientific_promotion_allowed=1)
+    with pytest.raises(ValueError, match="mechanism_status"):
+        replace(_legal_budget(), mechanism_status=True)
+
+    legal = _legal_budget()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"base_feature_slots": 4' in dumped
+    assert '"max_observations": 10' in dumped
+    assert '"lifecycle_state_nbytes": 32' in dumped
+    assert '"scientific_promotion_allowed": false' in dumped
+    assert '"base_feature_slots": true' not in dumped
+    assert '"max_observations": true' not in dumped
+    assert '"lifecycle_state_nbytes": true' not in dumped
+    assert '"scientific_promotion_allowed": 1' not in dumped


### PR DESCRIPTION
Closes #1257.

## What changed

The prototype-lifecycle resource-budget record now fails closed on leftover bool-as-int identities, leftover int-as-bool identities, leftover non-str status identities, and non-finite values.

On origin/main `daae959`, prototype-lifecycle config scalars already reject leftover boolean identities. `PrototypeFeatureLifecycleResourceBudget` had no `__post_init__` and accepted leftover identities (`base_feature_slots=True`, `max_observations=True`, `lifecycle_state_nbytes=NaN`, `scientific_promotion_allowed=1`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"base_feature_slots": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `prototype_feature_lifecycle.py` resource-budget records, not a republish of `#1198`/`#1199` (world-model-ensemble/recurrent-latent), `#1190`/`#1195` (model-replay), `#1191`/`#1193` (partner-fusion), `#1181`/`#1182`/`#1185`/`#1186` (learning-signals/option-search), `#1173` (mixer), `#1174` (behavior-model), `#1166`/`#1175` (gauntlet), or `#1159`/`#1161` (recurring-multiagent).

## Scope

- `alberta_framework/core/prototype_feature_lifecycle.py`
- `tests/test_prototype_feature_lifecycle_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is `#1253` (byt61 step2 sink only). These files were FREE.

## Verification

Exact candidate head: `ef5944c7aca4d24ec157cea1e1c05835462800eb`
Base: `daae959`

- Red on base: `replace(budget, base_feature_slots=True)` accepted; dump emitted `"base_feature_slots": true`
- Focused pytest `tests/test_prototype_feature_lifecycle_resource_budget.py`: 1 passed
- Existing prototype-lifecycle tests: 144 passed
- Combined: 145 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ef5944c7aca4d24ec157cea1e1c05835462800eb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
