### PR TITLE
fix(benchmarks): add fail-closed post_init validation to OCI build and driver contract dataclasses

### DIFF
--- a/alberta_framework/benchmarks/official_foragax_oci.py
+++ b/alberta_framework/benchmarks/official_foragax_oci.py
@@ -162,6 +162,27 @@ class OciBuildInputs:
     debian_manifest: Path
     output_context: Path
 
+    def __post_init__(self) -> None:
+        for name in (
+            "source_archive",
+            "dependency_lock",
+            "uv_binary",
+            "uv_cache_archive",
+            "debian_bundle",
+            "debian_manifest",
+            "output_context",
+        ):
+            if not isinstance(getattr(self, name), Path):
+                raise OfficialForagaxOciError(f"{name} must be a Path")
+        _require_sha256(self.source_archive_sha256, label="source_archive_sha256")
+        _require_sha256(self.dependency_lock_sha256, label="dependency_lock_sha256")
+        _require_sha256(self.uv_binary_sha256, label="uv_binary_sha256")
+        _require_sha256(self.uv_cache_archive_sha256, label="uv_cache_archive_sha256")
+        for name in ("source_commit", "source_tree_git_sha1", "base_image"):
+            val = getattr(self, name)
+            if type(val) is not str or not val:
+                raise OfficialForagaxOciError(f"{name} must be a non-empty string")
+
 
 @dataclasses.dataclass(frozen=True)
 class PreparedOciBuild:
@@ -172,6 +193,15 @@ class PreparedOciBuild:
     build_spec_sha256: str
     dockerfile_sha256: str
     launcher_sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.context, Path):
+            raise OfficialForagaxOciError("context must be a Path")
+        if not isinstance(self.build_spec, Mapping):
+            raise OfficialForagaxOciError("build_spec must be a mapping")
+        _require_sha256(self.build_spec_sha256, label="build_spec_sha256")
+        _require_sha256(self.dockerfile_sha256, label="dockerfile_sha256")
+        _require_sha256(self.launcher_sha256, label="launcher_sha256")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -184,6 +214,20 @@ class DriverLaunchContract:
     device_indices: tuple[int, ...]
     cuda_wheel_library_paths: tuple[str, ...]
     driver_user_library_paths: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.driver_host_path) is not str or not self.driver_host_path:
+            raise OfficialForagaxOciError("driver_host_path must be a non-empty string")
+        if type(self.driver_container_path) is not str or not self.driver_container_path:
+            raise OfficialForagaxOciError("driver_container_path must be a non-empty string")
+        for name in (
+            "device_paths",
+            "device_indices",
+            "cuda_wheel_library_paths",
+            "driver_user_library_paths",
+        ):
+            if type(getattr(self, name)) is not tuple:
+                raise OfficialForagaxOciError(f"{name} must be an exact tuple")
 
 
 def _canonical_json_bytes(value: Any, *, newline: bool = False) -> bytes:

--- a/tests/test_official_foragax_oci_hostile_validation.py
+++ b/tests/test_official_foragax_oci_hostile_validation.py
@@ -1,0 +1,79 @@
+"""Hostile input and boundary validation for official Foragax OCI dataclasses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.official_foragax_oci import (
+    DriverLaunchContract,
+    OfficialForagaxOciError,
+    PreparedOciBuild,
+)
+
+
+def test_prepared_oci_build_valid_construction() -> None:
+    build = PreparedOciBuild(
+        context=Path("/context"),
+        build_spec={},
+        build_spec_sha256="a" * 64,
+        dockerfile_sha256="b" * 64,
+        launcher_sha256="c" * 64,
+    )
+    assert build.build_spec_sha256 == "a" * 64
+
+
+def test_prepared_oci_build_rejects_invalid_inputs() -> None:
+    with pytest.raises(OfficialForagaxOciError, match="context must be a Path"):
+        PreparedOciBuild(
+            context="/context",  # type: ignore[arg-type]
+            build_spec={},
+            build_spec_sha256="a" * 64,
+            dockerfile_sha256="b" * 64,
+            launcher_sha256="c" * 64,
+        )
+
+    with pytest.raises(OfficialForagaxOciError, match="build_spec must be a mapping"):
+        PreparedOciBuild(
+            context=Path("/context"),
+            build_spec=None,  # type: ignore[arg-type]
+            build_spec_sha256="a" * 64,
+            dockerfile_sha256="b" * 64,
+            launcher_sha256="c" * 64,
+        )
+
+    with pytest.raises(
+        OfficialForagaxOciError, match="build_spec_sha256 must be a lowercase SHA-256"
+    ):
+        PreparedOciBuild(
+            context=Path("/context"),
+            build_spec={},
+            build_spec_sha256="invalid",
+            dockerfile_sha256="b" * 64,
+            launcher_sha256="c" * 64,
+        )
+
+
+def test_driver_launch_contract_rejects_invalid_inputs() -> None:
+    with pytest.raises(
+        OfficialForagaxOciError, match="driver_host_path must be a non-empty string"
+    ):
+        DriverLaunchContract(
+            driver_host_path="",
+            driver_container_path="/usr/lib",
+            device_paths=(),
+            device_indices=(),
+            cuda_wheel_library_paths=(),
+            driver_user_library_paths=(),
+        )
+
+    with pytest.raises(OfficialForagaxOciError, match="device_paths must be an exact tuple"):
+        DriverLaunchContract(
+            driver_host_path="/usr/lib",
+            driver_container_path="/usr/lib",
+            device_paths=[],  # type: ignore[arg-type]
+            device_indices=(),
+            cuda_wheel_library_paths=(),
+            driver_user_library_paths=(),
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across OCI build preparation and runtime driver launch contract dataclasses in `alberta_framework/benchmarks/official_foragax_oci.py`:

- `OciBuildInputs`: validates `Path` instances across all file/directory inputs (`source_archive`, `dependency_lock`, `uv_binary`, `uv_cache_archive`, `debian_bundle`, `debian_manifest`, `output_context`), 64-character lowercase hexadecimal SHA-256 digests, and non-empty metadata strings (`source_commit`, `source_tree_git_sha1`, `base_image`).
- `PreparedOciBuild`: validates `context` as a `Path`, mapping for `build_spec`, and 64-character lowercase hexadecimal SHA-256 digests for `build_spec_sha256`, `dockerfile_sha256`, and `launcher_sha256`.
- `DriverLaunchContract`: validates non-empty host and container driver paths, and strict tuple collections for device paths, indices, and library directories.

## Testing

- Added hostile input, invalid path types, invalid mappings, and malformed hash rejection tests in `tests/test_official_foragax_oci_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.