### PR TITLE
fix(core): complete nonlinear Horde update resource preflight

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -107,6 +107,11 @@ def _preflight_nonlinear_state(*, n_demons: int, hidden_size: int, feature_dim: 
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived nonlinear Horde {name} must fit signed int32")
+    update_scalars = (2 * n_demons + 4) * hidden_features + 8
+    if 4 * update_scalars > _INT32_MAX:
+        raise ValueError(
+            "derived nonlinear Horde update working set byte count must fit signed int32"
+        )
 
 
 def _require_typed_threefry_key(name: str, value: object) -> Array:

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -107,7 +107,28 @@ def _preflight_nonlinear_state(*, n_demons: int, hidden_size: int, feature_dim: 
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived nonlinear Horde {name} must fit signed int32")
-    update_scalars = (2 * n_demons + 4) * hidden_features + 8
+    # Conservatively charge every source-level aggregate that can coexist at
+    # publication: source, proposed, and selected states; the primary steps
+    # plus retained per-demon secondary proposals; and the current, next, and
+    # correction gradient families.  The tail covers the two observations and
+    # all per-demon masks, predictions, targets, errors, norms, and result
+    # diagnostics.  Charging logical leaves as four-byte scalars also covers
+    # the int32 counter and boolean predicates.
+    parameter_scalars = (
+        hidden_features * (n_demons + 1)
+        + hidden_size
+        + 3 * demon_hidden
+        + 2 * n_demons
+    )
+    one_gradient_scalars = hidden_features + 2 * hidden_size + 1
+    update_scalars = (
+        3 * logical_scalars
+        + parameter_scalars
+        + 3 * one_gradient_scalars
+        + 2 * feature_dim
+        + 24 * n_demons
+        + 32
+    )
     if 4 * update_scalars > _INT32_MAX:
         raise ValueError(
             "derived nonlinear Horde update working set byte count must fit signed int32"

--- a/tests/test_off_policy_horde_update_working_set.py
+++ b/tests/test_off_policy_horde_update_working_set.py
@@ -1,0 +1,90 @@
+"""Complete update working-set preflight for nonlinear shared GTD Horde."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.off_policy_horde import NonlinearSharedGTDHordeLearner
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 5_000_000
+_N_DEMONS = 2
+_HIDDEN = 16
+
+
+def _two_demon_spec() -> object:
+    demons = tuple(
+        GVFSpec(
+            name=f"demon_{i}",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.8,
+            lamda=0.0,
+            cumulant_index=i,
+        )  # type: ignore[call-arg]
+        for i in range(_N_DEMONS)
+    )
+    return create_horde_spec(demons)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_nonlinear_horde_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
+    fd = _WORKING_SET_OVERFLOW
+    hidden_features = _HIDDEN * fd
+    persist_scalars = (
+        hidden_features * (_N_DEMONS + 1)
+        + _HIDDEN
+        + 3 * _N_DEMONS * _HIDDEN
+        + 2 * _N_DEMONS
+        + 3
+    )
+    one_bank_bytes = 4 * hidden_features
+    persistent_bytes = 4 * persist_scalars
+    update_bytes = 4 * ((2 * _N_DEMONS + 4) * hidden_features + 8)
+    assert one_bank_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
+    learner = NonlinearSharedGTDHordeLearner(_two_demon_spec(), hidden_size=_HIDDEN)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(fd, jax.random.key(0))
+
+
+def test_nonlinear_horde_persistent_byte_bound_still_fires_first() -> None:
+    learner = NonlinearSharedGTDHordeLearner(_two_demon_spec(), hidden_size=_HIDDEN)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        learner.init(20_000_000, jax.random.key(0))
+
+
+def test_legal_nonlinear_horde_update_identity_is_unchanged() -> None:
+    learner = NonlinearSharedGTDHordeLearner(
+        _two_demon_spec(),
+        hidden_size=4,
+        primary_step_size=0.002,
+        secondary_step_size=1e-5,
+        ratio_clip=10.0,
+    )
+    state = learner.init(2, jax.random.key(7))
+    assert state.trunk_w.shape == (4, 2)
+    assert state.secondary_trunk_w.shape == (2, 4, 2)
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([1.0, 0.0], dtype=jnp.float32),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+        jnp.array([2.0, 0.0], dtype=jnp.float32),
+        jnp.array([0.8, 0.8], dtype=jnp.float32),
+    )
+    assert result.state.trunk_w.shape == (4, 2)
+    assert result.predictions.shape == (2,)
+    assert float(jnp.linalg.norm(result.state.trunk_w - state.trunk_w)) > 0.0

--- a/tests/test_off_policy_horde_update_working_set.py
+++ b/tests/test_off_policy_horde_update_working_set.py
@@ -6,7 +6,10 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from alberta_framework.core.off_policy_horde import NonlinearSharedGTDHordeLearner
+from alberta_framework.core.off_policy_horde import (
+    NonlinearSharedGTDHordeLearner,
+    _preflight_nonlinear_state,
+)
 from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
 
 _INT32_MAX = 2**31 - 1
@@ -51,7 +54,22 @@ def test_nonlinear_horde_one_bank_and_persistent_fit_while_update_working_set_do
     )
     one_bank_bytes = 4 * hidden_features
     persistent_bytes = 4 * persist_scalars
-    update_bytes = 4 * ((2 * _N_DEMONS + 4) * hidden_features + 8)
+    logical_scalars = persist_scalars
+    parameter_scalars = (
+        hidden_features * (_N_DEMONS + 1)
+        + _HIDDEN
+        + 3 * _N_DEMONS * _HIDDEN
+        + 2 * _N_DEMONS
+    )
+    one_gradient_scalars = hidden_features + 2 * _HIDDEN + 1
+    update_bytes = 4 * (
+        3 * logical_scalars
+        + parameter_scalars
+        + 3 * one_gradient_scalars
+        + 2 * fd
+        + 24 * _N_DEMONS
+        + 32
+    )
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
@@ -88,3 +106,34 @@ def test_legal_nonlinear_horde_update_identity_is_unchanged() -> None:
     assert result.state.trunk_w.shape == (4, 2)
     assert result.predictions.shape == (2,)
     assert float(jnp.linalg.norm(result.state.trunk_w - state.trunk_w)) > 0.0
+
+
+def test_nonlinear_horde_update_working_set_has_exact_adjacent_byte_boundary() -> None:
+    # For D=H=1, the complete formula reduces exactly to 13*feature_dim+98.
+    max_scalars = _INT32_MAX // 4
+    last_legal = (max_scalars - 98) // 13
+    first_overflowing = last_legal + 1
+    learner = NonlinearSharedGTDHordeLearner(
+        create_horde_spec(
+            (
+                GVFSpec(
+                    name="demon",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=0.8,
+                    lamda=0.0,
+                    cumulant_index=0,
+                ),  # type: ignore[call-arg]
+            )
+        ),
+        hidden_size=1,
+    )
+
+    # Exercise the arithmetic-only preflight without attempting either large
+    # allocation; the next scalar is the first byte-count overflow.
+    _preflight_nonlinear_state(n_demons=1, hidden_size=1, feature_dim=last_legal)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_nonlinear_state(n_demons=1, hidden_size=1, feature_dim=first_overflowing)
+
+    assert 4 * (13 * last_legal + 98) <= _INT32_MAX
+    assert 4 * (13 * first_overflowing + 98) > _INT32_MAX
+    assert learner.n_demons == 1


### PR DESCRIPTION
Supersedes #1399 and closes #1398.

Preserves contributor ss251 commit `e0ab587f` and corrects its partial working-set formula after deep review. The complete conservative source-level envelope charges source/proposed/selected state aggregates, retained primary and per-demon secondary proposals, current/next/correction gradient families, observations, masks, and published diagnostics. It adds an exact algebraic last-fit/first-overflow boundary in addition to the original large-shape and legal-update controls.

Focused verification:
- `pytest tests/test_off_policy_horde_update_working_set.py -q -x`: 5 passed
- Ruff: clean
- mypy `off_policy_horde.py`: clean

No benchmark, output, evidence, or scientific-claim changes.