### PR TITLE
fix(core): complete feature-route resource formula

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -405,6 +405,18 @@ def _saturating_increment(value: Array) -> Array:
     return jnp.where(value < _INT32_MAX, value + jnp.int32(1), value)
 
 
+def _preflight_route_working_set(active_slots: int) -> None:
+    """Reject route tensors the host cannot name. Config persist is unchanged."""
+    persist_bytes = 4 * (2 * active_slots + 2)
+    # Source and proposed router states plus three (slots, slots) bool
+    # compare planes: old-bank duplicates, new-bank duplicates, identity match.
+    update_working_set_bytes = 2 * persist_bytes + 3 * active_slots * active_slots
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "feature-bank router update working set byte count must fit signed int32"
+        )
+
+
 class FeatureBankRouter:
     """Atomic fixed-shape router for every downstream feature consumer."""
 
@@ -442,6 +454,7 @@ class FeatureBankRouter:
         Shape and dtype violations are rejected immediately.
         """
 
+        _preflight_route_working_set(self._config.active_slots)
         if descriptors is None:
             descriptor_array = jnp.tile(
                 jnp.asarray(INACTIVE_DESCRIPTOR, dtype=jnp.int32),
@@ -470,6 +483,7 @@ class FeatureBankRouter:
             active_slots=self._config.active_slots,
             location="descriptors",
         )
+        _preflight_route_working_set(self._config.active_slots)
         return _descriptor_validation(
             descriptor_array,
             base_dim=self._config.base_dim,
@@ -551,6 +565,7 @@ class FeatureBankRouter:
 
         if not isinstance(carry_survivors, bool):
             raise TypeError("carry_survivors must be a Python boolean")
+        _preflight_route_working_set(self._config.active_slots)
         self._require_state_contract(state)
         proposed = _require_descriptor_contract(
             new_descriptors,

--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -405,16 +405,39 @@ def _saturating_increment(value: Array) -> Array:
     return jnp.where(value < _INT32_MAX, value + jnp.int32(1), value)
 
 
-def _preflight_route_working_set(active_slots: int) -> None:
-    """Reject route tensors the host cannot name. Config persist is unchanged."""
+def _preflight_route_working_set(
+    active_slots: int,
+    *,
+    consumer_state_nbytes: int = 0,
+    consumer_dynamic_tail_nbytes: int = 0,
+) -> int:
+    """Reject the complete logical route result and its named working buffers."""
+
     persist_bytes = 4 * (2 * active_slots + 2)
     # Source and proposed router states plus three (slots, slots) bool
     # compare planes: old-bank duplicates, new-bank duplicates, identity match.
-    update_working_set_bytes = 2 * persist_bytes + 3 * active_slots * active_slots
+    compare_plane_bytes = 3 * active_slots * active_slots
+    proposed_descriptor_bytes = 2 * active_slots * 4
+    # Two nested descriptor validations plus route masks, source slots, counts,
+    # and scalar transaction diagnostics are returned with every route.
+    diagnostics_bytes = 17 * active_slots + 43
+    # Each consumer retains its source and returned arrays while a full-width
+    # candidate and the gathered/carried dynamic tails are formed.
+    consumer_working_bytes = (
+        3 * consumer_state_nbytes + 2 * consumer_dynamic_tail_nbytes
+    )
+    update_working_set_bytes = (
+        2 * persist_bytes
+        + compare_plane_bytes
+        + proposed_descriptor_bytes
+        + diagnostics_bytes
+        + consumer_working_bytes
+    )
     if update_working_set_bytes > _INT32_MAX:
         raise ValueError(
             "feature-bank router update working set byte count must fit signed int32"
         )
+    return update_working_set_bytes
 
 
 class FeatureBankRouter:
@@ -575,6 +598,21 @@ class FeatureBankRouter:
         consumer_leaves, consumer_tree, axes = self._consumer_layout(
             consumers,
             feature_axes,
+        )
+        consumer_state_nbytes = 0
+        consumer_dynamic_tail_nbytes = 0
+        for leaf, axis in zip(consumer_leaves, axes, strict=True):
+            scalar_count = int(leaf.size)
+            itemsize = int(leaf.dtype.itemsize)
+            feature_groups = scalar_count // int(leaf.shape[axis])
+            consumer_state_nbytes += scalar_count * itemsize
+            consumer_dynamic_tail_nbytes += (
+                feature_groups * self._config.active_slots * itemsize
+            )
+        _preflight_route_working_set(
+            self._config.active_slots,
+            consumer_state_nbytes=consumer_state_nbytes,
+            consumer_dynamic_tail_nbytes=consumer_dynamic_tail_nbytes,
         )
 
         old_validation = _descriptor_validation(

--- a/tests/test_feature_bank_router_update_working_set.py
+++ b/tests/test_feature_bank_router_update_working_set.py
@@ -1,0 +1,81 @@
+"""Complete update working-set preflight for feature-bank routing."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.feature_bank_router import (
+    FeatureBankRouter,
+    FeatureBankRouterConfig,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_LAST_LEGAL_PERSIST_SLOTS = 268_435_454
+_FIRST_WORKING_SET_OVERFLOW = 26_753
+
+
+def _persist_bytes(active_slots: int) -> int:
+    return 4 * (2 * active_slots + 2)
+
+
+def _route_working_set_bytes(active_slots: int) -> int:
+    return 2 * _persist_bytes(active_slots) + 3 * active_slots * active_slots
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_router_persist_fits_while_route_working_set_does_not() -> None:
+    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    config = FeatureBankRouterConfig(
+        base_dim=2, active_slots=_FIRST_WORKING_SET_OVERFLOW
+    )
+    assert _persist_bytes(config.active_slots) == persist
+    router = FeatureBankRouter(config)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        router.init()
+
+
+def test_router_last_legal_persistent_config_still_constructs() -> None:
+    boundary = FeatureBankRouterConfig(
+        base_dim=2, active_slots=_LAST_LEGAL_PERSIST_SLOTS
+    )
+    assert _persist_bytes(boundary.active_slots) == 2_147_483_640
+    assert _persist_bytes(boundary.active_slots) <= _INT32_MAX
+    assert _route_working_set_bytes(boundary.active_slots) > _INT32_MAX
+    FeatureBankRouter(boundary)
+    with pytest.raises(ValueError, match="router_state_nbytes"):
+        FeatureBankRouterConfig(base_dim=2, active_slots=_LAST_LEGAL_PERSIST_SLOTS + 1)
+
+
+def test_legal_router_init_and_route_identity_is_unchanged() -> None:
+    router = FeatureBankRouter(FeatureBankRouterConfig(base_dim=4, active_slots=4))
+    old = jnp.asarray(
+        [[0, 1], [0, 2], [1, 3], [-1, -1]],
+        dtype=jnp.int32,
+    )
+    new = jnp.asarray(
+        [[1, 3], [0, 1], [2, 3], [-1, -1]],
+        dtype=jnp.int32,
+    )
+    consumers = {
+        "weights": jnp.arange(8, dtype=jnp.float32),
+    }
+    state = router.init(old)
+    result = router.route(state, consumers, new)
+    assert result.state.descriptors.shape == (4, 2)
+    assert result.consumers["weights"].shape == (8,)
+    assert _persist_bytes(4) <= _INT32_MAX
+    assert _route_working_set_bytes(4) <= _INT32_MAX

