### PR TITLE
fix(forager): reject leftover paper-reference identities

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -4087,6 +4087,10 @@ class PaperBaseline:
     source: str
     official_config_path: str | None = None
 
+    def __post_init__(self) -> None:
+        if type(self.in_tree_implementation) is not bool:
+            raise ValueError("in_tree_implementation must be a boolean")
+
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
 
@@ -4471,6 +4475,15 @@ class PaperReferenceTarget:
     condition: str = "continuously_learning"
     source: str = FORAGER_PAPER_URL
     precision: str = "figure_digitized_approximation"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "central_estimate",
+            _require_real(self.central_estimate, name="central_estimate"),
+        )
+        if type(self.privileged) is not bool:
+            raise ValueError("privileged must be a boolean")
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -1,0 +1,75 @@
+"""Leftover-identity gates for forager paper-reference records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.benchmarks.forager import (
+    PaperBaseline,
+    PaperReferenceTarget,
+    paper_reference_targets,
+)
+
+
+def _legal_target() -> PaperReferenceTarget:
+    return PaperReferenceTarget("PPO", "mean_ewm_reward", 1.3)
+
+
+def _legal_baseline() -> PaperBaseline:
+    return PaperBaseline(
+        name="PPO",
+        family="ppo",
+        role="sota",
+        state_construction="pixels",
+        selected_hyperparameters={"step_size": 0.1},
+        in_tree_implementation=True,
+        source="https://arxiv.org/abs/2605.01131",
+    )
+
+
+def test_paper_reference_target_rejects_leftover_identities() -> None:
+    """Public paper-reference records must not keep leftover bool/int identities."""
+
+    with pytest.raises(ValueError, match="central_estimate"):
+        PaperReferenceTarget("PPO", "mean_ewm_reward", True)
+    with pytest.raises(ValueError, match="central_estimate"):
+        PaperReferenceTarget("PPO", "mean_ewm_reward", float("nan"))
+    with pytest.raises(ValueError, match="privileged"):
+        PaperReferenceTarget("PPO", "mean_ewm_reward", 1.3, privileged=1)
+
+    legal = _legal_target()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"central_estimate": 1.3' in dumped
+    assert '"privileged": false' in dumped
+    assert '"central_estimate": true' not in dumped
+    assert '"privileged": 1' not in dumped
+
+
+def test_paper_baseline_rejects_leftover_identities() -> None:
+    """Published baseline contracts must not keep leftover bool identities."""
+
+    with pytest.raises(ValueError, match="in_tree_implementation"):
+        PaperBaseline(
+            name="PPO",
+            family="ppo",
+            role="sota",
+            state_construction="pixels",
+            selected_hyperparameters={"step_size": 0.1},
+            in_tree_implementation=1,
+            source="https://arxiv.org/abs/2605.01131",
+        )
+
+    legal = _legal_baseline()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"in_tree_implementation": true' in dumped
+    assert '"in_tree_implementation": 1' not in dumped
+
+
+def test_paper_reference_targets_remain_legal() -> None:
+    targets = paper_reference_targets("relearning")
+    rtu = next(item for item in targets if item.method == "RTU-PPO")
+    assert rtu.central_estimate == pytest.approx(1.3)
+    dumped = json.dumps(rtu.to_dict(), allow_nan=False)
+    assert '"central_estimate": 1.3' in dumped


### PR DESCRIPTION
Closes #1285.

## What changed

Forager paper-reference and paper-baseline records now fail closed on leftover bool/int identities and non-finite central estimates.

On origin/main `67b6a2a`, `PaperReferenceTarget` and `PaperBaseline` had no leftover-identity `__post_init__`. `PaperReferenceTarget("PPO", "mean_ewm_reward", True, privileged=1)` constructed, and `json.dumps(record.to_dict(), allow_nan=False)` emitted `"central_estimate": true` and `"privileged": 1`. `PaperBaseline(..., in_tree_implementation=1)` emitted `"in_tree_implementation": 1`. `central_estimate=NaN` raised at dump time instead of failing closed at construction.

This is leftover tax on `forager.py` paper-reference records, not a ForagerRunResult NaN change, not forager-cli/matrix/results, and not a republish of `#1259`/`#1260`/`#1267`/`#1268` (resource-budget / resource-declaration).

## Scope

- `alberta_framework/benchmarks/forager.py`
- `tests/test_forager_paper_reference_leftover_identities.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is `#1283` (lalalune step7), `#1282`/`#1279` (byt61 experiments), `#1278` (byt61 streams), `#1277` (Svector-anu horde actor-critic), and `#1276` (byt61 historical provenance). These files were FREE.

## Verification

Exact candidate head: `3625f04b8e3f773d9367cd8c35b8325924d59653`
Base: `67b6a2a`

- Red on base: leftover `central_estimate=True` / `privileged=1` accepted; dump emitted JSON true/1
- Focused pytest `tests/test_forager_paper_reference_leftover_identities.py`: 3 passed
- Existing `tests/test_security_integration.py` not in this tree; related paper-reference assertions remain legal
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3625f04b8e3f773d9367cd8c35b8325924d59653 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
