### PR TITLE
fix(core): preflight Horde update working sets

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -107,6 +107,11 @@ def _preflight_nonlinear_state(*, n_demons: int, hidden_size: int, feature_dim: 
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived nonlinear Horde {name} must fit signed int32")
+    update_scalars = (2 * n_demons + 4) * hidden_features + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "derived nonlinear Horde update working set byte count must fit signed int32"
+        )
 
 
 def _require_typed_threefry_key(name: str, value: object) -> Array:

--- a/tests/test_off_policy_horde_update_working_set.py
+++ b/tests/test_off_policy_horde_update_working_set.py
@@ -1,0 +1,90 @@
+"""Complete update working-set preflight for nonlinear shared GTD Horde."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.off_policy_horde import NonlinearSharedGTDHordeLearner
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 5_000_000
+_N_DEMONS = 2
+_HIDDEN = 16
+
+
+def _two_demon_spec() -> object:
+    demons = tuple(
+        GVFSpec(
+            name=f"demon_{i}",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.8,
+            lamda=0.0,
+            cumulant_index=i,
+        )  # type: ignore[call-arg]
+        for i in range(_N_DEMONS)
+    )
+    return create_horde_spec(demons)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_nonlinear_horde_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    fd = _WORKING_SET_OVERFLOW
+    hidden_features = _HIDDEN * fd
+    persist_scalars = (
+        hidden_features * (_N_DEMONS + 1)
+        + _HIDDEN
+        + 3 * _N_DEMONS * _HIDDEN
+        + 2 * _N_DEMONS
+        + 3
+    )
+    one_bank_bytes = 4 * hidden_features
+    persistent_bytes = 4 * persist_scalars
+    update_bytes = 4 * ((2 * _N_DEMONS + 4) * hidden_features + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    learner = NonlinearSharedGTDHordeLearner(_two_demon_spec(), hidden_size=_HIDDEN)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(fd, jax.random.key(0))
+
+
+def test_nonlinear_horde_persistent_byte_bound_still_fires_first() -> None:
+    learner = NonlinearSharedGTDHordeLearner(_two_demon_spec(), hidden_size=_HIDDEN)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        learner.init(20_000_000, jax.random.key(0))
+
+
+def test_legal_nonlinear_horde_update_identity_is_unchanged() -> None:
+    learner = NonlinearSharedGTDHordeLearner(
+        _two_demon_spec(),
+        hidden_size=4,
+        primary_step_size=0.002,
+        secondary_step_size=1e-5,
+        ratio_clip=10.0,
+    )
+    state = learner.init(2, jax.random.key(7))
+    assert state.trunk_w.shape == (4, 2)
+    assert state.secondary_trunk_w.shape == (2, 4, 2)
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+        jnp.array([2.0, 0.0], dtype=jnp.float32),
+        jnp.array([0.8, 0.8], dtype=jnp.float32),
+    )
+    assert result.state.trunk_w.shape == (4, 2)
+    assert result.predictions.shape == (2,)
+    assert float(jnp.linalg.norm(result.state.trunk_w - state.trunk_w)) > 0.0


### PR DESCRIPTION
Closes #1398.

## What changed

Nonlinear shared GTD Horde now preflights the simultaneous update working set after the existing persistent-byte check.

On origin/main `10f1431`, `feature_dim = 5_000_000` with `hidden_size=16` and two demons keeps one trunk bank and the persistent aggregate nameable. Live secondary + trunk update tensors overflow signed int32. Existing `init(20_000_000)` still matches `persistent state bytes` first. Legal 2-wide updates are unchanged.

`behavior_model.py` was aborted: last-legal `init` must reach the allocator.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1378` or touch `intelligence_amplification.py`. `#1388` still owns `baseline_optimizers.py`. `#1390` still owns `optimizers.py`. `#1394` still owns `off_policy_td.py`. `#1396` still owns `reward_model.py`. `#1383` still owns IA.

## Scope

- `alberta_framework/core/off_policy_horde.py`
- `tests/test_off_policy_horde_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `off_policy_horde.py`.

## Verification

Exact candidate head: `84b699ec826ba35522e9db0ad5eaf3ddef4964bc`
Base: `10f1431`

- Red on base: `init(5_000_000)` constructed; persistent bytes fit; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_off_policy_horde_update_working_set.py` plus `tests/test_off_policy_horde.py`: 32 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_off_policy_horde_update_working_set.py tests/test_off_policy_horde.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one bank and persistent aggregate still fit at `5_000_000`; persistent bytes still fire first at `20_000_000`; legal 2-wide GTD Horde updates still apply
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:84b699ec826ba35522e9db0ad5eaf3ddef4964bc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
