### PR TITLE
fix(benchmarks): add fail-closed post_init validation to HistoricalForagerExecution and HistoricalForagerPairingIdentity

### DIFF
--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -914,6 +914,9 @@ class HistoricalForagerRunResult:
         }
 
 
+_SHA256_RE: Final = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
 @dataclass(frozen=True)
 class HistoricalForagerExecution[KernelStateT]:
     """Completed result plus the next kernel state/action for host-side inspection."""
@@ -922,6 +925,19 @@ class HistoricalForagerExecution[KernelStateT]:
     final_kernel_state: KernelStateT = field(repr=False)
     next_action: int
     manifest_sha256: str
+
+    def __post_init__(self) -> None:
+        if type(self.result) is not HistoricalForagerRunResult:
+            raise HistoricalForagerContractError("result must be a HistoricalForagerRunResult")
+        if type(self.next_action) is not int or isinstance(self.next_action, bool):
+            raise HistoricalForagerContractError("next_action must be an integer")
+        if (
+            type(self.manifest_sha256) is not str
+            or _SHA256_RE.fullmatch(self.manifest_sha256) is None
+        ):
+            raise HistoricalForagerContractError(
+                "manifest_sha256 must be a 64-character lowercase SHA-256"
+            )
 
 
 def _cleanup_incomplete_output(
@@ -1367,6 +1383,47 @@ class HistoricalForagerPairingIdentity:
     semantic_contract_sha256: str
     environment_adapter_mode: AdapterMode
     runtime_sha256: str
+
+    def __post_init__(self) -> None:
+        if type(self.family_id) is not str or not self.family_id:
+            raise HistoricalForagerContractError("family_id must be a non-empty string")
+        if (
+            type(self.provenance_sha256) is not str
+            or _SHA256_RE.fullmatch(self.provenance_sha256) is None
+        ):
+            raise HistoricalForagerContractError(
+                "provenance_sha256 must be a 64-character lowercase SHA-256"
+            )
+        if type(self.seed) is not int or not 0 <= self.seed <= _MAX_SEED:
+            raise HistoricalForagerContractError(f"seed must lie in [0, {_MAX_SEED}]")
+        if (
+            type(self.aperture_size) is not int
+            or self.aperture_size not in range(1, 16, 2)
+        ):
+            raise HistoricalForagerContractError(
+                "aperture_size must be one of 1, 3, 5, 7, 9, 11, 13, 15"
+            )
+        if type(self.steps) is not int or not 1 <= self.steps <= _MAX_STEPS:
+            raise HistoricalForagerContractError(f"steps must lie in [1, {_MAX_STEPS}]")
+        if (
+            type(self.semantic_contract_sha256) is not str
+            or _SHA256_RE.fullmatch(self.semantic_contract_sha256) is None
+        ):
+            raise HistoricalForagerContractError(
+                "semantic_contract_sha256 must be a 64-character lowercase SHA-256"
+            )
+        if self.environment_adapter_mode not in (
+            "golden_verified_read_only_source",
+            "development_unverified_factory",
+        ):
+            raise HistoricalForagerContractError("environment_adapter_mode is invalid")
+        if (
+            type(self.runtime_sha256) is not str
+            or _SHA256_RE.fullmatch(self.runtime_sha256) is None
+        ):
+            raise HistoricalForagerContractError(
+                "runtime_sha256 must be a 64-character lowercase SHA-256"
+            )
 
 
 def historical_artifact_pairing_identity(

--- a/tests/test_historical_forager_hostile_validation.py
+++ b/tests/test_historical_forager_hostile_validation.py
@@ -1,0 +1,96 @@
+"""Hostile input and boundary validation for historical Forager dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.historical_forager import (
+    HistoricalForagerContractError,
+    HistoricalForagerExecution,
+    HistoricalForagerPairingIdentity,
+    HistoricalForagerRunResult,
+)
+
+
+def _make_run_result() -> HistoricalForagerRunResult:
+    return HistoricalForagerRunResult(
+        seed=1,
+        aperture_size=9,
+        steps=100,
+        metrics={},
+        reward_sidecar={},
+        environment_adapter={},
+        runtime={},
+        kernel={},
+    )
+
+
+def test_historical_forager_execution_rejects_invalid_inputs() -> None:
+    with pytest.raises(HistoricalForagerContractError, match="result must be a"):
+        HistoricalForagerExecution(
+            result=None,  # type: ignore[arg-type]
+            final_kernel_state={},
+            next_action=0,
+            manifest_sha256="a" * 64,
+        )
+
+    with pytest.raises(HistoricalForagerContractError, match="next_action must be an integer"):
+        HistoricalForagerExecution(
+            result=_make_run_result(),
+            final_kernel_state={},
+            next_action=True,
+            manifest_sha256="a" * 64,
+        )
+
+
+def test_historical_forager_pairing_identity_valid_construction() -> None:
+    ident = HistoricalForagerPairingIdentity(
+        family_id="family_1",
+        provenance_sha256="a" * 64,
+        seed=1,
+        aperture_size=9,
+        steps=100,
+        semantic_contract_sha256="b" * 64,
+        environment_adapter_mode="golden_verified_read_only_source",
+        runtime_sha256="c" * 64,
+    )
+    assert ident.family_id == "family_1"
+    assert ident.aperture_size == 9
+
+
+def test_historical_forager_pairing_identity_rejects_invalid_inputs() -> None:
+    with pytest.raises(HistoricalForagerContractError, match="family_id must be a"):
+        HistoricalForagerPairingIdentity(
+            family_id="",
+            provenance_sha256="a" * 64,
+            seed=1,
+            aperture_size=9,
+            steps=100,
+            semantic_contract_sha256="b" * 64,
+            environment_adapter_mode="golden_verified_read_only_source",
+            runtime_sha256="c" * 64,
+        )
+
+    with pytest.raises(HistoricalForagerContractError, match="aperture_size must be one of"):
+        HistoricalForagerPairingIdentity(
+            family_id="family_1",
+            provenance_sha256="a" * 64,
+            seed=1,
+            aperture_size=8,
+            steps=100,
+            semantic_contract_sha256="b" * 64,
+            environment_adapter_mode="golden_verified_read_only_source",
+            runtime_sha256="c" * 64,
+        )
+
+    with pytest.raises(HistoricalForagerContractError, match="environment_adapter_mode is invalid"):
+        HistoricalForagerPairingIdentity(
+            family_id="family_1",
+            provenance_sha256="a" * 64,
+            seed=1,
+            aperture_size=9,
+            steps=100,
+            semantic_contract_sha256="b" * 64,
+            environment_adapter_mode="invalid_mode",  # type: ignore[arg-type]
+            runtime_sha256="c" * 64,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across historical Forager benchmark execution and pairing identity dataclasses in `alberta_framework/benchmarks/historical_forager.py`:

- `HistoricalForagerExecution`: validates strict `HistoricalForagerRunResult` type for `result`, integer for `next_action` (rejecting boolean subtypes), and 64-character lowercase hexadecimal SHA-256 string for `manifest_sha256`.
- `HistoricalForagerPairingIdentity`: validates non-empty `family_id`, bounds for integer `seed` and `steps`, odd integer aperture sizes in `range(1, 16, 2)`, validated `AdapterMode` literal, and 64-character lowercase hexadecimal SHA-256 strings for `provenance_sha256`, `semantic_contract_sha256`, and `runtime_sha256`.

## Testing

- Added hostile input, invalid types, booleans as integers, invalid aperture sizes, and invalid adapter mode tests in `tests/test_historical_forager_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.