### PR TITLE
fix(benchmarks): reject non-finite channel_priorities in official-foragax access classifier

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -4969,7 +4969,9 @@ def _classify_official_foragax_agent_access(
         and isinstance(channel_priorities, dict)
         and all(isinstance(key, str) for key in channel_priorities)
         and all(
-            isinstance(priority, (int, float)) and not isinstance(priority, bool)
+            isinstance(priority, (int, float))
+            and not isinstance(priority, bool)
+            and math.isfinite(priority)
             for priority in channel_priorities.values()
         )
     )

--- a/tests/test_official_foragax.py
+++ b/tests/test_official_foragax.py
@@ -2553,3 +2553,27 @@ def test_manifest_postpublication_keyboard_interrupt_removes_manifest_and_lock(
         run_official_foragax(request)
     assert not (request.output_dir / "manifest.json").exists()
     assert not (request.output_dir / ".running").exists()
+
+
+def test_agent_access_rejects_nonfinite_channel_priorities() -> None:
+    base = {
+        "agent": "Search-Oracle",
+        "semantic_environment": {
+            "aperture_size": -1,
+            "observation_type": "object",
+        },
+        "registry": {
+            "class": "algorithms.MCTSAgent.MCTSAgent",
+            "module": "algorithms.MCTSAgent",
+        },
+    }
+    for value in (float("nan"), float("inf"), float("-inf")):
+        result = official_foragax_module._classify_official_foragax_agent_access(
+            resolved_hyperparameters={
+                "mode": "world",
+                "channel_priorities": {"apple": value},
+            },
+            **base,
+        )
+        assert result["classified"] is False
+        assert result["role"] == "unclassified"


### PR DESCRIPTION
Closes #1363.

## What changed

`_classify_official_foragax_agent_access` accepted `NaN`, `inf`, and `-inf` in `channel_priorities`. The existing check required `int`/`float` and excluded `bool`, but never checked finiteness, so a non-finite priority produced `classified=True` and a privileged role (`privileged_control`) instead of the manifest being rejected as malformed.

## Fix

Require `math.isfinite(priority)` for every channel priority, matching the finite-input contract this validator already enforces elsewhere.

## Reachability

This is a standalone CLI harness module (`argparse` + `main()` + `if __name__ == "__main__"`), not part of the package's `__init__.py`-exported API surface — same framing as `official_foragax_oci.py` (round 55, #1006). `_classify_official_foragax_agent_access` is called from both `prepare_official_foragax_run` and manifest verification (`_verified_agent_access_sections`) with `resolved_hyperparameters` derived from `_validated_resolved_hyperparameters` — operator-supplied experiment config, not hardcoded-safe values — so this is reachable via the harness's real CLI/programmatic invocation path.

## Verification

Live reproduction against the unpatched tree:

```text
nan True privileged_control
inf True privileged_control
```

Added `test_agent_access_rejects_nonfinite_channel_priorities`, covering `NaN`, `+inf`, `-inf`.

Mutation check (source fix reverted, test kept):

```text
assert True is False
1 failed, 45 deselected
```

Fix restored: `1 passed, 45 deselected`.

`ruff check` and `mypy` both clean on the touched files.

Full `tests/test_official_foragax.py`: 24 pre-existing failures unrelated to this change — independently confirmed by running the *unmodified* tree (via `git stash`) and getting the identical 24 failures with the identical error signatures (`OfficialForagaxValidationError`, mostly checkout/harness-SHA integrity checks that don't hold in a worktree checkout). With the fix applied: 22 passed vs 21 passed on the clean tree — exactly one more, the new regression test, with zero additional failures either way.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), lint, mypy, and the reachability trace above were all re-run and re-confirmed by hand. The draft's report did not attempt a full-file test run; I ran it myself, found 24 failures, and confirmed via `git stash` comparison against the clean tree that all 24 are pre-existing and unrelated to this diff before shipping.

Attribution status: self-reported.
