### PR TITLE
fix(evaluation): add fail-closed validation and policy guards to artifact validation dataclasses

### DIFF
--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -74,6 +74,14 @@ class IAArtifactValidation:
     accepted: bool
     errors: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+
 
 def _finite_float(value: float) -> float | None:
     numeric = float(value)

--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -109,6 +109,14 @@ class ArtifactValidation:
     accepted: bool
     errors: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+
 
 def _finite_float(value: float) -> float | None:
     """Encode non-finite evidence as JSON ``null`` rather than non-standard NaN."""

--- a/alberta_framework/evaluation/ftl_decision_artifact.py
+++ b/alberta_framework/evaluation/ftl_decision_artifact.py
@@ -158,6 +158,14 @@ class ArtifactValidation:
     accepted: bool
     errors: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+
 
 def _finite_float(value: float) -> float | None:
     numeric = float(value)

--- a/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
@@ -226,6 +226,22 @@ class UPGDIPMNISTValidation:
     development_only: bool = True
     scientific_promotion_allowed: bool = False
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+        if type(self.partial_sha256) is not tuple:
+            raise ValueError("partial_sha256 must be a tuple")
+        if self.artifact_sha256 is not None and type(self.artifact_sha256) is not str:
+            raise ValueError("artifact_sha256 must be a string or None")
+        if type(self.observed_seed_pairs) is not tuple:
+            raise ValueError("observed_seed_pairs must be a tuple")
+        if self.development_only is not True:
+            raise ValueError("development_only must permanently remain True")
+        if self.scientific_promotion_allowed is not False:
+            raise ValueError("scientific_promotion_allowed must permanently remain False")
+
 
 @dataclass(frozen=True)
 class _Shard:

--- a/tests/test_artifact_validation_records_hostile_validation.py
+++ b/tests/test_artifact_validation_records_hostile_validation.py
@@ -1,0 +1,80 @@
+"""Hostile input, leftover identity, and policy validation for artifact validation records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import IAArtifactValidation
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    ArtifactValidation as MultiAgentArtifactValidation,
+)
+from alberta_framework.evaluation.ftl_decision_artifact import (
+    ArtifactValidation as FTLArtifactValidation,
+)
+from alberta_framework.evaluation.upgd_ipmnist_nonpromoting import UPGDIPMNISTValidation
+
+
+def test_upgd_ipmnist_validation_valid_construction() -> None:
+    val = UPGDIPMNISTValidation(
+        valid=True,
+        errors=(),
+        partial_sha256=(("sha", "val"),),
+        artifact_sha256="a" * 64,
+        observed_seed_pairs=(("learner", 42),),
+    )
+    assert val.valid is True
+    assert val.development_only is True
+    assert val.scientific_promotion_allowed is False
+
+
+def test_upgd_ipmnist_validation_rejects_promotion_bypass() -> None:
+    with pytest.raises(
+        ValueError, match="scientific_promotion_allowed must permanently remain False"
+    ):
+        UPGDIPMNISTValidation(
+            valid=True,
+            errors=(),
+            scientific_promotion_allowed=True,
+        )
+
+    with pytest.raises(ValueError, match="development_only must permanently remain True"):
+        UPGDIPMNISTValidation(
+            valid=True,
+            errors=(),
+            development_only=False,
+        )
+
+
+def test_upgd_ipmnist_validation_rejects_invalid_types() -> None:
+    with pytest.raises(ValueError, match="valid must be a boolean"):
+        UPGDIPMNISTValidation(valid=1, errors=())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="errors must be a tuple of strings"):
+        UPGDIPMNISTValidation(valid=True, errors=["err"])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="artifact_sha256 must be a string or None"):
+        UPGDIPMNISTValidation(valid=True, errors=(), artifact_sha256=123)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        FTLArtifactValidation,
+        MultiAgentArtifactValidation,
+        IAArtifactValidation,
+    ],
+)
+def test_artifact_validation_classes_construction_and_validation(cls: type) -> None:
+    inst = cls(valid=True, accepted=True, errors=())
+    assert inst.valid is True
+    assert inst.accepted is True
+    assert inst.errors == ()
+
+    with pytest.raises(ValueError, match="valid must be a boolean"):
+        cls(valid=1, accepted=True, errors=())
+
+    with pytest.raises(ValueError, match="accepted must be a boolean"):
+        cls(valid=True, accepted=1, errors=())
+
+    with pytest.raises(ValueError, match="errors must be a tuple of strings"):
+        cls(valid=True, accepted=True, errors=["error"])


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation and policy immutability guards to artifact validation dataclasses across evaluation modules:

- `UPGDIPMNISTValidation` (`alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py`): enforces boolean types, tuple error structures, and permanent policy guards (`development_only` must be `True`, `scientific_promotion_allowed` must be `False`).
- `ArtifactValidation` (`alberta_framework/evaluation/ftl_decision_artifact.py`): enforces boolean `valid` and `accepted` values and tuple string errors.
- `ArtifactValidation` (`alberta_framework/evaluation/continual_multiagent_artifact.py`): enforces boolean `valid` and `accepted` values and tuple string errors.
- `IAArtifactValidation` (`alberta_framework/evaluation/continual_ia_artifact.py`): enforces boolean `valid` and `accepted` values and tuple string errors.

## Testing

- Added hostile input, type coercion, and policy bypass tests in `tests/test_artifact_validation_records_hostile_validation.py`.
- Verified 58 tests passed across `test_artifact_validation_records_hostile_validation.py`, `test_upgd_ipmnist_nonpromoting.py`, `test_ftl_decision_artifact.py`, and `test_evidence_manifest.py`.
- `ruff check .` clean; `mypy` clean.