### PR TITLE
fix(validation): close post-merge record gaps

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -215,13 +215,13 @@ class CompletedCampaignBundle:
         if not isinstance(self.live_runtime, executor.LiveRuntimeIdentity):
             raise ForagerMatchedCampaignError("live_runtime must be a LiveRuntimeIdentity")
         if type(self.candidate_ids) is not tuple or not all(
-            isinstance(cid, str) and cid for cid in self.candidate_ids
+            type(cid) is str and bool(cid) for cid in self.candidate_ids
         ):
             raise ForagerMatchedCampaignError(
                 "candidate_ids must be a tuple of non-empty strings"
             )
         if type(self.active_seeds) is not tuple or not all(
-            isinstance(s, int) and s >= 0 for s in self.active_seeds
+            type(s) is int and s >= 0 for s in self.active_seeds
         ):
             raise ForagerMatchedCampaignError(
                 "active_seeds must be a tuple of non-negative ints"

--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -327,19 +327,26 @@ class ProbeInvocation:
     def __post_init__(self) -> None:
         if type(self.candidate_id) is not str or not self.candidate_id:
             raise ForagerMatchedQualificationError("candidate_id must be a non-empty string")
-        if self.source_key not in ("alberta", "upstream", "upstream_rng_isolated"):
+        if type(self.source_key) is not str or self.source_key not in (
+            "alberta",
+            "upstream",
+            "upstream_rng_isolated",
+        ):
             raise ForagerMatchedQualificationError("source_key is invalid")
         if not isinstance(self.source_root, Path):
             raise ForagerMatchedQualificationError("source_root must be a Path")
         if not isinstance(self.probe_path, Path):
             raise ForagerMatchedQualificationError("probe_path must be a Path")
-        if type(self.probe_sha256) is not str or len(self.probe_sha256) != 64:
+        if type(self.probe_sha256) is not str or _SHA256.fullmatch(self.probe_sha256) is None:
             raise ForagerMatchedQualificationError(
                 "probe_sha256 must be a 64-character hex string"
             )
         if not isinstance(self.configuration, Path):
             raise ForagerMatchedQualificationError("configuration must be a Path")
-        if type(self.configuration_sha256) is not str or len(self.configuration_sha256) != 64:
+        if (
+            type(self.configuration_sha256) is not str
+            or _SHA256.fullmatch(self.configuration_sha256) is None
+        ):
             raise ForagerMatchedQualificationError(
                 "configuration_sha256 must be a 64-character hex string"
             )
@@ -355,7 +362,10 @@ class ProbeInvocation:
             val = getattr(self, name)
             if type(val) is not str or not val:
                 raise ForagerMatchedQualificationError(f"{name} must be a non-empty string")
-        if type(self.entrypoint_sha256) is not str or len(self.entrypoint_sha256) != 64:
+        if (
+            type(self.entrypoint_sha256) is not str
+            or _SHA256.fullmatch(self.entrypoint_sha256) is None
+        ):
             raise ForagerMatchedQualificationError(
                 "entrypoint_sha256 must be a 64-character hex string"
             )

--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -147,8 +147,14 @@ class _OpenDirectory:
             raise ForagerMatchedSealError("path must be a Path")
         if type(self.descriptor) is not int or self.descriptor < 0:
             raise ForagerMatchedSealError("descriptor must be a non-negative int")
-        if type(self.inode_identity) is not tuple or len(self.inode_identity) != 3:
-            raise ForagerMatchedSealError("inode_identity must be a 3-element tuple")
+        if (
+            type(self.inode_identity) is not tuple
+            or len(self.inode_identity) != 3
+            or any(type(part) is not int or part < 0 for part in self.inode_identity)
+        ):
+            raise ForagerMatchedSealError(
+                "inode_identity must be a 3-element tuple of non-negative ints"
+            )
 
 
 def _plain(value: Any) -> Any:

--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -362,6 +362,8 @@ class EnvironmentTraceDigest:
             isinstance(t, TransitionDigest) for t in self.transitions
         ):
             raise ForagerRngParityError("transitions must be a tuple of TransitionDigest")
+        if type(self.trace_sha256) is not str:
+            raise ForagerRngParityError("trace.trace_sha256 must be a string")
         if self.trace_sha256:
             object.__setattr__(
                 self,
@@ -478,6 +480,8 @@ class ParityProbeResult:
             "direct_trace_sha256",
             _require_sha256(self.direct_trace_sha256, "direct_trace_sha256"),
         )
