### PR TITLE
fix(evaluation): reject leftover identities and invalid types in FTL decision fidelity records

### DIFF
--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -341,6 +341,13 @@ class SeedDecisionResult:
     seed: int
     metrics: tuple[DecisionMetrics, ...]
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "seed", _require_int32("seed", self.seed, minimum=0))
+        if not isinstance(self.metrics, tuple) or not all(
+            isinstance(m, DecisionMetrics) for m in self.metrics
+        ):
+            raise ValueError("metrics must be a tuple of DecisionMetrics")
+
 
 @dataclass(frozen=True)
 class BootstrapEstimate:
@@ -392,6 +399,22 @@ class ConditionAggregate:
     return_mae: BootstrapEstimate
     normalized_return_mae: BootstrapEstimate
 
+    def __post_init__(self) -> None:
+        if type(self.condition) is not str or not self.condition:
+            raise ValueError("condition must be a non-empty string")
+        for name in (
+            "normalized_regret",
+            "domain_a_normalized_regret",
+            "domain_b_normalized_regret",
+            "oracle_pick_rate",
+            "reward_mae",
+            "return_mae",
+            "normalized_return_mae",
+        ):
+            val = getattr(self, name)
+            if not isinstance(val, BootstrapEstimate):
+                raise ValueError(f"{name} must be a BootstrapEstimate")
+
 
 @dataclass(frozen=True)
 class PairedComparison:
@@ -400,6 +423,14 @@ class PairedComparison:
     name: str
     definition: str
     estimate: BootstrapEstimate
+
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if type(self.definition) is not str or not self.definition:
+            raise ValueError("definition must be a non-empty string")
+        if not isinstance(self.estimate, BootstrapEstimate):
+            raise ValueError("estimate must be a BootstrapEstimate")
 
 
 @dataclass(frozen=True)
@@ -411,6 +442,26 @@ class DecisionFidelityReport:
     seed_results: tuple[SeedDecisionResult, ...]
     aggregates: tuple[ConditionAggregate, ...]
     comparisons: tuple[PairedComparison, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.config, DecisionFidelityConfig):
+            raise ValueError("config must be a DecisionFidelityConfig")
+        if not isinstance(self.seeds, tuple) or not all(
+            type(s) is int and 0 <= s < _INT32_MAX for s in self.seeds
+        ):
+            raise ValueError("seeds must be a tuple of non-negative int32 seeds")
+        if not isinstance(self.seed_results, tuple) or not all(
+            isinstance(r, SeedDecisionResult) for r in self.seed_results
+        ):
+            raise ValueError("seed_results must be a tuple of SeedDecisionResult")
+        if not isinstance(self.aggregates, tuple) or not all(
+            isinstance(a, ConditionAggregate) for a in self.aggregates
+        ):
+            raise ValueError("aggregates must be a tuple of ConditionAggregate")
+        if not isinstance(self.comparisons, tuple) or not all(
+            isinstance(c, PairedComparison) for c in self.comparisons
+        ):
+            raise ValueError("comparisons must be a tuple of PairedComparison")
 
     def aggregate(self, condition: str) -> ConditionAggregate:
         """Return one named condition or fail rather than silently substituting."""

