### PR TITLE
fix(streams): reject leftover partial-observation mask modes

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -54,6 +54,18 @@ def _require_unit_interval_probability(name: str, value: object) -> float:
     return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
 
 
+def _require_mode(mode: object) -> MaskMode:
+    """Reject leftover string, bool, and int identities for ``mode``.
+
+    Leftover ``"FIXED"`` / ``"fixed"`` compare unequal to
+    ``MaskMode.FIXED``, so the wrapper stored the leftover, skipped the
+    fixed mask, and fell through to the periodic branch (fail-open).
+    """
+    if type(mode) is not MaskMode:
+        raise ValueError("mode must be an exact MaskMode")
+    return mode
+
+
 # =============================================================================
 # State
 # =============================================================================
@@ -86,7 +98,8 @@ class PartialObservationWrapper[InnerStateT]:
     Args:
         inner: The underlying ``ScanStream`` whose observations will be
             partially masked.
-        mode: Masking mode (FIXED / RANDOM / PERIODIC).
+        mode: Exact ``MaskMode`` member (FIXED / RANDOM / PERIODIC).
+            Leftover string, bool, and int identities are rejected.
         fixed_mask: Boolean mask of shape ``(feature_dim,)`` for FIXED.
             ``True`` means VISIBLE; ``False`` means HIDDEN.
         mask_prob: Per-channel KEEP probability for RANDOM. So
@@ -121,6 +134,7 @@ class PartialObservationWrapper[InnerStateT]:
         schedule: tuple[Bool[Array, " feature_dim"], ...] | None = None,
         sentinel: float = 0.0,
     ):
+        mode = _require_mode(mode)
         self._inner = inner
         self._mode = mode
         self._mask_prob = mask_prob

--- a/tests/test_partial_observation_leftover_mode.py
+++ b/tests/test_partial_observation_leftover_mode.py
@@ -1,0 +1,48 @@
+"""Leftover-identity gates for partial-observation mask modes."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.streams.partial_observation import (
+    MaskMode,
+    PartialObservationWrapper,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+
+def _inner() -> RandomWalkStream:
+    return RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.0)
+
+
+def _visible_odd_mask() -> jnp.ndarray:
+    return jnp.array([True, False, True, False])
+
+
+@pytest.mark.parametrize(
+    "leftover",
+    ("FIXED", "fixed", "RANDOM", "PERIODIC", 1, True, "not-a-mode"),
+)
+def test_partial_observation_rejects_leftover_mode_identities(leftover: object) -> None:
+    """Leftover mode identities must not skip the channel mask."""
+
+    with pytest.raises(ValueError, match="mode"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=leftover,  # type: ignore[arg-type]
+            fixed_mask=_visible_odd_mask(),
+        )
+
+
+def test_partial_observation_legal_fixed_mode_still_masks() -> None:
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.FIXED,
+        fixed_mask=_visible_odd_mask(),
+    )
+    assert wrapper.mode is MaskMode.FIXED
+    timestep, _ = wrapper.step(wrapper.init(jr.key(0)), jnp.array(0))
+    assert float(timestep.observation[1]) == 0.0
+    assert float(timestep.observation[3]) == 0.0


### PR DESCRIPTION
Closes #1353.

## What changed

Partial-observation mask modes now fail closed on leftover string, bool, and int identities.

On origin/main `939cdaa`, `PartialObservationWrapper(inner, mode="FIXED", fixed_mask=mask)` constructed and stored `_mode == "FIXED"`. The leftover compared unequal to `MaskMode.FIXED`, so `_fixed_mask` was set to `None` and `step()` fell through to the PERIODIC branch (`AssertionError: self._schedule is not None`). Leftover `"fixed"` / `"RANDOM"` / `1` / `True` / `"not-a-mode"` likewise accepted. Legal `MaskMode.FIXED` still masks hidden channels to `0.0`.

This is leftover tax on unknown-flag `mode` identities, not a republish of `#898` (leftover non-finite `sentinel` / `mask_prob` sentinels on the same file).

## Scope

- `alberta_framework/streams/partial_observation.py`
- `tests/test_partial_observation_leftover_mode.py`

## Why this is unowned

Live occupancy at publish time: ss251 open set is `#1287` (forager paper-reference) and `#1288` (security reward-weight). Kayvan `#1316`–`#1324` own other measurement/forager files. No open PR touches `partial_observation.py`.

## Verification

Exact candidate head: `4d7ddfb23d1fd13a879c4d43b9ce1ae8cdb46de1`
Base: `939cdaa`

- Red on base: leftover `mode="FIXED"` / `"fixed"` / `"RANDOM"` / `1` / `True` / `"not-a-mode"` accepted; leftover `"FIXED"` skipped the channel mask
- Focused pytest `tests/test_partial_observation_leftover_mode.py` plus existing `tests/test_partial_observation.py`: 32 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4d7ddfb23d1fd13a879c4d43b9ce1ae8cdb46de1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
