### PR TITLE
fix(steps): make Step 2 facade total

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -24,6 +24,7 @@ from fractions import Fraction
 from numbers import Real
 from typing import Any, Literal, SupportsIndex, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -166,8 +167,50 @@ def _require_exact_keys(
     payload: dict[str, object],
     expected: frozenset[str],
 ) -> None:
+    if type(payload) is not dict:
+        raise ValueError(f"{config_name} payload must be an exact dict")
+    if any(type(key) is not str for key in payload):
+        raise ValueError(f"{config_name} payload keys must be exact strings")
     if set(payload) != expected:
         raise ValueError(f"{config_name} payload keys must be exactly {sorted(expected)!r}")
+
+
+def _require_serialized_fields(
+    config_name: str,
+    payload: dict[str, object],
+    *,
+    integers: tuple[str, ...] = (),
+    numbers: tuple[str, ...] = (),
+    booleans: tuple[str, ...] = (),
+    strings: tuple[str, ...] = (),
+    integer_lists: tuple[str, ...] = (),
+    number_lists: tuple[str, ...] = (),
+) -> None:
+    """Require JSON-primitive field identities after the exact schema gate."""
+    for name in integers:
+        if type(payload[name]) is not int:
+            raise ValueError(f"serialized {name} must be a JSON integer")
+    for name in numbers:
+        if type(payload[name]) is not float:
+            raise ValueError(f"serialized {name} must be a JSON number")
+    for name in booleans:
+        if type(payload[name]) is not bool:
+            raise ValueError(f"serialized {name} must be a JSON boolean")
+    for name in strings:
+        if type(payload[name]) is not str:
+            raise ValueError(f"serialized {name} must be a JSON string")
+    for name in integer_lists:
+        value = payload[name]
+        if type(value) is not list:
+            raise ValueError(f"serialized {name} must be a JSON array")
+        if any(type(item) is not int for item in cast(list[object], value)):
+            raise ValueError(f"serialized {name} values must be JSON integers")
+    for name in number_lists:
+        value = payload[name]
+        if type(value) is not list:
+            raise ValueError(f"serialized {name} must be a JSON array")
+        if any(type(item) is not float for item in cast(list[object], value)):
+            raise ValueError(f"serialized {name} values must be JSON numbers")
 
 
 def finite_real_and_float32(name: str, value: object) -> tuple[Real, int, int, float]:
@@ -275,7 +318,25 @@ def _require_bool(name: str, value: object) -> bool:
     return value
 
 
+def _require_typed_key(name: str, value: object) -> Array:
+    """Require one scalar typed JAX key before stream dispatch."""
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise ValueError(f"{name} must be a typed JAX PRNG key")
+    key = cast(Array, value)
+    if key.shape != () or not jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+        key.dtype, jax.dtypes.prng_key
+    ):
+        raise ValueError(f"{name} must be a scalar typed JAX PRNG key")
+    return key
+
+
 def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
+    if type(config) is not Step2KernelConfig:
+        raise ValueError("config must be an exact Step2KernelConfig")
     feature_dim = _require_int(
         "feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX
     )
@@ -333,6 +394,8 @@ def _validate_step2_kernel_config(config: Step2KernelConfig) -> None:
 
 
 def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -> None:
+    if type(config) is not Step2StrictDigitReadoutConfig:
+        raise ValueError("config must be an exact Step2StrictDigitReadoutConfig")
     n_heads = _require_int(
         "n_heads", config.n_heads, minimum=1, maximum=_INT32_MAX
     )
@@ -354,6 +417,8 @@ def _validate_step2_strict_digit_config(config: Step2StrictDigitReadoutConfig) -
 
 
 def _validate_step2_memory_config(config: Step2MemoryConfig) -> None:
+    if type(config) is not Step2MemoryConfig:
+        raise ValueError("config must be an exact Step2MemoryConfig")
     feature_dim = _require_int(
         "feature_dim", config.feature_dim, minimum=1, maximum=_INT32_MAX
     )
@@ -410,9 +475,16 @@ class Step2KernelConfig:
     def from_dict(cls, payload: dict[str, object]) -> Step2KernelConfig:
         """Reconstruct from :meth:`to_dict` output."""
         _require_exact_keys(cls.__name__, payload, _STEP2_KERNEL_CONFIG_KEYS)
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=("feature_dim", "n_heads", "context_length"),
+            numbers=("step_size", "noise_std"),
+            strings=("stream", "readout_mode", "loss_normalization"),
+            integer_lists=("hidden_sizes",),
+        )
         config = dict(payload)
