### PR TITLE
fix(core): preflight complete baseline-optimizer resources

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -34,10 +34,12 @@ References:
   for AI Research" (arXiv: 2208.11173)
 """
 
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
 
@@ -53,6 +55,136 @@ from alberta_framework.core.update_safety import (
     neutralize_metrics,
     select_transaction,
 )
+
+_INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit signed int32")
+    return value
+
+
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    _require_derived_int32(f"{name} scalar count", float32_scalars)
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} byte count must fit signed int32")
+
+
+def _require_feature_dim(feature_dim: object) -> int:
+    return _require_int32("feature_dim", feature_dim, minimum=1)
+
+
+def _require_shape_scalars(shape: object) -> int:
+    if type(shape) is not tuple:
+        raise ValueError("shape must be an actual tuple")
+    total = 1
+    for index, dim in enumerate(cast(tuple[object, ...], shape)):
+        dim = _require_int32(f"shape[{index}]", dim, minimum=1)
+        total = _require_derived_int32("shape scalar count", total * dim, minimum=1)
+    return total
+
+
+def _preflight_optimizer_resources(
+    name: str,
+    n: int,
+    *,
+    persistent_vectors: int,
+    persistent_scalars: int,
+    update_vectors: int,
+    update_scalars: int,
+) -> None:
+    """Reject persistent and simultaneous-update working sets this optimizer owns."""
+
+    _require_derived_int32(f"{name} feature dim", n, minimum=1)
+    _require_float32_resource(f"{name} moment bank", float32_scalars=n)
+    _require_float32_resource(
+        f"{name} persistent state",
+        float32_scalars=persistent_vectors * n + persistent_scalars,
+    )
+    _require_float32_resource(
+        f"{name} update working set",
+        float32_scalars=update_vectors * n + update_scalars,
+    )
+
+
+def _preflight_adam_resources(n: int) -> None:
+    # Linear Adam owns two float32 moment banks plus seven named scalars
+    # (bias_m, bias_v, t, step_size, beta1, beta2, eps). t is a float32
+    # lifetime counter, not an int32 word.
+    _preflight_optimizer_resources(
+        "Adam",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=7,
+        # Live during update: observation, g, m, v, new_m, new_v, m_hat,
+        # v_hat, and weight_delta. Remaining scalars cover the bias path
+        # and transaction flags.
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_adam_param_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "Adam",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=5,
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_adagain_resources(n: int) -> None:
+    # AdaGain owns two float32 banks (step_sizes, gradient_trace) plus four
+    # named scalars (bias gain/trace, meta_step_size, forgetting_rate).
+    _preflight_optimizer_resources(
+        "AdaGain",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=4,
+        # Live during update: observation, gradient, step_sizes,
+        # gradient_trace, gain_correlation, meta_delta, new_step_sizes,
+        # weight_delta, and new_gradient_trace.
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_rmsprop_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "RMSprop",
+        n,
+        persistent_vectors=1,
+        persistent_scalars=4,
+        update_vectors=6,
+        update_scalars=6,
+    )
+
+
+def _preflight_nadaline_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "NADALINE",
+        n,
+        persistent_vectors=1,
+        persistent_scalars=3,
+        update_vectors=6,
+        update_scalars=6,
+    )
 
 
 def _skip_zero_scale(configured_scale: float, scale: Array, value: Array) -> Array:
@@ -271,6 +403,8 @@ class AdaGain(Optimizer[Any]):
 
     def init(self, feature_dim: int) -> AdaGainState:
         """Initialize AdaGain state."""
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_adagain_resources(feature_dim)
         return AdaGainState(
             step_sizes=jnp.full(
                 feature_dim, self._initial_step_size, dtype=jnp.float32
@@ -457,6 +591,8 @@ class Adam(Optimizer[Any]):
         Returns:
             Adam state with zero-initialized moments and ``t = 0``
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_adam_resources(feature_dim)
         return AdamState(
             m=jnp.zeros(feature_dim, dtype=jnp.float32),
             v=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -478,6 +614,7 @@ class Adam(Optimizer[Any]):
         Returns:
             ``AdamParamState`` with arrays matching the given shape
         """
