### PR TITLE
fix(benchmarks): add fail-closed post_init validation to ForagerPairedComparison and ForagerComparisonReport

### DIFF
--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -2300,6 +2300,39 @@ class ForagerPairedComparison:
     ci_high: float
     confidence: float
 
+    def __post_init__(self) -> None:
+        if type(self.candidate) is not str or not self.candidate:
+            raise ValueError("candidate must be a non-empty string")
+        if type(self.baseline) is not str or not self.baseline:
+            raise ValueError("baseline must be a non-empty string")
+        if type(self.candidate_privileged) is not bool:
+            raise TypeError("candidate_privileged must be an exact boolean")
+        if type(self.baseline_privileged) is not bool:
+            raise TypeError("baseline_privileged must be an exact boolean")
+        if self.metric not in (
+            "mean_reward",
+            "final_window_mean_reward",
+            "final_ewm_reward",
+            "mean_ewm_reward",
+            "fov_last_10pct_ema_auc",
+        ):
+            raise ValueError(f"metric {self.metric!r} is not a valid ForagerMetric")
+        if type(self.seeds) is not tuple:
+            raise TypeError("seeds must be an exact tuple")
+        if not self.seeds:
+            raise ValueError("seeds must not be empty")
+        for seed in self.seeds:
+            if type(seed) is not int or isinstance(seed, bool):
+                raise TypeError("seeds must contain integers")
+        if len(set(self.seeds)) != len(self.seeds):
+            raise ValueError("seeds must be unique")
+        for name in ("mean_difference", "ci_low", "ci_high"):
+            val = getattr(self, name)
+            if not isinstance(val, (int, float)) or not math.isfinite(val):
+                raise ValueError(f"{name} must be a finite float")
+        if not isinstance(self.confidence, (int, float)) or not (0.0 < self.confidence < 1.0):
+            raise ValueError("confidence must be a probability in (0, 1)")
+
     def to_dict(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)
         data["seeds"] = list(self.seeds)
@@ -2441,6 +2474,34 @@ class ForagerComparisonReport:
     summaries: Mapping[str, ForagerBenchmarkSummary]
     paired_comparisons: tuple[ForagerPairedComparison, ...]
     unpaired_methods: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.candidate) is not str or not self.candidate:
