### PR TITLE
fix(core): halt learner commits at clock exhaustion

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -124,6 +124,22 @@ def _preflight_float32_resources(name: str, scalar_count: int) -> None:
         raise ValueError(f"{name} resource must not exceed the 256 MiB budget")
 
 
+def _learner_clock_has_capacity(step_count: Array) -> Bool[Array, ""]:
+    """Validate one learner clock and report whether another commit is identifiable.
+
+    The int32 clock is the only committed-update identity carried by these
+    legacy states. Once it reaches ``INT32_MAX``, applying another parameter
+    update while retaining the same clock would alias two distinct commits.
+    """
+
+    if getattr(step_count, "shape", None) != ():
+        raise ValueError("learner step_count must be scalar")
+    if getattr(step_count, "dtype", None) != jnp.dtype(jnp.int32):
+        raise TypeError("learner step_count must have dtype int32")
+    maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    return (step_count >= 0) & (step_count < maximum)
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Skip a collapsed 0*inf product before it becomes NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -294,6 +310,7 @@ class LinearLearner:
         Returns:
             UpdateResult with new state, prediction, error, and metrics
         """
+        clock_has_capacity = _learner_clock_has_capacity(state.step_count)
         new_normalizer_state = state.normalizer_state
         obs = observation
         normalizer_update_applied = jnp.asarray(True, dtype=jnp.bool_)
@@ -358,7 +375,8 @@ class LinearLearner:
             jnp.isfinite(target)
         )
         update_applied = (
-            floating_tree_is_finite(state)
+            clock_has_capacity
+            & floating_tree_is_finite(state)
             & inputs_valid
             & normalizer_update_applied
             & opt_update.update_applied
@@ -1347,6 +1365,7 @@ class MLPLearner:
         target_scalar = jnp.squeeze(target)
 
         obs = observation
+        clock_has_capacity = _learner_clock_has_capacity(state.step_count)
         new_normalizer_state = state.normalizer_state
         normalizer_update_applied = jnp.asarray(True, dtype=jnp.bool_)
         if self._normalizer is not None and state.normalizer_state is not None:
@@ -1491,7 +1510,8 @@ class MLPLearner:
             )
         inputs_valid = jnp.all(jnp.isfinite(observation)) & jnp.isfinite(target_scalar)
         update_applied = (
-            inputs_valid
+            clock_has_capacity
+            & inputs_valid
             & floating_tree_is_finite(previous_checked)
             & floating_tree_is_finite(proposed_state)
             & normalizer_update_applied
@@ -1861,6 +1881,7 @@ class TDLinearLearner:
         Returns:
             TDUpdateResult with new state, prediction, TD error, and metrics
         """
+        clock_has_capacity = _learner_clock_has_capacity(state.step_count)
         prediction = self.predict(state, observation)
         next_prediction = self.predict(state, next_observation)
 
@@ -1908,7 +1929,8 @@ class TDLinearLearner:
             & jnp.all(jnp.isfinite(gamma))
         )
         update_applied = (
-            floating_tree_is_finite(state)
+            clock_has_capacity
+            & floating_tree_is_finite(state)
             & inputs_valid
             & opt_update.update_applied
             & floating_tree_is_finite(candidate_state)
@@ -2013,6 +2035,7 @@ class TrueOnlineTDLearner:
         gamma: Array,
     ) -> TrueOnlineTDUpdateResult:
         """Apply one True Online TD(lambda) update."""
+        clock_has_capacity = _learner_clock_has_capacity(state.step_count)
         alpha = jnp.asarray(self._step_size, dtype=jnp.float32)
         lamda = jnp.asarray(self._trace_decay, dtype=jnp.float32)
         gamma_scalar = jnp.squeeze(gamma).astype(jnp.float32)
@@ -2076,7 +2099,12 @@ class TrueOnlineTDLearner:
             & jnp.isfinite(proposed_state.bias_eligibility_trace)
             & jnp.isfinite(proposed_state.v_old)
         )
