### PR TITLE
fix(core): complete RTAC update resource formula

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -1860,7 +1860,13 @@ class RecurrentTraceActorCriticAgent:
     def init(self, feature_dim: int, key: Array) -> RecurrentTraceActorCriticState:
         """Initialize independent actor/critic parameters and streaming state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        self._config.state_resource_budget(feature_dim)
+        resources = self._config.state_resource_budget(feature_dim)
+        # Source state and proposed next state are live together in update().
+        update_working_set_bytes = 2 * resources["state_nbytes"]
+        if update_working_set_bytes > _INT32_MAX:
+            raise ValueError(
+                "recurrent-trace actor-critic update working set byte count must fit signed int32"
+            )
         actor_key, critic_key, policy_key = jr.split(key, 3)
         actor_params = initialize_rtu_network_parameters(
             actor_key,

--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -371,6 +371,25 @@ def _preflight_state_resources(
     return resources
 
 
+def _preflight_update_working_set(
+    config: RecurrentTraceActorCriticConfig,
+    state_resources: Mapping[str, int],
+) -> int:
+    """Preflight the source state and complete returned update result."""
+
+    # The result owns its returned state, one float32 policy value per action,
+    # one int32 action, nine float32 diagnostics, and one boolean verdict.
+    result_output_bytes = (
+        state_resources["state_nbytes"] + 4 * config.n_actions + 4 + 9 * 4 + 1
+    )
+    update_working_set_bytes = state_resources["state_nbytes"] + result_output_bytes
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "recurrent-trace actor-critic update working set byte count must fit signed int32"
+        )
+    return update_working_set_bytes
+
+
 def _copy_config_mapping(name: str, config: object) -> dict[str, Any]:
     """Copy a legacy-compatible mapping while normalizing hostile hooks."""
     if not isinstance(config, Mapping):
@@ -1861,12 +1880,7 @@ class RecurrentTraceActorCriticAgent:
         """Initialize independent actor/critic parameters and streaming state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         resources = self._config.state_resource_budget(feature_dim)
