### PR TITLE
fix(core): preflight off-policy TD update working sets

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -95,7 +95,13 @@ _INFINITY_TYPES = _ACTUAL_FLOAT_TYPES - {Fraction}
 
 
 def _require_feature_dim(
-    value: object, *, vectors: int, fixed_scalars: int, augmented: bool = False
+    value: object,
+    *,
+    vectors: int,
+    fixed_scalars: int,
+    update_vectors: int,
+    update_scalars: int = 16,
+    augmented: bool = False,
 ) -> int:
     maximum = _INT32_MAX - 1 if augmented else _INT32_MAX
     if type(value) not in _ACTUAL_INT_TYPES:
@@ -107,6 +113,9 @@ def _require_feature_dim(
     scalar_count = vectors * width + fixed_scalars
     if 4 * scalar_count > _INT32_MAX:
         raise ValueError("derived state_nbytes must fit in signed int32")
+    update_scalar_count = update_vectors * width + update_scalars
+    if 4 * update_scalar_count > _INT32_MAX:
+        raise ValueError("derived update working set byte count must fit in signed int32")
     return feature_dim
 
 
@@ -485,7 +494,9 @@ class OffPolicyTDLinearLearner:
 
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=2, fixed_scalars=3)
+        feature_dim = _require_feature_dim(
+            feature_dim, vectors=2, fixed_scalars=3, update_vectors=8
+        )
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -699,7 +710,9 @@ class ETDLinearLearner:
 
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=2, fixed_scalars=5)
+        feature_dim = _require_feature_dim(
+            feature_dim, vectors=2, fixed_scalars=5, update_vectors=8
+        )
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -927,7 +940,13 @@ class GradientTDLinearLearner:
 
     def init(self, feature_dim: int) -> GradientTDState:
         """Initialize primary weights, secondary weights, and traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=3, fixed_scalars=1, augmented=True)
+        feature_dim = _require_feature_dim(
+            feature_dim,
+            vectors=3,
+            fixed_scalars=1,
+            update_vectors=9,
+            augmented=True,
+        )
         augmented_dim = feature_dim + 1
         return GradientTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),

--- a/tests/test_off_policy_td_update_working_set.py
+++ b/tests/test_off_policy_td_update_working_set.py
@@ -1,0 +1,101 @@
+"""Complete update working-set preflight for off-policy TD learners."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.off_policy_td import (
+    ETDLinearLearner,
+    GradientTDLinearLearner,
+    OffPolicyTDLinearLearner,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_off_policy_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
+    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OffPolicyTDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_etd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 5)
+    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ETDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_gradient_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    width = _WORKING_SET_OVERFLOW + 1
+    one_bank_bytes = 4 * width
+    persistent_bytes = 4 * (3 * width + 1)
+    update_bytes = 4 * (9 * width + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GradientTDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_off_policy_td_persistent_byte_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="state_nbytes"):
+        OffPolicyTDLinearLearner().init(300_000_000)
+
+
+def test_legal_off_policy_td_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    next_observation = jnp.asarray([1.0, 0.0, 1.0, 0.0], dtype=jnp.float32)
+    reward = jnp.asarray(1.0, dtype=jnp.float32)
+    gamma = jnp.asarray(0.9, dtype=jnp.float32)
+    rho = jnp.asarray(1.0, dtype=jnp.float32)
+
+    off_policy = OffPolicyTDLinearLearner(step_size=0.05, trace_decay=0.5)
+    off_policy_state = off_policy.init(4)
+    assert off_policy_state.weights.shape == (4,)
+    assert off_policy_state.eligibility_traces.shape == (4,)
+    assert 4 * (2 * 4 + 3) <= _INT32_MAX
+    off_policy_result = off_policy.update(
+        off_policy_state, observation, reward, next_observation, gamma, rho
+    )
+    assert bool(off_policy_result.update_applied)
+    assert off_policy_result.state.weights.shape == (4,)
+    assert off_policy_result.metrics.shape == (5,)
+
+    etd = ETDLinearLearner(step_size=0.05, trace_decay=0.5)
+    etd_state = etd.init(4)
+    etd_result = etd.update(etd_state, observation, reward, next_observation, gamma, rho)
+    assert bool(etd_result.update_applied)
+    assert etd_result.state.weights.shape == (4,)
+    assert etd_result.state.eligibility_traces.shape == (4,)
+
+    gradient = GradientTDLinearLearner(step_size=0.05, trace_decay=0.5)
+    gradient_state = gradient.init(4)
+    assert gradient_state.weights.shape == (5,)
+    gradient_result = gradient.update(
+        gradient_state, observation, reward, next_observation, gamma, rho
+    )
+    assert bool(gradient_result.update_applied)
+    assert gradient_result.state.weights.shape == (5,)
+    assert gradient_result.state.secondary_weights.shape == (5,)


### PR DESCRIPTION
Closes #1393.

## What changed

Off-policy TD, ETD, and gradient TD now preflight the simultaneous update working set after the existing persistent-byte check.

On origin/main `6a9c8fc`, `feature_dim = 100_000_000` keeps one bank and OffPolicyTD's `2 × dim + 3` persistent aggregate nameable. Eight live update tensors overflow signed int32. ETD's `2 × dim + 5` and Gradient TD's `3 × (dim + 1) + 1` persistent aggregates likewise fit while the live update tensors do not. Existing persistent-bound tests still fire first (`state_nbytes` at `300_000_000`). Legal 4-wide updates are unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1378` or touch `intelligence_amplification.py`. `#1388` still owns `baseline_optimizers.py`. `#1390` still owns `optimizers.py`. `#1383` still owns IA.

## Scope

- `alberta_framework/core/off_policy_td.py`
- `tests/test_off_policy_td_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `off_policy_td.py`.

## Verification

Exact candidate head: `aeeead4337e72ccdf566330d3474b2ec47ce0886`
Base: `6a9c8fc`

- Red on base: `OffPolicyTDLinearLearner().init(100_000_000)` constructed; persistent bytes fit; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_off_policy_td_update_working_set.py` plus existing `test_init_preflights_state_bytes_and_augmented_width_before_allocation`: 9 passed
- Full `tests/test_off_policy_td.py` plus the new file: 104 passed; one pre-existing `np.longdouble("1e400")` host overflow on this machine (config-scalar sentinel test; untouched)
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_off_policy_td_update_working_set.py tests/test_off_policy_td.py::test_init_preflights_state_bytes_and_augmented_width_before_allocation -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one bank and persistent aggregates still fit at `100_000_000`; persistent `state_nbytes` still fires first at `300_000_000`; legal 4-wide OffPolicyTD / ETD / GTD updates still apply
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:aeeead4337e72ccdf566330d3474b2ec47ce0886 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
