### PR TITLE
fix(core): complete compositional update working-set preflight

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -150,6 +150,27 @@ def _compositional_state_nbytes(
     )
 
 
+def _compositional_update_working_set_bytes(
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    generator_resource_contexts: int,
+) -> int:
+    """Source persist, proposed persist, and returned non-state result bytes."""
+    persist_bytes = _compositional_state_nbytes(
+        n_features,
+        n_tasks,
+        candidate_count,
+        generator_resource_contexts,
+    )
+    # predictions/errors, metrics, two slot ids, applied flag, plus the
+    # published curation-trace banks that ride with one update result.
+    result_extras = (
+        227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    )
+    return 2 * persist_bytes + result_extras
+
+
 def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) -> None:
     annotations = get_type_hints(owner.__init__)
     for name, parameter in inspect.signature(owner).parameters.items():
@@ -1822,6 +1843,16 @@ class CompositionalFeatureLearner:
                     scalars=signed_scalars,
                     nbytes=4 * signed_scalars,
                 )
+
+        if _compositional_update_working_set_bytes(
+            self._n_features,
+            self._n_tasks,
+            self._candidate_count,
+            self._generator_resource_contexts,
+        ) > _INT32_MAX:
+            raise ValueError(
+                "compositional feature update working set byte count must fit signed int32"
+            )
 
         n_features = self._n_features
 

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -163,10 +163,12 @@ def _compositional_update_working_set_bytes(
         candidate_count,
         generator_resource_contexts,
     )
+    # JIT materializes the source and proposed state's Python birth/uptime
+    # fields as two float32 scalars each.  The remaining bytes are
     # predictions/errors, metrics, two slot ids, applied flag, plus the
     # published curation-trace banks that ride with one update result.
     result_extras = (
-        227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+        243 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
     )
     return 2 * persist_bytes + result_extras
 

