### PR TITLE
fix(prototype-agent): bind experiential resource identities

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -259,8 +259,7 @@ def feature_to_subtask_specs(
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 4_294_967_295
-_ACTUAL_INT_TYPES: frozenset[type] = frozenset(
-    {
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
         int,
         np.int8,
         np.int16,
@@ -272,12 +271,13 @@ _ACTUAL_INT_TYPES: frozenset[type] = frozenset(
         np.uint64,
         np.longlong,
         np.ulonglong,
-    }
 )
-_ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
-    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+_ACTUAL_FLOAT_TYPES: tuple[type, ...] = (
+    float,
+    Fraction,
+    *(np.dtype(code).type for code in ("e", "f", "d", "g")),
 )
-_ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+_ALLOWED_REAL_TYPES: tuple[type, ...] = _ACTUAL_INT_TYPES + _ACTUAL_FLOAT_TYPES
 
 
 def _require_int(
@@ -287,7 +287,8 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is candidate for candidate in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer")
     number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
@@ -298,7 +299,8 @@ def _require_int(
 
 
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in _ALLOWED_REAL_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is candidate for candidate in _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 
@@ -953,9 +955,9 @@ class PrototypeAgentConfig:
                 )
         if self.experiential_memory is not None:
             memory = self.experiential_memory
-            if not isinstance(memory, ExperientialMemoryConfig):
+            if type(memory) is not ExperientialMemoryConfig:
                 raise ValueError(
-                    "experiential_memory must be an ExperientialMemoryConfig"
+                    "experiential_memory must be an exact ExperientialMemoryConfig"
                 )
             # ExperientialMemoryConfig predates dataclass-level validation;
             # constructing the bounded substrate enforces its complete static
@@ -1226,10 +1228,7 @@ class PrototypeAgentConfig:
             else None
         )
         experiential_memory_raw = data.pop("experiential_memory", None)
-        if experiential_memory_raw is not None and not isinstance(
-            experiential_memory_raw,
-            dict,
-        ):
+        if experiential_memory_raw is not None and type(experiential_memory_raw) is not dict:
             raise ValueError("experiential_memory must be a configuration object")
         experiential_memory = (
             ExperientialMemoryConfig.from_config(experiential_memory_raw)
@@ -1739,6 +1738,11 @@ class PrototypeExperientialMemoryResourceDeclaration:
     additional query and is therefore zero for the fused transaction.
     """
 
+    memory_capacity: int
+    memory_observation_dim: int
+    memory_key_dim: int
+    memory_action_dim: int
+    memory_outcome_dim: int
     persistent_state_bytes: int
     categorical_policy_queries: int
     causal_step_queries: int
@@ -1749,7 +1753,17 @@ class PrototypeExperientialMemoryResourceDeclaration:
     hard_safety_values_interpreted: int
 
     def __post_init__(self) -> None:
+        if type(self) is not PrototypeExperientialMemoryResourceDeclaration:
+            raise TypeError(
+                "declaration must be an exact "
+                "PrototypeExperientialMemoryResourceDeclaration"
+            )
         for name in (
+            "memory_capacity",
+            "memory_observation_dim",
+            "memory_key_dim",
+            "memory_action_dim",
+            "memory_outcome_dim",
             "persistent_state_bytes",
             "categorical_policy_queries",
             "causal_step_queries",
@@ -1762,8 +1776,45 @@ class PrototypeExperientialMemoryResourceDeclaration:
             object.__setattr__(
                 self,
                 name,
-                _require_int(name, getattr(self, name), minimum=0),
+                _require_int(
+                    name,
+                    getattr(self, name),
+                    minimum=0,
+                    maximum=_INT32_MAX,
+                ),
             )
+        for name in (
+            "memory_capacity",
+            "memory_observation_dim",
+            "memory_key_dim",
+            "memory_action_dim",
+            "memory_outcome_dim",
+        ):
+            if getattr(self, name) < 1:
+                raise ValueError(f"{name} must be positive")
+
+        vector_values = (
+            self.memory_observation_dim
+            + self.memory_key_dim
+            + self.memory_action_dim
+            + self.memory_outcome_dim
+        )
+        expected_persistent_bytes = (
+            self.memory_capacity * (4 * (vector_values + 11) + 4) + 32
+        )
+        expected = {
+            "persistent_state_bytes": expected_persistent_bytes,
+            "categorical_policy_queries": 1,
+            "causal_step_queries": 0,
+            "total_deterministic_prestate_queries": 1,
+            "writes_attempted": 1,
+            "random_draws": 0,
+            "score_mass_values_interpreted": self.memory_action_dim,
+            "hard_safety_values_interpreted": self.memory_action_dim,
+        }
+        for name, expected_value in expected.items():
+            if getattr(self, name) != expected_value:
+                raise ValueError(f"{name} does not match its exact derived identity")
 
     def to_config(self) -> dict[str, int]:
         """Return the exact JSON-compatible resource declaration."""
@@ -2700,9 +2751,15 @@ class PrototypeAgent:
         if policy is None:
             return None
         policy_resources = policy.resource_declaration()
+        memory_config = policy.memory.config
         categorical_queries = policy_resources.memory_queries_per_proposal
         causal_queries = 0
         return PrototypeExperientialMemoryResourceDeclaration(
+            memory_capacity=memory_config.capacity,
+            memory_observation_dim=memory_config.observation_dim,
+            memory_key_dim=memory_config.key_dim,
+            memory_action_dim=memory_config.action_dim,
+            memory_outcome_dim=memory_config.outcome_dim,
             persistent_state_bytes=(
                 policy_resources.external_memory_persistent_state_bytes
             ),

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import warnings
 from fractions import Fraction
+from typing import Any, cast
 
 import chex
 import jax
@@ -532,6 +533,51 @@ class TestPrototypeAgentUpdateFull:
         assert int(result.state.world_model_state.step_count) == 1
 
 
+def test_experiential_memory_config_requires_exact_identity_before_hooks() -> None:
+    class HostileMemoryConfig(ExperientialMemoryConfig):
+        calls = 0
+
+        def __getattribute__(self, name: str) -> Any:
+            type(self).calls += 1
+            raise AssertionError(f"memory config hook must not run: {name}")
+
+    class HostileDict(dict[str, object]):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("mapping hook must not run")
+
+    hostile_config = object.__new__(HostileMemoryConfig)
+    HostileMemoryConfig.calls = 0
+    with pytest.raises(ValueError, match="exact ExperientialMemoryConfig"):
+        PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            experiential_memory=cast(Any, hostile_config),
+        )
+    assert HostileMemoryConfig.calls == 0
+
+    memory_config = ExperientialMemoryConfig(
+        capacity=3,
+        observation_dim=OBS_DIM,
+        key_dim=OBS_DIM,
+        action_dim=N_PRIM,
+        outcome_dim=OBS_DIM + 1,
+        top_k=1,
+        min_neighbors=1,
+    )
+    payload = PrototypeAgentConfig(
+        oak=_oak_cfg(), experiential_memory=memory_config
+    ).to_config()
+    payload["experiential_memory"] = HostileDict(
+        cast(dict[str, object], payload["experiential_memory"])
+    )
+    HostileDict.calls = 0
+    with pytest.raises(ValueError, match="experiential_memory must be a configuration object"):
+        PrototypeAgentConfig.from_config(cast(Any, payload))
+    assert HostileDict.calls == 0
+
+
 def test_experiential_memory_uses_one_accounted_policy_step() -> None:
     """Prototype proposal and write must share one recorded pre-state query."""
     memory_config = ExperientialMemoryConfig(
@@ -554,6 +600,14 @@ def test_experiential_memory_uses_one_accounted_policy_step() -> None:
     assert resources.categorical_policy_queries == 1
     assert resources.causal_step_queries == 0
     assert resources.total_deterministic_prestate_queries == 1
+    assert resources.memory_capacity == memory_config.capacity
+    assert resources.memory_observation_dim == memory_config.observation_dim
+    assert resources.memory_key_dim == memory_config.key_dim
+    assert resources.memory_action_dim == memory_config.action_dim
+    assert resources.memory_outcome_dim == memory_config.outcome_dim
+    assert resources.persistent_state_bytes == agent.experiential_memory.persistent_bytes
+    assert resources.score_mass_values_interpreted == memory_config.action_dim
+    assert resources.hard_safety_values_interpreted == memory_config.action_dim
 
     state = agent.start(agent.init(jr.key(31)), jnp.zeros(OBS_DIM, dtype=jnp.float32))
     transition = PrototypeTransition(

--- a/tests/test_prototype_experiential_memory_resource_declaration.py
+++ b/tests/test_prototype_experiential_memory_resource_declaration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from typing import Any, cast
 
 import pytest
 
@@ -14,7 +15,12 @@ from alberta_framework.core.prototype_agent import (
 
 def _legal_declaration() -> PrototypeExperientialMemoryResourceDeclaration:
     return PrototypeExperientialMemoryResourceDeclaration(
-        persistent_state_bytes=16,
+        memory_capacity=1,
+        memory_observation_dim=1,
+        memory_key_dim=1,
+        memory_action_dim=3,
+        memory_outcome_dim=2,
+        persistent_state_bytes=108,
         categorical_policy_queries=1,
         causal_step_queries=0,
         total_deterministic_prestate_queries=1,
@@ -33,13 +39,50 @@ def test_prototype_experiential_memory_resource_declaration_rejects_leftover_ide
     with pytest.raises(ValueError, match="random_draws"):
         replace(_legal_declaration(), random_draws=True)
     with pytest.raises(ValueError, match="score_mass_values_interpreted"):
-        replace(_legal_declaration(), score_mass_values_interpreted=float("nan"))
+        replace(
+            _legal_declaration(),
+            score_mass_values_interpreted=cast(Any, float("nan")),
+        )
 
     legal = _legal_declaration()
     dumped = json.dumps(legal.to_config(), allow_nan=False)
-    assert '"persistent_state_bytes": 16' in dumped
+    assert '"persistent_state_bytes": 108' in dumped
     assert '"random_draws": 0' in dumped
     assert '"score_mass_values_interpreted": 3' in dumped
     assert '"persistent_state_bytes": true' not in dumped
     assert '"random_draws": true' not in dumped
     assert '"score_mass_values_interpreted": true' not in dumped
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "persistent_state_bytes",
+        "categorical_policy_queries",
+        "causal_step_queries",
+        "total_deterministic_prestate_queries",
+        "writes_attempted",
+        "random_draws",
+        "score_mass_values_interpreted",
+        "hard_safety_values_interpreted",
+    ],
+)
+def test_resource_declaration_rejects_mutated_derived_identities(field: str) -> None:
+    declaration = _legal_declaration()
+    with pytest.raises(ValueError, match=field):
+        replace(declaration, **{field: getattr(declaration, field) + 1})
+
+
+def test_resource_declaration_rejects_subclass_before_attribute_hooks() -> None:
+    class HostileDeclaration(PrototypeExperientialMemoryResourceDeclaration):
+        calls = 0
+
+        def __getattribute__(self, name: str) -> Any:
+            type(self).calls += 1
+            raise AssertionError(f"attribute hook must not run: {name}")
+
+    value = object.__new__(HostileDeclaration)
+    HostileDeclaration.calls = 0
+    with pytest.raises(TypeError, match="exact PrototypeExperientialMemoryResourceDeclaration"):
+        PrototypeExperientialMemoryResourceDeclaration.__post_init__(cast(Any, value))
+    assert HostileDeclaration.calls == 0


### PR DESCRIPTION
Corrective successor to #1268 and compatible with the merged lower policy declaration hardening in #1267. Adds exact memory capacity/dimension provenance, exact persistent-slot byte formula, fixed fused-query/write/RNG equations, action-width score/safety work identities, exact declaration/config/container gates, and hook-free identity dispatch. No outputs or benchmark artifacts changed.\n\nValidation: 12 focused Prototype producer/config tests passed after rebase; 10 direct declaration tests passed; 83 adjacent memory/policy tests passed; 81 hostile validation tests passed; scoped Ruff and strict mypy clean; diff check clean.