### PR TITLE
fix(core): preflight complete IA cerebellum resources

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -128,11 +128,26 @@ def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
 
 
 def _preflight_cerebellum_resources(n_demons: int, obs_dim: int) -> None:
-    """Reject weight and concat widths the exo-cerebellum update cannot name."""
+    """Reject persistent and update working sets the cerebellum cannot name."""
 
+    weight_scalars = n_demons * obs_dim
+    # The agent owns the float32 weights, one int32 cumulant-index vector,
+    # one int32 telemetry scalar, and two uint32 lifetime words.  Every leaf
+    # occupies four bytes, so account for the aggregate rather than merely
+    # proving that the largest single array is nameable.
+    persistent_scalars = weight_scalars + n_demons + 3
     _require_float32_resource(
-        "exo-cerebellum weights",
-        float32_scalars=n_demons * obs_dim,
+        "exo-cerebellum persistent state",
+        float32_scalars=persistent_scalars,
+    )
+    # During update, weights, the outer-product delta, and candidate weights
+    # are simultaneously live.  The remaining term conservatively covers the
+    # two raw/safe observations, predictions, targets, errors, neutral result
+    # vectors, lifetime words, and transaction flags.
+    update_scalars = 3 * weight_scalars + 6 * n_demons + 4 * obs_dim + 16
+    _require_float32_resource(
+        "exo-cerebellum update working set",
+        float32_scalars=update_scalars,
     )
     _require_derived_int32("augmented observation dim", n_demons + obs_dim, minimum=2)
     _require_float32_resource(

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -115,6 +115,32 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit signed int32")
+    return value
+
+
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    _require_derived_int32(f"{name} scalar count", float32_scalars)
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} byte count must fit signed int32")
+
+
+def _preflight_cerebellum_resources(n_demons: int, obs_dim: int) -> None:
+    """Reject weight and concat widths the exo-cerebellum update cannot name."""
+
+    _require_float32_resource(
+        "exo-cerebellum weights",
+        float32_scalars=n_demons * obs_dim,
+    )
+    _require_derived_int32("augmented observation dim", n_demons + obs_dim, minimum=2)
+    _require_float32_resource(
+        "augmented observation",
+        float32_scalars=n_demons + obs_dim,
+    )
+
+
 def _positive_float32_scalar(name: str, value: object) -> float:
     """Validate and canonicalize a positive scalar in its execution dtype."""
     message = f"{name} must be a finite positive float32 scalar"
@@ -177,6 +203,7 @@ class ExoCerebellumConfig:
         )
         step_size = _positive_float32_scalar("step_size", self.step_size)
         object.__setattr__(self, "step_size", step_size)
+        _preflight_cerebellum_resources(self.n_demons, self.obs_dim)
 
     def to_config(self) -> dict[str, Any]:
         return {"type": "ExoCerebellumConfig", **dataclasses.asdict(self)}
@@ -623,6 +650,15 @@ class IAConfig:
                 f"cerebellum.obs_dim ({self.cerebellum.obs_dim}) must equal "
                 f"cortex.observation_dim ({self.cortex.observation_dim})"
             )
+        _require_derived_int32(
+            "augmented observation dim",
+            self.augmented_obs_dim,
+            minimum=2,
+        )
+        _require_float32_resource(
+            "augmented observation",
+            float32_scalars=self.augmented_obs_dim,
+        )
 
     @property
     def augmented_obs_dim(self) -> int:

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -140,11 +140,13 @@ def _preflight_cerebellum_resources(n_demons: int, obs_dim: int) -> None:
         "exo-cerebellum persistent state",
         float32_scalars=persistent_scalars,
     )
