### PR TITLE
fix(core): complete model-replay resource boundary

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -138,6 +138,12 @@ def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) 
     persistent_bytes = ensemble_bytes + replay_bytes + 7 * 4
     if persistent_bytes > _INT32_MAX:
         raise ValueError("model replay rehearsal state byte count must fit signed int32")
+    # Source ensemble, proposed real-update ensemble, and committed replay.
+    update_working_set_bytes = 2 * ensemble_bytes + replay_bytes
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "model replay rehearsal update working set byte count must fit signed int32"
+        )
 
 
 ReplayActionEncoding = Literal["scalar_index", "one_hot"]

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -78,6 +78,7 @@ MECHANISM_STATUS = "model-only-replay-mechanism-no-scientific-claim"
 _INT32_MAX = 2_147_483_647
 _UINT32_MAX = 4_294_967_295
 _MAX_EXACT_FLOAT32_INTEGER = 16_777_216
+_COMPOSER_ACCOUNTING_BYTES = 7 * 4
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
     np.int8,
@@ -135,11 +136,14 @@ def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) 
         ensemble_size=config.ensemble.ensemble_size,
     )
     _, replay_bytes = _allocation_sizes(config.replay)
-    persistent_bytes = ensemble_bytes + replay_bytes + 7 * 4
+    persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     if persistent_bytes > _INT32_MAX:
         raise ValueError("model replay rehearsal state byte count must fit signed int32")
