### PR TITLE
fix(streams): saturate synthetic lifetime clocks

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -20,6 +20,7 @@ from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -454,7 +455,7 @@ class AbruptChangeStream:
         new_state = AbruptChangeState(
             key=key,
             true_weights=new_weights,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
 
         return timestep, new_state
@@ -611,7 +612,7 @@ class SuttonExperiment1Stream:
             key=key,
             signs=new_signs,
             wt_irr=wt_irr,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
 
         return timestep, new_state
@@ -722,7 +723,7 @@ class CyclicStream:
         new_state = CyclicState(
             key=key,
             configurations=state.configurations,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
 
         return timestep, new_state
@@ -838,7 +839,7 @@ class PeriodicChangeStream:
             key=key,
             base_weights=state.base_weights,
             phases=state.phases,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
 
         return timestep, new_state
@@ -1170,7 +1171,7 @@ class DynamicScaleShiftStream:
             key=key,
             true_weights=new_weights,
             current_scales=new_scales,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
         return timestep, new_state
 
@@ -1313,7 +1314,7 @@ class ScaleDriftStream:
             key=key,
             true_weights=new_weights,
             log_scales=new_log_scales,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
         return timestep, new_state
 

--- a/tests/test_synthetic_lifetime_clock.py
+++ b/tests/test_synthetic_lifetime_clock.py
@@ -1,0 +1,85 @@
+"""Saturating lifetime clocks keep synthetic schedule identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.synthetic import (
+    AbruptChangeStream,
+    CyclicStream,
+    PeriodicChangeStream,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_cyclic_stream_wrap_would_change_config_slot() -> None:
+    """INT32_MAX+1 wrap selects a different cyclic configuration than saturate."""
+
+    stream = CyclicStream(
+        feature_dim=3,
+        cycle_length=1,
+        num_configurations=2,
+        noise_std=0.0,
+        feature_std=1.0,
+    )
+    planted = stream.init(jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    wrap_slot = int((jnp.asarray(_INT32_MIN, dtype=jnp.int32) // 1) % 2)
+    sat_slot = int((advanced.step_count // 1) % 2)
+    assert sat_slot != wrap_slot
+    assert sat_slot == 1
+    assert wrap_slot == 0
+
+
+def test_abrupt_change_wrap_would_silence_the_change_schedule() -> None:
+    """Wrap stores INT32_MIN, so the next interval-1 change is skipped."""
+
+    stream = AbruptChangeStream(
+        feature_dim=3,
+        change_interval=1,
+        noise_std=0.0,
+        feature_std=1.0,
+    )
+    planted = stream.init(jr.key(1)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    wrap_should_change = bool(
+        (jnp.asarray(_INT32_MIN, dtype=jnp.int32) > 0)
+        & (jnp.asarray(_INT32_MIN, dtype=jnp.int32) % 1 == 0)
+    )
+    sat_should_change = bool(
+        (advanced.step_count > 0) & (advanced.step_count % 1 == 0)
+    )
+    assert sat_should_change
+    assert not wrap_should_change
+
+
+def test_periodic_change_wrap_would_flip_the_oscillation_phase() -> None:
+    """float32(INT32_MIN) is the negated phase of float32(INT32_MAX)."""
+
+    stream = PeriodicChangeStream(
+        feature_dim=2,
+        period=8,
+        amplitude=1.0,
+        noise_std=0.0,
+        feature_std=1.0,
+    )
+    planted = stream.init(jr.key(2)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    t_sat = advanced.step_count.astype(jnp.float32)
+    t_wrap = jnp.asarray(_INT32_MIN, dtype=jnp.int32).astype(jnp.float32)
+    phase_sat = jnp.sin(2.0 * jnp.pi * t_sat / jnp.float32(8.0))
+    phase_wrap = jnp.sin(2.0 * jnp.pi * t_wrap / jnp.float32(8.0))
+    assert float(phase_sat) != float(phase_wrap)
+    assert float(phase_sat) == -float(phase_wrap)


### PR DESCRIPTION
Closes #1365.

## What changed

Synthetic stream ``step_count`` now uses the shared saturating int32 increment.

On origin/main `939cdaa`, ``INT32_MAX + 1`` wrapped to ``INT32_MIN`` and changed schedule identity: cyclic configuration slot, abrupt-change cadence, and periodic oscillation phase. Legal early-lifetime steps are unchanged. Hidden-state AR(2) has no lifetime clock and is untouched.

This is the saturating lifetime-clock family from merged `#1277` / the `#1032` successor to `#999`, not a leftover-identity reprint.

## Scope

- `alberta_framework/streams/synthetic.py`
- `tests/test_synthetic_lifetime_clock.py`

## Why this is unowned

Live occupancy at publish time: ss251 open set is `#1287`, `#1288`, `#1354`. No open PR touches `synthetic.py`. Closed-unmerged leftover-identity files are not in this tree.

## Verification

Exact candidate head: `e0b0c4247d5f1c4604ed6908651e4231fd7b7bcd`
Base: `939cdaa`

- Red on base: planted ``INT32_MAX`` then ``+ 1`` stored ``INT32_MIN``; next cyclic slot, abrupt-change gate, and periodic phase differed from saturate
- Focused pytest `tests/test_synthetic_lifetime_clock.py` plus existing `tests/test_synthetic_stream_validation.py`: 71 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary lifetime-clock saturation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e0b0c4247d5f1c4604ed6908651e4231fd7b7bcd -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
