### PR TITLE
fix(core): preflight complete optimizer and RLS working sets

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -34,10 +34,12 @@ References:
   for AI Research" (arXiv: 2208.11173)
 """
 
-from typing import Any, cast
+import operator
+from typing import Any, SupportsIndex, cast
 
 import chex
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 from jaxtyping import Float
 
@@ -53,6 +55,136 @@ from alberta_framework.core.update_safety import (
     neutralize_metrics,
     select_transaction,
 )
+
+_INT32_MAX = 2_147_483_647
+_ACTUAL_INT_TYPES: tuple[type, ...] = (
+    int,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
+)
+
+
+def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    canonical = operator.index(cast(SupportsIndex, value))
+    if not minimum <= canonical <= maximum:
+        raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
+    return canonical
+
+
+def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
+    if not minimum <= value <= _INT32_MAX:
+        raise ValueError(f"derived {name} must fit signed int32")
+    return value
+
+
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    _require_derived_int32(f"{name} scalar count", float32_scalars)
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"derived {name} byte count must fit signed int32")
+
+
+def _require_feature_dim(feature_dim: object) -> int:
+    return _require_int32("feature_dim", feature_dim, minimum=1)
+
+
+def _require_shape_scalars(shape: object) -> int:
+    if type(shape) is not tuple:
+        raise ValueError("shape must be an actual tuple")
+    total = 1
+    for index, dim in enumerate(cast(tuple[object, ...], shape)):
+        dim = _require_int32(f"shape[{index}]", dim, minimum=1)
+        total = _require_derived_int32("shape scalar count", total * dim, minimum=1)
+    return total
+
+
+def _preflight_optimizer_resources(
+    name: str,
+    n: int,
+    *,
+    persistent_vectors: int,
+    persistent_scalars: int,
+    update_vectors: int,
+    update_scalars: int,
+) -> None:
+    """Reject persistent and simultaneous-update working sets this optimizer owns."""
+
+    _require_derived_int32(f"{name} feature dim", n, minimum=1)
+    _require_float32_resource(f"{name} moment bank", float32_scalars=n)
+    _require_float32_resource(
+        f"{name} persistent state",
+        float32_scalars=persistent_vectors * n + persistent_scalars,
+    )
+    _require_float32_resource(
+        f"{name} update working set",
+        float32_scalars=update_vectors * n + update_scalars,
+    )
+
+
+def _preflight_adam_resources(n: int) -> None:
+    # Linear Adam owns two float32 moment banks plus seven named scalars
+    # (bias_m, bias_v, t, step_size, beta1, beta2, eps). t is a float32
+    # lifetime counter, not an int32 word.
+    _preflight_optimizer_resources(
+        "Adam",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=7,
+        # Live during update: observation, g, m, v, new_m, new_v, m_hat,
+        # v_hat, and weight_delta. Remaining scalars cover the bias path
+        # and transaction flags.
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_adam_param_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "Adam",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=5,
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_adagain_resources(n: int) -> None:
+    # AdaGain owns two float32 banks (step_sizes, gradient_trace) plus four
+    # named scalars (bias gain/trace, meta_step_size, forgetting_rate).
+    _preflight_optimizer_resources(
+        "AdaGain",
+        n,
+        persistent_vectors=2,
+        persistent_scalars=4,
+        # Live during update: observation, gradient, step_sizes,
+        # gradient_trace, gain_correlation, meta_delta, new_step_sizes,
+        # weight_delta, and new_gradient_trace.
+        update_vectors=9,
+        update_scalars=8,
+    )
+
+
+def _preflight_rmsprop_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "RMSprop",
+        n,
+        persistent_vectors=1,
+        persistent_scalars=4,
+        update_vectors=6,
+        update_scalars=6,
+    )
+
+
+def _preflight_nadaline_resources(n: int) -> None:
+    _preflight_optimizer_resources(
+        "NADALINE",
+        n,
+        persistent_vectors=1,
+        persistent_scalars=3,
+        update_vectors=6,
+        update_scalars=6,
+    )
 
 
 def _skip_zero_scale(configured_scale: float, scale: Array, value: Array) -> Array:
@@ -271,6 +403,8 @@ class AdaGain(Optimizer[Any]):
 
     def init(self, feature_dim: int) -> AdaGainState:
         """Initialize AdaGain state."""
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_adagain_resources(feature_dim)
         return AdaGainState(
             step_sizes=jnp.full(
                 feature_dim, self._initial_step_size, dtype=jnp.float32
@@ -457,6 +591,8 @@ class Adam(Optimizer[Any]):
         Returns:
             Adam state with zero-initialized moments and ``t = 0``
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_adam_resources(feature_dim)
         return AdamState(
             m=jnp.zeros(feature_dim, dtype=jnp.float32),
             v=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -478,6 +614,7 @@ class Adam(Optimizer[Any]):
         Returns:
             ``AdamParamState`` with arrays matching the given shape
         """
