### PR TITLE
fix(security): reject leftover reward-weight identities

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -190,6 +190,19 @@ class SecurityRewardWeights:
     compromise_cost: float = -1.0
     recovery: float = 0.5
 
+    def __post_init__(self) -> None:
+        for name in (
+            "threat_blocked",
+            "false_positive",
+            "service_disruption",
+            "alert_cost",
+            "latency_cost",
+            "compromise_cost",
+            "recovery",
+        ):
+            if type(getattr(self, name)) is bool:
+                raise ValueError(f"{name} must be a finite real number")
+
     def to_dict(self) -> dict[str, float]:
         """Return a JSON-serializable weight mapping."""
         payload = dataclasses.asdict(self)

--- a/tests/test_security_reward_weight_leftover_identities.py
+++ b/tests/test_security_reward_weight_leftover_identities.py
@@ -1,0 +1,27 @@
+"""Leftover-identity gates for security reward-weight records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.security import SecurityRewardWeights
+
+
+def test_security_reward_weights_reject_leftover_identities() -> None:
+    """Public reward-weight records must not keep leftover bool identities."""
+
+    with pytest.raises(ValueError, match="threat_blocked"):
+        SecurityRewardWeights(threat_blocked=True)
+    with pytest.raises(ValueError, match="false_positive"):
+        SecurityRewardWeights(false_positive=False)
+    with pytest.raises(ValueError, match="recovery"):
+        SecurityRewardWeights(recovery=True)
+
+    legal = SecurityRewardWeights()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"threat_blocked": 1.0' in dumped
+    assert '"recovery": 0.5' in dumped
+    assert '"threat_blocked": true' not in dumped
+    assert '"recovery": true' not in dumped


### PR DESCRIPTION
Closes #1286.

## What changed

Security reward-weight records now fail closed on leftover bool identities.

On origin/main `67b6a2a`, `SecurityRewardWeights` had no leftover-identity `__post_init__`. `SecurityRewardWeights(threat_blocked=True)` constructed, and `json.dumps(record.to_dict(), allow_nan=False)` emitted `"threat_blocked": true`. Non-finite weights already fail closed at `to_dict`; leftover bools do not.

This is leftover tax on `security.py` reward-weight records, not a republish of `#903` (boolean actions / non-finite risk scores) and not resource-budget / resource-declaration (`#1259`/`#1260`/`#1267`/`#1268`).

## Scope

- `alberta_framework/security.py`
- `tests/test_security_reward_weight_leftover_identities.py`

## Why this is unowned

Live occupancy at publish time: ASI open set is `#1283` (lalalune step7), `#1282`/`#1279` (byt61 experiments), `#1278` (byt61 streams), `#1277` (Svector-anu horde actor-critic), and `#1276` (byt61 historical provenance). These files were FREE.

## Verification

Exact candidate head: `870dd4b8e2f1984cecdaab2a6205f80587445f3c`
Base: `67b6a2a`

- Red on base: leftover `threat_blocked=True` accepted; dump emitted `"threat_blocked": true`
- Focused pytest leftover + existing `tests/test_security_integration.py`: 19 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:870dd4b8e2f1984cecdaab2a6205f80587445f3c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
