### PR TITLE
fix(utils): validate window in common_final_window

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -671,6 +671,7 @@ def common_final_window(step_counts: Mapping[str, int], window: int, metric: str
         ValueError: If ``step_counts`` is empty or the per-method
             ``min(window, n_steps)`` values disagree.
     """
+    window = _require_positive_int("window", window)
     if not step_counts:
         raise ValueError("at least one method is required to derive a final window")
     final_windows = {min(window, n_steps) for n_steps in step_counts.values()}

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -38,6 +38,7 @@ from alberta_framework.utils.statistics import (
     bonferroni_correction,
     bootstrap_ci,
     cohens_d,
+    common_final_window,
     compute_statistics,
     compute_timeseries_statistics,
     holm_correction,
@@ -1144,3 +1145,8 @@ class TestPairwiseComparisons:
 
         assert result[("short", "long")].effect_size == pytest.approx(0.0)
         assert not result[("short", "long")].significant
+
+    @pytest.mark.parametrize("window", [0, -1, True, 1.5])
+    def test_common_final_window_requires_positive_integer(self, window: object) -> None:
+        with pytest.raises(ValueError, match="window must be a positive integer"):
+            common_final_window({"learner": 10}, window, "squared_error")


### PR DESCRIPTION
Closes #1307.

## What changed

`common_final_window` documents `window: int` but never validated it. `window=0`, negative, `bool`, or fractional values were all silently accepted and used directly in `min(window, n_steps)`.

## Fix

Call the existing `_require_positive_int("window", window)` validator (already used at two other call sites in this same file) before using `window`.

## Reachability

Both current callers of this internal helper already validate `window` themselves before calling it — `pairwise_comparisons` (same file, `_require_positive_int` at line 723, before its call at line 759) and `get_final_performance` (`experiments.py`, its own `type(window) is not int` / `window <= 0` checks before its call at line 543). So this specific gap is **not** reachable with malformed input through either existing call path today, and `common_final_window` is not part of the public re-exported API surface (not in `alberta_framework/utils/__init__.py` or top-level `alberta_framework/__init__.py`).

This is a defense-in-depth fix closing the function's own documented contract directly, consistent with how every other function in this file validates its own inputs at its own boundary rather than trusting every current and future caller to keep re-implementing the same check.

## Verification

Live reproduction against the unpatched tree:

```text
window=0    -> returns 0
window=-1   -> returns -1
window=True -> returns 0
window=1.5  -> returns 1.5
```

Added `test_common_final_window_requires_positive_integer`, parametrized over `[0, -1, True, 1.5]`.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_statistics_validation.py::TestPairwiseComparisons::test_common_final_window_requires_positive_integer[0]
FAILED tests/test_statistics_validation.py::TestPairwiseComparisons::test_common_final_window_requires_positive_integer[-1]
FAILED tests/test_statistics_validation.py::TestPairwiseComparisons::test_common_final_window_requires_positive_integer[True]
FAILED tests/test_statistics_validation.py::TestPairwiseComparisons::test_common_final_window_requires_positive_integer[1.5]
4 failed, 233 deselected
```

Fix restored: `4 passed, 233 deselected`.

Full `tests/test_statistics_validation.py`: `237 passed`, 2 pre-existing unrelated SciPy precision-loss warnings.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), full test file, lint, mypy were all re-run and re-confirmed by hand. I also corrected the reachability claim: the draft's report implied this corrupts measurement through real callers today; tracing both actual call sites (`pairwise_comparisons`, `get_final_performance`) shows each already validates `window` before calling this function, so I rewrote the reachability section to say so honestly rather than overstate live exploitability.

Attribution status: self-reported.
