### PR TITLE
fix(core): enforce trust gates before hostile operations

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -96,15 +96,16 @@ def _integer_action_ids(
 ) -> tuple[Array, Bool[Array, " *shape"]]:
     """Validate original-width action IDs before exposing safe int32 indices."""
 
-    if isinstance(actions, jax.core.Tracer):
-        raw_shape = tuple(actions.shape)
-        raw_dtype = np.dtype(actions.dtype)
+    actual_type = type(actions)
+    if issubclass(actual_type, jax.core.Tracer):
+        traced_actions = cast(Any, actions)
+        raw_shape = tuple(traced_actions.shape)
+        raw_dtype = np.dtype(traced_actions.dtype)
     else:
-        actual_type = type(actions)
         trusted_host = (
             actual_type is np.ndarray
             or actual_type in _ACTUAL_INT_TYPES
-            or isinstance(actions, jax.Array)
+            or issubclass(actual_type, jax.Array)
         )
         if not trusted_host:
             raise TypeError("actions must be a trusted array")

--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -1014,6 +1014,8 @@ def normalizer_from_config(config: dict[str, Any]) -> Normalizer[Any]:
     Raises:
         ValueError: If the normalizer type is unknown
     """
+    if type(config) is not dict:
+        raise ValueError("normalizer config must be an exact dict")
     config = dict(config)
     type_name = config.pop("type")
     host_type_name = _require_exact_str("type_name", type_name)

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -741,8 +741,8 @@ class IDBD(Optimizer[IDBDState]):
                 declared domain (``initial_step_size`` positive;
                 ``meta_step_size`` nonnegative).
         """
-        if h_decay_mode not in ("prediction_grads", "loss_grads"):
-            host_mode = _require_exact_str("h_decay_mode", h_decay_mode)
+        host_mode = _require_exact_str("h_decay_mode", h_decay_mode)
+        if host_mode not in ("prediction_grads", "loss_grads"):
             raise ValueError(
                 f"Invalid h_decay_mode: '{host_mode}'. "
                 "Must be 'prediction_grads' or 'loss_grads'."
@@ -751,7 +751,7 @@ class IDBD(Optimizer[IDBDState]):
             "initial_step_size", initial_step_size, positive=True
         )
         self._meta_step_size = _validated_idbd_step_size("meta_step_size", meta_step_size)
