### PR TITLE
fix(step7): close metaclass and resource residuals

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -48,6 +48,7 @@ References:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from fractions import Fraction
 from numbers import Integral
 from typing import Any, Literal, cast
 
@@ -174,48 +175,58 @@ _STEP7_CONFIG_FIELDS = frozenset(
         "planning_utility_step_size",
     }
 )
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+_ACTUAL_INT_TYPES = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
+)
+_ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES + (
+    float,
+    Fraction,
+    np.dtype("e").type,
+    np.dtype("f").type,
+    np.dtype("d").type,
+    np.dtype("g").type,
 )
 
 
-def _require_exact_str(name: str, value: object) -> str:
-    if type(value) is not str:
-        raise ValueError(f"{name} must be an exact string")
-    return value
+def _finite_real_and_float32(name: str, value: object) -> tuple[Any, int, int, float]:
+    """Validate scalar identity without invoking hooks on its metaclass."""
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_REAL_TYPES):
+        mro = type.__getattribute__(actual_type, "__mro__")
+        has_real_lineage = actual_type is not bool and any(
+            base is int or base is float or base is Fraction for base in mro
+        )
+        requirement = "finite" if has_real_lineage else "a real number"
+        raise ValueError(f"{name} must be {requirement}")
+    return finite_real_and_float32(name, value)
 
 
-def _require_nonnegative_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_nonnegative_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real < 0.0 or numerator < 0 or narrowed < 0.0:
-        raise ValueError(f"{host_name} must be non-negative")
+        raise ValueError(f"{name} must be non-negative")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_positive_real(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, _, narrowed = finite_real_and_float32(host_name, value)
+def _require_positive_real(name: str, value: object) -> float:
+    real, numerator, _, narrowed = _finite_real_and_float32(name, value)
     if real <= 0.0 or numerator <= 0 or narrowed <= 0.0:
-        raise ValueError(f"{host_name} must be positive")
+        raise ValueError(f"{name} must be positive")
     return canonical_float32_storage(real, narrowed)
 
 
-def _require_unit_interval(name: object, value: object) -> float:
-    host_name = _require_exact_str("name", name)
-    real, numerator, denominator, narrowed = finite_real_and_float32(host_name, value)
+def _require_unit_interval(name: str, value: object) -> float:
+    real, numerator, denominator, narrowed = _finite_real_and_float32(name, value)
     if (
         real < 0.0
         or not real <= 1.0
@@ -224,37 +235,35 @@ def _require_unit_interval(name: object, value: object) -> float:
         or narrowed < 0.0
         or not narrowed <= 1.0
     ):
-        raise ValueError(f"{host_name} must be in [0, 1]")
+        raise ValueError(f"{name} must be in [0, 1]")
     return canonical_float32_storage(real, narrowed)
 
 
 def _require_int(
-    name: object,
+    name: str,
     value: object,
     *,
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    host_name = _require_exact_str("name", name)
     actual_type = type(value)
-    if actual_type not in _ACTUAL_INT_TYPES:
-        raise ValueError(f"{host_name} must be an integer")
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
+        raise ValueError(f"{name} must be an integer")
     number = int(cast(Integral, value))
     if minimum is not None and number < minimum:
         if minimum == 1:
-            raise ValueError(f"{host_name} must be positive")
+            raise ValueError(f"{name} must be positive")
         if minimum == 0:
-            raise ValueError(f"{host_name} must be non-negative")
-        raise ValueError(f"{host_name} must be >= {minimum}")
+            raise ValueError(f"{name} must be non-negative")
+        raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{host_name} must be at most int32 max")
+        raise ValueError(f"{name} must be at most int32 max")
     return number
 
 
-def _require_bool(name: object, value: object) -> bool:
-    host_name = _require_exact_str("name", name)
+def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
-        raise ValueError(f"{host_name} must be a built-in bool")
+        raise ValueError(f"{name} must be a built-in bool")
     return value
 
 
@@ -325,6 +334,14 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     planning_evaluations = planning_steps * planning_rollout_depth
     if planning_evaluations > _INT32_MAX:
         raise ValueError("derived planning evaluations per update must fit signed int32")
+    planning_result_bytes = 33 * planning_steps
+    rollout_result_bytes = 8 * planning_evaluations
+    if (
+        planning_result_bytes > _INT32_MAX
+        or rollout_result_bytes > _INT32_MAX
+        or planning_result_bytes + rollout_result_bytes > _INT32_MAX
+    ):
+        raise ValueError("derived Step 7 planning output bytes must fit signed int32")
     memory_scalars = (
         2 * planning_memory_size * config.world_model.observation_dim
         + 4 * planning_memory_size
@@ -1338,13 +1355,31 @@ def run_step7_smoke(
     cfg = Step7DynaConfig() if config is None else config
     if type(cfg) is not Step7DynaConfig:
         raise TypeError("config must be an actual Step7DynaConfig")
-    smoke_scalars = (steps + 1) * cfg.world_model.observation_dim + steps
-    planning_outputs = steps * cfg.planning_steps * 9
+    observation_dim = cfg.world_model.observation_dim
+    input_bytes = 4 * ((steps + 1) * observation_dim + steps)
+    # Six scalar numeric/bool outputs plus the vector model error are retained
+    # for every real transition. Six numeric arrays and one bool array are
+    # retained for every planning backup.
+    real_output_bytes = steps * (17 + 4 * observation_dim)
+    planning_output_bytes = steps * cfg.planning_steps * 25
+    memory_scalars = (
+        2 * cfg.planning_memory_size * observation_dim
+        + 4 * cfg.planning_memory_size
+        + 3
+    )
+    memory_bytes = 4 * memory_scalars
+    total_bytes = input_bytes + real_output_bytes + planning_output_bytes + memory_bytes
     if any(
-        count > _INT32_MAX or 4 * count > _INT32_MAX
-        for count in (smoke_scalars, planning_outputs, smoke_scalars + planning_outputs)
+        count > _INT32_MAX
+        for count in (
+            input_bytes,
+            real_output_bytes,
+            planning_output_bytes,
+            memory_bytes,
+            total_bytes,
+        )
     ):
-        raise ValueError("derived Step 7 smoke float32 resources exceed signed-int32 bounds")
+        raise ValueError("derived Step 7 smoke resources exceed signed-int32 bounds")
     agent, model = make_step7_components(cfg)
     data_key, state_key = jr.split(jr.key(seed))
     observations = jr.normal(

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -14,6 +14,7 @@ from alberta_framework.steps.step7 import (
     init_step7_state,
     make_step7_components,
     run_step7_scan,
+    run_step7_smoke,
 )
 from alberta_framework.steps.step8 import Step8WorldModelConfig
 
@@ -39,6 +40,10 @@ class _StringSubclass(str):
 class _HostileInt(int):
     calls = 0
 
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("HostileInt.__int__ must not be called")
+
     def __index__(self) -> int:  # type: ignore[override]
         type(self).calls += 1
         raise AssertionError("HostileInt.__index__ must not be called")
@@ -62,6 +67,30 @@ class _HostileFloat(float):
     def __repr__(self) -> str:
         type(self).calls += 1
         raise AssertionError("HostileFloat.__repr__ must not be called")
+
+
+class _HostileIntMeta(type):
+    calls = 0
+
+    def __hash__(cls) -> int:
+        type(cls).calls += 1
+        raise AssertionError("HostileIntMeta.__hash__ must not be called")
+
+
+class _MetaclassHostileInt(int, metaclass=_HostileIntMeta):
+    pass
+
+
+class _HostileFloatMeta(type):
+    calls = 0
+
+    def __hash__(cls) -> int:
+        type(cls).calls += 1
+        raise AssertionError("HostileFloatMeta.__hash__ must not be called")
+
+
+class _MetaclassHostileFloat(float, metaclass=_HostileFloatMeta):
+    pass
 
 
 def _valid_config_kwargs() -> dict[str, Any]:
@@ -97,6 +126,13 @@ def test_rejects_bool_and_hostile_int() -> None:
     assert "HostileInt" not in str(exc.value)
 
 
+def test_rejects_hostile_int_metaclass_without_hooks() -> None:
+    _HostileIntMeta.calls = 0
+    with pytest.raises(ValueError, match="must be an integer"):
+        Step7DynaConfig(**{**_valid_config_kwargs(), "planning_steps": _MetaclassHostileInt(2)})
+    assert _HostileIntMeta.calls == 0
+
+
 def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be") as exc:
@@ -106,14 +142,16 @@ def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     assert "!r" not in str(exc.value)
 
 
-def test_does_not_invoke_hostile_value_when_name_is_evil_via_sink() -> None:
-    from alberta_framework.steps._float32_validation import finite_real_and_float32
-
-    evil = _EvilStr("x")
-    _HostileFloat.calls = 0
-    with pytest.raises(ValueError, match="must be an exact string"):
-        finite_real_and_float32(evil, _HostileFloat(1.0))  # type: ignore[arg-type]
-    assert _HostileFloat.calls == 0
+def test_rejects_hostile_float_metaclass_without_hooks() -> None:
+    _HostileFloatMeta.calls = 0
+    with pytest.raises(ValueError, match="must be finite"):
+        Step7DynaConfig(
+            **{
+                **_valid_config_kwargs(),
+                "planning_utility_step_size": _MetaclassHostileFloat(0.1),
+            }
+        )
+    assert _HostileFloatMeta.calls == 0
 
 
 def test_rejects_plain_string_for_utility_step() -> None:
@@ -244,3 +282,14 @@ def test_init_and_scan_reject_hostile_arrays_without_hooks() -> None:
             jnp.zeros(1, dtype=jnp.int32),
             jnp.zeros((1, 2), dtype=jnp.float32),
         )
+
+
+def test_smoke_preflights_all_live_arrays_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_allocation(*args: object, **kwargs: object) -> None:
+        raise AssertionError("allocation must not start before resource preflight")
+
+    monkeypatch.setattr(jr, "normal", unexpected_allocation)
+    with pytest.raises(ValueError, match="smoke resources"):
+        run_step7_smoke(steps=50_000_000)

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -675,6 +675,8 @@ def test_step7_dyna_preserves_float32_boundaries() -> None:
 def test_step7_dyna_rejects_derived_work_and_memory_resources() -> None:
     with pytest.raises(ValueError, match="derived planning evaluations"):
         Step7DynaConfig(planning_steps=2**30, planning_rollout_depth=2)
+    with pytest.raises(ValueError, match="planning output bytes"):
+        Step7DynaConfig(planning_steps=2**26, planning_rollout_depth=1)
     with pytest.raises(ValueError, match="planning-memory bytes"):
         Step7DynaConfig(planning_memory_size=2**28)
 


### PR DESCRIPTION
Corrective atop merged Step 7 totalization: identity-only integer and real gates avoid hostile metaclass hooks; removes private helper-name overreach; accounts for direct planning, rollout, real-scan, planning-scan, input, and replay bytes before JAX allocation. Verification before final unrelated-main rebase: 138 focused passed; 168 full affected Step 7/RNG/planning passed; full Ruff passed; strict mypy 170 files; diff check passed.