### PR TITLE
fix(benchmarks): add fail-closed post_init validation to CampaignStatus and CompletedCampaignBundle

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -114,6 +114,51 @@ class CampaignStatus:
     score_evidence_sha256: str | None
     verification_subject_sha256: str | None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.output_root, Path):
+            raise ForagerMatchedCampaignError("output_root must be a Path")
+        if type(self.state) is not str or not self.state:
+            raise ForagerMatchedCampaignError("state must be a non-empty string")
+        if type(self.completed_cells) is not int or self.completed_cells < 0:
+            raise ForagerMatchedCampaignError("completed_cells must be a non-negative int")
+        if type(self.total_cells) is not int or self.total_cells < 0:
+            raise ForagerMatchedCampaignError("total_cells must be a non-negative int")
+        if self.completed_cells > self.total_cells:
+            raise ForagerMatchedCampaignError("completed_cells cannot exceed total_cells")
+        if self.next_candidate_id is not None and (
+            type(self.next_candidate_id) is not str or not self.next_candidate_id
+        ):
+            raise ForagerMatchedCampaignError(
+                "next_candidate_id must be a non-empty string or None"
+            )
+        if self.next_seed is not None and (
+            type(self.next_seed) is not int or self.next_seed < 0
+        ):
+            raise ForagerMatchedCampaignError("next_seed must be a non-negative int or None")
+        for name in (
+            "protocol_sha256",
+            "qualification_manifest_sha256",
+            "plan_sha256",
+            "live_runtime_identity_sha256",
+        ):
+            val = getattr(self, name)
+            if type(val) is not str or _SHA256_RE.fullmatch(val) is None:
+                raise ForagerMatchedCampaignError(
+                    f"{name} must be a 64-character lowercase SHA-256"
+                )
+        if self.score_evidence_sha256 is not None and (
+            type(self.score_evidence_sha256) is not str
+            or _SHA256_RE.fullmatch(self.score_evidence_sha256) is None
+        ):
+            raise ForagerMatchedCampaignError("score_evidence_sha256 must be a SHA-256 or None")
+        if self.verification_subject_sha256 is not None and (
+            type(self.verification_subject_sha256) is not str
+            or _SHA256_RE.fullmatch(self.verification_subject_sha256) is None
+        ):
+            raise ForagerMatchedCampaignError(
+                "verification_subject_sha256 must be a SHA-256 or None"
+            )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": "alberta.forager_matched_campaign_status.v2",
@@ -159,6 +204,48 @@ class CompletedCampaignBundle:
     verification_request: executor.VerificationRequest
     completion_summary: Mapping[str, Any]
     final_file_sha256: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.output_root, Path):