+            raise ValueError("candidate must be a non-empty string")
+        if self.metric not in (
+            "mean_reward",
+            "final_window_mean_reward",
+            "final_ewm_reward",
+            "mean_ewm_reward",
+            "fov_last_10pct_ema_auc",
+        ):
+            raise ValueError(f"metric {self.metric!r} is not a valid ForagerMetric")
+        if not isinstance(self.summaries, Mapping):
+            raise TypeError("summaries must be a mapping")
+        for name, summary in self.summaries.items():
+            if type(name) is not str or not name:
+                raise ValueError("summary names must be non-empty strings")
+            if type(summary) is not ForagerBenchmarkSummary:
+                raise TypeError("summaries must contain ForagerBenchmarkSummary instances")
+        if type(self.paired_comparisons) is not tuple:
+            raise TypeError("paired_comparisons must be an exact tuple")
+        if any(type(comp) is not ForagerPairedComparison for comp in self.paired_comparisons):
+            raise TypeError("paired_comparisons must contain ForagerPairedComparison instances")
+        if type(self.unpaired_methods) is not tuple:
+            raise TypeError("unpaired_methods must be an exact tuple")
+        for method in self.unpaired_methods:
+            if type(method) is not str or not method:
+                raise ValueError("unpaired_methods must contain non-empty strings")
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_results_comparison_hostile_validation.py
+++ b/tests/test_forager_results_comparison_hostile_validation.py
@@ -1,0 +1,105 @@
+"""Hostile input and boundary validation for Forager comparison dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_results import (
+    ForagerComparisonReport,
+    ForagerPairedComparison,
+)
+
+
+def test_forager_paired_comparison_valid_construction() -> None:
+    comp = ForagerPairedComparison(
+        candidate="cand_1",
+        baseline="base_1",
+        candidate_privileged=False,
+        baseline_privileged=False,
+        metric="mean_reward",
+        seeds=(1, 2, 3),
+        mean_difference=0.5,
+        ci_low=0.2,
+        ci_high=0.8,
+        confidence=0.95,
+    )
+    assert comp.candidate == "cand_1"
+    assert comp.seeds == (1, 2, 3)
+
+
+def test_forager_paired_comparison_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="candidate must be a non-empty string"):
+        ForagerPairedComparison(
+            candidate="",
+            baseline="base_1",
+            candidate_privileged=False,
+            baseline_privileged=False,
+            metric="mean_reward",
+            seeds=(1, 2),
+            mean_difference=0.5,
+            ci_low=0.2,
+            ci_high=0.8,
+            confidence=0.95,
+        )
+
+    with pytest.raises(TypeError, match="candidate_privileged must be an exact boolean"):
+        ForagerPairedComparison(
+            candidate="cand_1",
+            baseline="base_1",
+            candidate_privileged=1,  # type: ignore[arg-type]
+            baseline_privileged=False,
+            metric="mean_reward",
+            seeds=(1, 2),
+            mean_difference=0.5,
+            ci_low=0.2,
+            ci_high=0.8,
+            confidence=0.95,
+        )
+
+    with pytest.raises(ValueError, match="seeds must be unique"):
+        ForagerPairedComparison(
+            candidate="cand_1",
+            baseline="base_1",
+            candidate_privileged=False,
+            baseline_privileged=False,
+            metric="mean_reward",
+            seeds=(1, 1),
+            mean_difference=0.5,
+            ci_low=0.2,
+            ci_high=0.8,
+            confidence=0.95,
+        )
+
+    with pytest.raises(ValueError, match="mean_difference must be a finite float"):
+        ForagerPairedComparison(
+            candidate="cand_1",
+            baseline="base_1",
+            candidate_privileged=False,
+            baseline_privileged=False,
+            metric="mean_reward",
+            seeds=(1, 2),
+            mean_difference=float("nan"),
+            ci_low=0.2,
+            ci_high=0.8,
+            confidence=0.95,
+        )
+
+
+def test_forager_comparison_report_rejects_invalid_inputs() -> None:
+    with pytest.raises(TypeError, match="summaries must be a mapping"):
+        ForagerComparisonReport(
+            candidate="cand_1",
+            metric="mean_reward",
+            summaries=None,  # type: ignore[arg-type]
+            paired_comparisons=(),
+            unpaired_methods=(),
+        )
+
+    with pytest.raises(TypeError, match="paired_comparisons must be an exact tuple"):
+        ForagerComparisonReport(
+            candidate="cand_1",
+            metric="mean_reward",
+            summaries={},
+            paired_comparisons=[],  # type: ignore[arg-type]
+            unpaired_methods=(),
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across Forager benchmark comparison dataclasses in `alberta_framework/benchmarks/forager_results.py`:

- `ForagerPairedComparison`: validates non-empty identifiers (`candidate`, `baseline`), strict boolean flags (`candidate_privileged`, `baseline_privileged`), validated `ForagerMetric` literal, non-empty tuple of unique integer seeds, finite float statistics (`mean_difference`, `ci_low`, `ci_high`), and strictly bounded `confidence` probability in $(0, 1)$.
- `ForagerComparisonReport`: validates non-empty `candidate` identifier, validated `ForagerMetric` literal, strict mappings of `ForagerBenchmarkSummary` instances, exact tuples of `ForagerPairedComparison` instances, and non-empty string sequences for `unpaired_methods`.

## Testing

- Added hostile input, invalid types, empty strings, duplicate seeds, and non-finite value rejection tests in `tests/test_forager_results_comparison_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.