+        if type(self.payload_sha256) is not str:
+            raise ForagerRngParityError("payload_sha256 must be a string")
         if self.payload_sha256:
             object.__setattr__(
                 self,
@@ -524,7 +528,7 @@ class ParityCollectorResult:
     payload_sha256: str
 
     def __post_init__(self) -> None:
-        if self.collector not in ("wrapper", "direct"):
+        if type(self.collector) is not str or self.collector not in ("wrapper", "direct"):
             raise ForagerRngParityError("collector must be 'wrapper' or 'direct'")
         if not isinstance(self.runtime, VerifiedRuntimeIdentity):
             raise ForagerRngParityError("runtime must be a VerifiedRuntimeIdentity")
@@ -532,6 +536,8 @@ class ParityCollectorResult:
             raise ForagerRngParityError("config must be a FixedActionProbeConfig")
         if not isinstance(self.trace, EnvironmentTraceDigest):
             raise ForagerRngParityError("trace must be an EnvironmentTraceDigest")
+        if type(self.payload_sha256) is not str:
+            raise ForagerRngParityError("payload_sha256 must be a string")
         if self.payload_sha256:
             object.__setattr__(
                 self,

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -478,7 +478,7 @@ class IAAcceptanceEvidence:
     def __post_init__(self) -> None:
         if type(self.name) is not str or not self.name:
             raise ValueError("name must be a non-empty string")
-        if self.scope not in ("primary", "secondary"):
+        if type(self.scope) is not str or self.scope not in ("primary", "secondary"):
             raise ValueError("scope must be 'primary' or 'secondary'")
         if type(self.passed) is not bool:
             raise ValueError("passed must be a boolean")

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -447,7 +447,7 @@ class DecisionFidelityReport:
         if not isinstance(self.config, DecisionFidelityConfig):
             raise ValueError("config must be a DecisionFidelityConfig")
         if not isinstance(self.seeds, tuple) or not all(
-            type(s) is int and 0 <= s < _INT32_MAX for s in self.seeds
+            type(s) is int and 0 <= s <= _INT32_MAX for s in self.seeds
         ):
             raise ValueError("seeds must be a tuple of non-negative int32 seeds")
         if not isinstance(self.seed_results, tuple) or not all(

--- a/tests/test_acceptance_evidence_hostile_validation.py
+++ b/tests/test_acceptance_evidence_hostile_validation.py
@@ -28,6 +28,10 @@ class HostileBool:
         return True
 
 
+class StringSubclass(str):
+    """A leftover string identity that must not cross strict record boundaries."""
+
+
 def test_acceptance_evidence_valid_construction() -> None:
     evidence = AcceptanceEvidence(
         name="coadaptation_uplift",
@@ -43,6 +47,19 @@ def test_acceptance_evidence_valid_construction() -> None:
     assert evidence.comparator == ">="
     assert evidence.threshold == 0.05
     assert evidence.detail == "p-value: 0.001"
+
+
+def test_ia_acceptance_evidence_rejects_scope_string_subclass() -> None:
+    with pytest.raises(ValueError, match="scope must be 'primary' or 'secondary'"):
+        IAAcceptanceEvidence(
+            name="check",
+            scope=StringSubclass("primary"),  # type: ignore[arg-type]
+            passed=True,
+            actual=0.1,
+            comparator=">=",
+            threshold=0.0,
+            detail="ok",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forager_matched_campaign.py
+++ b/tests/test_forager_matched_campaign.py
@@ -479,13 +479,13 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
             "6a9315cb996fe5698e4c1580d30da9b0524e9875ce085d1399bb975cc5b510a8"
         ),
         "execution-plan.json": (
-            "da881ac9300f6d3bb2668855ab0ccd931fc3e162758867f387657cd07721abbb"
+            "3a7f51da14a269d2a7b722f982e85f44ef74ea372bc29872b08c88d1dcbe6eb4"
         ),
         "source-manifest.json": (
             "9aa2a792a6e48438ed91d3ac180e87348ce3f4781fd6a87a987634593b604f23"
         ),
         "executor-manifest.json": (
-            "162c5037803e2bd25c2d63705a107fbdc67bfb8bb9acff3eeac31c6abba59df3"
+            "bd0068f2c053ffbc4c298b36ee73c1b0ccb3fdb2308b3282bd385d9b80dcb326"
         ),
         "qualification-manifest.json": (
             "0ac448b2686c7f7da8cc3f2a489bc764f76e215193de67cd62308ac21d83d24a"
@@ -494,10 +494,10 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
             "06cbe35d345bc3e4fdc79d7628a181a0ac126f929e0c0b70c2b25d9ef250d7d5"
         ),
         "live-runtime.json": (
-            "d3ea32b2091b84146ff276b34d72b00e9fa2084fe00a50810277f69a35e35be1"
+            "439968e03e99a563f32066e6787083ca633fc8f92b31e97deff5b94403b6215b"
         ),
         "campaign.json": (
-            "9cb3fca20ffd4dbb1950da8da88fe59cf6ebf3aaabe9b4c1cc15c116e912a3dc"
+            "4cbad0fbc079d8b24859ccbafc04eeb5f69127157e3b5bc7677d432248f5e858"
         ),
     }
     assert frozen_schedule["schedule_sha256"] == (
@@ -517,7 +517,7 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
         attempt,
     )
     assert binding_sha256 == (
-        "890d4c8b8c6d21803c1aa7efd78c27286aaab9ccf1976acbece4309eb0e9e0ca"
+        "a2a424e3b5d6f0b8e35dc7f770c4fa484bc338f709741ff25fec94513b7ea85e"
     )
     artifact = executor.score_seed_archive(
         context.rebuilt.plan,
@@ -538,7 +538,7 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
         artifact.to_dict(),
     )
     assert bundle_sha256 == (
-        "1a1130d342bf689e8fed389e45bb26205bf246f49b920691d8998c6e2c10f679"
+        "a52bcab0809dddc3c8d52e462868ee771cfcfb7790b7a2463ab95fab85f3749b"
     )
     pointer = campaign._completion_pointer(
         context,
@@ -549,7 +549,7 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
         bundle_sha256,
     )
     assert digest(campaign.canonical_json_bytes(pointer)) == (
-        "a9fa7c0057215eb0689587973b2dd8fa560ac64cae6d0e3326c07488df540388"
+        "be9dec9f11a2272ffd87e0aa8b0de96dbce64a0ddfcfcbdd8ee8bdf5b0f54c6a"
     )
     campaign._persist_failure(
         attempt,
@@ -567,16 +567,16 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
     _complete_loader_context(completed_context)
     expected_final = {
         "execution-receipt-index.json": (
-            "a8dcafdb050d2c0f32d2ef6743750d187d0cdec5cac6783315dd2342796a7691"
+            "8aab743e5a6fbc70bdb736f0b4e5283e340a055b7a010676f3cb69acfa4fae5e"
         ),
         "score-evidence.json": (
-            "6fdfe584ac705b62da1042ba35d035c29e1fd574a93381a5b536d91d78df2266"
+            "bf0ad65eedf80744c6a9b2c3b7ad1d6e144fa76d0ce5c2d1efb9dc1f602d815b"
         ),
         "verification-request.json": (
-            "91567672900044aa8d7a5f10983e3dac423d11985993dc6f27672bfa3da0c591"
+            "f878093a9ae49daec11c7b15ea311f12867dda8c293379231b8fdcaee3db85ca"
         ),
         "completion-summary.json": (
-            "9553ec581ca9660d5975b38e227dd30116a15ff7a63d92f5e1d57a27e3f9f9eb"
+            "747cbd3222bab0800d7d5398adf16ca239f07384d8e51a31d20cc98bf48c09e9"
         ),
     }
     for name, expected_digest in expected_final.items():
@@ -591,7 +591,7 @@ def test_open_campaign_v2_golden_byte_contract(tmp_path: Path) -> None:
     )
     normalized_status = replace(status, output_root=Path("/golden/open-campaign"))
     assert digest(campaign.canonical_json_bytes(normalized_status.to_dict())) == (
-        "817f793086abb911dd7b21bd46114aa9fbab21f72365030ad92428007146e970"
+        "279d14a0a524029c39ad619c19b0b04f6dee35a5c7c0898e489fcfc8b1b24b1d"
     )
 
 

--- a/tests/test_forager_matched_qualification_hostile_validation.py
+++ b/tests/test_forager_matched_qualification_hostile_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -83,3 +84,10 @@ def test_probe_invocation_rejects_invalid_inputs() -> None:
             expected_agent=inv.expected_agent,
             horizon=0,
         )
+
+
+@pytest.mark.parametrize("field", ["probe_sha256", "configuration_sha256", "entrypoint_sha256"])
+def test_probe_invocation_rejects_nonhex_sha256(field: str) -> None:
+    inv = _make_probe_invocation()
+    with pytest.raises(ForagerMatchedQualificationError, match=f"{field} must be"):
+        replace(inv, **{field: "z" * 64})

--- a/tests/test_forager_matched_seal_hostile_validation.py
+++ b/tests/test_forager_matched_seal_hostile_validation.py
@@ -62,3 +62,10 @@ def test_open_directory_validation() -> None:
 
     with pytest.raises(ForagerMatchedSealError, match="inode_identity must be a 3-element tuple"):
         _OpenDirectory(path=Path("/tmp"), descriptor=3, inode_identity=(1, 2))  # type: ignore[arg-type]
+
+    with pytest.raises(ForagerMatchedSealError, match="inode_identity must be a 3-element tuple"):
+        _OpenDirectory(
+            path=Path("/tmp"),
+            descriptor=3,
+            inode_identity=(1, True, 3),
+        )

--- a/tests/test_forager_rng_parity.py
+++ b/tests/test_forager_rng_parity.py
@@ -153,6 +153,11 @@ def test_matching_traces_produce_canonical_hash_only_result() -> None:
         result.payload_sha256
         == hashlib.sha256(parity.canonical_json_bytes(result.unsigned_dict())).hexdigest()
     )
+
+    for invalid_digest in (None, False, 0):
+        with pytest.raises(parity.ForagerRngParityError, match="payload_sha256 must be a string"):
+            replace(result, payload_sha256=invalid_digest)  # type: ignore[arg-type]
+
     assert payload["status"] == parity.MATCH_STATUS
     assert payload["evidence_boundary"] == parity.CONTENT_IDENTITY_BOUNDARY
     assert payload["promotion_authorized"] is False
@@ -166,6 +171,14 @@ def test_matching_traces_produce_canonical_hash_only_result() -> None:
     }
     assert "values" not in transition["reward"]
     assert parity.validate_parity_result(result.canonical_bytes) == result