-        self._h_decay_mode = h_decay_mode
+        self._h_decay_mode = host_mode
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -1990,6 +1990,8 @@ StateBuilderConfig = (
 
 def state_builder_config_from_config(payload: dict[str, Any]) -> StateBuilderConfig:
     """Parse one known state-builder configuration without creating state."""
+    if type(payload) is not dict:
+        raise ValueError("state builder payload must be an exact dict")
     builder_type = payload.get("type")
     host_builder_type = _require_exact_str("payload.type", builder_type)
     if host_builder_type == "IdentityStateBuilder":

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1267,20 +1267,15 @@ class UPGDLearner:
         Returns:
             Configured :class:`UPGDLearner`.
         """
-        if loss_normalization not in {"target_structure", "target_density"}:
-            if type(loss_normalization) is str:
-                host_ln = _require_exact_str("loss_normalization", loss_normalization)
-                msg = (
-                    "step2_default loss_normalization must be 'target_structure' "
-                    f"or 'target_density', got '{host_ln}'"
-                )
-            else:
-                msg = (
-                    "step2_default loss_normalization must be 'target_structure' "
-                    "or 'target_density', got non-string"
-                )
+        host_loss_normalization = _require_exact_str("loss_normalization", loss_normalization)
+        if host_loss_normalization not in {"target_structure", "target_density"}:
+            msg = (
+                "step2_default loss_normalization must be 'target_structure' "
+                f"or 'target_density', got '{host_loss_normalization}'"
+            )
             raise ValueError(msg)
-        if readout_mode not in {
+        host_readout_mode = _require_exact_str("readout_mode", readout_mode)
+        if host_readout_mode not in {
             "linear_mse",
             "softmax_ce",
             "softmax_mse",
@@ -1289,23 +1284,13 @@ class UPGDLearner:
             "adaptive_factorized_simplex",
             "two_timescale_simplex",
         }:
-            if type(readout_mode) is str:
-                host_rm2 = _require_exact_str("readout_mode", readout_mode)
-                msg = (
-                    "step2_default readout_mode must be 'linear_mse', "
-                    "'softmax_ce', 'softmax_mse', 'adaptive_simplex', "
-                    "'factorized_simplex', 'adaptive_factorized_simplex', or "
-                    "'two_timescale_simplex', "
-                    f"got '{host_rm2}'"
-                )
-            else:
-                msg = (
-                    "step2_default readout_mode must be 'linear_mse', "
-                    "'softmax_ce', 'softmax_mse', 'adaptive_simplex', "
-                    "'factorized_simplex', 'adaptive_factorized_simplex', or "
-                    "'two_timescale_simplex', "
-                    "got non-string"
-                )
+            msg = (
+                "step2_default readout_mode must be 'linear_mse', "
+                "'softmax_ce', 'softmax_mse', 'adaptive_simplex', "
+                "'factorized_simplex', 'adaptive_factorized_simplex', or "
+                "'two_timescale_simplex', "
+                f"got '{host_readout_mode}'"
+            )
             raise ValueError(msg)
         return cls(
             n_heads=n_heads,
@@ -1319,8 +1304,8 @@ class UPGDLearner:
             utility_decay=0.995,
             perturbation_beta=2.0,
             perturbation_interval=16,
-            loss_normalization=loss_normalization,
-            readout_mode=readout_mode,
+            loss_normalization=host_loss_normalization,
+            readout_mode=host_readout_mode,
             readout_loss_mode=readout_loss_mode,
             readout_prediction_mode=readout_prediction_mode,
             readout_robust_q=readout_robust_q,

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -65,7 +65,7 @@ class DecisionOwnershipError(ValueError):
 
 def _require_safe_id(value: str, *, name: str) -> None:
     if (
-        not isinstance(value, str)
+        type(value) is not str
         or not value
         or len(value) > _MAX_ID_LENGTH
         or _SAFE_ID.fullmatch(value) is None
@@ -78,7 +78,7 @@ def _require_safe_id(value: str, *, name: str) -> None:
 
 
 def _require_sha256(value: str, *, name: str) -> None:
-    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
         raise ValueError(f"{name} must be a lowercase 64-character SHA-256 digest")
 
 
@@ -203,11 +203,8 @@ class ArrayValue:
             raise ValueError(f"unsupported dtype '{host_dtype}'") from exc
         if dtype.name not in _SUPPORTED_DTYPES or dtype.name != self.dtype:
             raise ValueError("ArrayValue dtype must be a portable canonical numeric dtype")
-        if not isinstance(self.shape, tuple) or any(
-            isinstance(dimension, bool)
-            or not isinstance(dimension, int)
-            or dimension <= 0
-            for dimension in self.shape
+        if type(self.shape) is not tuple or any(
+            type(dimension) is not int or dimension <= 0 for dimension in self.shape
         ):
             raise ValueError("ArrayValue shape must be a tuple of positive dimensions or ()")
         if not isinstance(self.payload, bytes):
@@ -262,11 +259,8 @@ class SpaceSpec:
 
     def __post_init__(self) -> None:
         _require_safe_id(self.semantic_id, name="semantic_id")
-        if not isinstance(self.shape, tuple) or any(
-            isinstance(dimension, bool)
-            or not isinstance(dimension, int)
-            or dimension <= 0
-            for dimension in self.shape
+        if type(self.shape) is not tuple or any(
+            type(dimension) is not int or dimension <= 0 for dimension in self.shape
         ):
             raise ValueError("shape must be a tuple of positive integer dimensions or ()")
         host_dtype = _require_exact_str("dtype", self.dtype)
@@ -284,7 +278,8 @@ class SpaceSpec:
         if _shape_size(self.shape) > _MAX_ARRAY_ELEMENTS:
             raise ValueError(f"space must contain <= {_MAX_ARRAY_ELEMENTS} elements")
 
-        if self.kind == "discrete":
+        host_kind = _require_exact_str("kind", self.kind)
+        if host_kind == "discrete":
             if self.shape != ():
                 raise ValueError("a discrete space must have scalar shape ()")
             if dtype.kind not in {"i", "u"}:
@@ -303,7 +298,7 @@ class SpaceSpec:
                 raise ValueError("a discrete space cannot declare box bounds")
             return
 
-        if self.kind != "box":
+        if host_kind != "box":
             raise ValueError("space kind must be 'discrete' or 'box'")
         if self.cardinality is not None:
             raise ValueError("a box space cannot declare a cardinality")
@@ -457,7 +452,7 @@ class AgentCapabilities:
     dispatch_rebinding: bool = False
 
     def __post_init__(self) -> None:
-        if not isinstance(self.dispatch_rebinding, bool):
+        if type(self.dispatch_rebinding) is not bool:
             raise ValueError("dispatch_rebinding must be boolean")
 
     def _descriptor(self) -> dict[str, Any]:
@@ -502,8 +497,8 @@ class AgentManifest:
     _config_json: str = dataclasses.field(repr=False)
 
     def __post_init__(self) -> None:
-        if self.schema != REFERENCE_AGENT_MANIFEST_SCHEMA:
-            host_schema = _require_exact_str("schema", self.schema)
+        host_schema = _require_exact_str("schema", self.schema)
+        if host_schema != REFERENCE_AGENT_MANIFEST_SCHEMA:
             host_expected = _require_exact_str("expected_schema", REFERENCE_AGENT_MANIFEST_SCHEMA)
             raise ValueError(
                 f"schema must be '{host_expected}', got '{host_schema}'"
@@ -649,8 +644,7 @@ class Decision:
                 f"maximum length is {_MAX_LIFECYCLE_ID_LENGTH}"
             )
         if (
-            isinstance(self.decision_index, bool)
-            or not isinstance(self.decision_index, int)
+            type(self.decision_index) is not int
             or self.decision_index < 0
             or self.decision_index > MAX_DECISION_INDEX
         ):
@@ -658,10 +652,10 @@ class Decision:
                 f"decision_index must be a uint64 integer no greater than {MAX_DECISION_INDEX}"
             )
         expected_id = f"{self.lifecycle_id}:{self.decision_index}"
+        _require_safe_id(self.decision_id, name="decision_id")
         if self.decision_id != expected_id:
             host_expected = _require_exact_str("expected_id", expected_id)
             raise ValueError(f"decision_id must use canonical value '{host_expected}'")
-        _require_safe_id(self.decision_id, name="decision_id")
         _require_safe_id(self.observation_id, name="observation_id")
         if not isinstance(self.observation, ArrayValue):
             raise ValueError("decision observation must be an ArrayValue")

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -226,6 +226,24 @@ class PavlovianPhase:
     cs_active: tuple[int, ...]
     compound_index: int = -1
 
+    def __post_init__(self) -> None:
+        if type(self.name) is not str or not self.name:
+            raise ValueError("phase name must be a non-empty exact string")
+        _require_builtin_int(self.n_steps, name="n_steps", minimum=1)
+        try:
+            _require_unit_interval(self.cs_us_contingency, name="cs_us_contingency")
+        except ValueError:
+            raise ValueError("cs_us_contingency must be a finite probability in [0, 1]") from None
+        if type(self.cs_active) is not tuple:
+            raise ValueError("cs_active must be an exact tuple")
+        if not self.cs_active:
+            raise ValueError("cs_active must contain at least one CS index")
+        if any(type(index) is not int or index < 0 for index in self.cs_active):
+            raise ValueError("cs_active indices must be non-negative built-in integers")
+        if len(set(self.cs_active)) != len(self.cs_active):
+            raise ValueError("cs_active indices must be unique")
+        _require_builtin_int(self.compound_index, name="compound_index", minimum=-1)
+
 
 @chex.dataclass(frozen=True)
 class PavlovianState:

--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -274,5 +274,5 @@ class Timer:
         if not 0.0 <= duration <= _MAX_DURATION_SECONDS:
             raise ValueError("duration is outside the finite telemetry bound")
         if duration > 0:
-            return f"Timer(name='{self.name}', duration={duration:.2f}s)"
-        return f"Timer(name='{self.name}')"
+            return f"Timer(name={repr(self.name)}, duration={duration:.2f}s)"
+        return f"Timer(name={repr(self.name)})"

--- a/tests/test_core_trust_ordering.py
+++ b/tests/test_core_trust_ordering.py
@@ -1,0 +1,149 @@
+"""Hostile values are rejected before conversion, comparison, or formatting hooks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.behavior_model import selected_action_probabilities
+from alberta_framework.core.normalizers import normalizer_from_config
+from alberta_framework.core.optimizers import IDBD
+from alberta_framework.core.state_builder import state_builder_config_from_config
+from alberta_framework.core.upgd import UPGDLearner
+from alberta_framework.reference_agent import (
+    AgentManifest,
+    Decision,
+    SpaceSpec,
+)
+from alberta_framework.utils.timing import Timer
+
+
+class _EqualityTrapStr(str):
+    calls = 0
+    __hash__ = str.__hash__
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("string equality hook must not run")
+
+    def __str__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("string formatting hook must not run")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("string repr hook must not run")
+
+
+@pytest.mark.parametrize(
+    ("factory", "field"),
+    [
+        (
+            lambda value: normalizer_from_config(
+                {"type": "EMANormalizer", "state_schema": value}
+            ),
+            "state_schema",
+        ),
+        (lambda value: IDBD(h_decay_mode=value), "h_decay_mode"),
+        (
+            lambda value: UPGDLearner.step2_default(2, loss_normalization=value),
+            "loss_normalization",
+        ),
+        (lambda value: UPGDLearner.step2_default(2, readout_mode=value), "readout_mode"),
+    ],
+)
+def test_identity_gates_precede_hostile_equality(factory: Any, field: str) -> None:
+    value = _EqualityTrapStr("leftover")
+    _EqualityTrapStr.calls = 0
+    with pytest.raises(ValueError, match="exact string"):
+        factory(value)
+    assert _EqualityTrapStr.calls == 0, field
+
+
+def test_config_parsers_reject_dict_subclasses_before_mapping_hooks() -> None:
+    class _HostileDict(dict[str, Any]):
+        def get(self, *args: object, **kwargs: object) -> object:  # pragma: no cover
+            raise AssertionError("mapping hook must not run")
+
+        def __iter__(self):  # type: ignore[no-untyped-def]  # pragma: no cover
+            raise AssertionError("mapping hook must not run")
+
+    with pytest.raises(ValueError, match="exact dict"):
+        normalizer_from_config(_HostileDict(type="EMANormalizer"))
+    with pytest.raises(ValueError, match="exact dict"):
+        state_builder_config_from_config(_HostileDict(type="IdentityStateBuilder"))
+
+
+def test_behavior_action_gate_avoids_instance_class_and_array_hooks() -> None:
+    class _ClassSpoof:
+        calls = 0
+
+        @property
+        def __class__(self) -> type:  # pragma: no cover
+            type(self).calls += 1
+            raise AssertionError("instance __class__ hook must not run")
+
+        def __array__(self, *args: object, **kwargs: object) -> np.ndarray:  # pragma: no cover
+            type(self).calls += 1
+            raise AssertionError("array hook must not run")
+
+    value = _ClassSpoof()
+    with pytest.raises(TypeError, match="trusted array"):
+        selected_action_probabilities(jnp.asarray([0.25, 0.75]), value)
+    assert _ClassSpoof.calls == 0
+
+
+def test_reference_records_gate_exact_strings_before_identity_comparison() -> None:
+    value = _EqualityTrapStr("leftover")
+    _EqualityTrapStr.calls = 0
+    with pytest.raises(ValueError, match="exact string"):
+        AgentManifest(
+            schema=value,
+            implementation_id="a.b",
+            state_schema="c.d",
+            config_sha256="0" * 64,
+            manifest_id="1" * 64,
+            observation_spec=None,  # type: ignore[arg-type]
+            action_spec=None,  # type: ignore[arg-type]
+            capabilities=None,  # type: ignore[arg-type]
+            _config_json="{}",
+        )
+    with pytest.raises(ValueError, match="lowercase identifier"):
+        Decision(
+            manifest_id="0" * 64,
+            lifecycle_id="life",
+            decision_index=0,
+            decision_id=value,
+            observation_id="observation",
+            observation=None,  # type: ignore[arg-type]
+            proposed_action=None,
+            armed=False,
+        )
+    assert _EqualityTrapStr.calls == 0
+
+
+def test_reference_space_rejects_leftover_kind_and_shape_identities() -> None:
+    with pytest.raises(ValueError, match="exact string"):
+        SpaceSpec(
+            kind=_EqualityTrapStr("box"),
+            shape=(),
+            dtype="float32",
+            semantic_id="space",
+        )
+    with pytest.raises(ValueError, match="shape"):
+        SpaceSpec(
+            kind="box",
+            shape=(np.int32(1),),  # type: ignore[arg-type]
+            dtype="float32",
+            semantic_id="space",
+        )
+
+
+def test_timer_repr_escapes_exact_but_untrusted_text() -> None:
+    timer = Timer("quote'\nline", verbose=False)
+    rendered = repr(timer)
+    assert rendered == 'Timer(name="quote\'\\nline")'
+    assert "\n" not in rendered

--- a/tests/test_pavlovian_phase_hostile_validation.py
+++ b/tests/test_pavlovian_phase_hostile_validation.py
@@ -1,0 +1,59 @@
+"""Standalone Pavlovian phase trust-boundary validation."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+import pytest
+
+from alberta_framework.streams.pavlovian import PavlovianPhase
+
+
+def _phase(**overrides: Any) -> PavlovianPhase:
+    values: dict[str, Any] = {
+        "name": "acquisition",
+        "n_steps": 10,
+        "cs_us_contingency": 1.0,
+        "cs_active": (0,),
+        "compound_index": -1,
+    }
+    values.update(overrides)
+    return PavlovianPhase(**values)
+
+
+class _HostileFloat(float):
+    def as_integer_ratio(self) -> tuple[int, int]:  # pragma: no cover
+        raise AssertionError("numeric hook must not run")
+
+
+@pytest.mark.parametrize("cs_active", [(), (0, 0), (True,), (-1,)])
+def test_phase_rejects_invalid_local_cs_sets(cs_active: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError, match="cs_active"):
+        _phase(cs_active=cs_active)
+
+
+def test_phase_rejects_hostile_values_without_numeric_hooks() -> None:
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        _phase(cs_us_contingency=_HostileFloat(0.5))
+
+
+def test_phase_preserves_supported_exact_fraction_probability() -> None:
+    phase = _phase(cs_us_contingency=Fraction(1, 2))
+    assert phase.cs_us_contingency == Fraction(1, 2)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("name", ""),
+        ("n_steps", True),
+        ("n_steps", 0),
+        ("cs_active", [0]),
+        ("compound_index", True),
+        ("compound_index", -2),
+    ],
+)
+def test_phase_rejects_noncanonical_fields(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        _phase(**{field: value})

--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -412,15 +412,13 @@ def test_construct_rejects_bad_cs_index():
 @pytest.mark.parametrize("contingency", [-0.1, 1.1, float("nan")])
 def test_construct_rejects_invalid_phase_contingency(contingency: float):
     """Every phase contingency must be a finite probability."""
-    bad_phase = PavlovianPhase(
-        name="bad",
-        n_steps=10,
-        cs_us_contingency=contingency,
-        cs_active=(0,),
-    )
-
-    with pytest.raises(ValueError, match="cs_us_contingency must be in"):
-        ClassicalConditioningStream(phases=(bad_phase,), n_cs=1)
+    with pytest.raises(ValueError, match="cs_us_contingency"):
+        PavlovianPhase(
+            name="bad",
+            n_steps=10,
+            cs_us_contingency=contingency,
+            cs_active=(0,),
+        )
 
 
 def test_partial_reinforcement_rejects_invalid_p():


### PR DESCRIPTION
Post-merge corrective for the core/steps/streams trust-boundary wave. Exact type gates now precede equality, membership, mapping, conversion, and formatting operations across normalizers, IDBD/UPGD, state-builder parsing, behavior action IDs, reference-agent identities, Timer repr, and standalone Pavlovian phase records. Pavlovian validation preserves the existing exact Fraction probability surface while rejecting hostile numeric subclasses and impossible local CS sets.

Verification:
- 239 focused/existing tests passed before authorized stop at 90%, zero failures
- 21 new adversarial tests passed
- Ruff and diff-check clean
- mypy clean on all 8 changed sources
- no benchmarks or outputs touched.