### PR TITLE
fix(benchmarks): add fail-closed post_init validation to Forager baseline, target, and state dataclasses

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -633,6 +633,17 @@ class ForagerFeatureState:
     last_reward: float
     reward_traces: tuple[float, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.last_action) is not int or isinstance(self.last_action, bool):
+            raise ValueError("last_action must be an integer")
+        if not isinstance(self.last_reward, (int, float)) or not math.isfinite(self.last_reward):
+            raise ValueError("last_reward must be a finite float")
+        if type(self.reward_traces) is not tuple:
+            raise ValueError("reward_traces must be a tuple")
+        for trace in self.reward_traces:
+            if not isinstance(trace, (int, float)) or not math.isfinite(trace):
+                raise ValueError("reward_traces values must be finite floats")
+
 
 def _observation_parts(observation: Any) -> tuple[Array, Array]:
     """Return ``(image, hint)`` for array and mapping observations."""
@@ -4087,6 +4098,22 @@ class PaperBaseline:
     source: str
     official_config_path: str | None = None
 
+    def __post_init__(self) -> None:
+        for attr in ("name", "family", "state_construction", "source"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if self.role not in ("lower_control", "learning_baseline", "sota", "upper_control"):
+            raise ValueError("role is invalid")
+        if not isinstance(self.selected_hyperparameters, Mapping):
+            raise ValueError("selected_hyperparameters must be a mapping")
+        if type(self.in_tree_implementation) is not bool:
+            raise ValueError("in_tree_implementation must be a boolean")
+        if self.official_config_path is not None and (
+            type(self.official_config_path) is not str or not self.official_config_path
+        ):
+            raise ValueError("official_config_path must be None or a non-empty string")
+
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
 
@@ -4471,6 +4498,18 @@ class PaperReferenceTarget:
     condition: str = "continuously_learning"
     source: str = FORAGER_PAPER_URL
     precision: str = "figure_digitized_approximation"
+
+    def __post_init__(self) -> None:
+        for attr in ("method", "metric", "condition", "source", "precision"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if not isinstance(self.central_estimate, (int, float)) or not math.isfinite(
+            self.central_estimate
+        ):
+            raise ValueError("central_estimate must be a finite float")
+        if type(self.privileged) is not bool:
+            raise ValueError("privileged must be a boolean")
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)

--- a/tests/test_forager_dataclasses_hostile_validation.py
+++ b/tests/test_forager_dataclasses_hostile_validation.py
@@ -1,0 +1,86 @@
+"""Hostile input and boundary validation for Forager benchmark dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import (
+    ForagerFeatureState,
+    PaperBaseline,
+    PaperReferenceTarget,
+)
+
+
+def test_forager_feature_state_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="last_action must be an integer"):
+        ForagerFeatureState(
+            last_action=True,
+            last_reward=0.0,
+            reward_traces=(),
+        )
+
+    with pytest.raises(ValueError, match="last_reward must be a finite float"):
+        ForagerFeatureState(
+            last_action=0,
+            last_reward=float("nan"),
+            reward_traces=(),
+        )
+
+    with pytest.raises(ValueError, match="reward_traces must be a tuple"):
+        ForagerFeatureState(
+            last_action=0,
+            last_reward=0.0,
+            reward_traces=[],  # type: ignore[arg-type]
+        )
+
+
+def test_paper_baseline_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        PaperBaseline(
+            name="",
+            family="family_1",
+            role="learning_baseline",
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation=True,
+            source="paper",
+        )
+
+    with pytest.raises(ValueError, match="role is invalid"):
+        PaperBaseline(
+            name="base",
+            family="family_1",
+            role="invalid_role",  # type: ignore[arg-type]
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation=True,
+            source="paper",
+        )
+
+    with pytest.raises(ValueError, match="in_tree_implementation must be a boolean"):
+        PaperBaseline(
+            name="base",
+            family="family_1",
+            role="learning_baseline",
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation="true",  # type: ignore[arg-type]
+            source="paper",
+        )
+
+
+def test_paper_reference_target_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="central_estimate must be a finite float"):
+        PaperReferenceTarget(
+            method="method_1",
+            metric="metric_1",
+            central_estimate=float("inf"),
+        )
+
+    with pytest.raises(ValueError, match="privileged must be a boolean"):
+        PaperReferenceTarget(
+            method="method_1",
+            metric="metric_1",
+            central_estimate=1.0,
+            privileged="no",  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across Forager benchmark baseline, reference target, and causal feature state dataclasses in `alberta_framework/benchmarks/forager.py`:

- `ForagerFeatureState`: validates integer `last_action` (rejecting boolean subtypes), finite float for `last_reward`, and strict tuple of finite floats for `reward_traces`.
- `PaperBaseline`: validates non-empty strings for `name`, `family`, `state_construction`, and `source`, valid `role` literal, strict mapping for `selected_hyperparameters`, strict boolean for `in_tree_implementation`, and non-empty string or `None` for `official_config_path`.
- `PaperReferenceTarget`: validates non-empty strings across descriptor fields, finite real numbers for `central_estimate`, and strict boolean for `privileged`.

## Testing

- Added hostile input, invalid boolean subtype, non-finite float, and role validation tests in `tests/test_forager_dataclasses_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.