### PR TITLE
fix(evaluation): reject leftover identities and non-finite values in acceptance evidence records

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -475,6 +475,20 @@ class IAAcceptanceEvidence:
     threshold: float
     detail: str
 
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if self.scope not in ("primary", "secondary"):
+            raise ValueError("scope must be 'primary' or 'secondary'")
+        if type(self.passed) is not bool:
+            raise ValueError("passed must be a boolean")
+        object.__setattr__(self, "actual", finite_real("actual", self.actual))
+        if type(self.comparator) is not str or not self.comparator:
+            raise ValueError("comparator must be a non-empty string")
+        object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))
+        if type(self.detail) is not str:
+            raise ValueError("detail must be a string")
+
 
 @dataclass(frozen=True)
 class IAAcceptanceResult:
@@ -484,6 +498,18 @@ class IAAcceptanceResult:
     primary_passed: bool
     secondary_passed: bool
     checks: tuple[IAAcceptanceEvidence, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.passed) is not bool:
+            raise ValueError("passed must be a boolean")
+        if type(self.primary_passed) is not bool:
+            raise ValueError("primary_passed must be a boolean")
+        if type(self.secondary_passed) is not bool:
+            raise ValueError("secondary_passed must be a boolean")
+        if not isinstance(self.checks, tuple) or not all(
+            isinstance(c, IAAcceptanceEvidence) for c in self.checks
+        ):
+            raise ValueError("checks must be a tuple of IAAcceptanceEvidence")
 
     @property
     def failures(self) -> tuple[IAAcceptanceEvidence, ...]:

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -449,6 +449,18 @@ class AcceptanceEvidence:
     threshold: float
     detail: str
 
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if type(self.passed) is not bool:
+            raise ValueError("passed must be a boolean")
+        object.__setattr__(self, "actual", finite_real("actual", self.actual))
+        if type(self.comparator) is not str or not self.comparator:
+            raise ValueError("comparator must be a non-empty string")
+        object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))
+        if type(self.detail) is not str:
+            raise ValueError("detail must be a string")
+
 
 @dataclass(frozen=True)
 class AcceptanceResult:
@@ -456,6 +468,14 @@ class AcceptanceResult:
 
     passed: bool
     checks: tuple[AcceptanceEvidence, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.passed) is not bool:
+            raise ValueError("passed must be a boolean")
+        if not isinstance(self.checks, tuple) or not all(
+            isinstance(c, AcceptanceEvidence) for c in self.checks
+        ):
+            raise ValueError("checks must be a tuple of AcceptanceEvidence")
 
     @property
     def failures(self) -> tuple[AcceptanceEvidence, ...]:

