### PR TITLE
fix(core): complete SARSA update working-set preflight

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -213,12 +213,17 @@ def _preflight_sarsa_direct_state(
     # last_observation, last_action, epsilon, step_count, and the two-word
     # Threefry key are all four-byte public-state leaves.
     aggregate_scalars = horde_direct_scalars + feature_dim + 5
+    persist_bytes = 4 * aggregate_scalars
     for name, value in (
         ("aggregate_direct_state_scalars", aggregate_scalars),
-        ("aggregate_direct_state_bytes", 4 * aggregate_scalars),
+        ("aggregate_direct_state_bytes", persist_bytes),
     ):
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived SARSA {name} must be at most {_INT32_MAX}")
+    # Source persist, proposed persist, and returned action/Q/td/reward extras.
+    update_working_set_bytes = 2 * persist_bytes + 12 + 4 * n_heads
+    if update_working_set_bytes > _INT32_MAX:
+        raise ValueError("SARSA update working set byte count must fit signed int32")
 
 
 @chex.dataclass(frozen=True)

--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -197,6 +197,7 @@ def _prediction_demon_from_config(config: object, *, index: int) -> GVFSpec:
 
 
 def _preflight_sarsa_direct_state(
+    n_actions: int,
     n_heads: int,
     hidden_sizes: tuple[int, ...],
     feature_dim: int,
@@ -221,7 +222,9 @@ def _preflight_sarsa_direct_state(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived SARSA {name} must be at most {_INT32_MAX}")
     # Source persist, proposed persist, and returned action/Q/td/reward extras.
-    update_working_set_bytes = 2 * persist_bytes + 12 + 4 * n_heads
+    # Prediction heads are persisted but update() returns Q values only for
+    # the control-action prefix.
+    update_working_set_bytes = 2 * persist_bytes + 12 + 4 * n_actions
     if update_working_set_bytes > _INT32_MAX:
         raise ValueError("SARSA update working set byte count must fit signed int32")
 
@@ -539,7 +542,12 @@ class SARSAAgent:
             _require_int32(f"hidden_sizes[{index}]", width, minimum=1)
             for index, width in enumerate(hidden_sizes)
         )
-        _preflight_sarsa_direct_state(total_heads, canonical_hidden, 1)
+        _preflight_sarsa_direct_state(
+            sarsa_config.n_actions,
+            total_heads,
+            canonical_hidden,
+            1,
+        )
 
         self._sarsa_config = sarsa_config
         self._hidden_sizes = canonical_hidden
@@ -732,6 +740,7 @@ class SARSAAgent:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _preflight_sarsa_direct_state(
+            self.n_actions,
             self._horde.n_demons,
             self._hidden_sizes,
             feature_dim,

--- a/tests/test_sarsa_update_working_set.py
+++ b/tests/test_sarsa_update_working_set.py
@@ -1,0 +1,71 @@
+"""Complete update working-set preflight for on-policy SARSA."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.sarsa import SARSAAgent, SARSAConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_FIRST_PERSIST_OVERFLOW = ((2**31 - 1) // 4 - 12) // 5 + 1
+_FIRST_WORKING_SET_OVERFLOW = 53_687_089
+
+
+def _linear_persist_bytes(feature_dim: int, n_heads: int = 2) -> int:
+    return 4 * (5 * feature_dim + 12)
+
+
+def _linear_working_set_bytes(feature_dim: int, n_heads: int = 2) -> int:
+    return 2 * _linear_persist_bytes(feature_dim, n_heads) + 12 + 4 * n_heads
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_sarsa_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _linear_persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(feature_dim=_FIRST_WORKING_SET_OVERFLOW, key=jr.key(0))
+
+
+def test_sarsa_persistent_aggregate_bound_still_fires_first() -> None:
+    assert _linear_persist_bytes(_FIRST_PERSIST_OVERFLOW) > _INT32_MAX
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    with pytest.raises(ValueError, match="aggregate_direct_state_bytes"):
+        agent.init(feature_dim=_FIRST_PERSIST_OVERFLOW, key=jr.key(0))
+
+
+def test_legal_sarsa_init_and_update_identity_is_unchanged() -> None:
+    agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
+    state = agent.init(feature_dim=4, key=jr.key(42))
+    obs = jnp.ones(4, dtype=jnp.float32)
+    action, new_key = agent.select_action(state, obs)
+    state = state.replace(last_action=action, last_observation=obs, rng_key=new_key)
+    next_obs = jnp.ones(4, dtype=jnp.float32) * 2.0
+    next_action, new_key = agent.select_action(state, next_obs)
+    state = state.replace(rng_key=new_key)
+    result = agent.update(
+        state,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=next_obs,
+        terminated=jnp.array(0.0, dtype=jnp.float32),
+        next_action=next_action,
+    )
+    assert result.q_values.shape == (2,)
+    assert result.action.shape == ()
+    assert _linear_persist_bytes(4) <= _INT32_MAX
+    assert _linear_working_set_bytes(4) <= _INT32_MAX

--- a/tests/test_sarsa_update_working_set.py
+++ b/tests/test_sarsa_update_working_set.py
@@ -14,12 +14,38 @@ _FIRST_PERSIST_OVERFLOW = ((2**31 - 1) // 4 - 12) // 5 + 1
 _FIRST_WORKING_SET_OVERFLOW = 53_687_089
 
 
-def _linear_persist_bytes(feature_dim: int, n_heads: int = 2) -> int:
-    return 4 * (5 * feature_dim + 12)
+def _direct_persist_bytes(
+    feature_dim: int,
+    n_heads: int = 2,
+    hidden_sizes: tuple[int, ...] = (),
+) -> int:
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_parameters = n_heads * (final_width + 1)
+    return 4 * (
+        2 * (trunk_parameters + head_parameters)
+        + sum(hidden_sizes)
+        + 3
+        + feature_dim
+        + 5
+    )
 
 
-def _linear_working_set_bytes(feature_dim: int, n_heads: int = 2) -> int:
-    return 2 * _linear_persist_bytes(feature_dim, n_heads) + 12 + 4 * n_heads
+def _working_set_bytes(
+    feature_dim: int,
+    n_actions: int = 2,
+    n_heads: int = 2,
+    hidden_sizes: tuple[int, ...] = (),
+) -> int:
+    return (
+        2 * _direct_persist_bytes(feature_dim, n_heads, hidden_sizes)
+        + 12
+        + 4 * n_actions
+    )
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -32,10 +58,10 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
 
 
 def test_sarsa_persist_fits_while_update_working_set_does_not() -> None:
-    persist = _linear_persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
-    working = _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    persist = _direct_persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
     assert persist <= _INT32_MAX
-    assert _linear_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert _working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
     assert working > _INT32_MAX
     agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
     with pytest.raises(ValueError, match="update working set byte count"):
@@ -43,7 +69,7 @@ def test_sarsa_persist_fits_while_update_working_set_does_not() -> None:
 
 
 def test_sarsa_persistent_aggregate_bound_still_fires_first() -> None:
-    assert _linear_persist_bytes(_FIRST_PERSIST_OVERFLOW) > _INT32_MAX
+    assert _direct_persist_bytes(_FIRST_PERSIST_OVERFLOW) > _INT32_MAX
     agent = SARSAAgent(SARSAConfig(n_actions=2), hidden_sizes=())
     with pytest.raises(ValueError, match="aggregate_direct_state_bytes"):
         agent.init(feature_dim=_FIRST_PERSIST_OVERFLOW, key=jr.key(0))
@@ -67,5 +93,17 @@ def test_legal_sarsa_init_and_update_identity_is_unchanged() -> None:
     )
     assert result.q_values.shape == (2,)
     assert result.action.shape == ()
-    assert _linear_persist_bytes(4) <= _INT32_MAX
-    assert _linear_working_set_bytes(4) <= _INT32_MAX
+    assert _direct_persist_bytes(4) <= _INT32_MAX
+    assert _working_set_bytes(4) <= _INT32_MAX
+
+
+def test_working_set_formula_uses_all_persisted_heads_but_only_returned_actions() -> None:
+    persist = _direct_persist_bytes(7, n_heads=5, hidden_sizes=(3, 2))
+    working = _working_set_bytes(
+        7,
+        n_actions=2,
+        n_heads=5,
+        hidden_sizes=(3, 2),
+    )
+    assert working == 2 * persist + 12 + 4 * 2
+    assert working != 2 * persist + 12 + 4 * 5


### PR DESCRIPTION
Contributor-preserving corrective successor to #1421. Closes #1419.

Preserves ss251/Cursor commit `c35ac3d0` and its pre-allocation gate. Deep formula review found that all Horde heads belong in persistent state, but `SARSAUpdateResult.q_values` contains only the control-action prefix. The original formula therefore overcounted returned bytes when prediction demons coexist. This passes `n_actions` separately and adds a general hidden-shape/mixed-head identity test.

Verification: 145 passed; Ruff clean; mypy changed source clean. No benchmark or `outputs/**` changes.