### PR TITLE
fix(core): preflight FTL update working sets

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -119,6 +119,15 @@ def _configured_state_nbytes(
     return 4 * (float_count + 1)
 
 
+def _preflight_update_working_set(feature_dim: int) -> None:
+    # Live Gram, proposed Gram, plus feature-width dense/cross/weight copies.
+    update_scalars = 2 * feature_dim * feature_dim + 5 * feature_dim + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "sparse FTL update working set byte count must fit signed int32"
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class SparseFTLWorldModelConfig:
     """Configuration for :class:`SparseFTLWorldModel`.
@@ -332,6 +341,7 @@ class SparseFTLWorldModel:
     def init(self, key: Array) -> SparseFTLWorldModelState:
         """Initialize fixed projections and zero sufficient statistics."""
         cfg = self._config
+        _preflight_update_working_set(cfg.feature_dim)
         projection = jr.normal(
             key,
             (cfg.projection_dim, cfg.input_dim),

--- a/tests/test_ftl_world_model_update_working_set.py
+++ b/tests/test_ftl_world_model_update_working_set.py
@@ -1,0 +1,84 @@
+"""Complete update working-set preflight for the sparse FTL world model."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.ftl_world_model import (
+    SparseFTLWorldModel,
+    SparseFTLWorldModelConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 10_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ftl_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=1,
+        action_dim=1,
+        projection_dim=_WORKING_SET_OVERFLOW,
+        bins=2,
+    )
+    feature_dim = config.feature_dim
+    one_bank_bytes = 4 * (feature_dim * feature_dim)
+    persistent_bytes = SparseFTLWorldModel(config).state_nbytes
+    update_bytes = 4 * (2 * feature_dim * feature_dim + 5 * feature_dim + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SparseFTLWorldModel(config).init(jr.key(0))
+
+
+def test_ftl_last_legal_persistent_config_still_constructs() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=1,
+        action_dim=1,
+        projection_dim=11_584,
+        bins=2,
+    )
+    model = SparseFTLWorldModel(config)
+    assert model.state_nbytes == 2_147_302_920
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=11_585,
+            bins=2,
+        )
+
+
+def test_legal_ftl_update_identity_is_unchanged() -> None:
+    model = SparseFTLWorldModel(
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=4,
+            bins=2,
+        )
+    )
+    state = model.init(jr.key(0))
+    assert state.gram.shape == (8, 8)
+    assert 4 * (8 * 8 + 5 * 8 + 8) <= _INT32_MAX
+    result = model.update(
+        state,
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+    )
+    assert result.state.gram.shape == (8, 8)
+    assert result.state.weights.shape == (8, 1)
+    assert result.prediction.next_observation.shape == (1,)


### PR DESCRIPTION
Closes #1401.

## What changed

Sparse FTL `init()` now preflights the simultaneous Gram update working set after the existing persistent-byte check on the config.

On origin/main `9cc74dd`, `projection_dim = 10_000` / `bins = 2` keeps one Gram bank and the persistent aggregate nameable. Two live `fd × fd` tensors overflow signed int32. Last-legal `projection_dim=11_584` still constructs. Existing `11_585` still matches `derived state_nbytes` first. Legal 8-wide updates are unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen Shaw-closed `#1388` / `#1390` / `#1394` / `#1396`. `#1397` still owns the optimizer/RLS/TD wave. `#1399` still owns `off_policy_horde.py`. `#1383` still owns IA. `#1400` still owns history features.

## Scope

- `alberta_framework/core/ftl_world_model.py`
- `tests/test_ftl_world_model_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `ftl_world_model.py`.

## Verification

Exact candidate head: `2f8d9ac582ca99414a2651a7e37a9002d2320623`
Base: `9cc74dd`

- Red on base: last-legal config constructed; `projection_dim=10_000` persistent bytes fit; `init()` would allocate the Gram; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_ftl_world_model_update_working_set.py` plus `tests/test_ftl_world_model.py`: 55 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_ftl_world_model_update_working_set.py tests/test_ftl_world_model.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one bank and persistent aggregate still fit at `projection_dim=10_000`; last-legal `11_584` still constructs; `11_585` still matches `derived state_nbytes`; legal 8-wide FTL updates still apply
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2f8d9ac582ca99414a2651a7e37a9002d2320623 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