-        update_applied = inputs_valid & floating_tree_is_finite(state) & proposed_finite
+        update_applied = (
+            clock_has_capacity
+            & inputs_valid
+            & floating_tree_is_finite(state)
+            & proposed_finite
+        )
         new_state = jax.lax.cond(
             update_applied,
             lambda: proposed_state,

--- a/tests/test_learners_lifetime_clock.py
+++ b/tests/test_learners_lifetime_clock.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
+import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework.core.learners import (
     LinearLearner,
@@ -33,6 +39,13 @@ def _committed_update_identity(step_count: jnp.ndarray) -> tuple[bool, bool]:
     return non_negative, matches_saturated_member
 
 
+def _assert_exhausted(result: Any, planted: Any) -> None:
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, planted)
+    chex.assert_trees_all_equal(result.prediction, jnp.zeros_like(result.prediction))
+    chex.assert_trees_all_equal(result.metrics, jnp.zeros_like(result.metrics))
+
+
 def test_int32_wrap_forges_a_different_update_identity() -> None:
     wrap = _wrap_clock()
     assert int(wrap) == _INT32_MIN
@@ -48,63 +61,98 @@ def test_int32_wrap_forges_a_different_update_identity() -> None:
 
 def test_linear_learner_clock_saturates_and_keeps_update_identity() -> None:
     learner = LinearLearner()
-    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    predecessor = learner.init(2).replace(
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
     result = learner.update(
-        planted,
+        predecessor,
         jnp.ones(2, dtype=jnp.float32),
         jnp.asarray(1.0, dtype=jnp.float32),
     )
+    assert bool(result.update_applied)
     assert int(result.state.step_count) == _INT32_MAX
     nonneg, matches = _committed_update_identity(result.state.step_count)
     assert nonneg and matches
-    wrap_nonneg, wrap_matches = _committed_update_identity(_wrap_clock())
-    assert not wrap_nonneg
-    assert not wrap_matches
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    _assert_exhausted(exhausted, result.state)
 
 
 def test_mlp_learner_clock_saturates_and_keeps_update_identity() -> None:
     learner = MLPLearner(hidden_sizes=(2,), use_layer_norm=False, sparsity=0.0)
-    planted = learner.init(2, jr.key(0)).replace(
-        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    predecessor = learner.init(2, jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
     )
     result = learner.update(
-        planted,
+        predecessor,
         jnp.ones(2, dtype=jnp.float32),
         jnp.asarray(1.0, dtype=jnp.float32),
     )
+    assert bool(result.update_applied)
     assert int(result.state.step_count) == _INT32_MAX
     nonneg, matches = _committed_update_identity(result.state.step_count)
     assert nonneg and matches
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    _assert_exhausted(exhausted, result.state)
 
 
 def test_td_learner_clock_saturates_and_keeps_update_identity() -> None:
     learner = TDLinearLearner()
-    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    predecessor = learner.init(2).replace(
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
     result = learner.update(
-        planted,
+        predecessor,
         jnp.ones(2, dtype=jnp.float32),
         jnp.asarray(1.0, dtype=jnp.float32),
         jnp.ones(2, dtype=jnp.float32) * 0.5,
         jnp.asarray(0.9, dtype=jnp.float32),
     )
+    assert bool(result.update_applied)
     assert int(result.state.step_count) == _INT32_MAX
     nonneg, matches = _committed_update_identity(result.state.step_count)
     assert nonneg and matches
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32) * 0.5,
+        jnp.asarray(0.9, dtype=jnp.float32),
+    )
+    _assert_exhausted(exhausted, result.state)
 
 
 def test_true_online_td_clock_saturates_and_keeps_update_identity() -> None:
     learner = TrueOnlineTDLearner()
-    planted = learner.init(2).replace(step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32))
+    predecessor = learner.init(2).replace(
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
     result = learner.update(
-        planted,
+        predecessor,
         jnp.ones(2, dtype=jnp.float32),
         jnp.asarray(1.0, dtype=jnp.float32),
         jnp.ones(2, dtype=jnp.float32) * 0.5,
         jnp.asarray(0.9, dtype=jnp.float32),
     )
+    assert bool(result.update_applied)
     assert int(result.state.step_count) == _INT32_MAX
     nonneg, matches = _committed_update_identity(result.state.step_count)
     assert nonneg and matches
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32) * 0.5,
+        jnp.asarray(0.9, dtype=jnp.float32),
+    )
+    _assert_exhausted(exhausted, result.state)
 
 
 def test_linear_learner_early_lifetime_still_increments() -> None:
