### PR TITLE
fix(benchmarks): add fail-closed post_init validation to SourceReplacement and IsolatedRTUPPOSource

### DIFF
--- a/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
+++ b/alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py
@@ -20,6 +20,7 @@ import difflib
 import hashlib
 import json
 import math
+import re
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, Final, cast
@@ -69,6 +70,9 @@ class RTUPPORngIsolationError(ValueError):
     """Raised when source identity or derived-runner structure is not exact."""
 
 
+_SHA256_RE: Final = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
 @dataclasses.dataclass(frozen=True)
 class SourceReplacement:
     """One exact, single-occurrence source transformation."""
@@ -76,6 +80,14 @@ class SourceReplacement:
     replacement_id: str
     before: bytes
     after: bytes
+
+    def __post_init__(self) -> None:
+        if type(self.replacement_id) is not str or not self.replacement_id:
+            raise RTUPPORngIsolationError("replacement_id must be a non-empty string")
+        if type(self.before) is not bytes or not self.before:
+            raise RTUPPORngIsolationError("before must be non-empty bytes")
+        if type(self.after) is not bytes or not self.after:
+            raise RTUPPORngIsolationError("after must be non-empty bytes")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -89,6 +101,23 @@ class IsolatedRTUPPOSource:
     patch_sha256: str
     descriptor: Mapping[str, Any]
     descriptor_sha256: str
+
+    def __post_init__(self) -> None:
+        if type(self.source) is not bytes or not self.source:
+            raise RTUPPORngIsolationError("source must be non-empty bytes")
+        if type(self.patch) is not bytes or not self.patch:
+            raise RTUPPORngIsolationError("patch must be non-empty bytes")
+        if not isinstance(self.descriptor, Mapping):
+            raise RTUPPORngIsolationError("descriptor must be a mapping")
+        for name in (
+            "upstream_source_sha256",
+            "source_sha256",
+            "patch_sha256",
+            "descriptor_sha256",
+        ):
+            val = getattr(self, name)
+            if type(val) is not str or _SHA256_RE.fullmatch(val) is None:
+                raise RTUPPORngIsolationError(f"{name} must be a 64-character lowercase SHA-256")
 
 
 _REPLACEMENTS: Final = (

--- a/tests/test_forager_rtu_ppo_rng_isolation_hostile_validation.py
+++ b/tests/test_forager_rtu_ppo_rng_isolation_hostile_validation.py
@@ -1,0 +1,69 @@
+"""Hostile input and boundary validation for RTU PPO RNG isolation dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_rtu_ppo_rng_isolation import (
+    IsolatedRTUPPOSource,
+    RTUPPORngIsolationError,
+    SourceReplacement,
+)
+
+
+def test_source_replacement_valid_construction() -> None:
+    rep = SourceReplacement(
+        replacement_id="rep_1",
+        before=b"before",
+        after=b"after",
+    )
+    assert rep.replacement_id == "rep_1"
+
+
+def test_source_replacement_rejects_empty_fields() -> None:
+    with pytest.raises(RTUPPORngIsolationError, match="replacement_id must be a non-empty string"):
+        SourceReplacement(
+            replacement_id="",
+            before=b"before",
+            after=b"after",
+        )
+
+    with pytest.raises(RTUPPORngIsolationError, match="before must be non-empty bytes"):
+        SourceReplacement(
+            replacement_id="rep_1",
+            before=b"",
+            after=b"after",
+        )
+
+    with pytest.raises(RTUPPORngIsolationError, match="after must be non-empty bytes"):
+        SourceReplacement(
+            replacement_id="rep_1",
+            before=b"before",
+            after=b"",
+        )
+
+
+def test_isolated_rtu_ppo_source_rejects_invalid_inputs() -> None:
+    with pytest.raises(RTUPPORngIsolationError, match="source must be non-empty bytes"):
+        IsolatedRTUPPOSource(
+            source=b"",
+            upstream_source_sha256="a" * 64,
+            source_sha256="b" * 64,
+            patch=b"patch",
+            patch_sha256="c" * 64,
+            descriptor={},
+            descriptor_sha256="d" * 64,
+        )
+
+    with pytest.raises(
+        RTUPPORngIsolationError, match="upstream_source_sha256 must be a 64-character lowercase"
+    ):
+        IsolatedRTUPPOSource(
+            source=b"source",
+            upstream_source_sha256="invalid",
+            source_sha256="b" * 64,
+            patch=b"patch",
+            patch_sha256="c" * 64,
+            descriptor={},
+            descriptor_sha256="d" * 64,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across source isolation dataclasses in `alberta_framework/benchmarks/forager_rtu_ppo_rng_isolation.py`:

- `SourceReplacement`: validates non-empty `replacement_id` and non-empty byte buffers for `before` and `after`.
- `IsolatedRTUPPOSource`: validates non-empty byte buffers for `source` and `patch`, strict mapping type for `descriptor`, and 64-character lowercase hexadecimal SHA-256 digests for all cryptographic hashes (`upstream_source_sha256`, `source_sha256`, `patch_sha256`, `descriptor_sha256`).

## Testing

- Added hostile input, invalid hash format, and empty payload rejection tests in `tests/test_forager_rtu_ppo_rng_isolation_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.