-        if isinstance(config["hidden_sizes"], list):
-            config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
+        config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         return cls(**cast(Any, config))
 
 
@@ -447,9 +519,15 @@ class Step2StrictDigitReadoutConfig:
     ) -> Step2StrictDigitReadoutConfig:
         """Reconstruct from :meth:`to_dict` output."""
         _require_exact_keys(cls.__name__, payload, _STEP2_STRICT_DIGIT_CONFIG_KEYS)
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=("n_heads",),
+            numbers=("step_size",),
+            integer_lists=("hidden_sizes",),
+        )
         config = dict(payload)
-        if isinstance(config["hidden_sizes"], list):
-            config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
+        config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         return cls(**cast(Any, config))
 
 
@@ -476,6 +554,12 @@ class Step2MemoryConfig:
     def from_dict(cls, payload: dict[str, object]) -> Step2MemoryConfig:
         """Reconstruct from :meth:`to_dict` output."""
         _require_exact_keys(cls.__name__, payload, _STEP2_MEMORY_CONFIG_KEYS)
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=("feature_dim", "n_classes", "slots_per_class"),
+            numbers=("update_rate", "novelty_threshold", "bandwidth"),
+        )
         return cls(**cast(Any, payload))
 
 
@@ -519,6 +603,37 @@ class Step2AssociativeConfig:
     def from_dict(cls, payload: dict[str, object]) -> Step2AssociativeConfig:
         """Reconstruct from :meth:`to_dict` output."""
         _require_exact_keys(cls.__name__, payload, _STEP2_ASSOCIATIVE_CONFIG_KEYS)
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=(
+                "vocab_size",
+                "block_size",
+                "suffix_length",
+                "max_features",
+                "min_effective_budget",
+            ),
+            numbers=(
+                "write_lr",
+                "retention",
+                "utility_lr",
+                "utility_decay",
+                "min_weight",
+                "max_weight",
+                "logit_scale",
+                "scope_lr",
+                "budget_lr",
+                "initial_budget_fraction",
+                "scope_logit_clip",
+            ),
+            booleans=(
+                "normalize_by_weight",
+                "adaptive_feature_family",
+                "adaptive_window",
+                "adaptive_budget",
+            ),
+            strings=("feature_family",),
+        )
         return cls(**cast(Any, payload))
 
     def to_core_config(self) -> AssociativeMemoryConfig:
@@ -601,6 +716,12 @@ class Step2HybridConfig:
     novelty_adaptation_rate: float = 0.02
     target_allocation_rate: float = 0.18
 
+    def __post_init__(self) -> None:
+        """Canonicalize through the exact core config and preflight resources."""
+        core = make_step2_hybrid_learner(self).config
+        for name in self.__dataclass_fields__:
+            object.__setattr__(self, name, getattr(core, name))
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
@@ -610,6 +731,27 @@ class Step2HybridConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step2HybridConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        expected = frozenset(cls.__dataclass_fields__)
+        _require_exact_keys(cls.__name__, payload, expected)
+        integer_fields = (
+            "feature_dim",
+            "n_heads",
+            "upgd_head_loss_pressure_warmup_steps",
+            "upgd_head_repetition_warmup_steps",
+            "slots_per_class",
+        )
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=integer_fields,
+            numbers=tuple(
+                name
+                for name in expected
+                if name not in {*integer_fields, "hidden_sizes", "readout_mode"}
+            ),
+            strings=("readout_mode",),
+            integer_lists=("hidden_sizes",),
+        )
         config = dict(payload)
         config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         return cls(**cast(Any, config))
@@ -649,6 +791,39 @@ class Step2TemporalContextConfig:
         192.0,
     )
 
