### PR TITLE
fix(prototype-agent): reject leftover experiential-memory resource identities

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -1748,6 +1748,23 @@ class PrototypeExperientialMemoryResourceDeclaration:
     score_mass_values_interpreted: int
     hard_safety_values_interpreted: int
 
+    def __post_init__(self) -> None:
+        for name in (
+            "persistent_state_bytes",
+            "categorical_policy_queries",
+            "causal_step_queries",
+            "total_deterministic_prestate_queries",
+            "writes_attempted",
+            "random_draws",
+            "score_mass_values_interpreted",
+            "hard_safety_values_interpreted",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_int(name, getattr(self, name), minimum=0),
+            )
+
     def to_config(self) -> dict[str, int]:
         """Return the exact JSON-compatible resource declaration."""
 

--- a/tests/test_prototype_experiential_memory_resource_declaration.py
+++ b/tests/test_prototype_experiential_memory_resource_declaration.py
@@ -1,0 +1,45 @@
+"""Leftover-identity gates for prototype experiential-memory resource declarations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from alberta_framework.core.prototype_agent import (
+    PrototypeExperientialMemoryResourceDeclaration,
+)
+
+
+def _legal_declaration() -> PrototypeExperientialMemoryResourceDeclaration:
+    return PrototypeExperientialMemoryResourceDeclaration(
+        persistent_state_bytes=16,
+        categorical_policy_queries=1,
+        causal_step_queries=0,
+        total_deterministic_prestate_queries=1,
+        writes_attempted=1,
+        random_draws=0,
+        score_mass_values_interpreted=3,
+        hard_safety_values_interpreted=3,
+    )
+
+
+def test_prototype_experiential_memory_resource_declaration_rejects_leftover_identities() -> None:
+    """Public resource declarations must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="persistent_state_bytes"):
+        replace(_legal_declaration(), persistent_state_bytes=True)
+    with pytest.raises(ValueError, match="random_draws"):
+        replace(_legal_declaration(), random_draws=True)
+    with pytest.raises(ValueError, match="score_mass_values_interpreted"):
+        replace(_legal_declaration(), score_mass_values_interpreted=float("nan"))
+
+    legal = _legal_declaration()
+    dumped = json.dumps(legal.to_config(), allow_nan=False)
+    assert '"persistent_state_bytes": 16' in dumped
+    assert '"random_draws": 0' in dumped
+    assert '"score_mass_values_interpreted": 3' in dumped
+    assert '"persistent_state_bytes": true' not in dumped
+    assert '"random_draws": true' not in dumped
+    assert '"score_mass_values_interpreted": true' not in dumped


### PR DESCRIPTION
Closes #1266.

## What changed

The prototype-agent experiential-memory resource-declaration record now fails closed on leftover bool-as-int identities and non-finite values.

On origin/main `495831b`, prototype-agent config scalars already reject leftover integer identities. `PrototypeExperientialMemoryResourceDeclaration` had no `__post_init__` and accepted leftover identities (`persistent_state_bytes=True`, `random_draws=True`, `score_mass_values_interpreted=NaN`). `json.dumps(record.to_config(), allow_nan=False)` then emitted `"persistent_state_bytes": true` or raised at dump time instead of failing closed at construction.

This is leftover tax on `prototype_agent.py` experiential-memory resource-declaration records, not a republish of `#1259` (prototype-lifecycle resource-budget), `#1260` (oak STOMP-adoption), `#1198`/`#1199` (world-model-ensemble/recurrent-latent), or `#1191`/`#1193` (partner-fusion).

## Scope

- `alberta_framework/core/prototype_agent.py`
- `tests/test_prototype_experiential_memory_resource_declaration.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is `#1260` (oak STOMP-adoption), `#1256` (byt61 step7), and `#1253` (byt61 step2). These files were FREE.

## Verification

Exact candidate head: `b1de7e02746712ccf2d1171061612c825c9ec2f1`
Base: `495831b`

- Red on base: `replace(declaration, persistent_state_bytes=True)` accepted; dump emitted `"persistent_state_bytes": true`
- Focused leftover test plus `test_experiential_memory_uses_one_accounted_policy_step`: 2 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b1de7e02746712ccf2d1171061612c825c9ec2f1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