+
+
+def test_collector_result_rejects_falsey_nonstring_payload_digest() -> None:
+    config = parity.FixedActionProbeConfig(seed=2_300_001, actions=(0, 3, 1, 2))
+    result = _collector_result("wrapper", config, _trace(config))
+    for invalid_digest in (None, False, 0):
+        with pytest.raises(parity.ForagerRngParityError, match="payload_sha256 must be a string"):
+            replace(result, payload_sha256=invalid_digest)  # type: ignore[arg-type]
 
 
 def test_live_orchestration_uses_distinct_collectors_and_detects_mismatch(

--- a/tests/test_forager_rng_parity_hostile_validation.py
+++ b/tests/test_forager_rng_parity_hostile_validation.py
@@ -103,3 +103,16 @@ def test_environment_trace_digest_validation() -> None:
             transitions=[_make_transition_digest()],  # type: ignore[arg-type]
             trace_sha256="d" * 64,
         )
+
+    for invalid_digest in (None, False, 0):
+        with pytest.raises(ForagerRngParityError, match="trace.trace_sha256 must be a string"):
+            td = _make_tree_digest()
+            EnvironmentTraceDigest(
+                seed=42,
+                action_sequence_sha256="c" * 64,
+                reset_keys=_make_key_frame(),
+                reset_observation=td,
+                reset_state=td,
+                transitions=(_make_transition_digest(),),
+                trace_sha256=invalid_digest,  # type: ignore[arg-type]
+            )

