### PR TITLE
fix(benchmarks): add fail-closed post_init validation to Forager matched protocol dataclasses

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -272,6 +272,10 @@ class EnvironmentRNGContract:
     identity: str
     schedule_sha256: str
 
+    def __post_init__(self) -> None:
+        _require_identifier(self.identity, "environment_rng.identity")
+        _require_sha256(self.schedule_sha256, "environment_rng.schedule_sha256")
+
     def to_dict(self) -> dict[str, Any]:
         return {"identity": self.identity, "schedule_sha256": self.schedule_sha256}
 
@@ -284,6 +288,7 @@ class AgentRNGContract:
     environment_key_shared: bool
 
     def __post_init__(self) -> None:
+        _require_identifier(self.identity, "agent_rng.identity")
         object.__setattr__(
             self,
             "environment_key_shared",
@@ -503,6 +508,7 @@ class SelectionSlot:
     rank: int
 
     def __post_init__(self) -> None:
+        _require_identifier(self.selection_group, "selection_slot.selection_group")
         object.__setattr__(
             self,
             "rank",
@@ -747,6 +753,15 @@ class ResolvedSelectionSlot:
     rank: int
     candidate_id: str
 
+    def __post_init__(self) -> None:
+        _require_identifier(self.selection_group, "resolved_slot.selection_group")
+        object.__setattr__(
+            self,
+            "rank",
+            _require_int(self.rank, "resolved_slot.rank", minimum=1, maximum=_MAX_CANDIDATES),
+        )
+        _require_identifier(self.candidate_id, "resolved_slot.candidate_id")
+
     @property
     def slot(self) -> SelectionSlot:
         return SelectionSlot(self.selection_group, self.rank)
@@ -784,6 +799,18 @@ class RankedSelectionGroup:
     selection_group: str
     ranked_candidate_ids: tuple[str, ...]
     ranking_evidence_sha256: str
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.selection_group, "ranked_selection_group.selection_group")
+        if type(self.ranked_candidate_ids) is not tuple or not all(
+            isinstance(cid, str) and cid for cid in self.ranked_candidate_ids
+        ):
+            raise ForagerMatchedProtocolError(
+                "ranked_candidate_ids must be a tuple of candidate IDs"
+            )
+        _require_sha256(
+            self.ranking_evidence_sha256, "ranked_selection_group.ranking_evidence_sha256"
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -882,6 +909,18 @@ class DescriptiveContext:
     analysis_role: Literal["descriptive_only"]
     selection_eligible: Literal[False]
     pairing_eligible: Literal[False]
+
+    def __post_init__(self) -> None:
+        if type(self.candidate_ids) is not tuple or not all(
+            isinstance(cid, str) and cid for cid in self.candidate_ids
+        ):
+            raise ForagerMatchedProtocolError("candidate_ids must be a tuple of candidate IDs")
+        if self.analysis_role != "descriptive_only":
+            raise ForagerMatchedProtocolError("analysis_role must be 'descriptive_only'")
+        if self.selection_eligible is not False:
+            raise ForagerMatchedProtocolError("selection_eligible must be False")
+        if self.pairing_eligible is not False:
+            raise ForagerMatchedProtocolError("pairing_eligible must be False")
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -1,0 +1,124 @@
+"""Hostile input, leftover identity, and type validation for protocol records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_protocol import (
+    AgentRNGContract,
+    DescriptiveContext,
+    EnvironmentRNGContract,
+    ForagerMatchedProtocolError,
+    RankedSelectionGroup,
+    ResolvedSelectionSlot,
+    SelectionSlot,
+)
+
+
+def test_environment_rng_contract_validation() -> None:
+    contract = EnvironmentRNGContract(
+        identity="env_rng.v1",
+        schedule_sha256="a" * 64,
+    )
+    assert contract.identity == "env_rng.v1"
+    assert contract.schedule_sha256 == "a" * 64
+
+    with pytest.raises(
+        ForagerMatchedProtocolError, match="must be a non-empty string of at most 128 characters"
+    ):
+        EnvironmentRNGContract(
+            identity="",
+            schedule_sha256="a" * 64,
+        )
+
+    with pytest.raises(
+        ForagerMatchedProtocolError,
+        match="must be a lowercase 64-character SHA-256 digest",
+    ):
+        EnvironmentRNGContract(
+            identity="env_rng.v1",
+            schedule_sha256="invalid",
+        )
+
+
+def test_agent_rng_contract_validation() -> None:
+    contract = AgentRNGContract(identity="agent_rng.v1", environment_key_shared=False)
+    assert contract.identity == "agent_rng.v1"
+    assert contract.environment_key_shared is False
+
+    with pytest.raises(
+        ForagerMatchedProtocolError, match="must be a non-empty string of at most 128 characters"
+    ):
+        AgentRNGContract(identity="", environment_key_shared=False)
+
+    with pytest.raises(ForagerMatchedProtocolError, match="must be a boolean"):
+        AgentRNGContract(identity="agent_rng.v1", environment_key_shared=1)  # type: ignore[arg-type]
+
+
+def test_selection_slot_validation() -> None:
+    slot = SelectionSlot(selection_group="group_a", rank=1)
+    assert slot.selection_group == "group_a"
+    assert slot.rank == 1
+
+    with pytest.raises(
+        ForagerMatchedProtocolError, match="must be a non-empty string of at most 128 characters"
+    ):
+        SelectionSlot(selection_group="", rank=1)
+
+    with pytest.raises(ForagerMatchedProtocolError, match="must lie in"):
+        SelectionSlot(selection_group="group_a", rank=0)
+
+
+def test_resolved_selection_slot_validation() -> None:
+    slot = ResolvedSelectionSlot(selection_group="group_a", rank=1, candidate_id="cand_1")
+    assert slot.selection_group == "group_a"
+    assert slot.rank == 1
+    assert slot.candidate_id == "cand_1"
+
+    with pytest.raises(
+        ForagerMatchedProtocolError, match="must be a non-empty string of at most 128 characters"
+    ):
+        ResolvedSelectionSlot(selection_group="group_a", rank=1, candidate_id="")
+
+
+def test_ranked_selection_group_validation() -> None:
+    group = RankedSelectionGroup(
+        selection_group="group_a",
+        ranked_candidate_ids=("cand_1", "cand_2"),
+        ranking_evidence_sha256="b" * 64,
+    )
+    assert group.selection_group == "group_a"
+    assert len(group.ranked_candidate_ids) == 2
+
+    with pytest.raises(ForagerMatchedProtocolError, match="must be a tuple of candidate IDs"):
+        RankedSelectionGroup(
+            selection_group="group_a",
+            ranked_candidate_ids=["cand_1"],  # type: ignore[arg-type]
+            ranking_evidence_sha256="b" * 64,
+        )
+
+
+def test_descriptive_context_validation() -> None:
+    ctx = DescriptiveContext(
+        candidate_ids=("cand_1",),
+        analysis_role="descriptive_only",
+        selection_eligible=False,
+        pairing_eligible=False,
+    )
+    assert ctx.analysis_role == "descriptive_only"
+
+    with pytest.raises(ForagerMatchedProtocolError, match="selection_eligible must be False"):
+        DescriptiveContext(
+            candidate_ids=("cand_1",),
+            analysis_role="descriptive_only",
+            selection_eligible=True,  # type: ignore[arg-type]
+            pairing_eligible=False,
+        )
+
+    with pytest.raises(ForagerMatchedProtocolError, match="pairing_eligible must be False"):
+        DescriptiveContext(
+            candidate_ids=("cand_1",),
+            analysis_role="descriptive_only",
+            selection_eligible=False,
+            pairing_eligible=True,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` validation across protocol contract dataclasses in `alberta_framework/benchmarks/forager_matched_protocol.py`:

- `EnvironmentRNGContract`: validates safe `identity` string and 64-character lowercase hexadecimal `schedule_sha256`.
- `AgentRNGContract`: validates safe `identity` string.
- `SelectionSlot`: validates safe `selection_group` identifier.
- `ResolvedSelectionSlot`: validates safe `selection_group`, bounded `rank`, and safe `candidate_id`.
- `RankedSelectionGroup`: validates safe `selection_group`, tuple of candidate IDs, and 64-character hexadecimal `ranking_evidence_sha256`.
- `DescriptiveContext`: validates tuple of candidate IDs and immutable policy invariants (`analysis_role == "descriptive_only"`, `selection_eligible is False`, `pairing_eligible is False`).

## Testing

- Added hostile input, invalid policy identity, and type validation tests in `tests/test_forager_matched_protocol_hostile_validation.py`.
- Verified all 74 tests passed across `test_forager_matched_protocol_hostile_validation.py` and `test_forager_matched_protocol.py`.
- `ruff check .` clean; `mypy` clean.