@@ -116,3 +164,63 @@ def test_linear_learner_early_lifetime_still_increments() -> None:
         jnp.asarray(1.0, dtype=jnp.float32),
     )
     assert int(result.state.step_count) == 1
+
+
+def test_exhausted_clock_is_atomic_under_jit_and_scan() -> None:
+    learner = LinearLearner()
+    initial = learner.init(2)
+    planted = initial.replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+        # JIT carries Python scalar leaves as float32; plant the same exact
+        # representation so this test isolates update atomicity.
+        birth_timestamp=float(jnp.asarray(initial.birth_timestamp, dtype=jnp.float32)),
+    )
+    observation = jnp.ones(2, dtype=jnp.float32)
+    target = jnp.asarray(1.0, dtype=jnp.float32)
+
+    jitted = jax.jit(lambda state: learner.update(state, observation, target))(planted)
+    _assert_exhausted(jitted, planted)
+
+    def body(state: Any, _: Any) -> tuple[Any, Any]:
+        update = learner.update(state, observation, target)
+        return update.state, update.update_applied
+
+    final, applied = jax.jit(lambda state: jax.lax.scan(body, state, None, length=3))(planted)
+    chex.assert_trees_all_equal(final, planted)
+    chex.assert_trees_all_equal(applied, jnp.zeros(3, dtype=jnp.bool_))
+
+
+@pytest.mark.parametrize(
+    "bad_clock",
+    [
+        jnp.asarray(-1, dtype=jnp.int32),
+        jnp.asarray(_INT32_MIN, dtype=jnp.int32),
+    ],
+)
+def test_negative_clock_is_an_atomic_neutral_noop(bad_clock: jnp.ndarray) -> None:
+    learner = LinearLearner()
+    planted = learner.init(2).replace(step_count=bad_clock)
+    result = learner.update(
+        planted,
+        jnp.ones(2, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    _assert_exhausted(result, planted)
+
+
+@pytest.mark.parametrize(
+    "replace_clock",
+    [
+        lambda: jnp.asarray(0, dtype=jnp.int16),
+        lambda: jnp.asarray([0], dtype=jnp.int32),
+    ],
+)
+def test_clock_schema_fails_before_update(replace_clock: Callable[[], jnp.ndarray]) -> None:
+    learner = LinearLearner()
+    planted = learner.init(2).replace(step_count=replace_clock())
+    with pytest.raises((TypeError, ValueError), match="step_count"):
+        learner.update(
+            planted,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.asarray(1.0, dtype=jnp.float32),
+        )


### PR DESCRIPTION
Corrects the post-merge audit of #1372. Saturating the only committed-update clock while continuing to change parameters aliases distinct commits at `INT32_MAX`. This successor makes `INT32_MAX - 1 -> INT32_MAX` the final accepted update, then fails closed as an atomic neutral no-op. It also rejects non-scalar/non-int32 clocks before execution and neutralizes negative clock state.

Coverage exercises all four learner families at the adjacent boundary, plus eager, JIT, and `lax.scan` atomicity. Contributor work from #1372 remains in main.

Verification:
- `tests/test_learners_lifetime_clock.py`: 11 passed
- combined transaction/optimizer panel: 138 passed; one unrelated pre-existing digest mismatch in compositional feature test on current main
- broader learner panel progressed beyond 90% with only the now-fixed JIT timestamp assertion visible
- Ruff changed files: clean
- mypy learners.py: clean

No benchmark run, output artifact, evidence promotion, or registered-source claim.