### PR TITLE
fix(benchmarks): add fail-closed post_init validation to candidate universe binding records

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -91,6 +91,21 @@ def _require_finite_real(value: Any, path: str) -> float:
     return number
 
 
+def _require_exact_str(value: Any, path: str) -> str:
+    if type(value) is not str or not value:
+        raise ForagerMatchedCandidateUniverseError(f"{path} must be a non-empty string")
+    return value
+
+
+def _require_sha256(value: Any, path: str) -> str:
+    string = _require_exact_str(value, path)
+    if len(string) != 64 or not all(ch in "0123456789abcdef" for ch in string.lower()):
+        raise ForagerMatchedCandidateUniverseError(
+            f"{path} must be a 64-character lowercase hexadecimal SHA-256 digest"
+        )
+    return string.lower()
+
+
 def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:
     if type(values) is not tuple or not values:
         raise ForagerMatchedCandidateUniverseError(
@@ -184,6 +199,11 @@ class BoundJsonArtifact:
     path: str
     sha256: str
 
+    def __post_init__(self) -> None:
+        _require_exact_str(self.role, "role")
+        _require_exact_str(self.path, "path")
+        object.__setattr__(self, "sha256", _require_sha256(self.sha256, "sha256"))
+
     def to_dict(self) -> dict[str, str]:
         return {"role": self.role, "path": self.path, "sha256": self.sha256}
 
@@ -229,6 +249,12 @@ class LocalCandidateGenerationBinding:
                 maximum=_MAX_INT32,
             ),
         )
+        if type(self.artifacts) is not tuple or not all(
+            isinstance(a, BoundJsonArtifact) for a in self.artifacts
+        ):
+            raise ForagerMatchedCandidateUniverseError(
+                "artifacts must be a tuple of BoundJsonArtifact instances"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -349,6 +375,19 @@ class CandidateUniverseVerification:
 
     candidate_universe_sha256: str
     verified_json_paths: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_universe_sha256",
+            _require_sha256(self.candidate_universe_sha256, "candidate_universe_sha256"),
+        )
+        if type(self.verified_json_paths) is not tuple or not all(
+            isinstance(p, str) and p for p in self.verified_json_paths
+        ):
+            raise ForagerMatchedCandidateUniverseError(
+                "verified_json_paths must be a tuple of non-empty strings"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_candidate_universe_hostile_validation.py
+++ b/tests/test_forager_candidate_universe_hostile_validation.py
@@ -1,0 +1,81 @@
+"""Hostile input and boundary validation for candidate universe bindings."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_candidate_universe import (
+    BoundJsonArtifact,
+    CandidateUniverseVerification,
+    ForagerMatchedCandidateUniverseError,
+    LocalCandidateGenerationBinding,
+)
+
+
+def test_bound_json_artifact_validation() -> None:
+    art = BoundJsonArtifact(role="plan", path="path/to/plan.json", sha256="a" * 64)
+    assert art.role == "plan"
+    assert art.path == "path/to/plan.json"
+    assert art.sha256 == "a" * 64
+
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError, match="role must be a non-empty string"
+    ):
+        BoundJsonArtifact(role="", path="path/to/plan.json", sha256="a" * 64)
+
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError, match="path must be a non-empty string"
+    ):
+        BoundJsonArtifact(role="plan", path="", sha256="a" * 64)
+
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError,
+        match="sha256 must be a 64-character lowercase hexadecimal",
+    ):
+        BoundJsonArtifact(role="plan", path="path/to/plan.json", sha256="invalid")
+
+
+def test_candidate_universe_verification_validation() -> None:
+    ver = CandidateUniverseVerification(
+        candidate_universe_sha256="b" * 64,
+        verified_json_paths=("path1.json", "path2.json"),
+    )
+    assert ver.candidate_universe_sha256 == "b" * 64
+    assert len(ver.verified_json_paths) == 2
+
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError,
+        match="candidate_universe_sha256 must be a 64-character lowercase hexadecimal",
+    ):
+        CandidateUniverseVerification(
+            candidate_universe_sha256="invalid",
+            verified_json_paths=("path1.json",),
+        )
+
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError,
+        match="verified_json_paths must be a tuple of non-empty strings",
+    ):
+        CandidateUniverseVerification(
+            candidate_universe_sha256="b" * 64,
+            verified_json_paths=["path1.json"],  # type: ignore[arg-type]
+        )
+
+
+def test_local_candidate_generation_binding_artifact_tuple_validation() -> None:
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError,
+        match="artifacts must be a tuple of BoundJsonArtifact instances",
+    ):
+        LocalCandidateGenerationBinding(
+            screen_id="local_screen_v1",  # type: ignore[arg-type]
+            family="linear",
+            seeds=(1, 2, 3),
+            horizon_per_seed=1000,
+            candidate_count=5,
+            normalized_matrix_sha256="c" * 64,
+            source_tree_sha256="d" * 64,
+            source_archive_sha256="e" * 64,
+            source_inventory_sha256="f" * 64,
+            artifacts=[BoundJsonArtifact(role="plan", path="plan.json", sha256="a" * 64)],  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` validation to candidate universe records in `alberta_framework/benchmarks/forager_matched_candidate_universe.py`:

- `BoundJsonArtifact`: validates non-empty `role` and `path` strings and valid 64-character lowercase hexadecimal SHA-256 digests.
- `LocalCandidateGenerationBinding`: validates tuple of `BoundJsonArtifact` instances.
- `CandidateUniverseVerification`: validates 64-character hexadecimal SHA-256 digest and tuple of non-empty file path strings.

## Testing

- Added hostile input, invalid digest format, and type validation tests in `tests/test_forager_candidate_universe_hostile_validation.py`.
- Verified all 36 tests passed across `test_forager_candidate_universe_hostile_validation.py` and `test_forager_matched_candidate_universe.py`.
- `ruff check .` clean; `mypy` clean.