### PR TITLE
fix(benchmarks): add fail-closed post_init validation to matched protocol bindings dataclasses

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -144,6 +144,14 @@ class AllowedTransform:
     value_type: Literal["string", "integer", "number", "boolean", "null"]
     value: TransformValue
 
+    def __post_init__(self) -> None:
+        if type(self.transform_type) is not str or not self.transform_type:
+            raise ForagerMatchedProtocolError("transform_type must be a non-empty string")
+        if type(self.target) is not str or not self.target:
+            raise ForagerMatchedProtocolError("target must be a non-empty string")
+        if self.value_type not in ("string", "integer", "number", "boolean", "null"):
+            raise ForagerMatchedProtocolError("invalid value_type")
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "transform_type": self.transform_type,
@@ -173,6 +181,18 @@ class SourceBinding:
     inventory_sha256: str
     snapshot_descriptor_sha256: str | None
 
+    def __post_init__(self) -> None:
+        if self.provenance_kind not in ("git_tree", "reviewed_snapshot"):
+            raise ForagerMatchedProtocolError(
+                "provenance_kind must be git_tree or reviewed_snapshot"
+            )
+        if type(self.repository) is not str or not self.repository:
+            raise ForagerMatchedProtocolError("repository must be a non-empty string")
+        _require_sha256(self.archive_sha256, "archive_sha256")
+        _require_sha256(self.inventory_sha256, "inventory_sha256")
+        if self.snapshot_descriptor_sha256 is not None:
+            _require_sha256(self.snapshot_descriptor_sha256, "snapshot_descriptor_sha256")
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "provenance_kind": self.provenance_kind,
@@ -193,6 +213,19 @@ class ConfigurationBinding:
     original_sha256: str
     derived_sha256: str
     allowed_transforms: tuple[AllowedTransform, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.original_path) is not str or not self.original_path:
