### PR TITLE
fix(core): preflight complete FTL update buffers

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -119,6 +119,15 @@ def _configured_state_nbytes(
     return 4 * (float_count + 1)
 
 
+def _preflight_update_working_set(feature_dim: int) -> None:
+    # Live Gram, proposed Gram, plus feature-width dense/cross/weight copies.
+    update_scalars = 2 * feature_dim * feature_dim + 5 * feature_dim + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "sparse FTL update working set byte count must fit signed int32"
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class SparseFTLWorldModelConfig:
     """Configuration for :class:`SparseFTLWorldModel`.
@@ -332,6 +341,7 @@ class SparseFTLWorldModel:
     def init(self, key: Array) -> SparseFTLWorldModelState:
         """Initialize fixed projections and zero sufficient statistics."""
         cfg = self._config
+        _preflight_update_working_set(cfg.feature_dim)
         projection = jr.normal(
             key,
             (cfg.projection_dim, cfg.input_dim),

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -119,9 +119,29 @@ def _configured_state_nbytes(
     return 4 * (float_count + 1)
 
 
-def _preflight_update_working_set(feature_dim: int) -> None:
-    # Live Gram, proposed Gram, plus feature-width dense/cross/weight copies.
-    update_scalars = 2 * feature_dim * feature_dim + 5 * feature_dim + 8
+def _preflight_update_working_set(
+    *,
+    projection_dim: int,
+    input_dim: int,
+    feature_dim: int,
+    observation_dim: int,
+    action_dim: int,
+) -> None:
+    """Reject the complete named logical update buffers before allocation."""
+
+    active_dim = 2 * projection_dim
+    update_scalars = (
+        projection_dim * input_dim  # fixed projection bank
+        + 2 * feature_dim * feature_dim  # stored and proposed Grams
+        + 4 * feature_dim * observation_dim  # stored/proposed cross and weights
+        + feature_dim  # dense sparse-feature materialization
+        + 2 * active_dim * active_dim  # active Gram and ridge system
+        + 4 * active_dim * observation_dim  # active solve/cross/weight intermediates
+        + 2 * active_dim  # sparse indices and values
+        + 6 * observation_dim  # observation/prediction/target/error vectors
+        + action_dim
+        + 8  # scalar statistics, counters, and update outputs
+    )
     if 4 * update_scalars > _INT32_MAX:
         raise ValueError(
             "sparse FTL update working set byte count must fit signed int32"
@@ -341,7 +361,13 @@ class SparseFTLWorldModel:
     def init(self, key: Array) -> SparseFTLWorldModelState:
         """Initialize fixed projections and zero sufficient statistics."""
         cfg = self._config
-        _preflight_update_working_set(cfg.feature_dim)
+        _preflight_update_working_set(
+            projection_dim=cfg.projection_dim,
+            input_dim=cfg.input_dim,
+            feature_dim=cfg.feature_dim,
+            observation_dim=cfg.observation_dim,
+            action_dim=cfg.action_dim,
+        )
         projection = jr.normal(
             key,
             (cfg.projection_dim, cfg.input_dim),

--- a/tests/test_ftl_world_model_update_working_set.py
+++ b/tests/test_ftl_world_model_update_working_set.py
@@ -1,0 +1,84 @@
+"""Complete update working-set preflight for the sparse FTL world model."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.ftl_world_model import (
+    SparseFTLWorldModel,
+    SparseFTLWorldModelConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 10_000
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ftl_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=1,
+        action_dim=1,
+        projection_dim=_WORKING_SET_OVERFLOW,
+        bins=2,
+    )
+    feature_dim = config.feature_dim
+    one_bank_bytes = 4 * (feature_dim * feature_dim)
+    persistent_bytes = SparseFTLWorldModel(config).state_nbytes
+    update_bytes = 4 * (2 * feature_dim * feature_dim + 5 * feature_dim + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SparseFTLWorldModel(config).init(jr.key(0))
+
+
+def test_ftl_last_legal_persistent_config_still_constructs() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=1,
+        action_dim=1,
+        projection_dim=11_584,
+        bins=2,
+    )
+    model = SparseFTLWorldModel(config)
+    assert model.state_nbytes == 2_147_302_920
+    with pytest.raises(ValueError, match="derived state_nbytes"):
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=11_585,
+            bins=2,
+        )
+
+
+def test_legal_ftl_update_identity_is_unchanged() -> None:
+    model = SparseFTLWorldModel(
+        SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=4,
+            bins=2,
+        )
+    )
+    state = model.init(jr.key(0))
+    assert state.gram.shape == (8, 8)
+    assert 4 * (8 * 8 + 5 * 8 + 8) <= _INT32_MAX
+    result = model.update(
+        state,
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([0.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+    )
+    assert result.state.gram.shape == (8, 8)
+    assert result.state.weights.shape == (8, 1)
+    assert result.prediction.next_observation.shape == (1,)

--- a/tests/test_ftl_world_model_update_working_set.py
+++ b/tests/test_ftl_world_model_update_working_set.py
@@ -9,11 +9,39 @@ import pytest
 from alberta_framework.core.ftl_world_model import (
     SparseFTLWorldModel,
     SparseFTLWorldModelConfig,
+    _preflight_update_working_set,
 )
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _WORKING_SET_OVERFLOW = 10_000
+
+
+def _working_scalars(config: SparseFTLWorldModelConfig) -> int:
+    feature_dim = config.feature_dim
+    active_dim = config.active_feature_count
+    return (
+        config.projection_dim * config.input_dim
+        + 2 * feature_dim * feature_dim
+        + 4 * feature_dim * config.observation_dim
+        + feature_dim
+        + 2 * active_dim * active_dim
+        + 4 * active_dim * config.observation_dim
+        + 2 * active_dim
+        + 6 * config.observation_dim
+        + config.action_dim
+        + 8
+    )
+
+
+def _preflight(config: SparseFTLWorldModelConfig) -> None:
+    _preflight_update_working_set(
+        projection_dim=config.projection_dim,
+        input_dim=config.input_dim,
+        feature_dim=config.feature_dim,
+        observation_dim=config.observation_dim,
+        action_dim=config.action_dim,
+    )
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -35,7 +63,7 @@ def test_ftl_one_bank_and_persistent_fit_while_update_working_set_does_not() -> 
     feature_dim = config.feature_dim
     one_bank_bytes = 4 * (feature_dim * feature_dim)
     persistent_bytes = SparseFTLWorldModel(config).state_nbytes
-    update_bytes = 4 * (2 * feature_dim * feature_dim + 5 * feature_dim + 8)
+    update_bytes = 4 * _working_scalars(config)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
@@ -72,7 +100,7 @@ def test_legal_ftl_update_identity_is_unchanged() -> None:
     )
     state = model.init(jr.key(0))
     assert state.gram.shape == (8, 8)
-    assert 4 * (8 * 8 + 5 * 8 + 8) <= _INT32_MAX
+    assert 4 * _working_scalars(model.config) <= _INT32_MAX
     result = model.update(
         state,
         jnp.array([0.0], dtype=jnp.float32),
@@ -82,3 +110,44 @@ def test_legal_ftl_update_identity_is_unchanged() -> None:
     assert result.state.gram.shape == (8, 8)
     assert result.state.weights.shape == (8, 1)
     assert result.prediction.next_observation.shape == (1,)
+
+
+def test_ftl_cross_and_weight_copies_are_scaled_by_observation_dim() -> None:
+    config = SparseFTLWorldModelConfig(
+        observation_dim=100_000,
+        action_dim=1,
+        projection_dim=1_000,
+        bins=2,
+    )
+    model = SparseFTLWorldModel(config)
+    contributor_formula = 2 * config.feature_dim**2 + 5 * config.feature_dim + 8
+    assert model.state_nbytes <= _INT32_MAX
+    assert 4 * contributor_formula <= _INT32_MAX
+    assert 4 * _working_scalars(config) > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(jr.key(1))
+
+
+def test_ftl_exact_last_legal_update_width_and_first_overflow() -> None:
+    def config(projection_dim: int) -> SparseFTLWorldModelConfig:
+        return SparseFTLWorldModelConfig(
+            observation_dim=1,
+            action_dim=1,
+            projection_dim=projection_dim,
+            bins=2,
+        )
+
+    low, high = 1, 11_584
+    while low < high:
+        middle = (low + high + 1) // 2
+        if 4 * _working_scalars(config(middle)) <= _INT32_MAX:
+            low = middle
+        else:
+            high = middle - 1
+    last_legal = config(low)
+    first_overflowing = config(low + 1)
+    assert 4 * _working_scalars(last_legal) <= _INT32_MAX
+    assert 4 * _working_scalars(first_overflowing) > _INT32_MAX
+    _preflight(last_legal)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight(first_overflowing)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1402. It retains the original commit and closes the general-shape residual found in deep review.

The original `2*F^2+5*F+8` formula was valid only for observation_dim=1 and omitted the fixed projection and active-block ridge solve. For general configurations, stored/proposed cross and weight matrices alone require `4*F*O`; a high-O config could pass the original init gate while its logical update buffers exceeded signed int32.

The corrected config-dependent formula accounts for the fixed projection, stored/proposed Grams, cross and weight matrices, dense sparse features, active Gram/ridge systems, active solve/cross/weight intermediates, sparse indices/values, and observation/action/result vectors before any allocation. Tests prove the high-O counterexample, exact last-fit/first-overflow boundary, persistent-bound ordering, and legal update identity; existing FTL tests retain hostile exact-int and NumPy canonicalization coverage.

Verification:
- FTL model/resource panel: 57 passed
- FTL decision-fidelity panel: 110 passed, 7 skipped
- Ruff changed files: clean
- strict mypy source: clean

No benchmark run or output artifact. This registered source change intentionally leaves frozen evidence fail-closed until separately rerun under its protocol; it does not promote or rewrite evidence.

Closes #1401.