### PR TITLE
fix(steps): complete Step 3 resource and key gates

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -136,6 +136,8 @@ def _require_typed_key(name: str, value: object) -> Array:
         key.dtype, jax.dtypes.prng_key
     ):
         raise ValueError(f"{name} must be a scalar typed JAX PRNG key")
+    if str(jr.key_impl(key)) != "threefry2x32":
+        raise ValueError(f"{name} must use Threefry2x32")
     return key
 
 
@@ -157,6 +159,29 @@ def _require_handoff_resources(
     if allocated_bytes > _INT32_MAX:
         raise ValueError("derived Step 3 handoff allocation bytes must fit signed int32")
     return feature_dim
+
+
+def _require_smoke_resources(
+    *,
+    steps: int,
+    raw_dim: int,
+    constructed_dim: int,
+    n_demons: int,
+) -> None:
+    """Preflight all arrays materialized by :func:`run_step3_smoke`."""
+    _require_handoff_resources(
+        steps=steps,
+        raw_dim=raw_dim,
+        constructed_dim=constructed_dim,
+        n_demons=n_demons,
+    )
+    # raw observations; product columns plus their stack; cumulants; and the
+    # concatenated current/next handoff matrices are simultaneously live.
+    allocated_bytes = steps * (
+        12 * raw_dim + 16 * constructed_dim + 4 * n_demons
+    )
+    if allocated_bytes > _INT32_MAX:
+        raise ValueError("derived Step 3 smoke allocation bytes must fit signed int32")
 
 
 Step3RoutingName = Literal["shared", "independent", "mixed"]
@@ -736,7 +761,7 @@ def run_step3_smoke(
 
     cfg = Step3HordeConfig() if config is None else config
     _validate_horde_config(cfg)
-    _require_handoff_resources(
+    _require_smoke_resources(
         steps=steps,
         raw_dim=raw_feature_dim,
         constructed_dim=constructed_feature_dim,

--- a/tests/test_step3_boundary_validation.py
+++ b/tests/test_step3_boundary_validation.py
@@ -176,6 +176,21 @@ def test_smoke_host_parameters_follow_exact_policy(field: str, value: object) ->
         run_step3_smoke(**{field: value})  # type: ignore[arg-type]
 
 
+def test_smoke_preflights_all_live_arrays_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_allocation(*args: object, **kwargs: object) -> None:
+        raise AssertionError("allocation must not start before resource preflight")
+
+    monkeypatch.setattr(jr, "normal", unexpected_allocation)
+    with pytest.raises(ValueError, match="smoke allocation bytes"):
+        run_step3_smoke(
+            steps=10_000_000,
+            raw_feature_dim=20,
+            constructed_feature_dim=0,
+        )
+
+
 def test_runtime_facade_rejects_narrowing_and_shape_mismatch() -> None:
     config = Step3HordeConfig(gammas=(0.0,), lamdas=(0.0,))
     horde = make_step3_horde(config)
@@ -194,6 +209,16 @@ def test_runtime_facade_rejects_narrowing_and_shape_mismatch() -> None:
             feature[None, :],
             jnp.ones((1, 2), dtype=jnp.float32),
             feature[None, :],
+        )
+
+
+def test_runtime_facade_requires_threefry_key() -> None:
+    horde = make_step3_horde(Step3HordeConfig(gammas=(0.0,), lamdas=(0.0,)))
+    with pytest.raises(ValueError, match="Threefry2x32"):
+        init_step3_state(
+            horde,
+            feature_dim=2,
+            key=jr.key(0, impl="rbg"),
         )
 
 


### PR DESCRIPTION
Post-merge audit corrective for #1249. Its handoff accounting was correct for caller-owned inputs, but `run_step3_smoke` reused that narrower formula and omitted the simultaneously live raw/product-column/stack/cumulant arrays. The public init key gate also accepted typed RBG keys despite the repository Threefry-root policy. This adds exact smoke-only live-allocation accounting and binds the public init key to Threefry2x32.\n\nFailing-test-first on exact merged baseline: the 10M x 20 smoke reached mocked allocation and an RBG typed key was accepted (2 failures). Green: 221 full Step3/direct-consumer tests, Ruff, strict file mypy, and diff check.