### PR TITLE
fix(core): preflight SARSA update working sets

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -213,12 +213,17 @@ def _preflight_sarsa_direct_state(
     # last_observation, last_action, epsilon, step_count, and the two-word
     # Threefry key are all four-byte public-state leaves.
     aggregate_scalars = horde_direct_scalars + feature_dim + 5
+    persist_bytes = 4 * aggregate_scalars
     for name, value in (
         ("aggregate_direct_state_scalars", aggregate_scalars),
-        ("aggregate_direct_state_bytes", 4 * aggregate_scalars),
+        ("aggregate_direct_state_bytes", persist_bytes),
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived SARSA {name} must be at most {_INT32_MAX}")
+    # Source persist, proposed persist, and returned action/Q/td/reward extras.
+    update_working_set_bytes = 2 * persist_bytes + 12 + 4 * n_heads
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError("SARSA update working set byte count must fit signed int32")
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_sarsa_update_working_set.py
+++ b/tests/test_sarsa_update_working_set.py
@@ -1,0 +1,71 @@
+"""Complete update working-set preflight for on-policy SARSA."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.sarsa import SARSAAgent, SARSAConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_FIRST_PERSIST_OVERFLOW = ((2**31 - 1) // 4 - 12) // 5 + 1
+_FIRST_WORKING_SET_OVERFLOW = 53_687_089
+
+
+def _linear_persist_bytes(feature_dim: int, n_heads: int = 2) -> int:
+    return 4 * (5 * feature_dim + 12)
+
+
+def _linear_working_set_bytes(feature_dim: int, n_heads: int = 2) -> int:
+    return 2 * _linear_persist_bytes(feature_dim, n_heads) + 12 + 4 * n_heads
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_sarsa_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _linear_persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(feature_dim=_FIRST_WORKING_SET_OVERFLOW, key=jr.key(0))
+
+
+def test_sarsa_persistent_aggregate_bound_still_fires_first() -> None:
+    assert _linear_persist_bytes(_FIRST_PERSIST_OVERFLOW) > _INT32_MAX
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    with pytest.raises(ValueError, match="aggregate_direct_state_bytes"):
+        agent.init(feature_dim=_FIRST_PERSIST_OVERFLOW, key=jr.key(0))
+
+
+def test_legal_sarsa_init_and_update_identity_is_unchanged() -> None:
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    state = agent.init(feature_dim=4, key=jr.key(42))
+    obs = jnp.ones(4, dtype=jnp.float32)
+    action, new_key = agent.select_action(state, obs)
+    state = state.replace(last_action=action, last_observation=obs, rng_key=new_key)
+    next_obs = jnp.ones(4, dtype=jnp.float32) * 2.0
+    next_action, new_key = agent.select_action(state, next_obs)
+    state = state.replace(rng_key=new_key)
+    result = agent.update(
+        state,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=next_obs,
+        terminated=jnp.array(0.0, dtype=jnp.float32),
+        next_action=next_action,
+    )
+    assert result.q_values.shape == (2,)
+    assert result.action.shape == ()
+    assert _linear_persist_bytes(4) <= _INT32_MAX
+    assert _linear_working_set_bytes(4) <= _INT32_MAX


### PR DESCRIPTION
Closes #1419.

## What changed

SARSA now preflights the simultaneous update working set after the existing persistent-aggregate check, before Horde allocation.

On origin/main `bf17149`, linear `feature_dim=53_687_089` keeps persist nameable. Source + proposed persist plus returned extras (`12 + 4*n_heads`) overflow (exact last-fit `53_687_088`). Persistent `aggregate_direct_state_bytes` still fires first at `107374180`. Legal 2-action linear init/update is unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1409` / `#1413`. `#1417` still owns compositional features. `#1415` still owns feature-bank routing. `#1414` still owns RTAC.

## Scope

- `alberta_framework/core/sarsa.py`
- `tests/test_sarsa_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `sarsa.py`.

## Verification

Exact candidate head: `c35ac3d05a89195dc971a2c56ada6d1c00092a73`
Base: `bf17149`

- Red on base: `53_687_089` persist fits; `init` would reach Horde allocation; existing persist overflow still matches `aggregate_direct_state_bytes`; int32 wrap stores `INT32_MIN`
- Focused pytest plus the existing SARSA file: 142 passed, 2 skipped
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_sarsa_update_working_set.py tests/test_sarsa.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist still fits at `53_687_089`; persist `aggregate_direct_state_bytes` still fires first at `107374180`; legal 2-action linear init/update still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c35ac3d05a89195dc971a2c56ada6d1c00092a73 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
