### PR TITLE
fix(evaluation): record non-finite acceptance evidence instead of crashing

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -99,11 +99,11 @@ def _require_exact_str(value: Any, path: str) -> str:
 
 def _require_sha256(value: Any, path: str) -> str:
     string = _require_exact_str(value, path)
-    if len(string) != 64 or not all(ch in "0123456789abcdef" for ch in string.lower()):
+    if len(string) != 64 or not all(ch in "0123456789abcdef" for ch in string):
         raise ForagerMatchedCandidateUniverseError(
             f"{path} must be a 64-character lowercase hexadecimal SHA-256 digest"
         )
-    return string.lower()
+    return string
 
 
 def _require_seed_identities(values: object, *, name: str) -> tuple[int, ...]:

--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -267,7 +267,8 @@ class PreparedCandidate:
             "alberta_single_seed_v1",
         ):
             raise ForagerMatchedExecutorError(
-                "invocation_style must be 'module_entrypoint' or 'inline_command'"
+                "invocation_style must be 'official_foragax_continuing_main_v4', "
+                "'official_foragax_ppo_frozen_updates_v1', or 'alberta_single_seed_v1'"
             )
         if self.rng_isolation_patch_sha256 is not None:
             _sha256(self.rng_isolation_patch_sha256, "rng_isolation_patch_sha256")

--- a/alberta_framework/evaluation/_measurement_validation.py
+++ b/alberta_framework/evaluation/_measurement_validation.py
@@ -6,6 +6,18 @@ import math
 from typing import cast
 
 
+def real_number(name: str, value: object) -> float:
+    """Return a builtin real float, finite or not, without accepting facade identities.
+
+    Acceptance records deliberately represent non-finite observed values as
+    recorded rejections (``passed=False``); only the host type is gated here.
+    """
+
+    if type(value) not in (int, float):
+        raise ValueError(f"{name} must be a real number")
+    return float(cast("int | float", value))
+
+
 def finite_real(name: str, value: object) -> float:
     """Return a finite builtin float without accepting facade identities."""
 

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -58,6 +58,7 @@ from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.evaluation._measurement_validation import (
     finite_real,
     nonnegative_finite_real,
+    real_number,
     validate_interval_bounds,
 )
 from alberta_framework.streams.closed_loop import (
@@ -482,7 +483,7 @@ class IAAcceptanceEvidence:
             raise ValueError("scope must be 'primary' or 'secondary'")
         if type(self.passed) is not bool:
             raise ValueError("passed must be a boolean")
-        object.__setattr__(self, "actual", finite_real("actual", self.actual))
+        object.__setattr__(self, "actual", real_number("actual", self.actual))
         if type(self.comparator) is not str or not self.comparator:
             raise ValueError("comparator must be a non-empty string")
         object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -49,6 +49,7 @@ from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.evaluation._measurement_validation import (
     finite_real,
     nonnegative_finite_real,
+    real_number,
     validate_interval_bounds,
 )
 from alberta_framework.streams.recurring_multiagent import (
@@ -454,7 +455,7 @@ class AcceptanceEvidence:
             raise ValueError("name must be a non-empty string")
         if type(self.passed) is not bool:
             raise ValueError("passed must be a boolean")
-        object.__setattr__(self, "actual", finite_real("actual", self.actual))
+        object.__setattr__(self, "actual", real_number("actual", self.actual))
         if type(self.comparator) is not str or not self.comparator:
             raise ValueError("comparator must be a non-empty string")
         object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))

--- a/tests/test_acceptance_evidence_hostile_validation.py
+++ b/tests/test_acceptance_evidence_hostile_validation.py
@@ -97,9 +97,6 @@ def test_acceptance_evidence_rejects_non_boolean_passed(invalid_passed: object) 
 @pytest.mark.parametrize(
     "invalid_actual",
     [
-        float("nan"),
-        float("inf"),
-        float("-inf"),
         True,
         False,
         "0.5",
@@ -108,7 +105,7 @@ def test_acceptance_evidence_rejects_non_boolean_passed(invalid_passed: object) 
     ],
 )
 def test_acceptance_evidence_rejects_invalid_actual(invalid_actual: object) -> None:
