### PR TITLE
fix(benchmarks): add fail-closed post_init validation to Forager matched seal bundle

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -106,6 +106,33 @@ class ContentVerifiedSealBundle:
     sealed_transition: Mapping[str, Any]
     sealed_transition_sha256: str
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.output_root, Path):
+            raise ForagerMatchedSealError("output_root must be a Path")
+        if not isinstance(self.manifest, Mapping):
+            raise ForagerMatchedSealError("manifest must be a Mapping")
+        if not isinstance(self.open_protocol, protocol.ForagerMatchedProtocol):
+            raise ForagerMatchedSealError("open_protocol must be a ForagerMatchedProtocol")
+        if not isinstance(self.open_score_evidence, evidence.MatchedScoreEvidence):
+            raise ForagerMatchedSealError("open_score_evidence must be a MatchedScoreEvidence")
+        if not isinstance(self.open_verification_request, executor.VerificationRequest):
+            raise ForagerMatchedSealError(
+                "open_verification_request must be a VerificationRequest"
+            )
+        if not isinstance(self.recorded_bindings_cache, Mapping):
+            raise ForagerMatchedSealError("recorded_bindings_cache must be a Mapping")
+        if not isinstance(self.selection_result, protocol.ForagerMatchedSelectionResult):
+            raise ForagerMatchedSealError(
+                "selection_result must be a ForagerMatchedSelectionResult"
+            )
+        if not isinstance(self.selection_report, Mapping):
+            raise ForagerMatchedSealError("selection_report must be a Mapping")
+        if not isinstance(self.sealed_protocol, protocol.ForagerMatchedProtocol):
+            raise ForagerMatchedSealError("sealed_protocol must be a ForagerMatchedProtocol")
+        if not isinstance(self.sealed_transition, Mapping):
+            raise ForagerMatchedSealError("sealed_transition must be a Mapping")
+        _require_sha256(self.sealed_transition_sha256, "sealed_transition_sha256")
+
 
 @dataclass(frozen=True, slots=True)
 class _OpenDirectory:
@@ -114,6 +141,14 @@ class _OpenDirectory:
     path: Path
     descriptor: int
     inode_identity: tuple[int, int, int]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path):
+            raise ForagerMatchedSealError("path must be a Path")
+        if type(self.descriptor) is not int or self.descriptor < 0:
+            raise ForagerMatchedSealError("descriptor must be a non-negative int")
+        if type(self.inode_identity) is not tuple or len(self.inode_identity) != 3:
+            raise ForagerMatchedSealError("inode_identity must be a 3-element tuple")
 
 
 def _plain(value: Any) -> Any:

--- a/tests/test_forager_matched_seal_hostile_validation.py
+++ b/tests/test_forager_matched_seal_hostile_validation.py
@@ -1,0 +1,64 @@
+"""Hostile input and boundary validation for Forager matched seal bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_seal import (
+    ContentVerifiedSealBundle,
+    ForagerMatchedSealError,
+)
+
+
+def test_content_verified_seal_bundle_rejects_invalid_root() -> None:
+    with pytest.raises(ForagerMatchedSealError, match="output_root must be a Path"):
+        ContentVerifiedSealBundle(
+            output_root="invalid/path",  # type: ignore[arg-type]
+            manifest={},
+            open_protocol=None,  # type: ignore[arg-type]
+            open_score_evidence=None,  # type: ignore[arg-type]
+            open_verification_request=None,  # type: ignore[arg-type]
+            recorded_bindings_cache={},
+            selection_result=None,  # type: ignore[arg-type]
+            selection_report={},
+            sealed_protocol=None,  # type: ignore[arg-type]
+            sealed_transition={},
+            sealed_transition_sha256="a" * 64,
+        )
+
+
+def test_content_verified_seal_bundle_rejects_invalid_protocol() -> None:
+    with pytest.raises(
+        ForagerMatchedSealError, match="open_protocol must be a ForagerMatchedProtocol"
+    ):
+        ContentVerifiedSealBundle(
+            output_root=Path("output/seal"),
+            manifest={},
+            open_protocol=None,  # type: ignore[arg-type]
+            open_score_evidence=None,  # type: ignore[arg-type]
+            open_verification_request=None,  # type: ignore[arg-type]
+            recorded_bindings_cache={},
+            selection_result=None,  # type: ignore[arg-type]
+            selection_report={},
+            sealed_protocol=None,  # type: ignore[arg-type]
+            sealed_transition={},
+            sealed_transition_sha256="a" * 64,
+        )
+
+
+def test_open_directory_validation() -> None:
+    from alberta_framework.benchmarks.forager_matched_seal import _OpenDirectory
+
+    d = _OpenDirectory(path=Path("/tmp"), descriptor=3, inode_identity=(1, 2, 3))
+    assert d.descriptor == 3
+
+    with pytest.raises(ForagerMatchedSealError, match="path must be a Path"):
+        _OpenDirectory(path="/tmp", descriptor=3, inode_identity=(1, 2, 3))  # type: ignore[arg-type]
+
+    with pytest.raises(ForagerMatchedSealError, match="descriptor must be a non-negative int"):
+        _OpenDirectory(path=Path("/tmp"), descriptor=-1, inode_identity=(1, 2, 3))
+
+    with pytest.raises(ForagerMatchedSealError, match="inode_identity must be a 3-element tuple"):
+        _OpenDirectory(path=Path("/tmp"), descriptor=3, inode_identity=(1, 2))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across Forager matched seal bundle dataclasses in `alberta_framework/benchmarks/forager_matched_seal.py`:

- `ContentVerifiedSealBundle`: validates `output_root` as a `Path`, mappings for `manifest`, `recorded_bindings_cache`, `selection_report`, and `sealed_transition`, strict protocol and score evidence types, and 64-character lowercase hexadecimal `sealed_transition_sha256`.
- `_OpenDirectory`: validates `path` as a `Path`, non-negative integer `descriptor`, and 3-element tuple `inode_identity`.

## Testing

- Added hostile input, invalid path, and protocol type validation tests in `tests/test_forager_matched_seal_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.