### PR TITLE
fix(benchmarks): add fail-closed post_init validation to _BatchPlan and _SourceSnapshot

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -468,6 +468,21 @@ class _BatchPlan:
     batch_index: int
     seeds: tuple[int, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.variant_id) is not str or not self.variant_id:
+            raise ForagerMatrixError("variant_id must be a non-empty string")
+        if (
+            type(self.batch_index) is not int
+            or isinstance(self.batch_index, bool)
+            or self.batch_index < 0
+        ):
+            raise ForagerMatrixError("batch_index must be a non-negative integer")
+        if type(self.seeds) is not tuple:
+            raise ForagerMatrixError("seeds must be a tuple")
+        for s in self.seeds:
+            if type(s) is not int or isinstance(s, bool) or s < 0:
+                raise ForagerMatrixError("seeds item must be a non-negative integer")
+
     @property
     def relative_path(self) -> str:
         return f"batches/{self.variant_id}/batch-{self.batch_index:05d}.json"
@@ -496,6 +511,24 @@ class _SourceSnapshot:
     tree_sha256: str
     inventory_sha256: str
     inventory: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if type(self.archive_bytes) is not bytes:
+            raise ForagerMatrixError("archive_bytes must be bytes")
+        for attr in ("archive_sha256", "tree_sha256", "inventory_sha256"):
+            val = getattr(self, attr)
+            if (
+                type(val) is not str
+                or len(val) != 64
+                or any(ch not in "0123456789abcdef" for ch in val)
+            ):
+                raise ForagerMatrixError(
+                    f"{attr} must be a 64-character lowercase hex string"
+                )
+        if hashlib.sha256(self.archive_bytes).hexdigest() != self.archive_sha256:
+            raise ForagerMatrixError("archive_sha256 does not match archive_bytes digest")
+        if not isinstance(self.inventory, Mapping):
+            raise ForagerMatrixError("inventory must be a Mapping")
 
     def metadata(self, source_execution_mode: SourceExecutionMode) -> dict[str, Any]:
         return {

--- a/tests/test_forager_matrix_batch_plan_hostile_validation.py
+++ b/tests/test_forager_matrix_batch_plan_hostile_validation.py
@@ -1,0 +1,66 @@
+"""Hostile input and boundary validation for matrix batch plan and source snapshot dataclasses."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matrix import (
+    ForagerMatrixError,
+    _BatchPlan,
+    _SourceSnapshot,
+)
+
+
+def test_batch_plan_rejects_invalid_inputs() -> None:
+    with pytest.raises(ForagerMatrixError, match="variant_id must be a non-empty string"):
+        _BatchPlan(
+            variant_id="",
+            batch_index=0,
+            seeds=(0, 1),
+        )
+
+    with pytest.raises(ForagerMatrixError, match="batch_index must be a non-negative integer"):
+        _BatchPlan(
+            variant_id="var1",
+            batch_index=-1,
+            seeds=(0, 1),
+        )
+
+    with pytest.raises(ForagerMatrixError, match="seeds item must be a non-negative integer"):
+        _BatchPlan(
+            variant_id="var1",
+            batch_index=0,
+            seeds=(True,),
+        )
+
+
+def test_source_snapshot_rejects_invalid_inputs() -> None:
+    payload = b"test payload"
+    digest = hashlib.sha256(payload).hexdigest()
+    valid_sha = "0" * 64
+
+    with pytest.raises(
+        ForagerMatrixError,
+        match="archive_sha256 does not match archive_bytes digest",
+    ):
+        _SourceSnapshot(
+            archive_bytes=payload,
+            archive_sha256=valid_sha,
+            tree_sha256=valid_sha,
+            inventory_sha256=valid_sha,
+            inventory={},
+        )
+
+    with pytest.raises(
+        ForagerMatrixError,
+        match="tree_sha256 must be a 64-character lowercase hex string",
+    ):
+        _SourceSnapshot(
+            archive_bytes=payload,
+            archive_sha256=digest,
+            tree_sha256="invalid",
+            inventory_sha256=valid_sha,
+            inventory={},
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across batch plan and snapshot dataclasses in `alberta_framework/benchmarks/forager_matrix.py`:

- `_BatchPlan`: Validates non-empty variant ID string, non-negative integer batch index (rejecting bool), and non-negative integer seeds tuple.
- `_SourceSnapshot`: Validates raw archive bytes, canonical 64-character lowercase hex digest strings for archive, tree, and inventory SHA-256 digests, matching digest verification against `hashlib.sha256(archive_bytes)`, and Mapping inventory instance type.

## Testing

- Added hostile input, invalid variant ID, negative batch index, bool seed rejection, digest mismatch, and non-canonical digest rejection tests in `tests/test_forager_matrix_batch_plan_hostile_validation.py`.
- Verified unit tests pass; `ruff check .` clean; `mypy` clean.