### PR TITLE
fix(streams): saturate feature-discovery lifetime clocks

### DIFF
--- a/alberta_framework/streams/feature_discovery.py
+++ b/alberta_framework/streams/feature_discovery.py
@@ -30,6 +30,7 @@ from alberta_framework._fixed_count_selection import (
     stable_smallest_mask,
 )
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 
 _INT32_MAX = 2**31 - 1
@@ -453,7 +454,10 @@ class NonlinearFeatureDiscoveryStream:
         target = target + noise
 
         timestep = TimeStep(observation=x, target=target)
-        new_state = state.replace(key=key, step_count=state.step_count + 1)  # type: ignore[attr-defined]
+        new_state = state.replace(  # type: ignore[attr-defined]
+            key=key,
+            step_count=_saturating_int32_counter_increment(state.step_count),
+        )
         return timestep, new_state
 
 
@@ -741,5 +745,8 @@ class InteractionFeatureDiscoveryStream:
         target = target + noise
 
         timestep = TimeStep(observation=x, target=target)
-        new_state = state.replace(key=key, step_count=state.step_count + 1)  # type: ignore[attr-defined]
+        new_state = state.replace(  # type: ignore[attr-defined]
+            key=key,
+            step_count=_saturating_int32_counter_increment(state.step_count),
+        )
         return timestep, new_state

--- a/tests/test_feature_discovery_lifetime_clock.py
+++ b/tests/test_feature_discovery_lifetime_clock.py
@@ -1,0 +1,64 @@
+"""Saturating lifetime clocks keep feature-discovery context identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.feature_discovery import (
+    InteractionFeatureDiscoveryStream,
+    NonlinearFeatureDiscoveryStream,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _wrap_slot() -> int:
+    return int((jnp.asarray(_INT32_MIN, dtype=jnp.int32) // 1) % 2)
+
+
+def _sat_slot() -> int:
+    return int((jnp.asarray(_INT32_MAX, dtype=jnp.int32) // 1) % 2)
+
+
+def test_nonlinear_feature_discovery_wrap_would_change_context_slot() -> None:
+    stream = NonlinearFeatureDiscoveryStream(
+        feature_dim=4,
+        n_tasks=2,
+        n_latents=4,
+        n_contexts=2,
+        context_length=1,
+        active_latents_per_context=1,
+        feature_std=1.0,
+        noise_std=0.0,
+    )
+    planted = stream.init(jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    sat_slot = int((advanced.step_count // 1) % 2)
+    assert sat_slot == _sat_slot() == 1
+    assert _wrap_slot() == 0
+    assert sat_slot != _wrap_slot()
+
+
+def test_interaction_feature_discovery_wrap_would_change_context_slot() -> None:
+    stream = InteractionFeatureDiscoveryStream(
+        feature_dim=4,
+        n_tasks=2,
+        n_contexts=2,
+        context_length=1,
+        active_pairs_per_context=1,
+        feature_std=1.0,
+        noise_std=0.0,
+    )
+    planted = stream.init(jr.key(1)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    sat_slot = int((advanced.step_count // 1) % 2)
+    assert sat_slot == _sat_slot() == 1
+    assert sat_slot != _wrap_slot()


### PR DESCRIPTION
Closes #1367.

## What changed

Feature-discovery stream ``step_count`` now uses the shared saturating int32 increment.

On origin/main `939cdaa`, ``INT32_MAX + 1`` wrapped to ``INT32_MIN`` and changed context identity: ``(step_count // context_length) % n_contexts`` jumps from slot 1 to slot 0 when ``context_length=1`` and ``n_contexts=2``. Legal early-lifetime steps are unchanged.

This is the saturating lifetime-clock family from `#1366` / `#1277`, not a leftover-identity reprint.

## Scope

- `alberta_framework/streams/feature_discovery.py`
- `tests/test_feature_discovery_lifetime_clock.py`

## Why this is unowned

Live occupancy at publish time: ss251 open set is `#1287`, `#1288`, `#1354`, `#1366` (synthetic clocks). No open PR touches `streams/feature_discovery.py`.

## Verification

Exact candidate head: `4b7649c905d69c13ad9b080e56a5eb338968e5db`
Base: `939cdaa`

- Red on base: planted ``INT32_MAX`` then ``+ 1`` stored ``INT32_MIN``; next context slot differed from saturate
- Focused pytest `tests/test_feature_discovery_lifetime_clock.py` plus existing `tests/test_feature_discovery.py`: 150 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary lifetime-clock saturation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4b7649c905d69c13ad9b080e56a5eb338968e5db -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