--- a/tests/test_feature_bank_router_update_working_set.py
+++ b/tests/test_feature_bank_router_update_working_set.py
@@ -8,20 +8,44 @@ import pytest
 from alberta_framework.core.feature_bank_router import (
     FeatureBankRouter,
     FeatureBankRouterConfig,
+    _preflight_route_working_set,
 )
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _LAST_LEGAL_PERSIST_SLOTS = 268_435_454
-_FIRST_WORKING_SET_OVERFLOW = 26_753
 
 
 def _persist_bytes(active_slots: int) -> int:
     return 4 * (2 * active_slots + 2)
 
 
-def _route_working_set_bytes(active_slots: int) -> int:
-    return 2 * _persist_bytes(active_slots) + 3 * active_slots * active_slots
+def _route_working_set_bytes(
+    active_slots: int,
+    *,
+    consumer_state_nbytes: int = 0,
+    consumer_dynamic_tail_nbytes: int = 0,
+) -> int:
+    return (
+        2 * _persist_bytes(active_slots)
+        + 3 * active_slots * active_slots
+        + 8 * active_slots
+        + 17 * active_slots
+        + 43
+        + 3 * consumer_state_nbytes
+        + 2 * consumer_dynamic_tail_nbytes
+    )
+
+
+def _last_legal_static_slots() -> int:
+    low, high = 1, _LAST_LEGAL_PERSIST_SLOTS
+    while low < high:
+        middle = (low + high + 1) // 2
+        if _route_working_set_bytes(middle) <= _INT32_MAX:
+            low = middle
+        else:
+            high = middle - 1
+    return low
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -34,13 +58,15 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
 
 
 def test_router_persist_fits_while_route_working_set_does_not() -> None:
