### PR TITLE
fix(benchmarks): add fail-closed post_init validation to OfficialForagaxRunPlan and BatchRunPlan

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -216,6 +216,19 @@ class OfficialForagaxValidationError(ValueError):
     """Raised when provenance or artifact verification fails closed."""
 
 
+def _require_string(value: Any, *, label: str) -> str:
+    if type(value) is not str or not value:
+        raise OfficialForagaxValidationError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_sha256(value: Any, *, label: str) -> str:
+    result = _require_string(value, label=label)
+    if _SHA256_PATTERN.fullmatch(result) is None:
+        raise OfficialForagaxValidationError(f"{label} must be a lowercase SHA-256")
+    return result
+
+
 @dataclass(frozen=True)
 class OfficialForagaxRunRequest:
     """Inputs for one official seed/index execution.
@@ -415,6 +428,20 @@ class OfficialForagaxRunPlan:
     config_snapshot_bytes: bytes = dataclasses.field(repr=False)
     execution_config_bytes: bytes = dataclasses.field(repr=False)
 
+    def __post_init__(self) -> None:
+        if type(self.request) is not OfficialForagaxRunRequest:
+            raise TypeError("request must be an OfficialForagaxRunRequest")
+        _require_sha256(self.interpreter_sha256, label="interpreter_sha256")
+        _require_sha256(self.package_freeze_sha256, label="package_freeze_sha256")
+        if not isinstance(self.command, tuple):
+            raise TypeError("command must be a tuple")
+        if not isinstance(self.package_freeze, tuple):
+            raise TypeError("package_freeze must be a tuple")
+        if not isinstance(self.config_snapshot_bytes, (bytes, bytearray)):
+            raise TypeError("config_snapshot_bytes must be bytes")
+        if not isinstance(self.execution_config_bytes, (bytes, bytearray)):
+            raise TypeError("execution_config_bytes must be bytes")
+
     @property
     def output_dir(self) -> Path:
         return _absolute_without_resolving_symlinks(self.request.output_dir)
@@ -476,6 +503,20 @@ class OfficialForagaxBatchRunPlan:
     runtime: Mapping[str, Any]
     config_snapshot_bytes: bytes = dataclasses.field(repr=False)
     execution_config_bytes: bytes = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self.request) is not OfficialForagaxBatchRunRequest:
+            raise TypeError("request must be an OfficialForagaxBatchRunRequest")
+        _require_sha256(self.interpreter_sha256, label="interpreter_sha256")
+        _require_sha256(self.package_freeze_sha256, label="package_freeze_sha256")
+        if not isinstance(self.command, tuple):
+            raise TypeError("command must be a tuple")
+        if not isinstance(self.package_freeze, tuple):
+            raise TypeError("package_freeze must be a tuple")
+        if not isinstance(self.config_snapshot_bytes, (bytes, bytearray)):
+            raise TypeError("config_snapshot_bytes must be bytes")
+        if not isinstance(self.execution_config_bytes, (bytes, bytearray)):
+            raise TypeError("execution_config_bytes must be bytes")
 
     @property
     def output_dir(self) -> Path:
@@ -1261,19 +1302,6 @@ def _expect_exact_keys(
         raise OfficialForagaxValidationError(
             f"{label} has an unexpected schema: missing={missing}, extra={extra}"
         )
-
-
-def _require_string(value: Any, *, label: str) -> str:
-    if type(value) is not str or not value:
-        raise OfficialForagaxValidationError(f"{label} must be a non-empty string")
-    return value
-
-
-def _require_sha256(value: Any, *, label: str) -> str:
-    result = _require_string(value, label=label)
-    if _SHA256_PATTERN.fullmatch(result) is None:
-        raise OfficialForagaxValidationError(f"{label} must be a lowercase SHA-256")
-    return result
 
 
 def _require_git_sha1(value: Any, *, label: str) -> str:

--- a/tests/test_official_foragax_run_plans_hostile_validation.py
+++ b/tests/test_official_foragax_run_plans_hostile_validation.py
@@ -1,0 +1,133 @@
+"""Hostile input and boundary validation for official foragax run plan dataclasses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.official_foragax import (
+    OfficialForagaxBatchRunPlan,
+    OfficialForagaxBatchRunRequest,
+    OfficialForagaxRunPlan,
+    OfficialForagaxRunRequest,
+    OfficialForagaxValidationError,
+)
+
+
+@pytest.fixture
+def dummy_run_request(tmp_path: Path) -> OfficialForagaxRunRequest:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / "configs/dqn.json"
+    config.parent.mkdir()
+    config.write_text("{}", encoding="utf-8")
+    return OfficialForagaxRunRequest(
+        repository=repo,
+        execution_commit="a" * 40,
+        config_path=config,
+        config_commit="b" * 40,
+        interpreter=Path("/usr/bin/python3"),
+        output_dir=tmp_path / "output",
+        index=0,
+    )
+
+
+@pytest.fixture
+def dummy_batch_request(tmp_path: Path) -> OfficialForagaxBatchRunRequest:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / "configs/dqn.json"
+    config.parent.mkdir()
+    config.write_text("{}", encoding="utf-8")
+    return OfficialForagaxBatchRunRequest(
+        repository=repo,
+        execution_commit="a" * 40,
+        config_path=config,
+        config_commit="b" * 40,
+        interpreter=Path("/usr/bin/python3"),
+        output_dir=tmp_path / "output",
+        indices=(0, 1),
+    )
+
+
+def test_official_foragax_run_plan_rejects_invalid_inputs(
+    dummy_run_request: OfficialForagaxRunRequest,
+) -> None:
+    with pytest.raises(TypeError, match="request must be an OfficialForagaxRunRequest"):
+        OfficialForagaxRunPlan(
+            request=None,  # type: ignore[arg-type]
+            trust={},
+            source={},
+            run={},
+            claim={},
+            command=("python",),
+            environment_overrides={},
+            relevant_environment={},
+            interpreter_sha256="a" * 64,
+            package_freeze=(),
+            package_freeze_sha256="b" * 64,
+            runtime={},
+            config_snapshot_bytes=b"{}",
+            execution_config_bytes=b"{}",
+        )
+
+    with pytest.raises(
+        OfficialForagaxValidationError, match="interpreter_sha256 must be a lowercase SHA-256"
+    ):
+        OfficialForagaxRunPlan(
+            request=dummy_run_request,
+            trust={},
+            source={},
+            run={},
+            claim={},
+            command=("python",),
+            environment_overrides={},
+            relevant_environment={},
+            interpreter_sha256="invalid",
+            package_freeze=(),
+            package_freeze_sha256="b" * 64,
+            runtime={},
+            config_snapshot_bytes=b"{}",
+            execution_config_bytes=b"{}",
+        )
+
+
+def test_official_foragax_batch_run_plan_rejects_invalid_inputs(
+    dummy_batch_request: OfficialForagaxBatchRunRequest,
+) -> None:
+    with pytest.raises(TypeError, match="request must be an OfficialForagaxBatchRunRequest"):
+        OfficialForagaxBatchRunPlan(
+            request=None,  # type: ignore[arg-type]
+            trust={},
+            source={},
+            run={},
+            claim={},
+            command=("python",),
+            environment_overrides={},
+            relevant_environment={},
+            interpreter_sha256="a" * 64,
+            package_freeze=(),
+            package_freeze_sha256="b" * 64,
+            runtime={},
+            config_snapshot_bytes=b"{}",
+            execution_config_bytes=b"{}",
+        )
+
+    with pytest.raises(TypeError, match="config_snapshot_bytes must be bytes"):
+        OfficialForagaxBatchRunPlan(
+            request=dummy_batch_request,
+            trust={},
+            source={},
+            run={},
+            claim={},
+            command=("python",),
+            environment_overrides={},
+            relevant_environment={},
+            interpreter_sha256="a" * 64,
+            package_freeze=(),
+            package_freeze_sha256="b" * 64,
+            runtime={},
+            config_snapshot_bytes="not bytes",  # type: ignore[arg-type]
+            execution_config_bytes=b"{}",
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to `OfficialForagaxRunPlan` and `OfficialForagaxBatchRunPlan` in `alberta_framework/benchmarks/official_foragax.py`:

- Enforces strict instance checks for `request` (`OfficialForagaxRunRequest` / `OfficialForagaxBatchRunRequest`).
- Validates 64-character lowercase SHA-256 strings for `interpreter_sha256` and `package_freeze_sha256`.
- Enforces strict `tuple` types for `command` and `package_freeze`.
- Enforces strict bytes/bytearray types for `config_snapshot_bytes` and `execution_config_bytes`.

## Testing

- Added hostile input, invalid request type, malformed hash, and non-bytes configuration rejection tests in `tests/test_official_foragax_run_plans_hostile_validation.py`.
- Verified all unit tests pass; `ruff check .` clean; `mypy` clean.