### PR TITLE
fix(core): complete optimizer transaction resource envelopes

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1190,9 +1190,12 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
             f"{path}: suite_version mismatch (expected {MICRO_GAUSS_SUITE_VERSION!r}, "
             f"got {payload.get('suite_version')!r})"
         )
-    if payload.get("arm_name") not in MICRO_ARM_REGISTRY:
-        raise ValueError(f"{path}: unknown arm {payload.get('arm_name')!r}")
-    arm_spec = MICRO_ARM_REGISTRY[payload["arm_name"]]
+    arm_name = payload.get("arm_name")
+    if type(arm_name) is not str:
+        raise ValueError(f"{path}: arm_name must be an exact string")
+    if arm_name not in MICRO_ARM_REGISTRY:
+        raise ValueError(f"{path}: unknown arm {arm_name!r}")
+    arm_spec = MICRO_ARM_REGISTRY[arm_name]
     if not isinstance(payload.get("mechanism"), str) or not payload["mechanism"]:
         raise ValueError(f"{path}: mechanism must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):

--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -130,10 +130,10 @@ def _preflight_adam_resources(n: int) -> None:
         n,
         persistent_vectors=2,
         persistent_scalars=7,
-        # Live during update: observation, g, m, v, new_m, new_v, m_hat,
-        # v_hat, and weight_delta. Remaining scalars cover the bias path
-        # and transaction flags.
-        update_vectors=9,
+        # Complete named logical envelope: source moments, observation and
+        # gradient, proposed moments, bias-corrected moments, weight delta,
+        # checked moments, selected result moments, and neutral output.
+        update_vectors=14,
         update_scalars=8,
     )
 
@@ -144,7 +144,9 @@ def _preflight_adam_param_resources(n: int) -> None:
         n,
         persistent_vectors=2,
         persistent_scalars=5,
-        update_vectors=9,
+        # The parameter path can additionally retain the parameter/decay
+        # input while producing its neutral selected output.
+        update_vectors=15,
         update_scalars=8,
     )
 
@@ -157,10 +159,10 @@ def _preflight_adagain_resources(n: int) -> None:
         n,
         persistent_vectors=2,
         persistent_scalars=4,
-        # Live during update: observation, gradient, step_sizes,
-        # gradient_trace, gain_correlation, meta_delta, new_step_sizes,
-        # weight_delta, and new_gradient_trace.
-        update_vectors=9,
+        # Source banks, observation/gradient, correlation/meta buffers,
+        # proposed banks and delta, checked trace, selected banks, and the
+        # neutral returned delta.
+        update_vectors=13,
         update_scalars=8,
     )
 
@@ -171,7 +173,7 @@ def _preflight_rmsprop_resources(n: int) -> None:
         n,
         persistent_vectors=1,
         persistent_scalars=4,
-        update_vectors=6,
+        update_vectors=8,
         update_scalars=6,
     )
 
@@ -182,7 +184,7 @@ def _preflight_nadaline_resources(n: int) -> None:
         n,
         persistent_vectors=1,
         persistent_scalars=3,
-        update_vectors=6,
+        update_vectors=9,
         update_scalars=6,
     )
 
@@ -920,7 +922,7 @@ class RMSprop(Optimizer[Any]):
             _require_shape_scalars(shape),
             persistent_vectors=1,
             persistent_scalars=3,