-    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
-    working = _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    last_legal = _last_legal_static_slots()
+    first_overflowing = last_legal + 1
+    persist = _persist_bytes(first_overflowing)
+    working = _route_working_set_bytes(first_overflowing)
     assert persist <= _INT32_MAX
-    assert _route_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert _route_working_set_bytes(last_legal) <= _INT32_MAX
     assert working > _INT32_MAX
     config = FeatureBankRouterConfig(
-        base_dim=2, active_slots=_FIRST_WORKING_SET_OVERFLOW
+        base_dim=2, active_slots=first_overflowing
     )
     assert _persist_bytes(config.active_slots) == persist
     router = FeatureBankRouter(config)
@@ -78,4 +104,31 @@ def test_legal_router_init_and_route_identity_is_unchanged() -> None:
     assert result.state.descriptors.shape == (4, 2)
     assert result.consumers["weights"].shape == (8,)
     assert _persist_bytes(4) <= _INT32_MAX
-    assert _route_working_set_bytes(4) <= _INT32_MAX
+    consumer_bytes = int(consumers["weights"].nbytes)
+    dynamic_tail_bytes = 4 * jnp.dtype(jnp.float32).itemsize
+    expected = _route_working_set_bytes(
+        4,
+        consumer_state_nbytes=consumer_bytes,
+        consumer_dynamic_tail_nbytes=dynamic_tail_bytes,
+    )
+    assert _preflight_route_working_set(
+        4,
+        consumer_state_nbytes=consumer_bytes,
+        consumer_dynamic_tail_nbytes=dynamic_tail_bytes,
+    ) == expected
+
+
+def test_router_consumer_shape_and_dtype_bytes_are_in_the_preallocation_gate() -> None:
+    slots = 4
+    static_bytes = _route_working_set_bytes(slots)
+    consumer_bytes = (_INT32_MAX - static_bytes) // 3 + 1
+    assert static_bytes <= _INT32_MAX
+    assert _route_working_set_bytes(
+        slots,
+        consumer_state_nbytes=consumer_bytes,
+    ) > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_route_working_set(
+            slots,
+            consumer_state_nbytes=consumer_bytes,
+        )


### PR DESCRIPTION
Contributor-preserving corrective successor to #1413. It retains the original commit and closes the general consumer-shape residual found in deep review.

The descriptor-only formula covered persistent router states and three pairwise compare planes, but `route()` also returns complete diagnostics and routes arbitrary mixed-dtype consumer PyTrees through gathered tails, full-width candidates, and result arrays. The corrected static gate includes source/result state, proposed descriptors, compare planes, and exact diagnostic payloads before descriptor work. A second preflight after static consumer layout adds exact dtype-aware source/candidate/result and gathered/carried-tail bytes before comparisons or routing allocations.

Coverage derives the adjacent descriptor-only last-fit/first-overflow boundary, proves consumer bytes independently cross the gate without allocating a huge array, verifies exact legal mixed-shape accounting, retains persistent-first ordering, and runs the existing hostile config/axis/schema/JIT suite.

Verification:
- complete feature-router + focused panel: 47 passed
- Ruff changed files: clean
- strict mypy source: clean

No benchmark run, output artifact, evidence promotion, or registered-source claim.

Closes #1412.