### PR TITLE
fix(benchmarks): add fail-closed post_init validation to _BoundPathComponent and _BoundDirectory

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1927,6 +1927,14 @@ class _BoundPathComponent:
     device: int
     inode: int
 
+    def __post_init__(self) -> None:
+        for attr in ("parent_descriptor", "child_descriptor", "device", "inode"):
+            val = getattr(self, attr)
+            if type(val) is not int or isinstance(val, bool):
+                raise ForagerMatrixStateError(f"{attr} must be an integer")
+        if type(self.name) is not str or not self.name:
+            raise ForagerMatrixStateError("name must be a non-empty string")
+
 
 @dataclass
 class _BoundDirectory:
@@ -1938,6 +1946,33 @@ class _BoundDirectory:
     device: int
     inode: int
     lock_identity: tuple[int, int] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path):
+            raise ForagerMatrixStateError("path must be a Path")
+        for attr in ("root_descriptor", "device", "inode"):
+            val = getattr(self, attr)
+            if type(val) is not int or isinstance(val, bool):
+                raise ForagerMatrixStateError(f"{attr} must be an integer")
+        if type(self.bindings) is not tuple:
+            raise ForagerMatrixStateError("bindings must be a tuple")
+        for binding in self.bindings:
+            if not isinstance(binding, _BoundPathComponent):
+                raise ForagerMatrixStateError(
+                    "bindings item must be a _BoundPathComponent"
+                )
+        if self.lock_identity is not None:
+            if (
+                type(self.lock_identity) is not tuple
+                or len(self.lock_identity) != 2
+                or any(
+                    type(x) is not int or isinstance(x, bool)
+                    for x in self.lock_identity
+                )
+            ):
+                raise ForagerMatrixStateError(
+                    "lock_identity must be None or a tuple of two integers"
+                )
 
     def assert_bound(self) -> None:
         opened = os.fstat(self.root_descriptor)

--- a/tests/test_forager_matrix_bound_directory_hostile_validation.py
+++ b/tests/test_forager_matrix_bound_directory_hostile_validation.py
@@ -1,0 +1,65 @@
+"""Hostile input and boundary validation for bound directory dataclasses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matrix import (
+    ForagerMatrixStateError,
+    _BoundDirectory,
+    _BoundPathComponent,
+)
+
+
+def test_bound_path_component_rejects_invalid_inputs() -> None:
+    with pytest.raises(ForagerMatrixStateError, match="name must be a non-empty string"):
+        _BoundPathComponent(
+            parent_descriptor=3,
+            name="",
+            child_descriptor=4,
+            device=1,
+            inode=2,
+        )
+
+    with pytest.raises(ForagerMatrixStateError, match="parent_descriptor must be an integer"):
+        _BoundPathComponent(
+            parent_descriptor=True,
+            name="subdir",
+            child_descriptor=4,
+            device=1,
+            inode=2,
+        )
+
+
+def test_bound_directory_rejects_invalid_inputs() -> None:
+    comp = _BoundPathComponent(
+        parent_descriptor=3,
+        name="subdir",
+        child_descriptor=4,
+        device=1,
+        inode=2,
+    )
+
+    with pytest.raises(ForagerMatrixStateError, match="path must be a Path"):
+        _BoundDirectory(
+            path="/not/a/path/object",  # type: ignore[arg-type]
+            root_descriptor=5,
+            bindings=(comp,),
+            device=1,
+            inode=2,
+        )
+
+    with pytest.raises(
+        ForagerMatrixStateError,
+        match=r"lock_identity must be None or a tuple of two integers",
+    ):
+        _BoundDirectory(
+            path=Path("/tmp"),
+            root_descriptor=5,
+            bindings=(comp,),
+            device=1,
+            inode=2,
+            lock_identity=(1, 2, 3),  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds fail-closed `__post_init__` boundary validation across bound directory dataclasses in `alberta_framework/benchmarks/forager_matrix.py`:

- `_BoundPathComponent`: Validates integer descriptors, device, inode (rejecting bool), and non-empty name string.
- `_BoundDirectory`: Validates Path instance type, integer root descriptor, device, inode, tuple of `_BoundPathComponent` bindings, and `None` or 2-integer tuple `lock_identity`.

## Testing

- Added hostile input, invalid descriptor, non-path object rejection, and invalid lock identity tests in `tests/test_forager_matrix_bound_directory_hostile_validation.py`.
- Verified unit tests pass; `ruff check .` clean; `mypy` clean.