### PR TITLE
fix(evaluation): add fail-closed post_init validation to EvidenceSpec

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -377,6 +377,36 @@ class EvidenceSpec:
     loader: Callable[[Path], Mapping[str, object]]
     validator: Callable[[Mapping[str, object]], ValidationResult]
 
+    def __post_init__(self) -> None:
+        for attr in ("name", "claim_scope", "expected_schema"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if type(self.promotes_scientific_claim) is not bool:
+            raise TypeError("promotes_scientific_claim must be a bool")
+        if not isinstance(self.relative_path, Path):
+            raise TypeError("relative_path must be a pathlib.Path")
+        for attr in (
+            "command_argv",
+            "limitations",
+            "required_environment_fields",
+            "source_paths",
+        ):
+            val = getattr(self, attr)
+            if type(val) is not tuple:
+                raise TypeError(f"{attr} must be a tuple")
+        for path in self.source_paths:
+            if not isinstance(path, Path):
+                raise TypeError("source_paths must contain only pathlib.Path objects")
+        for attr in ("protocol", "configuration", "seeds", "thresholds"):
+            val = getattr(self, attr)
+            if not isinstance(val, Mapping):
+                raise TypeError(f"{attr} must be a Mapping")
+        if not callable(self.loader):
+            raise TypeError("loader must be callable")
+        if not callable(self.validator):
+            raise TypeError("validator must be callable")
+
 
 @dataclass(frozen=True)
 class _HistoricalIAChainValidation:

--- a/tests/test_evidence_spec_hostile_validation.py
+++ b/tests/test_evidence_spec_hostile_validation.py
@@ -1,0 +1,68 @@
+"""Hostile input and boundary validation for EvidenceSpec dataclass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import (
+    EvidenceSpec,
+    ValidationResult,
+)
+
+
+class DummyValidationResult(ValidationResult):
+    @property
+    def valid(self) -> bool:
+        return True
+
+    @property
+    def accepted(self) -> bool:
+        return True
+
+    @property
+    def errors(self) -> tuple[str, ...]:
+        return ()
+
+
+def _make_spec(**kwargs: Any) -> EvidenceSpec:
+    base: dict[str, Any] = {
+        "name": "spec_1",
+        "claim_scope": "scope_1",
+        "evidence_class": "scientific_evidence",
+        "evidence_level": "gold",
+        "promotes_scientific_claim": True,
+        "relative_path": Path("outputs/test.json"),
+        "expected_schema": "schema_v1",
+        "command_argv": ("run.py",),
+        "protocol": {},
+        "configuration": {},
+        "seeds": {},
+        "thresholds": {},
+        "limitations": (),
+        "source_paths": (Path("src/test.py"),),
+        "required_environment_fields": (),
+        "loader": lambda p: {},
+        "validator": lambda p: DummyValidationResult(),
+    }
+    base.update(kwargs)
+    return EvidenceSpec(**base)
+
+
+def test_evidence_spec_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        _make_spec(name="")
+
+    with pytest.raises(TypeError, match="promotes_scientific_claim must be a bool"):
+        _make_spec(promotes_scientific_claim=1)
+
+    with pytest.raises(TypeError, match="relative_path must be a pathlib.Path"):
+        _make_spec(relative_path="outputs/test.json")
+
+    with pytest.raises(TypeError, match="source_paths must contain only pathlib.Path objects"):
+        _make_spec(source_paths=("src/test.py",))
+
+    with pytest.raises(TypeError, match="loader must be callable"):
+        _make_spec(loader=None)


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation to `EvidenceSpec` in `alberta_framework/evaluation/evidence_manifest.py`:

- Validates non-empty strings across `name`, `claim_scope`, and `expected_schema`.
- Enforces strict `bool` type for `promotes_scientific_claim`.
- Enforces strict `Path` instance for `relative_path`.
- Enforces strict `tuple` types for `command_argv`, `limitations`, `required_environment_fields`, and `source_paths`.
- Enforces that all items within `source_paths` are `Path` instances.
- Validates `Mapping` types across `protocol`, `configuration`, `seeds`, and `thresholds`.
- Validates that `loader` and `validator` are callables.

## Testing

- Added hostile input, invalid boolean type, non-path string, and non-callable rejection tests in `tests/test_evidence_spec_hostile_validation.py`.
- Verified all unit tests pass; `ruff check .` clean; `mypy` clean.