### PR TITLE
fix(core): exactly preflight compositional update working set

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -150,6 +150,27 @@ def _compositional_state_nbytes(
     )
 
 
+def _compositional_update_working_set_bytes(
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    generator_resource_contexts: int,
+) -> int:
+    """Source persist, proposed persist, and returned non-state result bytes."""
+    persist_bytes = _compositional_state_nbytes(
+        n_features,
+        n_tasks,
+        candidate_count,
+        generator_resource_contexts,
+    )
+    # predictions/errors, metrics, two slot ids, applied flag, plus the
+    # published curation-trace banks that ride with one update result.
+    result_extras = (
+        227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    )
+    return 2 * persist_bytes + result_extras
+
+
 def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) -> None:
     annotations = get_type_hints(owner.__init__)
     for name, parameter in inspect.signature(owner).parameters.items():
@@ -1822,6 +1843,16 @@ class CompositionalFeatureLearner:
                     scalars=signed_scalars,
                     nbytes=4 * signed_scalars,
                 )
+
+        if _compositional_update_working_set_bytes(
+            self._n_features,
+            self._n_tasks,
+            self._candidate_count,
+            self._generator_resource_contexts,
+        ) > _INT32_MAX:
+            raise ValueError(
+                "compositional feature update working set byte count must fit signed int32"
+            )
 
         n_features = self._n_features
 

--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -156,18 +156,17 @@ def _compositional_update_working_set_bytes(
     candidate_count: int,
     generator_resource_contexts: int,
 ) -> int:
-    """Source persist, proposed persist, and returned non-state result bytes."""
+    """Source persist, returned persist, and returned non-state result bytes."""
     persist_bytes = _compositional_state_nbytes(
         n_features,
         n_tasks,
         candidate_count,
         generator_resource_contexts,
     )
-    # predictions/errors, metrics, two slot ids, applied flag, plus the
-    # published curation-trace banks that ride with one update result.
-    result_extras = (
-        227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
-    )
+    # JIT materializes the state's two host telemetry floats as returned
+    # float32 leaves.  The rest is predictions/errors, metrics, two slot ids,
+    # the applied flag, and the published curation-trace banks.
+    result_extras = 235 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
     return 2 * persist_bytes + result_extras
 
 

