### PR TITLE
test(core): refresh intentional counter-schema digest

### DIFF
--- a/tests/test_optimizer_nonfinite_transactions.py
+++ b/tests/test_optimizer_nonfinite_transactions.py
@@ -548,6 +548,10 @@ def test_feature_finite_one_steps_are_bitwise_unchanged() -> None:
         jnp.array([0.4, -0.2], dtype=jnp.float32),
     )
     assert bool(compositional_result.update_applied)
+    # These event counters intentionally use int32 so they remain exact past
+    # the float32 consecutive-integer limit.  The golden digest includes dtype.
+    assert compositional_result.state.candidate_selector_action_counts.dtype == jnp.int32
+    assert compositional_result.state.generator_resource_state.action_counts.dtype == jnp.int32
     assert _digest(
         compositional_result.state,
         compositional_result.predictions,
@@ -556,4 +560,4 @@ def test_feature_finite_one_steps_are_bitwise_unchanged() -> None:
         compositional_result.replaced_slot,
         compositional_result.promoted_candidate,
         compositional_result.curation_trace,
-    ) == "e4b049797a2047b91ec8cfe34b76ec3536e4ecb662bcdb92effa49cd52a0635c"
+    ) == "cf84267749a5df5f6a0b499d1916d560c97b02648f070fe2ac0cc3eb1c66dfd1"


### PR DESCRIPTION
The sole broader optimizer failure is a stale dtype-sensitive golden, not a production regression. The expected digest predates the intentional long-lived action-counter migrations in 905e5dcb (generator resource manager) and 06b53aa7 (finite candidate selector). Both changed zero-valued action-count leaves from float32 to int32 so counts remain exact past 2^24; `_digest` deliberately includes dtype.

This narrow correction asserts both migrated leaves are int32 and updates the exact full-tree digest. The parent of 06b53aa7 reproduces the old golden; current main deterministically produces the new golden with the same numeric zero values in those leaves.

Verification:
- optimizer nonfinite + scalar residual + resource manager: 169 passed
- compositional alias/features/future utility: 94 passed
- Ruff changed test: clean

No production source, benchmark, output artifact, or evidence claim changed.