### PR TITLE
fix(core): close residual hostile type dispatches

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -55,8 +55,14 @@ _CONFIG_FIELDS = frozenset(
 )
 
 
+def _has_exact_type(value: object, allowed: tuple[type, ...] | frozenset[type]) -> bool:
+    """Match a concrete type without invoking an untrusted metaclass hook."""
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in allowed)
+
+
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    if not _has_exact_type(value, _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -66,7 +72,7 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     """Validate only trusted concrete host scalar types at the float32 sink."""
-    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+    if not _has_exact_type(value, _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 
@@ -104,7 +110,7 @@ def _integer_action_ids(
     else:
         trusted_host = (
             actual_type is np.ndarray
-            or actual_type in _ACTUAL_INT_TYPES
+            or any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES)
             or issubclass(actual_type, jax.Array)
         )
         if not trusted_host:

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -35,6 +35,7 @@ import dataclasses
 import functools
 import math
 import operator
+from fractions import Fraction
 from numbers import Real
 from typing import Any, SupportsIndex, cast
 
@@ -66,6 +67,15 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
+_ACTUAL_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | frozenset(
+    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+)
+
+
+def _has_exact_type(value: object, allowed: frozenset[type]) -> bool:
+    """Match a concrete type without invoking an untrusted metaclass hook."""
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in allowed)
 
 
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
@@ -74,7 +84,7 @@ def _skip_zero_scale(scale: Array, value: Array) -> Array:
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    if not _has_exact_type(value, _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -85,8 +95,9 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _finite_positive_normal_float32(name: str, value: object) -> float:
     """Return a concrete real after validation in the model's execution dtype."""
     message = f"{name} must be a finite positive normal float32"
-    preserve_builtin_payload = type(value) is int or type(value) is float
-    if isinstance(value, bool) or not isinstance(value, Real):
+    actual_type = type(value)
+    preserve_builtin_payload = actual_type is int or actual_type is float
+    if actual_type is bool or not _has_exact_type(value, _ACTUAL_REAL_TYPES):
         raise ValueError(message)
     try:
         narrowed = round_real_to_float32(value)
@@ -95,7 +106,7 @@ def _finite_positive_normal_float32(name: str, value: object) -> float:
     if not math.isfinite(narrowed) or narrowed < _FLOAT32_TINY:
         raise ValueError(message)
     if preserve_builtin_payload:
-        concrete = float(value)
+        concrete = float(cast(Real, value))
         if round_real_to_float32(cast(Real, concrete)) == narrowed:
             return concrete
     return narrowed

--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -82,7 +82,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -284,11 +285,16 @@ class HistoryFeatureExtractor:
     def _require_state_contract(self, state: HistoryFeatureState) -> None:
         if type(state) is not HistoryFeatureState:
             raise TypeError("state must be an exact HistoryFeatureState")
+        traces_type = type(state.traces)
+        if not (
+            issubclass(traces_type, jax.Array)
+            or issubclass(traces_type, jax.core.Tracer)
+        ):
+            raise TypeError("state.traces must be a JAX array")
         expected_shape = (len(self._decay_rates), len(self._channels))
         if state.traces.shape != expected_shape or state.traces.dtype != jnp.float32:
             raise ValueError("state.traces has an invalid shape or dtype")
 
-    @functools.partial(jax.jit, static_argnums=(0,))
     def step(
         self,
         state: HistoryFeatureState,
@@ -308,6 +314,18 @@ class HistoryFeatureExtractor:
             - ``new_state`` carries the updated trace values
         """
         self._require_state_contract(state)
+        return cast(
+            tuple[Float[Array, " out_dim"], HistoryFeatureState],
+            self._step_jit(state, observation),
+        )
+
+    @functools.partial(jax.jit, static_argnums=(0,))
+    def _step_jit(
+        self,
+        state: HistoryFeatureState,
+        observation: Float[Array, " raw_dim"],
+    ) -> tuple[Float[Array, " out_dim"], HistoryFeatureState]:
+        """Execute one validated history update."""
         # Select tracked channels
         channel_indices = jnp.asarray(self._channels, dtype=jnp.int32)
         observation = jnp.asarray(observation, dtype=jnp.float32)

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -97,7 +97,8 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
 def _require_int(
     name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX
 ) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer")
     number = operator.index(cast(SupportsIndex, value))
     if number < minimum:

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -64,8 +64,14 @@ _TRUSTED_REAL_TYPES = (
 )
 
 
+def _has_exact_type(value: object, allowed: frozenset[type]) -> bool:
+    """Match a concrete type without invoking an untrusted metaclass hook."""
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in allowed)
+
+
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    if not _has_exact_type(value, _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -74,7 +80,7 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 
 def _require_float32(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in _TRUSTED_REAL_TYPES:
+    if not _has_exact_type(value, _TRUSTED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 

--- a/alberta_framework/evaluation/_measurement_validation.py
+++ b/alberta_framework/evaluation/_measurement_validation.py
@@ -13,7 +13,8 @@ def real_number(name: str, value: object) -> float:
     recorded rejections (``passed=False``); only the host type is gated here.
     """
 
-    if type(value) not in (int, float):
+    actual_type = type(value)
+    if actual_type is not int and actual_type is not float:
         raise ValueError(f"{name} must be a real number")
     return float(cast("int | float", value))
 
@@ -21,7 +22,8 @@ def real_number(name: str, value: object) -> float:
 def finite_real(name: str, value: object) -> float:
     """Return a finite builtin float without accepting facade identities."""
 
-    if type(value) not in (int, float):
+    actual_type = type(value)
+    if actual_type is not int and actual_type is not float:
         raise ValueError(f"{name} must be a finite real number")
     numeric = float(cast("int | float", value))
     if not math.isfinite(numeric):

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -483,7 +483,10 @@ class IAAcceptanceEvidence:
             raise ValueError("scope must be 'primary' or 'secondary'")
         if type(self.passed) is not bool:
             raise ValueError("passed must be a boolean")
-        object.__setattr__(self, "actual", real_number("actual", self.actual))
+        actual = real_number("actual", self.actual)
+        if self.passed and not np.isfinite(actual):
+            raise ValueError("a passed check must have a finite actual value")
+        object.__setattr__(self, "actual", actual)
         if type(self.comparator) is not str or not self.comparator:
             raise ValueError("comparator must be a non-empty string")
         object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -455,7 +455,10 @@ class AcceptanceEvidence:
             raise ValueError("name must be a non-empty string")
         if type(self.passed) is not bool:
             raise ValueError("passed must be a boolean")
-        object.__setattr__(self, "actual", real_number("actual", self.actual))
+        actual = real_number("actual", self.actual)
+        if self.passed and not np.isfinite(actual):
+            raise ValueError("a passed check must have a finite actual value")
+        object.__setattr__(self, "actual", actual)
         if type(self.comparator) is not str or not self.comparator:
             raise ValueError("comparator must be a non-empty string")
         object.__setattr__(self, "threshold", finite_real("threshold", self.threshold))

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -81,6 +81,12 @@ _ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
 _ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
+def _has_exact_type(value: object, allowed: frozenset[type]) -> bool:
+    """Match a concrete type without invoking an untrusted metaclass hook."""
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in allowed)
+
+
 def _require_pavlovian_resources(
     *, n_phases: int, n_cs: int, n_distractors: int
 ) -> None:
@@ -104,7 +110,7 @@ def _require_finite_real(
     """Return a finite real, rejecting bools, NaN, and infinities."""
     # Exact-type whitelist prevents ``__class__`` spoofing and hostile
     # ``as_integer_ratio`` subclasses from reaching the narrowing routine.
-    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
+    if type(value) is bool or not _has_exact_type(value, _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real")
     real_value = cast(Real, value)
     try:
@@ -127,7 +133,7 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
     """
     # Exact-type whitelist rejects hostile subclasses before ``as_integer_ratio``
     # is ever consulted — mirrors the world-model ensemble gate.
-    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
+    if type(value) is bool or not _has_exact_type(value, _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a non-negative finite real")
     real_value = cast(Real, value)
     try:
@@ -151,7 +157,7 @@ def _require_nonnegative_float32(value: object, *, name: str) -> float:
 
 def _require_unit_interval(value: object, *, name: str) -> float:
     """Return a probability valid in both exact-host and float32 domains."""
-    if issubclass(type(value), bool) or type(value) not in _ALLOWED_REAL_TYPES:
+    if type(value) is bool or not _has_exact_type(value, _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be in [0, 1]")
     try:
         numerator, denominator, narrowed = round_real_to_float32_with_ratio(

--- a/alberta_framework/utils/timing.py
+++ b/alberta_framework/utils/timing.py
@@ -29,7 +29,7 @@ from types import TracebackType
 
 import numpy as np
 
-_ACTUAL_INT_TYPES = frozenset(
+_ACTUAL_INT_TYPES: frozenset[type] = frozenset(
     {
         int,
         np.int8,
@@ -44,7 +44,7 @@ _ACTUAL_INT_TYPES = frozenset(
         np.ulonglong,
     }
 )
-_ACTUAL_FLOAT_TYPES = frozenset(
+_ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
     {
         float,
         Fraction,
@@ -54,9 +54,15 @@ _ACTUAL_FLOAT_TYPES = frozenset(
         np.dtype("g").type,
     }
 )
-_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+_ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 _MAX_DURATION_SECONDS = 1.0e12
 _MAX_TIMER_SAMPLES = 2_147_483_647
+
+
+def _has_exact_type(value: object, allowed: frozenset[type]) -> bool:
+    """Match a concrete type without invoking an untrusted metaclass hook."""
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in allowed)
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -66,9 +72,9 @@ def _require_exact_str(name: str, value: object) -> str:
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    if type(value) in (bool, np.bool_):
+    if type(value) is bool or type(value) is np.bool_:
         raise ValueError(f"{name} must be a finite real number, not a boolean")
-    if type(value) not in _ALLOWED_REAL_TYPES:
+    if not _has_exact_type(value, _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real number")
     try:
         number = float(value)  # type: ignore[arg-type]

--- a/tests/test_wave_1400_1411_hostile_type_identity.py
+++ b/tests/test_wave_1400_1411_hostile_type_identity.py
@@ -1,0 +1,106 @@
+"""Regression checks for exact-type gates audited after PRs 1400--1411."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.behavior_model import selected_action_probabilities
+from alberta_framework.core.ftl_world_model import SparseFTLWorldModelConfig
+from alberta_framework.core.history_features import (
+    HistoryFeatureExtractor,
+    HistoryFeatureState,
+)
+from alberta_framework.core.model_replay_rehearsal import _require_int
+from alberta_framework.core.off_policy_horde import _require_float32, _require_int32
+from alberta_framework.evaluation._measurement_validation import real_number
+from alberta_framework.evaluation.continual_ia import IAAcceptanceEvidence
+from alberta_framework.evaluation.continual_multiagent import AcceptanceEvidence
+from alberta_framework.streams.pavlovian import PavlovianPhase
+from alberta_framework.utils.timing import format_duration
+
+
+class _HostileType(type):
+    calls = 0
+
+    def __hash__(cls) -> int:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass hash hook must not run")
+
+    def __eq__(cls, other: object) -> bool:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass equality hook must not run")
+
+
+class _HostileValue(metaclass=_HostileType):
+    @property
+    def __class__(self) -> type:  # pragma: no cover - must not execute
+        type(type(self)).calls += 1
+        raise AssertionError("instance class hook must not run")
+
+    def __array__(self, *args: object, **kwargs: object) -> Any:  # pragma: no cover
+        type(type(self)).calls += 1
+        raise AssertionError("array conversion hook must not run")
+
+    def __float__(self) -> float:  # pragma: no cover - must not execute
+        type(type(self)).calls += 1
+        raise AssertionError("float conversion hook must not run")
+
+    def __index__(self) -> int:  # pragma: no cover - must not execute
+        type(type(self)).calls += 1
+        raise AssertionError("index conversion hook must not run")
+
+
+@pytest.fixture(autouse=True)
+def _reset_calls() -> None:
+    _HostileType.calls = 0
+
+
+def test_changed_scalar_gates_do_not_dispatch_hostile_metaclass_hooks() -> None:
+    hostile = _HostileValue()
+    checks = (
+        lambda: HistoryFeatureExtractor(raw_dim=hostile),
+        lambda: SparseFTLWorldModelConfig(observation_dim=hostile, action_dim=1),
+        lambda: _require_int("value", hostile, minimum=0),
+        lambda: _require_int32("value", hostile, minimum=0),
+        lambda: _require_float32("value", hostile),
+        lambda: PavlovianPhase("phase", 1, hostile, (0,)),
+        lambda: format_duration(hostile),
+        lambda: real_number("value", hostile),
+    )
+    for check in checks:
+        with pytest.raises((TypeError, ValueError)):
+            check()
+    assert _HostileType.calls == 0
+
+
+@pytest.mark.parametrize("actual", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_acceptance_evidence_cannot_claim_success(actual: float) -> None:
+    with pytest.raises(ValueError, match="passed check must have a finite actual"):
+        AcceptanceEvidence("check", True, actual, ">=", 0.0, "detail")
+    with pytest.raises(ValueError, match="passed check must have a finite actual"):
+        IAAcceptanceEvidence("check", "primary", True, actual, ">=", 0.0, "detail")
+
+    assert not AcceptanceEvidence("check", False, actual, ">=", 0.0, "detail").passed
+    assert not IAAcceptanceEvidence(
+        "check", "primary", False, actual, ">=", 0.0, "detail"
+    ).passed
+
+
+def test_behavior_action_gate_does_not_hash_an_untrusted_runtime_type() -> None:
+    with pytest.raises(TypeError, match="trusted array"):
+        selected_action_probabilities(
+            jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+            _HostileValue(),
+        )
+    assert _HostileType.calls == 0
+
+
+def test_history_state_gate_precedes_hostile_array_metadata() -> None:
+    extractor = HistoryFeatureExtractor(raw_dim=1)
+    state = HistoryFeatureState(traces=_HostileValue())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state.traces must be a JAX array"):
+        extractor.step(state, jnp.ones((1,), dtype=jnp.float32))
+    assert _HostileType.calls == 0


### PR DESCRIPTION
Deep-review corrective for merged #1400, #1406, #1407, #1410, #1411, and #1420.

The prior exact-type gates still used set/tuple membership on `type(value)`. A custom metaclass therefore executed `__hash__`/`__eq__` before the value was rejected, contradicting the hostile-input boundary. This replaces those operations with identity-only scans across the affected history/behavior/FTL/replay/Horde/Pavlovian/timing surfaces.

History state validation is moved outside the jitted kernel: otherwise JAX hashes a hostile leaf type before the in-function gate can run. Exact JAX-array/tracer metadata is now checked before shape/dtype access.

The #1420 follow-up now also enforces its semantic invariant: non-finite `actual` values may represent failed comparisons, but can never be paired with `passed=True`; its new scalar validator also avoids metaclass equality dispatch.

Verification:
- 284 focused/existing tests passed
- Ruff clean on all changed files
- strict mypy clean on all 10 changed sources
- no benchmark, output artifact, protocol, threshold, or evidence promotion