+            raise ForagerMatchedProtocolError("original_path must be a non-empty string")
+        _require_sha256(self.original_sha256, "original_sha256")
+        _require_sha256(self.derived_sha256, "derived_sha256")
+        if type(self.allowed_transforms) is not tuple:
+            raise ForagerMatchedProtocolError("allowed_transforms must be a tuple")
+        for item in self.allowed_transforms:
+            if not isinstance(item, AllowedTransform):
+                raise ForagerMatchedProtocolError(
+                    "allowed_transforms item must be an AllowedTransform"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -217,6 +250,20 @@ class SeedContract:
     effective_seed_expression: Literal["active_seed", "active_seed_plus_offset"]
     effective_seed_proof_sha256: str
 
+    def __post_init__(self) -> None:
+        if self.transport not in (
+            "direct",
+            "top_level_seed",
+            "nested_experiment_seed_offset",
+            "adapter_injected",
+        ):
+            raise ForagerMatchedProtocolError("invalid transport")
+        if type(self.offset) is not int or isinstance(self.offset, bool):
+            raise ForagerMatchedProtocolError("offset must be an integer")
+        if self.effective_seed_expression not in ("active_seed", "active_seed_plus_offset"):
+            raise ForagerMatchedProtocolError("invalid effective_seed_expression")
+        _require_sha256(self.effective_seed_proof_sha256, "effective_seed_proof_sha256")
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "transport": self.transport,
@@ -233,6 +280,22 @@ class ExecutionSemantics:
     rollout_steps: int | None
     num_rollouts: int | None
     update_semantics: str
+
+    def __post_init__(self) -> None:
+        if self.rollout_steps is not None and (
+            type(self.rollout_steps) is not int
+            or isinstance(self.rollout_steps, bool)
+            or self.rollout_steps <= 0
+        ):
+            raise ForagerMatchedProtocolError("rollout_steps must be positive integer or None")
+        if self.num_rollouts is not None and (
+            type(self.num_rollouts) is not int
+            or isinstance(self.num_rollouts, bool)
+            or self.num_rollouts <= 0
+        ):
+            raise ForagerMatchedProtocolError("num_rollouts must be positive integer or None")
+        if type(self.update_semantics) is not str or not self.update_semantics:
+            raise ForagerMatchedProtocolError("update_semantics must be a non-empty string")
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_forager_matched_bindings_hostile_validation.py
+++ b/tests/test_forager_matched_bindings_hostile_validation.py
@@ -1,0 +1,107 @@
+"""Hostile input and boundary validation for matched protocol bindings dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_protocol import (
+    AllowedTransform,
+    ConfigurationBinding,
+    ExecutionSemantics,
+    ForagerMatchedProtocolError,
+    SeedContract,
+    SourceBinding,
+)
+
+
+def test_allowed_transform_rejects_invalid_inputs() -> None:
+    with pytest.raises(
+        ForagerMatchedProtocolError,
+        match="transform_type must be a non-empty string",
+    ):
+        AllowedTransform(
+            transform_type="",
+            target="lr",
+            value_type="number",
+            value=0.01,
+        )
+
+    with pytest.raises(ForagerMatchedProtocolError, match="invalid value_type"):
+        AllowedTransform(
+            transform_type="override",
+            target="lr",
+            value_type="invalid_type",  # type: ignore[arg-type]
+            value=0.01,
+        )
+
+
+def test_source_binding_rejects_invalid_inputs() -> None:
+    valid_sha = "0" * 64
+    with pytest.raises(
+        ForagerMatchedProtocolError,
+        match="provenance_kind must be git_tree or reviewed_snapshot",
+    ):
+        SourceBinding(
+            provenance_kind="invalid_kind",  # type: ignore[arg-type]
+            repository="repo",
+            base_commit="0" * 40,
+            tree_git_sha1=None,
+            archive_sha256=valid_sha,
+            inventory_sha256=valid_sha,
+            snapshot_descriptor_sha256=None,
+        )
+
+    with pytest.raises(ForagerMatchedProtocolError):
+        SourceBinding(
+            provenance_kind="git_tree",
+            repository="repo",
+            base_commit="0" * 40,
+            tree_git_sha1=None,
+            archive_sha256="not_a_sha",
+            inventory_sha256=valid_sha,
+            snapshot_descriptor_sha256=None,
+        )
+
+
+def test_configuration_binding_rejects_invalid_inputs() -> None:
+    valid_sha = "0" * 64
+    with pytest.raises(ForagerMatchedProtocolError, match="allowed_transforms must be a tuple"):
+        ConfigurationBinding(
+            original_path="config.json",
+            original_sha256=valid_sha,
+            derived_sha256=valid_sha,
+            allowed_transforms=[],  # type: ignore[arg-type]
+        )
+
+
+def test_seed_contract_rejects_invalid_inputs() -> None:
+    valid_sha = "0" * 64
+    with pytest.raises(ForagerMatchedProtocolError, match="offset must be an integer"):
+        SeedContract(
+            transport="direct",
+            offset="0",  # type: ignore[arg-type]
+            effective_seed_expression="active_seed",
+            effective_seed_proof_sha256=valid_sha,
+        )
+
+
+def test_execution_semantics_rejects_invalid_inputs() -> None:
+    with pytest.raises(
+        ForagerMatchedProtocolError,
+        match="rollout_steps must be positive integer or None",
+    ):
+        ExecutionSemantics(
+            rollout_steps=0,
+            num_rollouts=10,
+            update_semantics="sync",
+        )
+
+    with pytest.raises(
+        ForagerMatchedProtocolError,
+        match="update_semantics must be a non-empty string",
+    ):
+        ExecutionSemantics(
+            rollout_steps=100,
+            num_rollouts=10,
+            update_semantics="",
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across matched protocol bindings dataclasses in `alberta_framework/benchmarks/forager_matched_protocol.py`:

- `AllowedTransform`: Validates non-empty string for `transform_type` and `target`, and checks membership of `value_type`.
- `SourceBinding`: Validates provenance kind literal, non-empty `repository`, and canonical SHA-256 digests across `archive_sha256`, `inventory_sha256`, and optional `snapshot_descriptor_sha256`.
- `ConfigurationBinding`: Validates non-empty `original_path`, canonical SHA-256 digests, and strict tuple of `AllowedTransform` instances.
- `SeedContract`: Validates transport literal, integer offset (rejecting bool), effective seed expression, and canonical SHA-256 proof.
- `ExecutionSemantics`: Validates optional positive integers (rejecting bool) for `rollout_steps` / `num_rollouts`, and non-empty `update_semantics`.

## Testing

- Added hostile input, invalid literal type, non-sha digest, and empty string rejection tests in `tests/test_forager_matched_bindings_hostile_validation.py`.
- Verified all unit tests pass; `ruff check .` clean; `mypy` clean.