### PR TITLE
fix(benchmarks): repair constructor trust gates and matrix statistic

### DIFF
--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -180,7 +180,7 @@ class ScreenError(RuntimeError):
 
 
 def _require_string(value: Any, label: str) -> str:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ScreenError(f"{label} must be a non-empty string")
     return value
 
@@ -261,6 +261,8 @@ class ProtocolSnapshot:
             raise ScreenError("protocol must be a FrozenProtocol")
         if type(self.inventory) is not tuple:
             raise ScreenError("inventory must be a tuple")
+        if any(type(item) is not dict for item in self.inventory):
+            raise ScreenError("inventory must contain exact dictionaries")
         _require_sha256(self.inventory_sha256, "inventory_sha256")
 
 
@@ -275,9 +277,9 @@ class ProcessCapture:
     def __post_init__(self) -> None:
         if type(self.returncode) is not int or isinstance(self.returncode, bool):
             raise ScreenError("returncode must be an integer")
-        if not isinstance(self.stdout, (bytes, bytearray)):
+        if type(self.stdout) is not bytes:
             raise ScreenError("stdout must be bytes")
-        if not isinstance(self.stderr, (bytes, bytearray)):
+        if type(self.stderr) is not bytes:
             raise ScreenError("stderr must be bytes")
 
 

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -633,6 +633,17 @@ class ForagerFeatureState:
     last_reward: float
     reward_traces: tuple[float, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.last_action) is not int or isinstance(self.last_action, bool):
+            raise ValueError("last_action must be an integer")
+        if not isinstance(self.last_reward, (int, float)) or not math.isfinite(self.last_reward):
+            raise ValueError("last_reward must be a finite float")
+        if type(self.reward_traces) is not tuple:
+            raise ValueError("reward_traces must be a tuple")
+        for trace in self.reward_traces:
+            if not isinstance(trace, (int, float)) or not math.isfinite(trace):
+                raise ValueError("reward_traces values must be finite floats")
+
 
 def _observation_parts(observation: Any) -> tuple[Array, Array]:
     """Return ``(image, hint)`` for array and mapping observations."""
@@ -4088,8 +4099,22 @@ class PaperBaseline:
     official_config_path: str | None = None
 
     def __post_init__(self) -> None:
