### PR TITLE
fix(behavior-model): gate action ids on type before conversion

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -100,6 +100,14 @@ def _integer_action_ids(
         raw_shape = tuple(actions.shape)
         raw_dtype = np.dtype(actions.dtype)
     else:
+        actual_type = type(actions)
+        trusted_host = (
+            actual_type is np.ndarray
+            or actual_type in _ACTUAL_INT_TYPES
+            or isinstance(actions, jax.Array)
+        )
+        if not trusted_host:
+            raise TypeError("actions must be a trusted array")
         host_actions = np.asarray(actions)
         raw_shape = tuple(host_actions.shape)
         raw_dtype = host_actions.dtype

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -633,3 +633,44 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
     with pytest.raises(AssertionError, match="allocator reached"):
         model.init(max_feature_dim, jax.random.key(0))
     assert calls == 1
+
+
+def test_action_ids_reject_untrusted_arrays_without_running_conversion_hooks() -> None:
+    """The host path must gate on type before any conversion hook can run.
+
+    ``_integer_action_ids`` reaches ``np.asarray(actions)`` before validating
+    anything on the non-tracer path, so an untrusted ``__array__`` hook
+    executes ahead of the dtype and range checks and can decide the value that
+    is subsequently validated.
+    """
+
+    class _HostileArray:
+        def __array__(self, dtype: object = None, copy: object = None) -> np.ndarray:
+            raise AssertionError("array hook must not run")
+
+    probabilities = jnp.asarray([0.1, 0.2, 0.3, 0.4], dtype=jnp.float32)
+    with pytest.raises(TypeError, match="trusted array"):
+        selected_action_probabilities(probabilities, _HostileArray())
+
+    model = BehaviorModel(BehaviorModelConfig(n_actions=4, step_size=0.1))
+    state = model.init(feature_dim=2, key=jax.random.key(0))
+    observation = jnp.array([1.0, -0.5], dtype=jnp.float32)
+    with pytest.raises(TypeError, match="trusted array"):
+        model.update(state, observation, _HostileArray())
+
+
+def test_action_ids_still_accept_trusted_hosts_and_tracers() -> None:
+    """The gate must not reject the array types the module already supports."""
+    probabilities = jnp.asarray([0.1, 0.2, 0.3, 0.4], dtype=jnp.float32)
+    for action in (
+        jnp.asarray(2, dtype=jnp.int32),
+        np.array(2, dtype=np.int16),
+        np.int32(1),
+        2,
+    ):
+        chex.assert_tree_all_finite(selected_action_probabilities(probabilities, action))
+
+    traced = jax.jit(lambda a: selected_action_probabilities(probabilities, a))(
+        jnp.asarray(3, dtype=jnp.int32)
+    )
+    chex.assert_tree_all_finite(traced)


### PR DESCRIPTION
Fixes #1305.

## What moved

`_integer_action_ids` reached `np.asarray(actions)` on the non-tracer path before validating anything, so an untrusted `__array__` hook executed ahead of the dtype and `[0, n_actions)` range checks — and chose the value those checks then saw.

Confirmed on `939cdaaf` before the fix:

```text
=== untrusted __array__ hook ===
     !! __array__ hook EXECUTED before validation
     !! __array__ hook EXECUTED before validation
  -> ACCEPTED hostile object
```

This is the conversion-before-type-gate class #1168 closed for the associative sinks in `pipeline.py`. `intelligence_amplification._checked_partner_action` and `prototype_agent._strict_action_scalar` already reject hostile objects; this was the remaining reachable one I found.

**Scope note:** the wide-integer half is already fixed on `main` — int64 `2**31` is correctly rejected by the `[0, n_actions)` range check, which is stronger than a dtype-representability test. Only the hook ordering remained.

## The change

Gate on the concrete host type before converting, mirroring the #1168 helper:

```python
        actual_type = type(actions)
        trusted_host = (
            actual_type is np.ndarray
            or actual_type in _ACTUAL_INT_TYPES
            or isinstance(actions, jax.Array)
        )
        if not trusted_host:
            raise TypeError("actions must be a trusted array")
        host_actions = np.asarray(actions)
```

Reusing the module's existing `_ACTUAL_INT_TYPES` keeps Python and NumPy integer scalars working; the tracer path is untouched.

## Tests

Failing-test-first, added to `tests/test_behavior_model.py`:

- `test_action_ids_reject_untrusted_arrays_without_running_conversion_hooks` — asserts the hook never runs, via both `selected_action_probabilities` and `BehaviorModel.update`
- `test_action_ids_still_accept_trusted_hosts_and_tracers` — positive control over `jnp` arrays, `np.ndarray`, `np.int32`, Python `int`, and a jitted tracer

Before the fix: **1 failed, 1 passed** — the failure being `AssertionError: array hook must not run`, i.e. the hook demonstrably executing.

## Verification

Commit `94aea526a51f8e04a9e50be56510c759aef7a472`, based on `939cdaaf9`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_behavior_model.py
# 49 passed in 8.01s

python -m pytest -q -p no:randomly -o addopts= \
  tests/test_action_conditioned_world_model.py tests/test_behavior_model_resource_budget.py \
  tests/test_dreaming.py tests/test_differential_sarsa_discounts.py \
  tests/test_latent_world_model.py tests/test_step9_production.py \
  tests/test_step_float32_validation.py tests/test_step9_rng.py
# 518 passed in 128.69s

python -m ruff check .   # All checks passed!
python -m mypy           # Success: no issues found in 170 source files
```

Environment: Python 3.12.14, jax 0.11.0, numpy 2.5.2, CPU, network-isolated container built from `pyproject.toml` with `.[dev,gymnasium,forager]`.

## What remains open

I probed the other conversion-before-gate candidates I found by AST scan; the two nearest (`_checked_partner_action`, `_strict_action_scalar`) already reject both hostile hooks and wide integers. I did not audit every site in the tree.

<!-- evidence-head:94aea526a51f8e04a9e50be56510c759aef7a472 -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
