### PR TITLE
fix(benchmarks): add fail-closed post_init validation to Forager RNG parity trace records

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -291,6 +291,23 @@ class TransitionDigest:
     info: TreeDigest
     state: TreeDigest
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "index",
+            _require_int(self.index, "transition.index", minimum=0, maximum=MAX_ACTIONS),
+        )
+        object.__setattr__(
+            self,
+            "action",
+            _require_int(self.action, "transition.action", minimum=0, maximum=3),
+        )
+        if not isinstance(self.keys, KeyFrame):
+            raise ForagerRngParityError("keys must be a KeyFrame")
+        for name in ("observation", "reward", "done", "info", "state"):
+            if not isinstance(getattr(self, name), TreeDigest):
+                raise ForagerRngParityError(f"{name} must be a TreeDigest")
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "index": self.index,
@@ -315,6 +332,34 @@ class EnvironmentTraceDigest:
     reset_state: TreeDigest
     transitions: tuple[TransitionDigest, ...]
     trace_sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "seed",
+            _require_int(self.seed, "trace.seed", minimum=0, maximum=MAX_SEED),
+        )
+        object.__setattr__(
+            self,
+            "action_sequence_sha256",
+            _require_sha256(self.action_sequence_sha256, "trace.action_sequence_sha256"),
+        )
+        if not isinstance(self.reset_keys, KeyFrame):
+            raise ForagerRngParityError("reset_keys must be a KeyFrame")
+        if not isinstance(self.reset_observation, TreeDigest):
+            raise ForagerRngParityError("reset_observation must be a TreeDigest")
+        if not isinstance(self.reset_state, TreeDigest):
+            raise ForagerRngParityError("reset_state must be a TreeDigest")
+        if type(self.transitions) is not tuple or not all(
+            isinstance(t, TransitionDigest) for t in self.transitions
+        ):
+            raise ForagerRngParityError("transitions must be a tuple of TransitionDigest")
+        if self.trace_sha256:
+            object.__setattr__(
+                self,
+                "trace_sha256",
+                _require_sha256(self.trace_sha256, "trace.trace_sha256"),
+            )
 
     def unsigned_dict(self) -> dict[str, Any]:
         return {
@@ -408,6 +453,30 @@ class ParityProbeResult:
     direct_trace_sha256: str
     payload_sha256: str
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.runtime, VerifiedRuntimeIdentity):
+            raise ForagerRngParityError("runtime must be a VerifiedRuntimeIdentity")
+        if not isinstance(self.config, FixedActionProbeConfig):
+            raise ForagerRngParityError("config must be a FixedActionProbeConfig")
+        if not isinstance(self.matched_trace, EnvironmentTraceDigest):
+            raise ForagerRngParityError("matched_trace must be an EnvironmentTraceDigest")
+        object.__setattr__(
+            self,
+            "wrapper_trace_sha256",
+            _require_sha256(self.wrapper_trace_sha256, "wrapper_trace_sha256"),
+        )
+        object.__setattr__(
+            self,
+            "direct_trace_sha256",
+            _require_sha256(self.direct_trace_sha256, "direct_trace_sha256"),
+        )
+        if self.payload_sha256:
+            object.__setattr__(
+                self,
+                "payload_sha256",
+                _require_sha256(self.payload_sha256, "payload_sha256"),
+            )
+
     def unsigned_dict(self) -> dict[str, Any]:
         return {
             "schema_version": PARITY_RESULT_SCHEMA_VERSION,
@@ -445,6 +514,22 @@ class ParityCollectorResult:
     config: FixedActionProbeConfig
     trace: EnvironmentTraceDigest
     payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.collector not in ("wrapper", "direct"):
+            raise ForagerRngParityError("collector must be 'wrapper' or 'direct'")
+        if not isinstance(self.runtime, VerifiedRuntimeIdentity):
+            raise ForagerRngParityError("runtime must be a VerifiedRuntimeIdentity")
+        if not isinstance(self.config, FixedActionProbeConfig):
+            raise ForagerRngParityError("config must be a FixedActionProbeConfig")
+        if not isinstance(self.trace, EnvironmentTraceDigest):
+            raise ForagerRngParityError("trace must be an EnvironmentTraceDigest")
+        if self.payload_sha256:
+            object.__setattr__(
+                self,
+                "payload_sha256",
+                _require_sha256(self.payload_sha256, "payload_sha256"),
+            )
 
     def unsigned_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_rng_parity_hostile_validation.py
+++ b/tests/test_forager_rng_parity_hostile_validation.py
@@ -1,0 +1,105 @@
+"""Hostile input and boundary validation for Forager RNG parity records."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_rng_parity import (
+    EnvironmentTraceDigest,
+    ForagerRngParityError,
+    KeyFrame,
+    TransitionDigest,
+    TreeDigest,
+)
+
+
+def _make_key_frame() -> KeyFrame:
+    return KeyFrame(
+        input_key=(1, 2),
+        next_key=(3, 4),
+        environment_key=(5, 6),
+    )
+
+
+def _make_tree_digest() -> TreeDigest:
+    return TreeDigest(
+        leaf_count=10,
+        structure_sha256="a" * 64,
+        content_sha256="b" * 64,
+    )
+
+
+def _make_transition_digest() -> TransitionDigest:
+    td = _make_tree_digest()
+    return TransitionDigest(
+        index=0,
+        action=1,
+        keys=_make_key_frame(),
+        observation=td,
+        reward=td,
+        done=td,
+        info=td,
+        state=td,
+    )
+
+
+def _make_trace_digest() -> EnvironmentTraceDigest:
+    td = _make_tree_digest()
+    return EnvironmentTraceDigest(
+        seed=42,
+        action_sequence_sha256="c" * 64,
+        reset_keys=_make_key_frame(),
+        reset_observation=td,
+        reset_state=td,
+        transitions=(_make_transition_digest(),),
+        trace_sha256="d" * 64,
+    )
+
+
+def test_transition_digest_validation() -> None:
+    trans = _make_transition_digest()
+    assert trans.index == 0
+    assert trans.action == 1
+
+    with pytest.raises(ForagerRngParityError, match="transition.action must lie in"):
+        TransitionDigest(
+            index=0,
+            action=4,
+            keys=_make_key_frame(),
+            observation=_make_tree_digest(),
+            reward=_make_tree_digest(),
+            done=_make_tree_digest(),
+            info=_make_tree_digest(),
+            state=_make_tree_digest(),
+        )
+
+    with pytest.raises(ForagerRngParityError, match="keys must be a KeyFrame"):
+        TransitionDigest(
+            index=0,
+            action=1,
+            keys={"invalid": "key"},  # type: ignore[arg-type]
+            observation=_make_tree_digest(),
+            reward=_make_tree_digest(),
+            done=_make_tree_digest(),
+            info=_make_tree_digest(),
+            state=_make_tree_digest(),
+        )
+
+
+def test_environment_trace_digest_validation() -> None:
+    trace = _make_trace_digest()
+    assert trace.seed == 42
+
+    with pytest.raises(
+        ForagerRngParityError, match="transitions must be a tuple of TransitionDigest"
+    ):
+        td = _make_tree_digest()
+        EnvironmentTraceDigest(
+            seed=42,
+            action_sequence_sha256="c" * 64,
+            reset_keys=_make_key_frame(),
+            reset_observation=td,
+            reset_state=td,
+            transitions=[_make_transition_digest()],  # type: ignore[arg-type]
+            trace_sha256="d" * 64,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across Forager RNG parity trace records in `alberta_framework/benchmarks/forager_rng_parity.py`:

- `TransitionDigest`: validates bounded integer `index` and `action` in `[0, 3]`, strict `KeyFrame` keys, and `TreeDigest` instances across all observation/reward/done/info/state fields.
- `EnvironmentTraceDigest`: validates non-negative `seed`, valid `action_sequence_sha256`, strict `KeyFrame` reset keys, `TreeDigest` reset components, and tuple of `TransitionDigest`.
- `ParityProbeResult`: validates strict types for `runtime`, `config`, and `matched_trace`, as well as 64-character hex digests.
- `ParityCollectorResult`: validates collector kind (`"wrapper"`, `"direct"`), strict runtime, config, and trace types.

## Testing

- Added hostile input, invalid action boundary, and type validation tests in `tests/test_forager_rng_parity_hostile_validation.py`.
- Verified all 43 tests passed across `test_forager_rng_parity_hostile_validation.py` and `test_forager_rng_parity.py`.
- `ruff check .` clean; `mypy` clean.