### PR TITLE
fix(core): preflight feature-bank route working sets

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -405,6 +405,18 @@ def _saturating_increment(value: Array) -> Array:
     return jnp.where(value < _INT32_MAX, value + jnp.int32(1), value)
 
 
+def _preflight_route_working_set(active_slots: int) -> None:
+    """Reject route tensors the host cannot name. Config persist is unchanged."""
+    persist_bytes = 4 * (2 * active_slots + 2)
+    # Source and proposed router states plus three (slots, slots) bool
+    # compare planes: old-bank duplicates, new-bank duplicates, identity match.
+    update_working_set_bytes = 2 * persist_bytes + 3 * active_slots * active_slots
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "feature-bank router update working set byte count must fit signed int32"
+        )
+
+
 class FeatureBankRouter:
     """Atomic fixed-shape router for every downstream feature consumer."""
 
@@ -442,6 +454,7 @@ class FeatureBankRouter:
         Shape and dtype violations are rejected immediately.
         """
 
+        _preflight_route_working_set(self._config.active_slots)
         if descriptors is None:
             descriptor_array = jnp.tile(
                 jnp.asarray(INACTIVE_DESCRIPTOR, dtype=jnp.int32),
@@ -470,6 +483,7 @@ class FeatureBankRouter:
             active_slots=self._config.active_slots,
             location="descriptors",
         )
+        _preflight_route_working_set(self._config.active_slots)
         return _descriptor_validation(
             descriptor_array,
             base_dim=self._config.base_dim,
@@ -551,6 +565,7 @@ class FeatureBankRouter:
 
         if not isinstance(carry_survivors, bool):
             raise TypeError("carry_survivors must be a Python boolean")
+        _preflight_route_working_set(self._config.active_slots)
         self._require_state_contract(state)
         proposed = _require_descriptor_contract(
             new_descriptors,

--- a/tests/test_feature_bank_router_update_working_set.py
+++ b/tests/test_feature_bank_router_update_working_set.py
@@ -1,0 +1,81 @@
+"""Complete update working-set preflight for feature-bank routing."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.feature_bank_router import (
+    FeatureBankRouter,
+    FeatureBankRouterConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_LAST_LEGAL_PERSIST_SLOTS = 268_435_454
+_FIRST_WORKING_SET_OVERFLOW = 26_753
+
+
+def _persist_bytes(active_slots: int) -> int:
+    return 4 * (2 * active_slots + 2)
+
+
+def _route_working_set_bytes(active_slots: int) -> int:
+    return 2 * _persist_bytes(active_slots) + 3 * active_slots * active_slots
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_router_persist_fits_while_route_working_set_does_not() -> None:
+    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    config = FeatureBankRouterConfig(
+        base_dim=2, active_slots=_FIRST_WORKING_SET_OVERFLOW
+    )
+    assert _persist_bytes(config.active_slots) == persist
+    router = FeatureBankRouter(config)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        router.init()
+
+
+def test_router_last_legal_persistent_config_still_constructs() -> None:
+    boundary = FeatureBankRouterConfig(
+        base_dim=2, active_slots=_LAST_LEGAL_PERSIST_SLOTS
+    )
+    assert _persist_bytes(boundary.active_slots) == 2_147_483_640
+    assert _persist_bytes(boundary.active_slots) <= _INT32_MAX
+    assert _route_working_set_bytes(boundary.active_slots) > _INT32_MAX
+    FeatureBankRouter(boundary)
+    with pytest.raises(ValueError, match="router_state_nbytes"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=_LAST_LEGAL_PERSIST_SLOTS + 1)
+
+
+def test_legal_router_init_and_route_identity_is_unchanged() -> None:
+    router = FeatureBankRouter(FeatureBankRouterConfig(base_dim=4, active_slots=4))
+    old = jnp.asarray(
+        [[0, 1], [0, 2], [1, 3], [-1, -1]],
+        dtype=jnp.int32,
+    )
+    new = jnp.asarray(
+        [[1, 3], [0, 1], [2, 3], [-1, -1]],
+        dtype=jnp.int32,
+    )
+    consumers = {
+        "weights": jnp.arange(8, dtype=jnp.float32),
+    }
+    state = router.init(old)
+    result = router.route(state, consumers, new)
+    assert result.state.descriptors.shape == (4, 2)
+    assert result.consumers["weights"].shape == (8,)
+    assert _persist_bytes(4) <= _INT32_MAX
+    assert _route_working_set_bytes(4) <= _INT32_MAX


### PR DESCRIPTION
Closes #1412.

## What changed

Feature-bank routing now preflights the simultaneous route working set after the existing persistent-byte config check, before `init` / `route` / `validate_descriptors` allocate compare planes.

On origin/main `05a3c24`, last-legal `active_slots=268_435_454` still constructs. Persist `2147483640` fits. Source + proposed persist plus three `(slots, slots)` bool compare planes overflow at `26_753` (exact adjacent last-fit `26_752`). Persistent `router_state_nbytes` still fires first at `268_435_455`. Legal 4-slot init/route is unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1402` / `#1405` / `#1399`. `#1407` still owns FTL. `#1410` still owns model-replay. `#1411` still owns Horde. `#1409` still owns RTAC. `#1383` still owns IA. `#1400` still owns history features. `#1397` still owns the optimizer/RLS/TD wave.

## Scope

- `alberta_framework/core/feature_bank_router.py`
- `tests/test_feature_bank_router_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `feature_bank_router.py`.

## Verification

Exact candidate head: `bebb9fade6aa20a822a876494b3a463b0d8ca596`
Base: `05a3c24`

- Red on base: last-legal persist config constructs; `26_753` persist fits; `init` would reach pairwise compare planes; int32 wrap stores `INT32_MIN`
- Focused pytest plus the existing router file: 46 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_feature_bank_router_update_working_set.py tests/test_feature_bank_router.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: last-legal persist config still constructs at `active_slots=268_435_454`; persist `router_state_nbytes` still fires first at `268_435_455`; legal 4-slot init/route still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bebb9fade6aa20a822a876494b3a463b0d8ca596 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