--- a/tests/test_compositional_features_update_working_set.py
+++ b/tests/test_compositional_features_update_working_set.py
@@ -1,0 +1,88 @@
+"""Complete update working-set preflight for compositional features."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.compositional_features import CompositionalFeatureLearner
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_LAST_LEGAL_CONSTRUCTOR = (_INT32_MAX - 80) // 68
+_FIRST_WORKING_SET_OVERFLOW = 12_859_182
+
+
+def _persist_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    return (
+        20
+        + 48 * generator_resource_contexts
+        + 56 * n_features
+        + 12 * n_tasks
+        + 68 * candidate_count
+        + 12 * n_features * n_tasks
+        + 12 * n_tasks * candidate_count
+        + 4 * n_features * candidate_count
+    )
+
+
+def _update_working_set_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    extras = 227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    return 2 * _persist_bytes(
+        n_features, n_tasks, candidate_count, generator_resource_contexts
+    ) + extras
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_compositional_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    learner = CompositionalFeatureLearner(_FIRST_WORKING_SET_OVERFLOW, 1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(1, jr.key(0))
+
+
+def test_compositional_last_legal_constructor_still_constructs() -> None:
+    persist = _persist_bytes(_LAST_LEGAL_CONSTRUCTOR)
+    assert persist <= _INT32_MAX
+    assert persist == 2_147_483_600
+    assert _update_working_set_bytes(_LAST_LEGAL_CONSTRUCTOR) > _INT32_MAX
+    CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR, 1)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR + 1, 1)
+
+
+def test_legal_compositional_init_and_update_identity_is_unchanged() -> None:
+    learner = CompositionalFeatureLearner(4, 1)
+    state = learner.init(1, jr.key(0))
+    result = learner.update(
+        state,
+        jnp.zeros((1,), dtype=jnp.float32),
+        jnp.zeros((1,), dtype=jnp.float32),
+    )
+    assert state.ops.shape == (4,)
+    assert result.predictions.shape == (1,)
+    assert _persist_bytes(4) <= _INT32_MAX
+    assert _update_working_set_bytes(4) <= _INT32_MAX

--- a/tests/test_compositional_features_update_working_set.py
+++ b/tests/test_compositional_features_update_working_set.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax import Array
 
-from alberta_framework.core.compositional_features import CompositionalFeatureLearner
+from alberta_framework.core.compositional_features import (
+    CompositionalFeatureLearner,
+    _compositional_update_working_set_bytes,
+)
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
@@ -38,10 +43,18 @@ def _update_working_set_bytes(
     candidate_count: int = 0,
     generator_resource_contexts: int = 1,
 ) -> int:
-    extras = 227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    extras = 243 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
     return 2 * _persist_bytes(
         n_features, n_tasks, candidate_count, generator_resource_contexts
     ) + extras
+
+
+def _tree_array_nbytes(tree: object) -> int:
+    return sum(
+        leaf.size * leaf.dtype.itemsize
+        for leaf in jax.tree.leaves(tree)
+        if isinstance(leaf, Array)
+    )
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -59,6 +72,8 @@ def test_compositional_persist_fits_while_update_working_set_does_not() -> None:
     assert persist <= _INT32_MAX
     assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
     assert working > _INT32_MAX
+    assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) == 2_147_483_638
+    assert working == 2_147_483_805
     learner = CompositionalFeatureLearner(_FIRST_WORKING_SET_OVERFLOW, 1)
     with pytest.raises(ValueError, match="update working set byte count"):
         learner.init(1, jr.key(0))
@@ -86,3 +101,47 @@ def test_legal_compositional_init_and_update_identity_is_unchanged() -> None:
     assert result.predictions.shape == (1,)
     assert _persist_bytes(4) <= _INT32_MAX
     assert _update_working_set_bytes(4) <= _INT32_MAX
+
+
+@pytest.mark.parametrize(
+    ("n_features", "n_tasks", "candidate_count", "resource_contexts", "feature_dim"),
+    [(4, 1, 0, 1, 1), (7, 3, 2, 4, 2)],
+)
+def test_update_working_set_formula_matches_every_returned_array(
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    resource_contexts: int,
+    feature_dim: int,
+) -> None:
+    learner = CompositionalFeatureLearner(
+        n_features,
+        n_tasks,
+        candidate_count=candidate_count,
+        generator_resource_contexts=resource_contexts,
+    )
+    state = learner.init(feature_dim, jr.key(0))
+    first_result = learner.update(
+        state,
+        jnp.zeros((feature_dim,), dtype=jnp.float32),
+        jnp.zeros((n_tasks,), dtype=jnp.float32),
+    )
+    source_state = first_result.state
+    result = learner.update(
+        source_state,
+        jnp.zeros((feature_dim,), dtype=jnp.float32),
+        jnp.zeros((n_tasks,), dtype=jnp.float32),
+    )
+    expected = _update_working_set_bytes(
+        n_features,
+        n_tasks,
+        candidate_count,
+        resource_contexts,
+    )
+    assert expected == _compositional_update_working_set_bytes(
+        n_features,
+        n_tasks,
+        candidate_count,
+        resource_contexts,
+    )
+    assert expected == _tree_array_nbytes(source_state) + _tree_array_nbytes(result)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1417. Closes #1416.

Preserves ss251/Cursor commit `09891a44` and its pre-allocation gate. Deep array-level audit found that JIT materializes `birth_timestamp` and `uptime_s` as two float32 arrays: the original formula undercounted the first update by 8 bytes and steady-state source plus proposed states by 16 bytes. This corrects the fixed term from 227 to 243 and adds direct pytree byte-identity tests across general task/candidate/resource-context shapes, plus exact adjacent-boundary identities.

Verification:
- focused new tests: 6 passed
- complete prior compositional panel: 91 non-new tests passed during audit
- Ruff: clean
- mypy changed source: clean

No benchmark or `outputs/**` changes.