### PR TITLE
fix(core): preflight compositional update working sets

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -150,6 +150,27 @@ def _compositional_state_nbytes(
     )
 
 
+def _compositional_update_working_set_bytes(
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    generator_resource_contexts: int,
+) -> int:
+    """Source persist, proposed persist, and returned non-state result bytes."""
+    persist_bytes = _compositional_state_nbytes(
+        n_features,
+        n_tasks,
+        candidate_count,
+        generator_resource_contexts,
+    )
+    # predictions/errors, metrics, two slot ids, applied flag, plus the
+    # published curation-trace banks that ride with one update result.
+    result_extras = (
+        227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    )
+    return 2 * persist_bytes + result_extras
+
+
 def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) -> None:
     annotations = get_type_hints(owner.__init__)
     for name, parameter in inspect.signature(owner).parameters.items():
@@ -1822,6 +1843,16 @@ class CompositionalFeatureLearner:
                     scalars=signed_scalars,
                     nbytes=4 * signed_scalars,
                 )
+
+        if _compositional_update_working_set_bytes(
+            self._n_features,
+            self._n_tasks,
+            self._candidate_count,
+            self._generator_resource_contexts,
+        ) > _INT32_MAX:
+            raise ValueError(
+                "compositional feature update working set byte count must fit signed int32"
+            )
 
         n_features = self._n_features
 

--- a/tests/test_compositional_features_update_working_set.py
+++ b/tests/test_compositional_features_update_working_set.py
@@ -1,0 +1,88 @@
+"""Complete update working-set preflight for compositional features."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.compositional_features import CompositionalFeatureLearner
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_LAST_LEGAL_CONSTRUCTOR = (_INT32_MAX - 80) // 68
+_FIRST_WORKING_SET_OVERFLOW = 12_859_182
+
+
+def _persist_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    return (
+        20
+        + 48 * generator_resource_contexts
+        + 56 * n_features
+        + 12 * n_tasks
+        + 68 * candidate_count
+        + 12 * n_features * n_tasks
+        + 12 * n_tasks * candidate_count
+        + 4 * n_features * candidate_count
+    )
+
+
+def _update_working_set_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    extras = 227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    return 2 * _persist_bytes(
+        n_features, n_tasks, candidate_count, generator_resource_contexts
+    ) + extras
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_compositional_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    learner = CompositionalFeatureLearner(_FIRST_WORKING_SET_OVERFLOW, 1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(1, jr.key(0))
+
+
+def test_compositional_last_legal_constructor_still_constructs() -> None:
+    persist = _persist_bytes(_LAST_LEGAL_CONSTRUCTOR)
+    assert persist <= _INT32_MAX
+    assert persist == 2_147_483_600
+    assert _update_working_set_bytes(_LAST_LEGAL_CONSTRUCTOR) > _INT32_MAX
+    CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR, 1)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR + 1, 1)
+
+
+def test_legal_compositional_init_and_update_identity_is_unchanged() -> None:
+    learner = CompositionalFeatureLearner(4, 1)
+    state = learner.init(1, jr.key(0))
+    result = learner.update(
+        state,
+        jnp.zeros((1,), dtype=jnp.float32),
+        jnp.zeros((1,), dtype=jnp.float32),
+    )
+    assert state.ops.shape == (4,)
+    assert result.predictions.shape == (1,)
+    assert _persist_bytes(4) <= _INT32_MAX
+    assert _update_working_set_bytes(4) <= _INT32_MAX


### PR DESCRIPTION
Closes #1416.

## What changed

Compositional-feature `init()` now preflights the simultaneous update working set after the existing persistent-byte constructor check, before any state allocation.

On origin/main `bf17149`, last-legal `n_features=(_INT32_MAX-80)//68` still constructs. Persist `2147483600` fits. Source + proposed persist plus returned-result extras (`227 + 31*n_features + 8*n_tasks + 32*candidate_count`) overflow at `12_859_182` (exact last-fit `12_859_181`). Persistent constructor overflow still fires first at last-legal+1. Legal 4-wide init/update and recursive `init(30_000)` are unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1409` / `#1413`. `#1414` still owns RTAC. `#1415` still owns feature-bank routing. `#1411` still owns Horde. `#1410` still owns model-replay. `#1407` still owns FTL. `#1383` still owns IA.

## Scope

- `alberta_framework/core/compositional_features.py`
- `tests/test_compositional_features_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `compositional_features.py`.

## Verification

Exact candidate head: `09891a44f7155b9f05abf55118b723c3da38109c`
Base: `bf17149`

- Red on base: last-legal persist constructor succeeds; `12_859_182` persist fits; `init` would allocate before the working-set gate; int32 wrap stores `INT32_MIN`
- Focused pytest plus existing compositional panels: 91 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_compositional_features_update_working_set.py tests/test_compositional_features.py tests/test_compositional_feature_scalar_residuals.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: last-legal persist constructor still succeeds; persist `persistent state bytes` still fires first at last-legal+1; legal 4-wide init/update still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:09891a44f7155b9f05abf55118b723c3da38109c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
