### PR TITLE
fix(oak): bind exact external-adoption budget

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -357,6 +357,10 @@ class OaKExternalSTOMPAdoptionResourceBudget:
     caller_authenticated: bool
 
     def __post_init__(self) -> None:
+        if type(self) is not OaKExternalSTOMPAdoptionResourceBudget:
+            raise ValueError(
+                "budget must be an actual OaKExternalSTOMPAdoptionResourceBudget"
+            )
         for name in (
             "persistent_state_nbytes_before",
             "persistent_state_nbytes_after",
@@ -380,12 +384,26 @@ class OaKExternalSTOMPAdoptionResourceBudget:
                 name,
                 _require_exact_bool(name, getattr(self, name)),
             )
-        if self.persistent_state_growth_bytes != (
-            self.persistent_state_nbytes_after - self.persistent_state_nbytes_before
-        ):
-            raise ValueError(
-                "persistent_state_growth_bytes must equal after minus before"
-            )
+        if self.persistent_state_nbytes_before <= 0:
+            raise ValueError("persistent_state_nbytes_before must be positive")
+        if self.persistent_state_nbytes_before % 4 != 0:
+            raise ValueError("persistent state bytes must be aligned to four-byte JAX leaves")
+        if self.persistent_state_nbytes_after != self.persistent_state_nbytes_before:
+            raise ValueError("external adoption must preserve persistent state bytes")
+        if self.persistent_state_growth_bytes != 0:
+            raise ValueError("external adoption persistent state growth must be zero")
+        if self.stomp_update_evaluations_per_adopt != 0:
+            raise ValueError("external adoption must perform zero STOMP updates")
+        if self.stomp_update_evaluations_per_delegated_update != 1:
+            raise ValueError("delegated update must evaluate STOMP exactly once")
+        if self.derivation_recomputed_on_adopt:
+            raise ValueError("external adoption must not recompute the derivation")
+        if not self.source_result_integrity_checked:
+            raise ValueError("external adoption must check source-result integrity")
+        if not self.caller_authority_required:
+            raise ValueError("external adoption must require caller authority")
+        if self.caller_authenticated:
+            raise ValueError("external adoption does not authenticate its caller")
 
     def to_config(self) -> dict[str, int | bool]:
         """Return an exact JSON-compatible resource record."""
@@ -1733,6 +1751,8 @@ class OaKAgent:
     ) -> OaKExternalSTOMPAdoptionResourceBudget:
         """Report exact persistent cost and the adoption seam's trust limit."""
 
+        if type(state) is not OaKState:
+            raise TypeError("state must be an actual OaKState")
         persistent_nbytes = measure_oak_state_nbytes(state)
         return OaKExternalSTOMPAdoptionResourceBudget(
             persistent_state_nbytes_before=persistent_nbytes,

--- a/tests/test_oak_stomp_adoption_resource_budget.py
+++ b/tests/test_oak_stomp_adoption_resource_budget.py
@@ -50,15 +50,44 @@ def test_oak_stomp_adoption_resource_budget_rejects_leftover_identities() -> Non
     assert '"caller_authenticated": 1' not in dumped
 
 
-def test_oak_stomp_adoption_resource_budget_binds_growth_formula() -> None:
-    with pytest.raises(ValueError, match="growth_bytes must equal after minus before"):
+def test_oak_stomp_adoption_resource_budget_binds_zero_growth_formula() -> None:
+    with pytest.raises(ValueError, match="preserve persistent state bytes"):
         replace(_legal_budget(), persistent_state_nbytes_after=65)
-    with pytest.raises(ValueError, match="growth_bytes must equal after minus before"):
+    with pytest.raises(ValueError, match="growth must be zero"):
         replace(_legal_budget(), persistent_state_growth_bytes=1)
 
-    grown = replace(
-        _legal_budget(),
-        persistent_state_nbytes_after=65,
-        persistent_state_growth_bytes=1,
-    )
-    assert grown.persistent_state_growth_bytes == 1
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    (
+        ("persistent_state_nbytes_before", 0, "positive"),
+        ("persistent_state_nbytes_before", 65, "aligned"),
+        ("stomp_update_evaluations_per_adopt", 1, "zero STOMP updates"),
+        ("stomp_update_evaluations_per_delegated_update", 0, "exactly once"),
+        ("derivation_recomputed_on_adopt", True, "must not recompute"),
+        ("source_result_integrity_checked", False, "must check"),
+        ("caller_authority_required", False, "must require"),
+        ("caller_authenticated", True, "does not authenticate"),
+    ),
+)
+def test_oak_stomp_adoption_resource_budget_rejects_impossible_records(
+    field: str, value: object, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        replace(_legal_budget(), **{field: value})
+
+
+def test_oak_stomp_adoption_resource_budget_rejects_subclass_before_hooks() -> None:
+    class HostileBudget(OaKExternalSTOMPAdoptionResourceBudget):
+        calls = 0
+
+        def __getattribute__(self, name: str) -> object:
+            if name != "__class__":
+                type(self).calls += 1
+                raise AssertionError("attribute hook must not run")
+            return super().__getattribute__(name)
+
+    hostile = object.__new__(HostileBudget)
+    with pytest.raises(ValueError, match="actual OaKExternal"):
+        OaKExternalSTOMPAdoptionResourceBudget.__post_init__(hostile)
+    assert HostileBudget.calls == 0


### PR DESCRIPTION
## Summary\n- restrict direct adoption budgets to the producer's exact zero-growth/zero-recompute/one-delegated-update semantics\n- enforce positive aligned persistent bytes and fixed authority/integrity facts\n- reject record subclasses before attribute hooks and exact-type state inputs before measurement\n\n## Verification\n- 34 focused resource/adoption tests passed\n- Ruff and mypy passed\n\nFollow-up to #1260.