+            raise ForagerMatchedCampaignError("output_root must be a Path")
+        if not isinstance(self.protocol, ForagerMatchedProtocol):
+            raise ForagerMatchedCampaignError("protocol must be a ForagerMatchedProtocol")
+        if not isinstance(self.plan, executor.MatchedExecutionPlan):
+            raise ForagerMatchedCampaignError("plan must be a MatchedExecutionPlan")
+        if not isinstance(self.live_runtime, executor.LiveRuntimeIdentity):
+            raise ForagerMatchedCampaignError("live_runtime must be a LiveRuntimeIdentity")
+        if type(self.candidate_ids) is not tuple or not all(
+            isinstance(cid, str) and cid for cid in self.candidate_ids
+        ):
+            raise ForagerMatchedCampaignError(
+                "candidate_ids must be a tuple of non-empty strings"
+            )
+        if type(self.active_seeds) is not tuple or not all(
+            isinstance(s, int) and s >= 0 for s in self.active_seeds
+        ):
+            raise ForagerMatchedCampaignError(
+                "active_seeds must be a tuple of non-negative ints"
+            )
+        if not isinstance(self.schedule, Mapping):
+            raise ForagerMatchedCampaignError("schedule must be a Mapping")
+        if not isinstance(self.seed_artifacts, Mapping):
+            raise ForagerMatchedCampaignError("seed_artifacts must be a Mapping")
+        if not isinstance(
+            self.execution_receipt_index, executor.MatchedExecutionReceiptIndex
+        ):
+            raise ForagerMatchedCampaignError(
+                "execution_receipt_index must be a MatchedExecutionReceiptIndex"
+            )
+        if not isinstance(self.score_evidence, MatchedScoreEvidence):
+            raise ForagerMatchedCampaignError("score_evidence must be a MatchedScoreEvidence")
+        if not isinstance(self.verification_request, executor.VerificationRequest):
+            raise ForagerMatchedCampaignError(
+                "verification_request must be a VerificationRequest"
+            )
+        if not isinstance(self.completion_summary, Mapping):
+            raise ForagerMatchedCampaignError("completion_summary must be a Mapping")
+        if not isinstance(self.final_file_sha256, Mapping):
+            raise ForagerMatchedCampaignError("final_file_sha256 must be a Mapping")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_forager_matched_campaign_hostile_validation.py
+++ b/tests/test_forager_matched_campaign_hostile_validation.py
@@ -1,0 +1,104 @@
+"""Hostile input and boundary validation for Forager matched campaign records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_campaign import (
+    CampaignStatus,
+    CompletedCampaignBundle,
+    ForagerMatchedCampaignError,
+)
+
+
+def test_campaign_status_valid_construction() -> None:
+    status = CampaignStatus(
+        output_root=Path("campaign/output"),
+        state="running",
+        completed_cells=5,
+        total_cells=10,
+        next_candidate_id="cand_1",
+        next_seed=12345,
+        protocol_sha256="a" * 64,
+        qualification_manifest_sha256="b" * 64,
+        plan_sha256="c" * 64,
+        live_runtime_identity_sha256="d" * 64,
+        score_evidence_sha256="e" * 64,
+        verification_subject_sha256="f" * 64,
+    )
+    assert status.state == "running"
+    assert status.completed_cells == 5
+    assert status.total_cells == 10
+
+
+def test_campaign_status_rejects_invalid_inputs() -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match="output_root must be a Path"):
+        CampaignStatus(
+            output_root="campaign/output",  # type: ignore[arg-type]
+            state="running",
+            completed_cells=5,
+            total_cells=10,
+            next_candidate_id=None,
+            next_seed=None,
+            protocol_sha256="a" * 64,
+            qualification_manifest_sha256="b" * 64,
+            plan_sha256="c" * 64,
+            live_runtime_identity_sha256="d" * 64,
+            score_evidence_sha256=None,
+            verification_subject_sha256=None,
+        )
+
+    with pytest.raises(
+        ForagerMatchedCampaignError, match="completed_cells cannot exceed total_cells"
+    ):
+        CampaignStatus(
+            output_root=Path("campaign/output"),
+            state="running",
+            completed_cells=15,
+            total_cells=10,
+            next_candidate_id=None,
+            next_seed=None,
+            protocol_sha256="a" * 64,
+            qualification_manifest_sha256="b" * 64,
+            plan_sha256="c" * 64,
+            live_runtime_identity_sha256="d" * 64,
+            score_evidence_sha256=None,
+            verification_subject_sha256=None,
+        )
+
+    with pytest.raises(ForagerMatchedCampaignError, match="protocol_sha256 must be a 64-character"):
+        CampaignStatus(
+            output_root=Path("campaign/output"),
+            state="running",
+            completed_cells=5,
+            total_cells=10,
+            next_candidate_id=None,
+            next_seed=None,
+            protocol_sha256="invalid",
+            qualification_manifest_sha256="b" * 64,
+            plan_sha256="c" * 64,
+            live_runtime_identity_sha256="d" * 64,
+            score_evidence_sha256=None,
+            verification_subject_sha256=None,
+        )
+
+
+def test_completed_campaign_bundle_validation() -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match="output_root must be a Path"):
+        CompletedCampaignBundle(
+            output_root="invalid/path",  # type: ignore[arg-type]
+            protocol=None,  # type: ignore[arg-type]
+            plan=None,  # type: ignore[arg-type]
+            live_runtime=None,  # type: ignore[arg-type]
+            candidate_ids=("cand_1",),
+            active_seeds=(1, 2),
+            schedule={},
+            seed_artifacts={},
+            execution_receipt_index=None,  # type: ignore[arg-type]
+            score_evidence=None,  # type: ignore[arg-type]
+            verification_request=None,  # type: ignore[arg-type]
+            completion_summary={},
+            final_file_sha256={},
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across campaign tracking and bundle dataclasses in `alberta_framework/benchmarks/forager_matched_campaign.py`:

- `CampaignStatus`: validates `output_root` as a `Path`, non-empty `state`, non-negative cells with `completed_cells <= total_cells`, optional candidate ID / seed bounds, and 64-character lowercase SHA-256 digests.
- `CompletedCampaignBundle`: validates `output_root` as a `Path`, strict types for `protocol`, `plan`, `live_runtime`, `execution_receipt_index`, `score_evidence`, and `verification_request`, tuple of candidate strings and non-negative seeds, and strict mappings.

## Testing

- Added hostile input, invalid cell count, and type validation tests in `tests/test_forager_matched_campaign_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.