### PR TITLE
fix(research): keep void V4 arms out of sample-floor claims

### DIFF
--- a/outputs/new_directions/V4_fingerprints.json
+++ b/outputs/new_directions/V4_fingerprints.json
@@ -5421,6 +5421,12 @@
    }
   ]
  },
+ "deviations": [
+  "controls were computed after the first online cell in the shipped execution rather than before all online rows",
+  "the control implementation was changed from online-checkpoint to exact full-dataset statistics after the first runner draft",
+  "F3 reference correlation descriptors use batch statistics over the 5000 pre-shift examples; the inherited EMA statistics supply the relevance mask, not the correlation descriptor",
+  "F4b uses batch gradient-activation correlation rather than the preregistered EMA and is void because its oracle gate failed"
+ ],
  "evidence_policy": "development_screening_diagnostic; permanently nonpromoting. No frozen protocol, no held-out seed, no registered source edited.",
  "promotion": {
   "best_configuration": {
@@ -5460,7 +5466,8 @@
   ],
   "permutations": "build_schedule per-seed protocol permutations",
   "post_shift": "fresh statistics from stream start",
-  "reference": "annealed fast-EMA (decay 0.99) over 5000 samples",
+  "fingerprint_reference_statistics": "batch descriptors over the 5000 pre-shift examples",
+  "reference_relevance_statistics": "annealed fast-EMA mean/variance (decay 0.99) over 5000 samples",
   "reference_arm": "sigma0_ndecay099",
   "relevance_thresholds_on_reference_var": [
    0.001,

--- a/outputs/new_directions/V4_fingerprints.json
+++ b/outputs/new_directions/V4_fingerprints.json
@@ -5438,10 +5438,10 @@
    "F3b_topk/hungarian": "> 2000",
    "F3c_spectral/greedy": "> 2000",
    "F3c_spectral/hungarian": "> 2000",
-   "F4a_act_corr/greedy": "> 2000",
-   "F4a_act_corr/hungarian": "> 2000",
-   "F4b_grad_corr/greedy": "> 2000",
-   "F4b_grad_corr/hungarian": "> 2000"
+   "F4a_act_corr/greedy": "void",
+   "F4a_act_corr/hungarian": "void",
+   "F4b_grad_corr/greedy": "void",
+   "F4b_grad_corr/hungarian": "void"
   }
  },
  "protocol": {

--- a/outputs/new_directions/V4_fingerprints.md
+++ b/outputs/new_directions/V4_fingerprints.md
@@ -6,12 +6,12 @@ Pre-registered in [elizaOS/asi#1311](https://github.com/elizaOS/asi/issues/1311)
 
 ## Verdict: REFUTED — and the floor moves the wrong way
 
-No fingerprint reaches the pre-registered bar (>90% of relevant `var > 0.01`
-pixels within <=500 samples, min over the 9 seed x boundary cells). The
-secondary measurement is the one that carries the result:
+No control-valid fingerprint reaches the pre-registered bar (>90% of relevant
+`var > 0.01` pixels within <=500 samples, min over the 9 seed x boundary
+cells). The secondary measurement is the one that carries the F3 result:
 
 **`N*` — smallest N where mean relevant-pixel accuracy crosses 0.90 —
-is `> 2000` for every fingerprint and both solvers.**
+is `> 2000` for every control-valid F3 fingerprint and both solvers.**
 
 V1 measured `N* ~= 2000` for its best estimator. V4's second-order
 fingerprints do not beat that floor; they do not reach it.
@@ -58,8 +58,9 @@ this budget** — not unusable in principle.
 F4a and F4b **failed the pre-registered oracle gate** (0.002 / 0.000 against a
 0.95 bar). Per the pre-registration this makes them mis-implemented rather
 than uninformative, so their online numbers are recorded in the artifact,
-marked `void` in `control_verdict`, and are **not** reported as evidence about
-model-side probes.
+marked `void` in `control_verdict`, and have `N*` marked `void` rather than a
+sample-floor result. They are **not** reported as evidence about model-side
+probes.
 
 The two controls together diagnose the fault exactly:
 
@@ -104,6 +105,13 @@ Both controls use exact full-dataset statistics. They are pipeline-correctness
 checks, so running them at the online checkpoints would conflate estimator
 noise with an implementation fault — an error in the first draft of the
 runner, corrected before any headline number existed.
+
+The shipped runner computed the first seed/boundary's online diagnostic rows
+before computing its controls, rather than literally running the controls
+first as the preregistration required. The F3 controls passed, so this ordering
+does not change its deterministic measurements, but it is an execution-order
+deviation. The F4 controls failed and those arms remain void regardless of
+their recorded online rows.
 
 ## Consequence for the chain
 

--- a/outputs/new_directions/V4_fingerprints.md
+++ b/outputs/new_directions/V4_fingerprints.md
@@ -104,7 +104,8 @@ position confound the family carried under 7 effective dimensions.
 Both controls use exact full-dataset statistics. They are pipeline-correctness
 checks, so running them at the online checkpoints would conflate estimator
 noise with an implementation fault — an error in the first draft of the
-runner, corrected before any headline number existed.
+runner, corrected before any headline number existed. This is a protocol
+implementation deviation, not execution “unchanged.”
 
 The shipped runner computed the first seed/boundary's online diagnostic rows
 before computing its controls, rather than literally running the controls
@@ -112,6 +113,16 @@ first as the preregistration required. The F3 controls passed, so this ordering
 does not change its deterministic measurements, but it is an execution-order
 deviation. The F4 controls failed and those arms remain void regardless of
 their recorded online rows.
+
+Two estimator details also differed from the literal preregistration and bound
+the interpretation. F3 used batch correlation descriptors over the 5,000
+pre-shift examples; the inherited annealed fast-EMA supplied the reference
+variance used for relevance masks, not the correlation descriptors. This
+gives F3 the stronger reference estimate and leaves its negative online result
+usable as a conservative development diagnostic, but it is not the literal
+all-EMA implementation. F4b used batch correlation between absolute input
+gradients and activations rather than the preregistered EMA. F4b failed its
+oracle gate and is void, so that deviation licenses no model-side-probe claim.
 
 ## Consequence for the chain
 
@@ -145,3 +156,8 @@ before any numbers existed: it is the arm whose plain annealed fast-EMA
 (decay 0.99) is the pre-registered reference, and using the shift-triggered
 champion would have trained the probe under a different input normalizer than
 the reference statistics use.
+
+The JSON's four-item `deviations` field is the machine-readable record of
+these departures. Its raw 360 online rows and 20 control rows are unchanged;
+only derived void-arm sample-floor labels and disclosure metadata were
+corrected after review.

--- a/outputs/new_directions/V4_fingerprints_runner.py
+++ b/outputs/new_directions/V4_fingerprints_runner.py
@@ -4,7 +4,8 @@ Pre-registered in elizaOS/asi#1311. Development diagnostic, permanently
 nonpromoting (``development_screening_diagnostic``). Touches no pinned
 artifact, edits no registered source, consumes no promotion seed.
 
-Protocol is inherited from V1 (``V1_assignment.md``) unchanged: seeds {0,1,2}
+Protocol is inherited from V1 (``V1_assignment.md``) except for the deviations
+recorded in ``V4_fingerprints.md``: seeds {0,1,2}
 x boundaries {0,1,2}, post-shift checkpoints N in {50,200,500,2000}, reference
 statistics = annealed fast-EMA (decay 0.99, ``ema_normalize`` equations) over
 the 5,000-sample pre-shift task, relevance on reference variance, Hungarian
@@ -146,8 +147,10 @@ def f4_descriptors(
 
     act_corr = _coupling(samples.astype(np.float64), activations)
 
-    # F4b: |dL/dx_i| coupled to each hidden unit, using the protocol's own
-    # softmax cross-entropy on the post-prediction label.
+    # F4b: batch correlation of |dL/dx_i| with each hidden unit, using the
+    # protocol's own softmax cross-entropy on the post-prediction label.  The
+    # preregistration called this an EMA; that implementation deviation is
+    # recorded explicitly and the arm is void under its oracle gate.
     def per_example_input_grad(sample: Any, label: Any) -> Any:
         def loss(inp: Any) -> Any:
             logits, _, _, _, _ = screening._forward_with_activations(params, inp)  # noqa: SLF001
@@ -480,10 +483,34 @@ def main() -> int:
         "aggregates": aggregates,
         "controls": controls,
         "control_verdict": verdict,
+        "deviations": [
+            (
+                "controls were computed after the first online cell in the shipped "
+                "execution rather than before all online rows"
+            ),
+            (
+                "the control implementation was changed from online-checkpoint to exact "
+                "full-dataset statistics after the first runner draft"
+            ),
+            (
+                "F3 reference correlation descriptors use batch statistics over the "
+                "5000 pre-shift examples; the inherited EMA statistics supply the "
+                "relevance mask, not the correlation descriptor"
+            ),
+            (
+                "F4b uses batch gradient-activation correlation rather than the "
+                "preregistered EMA and is void because its oracle gate failed"
+            ),
+        ],
         "protocol": {
             "data": "IPMNIST protocol MNIST train split (load_mnist_train)",
             "permutations": "build_schedule per-seed protocol permutations",
-            "reference": "annealed fast-EMA (decay 0.99) over 5000 samples",
+            "reference_relevance_statistics": (
+                "annealed fast-EMA mean/variance (decay 0.99) over 5000 samples"
+            ),
+            "fingerprint_reference_statistics": (
+                "batch descriptors over the 5000 pre-shift examples"
+            ),
             "post_shift": "fresh statistics from stream start",
             "reference_arm": REFERENCE_ARM,
             "seeds": list(args.seeds),

--- a/outputs/new_directions/V4_fingerprints_runner.py
+++ b/outputs/new_directions/V4_fingerprints_runner.py
@@ -413,7 +413,6 @@ def main() -> int:
         schedule = build_schedule(jr.key(np.uint32(seed)), config, x.shape[0])
         for boundary in args.boundaries:
             params = train_reference_network(seed, boundary, x, y, schedule)
-            cells.extend(run_cell(seed, boundary, x, y, schedule, params))
 
             if not args.skip_controls and seed == args.seeds[0] and boundary == args.boundaries[0]:
                 controls["exact_statistic_oracle"] = run_cell(
@@ -422,6 +421,7 @@ def main() -> int:
                 controls["no_shift"] = run_cell(
                     seed, boundary, x, y, schedule, params, no_shift=True
                 )
+            cells.extend(run_cell(seed, boundary, x, y, schedule, params))
 
     # Pre-registered control gates decide which fingerprints carry a result at
     # all: a family that misses the oracle bar is mis-implemented, not
@@ -454,8 +454,15 @@ def main() -> int:
         }
 
     aggregates = aggregate(cells)
+    # A fingerprint that failed a preregistered correctness control has no
+    # licensed online result.  Preserve its raw diagnostic rows, but do not
+    # turn them into the protocol's secondary N* measurement.
     floors = {
-        f"{fingerprint}/{solver}": sample_floor(aggregates, fingerprint, solver)
+        f"{fingerprint}/{solver}": (
+            "void"
+            if verdict[fingerprint]["void"]
+            else sample_floor(aggregates, fingerprint, solver)
+        )
         for fingerprint in FINGERPRINTS
         for solver in SOLVERS
     }


### PR DESCRIPTION
Corrects the just-merged V4 diagnostic to obey its preregistered control semantics:

- F4a/F4b failed the oracle gate, so their N* values are now `void`, not `> 2000`.
- The headline now scopes the measured floor to the control-valid F3 arms.
- The runner executes controls before online diagnostic rows on reproduction.
- The report records that the original shipped execution computed the first online rows before controls; this did not change deterministic F3 measurements, but is a disclosed protocol-order deviation.

No raw measurement is changed. F3 remains a permanently nonpromoting development rejection; F4 remains void.