### PR TITLE
fix(core): preflight complete history-feature resources

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -90,6 +90,13 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int) -> i
     return canonical
 
 
+def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
+    if float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} scalar count must fit signed int32")
+    if 4 * float32_scalars > _INT32_MAX:
+        raise ValueError(f"{name} byte count must fit signed int32")
+
+
 def _require_decay_rates(value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError("decay_rates must be an actual tuple")
@@ -193,6 +200,10 @@ class HistoryFeatureExtractor:
             raise ValueError(
                 f"feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
             )
+        _require_float32_resource(
+            "history-feature traces",
+            float32_scalars=channel_count * len(decay_rates),
+        )
         if canonical_channels is None:
             canonical_channels = tuple(range(raw_dim))
 

--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -97,6 +97,39 @@ def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _preflight_history_resources(
+    *, raw_dim: int, n_decays: int, n_channels: int, feature_dim: int
+) -> None:
+    """Bound the trace state, output, and complete source-level step envelope."""
+
+    trace_scalars = n_decays * n_channels
+    _require_float32_resource(
+        "history-feature traces",
+        float32_scalars=trace_scalars,
+    )
+    _require_float32_resource(
+        "history-feature output",
+        float32_scalars=feature_dim,
+    )
+    # Charge source/product/zero/carried/contribution/proposed/finite-mask/
+    # selected trace banks; raw/finite/zero/safe observation vectors; channel
+    # indices and tracked observations; decay temporaries; the returned output;
+    # and scalar predicates. Every logical element is charged at four bytes,
+    # conservatively covering float32, int32, and boolean arrays.
+    step_scalars = (
+        8 * trace_scalars
+        + 4 * raw_dim
+        + 2 * n_channels
+        + 3 * n_decays
+        + feature_dim
+        + 16
+    )
+    _require_float32_resource(
+        "history-feature step working set",
+        float32_scalars=step_scalars,
+    )
+
+
 def _require_decay_rates(value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError("decay_rates must be an actual tuple")
@@ -200,9 +233,11 @@ class HistoryFeatureExtractor:
             raise ValueError(
                 f"feature_dim must be in [1, {_INT32_MAX}], got {feature_dim}"
             )
-        _require_float32_resource(
-            "history-feature traces",
-            float32_scalars=channel_count * len(decay_rates),
+        _preflight_history_resources(
+            raw_dim=raw_dim,
+            n_decays=len(decay_rates),
+            n_channels=channel_count,
+            feature_dim=feature_dim,
         )
         if canonical_channels is None:
             canonical_channels = tuple(range(raw_dim))
@@ -246,6 +281,13 @@ class HistoryFeatureExtractor:
         )
         return HistoryFeatureState(traces=traces)  # type: ignore[call-arg]
 
+    def _require_state_contract(self, state: HistoryFeatureState) -> None:
+        if type(state) is not HistoryFeatureState:
+            raise TypeError("state must be an exact HistoryFeatureState")
+        expected_shape = (len(self._decay_rates), len(self._channels))
+        if state.traces.shape != expected_shape or state.traces.dtype != jnp.float32:
+            raise ValueError("state.traces has an invalid shape or dtype")
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def step(
         self,
@@ -265,6 +307,7 @@ class HistoryFeatureExtractor:
               channel-major within each decay rate
             - ``new_state`` carries the updated trace values
         """
+        self._require_state_contract(state)
         # Select tracked channels
         channel_indices = jnp.asarray(self._channels, dtype=jnp.int32)
         observation = jnp.asarray(observation, dtype=jnp.float32)

--- a/tests/test_history_features.py
+++ b/tests/test_history_features.py
@@ -138,12 +138,14 @@ class TestValidation:
                 decay_rates=(0.5,),
                 channels=(0,),
             )
-        boundary = HistoryFeatureExtractor(
-            raw_dim=2**31 - 2,
-            decay_rates=(0.5,),
-            channels=(0,),
-        )
-        assert boundary.feature_dim() == 2**31 - 1
+        # A width that is nameable as int32 is still not executable when its
+        # float32 output bytes and simultaneous step envelope overflow.
+        with pytest.raises(ValueError, match="output byte count"):
+            HistoryFeatureExtractor(
+                raw_dim=2**31 - 2,
+                decay_rates=(0.5,),
+                channels=(0,),
+            )
 
     def test_hostile_integral_subclasses_are_rejected(self) -> None:
         class LieInt(int):

--- a/tests/test_history_features_trace_byte_preflight.py
+++ b/tests/test_history_features_trace_byte_preflight.py
@@ -33,13 +33,24 @@ def test_extractor_rejects_trace_bank_byte_overflow() -> None:
         )
 
 
-def test_width_boundary_from_661_still_constructs() -> None:
-    boundary = HistoryFeatureExtractor(
-        raw_dim=_INT32_MAX - 1,
-        decay_rates=(0.5,),
-        channels=(0,),
-    )
-    assert boundary.feature_dim() == _INT32_MAX
+def test_width_can_fit_while_output_bytes_do_not() -> None:
+    with pytest.raises(ValueError, match="output byte count"):
+        HistoryFeatureExtractor(
+            raw_dim=_INT32_MAX - 1,
+            decay_rates=(0.5,),
+            channels=(0,),
+        )
+
+
+def test_step_working_set_is_preflighted_before_default_channel_expansion() -> None:
+    # Trace/output banks each fit. The simultaneous trace temporaries and raw
+    # observation vectors do not; rejection must precede tuple(range(raw_dim)).
+    with pytest.raises(ValueError, match="step working set"):
+        HistoryFeatureExtractor(
+            raw_dim=40_000_000,
+            decay_rates=(0.5,),
+            include_raw=False,
+        )
 
 
 def test_legal_step_allocation_identity_is_unchanged() -> None:
@@ -55,3 +66,17 @@ def test_legal_step_allocation_identity_is_unchanged() -> None:
     augmented, advanced = extractor.step(state, jnp.ones(4, dtype=jnp.float32))
     assert augmented.shape == (8,)
     assert advanced.traces.shape == (2, 4)
+
+
+@pytest.mark.parametrize(
+    "bad_traces",
+    [
+        jnp.zeros((1, 4), dtype=jnp.float32),
+        jnp.zeros((2, 4), dtype=jnp.float16),
+    ],
+)
+def test_step_rejects_malformed_state_before_computation(bad_traces: jnp.ndarray) -> None:
+    extractor = HistoryFeatureExtractor(raw_dim=4, decay_rates=(0.5, 0.9))
+    state = extractor.init().replace(traces=bad_traces)
+    with pytest.raises(ValueError, match="state.traces"):
+        extractor.step(state, jnp.ones(4, dtype=jnp.float32))

--- a/tests/test_history_features_trace_byte_preflight.py
+++ b/tests/test_history_features_trace_byte_preflight.py
@@ -1,0 +1,57 @@
+"""Overflow preflight keeps history-feature trace allocation in signed int32."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.history_features import HistoryFeatureExtractor
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_TRACE_BYTE_OVERFLOW_CHANNELS = _INT32_MAX // 4 + 1
+
+
+def test_int32_wrap_forges_a_different_trace_allocation_identity() -> None:
+    feature_width = _TRACE_BYTE_OVERFLOW_CHANNELS
+    assert feature_width <= _INT32_MAX
+    trace_bytes = 4 * feature_width
+    assert trace_bytes == _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != trace_bytes
+
+
+def test_extractor_rejects_trace_bank_byte_overflow() -> None:
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        HistoryFeatureExtractor(
+            raw_dim=_TRACE_BYTE_OVERFLOW_CHANNELS,
+            decay_rates=(0.5,),
+            include_raw=False,
+        )
+
+
+def test_width_boundary_from_661_still_constructs() -> None:
+    boundary = HistoryFeatureExtractor(
+        raw_dim=_INT32_MAX - 1,
+        decay_rates=(0.5,),
+        channels=(0,),
+    )
+    assert boundary.feature_dim() == _INT32_MAX
+
+
+def test_legal_step_allocation_identity_is_unchanged() -> None:
+    extractor = HistoryFeatureExtractor(
+        raw_dim=4,
+        decay_rates=(0.5, 0.9),
+        include_raw=False,
+    )
+    assert extractor.feature_dim() == 8
+    state = extractor.init()
+    assert state.traces.shape == (2, 4)
+    assert 4 * int(state.traces.size) <= _INT32_MAX
+    augmented, advanced = extractor.step(state, jnp.ones(4, dtype=jnp.float32))
+    assert augmented.shape == (8,)
+    assert advanced.traces.shape == (2, 4)


### PR DESCRIPTION
Closes #1380.

Contributor-preserving successor to closed #1381. It retains ss251’s trace-bank overflow fix and closes the deeper allocation contract: an int32 feature width does not prove its float32 output bytes or the simultaneous `step()` envelope are nameable. The preflight now covers trace state, returned output, and the complete conservative source-level step working set before default channels expand into `tuple(range(raw_dim))`. It also gates exact state trace shape/dtype before JIT computation.

Verification:
- history panel: 63 passed
- Ruff changed files: clean
- mypy history_features.py: clean
- no benchmark/output/evidence artifacts touched.