### PR TITLE
fix(benchmarks): add fail-closed post_init validation to official Foragax verified evidence and run records

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -540,6 +540,23 @@ class VerifiedOfficialForagaxEvidence:
     endorsement_descriptor_sha256: str
     endorsement_sha256: str
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_path, Path):
+            raise OfficialForagaxValidationError("manifest_path must be a Path")
+        _require_sha256(self.manifest_sha256, label="manifest_sha256")
+        if self.manifest_kind not in ("official_foragax_single", "official_foragax_batch"):
+            raise OfficialForagaxValidationError(
+                "manifest_kind must be 'official_foragax_single' or 'official_foragax_batch'"
+            )
+        _require_string(self.trust_descriptor_id, label="trust_descriptor_id")
+        _require_sha256(self.trust_descriptor_sha256, label="trust_descriptor_sha256")
+        _require_string(self.profile_id, label="profile_id")
+        _require_sha256(self.profile_sha256, label="profile_sha256")
+        _require_sha256(self.artifact_identities_sha256, label="artifact_identities_sha256")
+        _require_string(self.endorsement_descriptor_id, label="endorsement_descriptor_id")
+        _require_sha256(self.endorsement_descriptor_sha256, label="endorsement_descriptor_sha256")
+        _require_sha256(self.endorsement_sha256, label="endorsement_sha256")
+
 
 @dataclass(frozen=True)
 class VerifiedOfficialForagaxManifest:
@@ -549,6 +566,20 @@ class VerifiedOfficialForagaxManifest:
     artifact_path: Path
     manifest: Mapping[str, Any]
     evidence: VerifiedOfficialForagaxEvidence | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_path, Path):
+            raise OfficialForagaxValidationError("manifest_path must be a Path")
+        if not isinstance(self.artifact_path, Path):
+            raise OfficialForagaxValidationError("artifact_path must be a Path")
+        if not isinstance(self.manifest, Mapping):
+            raise OfficialForagaxValidationError("manifest must be a Mapping")
+        if self.evidence is not None and not isinstance(
+            self.evidence, VerifiedOfficialForagaxEvidence
+        ):
+            raise OfficialForagaxValidationError(
+                "evidence must be a VerifiedOfficialForagaxEvidence or None"
+            )
 
 
 @dataclass(frozen=True)
@@ -560,6 +591,15 @@ class OfficialForagaxRun:
     manifest: Mapping[str, Any]
     resumed: bool
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_path, Path):
+            raise OfficialForagaxValidationError("manifest_path must be a Path")
+        if not isinstance(self.artifact_path, Path):
+            raise OfficialForagaxValidationError("artifact_path must be a Path")
+        if not isinstance(self.manifest, Mapping):
+            raise OfficialForagaxValidationError("manifest must be a Mapping")
+        _require_bool(self.resumed, label="resumed")
+
 
 @dataclass(frozen=True)
 class VerifiedOfficialForagaxBatchManifest:
@@ -570,6 +610,24 @@ class VerifiedOfficialForagaxBatchManifest:
     manifest: Mapping[str, Any]
     evidence: VerifiedOfficialForagaxEvidence | None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_path, Path):
+            raise OfficialForagaxValidationError("manifest_path must be a Path")
+        if type(self.artifact_paths) is not tuple or not all(
+            isinstance(p, Path) for p in self.artifact_paths
+        ):
+            raise OfficialForagaxValidationError(
+                "artifact_paths must be a tuple of Path instances"
+            )
+        if not isinstance(self.manifest, Mapping):
+            raise OfficialForagaxValidationError("manifest must be a Mapping")
+        if self.evidence is not None and not isinstance(
+            self.evidence, VerifiedOfficialForagaxEvidence
+        ):
+            raise OfficialForagaxValidationError(
+                "evidence must be a VerifiedOfficialForagaxEvidence or None"
+            )
+
 
 @dataclass(frozen=True)
 class OfficialForagaxBatchRun:
@@ -579,6 +637,19 @@ class OfficialForagaxBatchRun:
     artifact_paths: tuple[Path, ...]
     manifest: Mapping[str, Any]
     resumed: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest_path, Path):
+            raise OfficialForagaxValidationError("manifest_path must be a Path")
+        if type(self.artifact_paths) is not tuple or not all(
+            isinstance(p, Path) for p in self.artifact_paths
+        ):
+            raise OfficialForagaxValidationError(
+                "artifact_paths must be a tuple of Path instances"
+            )
+        if not isinstance(self.manifest, Mapping):
+            raise OfficialForagaxValidationError("manifest must be a Mapping")
+        _require_bool(self.resumed, label="resumed")
 
 
 def _absolute_without_resolving_symlinks(path: Path) -> Path:

