### PR TITLE
fix(benchmarks): add fail-closed post_init validation to ForagerMatrixManifest

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -426,6 +426,25 @@ class ForagerMatrixManifest:
     tuning_selection: ForagerTuningSelection | None = None
     source_path: Path | None = field(default=None, compare=False, repr=False)
 
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not str or not self.schema_version:
+            raise ValueError("schema_version must be a non-empty string")
+        for attr in ("steps", "jax_chunk_size", "seed_batch_size"):
+            val = getattr(self, attr)
+            if type(val) is not int or isinstance(val, bool) or val <= 0:
+                raise ValueError(f"{attr} must be a positive integer")
+        if type(self.selection_rule) is not ForagerTuningRule:
+            raise TypeError("selection_rule must be a ForagerTuningRule")
+        if not isinstance(self.variants, Mapping):
+            raise TypeError("variants must be a Mapping")
+        if (
+            self.tuning_selection is not None
+            and type(self.tuning_selection) is not ForagerTuningSelection
+        ):
+            raise TypeError(
+                "tuning_selection must be a ForagerTuningSelection or None"
+            )
+
     def to_dict(self) -> dict[str, Any]:
         """Return the normalized scientific configuration.
 

--- a/tests/test_forager_matrix_manifest_hostile_validation.py
+++ b/tests/test_forager_matrix_manifest_hostile_validation.py
@@ -1,0 +1,74 @@
+"""Hostile input and boundary validation for ForagerMatrixManifest."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matrix import (
+    ForagerMatrixManifest,
+    ForagerTuningRule,
+)
+
+
+@pytest.fixture
+def dummy_rule() -> ForagerTuningRule:
+    return ForagerTuningRule(
+        metric="mean_reward",
+        direction="maximize",
+        statistic="mean",
+        confidence=0.95,
+        bootstrap_resamples=100,
+        bootstrap_seed=0,
+    )
+
+
+def test_forager_matrix_manifest_rejects_invalid_inputs(
+    dummy_rule: ForagerTuningRule,
+) -> None:
+    with pytest.raises(ValueError, match="schema_version must be a non-empty string"):
+        ForagerMatrixManifest(
+            schema_version="",
+            preset="field_of_view",
+            stage="evaluation",
+            steps=100,
+            seeds=(0,),
+            jax_chunk_size=1,
+            seed_batch_size=1,
+            mode="strict",
+            source_execution_mode="live_tree_unsealed",
+            metric_evidence_mode="scalar_summary_unsealed",
+            selection_rule=dummy_rule,
+            variants={},
+        )
+
+    with pytest.raises(ValueError, match="steps must be a positive integer"):
+        ForagerMatrixManifest(
+            schema_version="2.3",
+            preset="field_of_view",
+            stage="evaluation",
+            steps=0,
+            seeds=(0,),
+            jax_chunk_size=1,
+            seed_batch_size=1,
+            mode="strict",
+            source_execution_mode="live_tree_unsealed",
+            metric_evidence_mode="scalar_summary_unsealed",
+            selection_rule=dummy_rule,
+            variants={},
+        )
+
+    with pytest.raises(TypeError, match="selection_rule must be a ForagerTuningRule"):
+        ForagerMatrixManifest(
+            schema_version="2.3",
+            preset="field_of_view",
+            stage="evaluation",
+            steps=100,
+            seeds=(0,),
+            jax_chunk_size=1,
+            seed_batch_size=1,
+            mode="strict",
+            source_execution_mode="live_tree_unsealed",
+            metric_evidence_mode="scalar_summary_unsealed",
+            selection_rule=None,  # type: ignore[arg-type]
+            variants={},
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to `ForagerMatrixManifest` in `alberta_framework/benchmarks/forager_matrix.py`:

- Validates non-empty string for `schema_version`.
- Validates positive integers (rejecting booleans) for `steps`, `jax_chunk_size`, and `seed_batch_size`.
- Validates exact `ForagerTuningRule` instance for `selection_rule`.
- Enforces strict `Mapping` type for `variants`.
- Enforces strict `ForagerTuningSelection` instance (or `None`) for `tuning_selection`.

## Testing

- Added hostile input, invalid string, negative step counts, and invalid tuning rule rejection tests in `tests/test_forager_matrix_manifest_hostile_validation.py`.
- Verified all unit tests pass; `ruff check .` clean; `mypy` clean.