### PR TITLE
fix(benchmarks): add fail-closed post_init validation to ContentVerifiedFinalAnalysisBundle and FreshFinalAnalysisBindings

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_final_analysis.py
+++ b/alberta_framework/benchmarks/forager_matched_final_analysis.py
@@ -279,6 +279,50 @@ class ContentVerifiedFinalAnalysisBundle:
     contract: statistics.MatchedComparisonContract
     result: statistics.MatchedComparisonResult
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.output_root, Path):
+            raise ForagerMatchedFinalAnalysisError("output_root must be a Path")
+        if not isinstance(self.manifest, Mapping):
+            raise ForagerMatchedFinalAnalysisError("manifest must be a Mapping")
+        if not isinstance(self.seal_content, seal.ContentVerifiedSealBundle):
+            raise ForagerMatchedFinalAnalysisError(
+                "seal_content must be a ContentVerifiedSealBundle"
+            )
+        if not isinstance(self.evaluation_score_evidence, evidence.MatchedScoreEvidence):
+            raise ForagerMatchedFinalAnalysisError(
+                "evaluation_score_evidence must be a MatchedScoreEvidence"
+            )
+        if not isinstance(
+            self.evaluation_verification_request, executor.VerificationRequest
+        ):
+            raise ForagerMatchedFinalAnalysisError(
+                "evaluation_verification_request must be a VerificationRequest"
+            )
+        if not isinstance(
+            self.open_bindings_cache, evidence.AuthenticatedEvidenceBindings
+        ):
+            raise ForagerMatchedFinalAnalysisError(
+                "open_bindings_cache must be an AuthenticatedEvidenceBindings"
+            )
+        if not isinstance(
+            self.evaluation_bindings_cache, evidence.AuthenticatedEvidenceBindings
+        ):
+            raise ForagerMatchedFinalAnalysisError(
+                "evaluation_bindings_cache must be an AuthenticatedEvidenceBindings"
+            )
+        if not isinstance(self.analysis_runtime_source, Mapping):
+            raise ForagerMatchedFinalAnalysisError(
+                "analysis_runtime_source must be a Mapping"
+            )
+        if not isinstance(self.contract, statistics.MatchedComparisonContract):
+            raise ForagerMatchedFinalAnalysisError(
+                "contract must be a MatchedComparisonContract"
+            )
+        if not isinstance(self.result, statistics.MatchedComparisonResult):
+            raise ForagerMatchedFinalAnalysisError(
+                "result must be a MatchedComparisonResult"
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class FreshFinalAnalysisBindings:
@@ -286,6 +330,18 @@ class FreshFinalAnalysisBindings:
 
     open_bindings: evidence.AuthenticatedEvidenceBindings
     evaluation_bindings: evidence.AuthenticatedEvidenceBindings
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.open_bindings, evidence.AuthenticatedEvidenceBindings):
+            raise ForagerMatchedFinalAnalysisError(
+                "open_bindings must be an AuthenticatedEvidenceBindings"
+            )
+        if not isinstance(
+            self.evaluation_bindings, evidence.AuthenticatedEvidenceBindings
+        ):
+            raise ForagerMatchedFinalAnalysisError(
+                "evaluation_bindings must be an AuthenticatedEvidenceBindings"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_forager_matched_final_analysis_hostile_validation.py
+++ b/tests/test_forager_matched_final_analysis_hostile_validation.py
@@ -1,0 +1,38 @@
+"""Hostile input and boundary validation for Forager matched final analysis bundle."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_final_analysis import (
+    ContentVerifiedFinalAnalysisBundle,
+    ForagerMatchedFinalAnalysisError,
+    FreshFinalAnalysisBindings,
+)
+
+
+def test_final_analysis_bundle_rejects_invalid_root() -> None:
+    with pytest.raises(ForagerMatchedFinalAnalysisError, match="output_root must be a Path"):
+        ContentVerifiedFinalAnalysisBundle(
+            output_root="invalid/path",  # type: ignore[arg-type]
+            manifest={},
+            seal_content=None,  # type: ignore[arg-type]
+            evaluation_score_evidence=None,  # type: ignore[arg-type]
+            evaluation_verification_request=None,  # type: ignore[arg-type]
+            open_bindings_cache=None,  # type: ignore[arg-type]
+            evaluation_bindings_cache=None,  # type: ignore[arg-type]
+            analysis_runtime_source={},
+            contract=None,  # type: ignore[arg-type]
+            result=None,  # type: ignore[arg-type]
+        )
+
+
+def test_fresh_final_analysis_bindings_rejects_invalid_bindings() -> None:
+    with pytest.raises(
+        ForagerMatchedFinalAnalysisError,
+        match="open_bindings must be an AuthenticatedEvidenceBindings",
+    ):
+        FreshFinalAnalysisBindings(
+            open_bindings=None,  # type: ignore[arg-type]
+            evaluation_bindings=None,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across final analysis bundle dataclasses in `alberta_framework/benchmarks/forager_matched_final_analysis.py`:

- `ContentVerifiedFinalAnalysisBundle`: validates `output_root` as a `Path`, mappings for `manifest` and `analysis_runtime_source`, and strict types for `seal_content`, `evaluation_score_evidence`, `evaluation_verification_request`, `open_bindings_cache`, `evaluation_bindings_cache`, `contract`, and `result`.
- `FreshFinalAnalysisBindings`: validates strict `AuthenticatedEvidenceBindings` types for `open_bindings` and `evaluation_bindings`.

## Testing

- Added hostile input, invalid root path, and missing binding type validation tests in `tests/test_forager_matched_final_analysis_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.