### PR TITLE
fix(benchmarks): add fail-closed post_init validation to PreparedCandidate and LiveRuntimeIdentity

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -245,6 +245,38 @@ class PreparedCandidate:
     capability_receipt_sha256: str
     source_inventory: Mapping[str, Any]
 
+    def __post_init__(self) -> None:
+        if type(self.candidate) is not MatchedCandidate:
+            raise ForagerMatchedExecutorError(
+                "candidate must be a MatchedCandidate"
+            )
+        for name, value in (
+            ("source_root", self.source_root),
+            ("source_archive", self.source_archive),
+            ("original_configuration", self.original_configuration),
+            ("configuration", self.configuration),
+        ):
+            if not isinstance(value, Path):
+                raise ForagerMatchedExecutorError(f"candidate {name} must be a Path")
+        _string(self.entrypoint_path, "entrypoint_path")
+        _string(self.python_import_root, "python_import_root")
+        _string(self.result_root, "result_root")
+        if self.invocation_style not in (
+            "official_foragax_continuing_main_v4",
+            "official_foragax_ppo_frozen_updates_v1",
+            "alberta_single_seed_v1",
+        ):
+            raise ForagerMatchedExecutorError(
+                "invocation_style must be 'module_entrypoint' or 'inline_command'"
+            )
+        if self.rng_isolation_patch_sha256 is not None:
+            _sha256(self.rng_isolation_patch_sha256, "rng_isolation_patch_sha256")
+        if not isinstance(self.capability_receipt, Mapping):
+            raise ForagerMatchedExecutorError("capability_receipt must be a mapping")
+        _sha256(self.capability_receipt_sha256, "capability_receipt_sha256")
+        if not isinstance(self.source_inventory, Mapping):
+            raise ForagerMatchedExecutorError("source_inventory must be a mapping")
+
 
 @dataclass(frozen=True, slots=True)
 class MatchedExecutionPlan:
@@ -658,6 +690,16 @@ class LiveRuntimeIdentity:
     version: Mapping[str, Any]
     image_inspection: Mapping[str, Any]
     executor_manifest_sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.executable, Path):
+            raise ForagerMatchedExecutorError("executable must be a Path")
+        _sha256(self.executable_sha256, "executable_sha256")
+        if not isinstance(self.version, Mapping):
+            raise ForagerMatchedExecutorError("version must be a mapping")
+        if not isinstance(self.image_inspection, Mapping):
+            raise ForagerMatchedExecutorError("image_inspection must be a mapping")
+        _sha256(self.executor_manifest_sha256, "executor_manifest_sha256")
 
     @property
     def unsigned_dict(self) -> dict[str, Any]:

--- a/tests/test_forager_matched_executor_hostile_validation.py
+++ b/tests/test_forager_matched_executor_hostile_validation.py
@@ -1,0 +1,61 @@
+"""Hostile input and boundary validation for Forager matched executor records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_executor import (
+    ForagerMatchedExecutorError,
+    LiveRuntimeIdentity,
+    PreparedCandidate,
+)
+
+
+def test_live_runtime_identity_validation() -> None:
+    ident = LiveRuntimeIdentity(
+        executable=Path("/usr/bin/podman"),
+        executable_sha256="a" * 64,
+        version={"major": 4},
+        image_inspection={"id": "image_id"},
+        executor_manifest_sha256="b" * 64,
+    )
+    assert ident.executable_sha256 == "a" * 64
+
+    with pytest.raises(ForagerMatchedExecutorError, match="executable must be a Path"):
+        LiveRuntimeIdentity(
+            executable="/usr/bin/podman",  # type: ignore[arg-type]
+            executable_sha256="a" * 64,
+            version={},
+            image_inspection={},
+            executor_manifest_sha256="b" * 64,
+        )
+
+    with pytest.raises(ForagerMatchedExecutorError, match="must be a lowercase SHA-256"):
+        LiveRuntimeIdentity(
+            executable=Path("/usr/bin/podman"),
+            executable_sha256="invalid",
+            version={},
+            image_inspection={},
+            executor_manifest_sha256="b" * 64,
+        )
+
+
+def test_prepared_candidate_validation() -> None:
+    with pytest.raises(ForagerMatchedExecutorError, match="candidate must be a MatchedCandidate"):
+        PreparedCandidate(
+            candidate=None,  # type: ignore[arg-type]
+            source_root=Path("/source"),
+            source_archive=Path("/source.tar"),
+            original_configuration=Path("/config.json"),
+            configuration=Path("/config_mod.json"),
+            entrypoint_path="main.py",
+            python_import_root=".",
+            invocation_style="alberta_single_seed_v1",
+            result_root="results",
+            rng_isolation_patch_sha256=None,
+            capability_receipt={},
+            capability_receipt_sha256="c" * 64,
+            source_inventory={},
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across candidate execution and live runtime dataclasses in `alberta_framework/benchmarks/forager_matched_executor.py`:

- `PreparedCandidate`: validates `candidate` as a `MatchedCandidate`, host path instances, bounded non-empty string path components, valid `invocation_style` literal, optional 64-character lowercase SHA-256 patch, and strict mappings for capability receipts and source inventories.
- `LiveRuntimeIdentity`: validates `executable` as a `Path`, 64-character lowercase SHA-256 digests, and strict mappings for `version` and `image_inspection`.

## Testing

- Added hostile input, invalid path type, and candidate type validation tests in `tests/test_forager_matched_executor_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.