### PR TITLE
fix(core): preflight history-feature trace bytes

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -90,6 +90,13 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int) -> i
     return canonical
 
 
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    if float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _require_decay_rates(value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError("decay_rates must be an actual tuple")
@@ -193,6 +200,10 @@ class HistoryFeatureExtractor:
             raise ValueError(
                 f"feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
             )
+        _require_float32_resource(
+            "history-feature traces",
+            float32_scalars=channel_count * len(decay_rates),
+        )
         if canonical_channels is None:
             canonical_channels = tuple(range(raw_dim))
 

--- a/tests/test_history_features_trace_byte_preflight.py
+++ b/tests/test_history_features_trace_byte_preflight.py
@@ -1,0 +1,57 @@
+"""Overflow preflight keeps history-feature trace allocation in signed int32."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.history_features import HistoryFeatureExtractor
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_TRACE_BYTE_OVERFLOW_CHANNELS = _INT32_MAX // 4 + 1
+
+
+def test_int32_wrap_forges_a_different_trace_allocation_identity() -> None:
+    feature_width = _TRACE_BYTE_OVERFLOW_CHANNELS
+    assert feature_width <= _INT32_MAX
+    trace_bytes = 4 * feature_width
+    assert trace_bytes == _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != trace_bytes
+
+
+def test_extractor_rejects_trace_bank_byte_overflow() -> None:
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        HistoryFeatureExtractor(
+            raw_dim=_TRACE_BYTE_OVERFLOW_CHANNELS,
+            decay_rates=(0.5,),
+            include_raw=False,
+        )
+
+
+def test_width_boundary_from_661_still_constructs() -> None:
+    boundary = HistoryFeatureExtractor(
+        raw_dim=_INT32_MAX - 1,
+        decay_rates=(0.5,),
+        channels=(0,),
+    )
+    assert boundary.feature_dim() == _INT32_MAX
+
+
+def test_legal_step_allocation_identity_is_unchanged() -> None:
+    extractor = HistoryFeatureExtractor(
+        raw_dim=4,
+        decay_rates=(0.5, 0.9),
+        include_raw=False,
+    )
+    assert extractor.feature_dim() == 8
+    state = extractor.init()
+    assert state.traces.shape == (2, 4)
+    assert 4 * int(state.traces.size) <= _INT32_MAX
+    augmented, advanced = extractor.step(state, jnp.ones(4, dtype=jnp.float32))
+    assert augmented.shape == (8,)
+    assert advanced.traces.shape == (2, 4)


### PR DESCRIPTION
Closes #1380.

## What changed

History-feature configs now preflight the traces tensor byte count into signed int32, before expanding ``channels=None`` into ``range(raw_dim)``.

On origin/main `32148d2`, ``#661`` bounded derived ``feature_dim`` only. ``include_raw=False`` with ``raw_dim = INT32_MAX // 4 + 1`` still constructed: width fit, but ``4 × n_decays × n_channels = INT32_MAX + 1``. That wrap forges a different traces allocation than the ``step()`` update writes. The ``#661`` one-channel width boundary (``feature_dim = INT32_MAX``) still constructs. Legal 4×2 steps are unchanged.

This is overflow-preflight of the allocation identity, not a leftover-identity reprint.

## Scope

- `alberta_framework/core/history_features.py`
- `tests/test_history_features_trace_byte_preflight.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `history_features.py`. ``#661`` already merged exact width contracts; this is the residual byte preflight.

## Verification

Exact candidate head: `a90832e5a8371174f498851036468993cb1a1473`
Base: `32148d2`

- Red on base: feature-width check accepted ``536870912`` traces whose byte count is ``INT32_MAX + 1``; int32 wrap stores ``INT32_MIN``
- Focused pytest `tests/test_history_features_trace_byte_preflight.py` plus ``#661`` width-boundary test: 5 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a90832e5a8371174f498851036468993cb1a1473 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
