### PR TITLE
fix(core): preflight optimizer update working sets

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -97,6 +97,12 @@ def _require_float32_state(name: str, scalar_count: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _require_float32_update_working_set(name: str, scalar_count: int) -> None:
+    """Reject simultaneous update tensors this optimizer cannot name."""
+
+    _require_float32_state(name, scalar_count)
+
+
 def _shape_size(shape: tuple[int, ...]) -> int:
     return prod(shape, start=1)
 
@@ -769,6 +775,11 @@ class IDBD(Optimizer[IDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("IDBD state", 2 * feature_dim + 3)
+        # Live during linear update: observation, traces, log_step_sizes,
+        # correlation, meta_delta, new_log, new_alphas, weight_delta, new_traces.
+        _require_float32_update_working_set(
+            "IDBD update working set", 9 * feature_dim + 8
+        )
         return IDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -789,7 +800,9 @@ class IDBD(Optimizer[IDBDState]):
             IDBDParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
-        _require_float32_state("IDBD parameter state", 2 * _shape_size(shape) + 1)
+        n = _shape_size(shape)
+        _require_float32_state("IDBD parameter state", 2 * n + 1)
+        _require_float32_update_working_set("IDBD update working set", 9 * n + 8)
         return IDBDParamState(
             log_step_sizes=jnp.full(shape, jnp.log(self._initial_step_size), dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1112,6 +1125,12 @@ class Autostep(Optimizer[AutostepState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("Autostep state", 3 * feature_dim + 5)
+        # Live during Table-1 update: observation, x^2, step_sizes, traces,
+        # normalizers, meta_gradient, v_update, new_normalizers, new_step_sizes,
+        # and weight_delta.
+        _require_float32_update_working_set(
+            "Autostep update working set", 10 * feature_dim + 8
+        )
         return AutostepState(
             step_sizes=jnp.full(feature_dim, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -1133,7 +1152,9 @@ class Autostep(Optimizer[AutostepState]):
             AutostepParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
-        _require_float32_state("Autostep parameter state", 3 * _shape_size(shape) + 2)
+        n = _shape_size(shape)
+        _require_float32_state("Autostep parameter state", 3 * n + 2)
+        _require_float32_update_working_set("Autostep update working set", 10 * n + 8)
         return AutostepParamState(
             step_sizes=jnp.full(shape, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1499,6 +1520,9 @@ class AutostepGTDLambda(Optimizer[AutostepGTDLambdaState]):
         """Initialize optimizer state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutostepGTDLambda state", 4 * feature_dim + 7)
+        _require_float32_update_working_set(
+            "AutostepGTDLambda update working set", 11 * feature_dim + 8
+        )
         base_state = self._base.init(feature_dim)
         return AutostepGTDLambdaState(
             step_sizes=base_state.step_sizes,
@@ -1644,6 +1668,7 @@ class ObGD(Optimizer[ObGDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("ObGD state", feature_dim + 5)
+        _require_float32_update_working_set("ObGD update working set", 5 * feature_dim + 8)
         return ObGDState(
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
             kappa=jnp.array(self._kappa, dtype=jnp.float32),
@@ -1873,6 +1898,9 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("TDIDBD state", 3 * feature_dim + 5)
+        _require_float32_update_working_set(
+            "TDIDBD update working set", 10 * feature_dim + 8
+        )
         return TDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -2087,6 +2115,9 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 7)
+        _require_float32_update_working_set(
+            "AutoTDIDBD update working set", 11 * feature_dim + 8
+        )
         return AutoTDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32

--- a/tests/test_optimizers_update_working_set.py
+++ b/tests/test_optimizers_update_working_set.py
@@ -1,0 +1,75 @@
+"""Complete update working-set preflight for IDBD and Autostep."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.optimizers import IDBD, Autostep
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_idbd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        IDBD().init(_WORKING_SET_OVERFLOW)
+
+
+def test_autostep_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (3 * _WORKING_SET_OVERFLOW + 5)
+    update_bytes = 4 * (10 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        Autostep().init(_WORKING_SET_OVERFLOW)
+
+
+def test_idbd_persistent_byte_bound_still_fires_first() -> None:
+    float32_scalar_limit = _INT32_MAX // 4
+    overflowing = (float32_scalar_limit - 3) // 2 + 1
+    with pytest.raises(ValueError, match="IDBD state byte count"):
+        IDBD().init(overflowing)
+
+
+def test_legal_idbd_and_autostep_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    error = jnp.asarray(0.5, dtype=jnp.float32)
+
+    idbd = IDBD()
+    idbd_state = idbd.init(4)
+    assert idbd_state.log_step_sizes.shape == (4,)
+    assert idbd_state.traces.shape == (4,)
+    assert 4 * (2 * 4 + 3) <= _INT32_MAX
+    idbd_result = idbd.update(idbd_state, error, observation)
+    assert bool(idbd_result.update_applied)
+    assert idbd_result.weight_delta.shape == (4,)
+    assert idbd_result.new_state.traces.shape == (4,)
+
+    autostep = Autostep()
+    autostep_state = autostep.init(4)
+    assert autostep_state.step_sizes.shape == (4,)
+    assert autostep_state.traces.shape == (4,)
+    assert autostep_state.normalizers.shape == (4,)
+    autostep_result = autostep.update(autostep_state, error, observation)
+    assert bool(autostep_result.update_applied)
+    assert autostep_result.weight_delta.shape == (4,)
+    assert autostep_result.new_state.normalizers.shape == (4,)


### PR DESCRIPTION
Closes #1389.

## What changed

IDBD and Autostep (and the other vector inits in the same module) now preflight the simultaneous update working set after the existing persistent-byte check.

On origin/main `6a9c8fc`, ``feature_dim = 100_000_000`` keeps one bank and IDBD's ``2 × dim + 3`` persistent aggregate nameable. Nine live update tensors overflow signed int32. Autostep's ``3 × dim + 5`` persistent aggregate likewise fits while ten Table-1 tensors do not. Existing persistent-bound tests still fire first. Legal 4-wide updates are unchanged.

This matches the ``#1383`` complete-aggregate bar. It does not reopen ``#1378`` or touch ``intelligence_amplification.py``. ``#1388`` still owns ``baseline_optimizers.py``.

## Scope

- `alberta_framework/core/optimizers.py`
- `tests/test_optimizers_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `optimizers.py`.

## Verification

Exact candidate head: `e8d18b34587527cf6497988e73b5bd39fbd95d56`
Base: `6a9c8fc`

- Red on base: ``IDBD().init(100_000_000)`` constructed; persistent bytes fit; update working-set bytes overflow; int32 wrap stores ``INT32_MIN``
- Focused pytest `tests/test_optimizers_update_working_set.py` plus `tests/test_optimizers.py`: 88 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e8d18b34587527cf6497988e73b5bd39fbd95d56 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
