### PR TITLE
fix(benchmarks): totalize historical provenance validation

### DIFF
--- a/alberta_framework/benchmarks/historical_forager_provenance.py
+++ b/alberta_framework/benchmarks/historical_forager_provenance.py
@@ -136,6 +136,14 @@ class HistoricalForagerFamilyMismatchError(ValueError):
     """Raised when a comparison attempts to cross environment families."""
 
 
+def _require_exact_str(name: object, value: object) -> str:
+    if type(name) is not str:
+        raise HistoricalForagerProvenanceError("name must be a string")
+    if type(value) is not str:
+        raise HistoricalForagerProvenanceError(f"{name} must be a string")
+    return value
+
+
 def _canonical_json_bytes(value: Any) -> bytes:
     try:
         return json.dumps(
@@ -175,14 +183,13 @@ def validate_historical_forager_provenance(value: Mapping[str, Any]) -> None:
         )
 
 
-def assert_historical_family_pairing(left_family_id: str, right_family_id: str) -> None:
+def assert_historical_family_pairing(left_family_id: object, right_family_id: object) -> None:
     """Reject cross-family and unknown-family pairing before metric comparison."""
-    if (
-        left_family_id != HISTORICAL_FORAGER_FAMILY_ID
-        or right_family_id != HISTORICAL_FORAGER_FAMILY_ID
-    ):
+    host_left = _require_exact_str("left_family_id", left_family_id)
+    host_right = _require_exact_str("right_family_id", right_family_id)
+    if host_left != HISTORICAL_FORAGER_FAMILY_ID or host_right != HISTORICAL_FORAGER_FAMILY_ID:
         raise HistoricalForagerFamilyMismatchError(
             "historical reconstructed results pair only with "
-            f"{HISTORICAL_FORAGER_FAMILY_ID!r}; received "
-            f"{left_family_id!r} and {right_family_id!r}"
+            f"'{HISTORICAL_FORAGER_FAMILY_ID}'; received "
+            f"'{host_left}' and '{host_right}'"
         )