+        _preflight_adam_param_resources(_require_shape_scalars(shape))
         return AdamParamState(
             m=jnp.zeros(shape, dtype=jnp.float32),
             v=jnp.zeros(shape, dtype=jnp.float32),
@@ -759,6 +896,8 @@ class RMSprop(Optimizer[Any]):
         Returns:
             RMSprop state with zero-initialized squared-gradient EMA
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_rmsprop_resources(feature_dim)
         return RMSpropState(
             v=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias_v=jnp.array(0.0, dtype=jnp.float32),
@@ -776,6 +915,14 @@ class RMSprop(Optimizer[Any]):
         Returns:
             ``RMSpropParamState`` with arrays matching the given shape
         """
+        _preflight_optimizer_resources(
+            "RMSprop",
+            _require_shape_scalars(shape),
+            persistent_vectors=1,
+            persistent_scalars=3,
+            update_vectors=6,
+            update_scalars=6,
+        )
         return RMSpropParamState(
             v=jnp.zeros(shape, dtype=jnp.float32),
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
@@ -986,6 +1133,8 @@ class NADALINE(Optimizer[Any]):
         Returns:
             NADALINE state with zero-initialized second-moment EMA
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_nadaline_resources(feature_dim)
         return NadalineState(
             feature_second_moment=jnp.zeros(feature_dim, dtype=jnp.float32),
             step_size=jnp.array(self._step_size, dtype=jnp.float32),

--- a/tests/test_baseline_optimizers_complete_aggregate.py
+++ b/tests/test_baseline_optimizers_complete_aggregate.py
@@ -1,0 +1,87 @@
+"""Complete aggregate preflight for Step 1 baseline optimizer state."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.baseline_optimizers import AdaGain, Adam
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_ONE_BANK_FITS = _INT32_MAX // 4
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_adam_one_moment_bank_fits_while_persistent_aggregate_does_not() -> None:
+    one_bank_bytes = 4 * _ONE_BANK_FITS
+    persistent_bytes = 4 * (2 * _ONE_BANK_FITS + 7)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="persistent state byte count"):
+        Adam().init(_ONE_BANK_FITS)
+
+
+def test_adagain_one_gain_bank_fits_while_persistent_aggregate_does_not() -> None:
+    one_bank_bytes = 4 * _ONE_BANK_FITS
+    persistent_bytes = 4 * (2 * _ONE_BANK_FITS + 4)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="persistent state byte count"):
+        AdaGain().init(_ONE_BANK_FITS)
+
+
+def test_adam_rejects_simultaneous_update_working_set() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 7)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        Adam().init(_WORKING_SET_OVERFLOW)
+
+
+def test_adagain_rejects_simultaneous_update_working_set() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 4)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        AdaGain().init(_WORKING_SET_OVERFLOW)
+
+
+def test_legal_adam_and_adagain_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    error = jnp.asarray(0.5, dtype=jnp.float32)
+
+    adam = Adam(step_size=0.01)
+    adam_state = adam.init(4)
+    assert adam_state.m.shape == (4,)
+    assert adam_state.v.shape == (4,)
+    assert 4 * (2 * 4 + 7) <= _INT32_MAX
+    adam_result = adam.update(adam_state, error, observation)
+    assert bool(adam_result.update_applied)
+    assert adam_result.weight_delta.shape == (4,)
+    assert adam_result.new_state.m.shape == (4,)
+    assert float(adam_result.new_state.t) == pytest.approx(1.0)
+
+    adagain = AdaGain()
+    adagain_state = adagain.init(4)
+    assert adagain_state.step_sizes.shape == (4,)
+    assert adagain_state.gradient_trace.shape == (4,)
+    adagain_result = adagain.update(adagain_state, error, observation)
+    assert bool(adagain_result.update_applied)
+    assert adagain_result.weight_delta.shape == (4,)
+    assert adagain_result.new_state.gradient_trace.shape == (4,)


### PR DESCRIPTION
Closes #1387.

## What changed

Adam and AdaGain (and the other linear inits in the same module) now preflight the persistent aggregate they actually own and the simultaneous update working set, not just one moment bank.

On origin/main `382b603`, ``feature_dim = INT32_MAX // 4`` keeps one float32 bank at ``2147483644`` bytes. Adam still constructs while ``4 × (2 × feature_dim + 7)`` persistent bytes overflow — the second bank plus ``bias_m``, ``bias_v``, float32 lifetime ``t``, and the three constructor scalars. ``feature_dim = 100_000_000`` keeps each bank and that persistent aggregate nameable while nine live update tensors overflow. ``INT32_MAX + 1`` wraps to ``INT32_MIN``. Legal 4-wide Adam/AdaGain updates are unchanged.

This matches the ``#1383`` complete-aggregate bar. It does not reopen ``#1378`` or touch ``intelligence_amplification.py``.

## Scope

- `alberta_framework/core/baseline_optimizers.py`
- `tests/test_baseline_optimizers_complete_aggregate.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `baseline_optimizers.py`. Shaw ``#1383`` owns IA. Thin history-features ``#1381`` stays abandoned.

## Verification

Exact candidate head: `9cb63402aa2aa7759fb1c9f49e2f068eec38061e`
Base: `382b603`

- Red on base: one Adam/AdaGain bank still fits signed int32 while persistent ``2 × dim + scalars`` and the ``9 × dim`` update working set do not; int32 wrap stores ``INT32_MIN``
- Focused pytest `tests/test_baseline_optimizers_complete_aggregate.py` plus existing optimizer tests: 80 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9cb63402aa2aa7759fb1c9f49e2f068eec38061e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
