### PR TITLE
fix(streams): add fail-closed post_init validation to PavlovianPhase

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -226,6 +226,31 @@ class PavlovianPhase:
     cs_active: tuple[int, ...]
     compound_index: int = -1
 
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if (
+            type(self.n_steps) is not int
+            or isinstance(self.n_steps, bool)
+            or self.n_steps <= 0
+        ):
+            raise ValueError("n_steps must be a positive integer")
+        if (
+            not isinstance(self.cs_us_contingency, (int, float))
+            or isinstance(self.cs_us_contingency, bool)
+            or not math.isfinite(self.cs_us_contingency)
+            or not (0.0 <= self.cs_us_contingency <= 1.0)
+        ):
+            raise ValueError("cs_us_contingency must be a float in [0.0, 1.0]")
+        if type(self.cs_active) is not tuple:
+            raise TypeError("cs_active must be a tuple")
+        if (
+            type(self.compound_index) is not int
+            or isinstance(self.compound_index, bool)
+            or self.compound_index < -1
+        ):
+            raise ValueError("compound_index must be an integer >= -1")
+
 
 @chex.dataclass(frozen=True)
 class PavlovianState:

--- a/tests/test_pavlovian_phase_hostile_validation.py
+++ b/tests/test_pavlovian_phase_hostile_validation.py
@@ -1,0 +1,39 @@
+"""Hostile input and boundary validation for PavlovianPhase dataclass."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from alberta_framework.streams.pavlovian import PavlovianPhase
+
+
+def _make_phase(**kwargs: Any) -> PavlovianPhase:
+    base: dict[str, Any] = {
+        "name": "acq",
+        "n_steps": 100,
+        "cs_us_contingency": 1.0,
+        "cs_active": (0,),
+        "compound_index": -1,
+    }
+    base.update(kwargs)
+    ctor: Any = PavlovianPhase
+    return cast(PavlovianPhase, ctor(**base))
+
+
+def test_pavlovian_phase_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        _make_phase(name="")
+
+    with pytest.raises(ValueError, match="n_steps must be a positive integer"):
+        _make_phase(n_steps=0)
+
+    with pytest.raises(ValueError, match=r"cs_us_contingency must be a float in \[0\.0, 1\.0\]"):
+        _make_phase(cs_us_contingency=1.5)
+
+    with pytest.raises(TypeError, match="cs_active must be a tuple"):
+        _make_phase(cs_active=[0])
+
+    with pytest.raises(ValueError, match="compound_index must be an integer >= -1"):
+        _make_phase(compound_index=-2)


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to `PavlovianPhase` in `alberta_framework/streams/pavlovian.py`:

- Validates non-empty string for phase `name`.
- Validates positive integer (rejecting bool) for `n_steps`.
- Validates finite float probability in `[0.0, 1.0]` for `cs_us_contingency`.
- Enforces strict `tuple` type for `cs_active`.
- Validates integer $\ge -1$ (rejecting bool) for `compound_index`.

## Testing

- Added hostile input, invalid probability range, negative step count, and non-tuple active CS rejection tests in `tests/test_pavlovian_phase_hostile_validation.py`.
- Verified all unit tests pass; `ruff check .` clean; `mypy` clean.