### PR TITLE
fix(benchmarks): add fail-closed post_init validation to MatchedCurrentRuntimeQualification and MatchedCurrentCandidateQualification

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -236,6 +236,21 @@ class MatchedCurrentRuntimeQualification:
     executor_qualification_receipt_sha256: str
     qualification_trust_anchor_identity: str
 
+    def __post_init__(self) -> None:
+        _require_real_sha256(self.image_sha256, "runtime.image_sha256")
+        _require_real_sha256(self.runtime_profile_sha256, "runtime.runtime_profile_sha256")
+        _require_real_sha256(
+            self.executor_qualification_receipt_sha256,
+            "runtime.executor_qualification_receipt_sha256",
+        )
+        if (
+            type(self.qualification_trust_anchor_identity) is not str
+            or not self.qualification_trust_anchor_identity
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "runtime.qualification_trust_anchor_identity must be a non-empty string"
+            )
+
 
 @dataclass(frozen=True)
 class MatchedCurrentCandidateQualification:
@@ -246,6 +261,26 @@ class MatchedCurrentCandidateQualification:
     effective_seed_proof_sha256: str
     capability_qualification_receipt_sha256: str
     resources: ResourceAccounting
+
+    def __post_init__(self) -> None:
+        if type(self.source) is not SourceBinding:
+            raise ForagerMatchedOpenProtocolBuildError("candidate source must be a SourceBinding")
+        if type(self.configuration) is not ConfigurationBinding:
+            raise ForagerMatchedOpenProtocolBuildError(
+                "candidate configuration must be a ConfigurationBinding"
+            )
+        _require_real_sha256(
+            self.effective_seed_proof_sha256,
+            "candidate.effective_seed_proof_sha256",
+        )
+        _require_real_sha256(
+            self.capability_qualification_receipt_sha256,
+            "candidate.capability_qualification_receipt_sha256",
+        )
+        if type(self.resources) is not ResourceAccounting:
+            raise ForagerMatchedOpenProtocolBuildError(
+                "candidate resources must be a ResourceAccounting"
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -1,0 +1,72 @@
+"""Hostile input and boundary validation for open protocol qualifications."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_open_protocol import (
+    ForagerMatchedOpenProtocolBuildError,
+    MatchedCurrentCandidateQualification,
+    MatchedCurrentRuntimeQualification,
+)
+
+
+def _digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_runtime_qualification_valid_construction() -> None:
+    qual = MatchedCurrentRuntimeQualification(
+        image_sha256=_digest(b"image"),
+        runtime_profile_sha256=_digest(b"profile"),
+        executor_qualification_receipt_sha256=_digest(b"executor"),
+        qualification_trust_anchor_identity="anchor_id",
+    )
+    assert qual.qualification_trust_anchor_identity == "anchor_id"
+
+
+def test_runtime_qualification_rejects_invalid_inputs() -> None:
+    with pytest.raises(
+        ForagerMatchedOpenProtocolBuildError, match="must be a lowercase SHA-256"
+    ):
+        MatchedCurrentRuntimeQualification(
+            image_sha256="invalid",
+            runtime_profile_sha256=_digest(b"profile"),
+            executor_qualification_receipt_sha256=_digest(b"executor"),
+            qualification_trust_anchor_identity="anchor_id",
+        )
+
+    with pytest.raises(
+        ForagerMatchedOpenProtocolBuildError, match="is a placeholder, not a real content binding"
+    ):
+        MatchedCurrentRuntimeQualification(
+            image_sha256="a" * 64,
+            runtime_profile_sha256=_digest(b"profile"),
+            executor_qualification_receipt_sha256=_digest(b"executor"),
+            qualification_trust_anchor_identity="anchor_id",
+        )
+
+    with pytest.raises(
+        ForagerMatchedOpenProtocolBuildError, match="must be a non-empty string"
+    ):
+        MatchedCurrentRuntimeQualification(
+            image_sha256=_digest(b"image"),
+            runtime_profile_sha256=_digest(b"profile"),
+            executor_qualification_receipt_sha256=_digest(b"executor"),
+            qualification_trust_anchor_identity="",
+        )
+
+
+def test_candidate_qualification_rejects_invalid_types() -> None:
+    with pytest.raises(
+        ForagerMatchedOpenProtocolBuildError, match="candidate source must be a SourceBinding"
+    ):
+        MatchedCurrentCandidateQualification(
+            source=None,  # type: ignore[arg-type]
+            configuration=None,  # type: ignore[arg-type]
+            effective_seed_proof_sha256=_digest(b"seed_proof"),
+            capability_qualification_receipt_sha256=_digest(b"receipt"),
+            resources=None,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across qualification contract dataclasses in `alberta_framework/benchmarks/forager_matched_open_protocol.py`:

- `MatchedCurrentRuntimeQualification`: validates non-placeholder 64-character lowercase hexadecimal SHA-256 digests (`image_sha256`, `runtime_profile_sha256`, `executor_qualification_receipt_sha256`) and non-empty `qualification_trust_anchor_identity`.
- `MatchedCurrentCandidateQualification`: validates strict types for `source` (`SourceBinding`), `configuration` (`ConfigurationBinding`), `resources` (`ResourceAccounting`), and non-placeholder SHA-256 digests for effective seed proofs and capability receipts.

## Testing

- Added hostile input, invalid type, and placeholder digest rejection tests in `tests/test_forager_matched_open_protocol_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.