### PR TITLE
fix(benchmarks): add fail-closed post_init validation to MicroTaskConfig and MicroStream

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1902,6 +1902,25 @@ class MicroTaskConfig:
     hidden2: int
     crop: bool
 
+    def __post_init__(self) -> None:
+        _require_nonempty_string(self.name, context="MicroTaskConfig.name")
+        _require_nonempty_string(self.kind, context="MicroTaskConfig.kind")
+        if self.role not in ("search", "holdout"):
+            raise ValueError("MicroTaskConfig.role must be 'search' or 'holdout'")
+        for field_name in (
+            "input_dim",
+            "n_classes",
+            "n_tasks",
+            "task_length",
+            "hidden1",
+            "hidden2",
+        ):
+            val = getattr(self, field_name)
+            if type(val) is not int or val <= 0:
+                raise ValueError(f"MicroTaskConfig.{field_name} must be a positive integer")
+        if type(self.crop) is not bool:
+            raise ValueError("MicroTaskConfig.crop must be a boolean")
+
 
 MICRO_SUITE: dict[str, MicroTaskConfig] = {
     "M1": MicroTaskConfig(
@@ -1949,6 +1968,19 @@ class MicroStream:
     example_indices: np.ndarray
     config: MicroTaskConfig
     seed: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.xs, np.ndarray):
+            raise TypeError("MicroStream.xs must be a numpy ndarray")
+        if not isinstance(self.ys, np.ndarray):
+            raise TypeError("MicroStream.ys must be a numpy ndarray")
+        if not isinstance(self.example_indices, np.ndarray):
+            raise TypeError("MicroStream.example_indices must be a numpy ndarray")
+        if type(self.config) is not MicroTaskConfig:
+            raise TypeError("MicroStream.config must be a MicroTaskConfig")
+        object.__setattr__(
+            self, "seed", require_jax_seed(self.seed, name="MicroStream.seed")
+        )
 
 
 @lru_cache(maxsize=2)

--- a/tests/test_micro_continual_hostile_validation.py
+++ b/tests/test_micro_continual_hostile_validation.py
@@ -1,0 +1,88 @@
+"""Hostile input and boundary validation for micro continual benchmark dataclasses."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.micro_continual import (
+    MicroStream,
+    MicroTaskConfig,
+)
+
+
+def test_micro_task_config_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="MicroTaskConfig.name must be a non-empty string"):
+        MicroTaskConfig(
+            name="",
+            kind="input_permutation",
+            role="search",
+            input_dim=64,
+            n_classes=10,
+            n_tasks=8,
+            task_length=500,
+            hidden1=32,
+            hidden2=16,
+            crop=False,
+        )
+
+    with pytest.raises(ValueError, match="MicroTaskConfig.role must be 'search' or 'holdout'"):
+        MicroTaskConfig(
+            name="M1",
+            kind="input_permutation",
+            role="invalid_role",
+            input_dim=64,
+            n_classes=10,
+            n_tasks=8,
+            task_length=500,
+            hidden1=32,
+            hidden2=16,
+            crop=False,
+        )
+
+    with pytest.raises(ValueError, match="MicroTaskConfig.input_dim must be a positive integer"):
+        MicroTaskConfig(
+            name="M1",
+            kind="input_permutation",
+            role="search",
+            input_dim=True,
+            n_classes=10,
+            n_tasks=8,
+            task_length=500,
+            hidden1=32,
+            hidden2=16,
+            crop=False,
+        )
+
+
+def test_micro_stream_rejects_invalid_inputs() -> None:
+    dummy_arr = np.zeros((1, 1))
+    valid_cfg = MicroTaskConfig(
+        name="M1",
+        kind="input_permutation",
+        role="search",
+        input_dim=64,
+        n_classes=10,
+        n_tasks=8,
+        task_length=500,
+        hidden1=32,
+        hidden2=16,
+        crop=False,
+    )
+    with pytest.raises(TypeError, match="MicroStream.xs must be a numpy ndarray"):
+        MicroStream(
+            xs=None,  # type: ignore[arg-type]
+            ys=dummy_arr,
+            example_indices=dummy_arr,
+            config=valid_cfg,
+            seed=0,
+        )
+
+    with pytest.raises(TypeError, match="MicroStream.config must be a MicroTaskConfig"):
+        MicroStream(
+            xs=dummy_arr,
+            ys=dummy_arr,
+            example_indices=dummy_arr,
+            config=None,  # type: ignore[arg-type]
+            seed=0,
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across micro continual benchmark task and stream dataclasses in `alberta_framework/benchmarks/micro_continual.py`:

- `MicroTaskConfig`: validates non-empty strings for `name` and `kind`, valid `role` literal (`search` or `holdout`), positive integer dimensions and task schedules (rejecting boolean subtypes), and strict boolean for `crop`.
- `MicroStream`: validates numpy `ndarray` instances across `xs`, `ys`, and `example_indices`, exact `MicroTaskConfig` instance for `config`, and JAX PRNG seed validation.

## Testing

- Added hostile input, invalid role, invalid array type, and boolean dimension rejection tests in `tests/test_micro_continual_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.