### PR TITLE
fix(benchmarks): add fail-closed post_init validation to IPMNISTRunResult and LabelEMNISTRunResult

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -810,7 +810,11 @@ class IPMNISTRunResult:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "learner", _require_nonempty_string("learner", self.learner))
+        if not isinstance(self.hyperparameters, dict):
+            raise TypeError("hyperparameters must be a dict")
         object.__setattr__(self, "seeds", _require_seed_identities(self.seeds, name="seeds"))
+        if type(self.config) is not IPMNISTConfig:
+            raise TypeError("config must be an IPMNISTConfig")
         object.__setattr__(
             self,
             "wall_clock_seconds",

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -469,7 +469,11 @@ class LabelEMNISTRunResult:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "learner", _require_nonempty_string("learner", self.learner))
+        if not isinstance(self.hyperparameters, dict):
+            raise TypeError("hyperparameters must be a dict")
         object.__setattr__(self, "seeds", _require_seed_identities(self.seeds, name="seeds"))
+        if type(self.config) is not LabelEMNISTConfig:
+            raise TypeError("config must be a LabelEMNISTConfig")
         object.__setattr__(
             self,
             "wall_clock_seconds",

--- a/tests/test_upgd_benchmarks_hostile_validation.py
+++ b/tests/test_upgd_benchmarks_hostile_validation.py
@@ -1,0 +1,73 @@
+"""Hostile input and boundary validation for UPGD benchmark results."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    IPMNISTRunResult,
+)
+from alberta_framework.benchmarks.upgd_label_emnist import (
+    LabelEMNISTConfig,
+    LabelEMNISTRunResult,
+)
+
+
+def test_ipmnist_run_result_rejects_invalid_inputs() -> None:
+    dummy_arr = np.zeros((1, 1))
+    with pytest.raises(TypeError, match="hyperparameters must be a dict"):
+        IPMNISTRunResult(
+            learner="upgd",
+            hyperparameters=None,  # type: ignore[arg-type]
+            seeds=(1,),
+            config=IPMNISTConfig(),
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            average_online_accuracy=dummy_arr,
+            wall_clock_seconds=1.0,
+        )
+
+    with pytest.raises(TypeError, match="config must be an IPMNISTConfig"):
+        IPMNISTRunResult(
+            learner="upgd",
+            hyperparameters={},
+            seeds=(1,),
+            config=None,  # type: ignore[arg-type]
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            average_online_accuracy=dummy_arr,
+            wall_clock_seconds=1.0,
+        )
+
+
+def test_label_emnist_run_result_rejects_invalid_inputs() -> None:
+    dummy_arr = np.zeros((1, 1))
+    with pytest.raises(TypeError, match="hyperparameters must be a dict"):
+        LabelEMNISTRunResult(
+            learner="upgd",
+            hyperparameters=None,  # type: ignore[arg-type]
+            seeds=(1,),
+            config=LabelEMNISTConfig(),
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            average_online_accuracy=dummy_arr,
+            wall_clock_seconds=1.0,
+        )
+
+    with pytest.raises(TypeError, match="config must be a LabelEMNISTConfig"):
+        LabelEMNISTRunResult(
+            learner="upgd",
+            hyperparameters={},
+            seeds=(1,),
+            config=None,  # type: ignore[arg-type]
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            average_online_accuracy=dummy_arr,
+            wall_clock_seconds=1.0,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across UPGD benchmark multi-seed result dataclasses:

- `IPMNISTRunResult` in `alberta_framework/benchmarks/upgd_ipmnist.py`: validates strict `dict` type for `hyperparameters` and `IPMNISTConfig` instance for `config`.
- `LabelEMNISTRunResult` in `alberta_framework/benchmarks/upgd_label_emnist.py`: validates strict `dict` type for `hyperparameters` and `LabelEMNISTConfig` instance for `config`.

## Testing

- Added hostile input, invalid dictionary, and invalid config type rejection tests in `tests/test_upgd_benchmarks_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.