-    # Source ensemble, proposed real-update ensemble, and committed replay.
-    update_working_set_bytes = 2 * ensemble_bytes + replay_bytes
+    # The complete source composer, including its seven accounting leaves,
+    # remains live beside the proposed real-update ensemble.
+    update_working_set_bytes = (
+        2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+    )
     if update_working_set_bytes > _INT32_MAX:
         raise ValueError(
             "model replay rehearsal update working set byte count must fit signed int32"

--- a/tests/test_model_replay_rehearsal_update_working_set.py
+++ b/tests/test_model_replay_rehearsal_update_working_set.py
@@ -1,0 +1,126 @@
+"""Complete update working-set preflight for model-replay rehearsal."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.dual_replay import DualReplayConfig, _allocation_sizes
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.model_replay_rehearsal import (
+    ModelReplayRehearsal,
+    ModelReplayRehearsalConfig,
+)
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import (
+    WorldModelEnsembleConfig,
+    _ensemble_state_resource_counts,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 9_000
+
+
+def _ensemble(*, observation_dim: int, n_actions: int = 2, ensemble_size: int = 2):
+    target_dim = observation_dim + 2
+    model = ActionConditionedWorldModelConfig(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        hidden_sizes=(),
+        gamma=0.95,
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+    signals = LearningSignalEstimatorConfig(
+        ensemble_size=ensemble_size,
+        target_dim=target_dim,
+        progress_warmup_steps=2,
+        change_calibration_steps=2,
+        fast_loss_decay=0.5,
+        slow_loss_decay=0.9,
+        max_input_magnitude=100.0,
+        max_predicted_variance=10_000.0,
+        max_observed_loss=10_000.0,
+    )
+    return WorldModelEnsembleConfig(
+        model=model,
+        signal_estimator=signals,
+        ensemble_size=ensemble_size,
+        bootstrap_probability=0.5,
+        residual_variance_decay=0.8,
+        residual_variance_warmup_steps=1,
+        residual_variance_floor=1e-6,
+    )
+
+
+def _replay(*, observation_dim: int, action_dim: int = 2, total_capacity: int = 4):
+    return DualReplayConfig(
+        total_capacity=total_capacity,
+        short_term_capacity=1,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        short_term_sample_size=1,
+        long_term_sample_size=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rehearsal_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    ensemble = _ensemble(observation_dim=_WORKING_SET_OVERFLOW)
+    replay = _replay(observation_dim=_WORKING_SET_OVERFLOW)
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=ensemble.model, ensemble_size=ensemble.ensemble_size
+    )
+    _, replay_bytes = _allocation_sizes(replay)
+    persistent_bytes = ensemble_bytes + replay_bytes + 28
+    update_bytes = 2 * ensemble_bytes + replay_bytes
+    assert ensemble_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    config = ModelReplayRehearsalConfig(
+        ensemble=ensemble, replay=replay, action_encoding="one_hot"
+    )
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ModelReplayRehearsal(config)
+
+
+def test_rehearsal_persistent_byte_bound_still_fires_first() -> None:
+    ensemble = _ensemble(observation_dim=10_000)
+    replay = _replay(observation_dim=10_000, total_capacity=7_000)
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=ensemble.model, ensemble_size=ensemble.ensemble_size
+    )
+    _, replay_bytes = _allocation_sizes(replay)
+    assert ensemble_bytes <= _INT32_MAX
+    assert ensemble_bytes + replay_bytes + 28 > _INT32_MAX
+    config = ModelReplayRehearsalConfig(
+        ensemble=ensemble, replay=replay, action_encoding="one_hot"
+    )
+    with pytest.raises(ValueError, match="state byte count"):
+        ModelReplayRehearsal(config)
+
+
+def test_legal_rehearsal_init_identity_is_unchanged() -> None:
+    config = ModelReplayRehearsalConfig(
+        ensemble=_ensemble(observation_dim=2),
+        replay=_replay(observation_dim=2),
+        action_encoding="one_hot",
+    )
+    rehearsal = ModelReplayRehearsal(config)
+    state = rehearsal.init(jr.key(0))
+    budget = rehearsal.resource_budget(state)
+    assert budget.persistent_state_bytes <= _INT32_MAX
+    assert state.ensemble_state is not None
+    assert int(state.real_attempt_count) == 0

--- a/tests/test_model_replay_rehearsal_update_working_set.py
+++ b/tests/test_model_replay_rehearsal_update_working_set.py
@@ -11,6 +11,7 @@ from alberta_framework.core.learning_signals import LearningSignalEstimatorConfi
 from alberta_framework.core.model_replay_rehearsal import (
     ModelReplayRehearsal,
     ModelReplayRehearsalConfig,
+    _preflight_model_replay_state_resources,
 )
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 from alberta_framework.core.world_model_ensemble import (
@@ -21,6 +22,7 @@ from alberta_framework.core.world_model_ensemble import (
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _WORKING_SET_OVERFLOW = 9_000
+_COMPOSER_ACCOUNTING_BYTES = 28
 
 
 def _ensemble(*, observation_dim: int, n_actions: int = 2, ensemble_size: int = 2):
@@ -85,7 +87,7 @@ def test_rehearsal_one_bank_and_persistent_fit_while_update_working_set_does_not
     )
     _, replay_bytes = _allocation_sizes(replay)
     persistent_bytes = ensemble_bytes + replay_bytes + 28
-    update_bytes = 2 * ensemble_bytes + replay_bytes
+    update_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     assert ensemble_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
@@ -124,3 +126,60 @@ def test_legal_rehearsal_init_identity_is_unchanged() -> None:
     assert budget.persistent_state_bytes <= _INT32_MAX
     assert state.ensemble_state is not None
     assert int(state.real_attempt_count) == 0
+
+
+def test_rehearsal_exact_last_legal_working_set_and_first_overflow() -> None:
+    def config(observation_dim: int) -> ModelReplayRehearsalConfig:
+        return ModelReplayRehearsalConfig(
+            ensemble=_ensemble(observation_dim=observation_dim),
+            replay=_replay(observation_dim=observation_dim),
+            action_encoding="one_hot",
+        )
+
+    low, high = 1, _WORKING_SET_OVERFLOW
+    while low < high:
+        middle = (low + high + 1) // 2
+        candidate = config(middle)
+        _, ensemble_bytes = _ensemble_state_resource_counts(
+            model=candidate.ensemble.model,
+            ensemble_size=candidate.ensemble.ensemble_size,
+        )
+        _, replay_bytes = _allocation_sizes(candidate.replay)
+        if (
+            2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+            <= _INT32_MAX
+        ):
+            low = middle
+        else:
+            high = middle - 1
+
+    last_legal = config(low)
+    first_overflowing = config(low + 1)
+    _preflight_model_replay_state_resources(last_legal)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_model_replay_state_resources(first_overflowing)
+
+
+def test_rehearsal_general_shape_formula_preflights_before_child_allocation() -> None:
+    ensemble = _ensemble(observation_dim=7_000, n_actions=5, ensemble_size=3)
+    replay = _replay(
+        observation_dim=7_000,
+        action_dim=5,
+        total_capacity=4,
+    )
+    config = ModelReplayRehearsalConfig(
+        ensemble=ensemble,
+        replay=replay,
+        action_encoding="one_hot",
+    )
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=ensemble.model,
+        ensemble_size=ensemble.ensemble_size,
+    )
+    _, replay_bytes = _allocation_sizes(replay)
+    persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+    update_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ModelReplayRehearsal(config)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1405. It retains the original commit and completes its exact aggregate formula.

The child byte functions already account for arbitrary ensemble size/model shape and replay capacity/action/observation dimensions without allocation. Deep review found the remaining exactness gap: the working-set formula omitted the source composer’s seven int32 accounting leaves. The complete issue-scoped aggregate is therefore source composer plus proposed ensemble: `2*ensemble_bytes + replay_bytes + 28`.

Coverage adds exact adjacent last-legal/first-overflow checks, a non-default three-member/five-action/high-observation general-shape preallocation case, persistent-first ordering, and the legal small constructor control. Existing config suites cover hostile exact-type/schema gates and NumPy canonicalization.

Verification:
- focused rehearsal validation/resource panel: 49 passed
- Ruff changed files: clean
- strict mypy source: clean

No benchmark run, output artifact, evidence promotion, or registered-source claim.

Closes #1404.