-    # During update, weights, the outer-product delta, and candidate weights
-    # are simultaneously live.  The remaining term conservatively covers the
-    # two raw/safe observations, predictions, targets, errors, neutral result
-    # vectors, lifetime words, and transaction flags.
-    update_scalars = 3 * weight_scalars + 6 * n_demons + 4 * obs_dim + 16
+    # During update, source weights, the outer-product delta, candidate
+    # weights, and the selected result weights are simultaneously live.  The
+    # remaining term covers the retained cumulant indices, predictions,
+    # targets, errors, neutral result vectors, two raw/safe observations,
+    # lifetime words, and transaction predicates. Charging every element as
+    # four bytes conservatively covers int32, uint32, and boolean arrays too.
+    update_scalars = 4 * weight_scalars + 6 * n_demons + 4 * obs_dim + 16
     _require_float32_resource(
         "exo-cerebellum update working set",
         float32_scalars=update_scalars,

--- a/tests/test_ia_cerebellum_overflow_preflight.py
+++ b/tests/test_ia_cerebellum_overflow_preflight.py
@@ -33,6 +33,20 @@ def test_cerebellum_config_rejects_weight_product_overflow() -> None:
         ExoCerebellumConfig(n_demons=65536, obs_dim=32768)
 
 
+def test_cerebellum_config_rejects_aggregate_before_allocation() -> None:
+    # The weight array alone is 4 bytes below INT32_MAX, but the persistent
+    # cumulant-index vector/counters and update working copies do not fit.
+    with pytest.raises(ValueError, match="persistent state byte count"):
+        ExoCerebellumConfig(n_demons=_INT32_MAX // 4, obs_dim=1)
+
+
+def test_cerebellum_config_rejects_simultaneous_update_working_set() -> None:
+    # Each individual matrix is below the byte ceiling; the live weights,
+    # outer product, and candidate matrix together exceed it.
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExoCerebellumConfig(n_demons=100_000_000, obs_dim=1)
+
+
 def test_ia_config_rejects_overflowing_published_update_width() -> None:
     cortex = _default_oak_config()
     overflowing_demons = _INT32_MAX - cortex.observation_dim + 1

--- a/tests/test_ia_cerebellum_overflow_preflight.py
+++ b/tests/test_ia_cerebellum_overflow_preflight.py
@@ -47,6 +47,13 @@ def test_cerebellum_config_rejects_simultaneous_update_working_set() -> None:
         ExoCerebellumConfig(n_demons=100_000_000, obs_dim=1)
 
 
+def test_cerebellum_working_set_includes_selected_result_weights() -> None:
+    # The previous three-matrix envelope fit here. Retaining the source,
+    # outer delta, candidate, and selected result matrices does not.
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExoCerebellumConfig(n_demons=1, obs_dim=70_000_000)
+
+
 def test_ia_config_rejects_overflowing_published_update_width() -> None:
     cortex = _default_oak_config()
     overflowing_demons = _INT32_MAX - cortex.observation_dim + 1

--- a/tests/test_ia_cerebellum_overflow_preflight.py
+++ b/tests/test_ia_cerebellum_overflow_preflight.py
@@ -1,0 +1,61 @@
+"""Overflow preflight keeps the IA update's published width in signed int32."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.intelligence_amplification import (
+    ExoCerebellumAgent,
+    ExoCerebellumConfig,
+    IAConfig,
+    _default_oak_config,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_update_width() -> None:
+    cortex_obs_dim = _default_oak_config().observation_dim
+    overflowing_demons = _INT32_MAX - cortex_obs_dim + 1
+    published_width = cortex_obs_dim + overflowing_demons
+    assert published_width == _INT32_MAX + 1
+    wrapped_width = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_width == _INT32_MIN
+    assert wrapped_width != published_width
+
+
+def test_cerebellum_config_rejects_weight_product_overflow() -> None:
+    with pytest.raises(ValueError, match="must fit signed int32"):
+        ExoCerebellumConfig(n_demons=65536, obs_dim=32768)
+
+
+def test_ia_config_rejects_overflowing_published_update_width() -> None:
+    cortex = _default_oak_config()
+    overflowing_demons = _INT32_MAX - cortex.observation_dim + 1
+    with pytest.raises(ValueError, match="must fit signed int32"):
+        IAConfig(
+            cerebellum=ExoCerebellumConfig(
+                n_demons=overflowing_demons,
+                obs_dim=cortex.observation_dim,
+            ),
+            cortex=cortex,
+        )
+
+
+def test_legal_cerebellum_update_identity_is_unchanged() -> None:
+    cfg = ExoCerebellumConfig(n_demons=4, obs_dim=3)
+    agent = ExoCerebellumAgent(cfg)
+    assert int(cfg.n_demons + cfg.obs_dim) == 7
+    assert list(agent._cumulant_indices) == [0, 1, 2, 0]
+    result = agent.update_result(
+        agent.init(),
+        jnp.ones(3, dtype=jnp.float32),
+        jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert result.state.weights.shape == (4, 3)
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
Contributor-preserving successor to #1378. It retains the derived weight/concat overflow fix and closes the residual aggregate hole: the agent also allocates an int32 cumulant-index vector, lifetime counters, and simultaneous weights/outer/candidate/result working arrays. A weight array could fit alone while constructor/update aggregate bytes exceeded signed int32. The revised preflight accounts for the persistent aggregate and a conservative complete update working set before allocation.

Verification: 6 focused boundary/legal-update tests passed; broader IA panel is green in progress; Ruff clean; strict source mypy clean; diff-check clean.