### PR TITLE
fix(steps): totalize Step 1 facade resources

### DIFF
--- a/alberta_framework/steps/step1.py
+++ b/alberta_framework/steps/step1.py
@@ -66,6 +66,7 @@ _VALID_OPTIMIZERS: frozenset[str] = frozenset(
 _VALID_NORMALIZERS: frozenset[str] = frozenset({"none", "ema", "welford", "streaming_batch"})
 _VALID_STREAMS: frozenset[str] = frozenset({"alberta", "xdist_shift"})
 _INT32_MAX: int = 2**31 - 1
+_MAX_RESOURCE_BYTES: int = 256 * 1024 * 1024
 _ACTUAL_INT_TYPES = (
         int,
         np.int8,
@@ -189,6 +190,8 @@ def _require_int(
 
 
 def _validate_step1_config(config: Step1KernelConfig) -> None:
+    if type(config) is not Step1KernelConfig:
+        raise TypeError("config must be an exact Step1KernelConfig")
     feature_dim = _require_int("feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX)
     num_relevant = _require_int("num_relevant", config.num_relevant, minimum=1, maximum=_INT32_MAX)
     if num_relevant > feature_dim:
@@ -274,7 +277,14 @@ class Step1KernelConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step1KernelConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        return cls(**cast(Any, payload))
+        if type(payload) is not dict:
+            raise ValueError("Step1KernelConfig payload must be an exact dictionary")
+        raw = cast(dict[object, object], payload)
+        if any(type(key) is not str for key in raw):
+            raise ValueError("Step1KernelConfig payload keys must be exact strings")
+        if cast(set[str], set(raw)) != frozenset(cls.__dataclass_fields__):
+            raise ValueError("Step1KernelConfig payload fields do not match the schema")
+        return cls(**cast(Any, dict(raw)))
 
 
 @dataclass(frozen=True)
@@ -289,6 +299,8 @@ class Step1SmokeResult:
     finite: bool
 
     def __post_init__(self) -> None:
+        if type(self.config) is not Step1KernelConfig:
+            raise TypeError("config must be an exact Step1KernelConfig")
         object.__setattr__(
             self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
         )
@@ -301,9 +313,14 @@ class Step1SmokeResult:
         object.__setattr__(
             self,
             "final_window_mse",
-            _require_real("final_window_mse", self.final_window_mse)[0],
+            _require_nonnegative_real("final_window_mse", self.final_window_mse),
         )
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        expected_columns = 3 if self.config.normalizer == "none" else 4
+        if self.metrics_shape != (self.steps, expected_columns):
+            raise ValueError(
+                "metrics_shape must match steps and the configured normalizer metric width"
+            )
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -313,6 +330,70 @@ class Step1SmokeResult:
         return payload
 
 
+def _require_step1_config(config: object) -> Step1KernelConfig:
+    if type(config) is not Step1KernelConfig:
+        raise TypeError("config must be an exact Step1KernelConfig")
+    return config
+
+
+def _checked_resource_sum(name: str, *terms: int) -> int:
+    total = 0
+    for term in terms:
+        if term < 0 or term > _INT32_MAX - total:
+            raise ValueError(f"derived {name} must fit signed int32")
+        total += term
+    return total
+
+
+def _checked_resource_product(name: str, *factors: int) -> int:
+    product = 1
+    for factor in factors:
+        if factor < 0 or (factor != 0 and product > _INT32_MAX // factor):
+            raise ValueError(f"derived {name} must fit signed int32")
+        product *= factor
+    return product
+
+
+def _step1_state_scalar_count(config: Step1KernelConfig) -> int:
+    optimizer_widths = {
+        "lms": 0,
+        "idbd": 2,
+        "autostep": 3,
+        "autostep_gtd": 4,
+        "adagain": 2,
+        "adam": 2,
+        "rmsprop": 1,
+        "nadaline": 1,
+    }
+    normalizer_widths = {"none": 0, "ema": 2, "welford": 3, "streaming_batch": 2}
+    stream_width = 1 if config.stream == "alberta" else 2
+    width = 1 + optimizer_widths[config.optimizer] + normalizer_widths[config.normalizer]
+    width += stream_width
+    return _checked_resource_sum(
+        "Step 1 resource persistent scalar count",
+        _checked_resource_product(
+            "Step 1 resource persistent vector count", width, config.feature_dim
+        ),
+        32,
+    )
+
+
+def _preflight_step1_resources(config: Step1KernelConfig, *, steps: int | None = None) -> None:
+    state_scalars = _step1_state_scalar_count(config)
+    output_scalars = 0
+    if steps is not None:
+        metric_columns = 3 if config.normalizer == "none" else 4
+        output_scalars = _checked_resource_product(
+            "Step 1 resource smoke output scalar count", steps, metric_columns + 1
+        )
+    total_scalars = _checked_resource_sum(
+        "Step 1 resource total scalar count", state_scalars, output_scalars
+    )
+    total_bytes = _checked_resource_product("Step 1 resource total byte count", 4, total_scalars)
+    if total_bytes > _MAX_RESOURCE_BYTES:
+        raise ValueError("Step 1 resources must not exceed the 256 MiB budget")
+
+
 def make_step1_optimizer(config: Step1KernelConfig) -> Any:
     """Construct a public Step 1 optimizer from ``config``.
 
@@ -320,7 +401,8 @@ def make_step1_optimizer(config: Step1KernelConfig) -> Any:
     rule is available in the cited sources, so the production package exposes
     only reproducible optimizers.
     """
-    name = config.optimizer.lower()
+    config = _require_step1_config(config)
+    name = config.optimizer
     if name == "lms":
         return LMS(step_size=config.step_size)
     if name == "idbd":
@@ -357,7 +439,8 @@ def make_step1_normalizer(
     config: Step1KernelConfig,
 ) -> Normalizer[Any] | None:
     """Construct an online normalizer from ``config``."""
-    name = config.normalizer.lower()
+    config = _require_step1_config(config)
+    name = config.normalizer
     if name == "none":
         return None
     if name == "ema":
@@ -374,6 +457,8 @@ def make_step1_stream(
     config: Step1KernelConfig,
 ) -> AlbertaPlanStep1Stream | XDistShiftStream:
     """Construct the configured Step 1 stream."""
+    config = _require_step1_config(config)
+    _preflight_step1_resources(config)
     if config.stream == "alberta":
         return AlbertaPlanStep1Stream(
             feature_dim=config.feature_dim,
@@ -396,7 +481,11 @@ def make_step1_stream(
 
 def make_step1_learner(config: Step1KernelConfig | None = None) -> LinearLearner:
     """Create the production Step 1 learner."""
-    cfg = config or Step1KernelConfig()
+    if config is None:
+        cfg = Step1KernelConfig()
+    else:
+        cfg = _require_step1_config(config)
+    _preflight_step1_resources(cfg)
     return LinearLearner(
         optimizer=make_step1_optimizer(cfg),
         normalizer=make_step1_normalizer(cfg),
@@ -419,7 +508,11 @@ def run_step1_smoke(
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
     seed = require_jax_seed(seed, name="seed")
     final_window = _require_int("final_window", final_window, minimum=1, maximum=steps)
-    cfg = config or Step1KernelConfig()
+    if config is None:
+        cfg = Step1KernelConfig()
+    else:
+        cfg = _require_step1_config(config)
+    _preflight_step1_resources(cfg, steps=steps)
     learner = make_step1_learner(cfg)
     stream = make_step1_stream(cfg)
     loop_result = cast(

--- a/tests/test_step1_int_validation.py
+++ b/tests/test_step1_int_validation.py
@@ -141,7 +141,7 @@ def _legal_step1_smoke_result(**overrides: object) -> Step1SmokeResult:
         "steps": 8,
         "seed": 0,
         "final_window_mse": 0.25,
-        "metrics_shape": (8, 2),
+        "metrics_shape": (8, 4),
         "finite": True,
     }
     payload.update(overrides)

--- a/tests/test_step1_total_boundary.py
+++ b/tests/test_step1_total_boundary.py
@@ -1,0 +1,115 @@
+"""Total public-boundary tests for the production Step 1 facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+
+from alberta_framework.steps.step1 import (
+    Step1KernelConfig,
+    Step1SmokeResult,
+    make_step1_learner,
+    make_step1_optimizer,
+    make_step1_stream,
+    run_step1_smoke,
+)
+
+
+class _HostileDict(dict[object, object]):
+    calls = 0
+
+    def __iter__(self) -> Iterator[object]:
+        type(self).calls += 1
+        raise AssertionError("mapping hook must not run")
+
+
+class _HostileConfig(Step1KernelConfig):
+    calls = 0
+
+    def __getattribute__(self, name: str) -> Any:
+        type(self).calls += 1
+        raise AssertionError(f"config hook must not run: {name}")
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("truthiness hook must not run")
+
+
+def _hostile_config() -> object:
+    return object.__new__(_HostileConfig)
+
+
+def _result(**overrides: object) -> Step1SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step1KernelConfig(),
+        "steps": 4,
+        "seed": 0,
+        "final_window_mse": 0.25,
+        "metrics_shape": (4, 4),
+        "finite": True,
+    }
+    payload.update(overrides)
+    return Step1SmokeResult(**cast(Any, payload))
+
+
+def test_config_parser_requires_exact_complete_schema_without_mapping_hooks() -> None:
+    payload = Step1KernelConfig().to_dict()
+    missing = {key: value for key, value in payload.items() if key != "stream"}
+    for bad in ({**payload, "extra": 1}, missing):
+        with pytest.raises(ValueError, match="schema"):
+            Step1KernelConfig.from_dict(cast(Any, bad))
+
+    hostile = _HostileDict(payload)
+    _HostileDict.calls = 0
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step1KernelConfig.from_dict(cast(Any, hostile))
+    assert _HostileDict.calls == 0
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [make_step1_optimizer, make_step1_stream, make_step1_learner],
+)
+def test_factories_reject_config_subclasses_before_attribute_hooks(factory: Any) -> None:
+    _HostileConfig.calls = 0
+    with pytest.raises(TypeError, match="exact Step1KernelConfig"):
+        factory(cast(Any, _hostile_config()))
+    assert _HostileConfig.calls == 0
+
+
+def test_smoke_rejects_config_subclass_without_truthiness_or_attribute_hooks() -> None:
+    _HostileConfig.calls = 0
+    with pytest.raises(TypeError, match="exact Step1KernelConfig"):
+        run_step1_smoke(cast(Any, _hostile_config()), steps=1, final_window=1)
+    assert _HostileConfig.calls == 0
+
+
+def test_selected_state_and_smoke_outputs_are_preflighted_before_jax_allocation() -> None:
+    huge = Step1KernelConfig(
+        feature_dim=2**31 - 1,
+        num_relevant=1,
+        optimizer="lms",
+        normalizer="none",
+    )
+    with pytest.raises(ValueError, match="resource"):
+        make_step1_learner(huge)
+    with pytest.raises(ValueError, match="resource"):
+        make_step1_stream(huge)
+    with pytest.raises(ValueError, match="resource"):
+        run_step1_smoke(steps=2**31 - 1)
+
+
+def test_smoke_record_requires_exact_config_metric_schema_and_nonnegative_mse() -> None:
+    with pytest.raises(TypeError, match="exact Step1KernelConfig"):
+        _result(config=cast(Any, _hostile_config()))
+    with pytest.raises(ValueError, match="metrics_shape"):
+        _result(metrics_shape=(4, 3))
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _result(final_window_mse=-0.25)
+
+    without_normalizer = _result(
+        config=Step1KernelConfig(normalizer="none"), metrics_shape=(4, 3)
+    )
+    assert without_normalizer.metrics_shape == (4, 3)


### PR DESCRIPTION
Corrective successor to #1251 and #1254. Preserves the contributor and hostile-metaclass scalar hardening while closing the remaining exact config/parser/result identity, config-truthiness, derived persistent-state and scan-output resource, metric-shape, and nonnegative-MSE boundaries. No benchmark or output artifacts changed.\n\nValidation: 62 focused Step 1 tests passed; scoped Ruff clean; strict mypy clean; diff check clean.