### PR TITLE
fix(core): preflight RTAC update working sets

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -1860,7 +1860,13 @@ class RecurrentTraceActorCriticAgent:
     def init(self, feature_dim: int, key: Array) -> RecurrentTraceActorCriticState:
         """Initialize independent actor/critic parameters and streaming state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        self._config.state_resource_budget(feature_dim)
+        resources = self._config.state_resource_budget(feature_dim)
+        # Source state and proposed next state are live together in update().
+        update_working_set_bytes = 2 * resources["state_nbytes"]
+        if update_working_set_bytes > _INT32_MAX:
+            raise ValueError(
+                "recurrent-trace actor-critic update working set byte count must fit signed int32"
+            )
         actor_key, critic_key, policy_key = jr.split(key, 3)
         actor_params = initialize_rtu_network_parameters(
             actor_key,

--- a/tests/test_recurrent_trace_actor_critic_update_working_set.py
+++ b/tests/test_recurrent_trace_actor_critic_update_working_set.py
@@ -1,0 +1,70 @@
+"""Complete update working-set preflight for recurrent-trace actor-critic."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.recurrent_trace_actor_critic import (
+    RecurrentTraceActorCriticAgent,
+    RecurrentTraceActorCriticConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 30_000_000
+
+
+def _small_config() -> RecurrentTraceActorCriticConfig:
+    return RecurrentTraceActorCriticConfig(
+        n_actions=3,
+        hidden_size=3,
+        encoder_width=2,
+        output_width=4,
+        sparsity=0.0,
+        r_min=0.1,
+        r_max=0.9,
+        normalize_observations=False,
+        normalize_rewards=False,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rtac_one_state_and_persistent_fit_while_update_working_set_does_not() -> None:
+    config = _small_config()
+    budget = config.state_resource_budget(_WORKING_SET_OVERFLOW)
+    persist = budget["state_nbytes"]
+    assert persist <= _INT32_MAX
+    assert 2 * persist > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RecurrentTraceActorCriticAgent(config).init(_WORKING_SET_OVERFLOW, jr.key(0))
+
+
+def test_rtac_persistent_derived_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="derived"):
+        RecurrentTraceActorCriticAgent(_small_config()).init(2**31 - 1, jr.key(0))
+
+
+def test_legal_rtac_init_and_update_identity_is_unchanged() -> None:
+    agent = RecurrentTraceActorCriticAgent(_small_config())
+    state = agent.init(2, jr.key(2))
+    budget = agent.config.state_resource_budget(2)
+    assert budget["state_nbytes"] <= _INT32_MAX
+    assert 2 * budget["state_nbytes"] <= _INT32_MAX
+    state, _, _ = agent.start(state, jnp.asarray((0.4, -0.2), dtype=jnp.float32))
+    result = agent.update(
+        state,
+        jnp.asarray(0.3, dtype=jnp.float32),
+        jnp.asarray((-0.1, 0.6), dtype=jnp.float32),
+    )
+    assert result.state.last_observation.shape == (2,)
+    assert result.action.shape == ()


### PR DESCRIPTION
Closes #1408.

## What changed

Recurrent-trace actor-critic now preflights the simultaneous update working set after the existing persistent-state budget, before RNG or allocation.

On origin/main `d067421`, `feature_dim = 30_000_000` keeps one persistent state nameable. Source + proposed states overflow signed int32. Persistent `derived` overflow still fires first at `2**31-1`. Legal 2-wide init/start/update is unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1402`. `#1407` still owns FTL. `#1399` still owns Horde. `#1405` still owns model-replay. `#1383` still owns IA. `#1400` still owns history features. `#1397` still owns the optimizer/RLS/TD wave.

## Scope

- `alberta_framework/core/recurrent_trace_actor_critic.py`
- `tests/test_recurrent_trace_actor_critic_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `recurrent_trace_actor_critic.py`.

## Verification

Exact candidate head: `20503cc8148d707568cd15fe9cc06bd285e28519`
Base: `d067421`

- Red on base: `feature_dim=30_000_000` persist fits; constructor/budget succeed; init would allocate before the working-set gate; int32 wrap stores `INT32_MIN`
- Focused pytest plus the existing RTAC file: 135 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_recurrent_trace_actor_critic_update_working_set.py tests/test_recurrent_trace_actor_critic.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: one persistent state still fits at `feature_dim=30_000_000`; persistent `derived` still fires first at `2**31-1`; legal 2-wide init/start/update still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:20503cc8148d707568cd15fe9cc06bd285e28519 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