--- a/alberta_framework/benchmarks/historical_forager_provenance.py
+++ b/alberta_framework/benchmarks/historical_forager_provenance.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
-from typing import Any, Final
+import math
+from typing import Any, Final, cast
 
 __all__ = [
     "CURRENT_FORAGAX_055_FAMILY_ID",
@@ -27,6 +27,9 @@ __all__ = [
 HISTORICAL_FORAGER_FAMILY_ID: Final = "historical_numpy_forager_d140_reconstructed"
 CURRENT_FORAGAX_055_FAMILY_ID: Final = "current_foragax_0_55"
 HISTORICAL_FORAGER_PROVENANCE_SCHEMA: Final = "alberta.historical_numpy_forager.provenance.v1"
+_MAX_PROVENANCE_DEPTH: Final = 8
+_MAX_PROVENANCE_NODES: Final = 4096
+_MAX_PROVENANCE_STRING_BYTES: Final = 1024 * 1024
 
 _HISTORICAL_FORAGER_PROVENANCE: Final[dict[str, Any]] = {
     "schema_version": HISTORICAL_FORAGER_PROVENANCE_SCHEMA,
@@ -144,7 +147,58 @@ def _require_exact_str(name: object, value: object) -> str:
     return value
 
 
-def _canonical_json_bytes(value: Any) -> bytes:
+def _validate_json_tree(
+    value: object,
+    *,
+    depth: int = 0,
+    budget: list[int] | None = None,
+) -> None:
+    """Bound exact JSON identities before serialization can dispatch hooks."""
+    if budget is None:
+        budget = [0, 0]
+    budget[0] += 1
+    if budget[0] > _MAX_PROVENANCE_NODES or depth > _MAX_PROVENANCE_DEPTH:
+        raise HistoricalForagerProvenanceError("historical Forager provenance is too large")
+    actual_type = type(value)
+    if actual_type is str:
+        budget[1] += len(cast(str, value).encode("utf-8"))
+        if budget[1] > _MAX_PROVENANCE_STRING_BYTES:
+            raise HistoricalForagerProvenanceError("historical Forager provenance is too large")
+        return
+    if actual_type in {bool, int, type(None)}:
+        return
+    if actual_type is float:
+        if not math.isfinite(cast(float, value)):
+            raise HistoricalForagerProvenanceError(
+                "historical Forager provenance numbers must be finite"
+            )
+        return
+    if actual_type is list:
+        sequence = cast(list[object], value)
+        if len(sequence) > _MAX_PROVENANCE_NODES:
+            raise HistoricalForagerProvenanceError("historical Forager provenance is too large")
+        for item in sequence:
+            _validate_json_tree(item, depth=depth + 1, budget=budget)
+        return
+    if actual_type is dict:
+        mapping = cast(dict[object, object], value)
+        if len(mapping) > _MAX_PROVENANCE_NODES:
+            raise HistoricalForagerProvenanceError("historical Forager provenance is too large")
+        for key, item in mapping.items():
+            if type(key) is not str:
+                raise HistoricalForagerProvenanceError(
+                    "historical Forager provenance keys must be exact strings"
+                )
+            _validate_json_tree(key, depth=depth + 1, budget=budget)
+            _validate_json_tree(item, depth=depth + 1, budget=budget)
+        return
+    raise HistoricalForagerProvenanceError(
+        "historical Forager provenance must contain exact JSON values"
+    )
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    _validate_json_tree(value)
     try:
         return json.dumps(
             value,
@@ -153,7 +207,7 @@ def _canonical_json_bytes(value: Any) -> bytes:
             separators=(",", ":"),
             sort_keys=True,
         ).encode("utf-8")
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, RecursionError) as exc:
         raise HistoricalForagerProvenanceError(
             "historical Forager provenance must be finite canonical JSON"
         ) from exc
@@ -168,15 +222,17 @@ HISTORICAL_FORAGER_PROVENANCE_SHA256: Final = hashlib.sha256(
 def historical_forager_provenance() -> dict[str, Any]:
     """Return a detached copy of the exact reconstructed-family provenance."""
     value = json.loads(_CANONICAL_PROVENANCE_BYTES)
-    if not isinstance(value, dict):  # pragma: no cover - module constant invariant
+    if type(value) is not dict:  # pragma: no cover - module constant invariant
         raise RuntimeError("canonical historical Forager provenance is not an object")
     return value
 
 
-def validate_historical_forager_provenance(value: Mapping[str, Any]) -> None:
+def validate_historical_forager_provenance(value: object) -> None:
     """Require byte-equivalent canonical provenance, including explicit false claims."""
-    if not isinstance(value, Mapping):
-        raise HistoricalForagerProvenanceError("historical Forager provenance must be a mapping")
+    if type(value) is not dict:
+        raise HistoricalForagerProvenanceError(
+            "historical Forager provenance must be an actual dictionary"
+        )
     if _canonical_json_bytes(value) != _CANONICAL_PROVENANCE_BYTES:
         raise HistoricalForagerProvenanceError(
             "historical Forager provenance differs from the audited reconstruction"
@@ -190,6 +246,5 @@ def assert_historical_family_pairing(left_family_id: object, right_family_id: ob
     if host_left != HISTORICAL_FORAGER_FAMILY_ID or host_right != HISTORICAL_FORAGER_FAMILY_ID:
         raise HistoricalForagerFamilyMismatchError(
             "historical reconstructed results pair only with "
-            f"'{HISTORICAL_FORAGER_FAMILY_ID}'; received "
-            f"'{host_left}' and '{host_right}'"
+            f"'{HISTORICAL_FORAGER_FAMILY_ID}'"
         )

--- a/tests/test_historical_provenance_hostile_validation.py
+++ b/tests/test_historical_provenance_hostile_validation.py
@@ -1,0 +1,75 @@
+"""Hostile validation for historical provenance facade."""
+
+import pytest
+
+from alberta_framework.benchmarks.historical_forager_provenance import (
+    HISTORICAL_FORAGER_FAMILY_ID,
+    HistoricalForagerFamilyMismatchError,
+    HistoricalForagerProvenanceError,
+    assert_historical_family_pairing,
+)
+
+
+class _EvilStr(str):
+    calls = 0
+
+    def __str__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_hostile_left_without_repr_leak() -> None:
+    evil = _EvilStr(HISTORICAL_FORAGER_FAMILY_ID)
+    _EvilStr.calls = 0
+    with pytest.raises(HistoricalForagerProvenanceError, match="must be a string") as exc:
+        assert_historical_family_pairing(evil, HISTORICAL_FORAGER_FAMILY_ID)  # type: ignore[arg-type]
+    assert _EvilStr.calls == 0
+    assert "EvilStr" not in str(exc.value)
+
+
+def test_hostile_right_without_repr_leak() -> None:
+    evil = _EvilStr(HISTORICAL_FORAGER_FAMILY_ID)
+    _EvilStr.calls = 0
+    with pytest.raises(HistoricalForagerProvenanceError, match="must be a string"):
+        assert_historical_family_pairing(HISTORICAL_FORAGER_FAMILY_ID, evil)  # type: ignore[arg-type]
+    assert _EvilStr.calls == 0
+
+
+def test_string_subclass_rejected() -> None:
+    with pytest.raises(HistoricalForagerProvenanceError, match="must be a string"):
+        assert_historical_family_pairing(
+            _StringSubclass(HISTORICAL_FORAGER_FAMILY_ID),
+            HISTORICAL_FORAGER_FAMILY_ID,
+        )  # type: ignore[arg-type]
+
+
+def test_mismatch_sanitized_without_repr() -> None:
+    with pytest.raises(
+        HistoricalForagerFamilyMismatchError,
+        match="historical reconstructed results pair only with",
+    ) as exc:
+        assert_historical_family_pairing("bad_left", "bad_right")
+    assert "!r" not in str(exc.value)
+    assert "bad_left" in str(exc.value)
+    msg = str(exc.value)
+    assert "'" in msg
+
+
+def test_valid_pairing_passes() -> None:
+    assert_historical_family_pairing(
+        HISTORICAL_FORAGER_FAMILY_ID, HISTORICAL_FORAGER_FAMILY_ID
+    )
+
+
+def test_mismatch_even_one_bad_rejected_sanitized() -> None:
+    with pytest.raises(HistoricalForagerFamilyMismatchError) as exc:
+        assert_historical_family_pairing(HISTORICAL_FORAGER_FAMILY_ID, "other")
+    assert "!r" not in str(exc.value)

--- a/tests/test_historical_provenance_hostile_validation.py
+++ b/tests/test_historical_provenance_hostile_validation.py
@@ -7,6 +7,8 @@ from alberta_framework.benchmarks.historical_forager_provenance import (
     HistoricalForagerFamilyMismatchError,
     HistoricalForagerProvenanceError,
     assert_historical_family_pairing,
+    historical_forager_provenance,
+    validate_historical_forager_provenance,
 )
 
 
@@ -58,7 +60,8 @@ def test_mismatch_sanitized_without_repr() -> None:
     ) as exc:
         assert_historical_family_pairing("bad_left", "bad_right")
     assert "!r" not in str(exc.value)
-    assert "bad_left" in str(exc.value)
+    assert "bad_left" not in str(exc.value)
+    assert "bad_right" not in str(exc.value)
     msg = str(exc.value)
     assert "'" in msg
 
@@ -73,3 +76,34 @@ def test_mismatch_even_one_bad_rejected_sanitized() -> None:
     with pytest.raises(HistoricalForagerFamilyMismatchError) as exc:
         assert_historical_family_pairing(HISTORICAL_FORAGER_FAMILY_ID, "other")
     assert "!r" not in str(exc.value)
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):
+        type(self).calls += 1
+        raise AssertionError("items hook must not run")
+
+
+def test_provenance_validator_rejects_dict_subclass_without_hooks() -> None:
+    _HostileDict.calls = 0
+    with pytest.raises(HistoricalForagerProvenanceError, match="actual dictionary"):
+        validate_historical_forager_provenance(_HostileDict())
+    assert _HostileDict.calls == 0
+
+
+def test_provenance_validator_rejects_nested_hostile_json_identity() -> None:
+    payload = historical_forager_provenance()
+    payload["agents"] = _HostileDict()
+    _HostileDict.calls = 0
+    with pytest.raises(HistoricalForagerProvenanceError, match="exact JSON values"):
+        validate_historical_forager_provenance(payload)
+    assert _HostileDict.calls == 0
+
+
+def test_provenance_validator_bounds_work_before_serialization() -> None:
+    payload = historical_forager_provenance()
+    payload["agents"] = {str(index): index for index in range(4097)}
+    with pytest.raises(HistoricalForagerProvenanceError, match="too large"):
+        validate_historical_forager_provenance(payload)


### PR DESCRIPTION
## Summary\n- retain #1276 hostile family-id gates while removing untrusted values from errors\n- validate bounded exact JSON identities before serialization\n- reject mapping/list/scalar subclasses and oversized/deep provenance before hooks or unbounded work\n\n## Verification\n- 46 focused provenance/reconstruction tests passed\n- Ruff and mypy passed\n- package build test reached an unrelated missing local hatchling dependency; no benchmark/output execution\n\nSupersedes #1276 while retaining its contributor commit.