--- a/tests/test_compositional_features_update_working_set.py
+++ b/tests/test_compositional_features_update_working_set.py
@@ -1,0 +1,88 @@
+"""Complete update working-set preflight for compositional features."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.compositional_features import CompositionalFeatureLearner
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_LAST_LEGAL_CONSTRUCTOR = (_INT32_MAX - 80) // 68
+_FIRST_WORKING_SET_OVERFLOW = 12_859_182
+
+
+def _persist_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    return (
+        20
+        + 48 * generator_resource_contexts
+        + 56 * n_features
+        + 12 * n_tasks
+        + 68 * candidate_count
+        + 12 * n_features * n_tasks
+        + 12 * n_tasks * candidate_count
+        + 4 * n_features * candidate_count
+    )
+
+
+def _update_working_set_bytes(
+    n_features: int,
+    n_tasks: int = 1,
+    candidate_count: int = 0,
+    generator_resource_contexts: int = 1,
+) -> int:
+    extras = 227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    return 2 * _persist_bytes(
+        n_features, n_tasks, candidate_count, generator_resource_contexts
+    ) + extras
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_compositional_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    working = _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
+    assert persist <= _INT32_MAX
+    assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
+    assert working > _INT32_MAX
+    learner = CompositionalFeatureLearner(_FIRST_WORKING_SET_OVERFLOW, 1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(1, jr.key(0))
+
+
+def test_compositional_last_legal_constructor_still_constructs() -> None:
+    persist = _persist_bytes(_LAST_LEGAL_CONSTRUCTOR)
+    assert persist <= _INT32_MAX
+    assert persist == 2_147_483_600
+    assert _update_working_set_bytes(_LAST_LEGAL_CONSTRUCTOR) > _INT32_MAX
+    CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR, 1)
+    with pytest.raises(ValueError, match="persistent state bytes"):
+        CompositionalFeatureLearner(_LAST_LEGAL_CONSTRUCTOR + 1, 1)
+
+
+def test_legal_compositional_init_and_update_identity_is_unchanged() -> None:
+    learner = CompositionalFeatureLearner(4, 1)
+    state = learner.init(1, jr.key(0))
+    result = learner.update(
+        state,
+        jnp.zeros((1,), dtype=jnp.float32),
+        jnp.zeros((1,), dtype=jnp.float32),
+    )
+    assert state.ops.shape == (4,)
+    assert result.predictions.shape == (1,)
+    assert _persist_bytes(4) <= _INT32_MAX
+    assert _update_working_set_bytes(4) <= _INT32_MAX

--- a/tests/test_compositional_features_update_working_set.py
+++ b/tests/test_compositional_features_update_working_set.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from alberta_framework.core.compositional_features import CompositionalFeatureLearner
+from alberta_framework.core.compositional_features import (
+    CompositionalFeatureLearner,
+    _compositional_update_working_set_bytes,
+)
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
@@ -38,7 +42,7 @@ def _update_working_set_bytes(
     candidate_count: int = 0,
     generator_resource_contexts: int = 1,
 ) -> int:
-    extras = 227 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
+    extras = 235 + 31 * n_features + 8 * n_tasks + 32 * candidate_count
     return 2 * _persist_bytes(
         n_features, n_tasks, candidate_count, generator_resource_contexts
     ) + extras
@@ -53,13 +57,20 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
     assert wrapped_bytes != published_bytes
 
 
-def test_compositional_persist_fits_while_update_working_set_does_not() -> None:
+def test_compositional_persist_fits_while_update_working_set_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     persist = _persist_bytes(_FIRST_WORKING_SET_OVERFLOW)
     working = _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW)
     assert persist <= _INT32_MAX
     assert _update_working_set_bytes(_FIRST_WORKING_SET_OVERFLOW - 1) <= _INT32_MAX
     assert working > _INT32_MAX
     learner = CompositionalFeatureLearner(_FIRST_WORKING_SET_OVERFLOW, 1)
+
+    def forbidden_split(*args: object, **kwargs: object) -> object:
+        raise AssertionError("RNG split must not run before update-resource validation")
+
+    monkeypatch.setattr(jr, "split", forbidden_split)
     with pytest.raises(ValueError, match="update working set byte count"):
         learner.init(1, jr.key(0))
 
@@ -86,3 +97,25 @@ def test_legal_compositional_init_and_update_identity_is_unchanged() -> None:
     assert result.predictions.shape == (1,)
     assert _persist_bytes(4) <= _INT32_MAX
     assert _update_working_set_bytes(4) <= _INT32_MAX
+
+
+def test_compositional_working_set_formula_matches_complete_returned_tree() -> None:
+    learner = CompositionalFeatureLearner(
+        n_features=5,
+        n_tasks=3,
+        candidate_count=2,
+        generator_resource_contexts=4,
+    )
+    state = learner.init(2, jr.key(4))
+    result = learner.update(
+        state,
+        jnp.asarray((0.25, -0.5), dtype=jnp.float32),
+        jnp.asarray((1.0, jnp.nan, -1.0), dtype=jnp.float32),
+    )
+
+    def tree_nbytes(tree: object) -> int:
+        return sum(int(getattr(leaf, "nbytes", 0)) for leaf in jax.tree.leaves(tree))
+
+    expected = tree_nbytes(state) + tree_nbytes(result)
+    assert expected == _update_working_set_bytes(5, 3, 2, 4)
+    assert expected == _compositional_update_working_set_bytes(5, 3, 2, 4)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1417. It retains the original commit and completes the exact returned-state formula found during deep review.

The original source-plus-result formula correctly identified the first overflowing configuration, but was eight bytes low: under the jitted update, the state's host `birth_timestamp` and `uptime_s` telemetry become two returned float32 array leaves. The exact aggregate therefore adds those eight bytes before any RNG split or state allocation. The adjacent boundary remains 12,859,181 / 12,859,182 features.

Coverage now measures the complete source tree plus complete returned result tree for a nontrivial 5-feature, 3-task, 2-candidate, 4-context configuration and proves exact equality with the static formula. It also proves pre-RNG rejection, last-fit/first-overflow behavior, persistent-first ordering, and unchanged legal update identity.

Verification:
- complete compositional focused panel: 92 passed
- Ruff changed files: clean
- strict mypy source: clean
- #1414 RTAC panel: pending only final completion in parallel; formula independently audited
- #1415 router panel: 47 passed; formula independently audited

No benchmark run, output artifact, evidence promotion, or registered-source claim.

Closes #1416.
