### PR TITLE
fix(core): preflight IA cerebellum overflow widths

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -115,6 +115,32 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit signed int32")
+    return value
+
+
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    _require_derived_int32(f"{name} scalar count", float32_scalars)
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} byte count must fit signed int32")
+
+
+def _preflight_cerebellum_resources(n_demons: int, obs_dim: int) -> None:
+    """Reject weight and concat widths the exo-cerebellum update cannot name."""
+
+    _require_float32_resource(
+        "exo-cerebellum weights",
+        float32_scalars=n_demons * obs_dim,
+    )
+    _require_derived_int32("augmented observation dim", n_demons + obs_dim, minimum=2)
+    _require_float32_resource(
+        "augmented observation",
+        float32_scalars=n_demons + obs_dim,
+    )
+
+
 def _positive_float32_scalar(name: str, value: object) -> float:
     """Validate and canonicalize a positive scalar in its execution dtype."""
     message = f"{name} must be a finite positive float32 scalar"
@@ -177,6 +203,7 @@ class ExoCerebellumConfig:
         )
         step_size = _positive_float32_scalar("step_size", self.step_size)
         object.__setattr__(self, "step_size", step_size)
+        _preflight_cerebellum_resources(self.n_demons, self.obs_dim)
 
     def to_config(self) -> dict[str, Any]:
         return {"type": "ExoCerebellumConfig", **dataclasses.asdict(self)}
@@ -623,6 +650,15 @@ class IAConfig:
                 f"cerebellum.obs_dim ({self.cerebellum.obs_dim}) must equal "
                 f"cortex.observation_dim ({self.cortex.observation_dim})"
             )
+        _require_derived_int32(
+            "augmented observation dim",
+            self.augmented_obs_dim,
+            minimum=2,
+        )
+        _require_float32_resource(
+            "augmented observation",
+            float32_scalars=self.augmented_obs_dim,
+        )
 
     @property
     def augmented_obs_dim(self) -> int:

--- a/tests/test_ia_cerebellum_overflow_preflight.py
+++ b/tests/test_ia_cerebellum_overflow_preflight.py
@@ -1,0 +1,61 @@
+"""Overflow preflight keeps the IA update's published width in signed int32."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.intelligence_amplification import (
+    ExoCerebellumAgent,
+    ExoCerebellumConfig,
+    IAConfig,
+    _default_oak_config,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_update_width() -> None:
+    cortex_obs_dim = _default_oak_config().observation_dim
+    overflowing_demons = _INT32_MAX - cortex_obs_dim + 1
+    published_width = cortex_obs_dim + overflowing_demons
+    assert published_width == _INT32_MAX + 1
+    wrapped_width = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_width == _INT32_MIN
+    assert wrapped_width != published_width
+
+
+def test_cerebellum_config_rejects_weight_product_overflow() -> None:
+    with pytest.raises(ValueError, match="must fit signed int32"):
+        ExoCerebellumConfig(n_demons=65536, obs_dim=32768)
+
+
+def test_ia_config_rejects_overflowing_published_update_width() -> None:
+    cortex = _default_oak_config()
+    overflowing_demons = _INT32_MAX - cortex.observation_dim + 1
+    with pytest.raises(ValueError, match="must fit signed int32"):
+        IAConfig(
+            cerebellum=ExoCerebellumConfig(
+                n_demons=overflowing_demons,
+                obs_dim=cortex.observation_dim,
+            ),
+            cortex=cortex,
+        )
+
+
+def test_legal_cerebellum_update_identity_is_unchanged() -> None:
+    cfg = ExoCerebellumConfig(n_demons=4, obs_dim=3)
+    agent = ExoCerebellumAgent(cfg)
+    assert int(cfg.n_demons + cfg.obs_dim) == 7
+    assert list(agent._cumulant_indices) == [0, 1, 2, 0]
+    result = agent.update_result(
+        agent.init(),
+        jnp.ones(3, dtype=jnp.float32),
+        jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert result.state.weights.shape == (4, 3)
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
Closes #1376.

## What changed

Exo-cerebellum and IA configs now preflight derived weight and concat widths into signed int32.

On origin/main `e9c2812`, ``INT32_MAX + 1`` wraps to ``INT32_MIN``. ``IAConfig`` accepted ``n_demons = INT32_MAX - 3`` with default ``obs_dim = 4``, so the published ``concat(partner_obs, predictions)`` width overflowed. The cerebellum update writes that concat and the ``(n_demons, obs_dim)`` weight tensor. Saturating/legal early-lifetime updates (4 demons × 3 features) are unchanged.

This is overflow-preflight of the update identity, not a leftover-identity reprint.

## Scope

- `alberta_framework/core/intelligence_amplification.py`
- `tests/test_ia_cerebellum_overflow_preflight.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `intelligence_amplification.py`. Prior IA work was dtype/nonfinite, not overflow preflight.

## Verification

Exact candidate head: `a2e1c953f77077761eaf010e0d1195af806b1d9d`
Base: `e9c2812`

- Red on base: ``IAConfig`` accepted an overflowing concat width; ``INT32_MAX + 1`` stored ``INT32_MIN``
- Focused pytest `tests/test_ia_cerebellum_overflow_preflight.py`: 4 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a2e1c953f77077761eaf010e0d1195af806b1d9d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
