### PR TITLE
fix(streams): saturate Step 1 lifetime clocks

### DIFF
--- a/alberta_framework/streams/alberta_plan_step1.py
+++ b/alberta_framework/streams/alberta_plan_step1.py
@@ -33,6 +33,7 @@ from jax import Array
 from jaxtyping import Float, Int, PRNGKeyArray
 
 from alberta_framework._float32 import round_real_to_float32_with_ratio
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 
 _INT32_MAX = 2**31 - 1
@@ -302,7 +303,7 @@ class AlbertaPlanStep1Stream:
             key=key,
             true_weights=new_weights,
             true_bias=new_bias,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
         return timestep, new_state
 
@@ -530,6 +531,6 @@ class XDistShiftStream:
             key=key,
             true_weights=state.true_weights,
             current_scales=new_scales,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
         )
         return timestep, new_state

--- a/tests/test_alberta_plan_step1_lifetime_clock.py
+++ b/tests/test_alberta_plan_step1_lifetime_clock.py
@@ -1,0 +1,47 @@
+"""Saturating lifetime clocks keep Step 1 scale-change identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.alberta_plan_step1 import (
+    AlbertaPlanStep1Stream,
+    XDistShiftStream,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_xdist_shift_wrap_would_silence_the_scale_change_schedule() -> None:
+    stream = XDistShiftStream(
+        feature_dim=3,
+        num_relevant=1,
+        scale_change_interval=1,
+        noise_std=0.0,
+        noise_in_target=False,
+    )
+    planted = stream.init(jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    wrap_should_change = bool(
+        (jnp.asarray(_INT32_MIN, dtype=jnp.int32) > 0)
+        & (jnp.asarray(_INT32_MIN, dtype=jnp.int32) % 1 == 0)
+    )
+    sat_should_change = bool(
+        (advanced.step_count > 0) & (advanced.step_count % 1 == 0)
+    )
+    assert sat_should_change
+    assert not wrap_should_change
+
+
+def test_alberta_plan_step1_clock_saturates_at_int32_max() -> None:
+    stream = AlbertaPlanStep1Stream(feature_dim=4, num_relevant=1, noise_std=0.0)
+    planted = stream.init(jr.key(1)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX


### PR DESCRIPTION
Closes #1369.

## What changed

Step 1 stream ``step_count`` now uses the shared saturating int32 increment.

On origin/main `939cdaa`, ``INT32_MAX + 1`` wrapped to ``INT32_MIN`` and silenced ``XDistShiftStream`` interval-1 scale changes (``step_count > 0`` fails after wrap). ``AlbertaPlanStep1Stream`` saturates the same clock so the file is complete. Legal early-lifetime steps are unchanged.

This is the saturating lifetime-clock family from `#1366` / `#1368` / `#1277`, not a leftover-identity reprint.

## Scope

- `alberta_framework/streams/alberta_plan_step1.py`
- `tests/test_alberta_plan_step1_lifetime_clock.py`

## Why this is unowned

Live occupancy at publish time: ss251 open set is `#1287`, `#1288`, `#1354`, `#1366`, `#1368`. No open PR touches `alberta_plan_step1.py`.

## Verification

Exact candidate head: `d4bc6d16d777f1fdabd3ec3a1d53be1444011768`
Base: `939cdaa`

- Red on base: planted ``INT32_MAX`` then ``+ 1`` stored ``INT32_MIN``; next scale-change gate differed from saturate
- Focused pytest `tests/test_alberta_plan_step1_lifetime_clock.py` plus existing `tests/test_alberta_plan_step1_streams.py`: 70 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary lifetime-clock saturation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d4bc6d16d777f1fdabd3ec3a1d53be1444011768 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