+    def __post_init__(self) -> None:
+        """Validate exact schema and derived phase-product resources."""
+        feature_dim = _require_int(
+            "feature_dim", self.feature_dim, minimum=1, maximum=_INT32_MAX
+        )
+        n_heads = _require_int(
+            "n_heads", self.n_heads, minimum=1, maximum=_INT32_MAX
+        )
+        if type(self.hidden_sizes) is not tuple:
+            raise ValueError("hidden_sizes must be an exact tuple")
+        hidden_sizes = tuple(
+            _require_int("hidden_sizes element", value, minimum=1, maximum=_INT32_MAX)
+            for value in self.hidden_sizes
+        )
+        step_size = _require_nonnegative_real("step_size", self.step_size)
+        if type(self.periods) is not tuple:
+            raise ValueError("periods must be an exact tuple")
+        periods = tuple(_require_positive_real("period", value) for value in self.periods)
+        phase_dim = 2 * len(periods)
+        output_dim = feature_dim + phase_dim + phase_dim * feature_dim
+        if output_dim > _INT32_MAX or 4 * output_dim > _INT32_MAX:
+            raise ValueError("derived temporal feature bytes must fit signed int32")
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "n_heads", n_heads)
+        object.__setattr__(self, "hidden_sizes", hidden_sizes)
+        object.__setattr__(self, "step_size", step_size)
+        object.__setattr__(self, "periods", periods)
+        UPGDLearner.step2_default(
+            n_heads=n_heads,
+            hidden_sizes=hidden_sizes,
+            step_size=step_size,
+        )
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
         payload = asdict(self)
@@ -659,6 +834,16 @@ class Step2TemporalContextConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step2TemporalContextConfig:
         """Reconstruct from :meth:`to_dict` output."""
+        expected = frozenset(cls.__dataclass_fields__)
+        _require_exact_keys(cls.__name__, payload, expected)
+        _require_serialized_fields(
+            cls.__name__,
+            payload,
+            integers=("feature_dim", "n_heads"),
+            numbers=("step_size",),
+            integer_lists=("hidden_sizes",),
+            number_lists=("periods",),
+        )
         config = dict(payload)
         config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
         config["periods"] = tuple(cast(list[float], config["periods"]))
@@ -745,9 +930,18 @@ class Step2AssociativeSmokeResult:
         return payload
 
 
+def _exact_config_or_default(name: str, value: object, expected: type[Any]) -> Any:
+    """Return one exact config without invoking supplied truthiness hooks."""
+    if value is None:
+        return expected()
+    if type(value) is not expected:
+        raise ValueError(f"{name} must be an exact {expected.__name__}")
+    return value
+
+
 def make_step2_learner(config: Step2KernelConfig | None = None) -> UPGDLearner:
     """Create the packaged Step 2 target-structure UPGD learner."""
