### PR TITLE
fix(step10): close metaclass validation hooks

### DIFF
--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -37,6 +37,7 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from fractions import Fraction
 from numbers import Integral
 from typing import Any, cast
 
@@ -208,32 +209,44 @@ _STEP10_CONFIG_FIELDS = frozenset(
     {"type", "subtask_specs", *Step10STOMPConfig.__dataclass_fields__}
 )
 _SUBTASK_SPEC_FIELDS = frozenset(SubtaskSpec.__dataclass_fields__)
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+_ACTUAL_INT_TYPES = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES + (
+    float,
+    Fraction,
+    np.dtype("e").type,
+    np.dtype("f").type,
+    np.dtype("d").type,
+    np.dtype("g").type,
 )
 
 
-def _require_exact_str(name: str, value: object) -> str:
-    if type(value) is not str:
-        raise ValueError(f"{name} must be an exact string")
-    return value
+def _finite_real_and_float32(name: str, value: object) -> tuple[Any, int, int, float]:
+    """Validate the runtime type without invoking hooks on its metaclass."""
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_REAL_TYPES):
+        mro = type.__getattribute__(actual_type, "__mro__")
+        has_real_lineage = actual_type is not bool and any(
+            base is int or base is float or base is Fraction for base in mro
+        )
+        requirement = "finite" if has_real_lineage else "a real number"
+        raise ValueError(f"{name} must be {requirement}")
+    return finite_real_and_float32(name, value)
 
 
-def _require_unit_interval(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, denominator, narrowed = finite_real_and_float32(host_name, value)
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = _finite_real_and_float32(name, value)
     if (
         real < 0.0
         or not real <= 1.0
@@ -242,56 +255,52 @@ def _require_unit_interval(name: object, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{host_name} must be in [0, 1]")
+        raise ValueError(f"{name} must be in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_nonnegative_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{host_name} must be non-negative")
+        raise ValueError(f"{name} must be non-negative")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_positive_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{host_name} must be positive")
+        raise ValueError(f"{name} must be positive")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(
-    name: object,
+    name: str,
     value: object,
     *,
     minimum: int | None = None,
     maximum: int | None = None,
     exclusive_maximum: int | None = None,
 ) -> int:
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
-    if actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{host_name} must be an integer")
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
+        raise ValueError(f"{name} must be an integer")
     number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{host_name} must be positive")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{host_name} must be non-negative")
-        raise ValueError(f"{host_name} must be >= {minimum}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{host_name} must be <= {maximum}")
+        raise ValueError(f"{name} must be <= {maximum}")
     if exclusive_maximum is not None and number >= exclusive_maximum:
-        raise ValueError(f"{host_name} must be smaller than int32 max")
+        raise ValueError(f"{name} must be smaller than int32 max")
     return number
 
 
-def _require_bool(name: object, value: object) -> bool:
-    host_name = _require_exact_str("name", name)
+def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
-        raise ValueError(f"{host_name} must be a built-in bool")
+        raise ValueError(f"{name} must be a built-in bool")
     return value
 
 

--- a/tests/test_step10_hostile_validation.py
+++ b/tests/test_step10_hostile_validation.py
@@ -29,6 +29,10 @@ class _StringSubclass(str):
 class _HostileInt(int):
     calls = 0
 
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("HostileInt.__int__ must not be called")
+
     def __index__(self) -> int:  # type: ignore[override]
         type(self).calls += 1
         raise AssertionError("HostileInt.__index__ must not be called")
@@ -54,6 +58,30 @@ class _HostileFloat(float):
         raise AssertionError("HostileFloat.__repr__ must not be called")
 
 
+class _HostileIntMeta(type):
+    calls = 0
+
+    def __hash__(cls) -> int:
+        type(cls).calls += 1
+        raise AssertionError("HostileIntMeta.__hash__ must not be called")
+
+
+class _MetaclassHostileInt(int, metaclass=_HostileIntMeta):
+    pass
+
+
+class _HostileFloatMeta(type):
+    calls = 0
+
+    def __hash__(cls) -> int:
+        type(cls).calls += 1
+        raise AssertionError("HostileFloatMeta.__hash__ must not be called")
+
+
+class _MetaclassHostileFloat(float, metaclass=_HostileFloatMeta):
+    pass
+
+
 def test_rejects_string_subclass_for_observation_dim() -> None:
     with pytest.raises(ValueError, match="must be an integer"):
         Step10STOMPConfig(observation_dim=_StringSubclass("4"))  # type: ignore[arg-type]
@@ -77,6 +105,13 @@ def test_rejects_bool_and_hostile_int() -> None:
     assert "HostileInt" not in str(exc.value)
 
 
+def test_rejects_hostile_int_metaclass_without_hooks() -> None:
+    _HostileIntMeta.calls = 0
+    with pytest.raises(ValueError, match="must be an integer"):
+        Step10STOMPConfig(observation_dim=_MetaclassHostileInt(4))
+    assert _HostileIntMeta.calls == 0
+
+
 def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be finite") as exc:
@@ -86,14 +121,11 @@ def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     assert "!r" not in str(exc.value)
 
 
-def test_does_not_invoke_hostile_value_when_name_is_evil_via_sink() -> None:
-    from alberta_framework.steps._float32_validation import finite_real_and_float32
-
-    evil = _EvilStr("x")
-    _HostileFloat.calls = 0
-    with pytest.raises(ValueError, match="must be an exact string"):
-        finite_real_and_float32(evil, _HostileFloat(1.0))  # type: ignore[arg-type]
-    assert _HostileFloat.calls == 0
+def test_rejects_hostile_float_metaclass_without_hooks() -> None:
+    _HostileFloatMeta.calls = 0
+    with pytest.raises(ValueError, match="must be finite"):
+        Step10STOMPConfig(base_step_size=_MetaclassHostileFloat(0.05))
+    assert _HostileFloatMeta.calls == 0
 
 
 def test_rejects_plain_string_for_option_gamma() -> None:
@@ -117,6 +149,45 @@ def test_rejects_subtask_specs_non_tuple_without_repr() -> None:
     with pytest.raises(ValueError, match="must be a tuple of SubtaskSpec") as exc:
         Step10STOMPConfig(subtask_specs=[SubtaskSpec(feature_index=0)])  # type: ignore[arg-type]
     assert "!r" not in str(exc.value)
+
+
+def test_rejects_tuple_and_subtask_spec_subclasses_without_hooks() -> None:
+    calls: list[str] = []
+
+    class HostileTuple(tuple[SubtaskSpec, ...]):
+        def __iter__(self):  # type: ignore[override]
+            calls.append("iter")
+            raise AssertionError("HostileTuple.__iter__ must not be called")
+
+        def __repr__(self) -> str:
+            calls.append("repr")
+            raise AssertionError("HostileTuple.__repr__ must not be called")
+
+    class HostileSpec(SubtaskSpec):
+        def __repr__(self) -> str:
+            calls.append("spec-repr")
+            raise AssertionError("HostileSpec.__repr__ must not be called")
+
+    with pytest.raises(ValueError, match="must be a tuple of SubtaskSpec"):
+        Step10STOMPConfig(subtask_specs=HostileTuple((SubtaskSpec(feature_index=0),)))
+    with pytest.raises(ValueError, match="must contain SubtaskSpec values"):
+        Step10STOMPConfig(subtask_specs=(HostileSpec(feature_index=0),))
+    assert calls == []
+
+
+def test_smoke_preflights_steps_and_seed_without_hostile_hooks() -> None:
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step10_smoke(steps=_HostileInt(1))
+    with pytest.raises(ValueError, match="seed must be a built-in integer"):
+        run_step10_smoke(steps=1, seed=_HostileInt(0))
+    assert _HostileInt.calls == 0
+
+
+def test_smoke_accepts_full_uint32_seed_and_bounds_steps() -> None:
+    assert run_step10_smoke(steps=1, seed=2**32 - 1).seed == 2**32 - 1
+    with pytest.raises(ValueError, match="steps must be <="):
+        run_step10_smoke(steps=2**31)
 
 
 def test_rejects_feature_index_out_of_range_without_repr() -> None:

--- a/tests/test_step10_production.py
+++ b/tests/test_step10_production.py
@@ -307,13 +307,12 @@ def test_step10_stomp_fields_reject_invalid_inputs(field: str, value: object) ->
 @pytest.mark.unit
 def test_step10_stomp_int_dimensions_stay_within_int32() -> None:
     int32_max = 2**31 - 1
-    upper = Step10STOMPConfig(
-        subtask_specs=(_SPEC1,),
-        observation_dim=int32_max,
-        n_primitive_actions=int32_max,
-    )
-    assert upper.observation_dim == int32_max
-    assert upper.n_primitive_actions == int32_max
+    # Individual dimensions may fit int32 while the arrays derived from them
+    # do not. The core resource contract must reject those combinations too.
+    with pytest.raises(ValueError, match="derived STOMP direct array bytes"):
+        Step10STOMPConfig(subtask_specs=(_SPEC1,), observation_dim=int32_max)
+    with pytest.raises(ValueError, match="derived n_total_actions"):
+        Step10STOMPConfig(subtask_specs=(_SPEC1,), n_primitive_actions=int32_max)
     with pytest.raises(ValueError, match="observation_dim"):
         Step10STOMPConfig(subtask_specs=(_SPEC1,), observation_dim=int32_max + 1)
     with pytest.raises(ValueError, match="n_primitive_actions"):
@@ -330,8 +329,8 @@ def test_step10_stomp_feature_index_stays_within_int32() -> None:
             observation_dim=2**40,
         )
     spec = SubtaskSpec(feature_index=2**31 - 2)
-    cfg = Step10STOMPConfig(subtask_specs=(spec,), observation_dim=2**31 - 1)
-    assert cfg.subtask_specs[0].feature_index == 2**31 - 2
+    with pytest.raises(ValueError, match="derived STOMP direct array bytes"):
+        Step10STOMPConfig(subtask_specs=(spec,), observation_dim=2**31 - 1)
 
 
 class _SpoofedInt:


### PR DESCRIPTION
Summary: identity-only Step 10 scalar gates; hook-free numeric-subclass rejection; preserve exact schema and resource contracts. Failing-first: hostile integer and float metaclass probes invoked custom hash hooks. Verification: 187 focused passed; 241 broad affected passed; Ruff passed; strict mypy 170 files; diff check passed.