--- a/tests/test_official_foragax_verified_records_hostile_validation.py
+++ b/tests/test_official_foragax_verified_records_hostile_validation.py
@@ -1,0 +1,103 @@
+"""Hostile input and boundary validation for official Foragax verification records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.official_foragax import (
+    OfficialForagaxBatchRun,
+    OfficialForagaxRun,
+    OfficialForagaxValidationError,
+    VerifiedOfficialForagaxEvidence,
+)
+
+
+def _make_evidence() -> VerifiedOfficialForagaxEvidence:
+    return VerifiedOfficialForagaxEvidence(
+        manifest_path=Path("output/manifest.json"),
+        manifest_sha256="a" * 64,
+        manifest_kind="official_foragax_single",
+        trust_descriptor_id="trust.v1",
+        trust_descriptor_sha256="b" * 64,
+        profile_id="profile.v1",
+        profile_sha256="c" * 64,
+        artifact_identities_sha256="d" * 64,
+        endorsement_descriptor_id="endorsement.v1",
+        endorsement_descriptor_sha256="e" * 64,
+        endorsement_sha256="f" * 64,
+    )
+
+
+def test_verified_official_foragax_evidence_validation() -> None:
+    ev = _make_evidence()
+    assert ev.manifest_kind == "official_foragax_single"
+
+    with pytest.raises(OfficialForagaxValidationError, match="manifest_path must be a Path"):
+        VerifiedOfficialForagaxEvidence(
+            manifest_path="output/manifest.json",  # type: ignore[arg-type]
+            manifest_sha256="a" * 64,
+            manifest_kind="official_foragax_single",
+            trust_descriptor_id="trust.v1",
+            trust_descriptor_sha256="b" * 64,
+            profile_id="profile.v1",
+            profile_sha256="c" * 64,
+            artifact_identities_sha256="d" * 64,
+            endorsement_descriptor_id="endorsement.v1",
+            endorsement_descriptor_sha256="e" * 64,
+            endorsement_sha256="f" * 64,
+        )
+
+    with pytest.raises(OfficialForagaxValidationError, match="manifest_kind must be"):
+        VerifiedOfficialForagaxEvidence(
+            manifest_path=Path("output/manifest.json"),
+            manifest_sha256="a" * 64,
+            manifest_kind="invalid_kind",  # type: ignore[arg-type]
+            trust_descriptor_id="trust.v1",
+            trust_descriptor_sha256="b" * 64,
+            profile_id="profile.v1",
+            profile_sha256="c" * 64,
+            artifact_identities_sha256="d" * 64,
+            endorsement_descriptor_id="endorsement.v1",
+            endorsement_descriptor_sha256="e" * 64,
+            endorsement_sha256="f" * 64,
+        )
+
+
+def test_official_foragax_run_validation() -> None:
+    run = OfficialForagaxRun(
+        manifest_path=Path("manifest.json"),
+        artifact_path=Path("artifact.json"),
+        manifest={"key": "val"},
+        resumed=False,
+    )
+    assert run.resumed is False
+
+    with pytest.raises(OfficialForagaxValidationError, match="resumed must be an exact boolean"):
+        OfficialForagaxRun(
+            manifest_path=Path("manifest.json"),
+            artifact_path=Path("artifact.json"),
+            manifest={"key": "val"},
+            resumed=0,  # type: ignore[arg-type]
+        )
+
+
+def test_official_foragax_batch_run_validation() -> None:
+    batch = OfficialForagaxBatchRun(
+        manifest_path=Path("manifest.json"),
+        artifact_paths=(Path("artifact_0.json"), Path("artifact_1.json")),
+        manifest={"key": "val"},
+        resumed=True,
+    )
+    assert batch.resumed is True
+
+    with pytest.raises(
+        OfficialForagaxValidationError, match="artifact_paths must be a tuple of Path instances"
+    ):
+        OfficialForagaxBatchRun(
+            manifest_path=Path("manifest.json"),
+            artifact_paths=[Path("artifact_0.json")],  # type: ignore[arg-type]
+            manifest={"key": "val"},
+            resumed=True,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` validation across verified official Foragax evidence and run records in `alberta_framework/benchmarks/official_foragax.py`:

- `VerifiedOfficialForagaxEvidence`: validates `manifest_path` as a `Path`, valid `manifest_kind` (`"official_foragax_single"`, `"official_foragax_batch"`), non-empty descriptor/profile IDs, and 64-character lowercase hexadecimal SHA-256 digests.
- `VerifiedOfficialForagaxManifest`: validates `manifest_path` and `artifact_path` as `Path`, `manifest` as `Mapping`, and optional `VerifiedOfficialForagaxEvidence`.
- `OfficialForagaxRun`: validates `manifest_path` and `artifact_path` as `Path`, `manifest` as `Mapping`, and strict boolean `resumed`.
- `VerifiedOfficialForagaxBatchManifest`: validates tuple of `Path` instances and strict mapping/evidence types.
- `OfficialForagaxBatchRun`: validates tuple of `Path` instances, strict mapping, and strict boolean `resumed`.

## Testing

- Added hostile input, invalid kind, and type validation tests in `tests/test_official_foragax_verified_records_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.