--- a/tests/test_ftl_decision_fidelity_hostile_validation.py
+++ b/tests/test_ftl_decision_fidelity_hostile_validation.py
@@ -180,6 +180,16 @@ def test_decision_fidelity_report_validation() -> None:
     assert report.config == config
     assert report.seeds == seeds
 
+    max_seed_result = SeedDecisionResult(seed=2**31 - 1, metrics=(_make_dummy_metrics(),))
+    max_seed_report = DecisionFidelityReport(
+        config=config,
+        seeds=(2**31 - 1,),
+        seed_results=(max_seed_result,),
+        aggregates=aggregates,
+        comparisons=comparisons,
+    )
+    assert max_seed_report.seeds == (2**31 - 1,)
+
     with pytest.raises(ValueError, match="config must be a DecisionFidelityConfig"):
         DecisionFidelityReport(
             config="invalid",  # type: ignore[arg-type]


### PR DESCRIPTION
Corrective successor to the #1312–#1330 record-validation tranche.\n\nDeep combined review found six concrete residuals: falsey non-string trace/payload digests bypassed RNG parity validation; ProbeInvocation accepted any 64-character non-hex string as SHA-256; the report aggregate rejected INT32_MAX although its seed record accepts it; IA scope admitted string subclasses; campaign seeds admitted bool; and open-directory inode tuples did not validate their members.\n\nThis preserves the intentional empty-string draft hash state while rejecting every other non-string identity. It also refreshes the open-campaign golden byte hashes because qualification/RNG source identities are load-bearing; no artifact or scientific claim is promoted.\n\nVerification on current main: 381 passed, 7 skipped across all directly affected retained suites; exact post-rebase corrective selection 67 passed; Ruff clean; strict mypy clean.