-    with pytest.raises(ValueError, match="actual must be a finite real number"):
+    with pytest.raises(ValueError, match="actual must be a real number"):
         AcceptanceEvidence(
             name="check",
             passed=True,
@@ -223,9 +220,6 @@ def test_ia_acceptance_evidence_rejects_invalid_scope(invalid_scope: object) -> 
 @pytest.mark.parametrize(
     "invalid_actual",
     [
-        float("nan"),
-        float("inf"),
-        float("-inf"),
         True,
         False,
         "0.5",
@@ -234,7 +228,7 @@ def test_ia_acceptance_evidence_rejects_invalid_scope(invalid_scope: object) -> 
     ],
 )
 def test_ia_acceptance_evidence_rejects_invalid_actual(invalid_actual: object) -> None:
-    with pytest.raises(ValueError, match="actual must be a finite real number"):
+    with pytest.raises(ValueError, match="actual must be a real number"):
         IAAcceptanceEvidence(
             name="check",
             scope="primary",
@@ -299,3 +293,46 @@ def test_ia_acceptance_result_validation() -> None:
             secondary_passed=True,
             checks=[evidence],  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.parametrize("nonfinite_actual", [float("nan"), float("inf"), float("-inf")])
+def test_acceptance_evidence_records_nonfinite_actual(nonfinite_actual: float) -> None:
+    """Non-finite observed values are recorded rejections, never construction crashes."""
+    evidence = AcceptanceEvidence(
+        name="mean_recurrence_recovery_steps",
+        passed=False,
+        actual=nonfinite_actual,
+        comparator="<=",
+        threshold=1.0,
+        detail="non-finite evidence fails the comparison without a skipped state",
+    )
+    assert evidence.passed is False
+    assert evidence.actual != evidence.actual or abs(evidence.actual) == float("inf")
+
+
+@pytest.mark.parametrize("nonfinite_actual", [float("nan"), float("inf"), float("-inf")])
+def test_ia_acceptance_evidence_records_nonfinite_actual(nonfinite_actual: float) -> None:
+    evidence = IAAcceptanceEvidence(
+        name="check",
+        scope="primary",
+        passed=False,
+        actual=nonfinite_actual,
+        comparator=">=",
+        threshold=0.0,
+        detail="recorded rejection",
+    )
+    assert evidence.passed is False
+
+
+def test_minimum_check_records_failed_comparison_for_nonfinite() -> None:
+    """The evaluator's documented contract: no skipped or 'not evaluated' state."""
+    from alberta_framework.evaluation.continual_multiagent import (
+        _maximum_check,
+        _minimum_check,
+    )
+
+    for value in (float("nan"), float("inf"), float("-inf")):
+        low = _minimum_check("check", value, 1.0, "detail")
+        high = _maximum_check("check", value, 1.0, "detail")
+        assert low.passed is False
+        assert high.passed is False


### PR DESCRIPTION
Post-sweep repair of three residual defects that landed during the mass PR triage:

1. **#1316 regression (real bug):** `AcceptanceEvidence`/`IAAcceptanceEvidence` gained a `finite_real` gate on `actual`, but the evaluators' documented contract is that missing/non-finite evidence *fails the relevant comparison* — there is no skipped or 'not evaluated' acceptance state. `_minimum_check`/`_maximum_check` deliberately construct records with non-finite `actual` and `passed=False` (`mean_recurrence_recovery_steps` is `float('inf')` by construction when no recurrence recovers), so the gate turned a designed recorded rejection into an evaluator crash — reproduced on main before this fix. New `real_number` validator keeps the exact host-type gate (bool/str/facade rejection unchanged) but permits non-finite for `actual` only; thresholds stay `finite_real`. Tests updated plus new contract tests for the recorded-rejection path.
2. **#1329 residue:** the `invocation_style` rejection message named `'module_entrypoint' or 'inline_command'` — literals that exist nowhere in this codebase. It now names the three real styles.
3. **#1321 residue:** candidate-universe `_require_sha256` silently lowercased mixed-case digests via `object.__setattr__`; it now rejects non-lowercase input per the repo-wide fail-closed convention.

Note: `continual_ia.py`/`continual_multiagent.py` are registered evidence sources whose bytes already drifted from the pinned artifacts before this sweep (registry exit 2 is the long-standing documented state since the July campaign), so this edit does not change registry status.

Verification: 53 acceptance-evidence tests, 35 multiagent/executor/candidate-universe tests pass; ruff clean; mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)