--- a/tests/test_ftl_decision_fidelity_hostile_validation.py
+++ b/tests/test_ftl_decision_fidelity_hostile_validation.py
@@ -1,0 +1,217 @@
+"""Hostile input, leftover identity, and boundary validation for FTL decision-fidelity records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.ftl_decision_fidelity import (
+    BootstrapEstimate,
+    ConditionAggregate,
+    DecisionFidelityConfig,
+    DecisionFidelityReport,
+    DecisionMetrics,
+    PairedComparison,
+    SeedDecisionResult,
+)
+
+
+def _make_dummy_estimate() -> BootstrapEstimate:
+    return BootstrapEstimate(
+        estimate=0.1,
+        lower=0.05,
+        upper=0.15,
+        confidence_level=0.95,
+        resamples=100,
+        sample_size=10,
+    )
+
+
+def _make_dummy_metrics(condition: str = "oracle") -> DecisionMetrics:
+    return DecisionMetrics(
+        condition=condition,
+        normalized_regret=0.1,
+        domain_a_normalized_regret=0.1,
+        domain_b_normalized_regret=0.1,
+        oracle_pick_rate=0.9,
+        reward_mae=0.05,
+        return_mae=0.05,
+        normalized_return_mae=0.05,
+    )
+
+
+def _make_dummy_aggregate(condition: str = "oracle") -> ConditionAggregate:
+    est = _make_dummy_estimate()
+    return ConditionAggregate(
+        condition=condition,
+        normalized_regret=est,
+        domain_a_normalized_regret=est,
+        domain_b_normalized_regret=est,
+        oracle_pick_rate=est,
+        reward_mae=est,
+        return_mae=est,
+        normalized_return_mae=est,
+    )
+
+
+def test_seed_decision_result_validation() -> None:
+    metrics = (_make_dummy_metrics(),)
+    result = SeedDecisionResult(seed=42, metrics=metrics)
+    assert result.seed == 42
+    assert result.metrics == metrics
+
+    # Hostile / invalid seeds
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        SeedDecisionResult(seed=True, metrics=metrics)
+
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        SeedDecisionResult(seed=-1, metrics=metrics)
+
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        SeedDecisionResult(seed="42", metrics=metrics)  # type: ignore[arg-type]
+
+    # Hostile / invalid metrics
+    with pytest.raises(ValueError, match="metrics must be a tuple of DecisionMetrics"):
+        SeedDecisionResult(seed=42, metrics=[_make_dummy_metrics()])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="metrics must be a tuple of DecisionMetrics"):
+        SeedDecisionResult(seed=42, metrics=(metrics[0], "invalid"))  # type: ignore[arg-type]
+
+
+def test_condition_aggregate_validation() -> None:
+    est = _make_dummy_estimate()
+    agg = ConditionAggregate(
+        condition="oracle",
+        normalized_regret=est,
+        domain_a_normalized_regret=est,
+        domain_b_normalized_regret=est,
+        oracle_pick_rate=est,
+        reward_mae=est,
+        return_mae=est,
+        normalized_return_mae=est,
+    )
+    assert agg.condition == "oracle"
+
+    # Hostile / invalid condition string
+    with pytest.raises(ValueError, match="condition must be a non-empty string"):
+        ConditionAggregate(
+            condition="",
+            normalized_regret=est,
+            domain_a_normalized_regret=est,
+            domain_b_normalized_regret=est,
+            oracle_pick_rate=est,
+            reward_mae=est,
+            return_mae=est,
+            normalized_return_mae=est,
+        )
+
+    with pytest.raises(ValueError, match="condition must be a non-empty string"):
+        ConditionAggregate(
+            condition=123,  # type: ignore[arg-type]
+            normalized_regret=est,
+            domain_a_normalized_regret=est,
+            domain_b_normalized_regret=est,
+            oracle_pick_rate=est,
+            reward_mae=est,
+            return_mae=est,
+            normalized_return_mae=est,
+        )
+
+    # Invalid metric estimate type
+    with pytest.raises(ValueError, match="normalized_regret must be a BootstrapEstimate"):
+        ConditionAggregate(
+            condition="oracle",
+            normalized_regret=0.1,  # type: ignore[arg-type]
+            domain_a_normalized_regret=est,
+            domain_b_normalized_regret=est,
+            oracle_pick_rate=est,
+            reward_mae=est,
+            return_mae=est,
+            normalized_return_mae=est,
+        )
+
+
+def test_paired_comparison_validation() -> None:
+    est = _make_dummy_estimate()
+    comp = PairedComparison(
+        name="delta_regret",
+        definition="model - oracle",
+        estimate=est,
+    )
+    assert comp.name == "delta_regret"
+    assert comp.definition == "model - oracle"
+    assert comp.estimate == est
+
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        PairedComparison(name="", definition="model - oracle", estimate=est)
+
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        PairedComparison(name=None, definition="model - oracle", estimate=est)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="definition must be a non-empty string"):
+        PairedComparison(name="delta", definition="", estimate=est)
+
+    with pytest.raises(ValueError, match="estimate must be a BootstrapEstimate"):
+        PairedComparison(name="delta", definition="def", estimate=0.5)  # type: ignore[arg-type]
+
+
+def test_decision_fidelity_report_validation() -> None:
+    config = DecisionFidelityConfig()
+    seeds = (42, 43)
+    seed_results = (
+        SeedDecisionResult(seed=42, metrics=(_make_dummy_metrics(),)),
+        SeedDecisionResult(seed=43, metrics=(_make_dummy_metrics(),)),
+    )
+    aggregates = (_make_dummy_aggregate(),)
+    comparisons = (
+        PairedComparison(
+            name="delta",
+            definition="model - oracle",
+            estimate=_make_dummy_estimate(),
+        ),
+    )
+
+    report = DecisionFidelityReport(
+        config=config,
+        seeds=seeds,
+        seed_results=seed_results,
+        aggregates=aggregates,
+        comparisons=comparisons,
+    )
+    assert report.config == config
+    assert report.seeds == seeds
+
+    with pytest.raises(ValueError, match="config must be a DecisionFidelityConfig"):
+        DecisionFidelityReport(
+            config="invalid",  # type: ignore[arg-type]
+            seeds=seeds,
+            seed_results=seed_results,
+            aggregates=aggregates,
+            comparisons=comparisons,
+        )
+
+    with pytest.raises(ValueError, match="seeds must be a tuple of non-negative int32 seeds"):
+        DecisionFidelityReport(
+            config=config,
+            seeds=[42, 43],  # type: ignore[arg-type]
+            seed_results=seed_results,
+            aggregates=aggregates,
+            comparisons=comparisons,
+        )
+
+    with pytest.raises(ValueError, match="seeds must be a tuple of non-negative int32 seeds"):
+        DecisionFidelityReport(
+            config=config,
+            seeds=(42, -1),
+            seed_results=seed_results,
+            aggregates=aggregates,
+            comparisons=comparisons,
+        )
+
+    with pytest.raises(ValueError, match="seed_results must be a tuple of SeedDecisionResult"):
+        DecisionFidelityReport(
+            config=config,
+            seeds=seeds,
+            seed_results=[seed_results[0]],  # type: ignore[arg-type]
+            aggregates=aggregates,
+            comparisons=comparisons,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to decision fidelity dataclass records in `alberta_framework/evaluation/ftl_decision_fidelity.py`:

- `SeedDecisionResult`: validates non-negative `int32` seed via `_require_int32` (rejecting boolean identities and negative seeds) and validates tuple of `DecisionMetrics`.
- `ConditionAggregate`: validates non-empty `condition` name and strict `BootstrapEstimate` instances across all 7 evaluation metric fields.
- `PairedComparison`: validates non-empty `name`, non-empty `definition`, and strict `BootstrapEstimate` instance.
- `DecisionFidelityReport`: validates strict `DecisionFidelityConfig`, tuple of non-negative `int32` seeds, and tuples of `SeedDecisionResult`, `ConditionAggregate`, and `PairedComparison`.

## Testing

- Added hostile input, leftover boolean identity, and type boundary validation test suite in `tests/test_ftl_decision_fidelity_hostile_validation.py`.
- Verified all 121 tests passed across `test_ftl_decision_fidelity_hostile_validation.py` and `test_ftl_decision_fidelity.py`.
- `ruff check .` clean; `mypy` clean.