-    cfg = config or Step2KernelConfig()
+    cfg = cast(Step2KernelConfig, _exact_config_or_default("config", config, Step2KernelConfig))
     return UPGDLearner.step2_default(
         n_heads=cfg.n_heads,
         hidden_sizes=cfg.hidden_sizes,
@@ -766,7 +960,10 @@ def make_step2_strict_digit_readout_learner(
     sklearn-digits-style one-hot online classification streams.  The broad
     supervised default remains :func:`make_step2_learner`.
     """
-    cfg = config or Step2StrictDigitReadoutConfig()
+    cfg = cast(
+        Step2StrictDigitReadoutConfig,
+        _exact_config_or_default("config", config, Step2StrictDigitReadoutConfig),
+    )
     return UPGDLearner.step2_strict_digit_readout_default(
         n_heads=cfg.n_heads,
         hidden_sizes=cfg.hidden_sizes,
@@ -778,7 +975,7 @@ def make_step2_memory_learner(
     config: Step2MemoryConfig | None = None,
 ) -> PrototypeMemoryLearner:
     """Create the packaged Step 2 retained-view memory learner."""
-    cfg = config or Step2MemoryConfig()
+    cfg = cast(Step2MemoryConfig, _exact_config_or_default("config", config, Step2MemoryConfig))
     return PrototypeMemoryLearner(
         PrototypeMemoryConfig(
             feature_dim=cfg.feature_dim,
@@ -795,7 +992,10 @@ def make_step2_associative_learner(
     config: Step2AssociativeConfig | None = None,
 ) -> AssociativeMemoryLearner:
     """Create the Step 2 fast/slow associative sequence learner."""
-    cfg = config or Step2AssociativeConfig()
+    cfg = cast(
+        Step2AssociativeConfig,
+        _exact_config_or_default("config", config, Step2AssociativeConfig),
+    )
     return AssociativeMemoryLearner(cfg.to_core_config())
 
 
@@ -803,7 +1003,7 @@ def make_step2_hybrid_learner(
     config: Step2HybridConfig | None = None,
 ) -> UPGDMemoryLearner:
     """Create the Step 2 UPGD plus adaptive prototype-memory learner."""
-    cfg = config or Step2HybridConfig()
+    cfg = cast(Step2HybridConfig, _exact_config_or_default("config", config, Step2HybridConfig))
     return UPGDMemoryLearner(
         UPGDMemoryConfig(
             feature_dim=cfg.feature_dim,
@@ -858,7 +1058,10 @@ def make_step2_temporal_context(
     config: Step2TemporalContextConfig | None = None,
 ) -> TemporalContextFeaturizer:
     """Create the packaged causal phase-product context featurizer."""
-    cfg = config or Step2TemporalContextConfig()
+    cfg = cast(
+        Step2TemporalContextConfig,
+        _exact_config_or_default("config", config, Step2TemporalContextConfig),
+    )
     return TemporalContextFeaturizer(
         TemporalContextConfig(
             input_dim=cfg.feature_dim,
@@ -876,7 +1079,10 @@ def make_step2_temporal_learner(
     config: Step2TemporalContextConfig | None = None,
 ) -> UPGDLearner:
     """Create UPGD configured for temporal-context features."""
-    cfg = config or Step2TemporalContextConfig()
+    cfg = cast(
+        Step2TemporalContextConfig,
+        _exact_config_or_default("config", config, Step2TemporalContextConfig),
+    )
     return UPGDLearner.step2_default(
         n_heads=cfg.n_heads,
         hidden_sizes=cfg.hidden_sizes,
@@ -888,7 +1094,7 @@ def make_step2_stream(
     config: Step2KernelConfig | None = None,
 ) -> OutOfClassPolynomialStream | FrequencyMismatchStream | CompositionalStream:
     """Construct a representative Step 2 stream for integration testing."""
-    cfg = config or Step2KernelConfig()
+    cfg = cast(Step2KernelConfig, _exact_config_or_default("config", config, Step2KernelConfig))
     if cfg.stream == "polynomial":
         return OutOfClassPolynomialStream(
             feature_dim=cfg.feature_dim,
@@ -927,6 +1133,18 @@ def collect_step2_arrays(
     baselines, and paired seed statistics.
     """
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
+    if type(stream) not in (
+        OutOfClassPolynomialStream,
+        FrequencyMismatchStream,
+        CompositionalStream,
+    ):
+        raise ValueError("stream must be an exact packaged Step 2 stream")
+    key = _require_typed_key("key", key)
+    feature_dim = int(stream.feature_dim)
+    target_dim = int(stream.target_dim)
+    output_bytes = 4 * steps * (feature_dim + target_dim)
+    if output_bytes > _INT32_MAX:
+        raise ValueError("derived Step 2 collection bytes must fit signed int32")
     state = stream.init(key)
     observations = []
     targets = []
@@ -953,7 +1171,7 @@ def run_step2_smoke(
     steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
     seed = require_jax_seed(seed, name="seed")
     final_window = _require_int("final_window", final_window, minimum=1, maximum=steps)
-    cfg = config or Step2KernelConfig()
+    cfg = cast(Step2KernelConfig, _exact_config_or_default("config", config, Step2KernelConfig))
     learner = make_step2_learner(cfg)
     stream = make_step2_stream(cfg)
     data_key, learner_key = jr.split(jr.key(seed))
@@ -988,7 +1206,10 @@ def run_step2_associative_smoke(
     not shipped in this fork. It repeats a small set of contexts so a healthy
     associative table should lower NLL over time.
     """
-    cfg = config or Step2AssociativeConfig()
+    cfg = cast(
+        Step2AssociativeConfig,
+        _exact_config_or_default("config", config, Step2AssociativeConfig),
+    )
     steps = _require_int("steps", steps, minimum=2, maximum=_INT32_MAX)
     seed = require_jax_seed(seed, name="seed")
     window = _require_int("window", window, minimum=1, maximum=steps // 2)

--- a/tests/test_step2_boundary_validation.py
+++ b/tests/test_step2_boundary_validation.py
@@ -1,0 +1,139 @@
+"""Exact schema, resource, and runtime tests for the Step 2 facade."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.steps.step2 import (
+    Step2HybridConfig,
+    Step2KernelConfig,
+    Step2MemoryConfig,
+    Step2StrictDigitReadoutConfig,
+    Step2TemporalContextConfig,
+    collect_step2_arrays,
+    make_step2_learner,
+    make_step2_stream,
+)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        Step2KernelConfig(),
+        Step2StrictDigitReadoutConfig(),
+        Step2MemoryConfig(),
+        Step2HybridConfig(),
+        Step2TemporalContextConfig(),
+    ],
+)
+def test_serialized_configs_require_exact_complete_json_schema(config: Any) -> None:
+    payload = config.to_dict()
+
+    class DictSubclass(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="exact dict"):
+        type(config).from_dict(DictSubclass(payload))
+    first = next(iter(payload))
+    with pytest.raises(ValueError, match="keys"):
+        type(config).from_dict({key: value for key, value in payload.items() if key != first})
+    with pytest.raises(ValueError, match="keys"):
+        type(config).from_dict({**payload, "extra": 1})
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"feature_dim": np.int32(4)},
+        {"hidden_sizes": (8,)},
+        {"upgd_step_size": np.float32(0.03)},
+        {"readout_mode": np.str_("softmax_ce")},
+    ],
+)
+def test_hybrid_serialized_fields_are_json_exact(mutation: dict[str, object]) -> None:
+    payload = Step2HybridConfig(feature_dim=4, hidden_sizes=(8,)).to_dict()
+    payload.update(mutation)
+    with pytest.raises(ValueError, match="serialized"):
+        Step2HybridConfig.from_dict(payload)
+
+
+def test_hybrid_direct_config_is_total_and_canonical() -> None:
+    config = Step2HybridConfig(
+        feature_dim=np.int32(4),
+        n_heads=np.int64(2),
+        hidden_sizes=(np.int32(8),),
+        upgd_step_size=np.float32(0.03),
+    )
+    assert type(config.feature_dim) is int
+    assert type(config.upgd_step_size) is float
+    assert config.hidden_sizes == (8,)
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        Step2HybridConfig(feature_dim=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="upgd_step_size"):
+        Step2HybridConfig(upgd_step_size=float("nan"))
+
+
+def test_temporal_config_validates_derived_output_bytes() -> None:
+    last_feature_dim = ((2**31 - 1) // 4 - 2) // 3
+    Step2TemporalContextConfig(
+        feature_dim=last_feature_dim,
+        hidden_sizes=(),
+        periods=(1.0,),
+    )
+    with pytest.raises(ValueError, match="temporal feature bytes"):
+        Step2TemporalContextConfig(
+            feature_dim=last_feature_dim + 1,
+            hidden_sizes=(),
+            periods=(1.0,),
+        )
+
+
+def test_factory_rejects_hostile_config_without_truthiness_hook() -> None:
+    class Hostile:
+        calls = 0
+
+        def __bool__(self) -> bool:
+            type(self).calls += 1
+            raise AssertionError("truthiness hook executed")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="config must be"):
+        make_step2_learner(hostile)  # type: ignore[arg-type]
+    assert Hostile.calls == 0
+
+
+def test_collector_rejects_hostile_stream_and_legacy_key_without_hooks() -> None:
+    class Hostile:
+        calls = 0
+
+        def __getattribute__(self, name: str) -> Any:
+            if name == "calls":
+                return object.__getattribute__(self, name)
+            type(self).calls += 1
+            raise AssertionError("attribute hook executed")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="stream must be"):
+        collect_step2_arrays(hostile, steps=1, key=jax.random.key(0))
+    assert Hostile.calls == 0
+
+    stream = make_step2_stream(Step2KernelConfig(feature_dim=3))
+    with pytest.raises(ValueError, match="typed JAX PRNG key"):
+        collect_step2_arrays(
+            stream,
+            steps=1,
+            key=jnp.asarray([0, 0], dtype=jnp.uint32),
+        )
+
+
+def test_collector_preflights_output_bytes_before_stream_init() -> None:
+    stream = make_step2_stream(Step2KernelConfig(feature_dim=3, n_heads=1))
+    stream._feature_dim = 2**31 - 1  # type: ignore[attr-defined]
+    with pytest.raises(ValueError, match="collection bytes"):
+        collect_step2_arrays(stream, steps=1, key=jax.random.key(0))


### PR DESCRIPTION
Corrective follow-up to #1253 after its merge.

- enforce exact complete primitive JSON schemas across every Step 2 config
- make hybrid and temporal config construction preflight derived core/resource bounds
- reject hostile config truthiness and require exact typed PRNG keys/packaged streams
- preflight collector output bytes before initialization
- add adjacent-boundary, hostile-hook, and round-trip coverage

Validation: 413 focused/broad tests passed; Ruff and strict mypy passed.