--- a/tests/test_acceptance_evidence_hostile_validation.py
+++ b/tests/test_acceptance_evidence_hostile_validation.py
@@ -1,0 +1,284 @@
+"""Hostile input, leftover identity, and boundary validation for evaluation acceptance records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia import (
+    IAAcceptanceEvidence,
+    IAAcceptanceResult,
+)
+from alberta_framework.evaluation.continual_multiagent import (
+    AcceptanceEvidence,
+    AcceptanceResult,
+)
+
+
+class HostileFloat:
+    """Object attempting to bypass finite float validation."""
+
+    def __float__(self) -> float:
+        return 1.0
+
+
+class HostileBool:
+    """Object attempting to bypass bool validation."""
+
+    def __bool__(self) -> bool:
+        return True
+
+
+def test_acceptance_evidence_valid_construction() -> None:
+    evidence = AcceptanceEvidence(
+        name="coadaptation_uplift",
+        passed=True,
+        actual=0.15,
+        comparator=">=",
+        threshold=0.05,
+        detail="p-value: 0.001",
+    )
+    assert evidence.name == "coadaptation_uplift"
+    assert evidence.passed is True
+    assert evidence.actual == 0.15
+    assert evidence.comparator == ">="
+    assert evidence.threshold == 0.05
+    assert evidence.detail == "p-value: 0.001"
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    ["", 123, None, True, False],
+)
+def test_acceptance_evidence_rejects_invalid_name(invalid_name: object) -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        AcceptanceEvidence(
+            name=invalid_name,  # type: ignore[arg-type]
+            passed=True,
+            actual=0.1,
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_passed",
+    [1, 0, "True", "False", None, HostileBool(), 1.0],
+)
+def test_acceptance_evidence_rejects_non_boolean_passed(invalid_passed: object) -> None:
+    with pytest.raises(ValueError, match="passed must be a boolean"):
+        AcceptanceEvidence(
+            name="check",
+            passed=invalid_passed,  # type: ignore[arg-type]
+            actual=0.1,
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_actual",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        False,
+        "0.5",
+        None,
+        HostileFloat(),
+    ],
+)
+def test_acceptance_evidence_rejects_invalid_actual(invalid_actual: object) -> None:
+    with pytest.raises(ValueError, match="actual must be a finite real number"):
+        AcceptanceEvidence(
+            name="check",
+            passed=True,
+            actual=invalid_actual,  # type: ignore[arg-type]
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_threshold",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        False,
+        "0.5",
+        None,
+        HostileFloat(),
+    ],
+)
+def test_acceptance_evidence_rejects_invalid_threshold(invalid_threshold: object) -> None:
+    with pytest.raises(ValueError, match="threshold must be a finite real number"):
+        AcceptanceEvidence(
+            name="check",
+            passed=True,
+            actual=0.1,
+            comparator=">=",
+            threshold=invalid_threshold,  # type: ignore[arg-type]
+            detail="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_comparator",
+    ["", 123, None, True, False],
+)
+def test_acceptance_evidence_rejects_invalid_comparator(invalid_comparator: object) -> None:
+    with pytest.raises(ValueError, match="comparator must be a non-empty string"):
+        AcceptanceEvidence(
+            name="check",
+            passed=True,
+            actual=0.1,
+            comparator=invalid_comparator,  # type: ignore[arg-type]
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+def test_acceptance_result_validation() -> None:
+    evidence = AcceptanceEvidence(
+        name="check",
+        passed=True,
+        actual=0.1,
+        comparator=">=",
+        threshold=0.0,
+        detail="ok",
+    )
+    result = AcceptanceResult(passed=True, checks=(evidence,))
+    assert result.passed is True
+    assert result.checks == (evidence,)
+    assert len(result.failures) == 0
+
+    with pytest.raises(ValueError, match="passed must be a boolean"):
+        AcceptanceResult(passed=1, checks=(evidence,))  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="checks must be a tuple of AcceptanceEvidence"):
+        AcceptanceResult(passed=True, checks=[evidence])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="checks must be a tuple of AcceptanceEvidence"):
+        AcceptanceResult(passed=True, checks=(evidence, "invalid"))  # type: ignore[arg-type]
+
+
+def test_ia_acceptance_evidence_valid_construction() -> None:
+    evidence = IAAcceptanceEvidence(
+        name="primary_uplift",
+        scope="primary",
+        passed=True,
+        actual=0.25,
+        comparator=">=",
+        threshold=0.1,
+        detail="statistically significant",
+    )
+    assert evidence.name == "primary_uplift"
+    assert evidence.scope == "primary"
+    assert evidence.passed is True
+    assert evidence.actual == 0.25
+    assert evidence.comparator == ">="
+    assert evidence.threshold == 0.1
+    assert evidence.detail == "statistically significant"
+
+
+@pytest.mark.parametrize(
+    "invalid_scope",
+    ["tertiary", "other", "", 123, None, True],
+)
+def test_ia_acceptance_evidence_rejects_invalid_scope(invalid_scope: object) -> None:
+    with pytest.raises(ValueError, match="scope must be 'primary' or 'secondary'"):
+        IAAcceptanceEvidence(
+            name="check",
+            scope=invalid_scope,  # type: ignore[arg-type]
+            passed=True,
+            actual=0.1,
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "invalid_actual",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        False,
+        "0.5",
+        None,
+        HostileFloat(),
+    ],
+)
+def test_ia_acceptance_evidence_rejects_invalid_actual(invalid_actual: object) -> None:
+    with pytest.raises(ValueError, match="actual must be a finite real number"):
+        IAAcceptanceEvidence(
+            name="check",
+            scope="primary",
+            passed=True,
+            actual=invalid_actual,  # type: ignore[arg-type]
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
+
+
+def test_ia_acceptance_result_validation() -> None:
+    evidence = IAAcceptanceEvidence(
+        name="check",
+        scope="primary",
+        passed=True,
+        actual=0.1,
+        comparator=">=",
+        threshold=0.0,
+        detail="ok",
+    )
+    result = IAAcceptanceResult(
+        passed=True,
+        primary_passed=True,
+        secondary_passed=True,
+        checks=(evidence,),
+    )
+    assert result.passed is True
+    assert result.primary_passed is True
+    assert result.secondary_passed is True
+    assert result.checks == (evidence,)
+    assert len(result.failures) == 0
+
+    with pytest.raises(ValueError, match="passed must be a boolean"):
+        IAAcceptanceResult(
+            passed=1,  # type: ignore[arg-type]
+            primary_passed=True,
+            secondary_passed=True,
+            checks=(evidence,),
+        )
+
+    with pytest.raises(ValueError, match="primary_passed must be a boolean"):
+        IAAcceptanceResult(
+            passed=True,
+            primary_passed=1,  # type: ignore[arg-type]
+            secondary_passed=True,
+            checks=(evidence,),
+        )
+
+    with pytest.raises(ValueError, match="secondary_passed must be a boolean"):
+        IAAcceptanceResult(
+            passed=True,
+            primary_passed=True,
+            secondary_passed=1,  # type: ignore[arg-type]
+            checks=(evidence,),
+        )
+
+    with pytest.raises(ValueError, match="checks must be a tuple of IAAcceptanceEvidence"):
+        IAAcceptanceResult(
+            passed=True,
+            primary_passed=True,
+            secondary_passed=True,
+            checks=[evidence],  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation using canonical `finite_real` to evaluation acceptance records across continual multiagent and continual intelligence-amplification benchmarks:

- `AcceptanceEvidence` (`alberta_framework/evaluation/continual_multiagent.py`): validates non-empty `name`, exact `bool` `passed`, finite real `actual` and `threshold`, non-empty `comparator`, and `str` `detail`.
- `AcceptanceResult` (`alberta_framework/evaluation/continual_multiagent.py`): validates exact `bool` `passed` and tuple of `AcceptanceEvidence`.
- `IAAcceptanceEvidence` (`alberta_framework/evaluation/continual_ia.py`): validates non-empty `name`, exact scope `("primary", "secondary")`, exact `bool` `passed`, finite real `actual` and `threshold`, non-empty `comparator`, and `str` `detail`.
- `IAAcceptanceResult` (`alberta_framework/evaluation/continual_ia.py`): validates exact `bool` `passed`, `primary_passed`, `secondary_passed`, and tuple of `IAAcceptanceEvidence`.

## Testing

- Added 51 hostile input, non-finite float, and leftover boolean identity validation tests in `tests/test_acceptance_evidence_hostile_validation.py`.
- Verified existing test suites: 324 passed in `tests/test_continual_multiagent_validation.py` and `tests/test_continual_ia_evidence.py`.
- `ruff check .` clean; `mypy` clean.