+        for attr in ("name", "family", "state_construction", "source"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if type(self.role) is not str:
+            raise ValueError("role must be an exact string")
+        if self.role not in ("lower_control", "learning_baseline", "sota", "upper_control"):
+            raise ValueError("role is invalid")
+        if not isinstance(self.selected_hyperparameters, Mapping):
+            raise ValueError("selected_hyperparameters must be a mapping")
         if type(self.in_tree_implementation) is not bool:
             raise ValueError("in_tree_implementation must be a boolean")
+        if self.official_config_path is not None and (
+            type(self.official_config_path) is not str or not self.official_config_path
+        ):
+            raise ValueError("official_config_path must be None or a non-empty string")
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -4477,6 +4502,10 @@ class PaperReferenceTarget:
     precision: str = "figure_digitized_approximation"
 
     def __post_init__(self) -> None:
+        for attr in ("method", "metric", "condition", "source", "precision"):
+            val = getattr(self, attr)
+            if type(val) is not str or not val:
+                raise ValueError(f"{attr} must be a non-empty string")
         object.__setattr__(
             self,
             "central_estimate",

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -636,12 +636,12 @@ class ForagerFeatureState:
     def __post_init__(self) -> None:
         if type(self.last_action) is not int or isinstance(self.last_action, bool):
             raise ValueError("last_action must be an integer")
-        if not isinstance(self.last_reward, (int, float)) or not math.isfinite(self.last_reward):
+        if type(self.last_reward) not in (int, float) or not math.isfinite(self.last_reward):
             raise ValueError("last_reward must be a finite float")
         if type(self.reward_traces) is not tuple:
             raise ValueError("reward_traces must be a tuple")
         for trace in self.reward_traces:
-            if not isinstance(trace, (int, float)) or not math.isfinite(trace):
+            if type(trace) not in (int, float) or not math.isfinite(trace):
                 raise ValueError("reward_traces values must be finite floats")
 
 

--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -345,30 +345,32 @@ class ForagerTuningRule:
     def __post_init__(self) -> None:
         if type(self.metric) is not str or not self.metric:
             raise ForagerMatrixManifestError("metric must be a non-empty string")
-        if self.direction not in ("maximize", "minimize"):
+        if type(self.direction) is not str or self.direction not in ("maximize", "minimize"):
             raise ForagerMatrixManifestError("direction must be 'maximize' or 'minimize'")
-        if self.statistic not in ("mean", "median"):
-            raise ForagerMatrixManifestError("statistic must be 'mean' or 'median'")
+        if type(self.statistic) is not str or self.statistic not in (
+            "mean",
+            "conservative_ci_endpoint",
+        ):
+            raise ForagerMatrixManifestError(
+                "statistic must be 'mean' or 'conservative_ci_endpoint'"
+            )
         if (
-            isinstance(self.confidence, bool)
-            or not isinstance(self.confidence, (int, float))
+            type(self.confidence) not in (int, float)
             or not math.isfinite(float(self.confidence))
             or not 0.0 < float(self.confidence) < 1.0
         ):
             raise ForagerMatrixManifestError("confidence must be a finite float in (0.0, 1.0)")
         if (
-            isinstance(self.bootstrap_resamples, bool)
-            or not isinstance(self.bootstrap_resamples, int)
+            type(self.bootstrap_resamples) is not int
             or self.bootstrap_resamples < 1
         ):
             raise ForagerMatrixManifestError("bootstrap_resamples must be an integer >= 1")
         if (
-            isinstance(self.bootstrap_seed, bool)
-            or not isinstance(self.bootstrap_seed, int)
+            type(self.bootstrap_seed) is not int
             or not 0 <= self.bootstrap_seed <= 2**31 - 1
         ):
             raise ForagerMatrixManifestError("bootstrap_seed must be an integer in [0, 2**31 - 1]")
-        if self.tie_break != "variant_id_ascending":
+        if type(self.tie_break) is not str or self.tie_break != "variant_id_ascending":
             raise ForagerMatrixManifestError("tie_break must be 'variant_id_ascending'")
 
     def to_dict(self) -> dict[str, Any]:
@@ -432,8 +434,8 @@ class ForagerTuningSelection:
     def __post_init__(self) -> None:
         if type(self.report_path) is not str or not self.report_path:
             raise ForagerMatrixManifestError("report_path must be a non-empty string")
-        if type(self.file_sha256) is not str or len(self.file_sha256) != 64:
-            raise ForagerMatrixManifestError("file_sha256 must be a 64-character hex string")
+        if type(self.file_sha256) is not str or _SHA256.fullmatch(self.file_sha256) is None:
+            raise ForagerMatrixManifestError("file_sha256 must be a lowercase SHA-256 digest")
         if not isinstance(self.selected_variants, Mapping):
             raise ForagerMatrixManifestError("selected_variants must be a mapping")
 

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -2309,14 +2309,14 @@ class ForagerPairedComparison:
             raise TypeError("candidate_privileged must be an exact boolean")
         if type(self.baseline_privileged) is not bool:
             raise TypeError("baseline_privileged must be an exact boolean")
-        if self.metric not in (
+        if type(self.metric) is not str or self.metric not in (
             "mean_reward",
             "final_window_mean_reward",
             "final_ewm_reward",
             "mean_ewm_reward",
             "fov_last_10pct_ema_auc",
         ):
-            raise ValueError(f"metric {self.metric!r} is not a valid ForagerMetric")
+            raise ValueError("metric is not a valid ForagerMetric")
         if type(self.seeds) is not tuple:
             raise TypeError("seeds must be an exact tuple")
         if not self.seeds:
@@ -2328,9 +2328,11 @@ class ForagerPairedComparison:
             raise ValueError("seeds must be unique")
         for name in ("mean_difference", "ci_low", "ci_high"):
             val = getattr(self, name)
-            if not isinstance(val, (int, float)) or not math.isfinite(val):
+            if type(val) not in (int, float) or not math.isfinite(val):
                 raise ValueError(f"{name} must be a finite float")
-        if not isinstance(self.confidence, (int, float)) or not (0.0 < self.confidence < 1.0):
+        if type(self.confidence) not in (int, float) or not (
+            0.0 < self.confidence < 1.0
+        ):
             raise ValueError("confidence must be a probability in (0, 1)")
 
     def to_dict(self) -> dict[str, Any]:
@@ -2478,16 +2480,16 @@ class ForagerComparisonReport:
     def __post_init__(self) -> None:
         if type(self.candidate) is not str or not self.candidate:
             raise ValueError("candidate must be a non-empty string")
-        if self.metric not in (
+        if type(self.metric) is not str or self.metric not in (
             "mean_reward",
             "final_window_mean_reward",
             "final_ewm_reward",
             "mean_ewm_reward",
             "fov_last_10pct_ema_auc",
         ):
-            raise ValueError(f"metric {self.metric!r} is not a valid ForagerMetric")
-        if not isinstance(self.summaries, Mapping):
-            raise TypeError("summaries must be a mapping")
+            raise ValueError("metric is not a valid ForagerMetric")
+        if type(self.summaries) is not dict:
+            raise TypeError("summaries must be an exact dictionary")
         for name, summary in self.summaries.items():
             if type(name) is not str or not name:
                 raise ValueError("summary names must be non-empty strings")

--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -1412,7 +1412,7 @@ class HistoricalForagerPairingIdentity:
             raise HistoricalForagerContractError(
                 "semantic_contract_sha256 must be a 64-character lowercase SHA-256"
             )
-        if self.environment_adapter_mode not in (
+        if type(self.environment_adapter_mode) is not str or self.environment_adapter_mode not in (
             "golden_verified_read_only_source",
             "development_unverified_factory",
         ):

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -5326,7 +5326,7 @@ class ScreeningSpec:
             val = getattr(self, attr)
             if type(val) is not str or not val:
                 raise ValueError(f"{attr} must be a non-empty string")
-        if not isinstance(self.hyperparameters, dict):
+        if type(self.hyperparameters) is not dict:
             raise TypeError("hyperparameters must be a dict")
         if not callable(self.factory):
             raise TypeError("factory must be callable")
@@ -7694,15 +7694,15 @@ class ScreeningRunResult:
             val = getattr(self, attr)
             if type(val) is not str or not val:
                 raise ValueError(f"{attr} must be a non-empty string")
-        if not isinstance(self.hyperparameters, dict):
+        if type(self.hyperparameters) is not dict:
             raise TypeError("hyperparameters must be a dict")
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
         if type(self.config) is not IPMNISTConfig:
             raise TypeError("config must be an IPMNISTConfig")
         for arr_name in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
-            if not isinstance(getattr(self, arr_name), np.ndarray):
+            if type(getattr(self, arr_name)) is not np.ndarray:
                 raise TypeError(f"{arr_name} must be a numpy ndarray")
-        if not isinstance(self.wall_clock_seconds, (int, float)) or not math.isfinite(
+        if type(self.wall_clock_seconds) not in (int, float) or not math.isfinite(
             self.wall_clock_seconds
         ):
             raise ValueError("wall_clock_seconds must be a finite float")

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1905,7 +1905,7 @@ class MicroTaskConfig:
     def __post_init__(self) -> None:
         _require_nonempty_string(self.name, context="MicroTaskConfig.name")
         _require_nonempty_string(self.kind, context="MicroTaskConfig.kind")
-        if self.role not in ("search", "holdout"):
+        if type(self.role) is not str or self.role not in ("search", "holdout"):
             raise ValueError("MicroTaskConfig.role must be 'search' or 'holdout'")
         for field_name in (
             "input_dim",

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -433,13 +433,15 @@ class OfficialForagaxRunPlan:
             raise TypeError("request must be an OfficialForagaxRunRequest")
         _require_sha256(self.interpreter_sha256, label="interpreter_sha256")
         _require_sha256(self.package_freeze_sha256, label="package_freeze_sha256")
-        if not isinstance(self.command, tuple):
+        if type(self.command) is not tuple or any(type(item) is not str for item in self.command):
             raise TypeError("command must be a tuple")
-        if not isinstance(self.package_freeze, tuple):
+        if type(self.package_freeze) is not tuple or any(
+            type(item) is not str for item in self.package_freeze
+        ):
             raise TypeError("package_freeze must be a tuple")
-        if not isinstance(self.config_snapshot_bytes, (bytes, bytearray)):
+        if type(self.config_snapshot_bytes) is not bytes:
             raise TypeError("config_snapshot_bytes must be bytes")
-        if not isinstance(self.execution_config_bytes, (bytes, bytearray)):
+        if type(self.execution_config_bytes) is not bytes:
             raise TypeError("execution_config_bytes must be bytes")
 
     @property
@@ -509,13 +511,15 @@ class OfficialForagaxBatchRunPlan:
             raise TypeError("request must be an OfficialForagaxBatchRunRequest")
         _require_sha256(self.interpreter_sha256, label="interpreter_sha256")
         _require_sha256(self.package_freeze_sha256, label="package_freeze_sha256")
-        if not isinstance(self.command, tuple):
+        if type(self.command) is not tuple or any(type(item) is not str for item in self.command):
             raise TypeError("command must be a tuple")
-        if not isinstance(self.package_freeze, tuple):
+        if type(self.package_freeze) is not tuple or any(
+            type(item) is not str for item in self.package_freeze
+        ):
             raise TypeError("package_freeze must be a tuple")
-        if not isinstance(self.config_snapshot_bytes, (bytes, bytearray)):
+        if type(self.config_snapshot_bytes) is not bytes:
             raise TypeError("config_snapshot_bytes must be bytes")
-        if not isinstance(self.execution_config_bytes, (bytes, bytearray)):
+        if type(self.execution_config_bytes) is not bytes:
             raise TypeError("execution_config_bytes must be bytes")
 
     @property

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -820,7 +820,7 @@ class IPMNISTRunResult:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "learner", _require_nonempty_string("learner", self.learner))
-        if not isinstance(self.hyperparameters, dict):
+        if type(self.hyperparameters) is not dict:
             raise TypeError("hyperparameters must be a dict")
         object.__setattr__(self, "seeds", _require_seed_identities(self.seeds, name="seeds"))
         if type(self.config) is not IPMNISTConfig:

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -496,7 +496,7 @@ class LabelEMNISTRunResult:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "learner", _require_nonempty_string("learner", self.learner))
-        if not isinstance(self.hyperparameters, dict):
+        if type(self.hyperparameters) is not dict:
             raise TypeError("hyperparameters must be a dict")
         object.__setattr__(self, "seeds", _require_seed_identities(self.seeds, name="seeds"))
         if type(self.config) is not LabelEMNISTConfig:

--- a/tests/test_foragax_open_screen_hostile_validation.py
+++ b/tests/test_foragax_open_screen_hostile_validation.py
@@ -61,6 +61,28 @@ def test_process_capture_rejects_invalid_inputs() -> None:
         )
 
     with pytest.raises(ScreenError, match="stdout must be bytes"):
+        ProcessCapture(returncode=0, stdout=bytearray(), stderr=b"")
+
+
+def test_frozen_configuration_rejects_string_subclass_before_len_hook() -> None:
+    calls = 0
+
+    class HostileString(str):
+        def __len__(self) -> int:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("length hook reached")
+
+    with pytest.raises(ScreenError, match="path must be a non-empty string"):
+        FrozenConfiguration(
+            path=HostileString("config.json"),
+            sha256="a" * 64,
+            agent="dqn",
+            entrypoint="main.py",
+        )
+    assert calls == 0
+
+    with pytest.raises(ScreenError, match="stdout must be bytes"):
         ProcessCapture(
             returncode=0,
             stdout="not bytes",  # type: ignore[arg-type]

--- a/tests/test_forager_dataclasses_hostile_validation.py
+++ b/tests/test_forager_dataclasses_hostile_validation.py
@@ -1,0 +1,86 @@
+"""Hostile input and boundary validation for Forager benchmark dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import (
+    ForagerFeatureState,
+    PaperBaseline,
+    PaperReferenceTarget,
+)
+
+
+def test_forager_feature_state_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="last_action must be an integer"):
+        ForagerFeatureState(
+            last_action=True,
+            last_reward=0.0,
+            reward_traces=(),
+        )
+
+    with pytest.raises(ValueError, match="last_reward must be a finite float"):
+        ForagerFeatureState(
+            last_action=0,
+            last_reward=float("nan"),
+            reward_traces=(),
+        )
+
+    with pytest.raises(ValueError, match="reward_traces must be a tuple"):
+        ForagerFeatureState(
+            last_action=0,
+            last_reward=0.0,
+            reward_traces=[],  # type: ignore[arg-type]
+        )
+
+
+def test_paper_baseline_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        PaperBaseline(
+            name="",
+            family="family_1",
+            role="learning_baseline",
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation=True,
+            source="paper",
+        )
+
+    with pytest.raises(ValueError, match="role is invalid"):
+        PaperBaseline(
+            name="base",
+            family="family_1",
+            role="invalid_role",  # type: ignore[arg-type]
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation=True,
+            source="paper",
+        )
+
+    with pytest.raises(ValueError, match="in_tree_implementation must be a boolean"):
+        PaperBaseline(
+            name="base",
+            family="family_1",
+            role="learning_baseline",
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation="true",  # type: ignore[arg-type]
+            source="paper",
+        )
+
+
+def test_paper_reference_target_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="central_estimate must be a finite float"):
+        PaperReferenceTarget(
+            method="method_1",
+            metric="metric_1",
+            central_estimate=float("inf"),
+        )
+
+    with pytest.raises(ValueError, match="privileged must be a boolean"):
+        PaperReferenceTarget(
+            method="method_1",
+            metric="metric_1",
+            central_estimate=1.0,
+            privileged="no",  # type: ignore[arg-type]
+        )

--- a/tests/test_forager_dataclasses_hostile_validation.py
+++ b/tests/test_forager_dataclasses_hostile_validation.py
@@ -92,7 +92,7 @@ def test_paper_baseline_role_rejects_before_comparison_hook() -> None:
 
 
 def test_paper_reference_target_rejects_invalid_inputs() -> None:
-    with pytest.raises(ValueError, match="central_estimate must be a finite float"):
+    with pytest.raises(ValueError, match="central_estimate must be finite"):
         PaperReferenceTarget(
             method="method_1",
             metric="metric_1",

--- a/tests/test_forager_dataclasses_hostile_validation.py
+++ b/tests/test_forager_dataclasses_hostile_validation.py
@@ -46,6 +46,28 @@ def test_paper_baseline_rejects_invalid_inputs() -> None:
             source="paper",
         )
 
+
+def test_paper_baseline_role_rejects_before_comparison_hook() -> None:
+    calls = 0
+
+    class Hostile:
+        def __eq__(self, _other: object) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("comparison hook reached")
+
+    with pytest.raises(ValueError, match="role must be an exact string"):
+        PaperBaseline(
+            name="base",
+            family="family",
+            role=Hostile(),  # type: ignore[arg-type]
+            state_construction="raw",
+            selected_hyperparameters={},
+            in_tree_implementation=True,
+            source="paper",
+        )
+    assert calls == 0
+
     with pytest.raises(ValueError, match="role is invalid"):
         PaperBaseline(
             name="base",

--- a/tests/test_forager_matrix_manifest_hostile_validation.py
+++ b/tests/test_forager_matrix_manifest_hostile_validation.py
@@ -22,6 +22,18 @@ def dummy_rule() -> ForagerTuningRule:
     )
 
 
+def test_tuning_rule_accepts_parser_supported_conservative_statistic() -> None:
+    rule = ForagerTuningRule(
+        metric="mean_reward",
+        direction="maximize",
+        statistic="conservative_ci_endpoint",
+        confidence=0.95,
+        bootstrap_resamples=100,
+        bootstrap_seed=0,
+    )
+    assert rule.statistic == "conservative_ci_endpoint"
+
+
 def test_forager_matrix_manifest_rejects_invalid_inputs(
     dummy_rule: ForagerTuningRule,
 ) -> None:

--- a/tests/test_forager_matrix_tuning_hostile_validation.py
+++ b/tests/test_forager_matrix_tuning_hostile_validation.py
@@ -100,9 +100,7 @@ def test_forager_tuning_selection_validation() -> None:
             selected_variants={},
         )
 
-    with pytest.raises(
-        ForagerMatrixManifestError, match="file_sha256 must be a 64-character hex string"
-    ):
+    with pytest.raises(ForagerMatrixManifestError, match="lowercase SHA-256 digest"):
         ForagerTuningSelection(
             report_path="tuning/report.json",
             file_sha256="invalid",

--- a/tests/test_forager_results_comparison_hostile_validation.py
+++ b/tests/test_forager_results_comparison_hostile_validation.py
@@ -86,7 +86,7 @@ def test_forager_paired_comparison_rejects_invalid_inputs() -> None:
 
 
 def test_forager_comparison_report_rejects_invalid_inputs() -> None:
-    with pytest.raises(TypeError, match="summaries must be a mapping"):
+    with pytest.raises(TypeError, match="summaries must be an exact dictionary"):
         ForagerComparisonReport(
             candidate="cand_1",
             metric="mean_reward",
@@ -94,6 +94,36 @@ def test_forager_comparison_report_rejects_invalid_inputs() -> None:
             paired_comparisons=(),
             unpaired_methods=(),
         )
+
+
+def test_forager_comparison_literals_reject_before_hooks() -> None:
+    calls = 0
+
+    class Hostile:
+        def __eq__(self, _other: object) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("comparison hook reached")
+
+        def __repr__(self) -> str:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("repr hook reached")
+
+    with pytest.raises(ValueError, match="metric is not a valid ForagerMetric"):
+        ForagerPairedComparison(
+            candidate="candidate",
+            baseline="baseline",
+            candidate_privileged=False,
+            baseline_privileged=False,
+            metric=Hostile(),  # type: ignore[arg-type]
+            seeds=(0,),
+            mean_difference=0.0,
+            ci_low=0.0,
+            ci_high=0.0,
+            confidence=0.95,
+        )
+    assert calls == 0
 
     with pytest.raises(TypeError, match="paired_comparisons must be an exact tuple"):
         ForagerComparisonReport(

--- a/tests/test_historical_forager_hostile_validation.py
+++ b/tests/test_historical_forager_hostile_validation.py
@@ -71,6 +71,29 @@ def test_historical_forager_pairing_identity_rejects_invalid_inputs() -> None:
             runtime_sha256="c" * 64,
         )
 
+
+def test_historical_adapter_mode_rejects_before_comparison_hook() -> None:
+    calls = 0
+
+    class Hostile:
+        def __eq__(self, _other: object) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("comparison hook reached")
+
+    with pytest.raises(HistoricalForagerContractError, match="adapter_mode is invalid"):
+        HistoricalForagerPairingIdentity(
+            family_id="family_1",
+            provenance_sha256="a" * 64,
+            seed=1,
+            aperture_size=9,
+            steps=100,
+            semantic_contract_sha256="b" * 64,
+            environment_adapter_mode=Hostile(),  # type: ignore[arg-type]
+            runtime_sha256="c" * 64,
+        )
+    assert calls == 0
+
     with pytest.raises(HistoricalForagerContractError, match="aperture_size must be one of"):
         HistoricalForagerPairingIdentity(
             family_id="family_1",


### PR DESCRIPTION
Finishes and repairs the #1334/#1336/#1341/#1347 constructor hardening work plus defects found in raced merged constructor PRs.

Critical compatibility fix:
- `ForagerTuningRule.statistic` again accepts the parser/runtime-supported `conservative_ci_endpoint` literal (not the nonexistent `median`). All retained Forager matrix tests now pass.

Boundary repairs:
- exact-type gates precede Literal membership so hostile equality/repr/length hooks cannot execute;
- mutable bytearrays and tuple/string subclasses are rejected from immutable run/capture plans;
- direct result/config hyperparameter and ndarray containers use the promised exact types;
- tuning-selection digests require lowercase SHA-256, matching the parser.

Carries the original authored changes from #1336, #1341, and #1347 with conflict resolution; #1334 was merged concurrently and is corrected here.