### PR TITLE
fix(core): preflight model-replay update working sets

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -138,6 +138,12 @@ def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) 
     persistent_bytes = ensemble_bytes + replay_bytes + 7 * 4
     if persistent_bytes > _INT32_MAX:
         raise ValueError("model replay rehearsal state byte count must fit signed int32")
+    # Source ensemble, proposed real-update ensemble, and committed replay.
+    update_working_set_bytes = 2 * ensemble_bytes + replay_bytes
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "model replay rehearsal update working set byte count must fit signed int32"
+        )
 
 
 ReplayActionEncoding = Literal["scalar_index", "one_hot"]

--- a/tests/test_model_replay_rehearsal_update_working_set.py
+++ b/tests/test_model_replay_rehearsal_update_working_set.py
@@ -1,0 +1,126 @@
+"""Complete update working-set preflight for model-replay rehearsal."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.dual_replay import DualReplayConfig, _allocation_sizes
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.model_replay_rehearsal import (
+    ModelReplayRehearsal,
+    ModelReplayRehearsalConfig,
+)
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import (
+    WorldModelEnsembleConfig,
+    _ensemble_state_resource_counts,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 9_000
+
+
+def _ensemble(*, observation_dim: int, n_actions: int = 2, ensemble_size: int = 2):
+    target_dim = observation_dim + 2
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        hidden_sizes=(),
+        gamma=0.95,
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=ensemble_size,
+        target_dim=target_dim,
+        progress_warmup_steps=2,
+        change_calibration_steps=2,
+        fast_loss_decay=0.5,
+        slow_loss_decay=0.9,
+        max_input_magnitude=100.0,
+        max_predicted_variance=10_000.0,
+        max_observed_loss=10_000.0,
+    )
+    return WorldModelEnsembleConfig(
+        model=model,
+        signal_estimator=signals,
+        ensemble_size=ensemble_size,
+        bootstrap_probability=0.5,
+        residual_variance_decay=0.8,
+        residual_variance_warmup_steps=1,
+        residual_variance_floor=1e-6,
+    )
+
+
+def _replay(*, observation_dim: int, action_dim: int = 2, total_capacity: int = 4):
+    return DualReplayConfig(
+        total_capacity=total_capacity,
+        short_term_capacity=1,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        short_term_sample_size=1,
+        long_term_sample_size=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rehearsal_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    ensemble = _ensemble(observation_dim=_WORKING_SET_OVERFLOW)
+    replay = _replay(observation_dim=_WORKING_SET_OVERFLOW)
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=ensemble.model, ensemble_size=ensemble.ensemble_size
+    )
+    _, replay_bytes = _allocation_sizes(replay)
+    persistent_bytes = ensemble_bytes + replay_bytes + 28
+    update_bytes = 2 * ensemble_bytes + replay_bytes
+    assert ensemble_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    config = ModelReplayRehearsalConfig(
+        ensemble=ensemble, replay=replay, action_encoding="one_hot"
+    )
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ModelReplayRehearsal(config)
+
+
+def test_rehearsal_persistent_byte_bound_still_fires_first() -> None:
+    ensemble = _ensemble(observation_dim=10_000)
+    replay = _replay(observation_dim=10_000, total_capacity=7_000)
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=ensemble.model, ensemble_size=ensemble.ensemble_size
+    )
+    _, replay_bytes = _allocation_sizes(replay)
+    assert ensemble_bytes <= _INT32_MAX
+    assert ensemble_bytes + replay_bytes + 28 > _INT32_MAX
+    config = ModelReplayRehearsalConfig(
+        ensemble=ensemble, replay=replay, action_encoding="one_hot"
+    )
+    with pytest.raises(ValueError, match="state byte count"):
+        ModelReplayRehearsal(config)
+
+
+def test_legal_rehearsal_init_identity_is_unchanged() -> None:
+    config = ModelReplayRehearsalConfig(
+        ensemble=_ensemble(observation_dim=2),
+        replay=_replay(observation_dim=2),
+        action_encoding="one_hot",
+    )
+    rehearsal = ModelReplayRehearsal(config)
+    state = rehearsal.init(jr.key(0))
+    budget = rehearsal.resource_budget(state)
+    assert budget.persistent_state_bytes <= _INT32_MAX
+    assert state.ensemble_state is not None
+    assert int(state.real_attempt_count) == 0


### PR DESCRIPTION
Closes #1404.

## What changed

Model-replay rehearsal now preflights the simultaneous update working set after the existing persistent-byte check, before either child allocates.

On origin/main `9cc74dd`, `observation_dim = 9_000` keeps one ensemble bank and the persistent aggregate nameable. Source + proposed ensembles plus committed replay overflow signed int32. Persistent overflow still matches `state byte count` first when replay capacity is raised. Legal 2-wide init is unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1388` / `#1390` / `#1394` / `#1396`. `#1397` still owns the optimizer/RLS/TD wave. `#1399` still owns Horde. `#1402` still owns FTL. `#1383` still owns IA. `#1400` still owns history features.

## Scope

- `alberta_framework/core/model_replay_rehearsal.py`
- `tests/test_model_replay_rehearsal_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `model_replay_rehearsal.py`.

## Verification

Exact candidate head: `46cbf3d3088d1879a7a486b52b76aedf9835be62`
Base: `9cc74dd`

- Red on base: `observation_dim=9_000` constructed; persistent bytes fit; constructor would allocate both children; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_model_replay_rehearsal_update_working_set.py` plus existing rehearsal tests: 47 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_model_replay_rehearsal_update_working_set.py tests/test_model_replay_rehearsal_validation.py tests/test_model_replay_rehearsal_resource_budget.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one ensemble bank and persistent aggregate still fit at `observation_dim=9_000`; persistent `state byte count` still fires first with enlarged replay; legal 2-wide init still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:46cbf3d3088d1879a7a486b52b76aedf9835be62 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
