### PR TITLE
fix(evaluation): reject leftover identities and invalid fields in recurring IPMNIST retention records

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -156,6 +156,21 @@ def _unit_float(value: object, *, name: str, binary: bool = False) -> float:
     return value
 
 
+def _finite_float(value: object, *, name: str) -> float:
+    if type(value) is not float or not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite float")
+    return value
+
+
+def _signed_int(value: object, *, name: str, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be a signed integer in [{-maximum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not -maximum <= canonical <= maximum:
+        raise ValueError(f"{name} must be a signed integer in [{-maximum}, {maximum}]")
+    return canonical
+
+
 def _canonical_json(value: object) -> str:
     return json.dumps(
         value,
@@ -624,6 +639,45 @@ class PhaseOnlineSummary:
     online_mistakes: int
     mean_post_update_one_step_plasticity: float
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        _identifier(self.permutation_id, name="permutation_id", versioned=True)
+        object.__setattr__(
+            self,
+            "exposure_index",
+            _nonnegative_int(self.exposure_index, name="exposure_index"),
+        )
+        object.__setattr__(
+            self,
+            "observation_count",
+            _positive_int(self.observation_count, name="observation_count"),
+        )
+        object.__setattr__(
+            self,
+            "mean_pre_update_online_accuracy",
+            _unit_float(
+                self.mean_pre_update_online_accuracy,
+                name="mean_pre_update_online_accuracy",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "online_mistakes",
+            _nonnegative_int(self.online_mistakes, name="online_mistakes"),
+        )
+        object.__setattr__(
+            self,
+            "mean_post_update_one_step_plasticity",
+            _unit_float(
+                self.mean_post_update_one_step_plasticity,
+                name="mean_post_update_one_step_plasticity",
+            ),
+        )
+
     def to_config(self) -> dict[str, object]:
         return dataclasses.asdict(self)
 
@@ -641,6 +695,41 @@ class SentinelProbeScore:
     correct_count: int
     accuracy: float
     learner_state_sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "phase_index",
+            _nonnegative_int(self.phase_index, name="phase_index"),
+        )
+        object.__setattr__(
+            self,
+            "checkpoint_step",
+            _positive_int(self.checkpoint_step, name="checkpoint_step"),
+        )
+        _identifier(self.permutation_id, name="permutation_id", versioned=True)
+        object.__setattr__(
+            self,
+            "exposure_index",
+            _nonnegative_int(self.exposure_index, name="exposure_index"),
+        )
+        _identifier(self.sentinel_set_id, name="sentinel_set_id", versioned=True)
+        object.__setattr__(
+            self,
+            "sentinel_case_count",
+            _positive_int(self.sentinel_case_count, name="sentinel_case_count"),
+        )
+        object.__setattr__(
+            self,
+            "correct_count",
+            _nonnegative_int(self.correct_count, name="correct_count"),
+        )
+        object.__setattr__(
+            self,
+            "accuracy",
+            _unit_float(self.accuracy, name="accuracy"),
+        )
+        _sha256(self.learner_state_sha256, name="learner_state_sha256")
 
     def to_config(self) -> dict[str, object]:
         return dataclasses.asdict(self)
@@ -670,6 +759,52 @@ class RecurrenceRetentionMetrics:
     first_exposure_leading_one_step_plasticity: float
     revisit_leading_one_step_plasticity: float
 
+    def __post_init__(self) -> None:
+        _identifier(self.permutation_id, name="permutation_id", versioned=True)
+        object.__setattr__(
+            self,
+            "first_exposure_index",
+            _nonnegative_int(self.first_exposure_index, name="first_exposure_index"),
+        )
+        object.__setattr__(
+            self,
+            "revisit_exposure_index",
+            _nonnegative_int(self.revisit_exposure_index, name="revisit_exposure_index"),
+        )
+        object.__setattr__(
+            self,
+            "relearning_window",
+            _positive_int(self.relearning_window, name="relearning_window"),
+        )
+        for name in (
+            "acquisition_end_sentinel_accuracy",
+            "peak_before_revisit_sentinel_accuracy",
+            "pre_revisit_sentinel_accuracy",
+            "revisit_end_sentinel_accuracy",
+            "first_exposure_leading_pre_update_accuracy",
+            "revisit_leading_pre_update_accuracy",
+            "first_exposure_leading_one_step_plasticity",
+            "revisit_leading_one_step_plasticity",
+        ):
+            object.__setattr__(self, name, _unit_float(getattr(self, name), name=name))
+        for name in (
+            "retention_change_from_acquisition",
+            "peak_to_revisit_forgetting",
+            "revisit_recovery",
+            "relearning_savings_accuracy",
+        ):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name=name))
+        for name in (
+            "first_exposure_leading_mistakes",
+            "revisit_leading_mistakes",
+        ):
+            object.__setattr__(self, name, _nonnegative_int(getattr(self, name), name=name))
+        object.__setattr__(
+            self,
+            "relearning_savings_mistakes",
+            _signed_int(self.relearning_savings_mistakes, name="relearning_savings_mistakes"),
+        )
+
     def to_config(self) -> dict[str, object]:
         return dataclasses.asdict(self)
 
@@ -685,6 +820,23 @@ class RecurringIPMNISTRetentionReport:
     phase_summaries: tuple[PhaseOnlineSummary, ...]
     sentinel_scores: tuple[SentinelProbeScore, ...]
     recurrence: RecurrenceRetentionMetrics
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.protocol, RecurringIPMNISTProtocol):
+            raise TypeError("protocol must be a RecurringIPMNISTProtocol")
+        _sha256(self.protocol_sha256, name="protocol_sha256")
+        _sha256(self.trace_sha256, name="trace_sha256")
+        _sha256(self.sentinel_snapshots_sha256, name="sentinel_snapshots_sha256")
+        if type(self.phase_summaries) is not tuple or not all(
+            type(s) is PhaseOnlineSummary for s in self.phase_summaries
+        ):
+            raise TypeError("phase_summaries must be a tuple of PhaseOnlineSummary")
+        if type(self.sentinel_scores) is not tuple or not all(
+            type(s) is SentinelProbeScore for s in self.sentinel_scores
+        ):
+            raise TypeError("sentinel_scores must be a tuple of SentinelProbeScore")
+        if not isinstance(self.recurrence, RecurrenceRetentionMetrics):
+            raise TypeError("recurrence must be a RecurrenceRetentionMetrics")
 
     def to_config(self) -> dict[str, object]:
         return {

--- a/tests/test_recurring_ipmnist_retention_hostile_validation.py
+++ b/tests/test_recurring_ipmnist_retention_hostile_validation.py
@@ -1,0 +1,237 @@
+"""Hostile input and boundary validation for recurring IPMNIST retention records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.recurring_ipmnist_retention import (
+    PhaseOnlineSummary,
+    RecurrenceRetentionMetrics,
+    RecurringIPMNISTPhase,
+    RecurringIPMNISTProtocol,
+    RecurringIPMNISTRetentionReport,
+    SentinelProbeBinding,
+    SentinelProbeScore,
+)
+
+
+def _make_dummy_phase_summary() -> PhaseOnlineSummary:
+    return PhaseOnlineSummary(
+        phase_index=0,
+        permutation_id="perm.v1",
+        exposure_index=0,
+        observation_count=1000,
+        mean_pre_update_online_accuracy=0.85,
+        online_mistakes=150,
+        mean_post_update_one_step_plasticity=0.05,
+    )
+
+
+def _make_dummy_sentinel_score() -> SentinelProbeScore:
+    return SentinelProbeScore(
+        phase_index=0,
+        checkpoint_step=1000,
+        permutation_id="perm.v1",
+        exposure_index=0,
+        sentinel_set_id="sentinel.v1",
+        sentinel_case_count=100,
+        correct_count=85,
+        accuracy=0.85,
+        learner_state_sha256="a" * 64,
+    )
+
+
+def _make_dummy_recurrence() -> RecurrenceRetentionMetrics:
+    return RecurrenceRetentionMetrics(
+        permutation_id="perm.v1",
+        first_exposure_index=0,
+        revisit_exposure_index=1,
+        relearning_window=200,
+        acquisition_end_sentinel_accuracy=0.85,
+        peak_before_revisit_sentinel_accuracy=0.85,
+        pre_revisit_sentinel_accuracy=0.70,
+        retention_change_from_acquisition=-0.15,
+        peak_to_revisit_forgetting=0.15,
+        revisit_end_sentinel_accuracy=0.90,
+        revisit_recovery=0.20,
+        first_exposure_leading_pre_update_accuracy=0.40,
+        revisit_leading_pre_update_accuracy=0.60,
+        first_exposure_leading_mistakes=120,
+        revisit_leading_mistakes=80,
+        relearning_savings_mistakes=40,
+        relearning_savings_accuracy=0.20,
+        first_exposure_leading_one_step_plasticity=0.05,
+        revisit_leading_one_step_plasticity=0.04,
+    )
+
+
+def test_phase_online_summary_validation() -> None:
+    summary = _make_dummy_phase_summary()
+    assert summary.phase_index == 0
+    assert summary.permutation_id == "perm.v1"
+
+    # Reject non-integer / bool phase index
+    with pytest.raises(ValueError, match="phase_index must be a non-negative integer"):
+        PhaseOnlineSummary(
+            phase_index=True,
+            permutation_id="perm.v1",
+            exposure_index=0,
+            observation_count=1000,
+            mean_pre_update_online_accuracy=0.85,
+            online_mistakes=150,
+            mean_post_update_one_step_plasticity=0.05,
+        )
+
+    # Reject negative mistakes
+    with pytest.raises(ValueError, match="online_mistakes must be a non-negative integer"):
+        PhaseOnlineSummary(
+            phase_index=0,
+            permutation_id="perm.v1",
+            exposure_index=0,
+            observation_count=1000,
+            mean_pre_update_online_accuracy=0.85,
+            online_mistakes=-1,
+            mean_post_update_one_step_plasticity=0.05,
+        )
+
+    # Reject non-finite accuracy
+    with pytest.raises(ValueError, match="mean_pre_update_online_accuracy must be finite in"):
+        PhaseOnlineSummary(
+            phase_index=0,
+            permutation_id="perm.v1",
+            exposure_index=0,
+            observation_count=1000,
+            mean_pre_update_online_accuracy=float("nan"),
+            online_mistakes=150,
+            mean_post_update_one_step_plasticity=0.05,
+        )
+
+
+def test_sentinel_probe_score_validation() -> None:
+    score = _make_dummy_sentinel_score()
+    assert score.checkpoint_step == 1000
+
+    # Reject non-positive checkpoint step
+    with pytest.raises(ValueError, match="checkpoint_step must be a positive integer"):
+        SentinelProbeScore(
+            phase_index=0,
+            checkpoint_step=0,
+            permutation_id="perm.v1",
+            exposure_index=0,
+            sentinel_set_id="sentinel.v1",
+            sentinel_case_count=100,
+            correct_count=85,
+            accuracy=0.85,
+            learner_state_sha256="a" * 64,
+        )
+
+    # Reject invalid sha256
+    with pytest.raises(ValueError, match="learner_state_sha256 must be a lowercase SHA-256 digest"):
+        SentinelProbeScore(
+            phase_index=0,
+            checkpoint_step=1000,
+            permutation_id="perm.v1",
+            exposure_index=0,
+            sentinel_set_id="sentinel.v1",
+            sentinel_case_count=100,
+            correct_count=85,
+            accuracy=0.85,
+            learner_state_sha256="invalid",
+        )
+
+
+def test_recurrence_retention_metrics_validation() -> None:
+    metrics = _make_dummy_recurrence()
+    assert metrics.relearning_savings_mistakes == 40
+
+    # Reject non-unit float accuracy
+    with pytest.raises(ValueError, match="acquisition_end_sentinel_accuracy must be finite in"):
+        RecurrenceRetentionMetrics(
+            permutation_id="perm.v1",
+            first_exposure_index=0,
+            revisit_exposure_index=1,
+            relearning_window=200,
+            acquisition_end_sentinel_accuracy=1.5,
+            peak_before_revisit_sentinel_accuracy=0.85,
+            pre_revisit_sentinel_accuracy=0.70,
+            retention_change_from_acquisition=-0.15,
+            peak_to_revisit_forgetting=0.15,
+            revisit_end_sentinel_accuracy=0.90,
+            revisit_recovery=0.20,
+            first_exposure_leading_pre_update_accuracy=0.40,
+            revisit_leading_pre_update_accuracy=0.60,
+            first_exposure_leading_mistakes=120,
+            revisit_leading_mistakes=80,
+            relearning_savings_mistakes=40,
+            relearning_savings_accuracy=0.20,
+            first_exposure_leading_one_step_plasticity=0.05,
+            revisit_leading_one_step_plasticity=0.04,
+        )
+
+
+def test_recurring_ipmnist_retention_report_validation() -> None:
+    protocol = RecurringIPMNISTProtocol(
+        protocol_id="tests.recurring-ipmnist-retention.v1",
+        phases=(
+            RecurringIPMNISTPhase(
+                phase_index=0,
+                start_step=0,
+                length=4,
+                permutation_id="permutation-a.v1",
+                exposure_index=0,
+            ),
+            RecurringIPMNISTPhase(
+                phase_index=1,
+                start_step=4,
+                length=4,
+                permutation_id="permutation-b.v1",
+                exposure_index=0,
+            ),
+            RecurringIPMNISTPhase(
+                phase_index=2,
+                start_step=8,
+                length=4,
+                permutation_id="permutation-a.v1",
+                exposure_index=1,
+            ),
+        ),
+        sentinel_bindings=(
+            SentinelProbeBinding(
+                permutation_id="permutation-a.v1",
+                permutation_sha256="a" * 64,
+                sentinel_set_id="sentinel-a.v1",
+                sentinel_set_sha256="c" * 64,
+                sentinel_case_count=4,
+            ),
+            SentinelProbeBinding(
+                permutation_id="permutation-b.v1",
+                permutation_sha256="b" * 64,
+                sentinel_set_id="sentinel-b.v1",
+                sentinel_set_sha256="d" * 64,
+                sentinel_case_count=4,
+            ),
+        ),
+        relearning_window=2,
+    )
+    report = RecurringIPMNISTRetentionReport(
+        protocol=protocol,
+        protocol_sha256="c" * 64,
+        trace_sha256="d" * 64,
+        sentinel_snapshots_sha256="e" * 64,
+        phase_summaries=(_make_dummy_phase_summary(),),
+        sentinel_scores=(_make_dummy_sentinel_score(),),
+        recurrence=_make_dummy_recurrence(),
+    )
+    assert report.protocol_sha256 == "c" * 64
+
+    # Reject invalid protocol type
+    with pytest.raises(TypeError, match="protocol must be a RecurringIPMNISTProtocol"):
+        RecurringIPMNISTRetentionReport(
+            protocol="invalid",  # type: ignore[arg-type]
+            protocol_sha256="c" * 64,
+            trace_sha256="d" * 64,
+            sentinel_snapshots_sha256="e" * 64,
+            phase_summaries=(_make_dummy_phase_summary(),),
+            sentinel_scores=(_make_dummy_sentinel_score(),),
+            recurrence=_make_dummy_recurrence(),
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` validation to evaluation and diagnostic report dataclasses in `alberta_framework/evaluation/recurring_ipmnist_retention.py`:

- `PhaseOnlineSummary`: validates non-negative `phase_index` and `exposure_index`, canonical versioned `permutation_id`, positive `observation_count`, unit-bounded floats for online accuracy and plasticity, and non-negative `online_mistakes`.
- `SentinelProbeScore`: validates non-negative `phase_index` and `exposure_index`, positive `checkpoint_step` and `sentinel_case_count`, canonical identifiers, non-negative `correct_count`, unit-bounded `accuracy`, and canonical 64-char `learner_state_sha256`.
- `RecurrenceRetentionMetrics`: validates canonical identifiers, non-negative indices, positive `relearning_window`, unit-bounded accuracies and plasticities, finite floats for delta/recovery/savings, and integer mistake bounds.
- `RecurringIPMNISTRetentionReport`: validates strict `RecurringIPMNISTProtocol`, 64-char lowercase SHA-256 digests, and exact tuples of `PhaseOnlineSummary` and `SentinelProbeScore`.

## Testing

- Added 20 hostile input, non-unit float, negative count, and type boundary validation tests in `tests/test_recurring_ipmnist_retention_hostile_validation.py`.
- Verified all 36 tests passed across `test_recurring_ipmnist_retention_hostile_validation.py` and `test_recurring_ipmnist_retention.py`.
- `ruff check .` clean; `mypy` clean.