-        # Source state and proposed next state are live together in update().
-        update_working_set_bytes = 2 * resources["state_nbytes"]
-        if update_working_set_bytes > _INT32_MAX:
-            raise ValueError(
-                "recurrent-trace actor-critic update working set byte count must fit signed int32"
-            )
+        _preflight_update_working_set(self._config, resources)
         actor_key, critic_key, policy_key = jr.split(key, 3)
         actor_params = initialize_rtu_network_parameters(
             actor_key,

--- a/tests/test_recurrent_trace_actor_critic_update_working_set.py
+++ b/tests/test_recurrent_trace_actor_critic_update_working_set.py
@@ -1,0 +1,70 @@
+"""Complete update working-set preflight for recurrent-trace actor-critic."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.recurrent_trace_actor_critic import (
+    RecurrentTraceActorCriticAgent,
+    RecurrentTraceActorCriticConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_WORKING_SET_OVERFLOW = 30_000_000
+
+
+def _small_config() -> RecurrentTraceActorCriticConfig:
+    return RecurrentTraceActorCriticConfig(
+        n_actions=3,
+        hidden_size=3,
+        encoder_width=2,
+        output_width=4,
+        sparsity=0.0,
+        r_min=0.1,
+        r_max=0.9,
+        normalize_observations=False,
+        normalize_rewards=False,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_rtac_one_state_and_persistent_fit_while_update_working_set_does_not() -> None:
+    config = _small_config()
+    budget = config.state_resource_budget(_WORKING_SET_OVERFLOW)
+    persist = budget["state_nbytes"]
+    assert persist <= _INT32_MAX
+    assert 2 * persist > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RecurrentTraceActorCriticAgent(config).init(_WORKING_SET_OVERFLOW, jr.key(0))
+
+
+def test_rtac_persistent_derived_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="derived"):
+        RecurrentTraceActorCriticAgent(_small_config()).init(2**31 - 1, jr.key(0))
+
+
+def test_legal_rtac_init_and_update_identity_is_unchanged() -> None:
+    agent = RecurrentTraceActorCriticAgent(_small_config())
+    state = agent.init(2, jr.key(2))
+    budget = agent.config.state_resource_budget(2)
+    assert budget["state_nbytes"] <= _INT32_MAX
+    assert 2 * budget["state_nbytes"] <= _INT32_MAX
+    state, _, _ = agent.start(state, jnp.asarray((0.4, -0.2), dtype=jnp.float32))
+    result = agent.update(
+        state,
+        jnp.asarray(0.3, dtype=jnp.float32),
+        jnp.asarray((-0.1, 0.6), dtype=jnp.float32),
+    )
+    assert result.state.last_observation.shape == (2,)
+    assert result.action.shape == ()

--- a/tests/test_recurrent_trace_actor_critic_update_working_set.py
+++ b/tests/test_recurrent_trace_actor_critic_update_working_set.py
@@ -6,9 +6,11 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
+import alberta_framework.core.recurrent_trace_actor_critic as rtac_module
 from alberta_framework.core.recurrent_trace_actor_critic import (
     RecurrentTraceActorCriticAgent,
     RecurrentTraceActorCriticConfig,
+    _preflight_update_working_set,
 )
 
 _INT32_MAX = 2**31 - 1
@@ -39,12 +41,19 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
     assert wrapped_bytes != published_bytes
 
 
-def test_rtac_one_state_and_persistent_fit_while_update_working_set_does_not() -> None:
+def test_rtac_one_state_and_persistent_fit_while_update_working_set_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     config = _small_config()
     budget = config.state_resource_budget(_WORKING_SET_OVERFLOW)
     persist = budget["state_nbytes"]
     assert persist <= _INT32_MAX
-    assert 2 * persist > _INT32_MAX
+    assert 2 * persist + 4 * config.n_actions + 41 > _INT32_MAX
+
+    def forbidden_split(*args: object, **kwargs: object) -> object:
+        raise AssertionError("RNG split must not run before update-resource validation")
+
+    monkeypatch.setattr(rtac_module.jr, "split", forbidden_split)
     with pytest.raises(ValueError, match="update working set byte count"):
         RecurrentTraceActorCriticAgent(config).init(_WORKING_SET_OVERFLOW, jr.key(0))
 
@@ -59,7 +68,9 @@ def test_legal_rtac_init_and_update_identity_is_unchanged() -> None:
     state = agent.init(2, jr.key(2))
     budget = agent.config.state_resource_budget(2)
     assert budget["state_nbytes"] <= _INT32_MAX
-    assert 2 * budget["state_nbytes"] <= _INT32_MAX
+    assert _preflight_update_working_set(agent.config, budget) == (
+        2 * budget["state_nbytes"] + 4 * agent.config.n_actions + 41
+    )
     state, _, _ = agent.start(state, jnp.asarray((0.4, -0.2), dtype=jnp.float32))
     result = agent.update(
         state,
@@ -68,3 +79,36 @@ def test_legal_rtac_init_and_update_identity_is_unchanged() -> None:
     )
     assert result.state.last_observation.shape == (2,)
     assert result.action.shape == ()
+
+
+def test_rtac_exact_large_action_optional_state_boundary() -> None:
+    config = RecurrentTraceActorCriticConfig(
+        n_actions=1_000,
+        hidden_size=3,
+        encoder_width=2,
+        output_width=4,
+        sparsity=0.0,
+        r_min=0.1,
+        r_max=0.9,
+        normalize_observations=False,
+        normalize_rewards=False,
+        rtrl_taylor_correction=True,
+        adaptive_obgd=True,
+    )
+
+    low, high = 1, 30_000_000
+    while low < high:
+        middle = (low + high + 1) // 2
+        resources = config.state_resource_budget(middle)
+        complete = 2 * resources["state_nbytes"] + 4 * config.n_actions + 41
+        if complete <= _INT32_MAX:
+            low = middle
+        else:
+            high = middle - 1
+
+    last_resources = config.state_resource_budget(low)
+    first_resources = config.state_resource_budget(low + 1)
+    assert _preflight_update_working_set(config, last_resources) <= _INT32_MAX
+    assert 2 * first_resources["state_nbytes"] <= _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_update_working_set(config, first_resources)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1409. It retains the original commit and completes the exact logical source-plus-result formula.

The persistent-state formula was already exact across feature width, action width, Taylor traces, and adaptive-ObGD trees. Deep review found `2*state_nbytes` omitted the non-state portion of the complete returned update result: one float32 policy entry per action, one int32 action, nine float32 diagnostics, and one boolean verdict. The exact preallocation gate is `2*state_nbytes + 4*n_actions + 41`.

Coverage proves the pre-RNG gate, legal update identity, persistent-first ordering, and an exact adjacent last-fit/first-overflow boundary with 1,000 actions plus Taylor and adaptive optional state. Existing RTAC tests retain hostile exact-int/schema and NumPy integer coverage.

Verification:
- complete RTAC + focused panel: 136 passed
- post-rebase focused: 5 passed
- Ruff changed files: clean
- strict mypy source: clean

No benchmark run, output artifact, evidence promotion, or registered-source claim.

Closes #1408.