### PR TITLE
fix(benchmarks): add fail-closed post_init validation to IPMNIST screening dataclasses

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -2183,6 +2183,12 @@ class _CBPLayerRefs:
     in_bias: str
     out_weight: str
 
+    def __post_init__(self) -> None:
+        for attr in ("in_weight", "in_bias", "out_weight"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+
 
 _CBP_LAYERS = (
     _CBPLayerRefs(in_weight="w1", in_bias="b1", out_weight="w2"),
@@ -5315,6 +5321,16 @@ class ScreeningSpec:
     noise_update: NoiseUpdateFn | None = None
     frozen_probe_input: FrozenProbeInputFn = _raw_frozen_probe_input
 
+    def __post_init__(self) -> None:
+        for attr in ("name", "base_learner", "mechanism"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if not isinstance(self.hyperparameters, dict):
+            raise TypeError("hyperparameters must be a dict")
+        if not callable(self.factory):
+            raise TypeError("factory must be callable")
+
 
 def _upgd_hp(**overrides: float) -> dict[str, float]:
     merged = dict(UPGD_W_PROTOCOL_HYPERPARAMETERS)
@@ -7672,6 +7688,24 @@ class ScreeningRunResult:
     wall_clock_seconds: float
     noise_mode: str = "step"
     noise_pool_steps: int | None = None
+
+    def __post_init__(self) -> None:
+        for attr in ("config_name", "base_learner", "noise_mode"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if not isinstance(self.hyperparameters, dict):
+            raise TypeError("hyperparameters must be a dict")
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        if type(self.config) is not IPMNISTConfig:
+            raise TypeError("config must be an IPMNISTConfig")
+        for arr_name in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
+            if not isinstance(getattr(self, arr_name), np.ndarray):
+                raise TypeError(f"{arr_name} must be a numpy ndarray")
+        if not isinstance(self.wall_clock_seconds, (int, float)) or not math.isfinite(
+            self.wall_clock_seconds
+        ):
+            raise ValueError("wall_clock_seconds must be a finite float")
 
 
 def run_screening_config(

--- a/tests/test_ipmnist_screening_hostile_validation.py
+++ b/tests/test_ipmnist_screening_hostile_validation.py
@@ -1,0 +1,73 @@
+"""Hostile input and boundary validation for IPMNIST screening dataclasses."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    ScreeningRunResult,
+    ScreeningSpec,
+    _CBPLayerRefs,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+
+def test_cbp_layer_refs_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="in_weight must be a non-empty string"):
+        _CBPLayerRefs(
+            in_weight="",
+            in_bias="b1",
+            out_weight="w2",
+        )
+
+
+def test_screening_spec_rejects_invalid_inputs() -> None:
+    factory = screening_spec("upgd_w_control").factory
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        ScreeningSpec(
+            name="",
+            base_learner="upgd_w",
+            mechanism="test",
+            hyperparameters={},
+            factory=factory,
+        )
+
+    with pytest.raises(TypeError, match="hyperparameters must be a dict"):
+        ScreeningSpec(
+            name="test",
+            base_learner="upgd_w",
+            mechanism="test",
+            hyperparameters=None,  # type: ignore[arg-type]
+            factory=factory,
+        )
+
+
+def test_screening_run_result_rejects_invalid_inputs() -> None:
+    dummy_arr = np.zeros((1, 1))
+    with pytest.raises(TypeError, match="config must be an IPMNISTConfig"):
+        ScreeningRunResult(
+            config_name="test",
+            base_learner="upgd_w",
+            hyperparameters={},
+            seed=0,
+            config=None,  # type: ignore[arg-type]
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            wall_clock_seconds=1.0,
+        )
+
+    with pytest.raises(ValueError, match="wall_clock_seconds must be a finite float"):
+        ScreeningRunResult(
+            config_name="test",
+            base_learner="upgd_w",
+            hyperparameters={},
+            seed=0,
+            config=IPMNISTConfig(),
+            per_task_accuracy=dummy_arr,
+            per_task_loss=dummy_arr,
+            per_task_plasticity=dummy_arr,
+            wall_clock_seconds=float("inf"),
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across IPMNIST screening benchmark dataclasses in `alberta_framework/benchmarks/ipmnist_screening.py`:

- `_CBPLayerRefs`: validates non-empty strings across layer parameter references (`in_weight`, `in_bias`, `out_weight`).
- `ScreeningSpec`: validates non-empty strings for identifier and metadata fields, strict `dict` type for `hyperparameters`, and callable check for `factory`.
- `ScreeningRunResult`: validates non-empty strings for `config_name`, `base_learner`, and `noise_mode`, strict `dict` type for `hyperparameters`, validated JAX PRNG integer seed, strict `IPMNISTConfig` instance for `config`, numpy ndarrays for metric arrays, and finite real number for `wall_clock_seconds`.

## Testing

- Added hostile input, invalid dictionary type, invalid config type, and non-finite float rejection tests in `tests/test_ipmnist_screening_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.