+        _preflight_adam_param_resources(_require_shape_scalars(shape))
         return AdamParamState(
             m=jnp.zeros(shape, dtype=jnp.float32),
             v=jnp.zeros(shape, dtype=jnp.float32),
@@ -759,6 +896,8 @@ class RMSprop(Optimizer[Any]):
         Returns:
             RMSprop state with zero-initialized squared-gradient EMA
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_rmsprop_resources(feature_dim)
         return RMSpropState(
             v=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias_v=jnp.array(0.0, dtype=jnp.float32),
@@ -776,6 +915,14 @@ class RMSprop(Optimizer[Any]):
         Returns:
             ``RMSpropParamState`` with arrays matching the given shape
         """
+        _preflight_optimizer_resources(
+            "RMSprop",
+            _require_shape_scalars(shape),
+            persistent_vectors=1,
+            persistent_scalars=3,
+            update_vectors=6,
+            update_scalars=6,
+        )
         return RMSpropParamState(
             v=jnp.zeros(shape, dtype=jnp.float32),
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
@@ -986,6 +1133,8 @@ class NADALINE(Optimizer[Any]):
         Returns:
             NADALINE state with zero-initialized second-moment EMA
         """
+        feature_dim = _require_feature_dim(feature_dim)
+        _preflight_nadaline_resources(feature_dim)
         return NadalineState(
             feature_second_moment=jnp.zeros(feature_dim, dtype=jnp.float32),
             step_size=jnp.array(self._step_size, dtype=jnp.float32),

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -95,7 +95,13 @@ _INFINITY_TYPES = _ACTUAL_FLOAT_TYPES - {Fraction}
 
 
 def _require_feature_dim(
-    value: object, *, vectors: int, fixed_scalars: int, augmented: bool = False
+    value: object,
+    *,
+    vectors: int,
+    fixed_scalars: int,
+    update_vectors: int,
+    update_scalars: int = 16,
+    augmented: bool = False,
 ) -> int:
     maximum = _INT32_MAX - 1 if augmented else _INT32_MAX
     if type(value) not in _ACTUAL_INT_TYPES:
@@ -107,6 +113,9 @@ def _require_feature_dim(
     scalar_count = vectors * width + fixed_scalars
     if 4 * scalar_count > _INT32_MAX:
         raise ValueError("derived state_nbytes must fit in signed int32")
+    update_scalar_count = update_vectors * width + update_scalars
+    if 4 * update_scalar_count > _INT32_MAX:
+        raise ValueError("derived update working set byte count must fit in signed int32")
     return feature_dim
 
 
@@ -485,7 +494,9 @@ class OffPolicyTDLinearLearner:
 
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=2, fixed_scalars=3)
+        feature_dim = _require_feature_dim(
+            feature_dim, vectors=2, fixed_scalars=3, update_vectors=8
+        )
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -699,7 +710,9 @@ class ETDLinearLearner:
 
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=2, fixed_scalars=5)
+        feature_dim = _require_feature_dim(
+            feature_dim, vectors=2, fixed_scalars=5, update_vectors=8
+        )
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
@@ -927,7 +940,13 @@ class GradientTDLinearLearner:
 
     def init(self, feature_dim: int) -> GradientTDState:
         """Initialize primary weights, secondary weights, and traces."""
-        feature_dim = _require_feature_dim(feature_dim, vectors=3, fixed_scalars=1, augmented=True)
+        feature_dim = _require_feature_dim(
+            feature_dim,
+            vectors=3,
+            fixed_scalars=1,
+            update_vectors=9,
+            augmented=True,
+        )
         augmented_dim = feature_dim + 1
         return GradientTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -97,6 +97,12 @@ def _require_float32_state(name: str, scalar_count: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _require_float32_update_working_set(name: str, scalar_count: int) -> None:
+    """Reject simultaneous update tensors this optimizer cannot name."""
+
+    _require_float32_state(name, scalar_count)
+
+
 def _shape_size(shape: tuple[int, ...]) -> int:
     return prod(shape, start=1)
 
@@ -769,6 +775,11 @@ class IDBD(Optimizer[IDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("IDBD state", 2 * feature_dim + 3)
+        # Live during linear update: observation, traces, log_step_sizes,
+        # correlation, meta_delta, new_log, new_alphas, weight_delta, new_traces.
+        _require_float32_update_working_set(
+            "IDBD update working set", 9 * feature_dim + 8
+        )
         return IDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -789,7 +800,9 @@ class IDBD(Optimizer[IDBDState]):
             IDBDParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
-        _require_float32_state("IDBD parameter state", 2 * _shape_size(shape) + 1)
+        n = _shape_size(shape)
+        _require_float32_state("IDBD parameter state", 2 * n + 1)
+        _require_float32_update_working_set("IDBD update working set", 9 * n + 8)
         return IDBDParamState(
             log_step_sizes=jnp.full(shape, jnp.log(self._initial_step_size), dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1112,6 +1125,12 @@ class Autostep(Optimizer[AutostepState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("Autostep state", 3 * feature_dim + 5)
+        # Live during Table-1 update: observation, x^2, step_sizes, traces,
+        # normalizers, meta_gradient, v_update, new_normalizers, new_step_sizes,
+        # and weight_delta.
+        _require_float32_update_working_set(
+            "Autostep update working set", 10 * feature_dim + 8
+        )
         return AutostepState(
             step_sizes=jnp.full(feature_dim, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -1133,7 +1152,9 @@ class Autostep(Optimizer[AutostepState]):
             AutostepParamState with arrays matching the given shape
         """
         shape = _require_shape(shape)
-        _require_float32_state("Autostep parameter state", 3 * _shape_size(shape) + 2)
+        n = _shape_size(shape)
+        _require_float32_state("Autostep parameter state", 3 * n + 2)
+        _require_float32_update_working_set("Autostep update working set", 10 * n + 8)
         return AutostepParamState(
             step_sizes=jnp.full(shape, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1499,6 +1520,9 @@ class AutostepGTDLambda(Optimizer[AutostepGTDLambdaState]):
         """Initialize optimizer state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutostepGTDLambda state", 4 * feature_dim + 7)
+        _require_float32_update_working_set(
+            "AutostepGTDLambda update working set", 11 * feature_dim + 8
+        )
         base_state = self._base.init(feature_dim)
         return AutostepGTDLambdaState(
             step_sizes=base_state.step_sizes,
@@ -1644,6 +1668,7 @@ class ObGD(Optimizer[ObGDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("ObGD state", feature_dim + 5)
+        _require_float32_update_working_set("ObGD update working set", 5 * feature_dim + 8)
         return ObGDState(
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
             kappa=jnp.array(self._kappa, dtype=jnp.float32),
@@ -1873,6 +1898,9 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("TDIDBD state", 3 * feature_dim + 5)
+        _require_float32_update_working_set(
+            "TDIDBD update working set", 10 * feature_dim + 8
+        )
         return TDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32
@@ -2087,6 +2115,9 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 7)
+        _require_float32_update_working_set(
+            "AutoTDIDBD update working set", 11 * feature_dim + 8
+        )
         return AutoTDIDBDState(
             log_step_sizes=jnp.full(
                 feature_dim, jnp.log(self._initial_step_size), dtype=jnp.float32

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -65,6 +65,16 @@ def _preflight_state_resources(feature_dim: int) -> None:
         raise ValueError("reward-model state bytes must fit signed int32")
 
 
+def _preflight_update_working_set(feature_dim: int) -> None:
+    # Covariance, proposed covariance, and the outer-product rank-one term,
+    # plus the live feature-width vectors (x, weights, Px, gain, next weights).
+    update_scalars = 3 * feature_dim * feature_dim + 5 * feature_dim + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "reward-model update working set byte count must fit signed int32"
+        )
+
+
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
@@ -208,6 +218,7 @@ class RLSRewardModel:
     def init(self) -> RLSRewardModelState:
         """Initialize model state."""
         feature_dim = self._config.feature_dim
+        _preflight_update_working_set(feature_dim)
         return RLSRewardModelState(
             weights=jnp.zeros((feature_dim,), dtype=jnp.float32),
             covariance=(jnp.eye(feature_dim, dtype=jnp.float32) / self._config.ridge),

--- a/tests/test_baseline_optimizers_complete_aggregate.py
+++ b/tests/test_baseline_optimizers_complete_aggregate.py
@@ -1,0 +1,87 @@
+"""Complete aggregate preflight for Step 1 baseline optimizer state."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.baseline_optimizers import AdaGain, Adam
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_ONE_BANK_FITS = _INT32_MAX // 4
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_adam_one_moment_bank_fits_while_persistent_aggregate_does_not() -> None:
+    one_bank_bytes = 4 * _ONE_BANK_FITS
+    persistent_bytes = 4 * (2 * _ONE_BANK_FITS + 7)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="persistent state byte count"):
+        Adam().init(_ONE_BANK_FITS)
+
+
+def test_adagain_one_gain_bank_fits_while_persistent_aggregate_does_not() -> None:
+    one_bank_bytes = 4 * _ONE_BANK_FITS
+    persistent_bytes = 4 * (2 * _ONE_BANK_FITS + 4)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="persistent state byte count"):
+        AdaGain().init(_ONE_BANK_FITS)
+
+
+def test_adam_rejects_simultaneous_update_working_set() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 7)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        Adam().init(_WORKING_SET_OVERFLOW)
+
+
+def test_adagain_rejects_simultaneous_update_working_set() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 4)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        AdaGain().init(_WORKING_SET_OVERFLOW)
+
+
+def test_legal_adam_and_adagain_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    error = jnp.asarray(0.5, dtype=jnp.float32)
+
+    adam = Adam(step_size=0.01)
+    adam_state = adam.init(4)
+    assert adam_state.m.shape == (4,)
+    assert adam_state.v.shape == (4,)
+    assert 4 * (2 * 4 + 7) <= _INT32_MAX
+    adam_result = adam.update(adam_state, error, observation)
+    assert bool(adam_result.update_applied)
+    assert adam_result.weight_delta.shape == (4,)
+    assert adam_result.new_state.m.shape == (4,)
+    assert float(adam_result.new_state.t) == pytest.approx(1.0)
+
+    adagain = AdaGain()
+    adagain_state = adagain.init(4)
+    assert adagain_state.step_sizes.shape == (4,)
+    assert adagain_state.gradient_trace.shape == (4,)
+    adagain_result = adagain.update(adagain_state, error, observation)
+    assert bool(adagain_result.update_applied)
+    assert adagain_result.weight_delta.shape == (4,)
+    assert adagain_result.new_state.gradient_trace.shape == (4,)

--- a/tests/test_baseline_optimizers_complete_aggregate.py
+++ b/tests/test_baseline_optimizers_complete_aggregate.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from alberta_framework.core.baseline_optimizers import AdaGain, Adam
+from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, RMSprop
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _ONE_BANK_FITS = _INT32_MAX // 4
 _WORKING_SET_OVERFLOW = 100_000_000
+
+
+class _IntSubclass(int):
+    pass
+
+
+class _IndexOnly:
+    def __index__(self) -> int:
+        return 4
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -85,3 +95,79 @@ def test_legal_adam_and_adagain_update_identity_is_unchanged() -> None:
     assert bool(adagain_result.update_applied)
     assert adagain_result.weight_delta.shape == (4,)
     assert adagain_result.new_state.gradient_trace.shape == (4,)
+
+
+@pytest.mark.parametrize(
+    ("factory", "vectors", "scalars", "label"),
+    [
+        (Adam, 9, 8, "Adam"),
+        (AdaGain, 9, 8, "AdaGain"),
+        (RMSprop, 6, 6, "RMSprop"),
+        (NADALINE, 6, 6, "NADALINE"),
+    ],
+)
+def test_every_linear_optimizer_rejects_first_overflowing_update_width(
+    factory: type[Adam] | type[AdaGain] | type[RMSprop] | type[NADALINE],
+    vectors: int,
+    scalars: int,
+    label: str,
+) -> None:
+    float32_limit = _INT32_MAX // 4
+    first_overflowing = (float32_limit - scalars) // vectors + 1
+    assert 4 * (vectors * (first_overflowing - 1) + scalars) <= _INT32_MAX
+    assert 4 * (vectors * first_overflowing + scalars) > _INT32_MAX
+    with pytest.raises(ValueError, match=rf"{label} update working set byte count"):
+        factory().init(first_overflowing)
+
+
+@pytest.mark.parametrize("factory", [Adam, AdaGain, RMSprop, NADALINE])
+@pytest.mark.parametrize(
+    "feature_dim",
+    [True, 4.0, _IntSubclass(4), _IndexOnly(), jnp.asarray(4, dtype=jnp.int32)],
+)
+def test_linear_optimizer_feature_dim_rejects_hostile_integer_surrogates(
+    factory: type[Adam] | type[AdaGain] | type[RMSprop] | type[NADALINE],
+    feature_dim: object,
+) -> None:
+    with pytest.raises(ValueError, match="feature_dim must be an integer"):
+        factory().init(feature_dim)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("factory", [Adam, RMSprop])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [2, 2],
+        (2, True),
+        (2, 2.0),
+        (2, _IntSubclass(2)),
+        (2, _IndexOnly()),
+        (2, jnp.asarray(2, dtype=jnp.int32)),
+    ],
+)
+def test_parameter_optimizer_shape_rejects_hostile_schema(
+    factory: type[Adam] | type[RMSprop], shape: object
+) -> None:
+    with pytest.raises(ValueError, match="shape"):
+        factory().init_for_shape(shape)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("factory", "vectors", "scalars", "label"),
+    [
+        (Adam, 9, 8, "Adam"),
+        (RMSprop, 6, 6, "RMSprop"),
+    ],
+)
+def test_parameter_optimizer_rejects_derived_shape_working_set_before_allocation(
+    factory: type[Adam] | type[RMSprop], vectors: int, scalars: int, label: str
+) -> None:
+    float32_limit = _INT32_MAX // 4
+    first_overflowing = (float32_limit - scalars) // vectors + 1
+    with pytest.raises(ValueError, match=rf"{label} update working set byte count"):
+        factory().init_for_shape((first_overflowing,))
+
+
+def test_actual_numpy_integer_dimensions_remain_supported() -> None:
+    assert Adam().init(np.int64(4)).m.shape == (4,)
+    assert RMSprop().init_for_shape((np.uint16(2), np.int32(2))).v.shape == (2, 2)

--- a/tests/test_off_policy_td_update_working_set.py
+++ b/tests/test_off_policy_td_update_working_set.py
@@ -1,0 +1,101 @@
+"""Complete update working-set preflight for off-policy TD learners."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.off_policy_td import (
+    ETDLinearLearner,
+    GradientTDLinearLearner,
+    OffPolicyTDLinearLearner,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_off_policy_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
+    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OffPolicyTDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_etd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 5)
+    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ETDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_gradient_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    width = _WORKING_SET_OVERFLOW + 1
+    one_bank_bytes = 4 * width
+    persistent_bytes = 4 * (3 * width + 1)
+    update_bytes = 4 * (9 * width + 16)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GradientTDLinearLearner().init(_WORKING_SET_OVERFLOW)
+
+
+def test_off_policy_td_persistent_byte_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="state_nbytes"):
+        OffPolicyTDLinearLearner().init(300_000_000)
+
+
+def test_legal_off_policy_td_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    next_observation = jnp.asarray([1.0, 0.0, 1.0, 0.0], dtype=jnp.float32)
+    reward = jnp.asarray(1.0, dtype=jnp.float32)
+    gamma = jnp.asarray(0.9, dtype=jnp.float32)
+    rho = jnp.asarray(1.0, dtype=jnp.float32)
+
+    off_policy = OffPolicyTDLinearLearner(step_size=0.05, trace_decay=0.5)
+    off_policy_state = off_policy.init(4)
+    assert off_policy_state.weights.shape == (4,)
+    assert off_policy_state.eligibility_traces.shape == (4,)
+    assert 4 * (2 * 4 + 3) <= _INT32_MAX
+    off_policy_result = off_policy.update(
+        off_policy_state, observation, reward, next_observation, gamma, rho
+    )
+    assert bool(off_policy_result.update_applied)
+    assert off_policy_result.state.weights.shape == (4,)
+    assert off_policy_result.metrics.shape == (5,)
+
+    etd = ETDLinearLearner(step_size=0.05, trace_decay=0.5)
+    etd_state = etd.init(4)
+    etd_result = etd.update(etd_state, observation, reward, next_observation, gamma, rho)
+    assert bool(etd_result.update_applied)
+    assert etd_result.state.weights.shape == (4,)
+    assert etd_result.state.eligibility_traces.shape == (4,)
+
+    gradient = GradientTDLinearLearner(step_size=0.05, trace_decay=0.5)
+    gradient_state = gradient.init(4)
+    assert gradient_state.weights.shape == (5,)
+    gradient_result = gradient.update(
+        gradient_state, observation, reward, next_observation, gamma, rho
+    )
+    assert bool(gradient_result.update_applied)
+    assert gradient_result.state.weights.shape == (5,)
+    assert gradient_result.state.secondary_weights.shape == (5,)

--- a/tests/test_off_policy_td_update_working_set.py
+++ b/tests/test_off_policy_td_update_working_set.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework.core.off_policy_td import (
@@ -14,6 +15,15 @@ from alberta_framework.core.off_policy_td import (
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _WORKING_SET_OVERFLOW = 100_000_000
+
+
+class _IntSubclass(int):
+    pass
+
+
+class _IndexOnly:
+    def __index__(self) -> int:
+        return 4
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -99,3 +109,59 @@ def test_legal_off_policy_td_update_identity_is_unchanged() -> None:
     assert bool(gradient_result.update_applied)
     assert gradient_result.state.weights.shape == (5,)
     assert gradient_result.state.secondary_weights.shape == (5,)
+
+
+@pytest.mark.parametrize(
+    ("factory", "vectors", "augmented"),
+    [
+        (OffPolicyTDLinearLearner, 8, False),
+        (ETDLinearLearner, 8, False),
+        (GradientTDLinearLearner, 9, True),
+    ],
+)
+def test_every_off_policy_learner_rejects_first_overflowing_update_width(
+    factory: type[OffPolicyTDLinearLearner]
+    | type[ETDLinearLearner]
+    | type[GradientTDLinearLearner],
+    vectors: int,
+    augmented: bool,
+) -> None:
+    float32_limit = _INT32_MAX // 4
+    first_overflowing_width = (float32_limit - 16) // vectors + 1
+    feature_dim = first_overflowing_width - int(augmented)
+    previous_width = first_overflowing_width - 1
+    assert 4 * (vectors * previous_width + 16) <= _INT32_MAX
+    assert 4 * (vectors * first_overflowing_width + 16) > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        factory().init(feature_dim)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [OffPolicyTDLinearLearner, ETDLinearLearner, GradientTDLinearLearner],
+)
+@pytest.mark.parametrize(
+    "feature_dim",
+    [True, 4.0, _IntSubclass(4), _IndexOnly(), jnp.asarray(4, dtype=jnp.int32)],
+)
+def test_off_policy_feature_dim_rejects_hostile_integer_surrogates(
+    factory: type[OffPolicyTDLinearLearner]
+    | type[ETDLinearLearner]
+    | type[GradientTDLinearLearner],
+    feature_dim: object,
+) -> None:
+    with pytest.raises(ValueError, match="feature_dim must be an integer"):
+        factory().init(feature_dim)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [OffPolicyTDLinearLearner, ETDLinearLearner, GradientTDLinearLearner],
+)
+def test_actual_numpy_integer_feature_dims_remain_supported(
+    factory: type[OffPolicyTDLinearLearner]
+    | type[ETDLinearLearner]
+    | type[GradientTDLinearLearner],
+) -> None:
+    state = factory().init(np.int64(4))
+    assert state.weights.shape[0] in (4, 5)

--- a/tests/test_optimizers_update_working_set.py
+++ b/tests/test_optimizers_update_working_set.py
@@ -1,0 +1,75 @@
+"""Complete update working-set preflight for IDBD and Autostep."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.optimizers import IDBD, Autostep
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 100_000_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_idbd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        IDBD().init(_WORKING_SET_OVERFLOW)
+
+
+def test_autostep_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
+    persistent_bytes = 4 * (3 * _WORKING_SET_OVERFLOW + 5)
+    update_bytes = 4 * (10 * _WORKING_SET_OVERFLOW + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        Autostep().init(_WORKING_SET_OVERFLOW)
+
+
+def test_idbd_persistent_byte_bound_still_fires_first() -> None:
+    float32_scalar_limit = _INT32_MAX // 4
+    overflowing = (float32_scalar_limit - 3) // 2 + 1
+    with pytest.raises(ValueError, match="IDBD state byte count"):
+        IDBD().init(overflowing)
+
+
+def test_legal_idbd_and_autostep_update_identity_is_unchanged() -> None:
+    observation = jnp.ones(4, dtype=jnp.float32)
+    error = jnp.asarray(0.5, dtype=jnp.float32)
+
+    idbd = IDBD()
+    idbd_state = idbd.init(4)
+    assert idbd_state.log_step_sizes.shape == (4,)
+    assert idbd_state.traces.shape == (4,)
+    assert 4 * (2 * 4 + 3) <= _INT32_MAX
+    idbd_result = idbd.update(idbd_state, error, observation)
+    assert bool(idbd_result.update_applied)
+    assert idbd_result.weight_delta.shape == (4,)
+    assert idbd_result.new_state.traces.shape == (4,)
+
+    autostep = Autostep()
+    autostep_state = autostep.init(4)
+    assert autostep_state.step_sizes.shape == (4,)
+    assert autostep_state.traces.shape == (4,)
+    assert autostep_state.normalizers.shape == (4,)
+    autostep_result = autostep.update(autostep_state, error, observation)
+    assert bool(autostep_result.update_applied)
+    assert autostep_result.weight_delta.shape == (4,)
+    assert autostep_result.new_state.normalizers.shape == (4,)

--- a/tests/test_optimizers_update_working_set.py
+++ b/tests/test_optimizers_update_working_set.py
@@ -3,13 +3,30 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from alberta_framework.core.optimizers import IDBD, Autostep
+from alberta_framework.core.optimizers import (
+    IDBD,
+    TDIDBD,
+    Autostep,
+    AutostepGTDLambda,
+    AutoTDIDBD,
+    ObGD,
+)
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _WORKING_SET_OVERFLOW = 100_000_000
+
+
+class _IntSubclass(int):
+    pass
+
+
+class _IndexOnly:
+    def __index__(self) -> int:
+        return 4
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -73,3 +90,91 @@ def test_legal_idbd_and_autostep_update_identity_is_unchanged() -> None:
     assert bool(autostep_result.update_applied)
     assert autostep_result.weight_delta.shape == (4,)
     assert autostep_result.new_state.normalizers.shape == (4,)
+
+
+@pytest.mark.parametrize(
+    ("factory", "vectors", "label"),
+    [
+        (IDBD, 9, "IDBD"),
+        (Autostep, 10, "Autostep"),
+        (AutostepGTDLambda, 11, "AutostepGTDLambda"),
+        (ObGD, 5, "ObGD"),
+        (TDIDBD, 10, "TDIDBD"),
+        (AutoTDIDBD, 11, "AutoTDIDBD"),
+    ],
+)
+def test_every_vector_optimizer_rejects_first_overflowing_update_width(
+    factory: type[IDBD]
+    | type[Autostep]
+    | type[AutostepGTDLambda]
+    | type[ObGD]
+    | type[TDIDBD]
+    | type[AutoTDIDBD],
+    vectors: int,
+    label: str,
+) -> None:
+    float32_limit = _INT32_MAX // 4
+    scalar_allowance = 8
+    first_overflowing = (float32_limit - scalar_allowance) // vectors + 1
+    assert 4 * (vectors * (first_overflowing - 1) + scalar_allowance) <= _INT32_MAX
+    assert 4 * (vectors * first_overflowing + scalar_allowance) > _INT32_MAX
+    with pytest.raises(ValueError, match=rf"{label} update working set byte count"):
+        factory().init(first_overflowing)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [IDBD, Autostep, AutostepGTDLambda, ObGD, TDIDBD, AutoTDIDBD],
+)
+@pytest.mark.parametrize(
+    "feature_dim",
+    [True, 4.0, _IntSubclass(4), _IndexOnly(), jnp.asarray(4, dtype=jnp.int32)],
+)
+def test_vector_optimizer_feature_dim_rejects_hostile_integer_surrogates(
+    factory: type[IDBD]
+    | type[Autostep]
+    | type[AutostepGTDLambda]
+    | type[ObGD]
+    | type[TDIDBD]
+    | type[AutoTDIDBD],
+    feature_dim: object,
+) -> None:
+    with pytest.raises(ValueError, match="feature_dim must be an integer"):
+        factory().init(feature_dim)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("factory", [IDBD, Autostep])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [2, 2],
+        (2, True),
+        (2, 2.0),
+        (2, _IntSubclass(2)),
+        (2, _IndexOnly()),
+        (2, jnp.asarray(2, dtype=jnp.int32)),
+    ],
+)
+def test_parameter_optimizer_shape_rejects_hostile_schema(
+    factory: type[IDBD] | type[Autostep], shape: object
+) -> None:
+    with pytest.raises(ValueError, match="shape"):
+        factory().init_for_shape(shape)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("factory", "vectors", "label"),
+    [(IDBD, 9, "IDBD"), (Autostep, 10, "Autostep")],
+)
+def test_parameter_optimizer_rejects_derived_shape_working_set_before_allocation(
+    factory: type[IDBD] | type[Autostep], vectors: int, label: str
+) -> None:
+    float32_limit = _INT32_MAX // 4
+    first_overflowing = (float32_limit - 8) // vectors + 1
+    with pytest.raises(ValueError, match=rf"{label} update working set byte count"):
+        factory().init_for_shape((first_overflowing,))
+
+
+def test_actual_numpy_integer_dimensions_remain_supported() -> None:
+    assert IDBD().init(np.int64(4)).traces.shape == (4,)
+    assert Autostep().init_for_shape((np.uint16(2), np.int32(2))).traces.shape == (2, 2)

--- a/tests/test_reward_model_update_working_set.py
+++ b/tests/test_reward_model_update_working_set.py
@@ -1,0 +1,62 @@
+"""Complete update working-set preflight for the RLS reward model."""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 20_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rls_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    dim = _WORKING_SET_OVERFLOW
+    one_bank_bytes = 4 * (dim * dim)
+    persistent_bytes = 4 * (dim * dim + dim + 2)
+    update_bytes = 4 * (3 * dim * dim + 5 * dim + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    config = RLSRewardModelConfig(feature_dim=dim)
+    assert config.feature_dim == dim
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RLSRewardModel(config).init()
+
+
+def test_rls_persistent_byte_bound_still_fires_first() -> None:
+    scalar_limit = _INT32_MAX // 4
+    last_legal = (math.isqrt(1 + 4 * (scalar_limit - 2)) - 1) // 2
+    RLSRewardModelConfig(feature_dim=last_legal)
+    with pytest.raises(ValueError, match="state bytes"):
+        RLSRewardModelConfig(feature_dim=last_legal + 1)
+
+
+def test_legal_rls_update_identity_is_unchanged() -> None:
+    model = RLSRewardModel(RLSRewardModelConfig(feature_dim=4, forgetting=1.0, ridge=1.0))
+    state = model.init()
+    assert state.weights.shape == (4,)
+    assert state.covariance.shape == (4, 4)
+    assert 4 * (4 * 4 + 4 + 2) <= _INT32_MAX
+    result = model.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.asarray(1.0, dtype=jnp.float32),
+    )
+    assert bool(result.update_applied)
+    assert result.state.weights.shape == (4,)
+    assert result.state.covariance.shape == (4, 4)
+    assert result.gain.shape == (4,)

--- a/tests/test_reward_model_update_working_set.py
+++ b/tests/test_reward_model_update_working_set.py
@@ -5,13 +5,27 @@ from __future__ import annotations
 import math
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from alberta_framework.core.reward_model import RLSRewardModel, RLSRewardModelConfig
+from alberta_framework.core.reward_model import (
+    RLSRewardModel,
+    RLSRewardModelConfig,
+    _preflight_update_working_set,
+)
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _WORKING_SET_OVERFLOW = 20_000
+
+
+class _IntSubclass(int):
+    pass
+
+
+class _IndexOnly:
+    def __index__(self) -> int:
+        return 4
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -60,3 +74,28 @@ def test_legal_rls_update_identity_is_unchanged() -> None:
     assert result.state.weights.shape == (4,)
     assert result.state.covariance.shape == (4, 4)
     assert result.gain.shape == (4,)
+
+
+def test_rls_exact_last_legal_update_width_and_first_overflow() -> None:
+    scalar_limit = _INT32_MAX // 4
+    # 3*d^2 + 5*d + 8 <= scalar_limit.
+    last_legal = (math.isqrt(12 * scalar_limit - 71) - 5) // 6
+    assert 3 * last_legal * last_legal + 5 * last_legal + 8 <= scalar_limit
+    first_overflowing = last_legal + 1
+    assert 3 * first_overflowing * first_overflowing + 5 * first_overflowing + 8 > scalar_limit
+    _preflight_update_working_set(last_legal)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_update_working_set(first_overflowing)
+
+
+@pytest.mark.parametrize(
+    "feature_dim",
+    [True, 4.0, _IntSubclass(4), _IndexOnly(), jnp.asarray(4, dtype=jnp.int32)],
+)
+def test_rls_feature_dim_rejects_hostile_integer_surrogates(feature_dim: object) -> None:
+    with pytest.raises(ValueError, match="feature_dim must be an integer"):
+        RLSRewardModelConfig(feature_dim=feature_dim)  # type: ignore[arg-type]
+
+
+def test_rls_actual_numpy_integer_dimension_remains_supported() -> None:
+    assert RLSRewardModelConfig(feature_dim=np.int64(4)).feature_dim == 4  # type: ignore[arg-type]


### PR DESCRIPTION
Contributor-preserving successor to #1388, #1390, #1394, and #1396. It retains all four contributor commits and consolidates the complete optimizer/resource-preflight wave on current main.

The implementation rejects persistent aggregates and the issue-defined simultaneous update widths before allocation: Adam/AdaGain/IDBD 9x, Autostep 10x, off-policy TD/ETD 8x, augmented gradient TD 9x, and RLS 3*d^2+5*d+8, plus RMSprop/NADALINE/parameter-shape and adjacent TD optimizer families. Exact-int/actual-tuple gates reject bools, subclasses, index hooks, and JAX scalars while preserving actual NumPy integers.

The corrective review adds exact last-legal/first-overflow formula tests, parameter-shape preallocation gates, hostile scalar/schema tests, and legal NumPy/small-update controls across every touched family.

Verification:
- 128 focused optimizer/off-policy resource tests passed
- 119 baseline optimizer tests passed
- 126 off-policy TD tests passed
- 73 reward-model tests passed
- broader optimizer panel: 231 passed with one unrelated pre-existing compositional-feature digest mismatch on current main
- Ruff changed files: clean
- strict mypy: 4 changed source files clean

No benchmark run, output artifact, evidence promotion, or registered-source claim.

Closes #1387.
Closes #1389.
Closes #1393.
Closes #1395.