### PR TITLE
fix(core): preflight reward-model update working sets

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -65,6 +65,16 @@ def _preflight_state_resources(feature_dim: int) -> None:
         raise ValueError("reward-model state bytes must fit signed int32")
 
 
+def _preflight_update_working_set(feature_dim: int) -> None:
+    # Covariance, proposed covariance, and the outer-product rank-one term,
+    # plus the live feature-width vectors (x, weights, Px, gain, next weights).
+    update_scalars = 3 * feature_dim * feature_dim + 5 * feature_dim + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "reward-model update working set byte count must fit signed int32"
+        )
+
+
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
@@ -208,6 +218,7 @@ class RLSRewardModel:
     def init(self) -> RLSRewardModelState:
         """Initialize model state."""
         feature_dim = self._config.feature_dim
+        _preflight_update_working_set(feature_dim)
         return RLSRewardModelState(
             weights=jnp.zeros((feature_dim,), dtype=jnp.float32),
             covariance=(jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge),

--- a/tests/test_reward_model_update_working_set.py
+++ b/tests/test_reward_model_update_working_set.py
@@ -1,0 +1,62 @@
+"""Complete update working-set preflight for the RLS reward model."""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 20_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rls_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    dim = _WORKING_SET_OVERFLOW
+    one_bank_bytes = 4 * (dim * dim)
+    persistent_bytes = 4 * (dim * dim + dim + 2)
+    update_bytes = 4 * (3 * dim * dim + 5 * dim + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    config = RLSRewardModelConfig(feature_dim=dim)
+    assert config.feature_dim == dim
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RLSRewardModel(config).init()
+
+
+def test_rls_persistent_byte_bound_still_fires_first() -> None:
+    scalar_limit = _INT32_MAX // 4
+    last_legal = (math.isqrt(1 + 4 * (scalar_limit - 2)) - 1) // 2
+    RLSRewardModelConfig(feature_dim=last_legal)
+    with pytest.raises(ValueError, match="state bytes"):
+        RLSRewardModelConfig(feature_dim=last_legal + 1)
+
+
+def test_legal_rls_update_identity_is_unchanged() -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=4, forgetting=1.0, ridge=1.0))
+    state = model.init()
+    assert state.weights.shape == (4,)
+    assert state.covariance.shape == (4, 4)
+    assert 4 * (4 * 4 + 4 + 2) <= _INT32_MAX
+    result = model.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert result.state.weights.shape == (4,)
+    assert result.state.covariance.shape == (4, 4)
+    assert result.gain.shape == (4,)


### PR DESCRIPTION
Closes #1395.

## What changed

RLS reward-model `init()` now preflights the simultaneous update working set after the existing persistent-byte check on the config.

On origin/main `10f1431`, `feature_dim = 20_000` keeps one covariance bank and the `fd² + fd + 2` persistent aggregate nameable. Three live `fd × fd` tensors plus five feature-width vectors overflow signed int32. Existing persistent-bound tests still fire first (`state bytes` at last-legal + 1). Legal 4-wide updates are unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1378` or touch `intelligence_amplification.py`. `#1388` still owns `baseline_optimizers.py`. `#1390` still owns `optimizers.py`. `#1394` still owns `off_policy_td.py`. `#1383` still owns IA.

## Scope

- `alberta_framework/core/reward_model.py`
- `tests/test_reward_model_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `reward_model.py`.

## Verification

Exact candidate head: `64211a33ca5c16df405f46451eae22070017b763`
Base: `10f1431`

- Red on base: `RLSRewardModelConfig(feature_dim=20_000)` constructed; persistent bytes fit; `init()` would allocate; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_reward_model_update_working_set.py` plus `tests/test_reward_model.py`: 66 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_reward_model_update_working_set.py tests/test_reward_model.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one bank and persistent aggregate still fit at `20_000`; persistent `state bytes` still fires first at last-legal + 1; legal 4-wide RLS updates still apply
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:64211a33ca5c16df405f46451eae22070017b763 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
