### PR TITLE
fix(prototype-lifecycle): bind exact resource formulas

### DIFF
--- a/alberta_framework/core/prototype_feature_lifecycle.py
+++ b/alberta_framework/core/prototype_feature_lifecycle.py
@@ -75,8 +75,9 @@ PROTOTYPE_FEATURE_LIFECYCLE_SCIENTIFIC_PROMOTION_ALLOWED = False
 
 _CONFIG_TYPE = "PrototypeFeatureLifecycleConfig"
 _INT32_MAX = 2_147_483_647
-_ACTUAL_INT_TYPES = frozenset(
-    {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
+_ACTUAL_INT_TYPES = (
+    int,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
 )
 _MAX_TOTAL_FEATURE_DIM = 4_096
 _MAX_PAIR_SLOTS = 262_144
@@ -96,7 +97,8 @@ def _strict_int(
 ) -> int:
     """Validate and canonicalize a supported concrete host integer."""
 
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is candidate for candidate in _ACTUAL_INT_TYPES):
         raise ValueError(
             f"{name} must be a strict integer in [{minimum}, {maximum}]"
         )
@@ -591,8 +593,13 @@ class PrototypeFeatureLifecycleResourceBudget:
     max_observations: int
 
     def __post_init__(self) -> None:
-        if type(self.mechanism_status) is not str:
-            raise ValueError("mechanism_status must be an actual str")
+        if type(self) is not PrototypeFeatureLifecycleResourceBudget:
+            raise ValueError("resource budget must be an actual record")
+        if (
+            type(self.mechanism_status) is not str
+            or self.mechanism_status != PROTOTYPE_FEATURE_LIFECYCLE_MECHANISM_STATUS
+        ):
+            raise ValueError("mechanism_status must be the lifecycle development status")
         object.__setattr__(
             self,
             "scientific_promotion_allowed",
@@ -630,6 +637,47 @@ class PrototypeFeatureLifecycleResourceBudget:
                 name,
                 _strict_int(getattr(self, name), name=name, minimum=0),
             )
+        if self.scientific_promotion_allowed is not False:
+            raise ValueError("scientific_promotion_allowed must remain false")
+        expected_fields = {
+            "managed_oak_feature_width": self.base_feature_slots + self.active_pair_slots,
+            "lifecycle_state_nbytes": (
+                self.learner_persistent_state_nbytes
+                + self.router_persistent_state_nbytes
+                + self.lifecycle_counter_nbytes
+            ),
+            "consumer_binding_persistent_nbytes": 4 + 8 * self.active_pair_slots,
+            "internal_template_nbytes": (
+                self.internal_learner_template_nbytes
+                + self.internal_oak_template_nbytes
+            ),
+            "owned_persistent_state_nbytes": (
+                self.lifecycle_state_nbytes + self.internal_template_nbytes
+            ),
+            "managed_oak_consumer_nbytes": (
+                4
+                * self.managed_oak_feature_width
+                * (self.input_route_feature_groups + 1)
+            ),
+            "rebuilt_base_cache_nbytes": 4 * self.managed_oak_feature_width,
+            "router_calls_per_observe": 2,
+            "router_calls_per_committed_curation": 2,
+            "max_active_pair_products_per_observe": 5 * self.active_pair_slots,
+            "max_candidate_pair_products_per_observe": self.candidate_pair_slots,
+        }
+        for name, expected in expected_fields.items():
+            if getattr(self, name) != expected:
+                raise ValueError(f"{name} does not match the lifecycle resource formula")
+        positive_fields = (
+            "base_feature_slots",
+            "active_pair_slots",
+            "managed_oak_feature_width",
+            "input_route_feature_groups",
+            "output_route_feature_groups",
+            "max_observations",
+        )
+        if any(getattr(self, name) < 1 for name in positive_fields):
+            raise ValueError("lifecycle resource dimensions and horizon must be positive")
 
     def to_config(self) -> dict[str, str | int | bool]:
         """Return an exact JSON-compatible resource record."""

--- a/tests/test_prototype_feature_lifecycle_resource_budget.py
+++ b/tests/test_prototype_feature_lifecycle_resource_budget.py
@@ -24,12 +24,12 @@ def _legal_budget() -> PrototypeFeatureLifecycleResourceBudget:
         router_persistent_state_nbytes=8,
         lifecycle_counter_nbytes=16,
         lifecycle_state_nbytes=32,
-        consumer_binding_persistent_nbytes=8,
+        consumer_binding_persistent_nbytes=12,
         internal_learner_template_nbytes=8,
         internal_oak_template_nbytes=8,
         internal_template_nbytes=16,
         owned_persistent_state_nbytes=48,
-        managed_oak_consumer_nbytes=24,
+        managed_oak_consumer_nbytes=60,
         rebuilt_base_cache_nbytes=20,
         input_route_feature_groups=2,
         output_route_feature_groups=1,
@@ -54,6 +54,10 @@ def test_prototype_lifecycle_resource_budget_rejects_leftover_identities() -> No
         replace(_legal_budget(), scientific_promotion_allowed=1)
     with pytest.raises(ValueError, match="mechanism_status"):
         replace(_legal_budget(), mechanism_status=True)
+    with pytest.raises(ValueError, match="mechanism_status"):
+        replace(_legal_budget(), mechanism_status="other")
+    with pytest.raises(ValueError, match="scientific_promotion_allowed"):
+        replace(_legal_budget(), scientific_promotion_allowed=True)
 
     legal = _legal_budget()
     dumped = json.dumps(legal.to_config(), allow_nan=False)
@@ -65,3 +69,64 @@ def test_prototype_lifecycle_resource_budget_rejects_leftover_identities() -> No
     assert '"max_observations": true' not in dumped
     assert '"lifecycle_state_nbytes": true' not in dumped
     assert '"scientific_promotion_allowed": 1' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "managed_oak_feature_width",
+        "lifecycle_state_nbytes",
+        "consumer_binding_persistent_nbytes",
+        "internal_template_nbytes",
+        "owned_persistent_state_nbytes",
+        "managed_oak_consumer_nbytes",
+        "rebuilt_base_cache_nbytes",
+        "router_calls_per_observe",
+        "router_calls_per_committed_curation",
+        "max_active_pair_products_per_observe",
+        "max_candidate_pair_products_per_observe",
+    ),
+)
+def test_prototype_lifecycle_resource_budget_rejects_formula_drift(field: str) -> None:
+    budget = _legal_budget()
+    with pytest.raises(ValueError, match=field):
+        replace(budget, **{field: getattr(budget, field) + 1})
+
+
+def test_prototype_lifecycle_resource_budget_rejects_hooks_and_subclasses() -> None:
+    class HostileMeta(type):
+        calls = 0
+
+        def __hash__(cls) -> int:
+            HostileMeta.calls += 1
+            raise AssertionError("HostileMeta.__hash__ must not run")
+
+    class HostileInt(int, metaclass=HostileMeta):
+        def __int__(self) -> int:
+            raise AssertionError("HostileInt.__int__ must not run")
+
+        def __index__(self) -> int:
+            raise AssertionError("HostileInt.__index__ must not run")
+
+    HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="base_feature_slots"):
+        replace(_legal_budget(), base_feature_slots=HostileInt(4))
+    assert HostileMeta.calls == 0
+
+    class HostileStr(str):
+        calls = 0
+
+        def __eq__(self, other: object) -> bool:
+            type(self).calls += 1
+            raise AssertionError("HostileStr.__eq__ must not run")
+
+    HostileStr.calls = 0
+    with pytest.raises(ValueError, match="mechanism_status"):
+        replace(_legal_budget(), mechanism_status=HostileStr("development_mechanism_only"))
+    assert HostileStr.calls == 0
+
+    class BudgetSubclass(PrototypeFeatureLifecycleResourceBudget):
+        pass
+
+    with pytest.raises(ValueError, match="actual record"):
+        BudgetSubclass(**_legal_budget().to_config())  # type: ignore[arg-type]


### PR DESCRIPTION
Corrective successor to #1259, which raced and merged before deep-review repairs could land. The original identity checks still used frozenset membership and could invoke an attacker-controlled metaclass hash; the purported exact budget also accepted inconsistent state, binding, template, owned, consumer, cache, router-call, and pair-product formulas plus mechanism/promotion drift. This uses identity-only trusted integer dispatch, exact record/status/no-promotion gates, and binds every derivable resource relationship to the live lifecycle layout. Validation before final rebase: 157 affected lifecycle/checkpoint/JIT tests passed; Ruff and strict mypy clean; initialized resource probes matched for default, zero-candidate, and reduced-slot configurations.