### PR TITLE
fix(core): saturate learner lifetime clocks

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -39,6 +39,7 @@ from alberta_framework.core.normalizers import (
     Normalizer,
     StreamingBatchNormalizerState,
     WelfordNormalizerState,
+    _saturating_int32_counter_increment,
 )
 from alberta_framework.core.optimizers import (
     LMS,
@@ -333,7 +334,7 @@ class LinearLearner:
             bias=new_bias,
             optimizer_state=opt_update.new_state,
             normalizer_state=new_normalizer_state,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -1470,7 +1471,7 @@ class MLPLearner:
             traces=tuple(new_traces),
             normalizer_state=new_normalizer_state,
             neuron_utility=new_neuron_utility,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -1886,7 +1887,7 @@ class TDLinearLearner:
             weights=new_weights,
             bias=new_bias,
             optimizer_state=opt_update.new_state,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -2056,7 +2057,7 @@ class TrueOnlineTDLearner:
             eligibility_traces=stored_traces,
             bias_eligibility_trace=stored_bias_trace,
             v_old=new_v_old,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )

--- a/tests/test_learners_lifetime_clock.py
+++ b/tests/test_learners_lifetime_clock.py
@@ -1,0 +1,118 @@
+"""Saturating lifetime clocks keep learner update identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.core.learners import (
+    LinearLearner,
+    MLPLearner,
+    TDLinearLearner,
+    TrueOnlineTDLearner,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _wrap_clock() -> jnp.ndarray:
+    return jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+
+
+def _committed_update_identity(step_count: jnp.ndarray) -> tuple[bool, bool]:
+    """Ensemble/gate contracts that bind the committed learner clock.
+
+    ``WorldModelEnsemble._member_state_valid`` requires ``step_count >= 0``
+    and ``learner_state.step_count ==`` the saturated member clock.
+    ``recurring_feature_gate`` publishes ``steps_seen=int(step_count)``.
+    """
+    ensemble_clock = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    non_negative = bool(step_count >= 0)
+    matches_saturated_member = bool(step_count == ensemble_clock)
+    return non_negative, matches_saturated_member
+
+
+def test_int32_wrap_forges_a_different_update_identity() -> None:
+    wrap = _wrap_clock()
+    assert int(wrap) == _INT32_MIN
+    wrap_nonneg, wrap_matches = _committed_update_identity(wrap)
+    sat_nonneg, sat_matches = _committed_update_identity(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    assert sat_nonneg and sat_matches
+    assert not wrap_nonneg
+    assert not wrap_matches
+    assert int(wrap) != _INT32_MAX
+
+
+def test_linear_learner_clock_saturates_and_keeps_update_identity() -> None:
+    learner = LinearLearner()
+    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    result = learner.update(
+        planted,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    nonneg, matches = _committed_update_identity(result.state.step_count)
+    assert nonneg and matches
+    wrap_nonneg, wrap_matches = _committed_update_identity(_wrap_clock())
+    assert not wrap_nonneg
+    assert not wrap_matches
+
+
+def test_mlp_learner_clock_saturates_and_keeps_update_identity() -> None:
+    learner = MLPLearner(hidden_sizes=(2,), use_layer_norm=False, sparsity=0.0)
+    planted = learner.init(2, jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    result = learner.update(
+        planted,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    nonneg, matches = _committed_update_identity(result.state.step_count)
+    assert nonneg and matches
+
+
+def test_td_learner_clock_saturates_and_keeps_update_identity() -> None:
+    learner = TDLinearLearner()
+    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    result = learner.update(
+        planted,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32) * 0.5,
+        jnp.asarray(0.9, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    nonneg, matches = _committed_update_identity(result.state.step_count)
+    assert nonneg and matches
+
+
+def test_true_online_td_clock_saturates_and_keeps_update_identity() -> None:
+    learner = TrueOnlineTDLearner()
+    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    result = learner.update(
+        planted,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32) * 0.5,
+        jnp.asarray(0.9, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    nonneg, matches = _committed_update_identity(result.state.step_count)
+    assert nonneg and matches
+
+
+def test_linear_learner_early_lifetime_still_increments() -> None:
+    learner = LinearLearner()
+    state = learner.init(2)
+    result = learner.update(
+        state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
Closes #1371.

## What changed

Learner ``step_count`` now uses the shared saturating int32 increment on all four update sites.

On origin/main `939cdaa`, ``INT32_MAX + 1`` wrapped to ``INT32_MIN``. That forged a different committed update identity: ``step_count >= 0`` fails, and ``learner_state.step_count ==`` the saturated member clock fails in ``WorldModelEnsemble._member_state_valid``. Saturate keeps ``INT32_MAX`` so those contracts stay true. ``recurring_feature_gate`` publishes ``steps_seen=int(step_count)``; wrap would report a negative lifetime. Legal early-lifetime increments (0 → 1) are unchanged.

This is the saturating lifetime-clock family from `#1366` / `#1368` / `#1370` / `#1277`, not a leftover-identity reprint.

## Scope

- `alberta_framework/core/learners.py`
- `tests/test_learners_lifetime_clock.py`

## Why this is unowned

Live occupancy at publish time: ss251 open set is `#1287`, `#1288`, `#1354`, `#1366`, `#1368`, `#1370`. No open PR touches `alberta_framework/core/learners.py`. Closed `#936` was leftover integer validation on the same file; this is a different family.

## Verification

Exact candidate head: `0a48b582af9768348a2df6bdbd75f7fb87380cc1`
Base: `939cdaa`

- Red on base: planted ``INT32_MAX`` then ``+ 1`` stored ``INT32_MIN``; wrap failed ``step_count >= 0`` and equality with the saturated ensemble clock, saturate kept both
- Focused pytest `tests/test_learners_lifetime_clock.py`: 6 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary lifetime-clock saturation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0a48b582af9768348a2df6bdbd75f7fb87380cc1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
