### PR TITLE
fix(benchmarks): add fail-closed post_init validation to EnvironmentRuntimeIdentity

### DIFF
--- a/alberta_framework/benchmarks/runtime_profile.py
+++ b/alberta_framework/benchmarks/runtime_profile.py
@@ -1107,6 +1107,17 @@ class EnvironmentRuntimeIdentity:
     environment_rng_schedule: EnvironmentRngSchedule
     environment_rng_schedule_sha256: str
 
+    def __post_init__(self) -> None:
+        _string(self.runtime_profile_id, label="runtime_profile_id")
+        _sha256(
+            self.environment_runtime_profile_sha256,
+            label="environment_runtime_profile_sha256",
+        )
+        _sha256(
+            self.environment_rng_schedule_sha256,
+            label="environment_rng_schedule_sha256",
+        )
+
 
 def validate_environment_runtime_identity(
     *,

--- a/tests/test_runtime_profile_hostile_validation.py
+++ b/tests/test_runtime_profile_hostile_validation.py
@@ -1,0 +1,49 @@
+"""Hostile input and boundary validation for runtime profile dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.runtime_profile import (
+    EnvironmentRuntimeIdentity,
+)
+
+
+def test_environment_runtime_identity_valid_construction() -> None:
+    ident = EnvironmentRuntimeIdentity(
+        runtime_profile_id="profile_1",
+        environment_runtime_profile_sha256="a" * 64,
+        environment_rng_schedule="dedicated_environment_split_chain_v1",
+        environment_rng_schedule_sha256="b" * 64,
+    )
+    assert ident.runtime_profile_id == "profile_1"
+
+
+def test_environment_runtime_identity_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="runtime_profile_id must be a non-empty string"):
+        EnvironmentRuntimeIdentity(
+            runtime_profile_id="",
+            environment_runtime_profile_sha256="a" * 64,
+            environment_rng_schedule="dedicated_environment_split_chain_v1",
+            environment_rng_schedule_sha256="b" * 64,
+        )
+
+    with pytest.raises(
+        ValueError, match="environment_runtime_profile_sha256 must be a lowercase SHA-256"
+    ):
+        EnvironmentRuntimeIdentity(
+            runtime_profile_id="profile_1",
+            environment_runtime_profile_sha256="invalid",
+            environment_rng_schedule="dedicated_environment_split_chain_v1",
+            environment_rng_schedule_sha256="b" * 64,
+        )
+
+    with pytest.raises(
+        ValueError, match="environment_rng_schedule_sha256 must be a lowercase SHA-256"
+    ):
+        EnvironmentRuntimeIdentity(
+            runtime_profile_id="profile_1",
+            environment_runtime_profile_sha256="a" * 64,
+            environment_rng_schedule="dedicated_environment_split_chain_v1",
+            environment_rng_schedule_sha256="invalid",
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to `EnvironmentRuntimeIdentity` in `alberta_framework/benchmarks/runtime_profile.py`:

- Validates non-empty string for `runtime_profile_id`.
- Validates 64-character lowercase hexadecimal SHA-256 strings for `environment_runtime_profile_sha256` and `environment_rng_schedule_sha256`.

## Testing

- Added hostile input, invalid string, and malformed hash rejection tests in `tests/test_runtime_profile_hostile_validation.py`.
- Verified all tests pass; `ruff check .` clean; `mypy` clean.