### PR TITLE
fix(evaluation): add fail-closed post_init validation to feature artifacts and historical evidence chain records

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -387,6 +387,16 @@ class _HistoricalIAChainValidation:
     artifacts: tuple[dict[str, object], ...]
     record: dict[str, object]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+        if type(self.artifacts) is not tuple:
+            raise ValueError("artifacts must be a tuple")
+        if type(self.record) is not dict:
+            raise ValueError("record must be a dict")
+
 
 @dataclass(frozen=True)
 class _HistoricalFTLChainValidation:
@@ -397,6 +407,18 @@ class _HistoricalFTLChainValidation:
     errors: tuple[str, ...]
     artifacts: tuple[dict[str, object], ...]
     record: dict[str, object]
+
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+        if type(self.artifacts) is not tuple:
+            raise ValueError("artifacts must be a tuple")
+        if type(self.record) is not dict:
+            raise ValueError("record must be a dict")
 
 
 def _required_mapping(

--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -100,6 +100,14 @@ class ArtifactValidation:
     accepted: bool
     errors: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+
 
 def _finite_float(value: float) -> float | None:
     numeric = float(value)

--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -195,6 +195,14 @@ class ArtifactValidation:
     accepted: bool
     errors: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.valid) is not bool:
+            raise ValueError("valid must be a boolean")
+        if type(self.accepted) is not bool:
+            raise ValueError("accepted must be a boolean")
+        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+            raise ValueError("errors must be a tuple of strings")
+
 
 def _threshold_payload() -> dict[str, object]:
     return {

--- a/tests/test_feature_artifact_and_evidence_chain_hostile_validation.py
+++ b/tests/test_feature_artifact_and_evidence_chain_hostile_validation.py
@@ -1,0 +1,122 @@
+"""Hostile input and type validation for feature artifact and historical chain records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import (
+    _HistoricalFTLChainValidation,
+    _HistoricalIAChainValidation,
+)
+from alberta_framework.evaluation.recurring_feature_artifact import (
+    ArtifactValidation as RecurringArtifactValidation,
+)
+from alberta_framework.evaluation.scale_robust_feature_artifact import (
+    ArtifactValidation as ScaleRobustArtifactValidation,
+)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        RecurringArtifactValidation,
+        ScaleRobustArtifactValidation,
+    ],
+)
+def test_feature_artifact_validation_construction_and_guards(cls: type) -> None:
+    inst = cls(valid=True, accepted=True, errors=())
+    assert inst.valid is True
+    assert inst.accepted is True
+    assert inst.errors == ()
+
+    with pytest.raises(ValueError, match="valid must be a boolean"):
+        cls(valid=1, accepted=True, errors=())
+
+    with pytest.raises(ValueError, match="accepted must be a boolean"):
+        cls(valid=True, accepted=1, errors=())
+
+    with pytest.raises(ValueError, match="errors must be a tuple of strings"):
+        cls(valid=True, accepted=True, errors=["error"])
+
+
+def test_historical_ia_chain_validation() -> None:
+    inst = _HistoricalIAChainValidation(
+        valid=True,
+        errors=(),
+        artifacts=({"key": "val"},),
+        record={"rec": 1},
+    )
+    assert inst.valid is True
+    assert inst.errors == ()
+
+    with pytest.raises(ValueError, match="valid must be a boolean"):
+        _HistoricalIAChainValidation(
+            valid=1,  # type: ignore[arg-type]
+            errors=(),
+            artifacts=(),
+            record={},
+        )
+
+    with pytest.raises(ValueError, match="errors must be a tuple of strings"):
+        _HistoricalIAChainValidation(
+            valid=True,
+            errors=["error"],  # type: ignore[arg-type]
+            artifacts=(),
+            record={},
+        )
+
+    with pytest.raises(ValueError, match="artifacts must be a tuple"):
+        _HistoricalIAChainValidation(
+            valid=True,
+            errors=(),
+            artifacts=[{"key": "val"}],  # type: ignore[arg-type]
+            record={},
+        )
+
+    with pytest.raises(ValueError, match="record must be a dict"):
+        _HistoricalIAChainValidation(
+            valid=True,
+            errors=(),
+            artifacts=(),
+            record=(),  # type: ignore[arg-type]
+        )
+
+
+def test_historical_ftl_chain_validation() -> None:
+    inst = _HistoricalFTLChainValidation(
+        valid=True,
+        accepted=True,
+        errors=(),
+        artifacts=({"key": "val"},),
+        record={"rec": 1},
+    )
+    assert inst.valid is True
+    assert inst.accepted is True
+    assert inst.errors == ()
+
+    with pytest.raises(ValueError, match="valid must be a boolean"):
+        _HistoricalFTLChainValidation(
+            valid=1,  # type: ignore[arg-type]
+            accepted=True,
+            errors=(),
+            artifacts=(),
+            record={},
+        )
+
+    with pytest.raises(ValueError, match="accepted must be a boolean"):
+        _HistoricalFTLChainValidation(
+            valid=True,
+            accepted="yes",  # type: ignore[arg-type]
+            errors=(),
+            artifacts=(),
+            record={},
+        )
+
+    with pytest.raises(ValueError, match="artifacts must be a tuple"):
+        _HistoricalFTLChainValidation(
+            valid=True,
+            accepted=True,
+            errors=(),
+            artifacts=[{"key": "val"}],  # type: ignore[arg-type]
+            record={},
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across remaining feature evaluation artifact and historical evidence chain dataclasses:

- `ArtifactValidation` (`alberta_framework/evaluation/recurring_feature_artifact.py`): validates boolean `valid` and `accepted` values and tuple string errors.
- `ArtifactValidation` (`alberta_framework/evaluation/scale_robust_feature_artifact.py`): validates boolean `valid` and `accepted` values and tuple string errors.
- `_HistoricalIAChainValidation` (`alberta_framework/evaluation/evidence_manifest.py`): validates boolean `valid`, tuple string errors, tuple artifacts, and dict record.
- `_HistoricalFTLChainValidation` (`alberta_framework/evaluation/evidence_manifest.py`): validates boolean `valid` and `accepted`, tuple string errors, tuple artifacts, and dict record.

## Testing

- Added hostile input, type coercion, and container integrity tests in `tests/test_feature_artifact_and_evidence_chain_hostile_validation.py`.
- Verified all tests passed across `test_feature_artifact_and_evidence_chain_hostile_validation.py`, `test_recurring_feature_artifact.py`, `test_historical_ia_evidence_chain.py`, `test_historical_ftl_evidence_chain.py`, and `test_evidence_manifest.py`.
- `ruff check .` clean; `mypy` clean.