-            update_vectors=6,
+            update_vectors=8,
             update_scalars=6,
         )
         return RMSpropParamState(

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -495,7 +495,7 @@ class OffPolicyTDLinearLearner:
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_feature_dim(
-            feature_dim, vectors=2, fixed_scalars=3, update_vectors=8
+            feature_dim, vectors=2, fixed_scalars=3, update_vectors=9
         )
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -711,7 +711,7 @@ class ETDLinearLearner:
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_feature_dim(
-            feature_dim, vectors=2, fixed_scalars=5, update_vectors=8
+            feature_dim, vectors=2, fixed_scalars=5, update_vectors=9
         )
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -944,7 +944,7 @@ class GradientTDLinearLearner:
             feature_dim,
             vectors=3,
             fixed_scalars=1,
-            update_vectors=9,
+            update_vectors=15,
             augmented=True,
         )
         augmented_dim = feature_dim + 1

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -775,10 +775,11 @@ class IDBD(Optimizer[IDBDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("IDBD state", 2 * feature_dim + 3)
-        # Live during linear update: observation, traces, log_step_sizes,
-        # correlation, meta_delta, new_log, new_alphas, weight_delta, new_traces.
+        # Complete named logical envelope for both linear and parameter
+        # paths, including checked source banks, selected result banks, and
+        # the neutral returned step/delta.
         _require_float32_update_working_set(
-            "IDBD update working set", 9 * feature_dim + 8
+            "IDBD update working set", 18 * feature_dim + 8
         )
         return IDBDState(
             log_step_sizes=jnp.full(
@@ -802,7 +803,7 @@ class IDBD(Optimizer[IDBDState]):
         shape = _require_shape(shape)
         n = _shape_size(shape)
         _require_float32_state("IDBD parameter state", 2 * n + 1)
-        _require_float32_update_working_set("IDBD update working set", 9 * n + 8)
+        _require_float32_update_working_set("IDBD update working set", 18 * n + 8)
         return IDBDParamState(
             log_step_sizes=jnp.full(shape, jnp.log(self._initial_step_size), dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1125,11 +1126,11 @@ class Autostep(Optimizer[AutostepState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("Autostep state", 3 * feature_dim + 5)
-        # Live during Table-1 update: observation, x^2, step_sizes, traces,
-        # normalizers, meta_gradient, v_update, new_normalizers, new_step_sizes,
-        # and weight_delta.
+        # Table-1's parameter path retains the source banks plus its squared
+        # feature, meta, normalizer, normalized-step, trace, checked-source,
+        # selected-result, and neutral-output buffers.
         _require_float32_update_working_set(
-            "Autostep update working set", 10 * feature_dim + 8
+            "Autostep update working set", 30 * feature_dim + 8
         )
         return AutostepState(
             step_sizes=jnp.full(feature_dim, self._initial_step_size, dtype=jnp.float32),
@@ -1154,7 +1155,7 @@ class Autostep(Optimizer[AutostepState]):
         shape = _require_shape(shape)
         n = _shape_size(shape)
         _require_float32_state("Autostep parameter state", 3 * n + 2)
-        _require_float32_update_working_set("Autostep update working set", 10 * n + 8)
+        _require_float32_update_working_set("Autostep update working set", 30 * n + 8)
         return AutostepParamState(
             step_sizes=jnp.full(shape, self._initial_step_size, dtype=jnp.float32),
             traces=jnp.zeros(shape, dtype=jnp.float32),
@@ -1521,7 +1522,7 @@ class AutostepGTDLambda(Optimizer[AutostepGTDLambdaState]):
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutostepGTDLambda state", 4 * feature_dim + 7)
         _require_float32_update_working_set(
-            "AutostepGTDLambda update working set", 11 * feature_dim + 8
+            "AutostepGTDLambda update working set", 40 * feature_dim + 8
         )
         base_state = self._base.init(feature_dim)
         return AutostepGTDLambdaState(
@@ -1668,7 +1669,7 @@ class ObGD(Optimizer[ObGDState]):
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("ObGD state", feature_dim + 5)
-        _require_float32_update_working_set("ObGD update working set", 5 * feature_dim + 8)
+        _require_float32_update_working_set("ObGD update working set", 12 * feature_dim + 8)
         return ObGDState(
             step_size=jnp.array(self._step_size, dtype=jnp.float32),
             kappa=jnp.array(self._kappa, dtype=jnp.float32),
@@ -1899,7 +1900,7 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("TDIDBD state", 3 * feature_dim + 5)
         _require_float32_update_working_set(
-            "TDIDBD update working set", 10 * feature_dim + 8
+            "TDIDBD update working set", 22 * feature_dim + 8
         )
         return TDIDBDState(
             log_step_sizes=jnp.full(
@@ -2116,7 +2117,7 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 7)
         _require_float32_update_working_set(
-            "AutoTDIDBD update working set", 11 * feature_dim + 8
+            "AutoTDIDBD update working set", 32 * feature_dim + 8
         )
         return AutoTDIDBDState(
             log_step_sizes=jnp.full(

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -66,9 +66,13 @@ def _preflight_state_resources(feature_dim: int) -> None:
 
 
 def _preflight_update_working_set(feature_dim: int) -> None:
-    # Covariance, proposed covariance, and the outer-product rank-one term,
-    # plus the live feature-width vectors (x, weights, Px, gain, next weights).
-    update_scalars = 3 * feature_dim * feature_dim + 5 * feature_dim + 8
+    # The update retains the source covariance, the rank-one outer product,
+    # the proposed covariance, and the transaction-selected covariance.  The
+    # width terms are x, source weights, Px, gain, proposed weights, selected
+    # weights, and the neutralized gain returned to the caller.  In
+    # particular, the selected result is a distinct logical buffer even when
+    # an execution backend can sometimes donate/alias it.
+    update_scalars = 4 * feature_dim * feature_dim + 7 * feature_dim + 8
     if 4 * update_scalars > _INT32_MAX:
         raise ValueError(
             "reward-model update working set byte count must fit signed int32"

--- a/tests/test_baseline_optimizers_complete_aggregate.py
+++ b/tests/test_baseline_optimizers_complete_aggregate.py
@@ -11,7 +11,7 @@ from alberta_framework.core.baseline_optimizers import NADALINE, AdaGain, Adam, 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _ONE_BANK_FITS = _INT32_MAX // 4
-_WORKING_SET_OVERFLOW = 100_000_000
+_WORKING_SET_OVERFLOW = 50_000_000
 
 
 class _IntSubclass(int):
@@ -53,9 +53,11 @@ def test_adagain_one_gain_bank_fits_while_persistent_aggregate_does_not() -> Non
 def test_adam_rejects_simultaneous_update_working_set() -> None:
     one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
     persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 7)
-    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    contributor_update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    update_bytes = 4 * (14 * _WORKING_SET_OVERFLOW + 8)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         Adam().init(_WORKING_SET_OVERFLOW)
@@ -64,9 +66,11 @@ def test_adam_rejects_simultaneous_update_working_set() -> None:
 def test_adagain_rejects_simultaneous_update_working_set() -> None:
     one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
     persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 4)
-    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    contributor_update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    update_bytes = 4 * (13 * _WORKING_SET_OVERFLOW + 8)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         AdaGain().init(_WORKING_SET_OVERFLOW)
@@ -100,10 +104,10 @@ def test_legal_adam_and_adagain_update_identity_is_unchanged() -> None:
 @pytest.mark.parametrize(
     ("factory", "vectors", "scalars", "label"),
     [
-        (Adam, 9, 8, "Adam"),
-        (AdaGain, 9, 8, "AdaGain"),
-        (RMSprop, 6, 6, "RMSprop"),
-        (NADALINE, 6, 6, "NADALINE"),
+        (Adam, 14, 8, "Adam"),
+        (AdaGain, 13, 8, "AdaGain"),
+        (RMSprop, 8, 6, "RMSprop"),
+        (NADALINE, 9, 6, "NADALINE"),
     ],
 )
 def test_every_linear_optimizer_rejects_first_overflowing_update_width(
@@ -155,8 +159,8 @@ def test_parameter_optimizer_shape_rejects_hostile_schema(
 @pytest.mark.parametrize(
     ("factory", "vectors", "scalars", "label"),
     [
-        (Adam, 9, 8, "Adam"),
-        (RMSprop, 6, 6, "RMSprop"),
+        (Adam, 15, 8, "Adam"),
+        (RMSprop, 8, 6, "RMSprop"),
     ],
 )
 def test_parameter_optimizer_rejects_derived_shape_working_set_before_allocation(

--- a/tests/test_micro_continual_hostile_validation.py
+++ b/tests/test_micro_continual_hostile_validation.py
@@ -2,13 +2,47 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.micro_continual import (
+    MICRO_ARM_REGISTRY,
+    MicroRunResult,
     MicroStream,
+    MicroStreamConfig,
     MicroTaskConfig,
+    load_micro_shard,
+    micro_shard_payload,
 )
+
+
+def test_micro_shard_rejects_unhashable_arm_name_as_validation_error(tmp_path: Path) -> None:
+    path = tmp_path / "shard.json"
+    config = MicroStreamConfig(n_regimes=1, regime_length=1, dim=10)
+    arm = next(iter(MICRO_ARM_REGISTRY.values()))
+    result = MicroRunResult(
+        family=config.family,
+        arm_name=arm.name,
+        mechanism=arm.mechanism,
+        hyperparameters=arm.hyperparameters,
+        seed=0,
+        hidden1=1,
+        hidden2=1,
+        stream_config=config,
+        per_regime_accuracy=np.asarray([0.5]),
+        per_regime_loss=np.asarray([0.5]),
+        per_regime_plasticity=np.asarray([0.5]),
+        overall_accuracy=0.5,
+        wall_clock_seconds=0.1,
+    )
+    payload = micro_shard_payload(result)
+    payload["arm_name"] = []
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="arm_name must be an exact string"):
+        load_micro_shard(path)
 
 
 def test_micro_task_config_rejects_invalid_inputs() -> None:

--- a/tests/test_off_policy_td_update_working_set.py
+++ b/tests/test_off_policy_td_update_working_set.py
@@ -14,7 +14,7 @@ from alberta_framework.core.off_policy_td import (
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
-_WORKING_SET_OVERFLOW = 100_000_000
+_WORKING_SET_OVERFLOW = 60_000_000
 
 
 class _IntSubclass(int):
@@ -38,9 +38,11 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
 def test_off_policy_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
     one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
     persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
-    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    contributor_update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 16)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         OffPolicyTDLinearLearner().init(_WORKING_SET_OVERFLOW)
@@ -49,21 +51,25 @@ def test_off_policy_td_one_bank_and_persistent_fit_while_update_working_set_does
 def test_etd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
     one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
     persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 5)
-    update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    contributor_update_bytes = 4 * (8 * _WORKING_SET_OVERFLOW + 16)
+    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 16)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         ETDLinearLearner().init(_WORKING_SET_OVERFLOW)
 
 
 def test_gradient_td_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
-    width = _WORKING_SET_OVERFLOW + 1
+    width = 40_000_001
     one_bank_bytes = 4 * width
     persistent_bytes = 4 * (3 * width + 1)
-    update_bytes = 4 * (9 * width + 16)
+    contributor_update_bytes = 4 * (9 * width + 16)
+    update_bytes = 4 * (15 * width + 16)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         GradientTDLinearLearner().init(_WORKING_SET_OVERFLOW)
@@ -114,9 +120,9 @@ def test_legal_off_policy_td_update_identity_is_unchanged() -> None:
 @pytest.mark.parametrize(
     ("factory", "vectors", "augmented"),
     [
-        (OffPolicyTDLinearLearner, 8, False),
-        (ETDLinearLearner, 8, False),
-        (GradientTDLinearLearner, 9, True),
+        (OffPolicyTDLinearLearner, 9, False),
+        (ETDLinearLearner, 9, False),
+        (GradientTDLinearLearner, 15, True),
     ],
 )
 def test_every_off_policy_learner_rejects_first_overflowing_update_width(

--- a/tests/test_optimizers_update_working_set.py
+++ b/tests/test_optimizers_update_working_set.py
@@ -17,7 +17,7 @@ from alberta_framework.core.optimizers import (
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
-_WORKING_SET_OVERFLOW = 100_000_000
+_WORKING_SET_OVERFLOW = 30_000_000
 
 
 class _IntSubclass(int):
@@ -39,22 +39,27 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
 
 
 def test_idbd_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
-    one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
-    persistent_bytes = 4 * (2 * _WORKING_SET_OVERFLOW + 3)
-    update_bytes = 4 * (9 * _WORKING_SET_OVERFLOW + 8)
+    width = 40_000_000
+    one_bank_bytes = 4 * width
+    persistent_bytes = 4 * (2 * width + 3)
+    contributor_update_bytes = 4 * (9 * width + 8)
+    update_bytes = 4 * (18 * width + 8)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
-        IDBD().init(_WORKING_SET_OVERFLOW)
+        IDBD().init(width)
 
 
 def test_autostep_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
     one_bank_bytes = 4 * _WORKING_SET_OVERFLOW
     persistent_bytes = 4 * (3 * _WORKING_SET_OVERFLOW + 5)
-    update_bytes = 4 * (10 * _WORKING_SET_OVERFLOW + 8)
+    contributor_update_bytes = 4 * (10 * _WORKING_SET_OVERFLOW + 8)
+    update_bytes = 4 * (30 * _WORKING_SET_OVERFLOW + 8)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         Autostep().init(_WORKING_SET_OVERFLOW)
@@ -95,12 +100,12 @@ def test_legal_idbd_and_autostep_update_identity_is_unchanged() -> None:
 @pytest.mark.parametrize(
     ("factory", "vectors", "label"),
     [
-        (IDBD, 9, "IDBD"),
-        (Autostep, 10, "Autostep"),
-        (AutostepGTDLambda, 11, "AutostepGTDLambda"),
-        (ObGD, 5, "ObGD"),
-        (TDIDBD, 10, "TDIDBD"),
-        (AutoTDIDBD, 11, "AutoTDIDBD"),
+        (IDBD, 18, "IDBD"),
+        (Autostep, 30, "Autostep"),
+        (AutostepGTDLambda, 40, "AutostepGTDLambda"),
+        (ObGD, 12, "ObGD"),
+        (TDIDBD, 22, "TDIDBD"),
+        (AutoTDIDBD, 32, "AutoTDIDBD"),
     ],
 )
 def test_every_vector_optimizer_rejects_first_overflowing_update_width(
@@ -164,7 +169,7 @@ def test_parameter_optimizer_shape_rejects_hostile_schema(
 
 @pytest.mark.parametrize(
     ("factory", "vectors", "label"),
-    [(IDBD, 9, "IDBD"), (Autostep, 10, "Autostep")],
+    [(IDBD, 18, "IDBD"), (Autostep, 30, "Autostep")],
 )
 def test_parameter_optimizer_rejects_derived_shape_working_set_before_allocation(
     factory: type[IDBD] | type[Autostep], vectors: int, label: str

--- a/tests/test_reward_model_update_working_set.py
+++ b/tests/test_reward_model_update_working_set.py
@@ -16,7 +16,7 @@ from alberta_framework.core.reward_model import (
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
-_WORKING_SET_OVERFLOW = 20_000
+_WORKING_SET_OVERFLOW = 12_000
 
 
 class _IntSubclass(int):
@@ -41,9 +41,11 @@ def test_rls_one_bank_and_persistent_fit_while_update_working_set_does_not() -> 
     dim = _WORKING_SET_OVERFLOW
     one_bank_bytes = 4 * (dim * dim)
     persistent_bytes = 4 * (dim * dim + dim + 2)
-    update_bytes = 4 * (3 * dim * dim + 5 * dim + 8)
+    contributor_update_bytes = 4 * (3 * dim * dim + 5 * dim + 8)
+    update_bytes = 4 * (4 * dim * dim + 7 * dim + 8)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_update_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     config = RLSRewardModelConfig(feature_dim=dim)
     assert config.feature_dim == dim
@@ -78,11 +80,11 @@ def test_legal_rls_update_identity_is_unchanged() -> None:
 
 def test_rls_exact_last_legal_update_width_and_first_overflow() -> None:
     scalar_limit = _INT32_MAX // 4
-    # 3*d^2 + 5*d + 8 <= scalar_limit.
-    last_legal = (math.isqrt(12 * scalar_limit - 71) - 5) // 6
-    assert 3 * last_legal * last_legal + 5 * last_legal + 8 <= scalar_limit
+    # 4*d^2 + 7*d + 8 <= scalar_limit.
+    last_legal = (math.isqrt(16 * scalar_limit - 79) - 7) // 8
+    assert 4 * last_legal * last_legal + 7 * last_legal + 8 <= scalar_limit
     first_overflowing = last_legal + 1
-    assert 3 * first_overflowing * first_overflowing + 5 * first_overflowing + 8 > scalar_limit
+    assert 4 * first_overflowing * first_overflowing + 7 * first_overflowing + 8 > scalar_limit
     _preflight_update_working_set(last_legal)
     with pytest.raises(ValueError, match="update working set byte count"):
         _preflight_update_working_set(first_overflowing)


### PR DESCRIPTION
## Summary
- count transaction-selected state and neutral output buffers in the optimizer, off-policy TD, and RLS resource preflights merged through #1397
- pin the revised exact signed-int32 boundaries and demonstrate cases the contributor formulas admitted despite the complete named logical envelope overflowing
- totalize the reconciled micro-shard arm lookup before hashing an untrusted JSON value

## Audit basis
#1383 correctly established that a transaction-selected result is a distinct logical buffer even when a backend may donate or alias storage. The #1397 aggregate did not apply that rule consistently: e.g. RLS counted source covariance, rank-one term, and proposed covariance, but omitted the selected covariance; optimizer envelopes omitted checked/selected banks and neutral outputs. This change makes those declarations conservative and backend-independent. It changes admission bounds only; legal update behavior is unchanged.

No pinned output artifact is modified and no evidence is promoted. These source edits can invalidate source-bound development receipts as designed.

## Verification
- 142 focused resource/trust tests passed
- 26 IA/clock/result-boundary tests passed
- 69 matched-validation hostile-input tests passed
- Ruff passed on every changed file
