### PR TITLE
fix(step5): close record and resource accounting gaps

### DIFF
--- a/alberta_framework/steps/step5.py
+++ b/alberta_framework/steps/step5.py
@@ -235,8 +235,7 @@ class Step5SmokeResult:
         for name in ("predictions_shape", "td_errors_shape", "average_rewards_shape"):
             if getattr(self, name) != (self.steps,):
                 raise ValueError(f"{name} must be exactly (steps,)")
-        if type(self.learner_config) is not dict:
-            raise ValueError("learner_config must be an actual dict")
+        _require_closed_json_object("learner_config", self.learner_config)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -279,11 +278,57 @@ def _preflight_smoke_resources(steps: int, feature_dim: int) -> None:
     # addition to the learner's two D-vectors and four scalar leaves.
     learner_scalars = 2 * feature_dim + 4
     input_scalars = (steps + 1) * feature_dim + steps
-    if any(
-        count > _INT32_MAX or 4 * count > _INT32_MAX
-        for count in (learner_scalars, input_scalars, learner_scalars + input_scalars)
+    output_float_scalars = 7 * steps
+    output_bool_bytes = steps
+    total_bytes = 4 * (learner_scalars + input_scalars + output_float_scalars)
+    total_bytes += output_bool_bytes
+    if (
+        any(
+            count > _INT32_MAX or 4 * count > _INT32_MAX
+            for count in (learner_scalars, input_scalars, output_float_scalars)
+        )
+        or output_bool_bytes > _INT32_MAX
+        or total_bytes > _INT32_MAX
     ):
         raise ValueError("derived Step 5 smoke float32 resources exceed signed-int32 bounds")
+
+
+def _require_closed_json_object(name: str, value: object) -> dict[str, Any]:
+    """Require an acyclic tree of exact built-in JSON identities."""
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an actual dict")
+    active_containers: set[int] = set()
+    stack: list[tuple[bool, object]] = [(True, value)]
+    while stack:
+        entering, item = stack.pop()
+        if not entering:
+            active_containers.remove(id(item))
+            continue
+        if type(item) is dict:
+            identity = id(item)
+            if identity in active_containers:
+                raise ValueError(f"{name} must be an acyclic JSON object")
+            active_containers.add(identity)
+            mapping = cast(dict[object, object], item)
+            if any(type(key) is not str for key in mapping):
+                raise ValueError(f"{name} keys must be exact strings")
+            stack.append((False, item))
+            stack.extend((True, child) for child in mapping.values())
+        elif type(item) is list:
+            identity = id(item)
+            if identity in active_containers:
+                raise ValueError(f"{name} must be an acyclic JSON object")
+            active_containers.add(identity)
+            stack.append((False, item))
+            stack.extend((True, child) for child in cast(list[object], item))
+        elif item is None or type(item) in (str, bool, int):
+            continue
+        elif type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError(f"{name} floats must be finite")
+        else:
+            raise ValueError(f"{name} must contain only exact JSON identities")
+    return cast(dict[str, Any], value)
 
 
 def _state_feature_dim(state: DifferentialTDState) -> int:

--- a/tests/test_step5_hostile_validation.py
+++ b/tests/test_step5_hostile_validation.py
@@ -214,6 +214,18 @@ class _HostileArray:
         raise AssertionError("shape hook must not run")
 
 
+class _HostileJsonLeaf:
+    calls = 0
+
+    def __deepcopy__(self, memo: object) -> object:
+        type(self).calls += 1
+        raise AssertionError("HostileJsonLeaf.__deepcopy__ must not be called")
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("HostileJsonLeaf.__repr__ must not be called")
+
+
 def test_scan_rejects_hostile_arrays_without_hooks() -> None:
     learner = make_step5_td_learner()
     state = learner.init(2)
@@ -253,3 +265,32 @@ def test_scan_requires_exact_float32_shapes() -> None:
 def test_smoke_rejects_derived_allocation_before_jax() -> None:
     with pytest.raises(ValueError, match="derived Step 5 smoke"):
         run_step5_smoke(steps=2**20, feature_dim=2**20)
+
+
+def test_smoke_preflight_accounts_for_scan_outputs() -> None:
+    with pytest.raises(ValueError, match="derived Step 5 smoke"):
+        run_step5_smoke(steps=100_000_000, feature_dim=1)
+
+
+def test_smoke_result_requires_closed_json_learner_config_without_hooks() -> None:
+    payload = {
+        "config": Step5AverageRewardTDConfig(),
+        "steps": 1,
+        "seed": 0,
+        "predictions_shape": (1,),
+        "td_errors_shape": (1,),
+        "average_rewards_shape": (1,),
+        "finite": True,
+    }
+    _HostileJsonLeaf.calls = 0
+    with pytest.raises(ValueError, match="exact JSON identities"):
+        Step5SmokeResult(**payload, learner_config={"bad": _HostileJsonLeaf()})
+    assert _HostileJsonLeaf.calls == 0
+
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+    with pytest.raises(ValueError, match="acyclic JSON object"):
+        Step5SmokeResult(**payload, learner_config=cyclic)
+
+    with pytest.raises(ValueError, match="floats must be finite"):
+        Step5SmokeResult(**payload, learner_config={"bad": float("nan")})


### PR DESCRIPTION
Corrective follow-up to #1252. Its allocation preflight omitted the seven per-step float32 scan outputs and per-step boolean output, allowing configurations whose derived output allocation exceeded the signed-int32 byte budget. Its public learner_config record also admitted arbitrary, nonfinite, cyclic, or hook-bearing values that could reach dataclasses.asdict/deepcopy despite the closed-JSON contract. This adds complete input/state/output byte accounting and iterative exact-built-in, finite, acyclic JSON-tree validation. Validation: full six-file Step5/6/shared float32 panel 350 passed; latest hostile panel 20 passed; Ruff and strict mypy clean; diff clean.