### PR TITLE
fix(core): preflight world-model update working sets

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -123,14 +123,14 @@ def _checked_product(name: str, left: int, right: int) -> int:
     return left * right
 
 
-def _validate_world_model_resources(
+def _world_model_direct_state_scalars(
     *,
     observation_dim: int,
     action_feature_dim: int,
     hidden_sizes: tuple[int, ...],
     n_heads: int,
     outer_state_scalars: int,
-) -> None:
+) -> int:
     if observation_dim > _INT32_MAX - action_feature_dim:
         raise ValueError("derived input_dim must fit in signed int32")
     input_dim = observation_dim + action_feature_dim
@@ -146,11 +146,88 @@ def _validate_world_model_resources(
         for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
     )
     head_parameters = n_heads * (head_input + 1)
-    direct_scalars = (
+    return (
         2 * (trunk_parameters + head_parameters)
         + sum(hidden_sizes)
         + 3
         + outer_state_scalars
+    )
+
+
+def _world_model_update_result_extras_bytes(*, observation_dim: int, n_heads: int) -> int:
+    """Published ``WorldModelUpdateResult`` extras excluding persistent state.
+
+    The +4 float32 scalars cover JIT-materialized ``birth_timestamp`` and
+    ``uptime_s`` on both the source and proposed learner states. Persistent
+    byte counts omit those host-only leaves; the update working set cannot.
+    """
+    extras_scalars = (
+        2 * observation_dim
+        + 7 * n_heads
+        + 7
+        + 4
+    )
+    extras_bools = 6
+    return 4 * extras_scalars + extras_bools
+
+
+def _world_model_update_working_set_bytes(
+    *,
+    observation_dim: int,
+    action_feature_dim: int,
+    hidden_sizes: tuple[int, ...],
+    n_heads: int,
+    outer_state_scalars: int,
+) -> int:
+    persist_bytes = 4 * _world_model_direct_state_scalars(
+        observation_dim=observation_dim,
+        action_feature_dim=action_feature_dim,
+        hidden_sizes=hidden_sizes,
+        n_heads=n_heads,
+        outer_state_scalars=outer_state_scalars,
+    )
+    extras_bytes = _world_model_update_result_extras_bytes(
+        observation_dim=observation_dim,
+        n_heads=n_heads,
+    )
+    return 2 * persist_bytes + extras_bytes
+
+
+def _preflight_world_model_update_working_set(
+    *,
+    observation_dim: int,
+    action_feature_dim: int,
+    hidden_sizes: tuple[int, ...],
+    n_heads: int,
+    outer_state_scalars: int,
+) -> None:
+    working_set_bytes = _world_model_update_working_set_bytes(
+        observation_dim=observation_dim,
+        action_feature_dim=action_feature_dim,
+        hidden_sizes=hidden_sizes,
+        n_heads=n_heads,
+        outer_state_scalars=outer_state_scalars,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "world-model update working set byte count must fit signed int32"
+        )
+
+
+def _validate_world_model_resources(
+    *,
+    observation_dim: int,
+    action_feature_dim: int,
+    hidden_sizes: tuple[int, ...],
+    n_heads: int,
+    outer_state_scalars: int,
+) -> None:
+    direct_scalars = _world_model_direct_state_scalars(
+        observation_dim=observation_dim,
+        action_feature_dim=action_feature_dim,
+        hidden_sizes=hidden_sizes,
+        n_heads=n_heads,
+        outer_state_scalars=outer_state_scalars,
     )
     for name, value in (
         ("combined_direct_state_scalars", direct_scalars),
@@ -632,6 +709,13 @@ class ActionConditionedWorldModel:
     def init(self, key: Array) -> ActionConditionedWorldModelState:
         """Initialize model state."""
         obs_dim = self._config.observation_dim
+        _preflight_world_model_update_working_set(
+            observation_dim=obs_dim,
+            action_feature_dim=self.input_dim - obs_dim,
+            hidden_sizes=self._config.hidden_sizes,
+            n_heads=self.n_heads,
+            outer_state_scalars=2 * obs_dim + 4,
+        )
         return ActionConditionedWorldModelState(
             learner_state=self._learner.init(self.input_dim, key),
             observation_min=jnp.full((obs_dim,), jnp.inf, dtype=jnp.float32),
@@ -1293,6 +1377,13 @@ class OneStepWorldModel:
 
     def init(self, key: Array) -> WorldModelState:
         """Initialize model state."""
+        _preflight_world_model_update_working_set(
+            observation_dim=self._config.observation_dim,
+            action_feature_dim=self._action_feature_dim,
+            hidden_sizes=self._config.hidden_sizes,
+            n_heads=self._config.observation_dim + 1,
+            outer_state_scalars=1,
+        )
         return WorldModelState(
             learner_state=self._learner.init(self.input_dim, key),
             step_count=jnp.array(0, dtype=jnp.int32),

--- a/tests/test_world_model_update_working_set.py
+++ b/tests/test_world_model_update_working_set.py
@@ -1,0 +1,175 @@
+"""Complete update working-set preflight for action-conditioned world models."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.world_model import (
+    ActionConditionedWorldModel,
+    ActionConditionedWorldModelConfig,
+    OneStepWorldModel,
+    WorldModelConfig,
+    _preflight_world_model_update_working_set,
+    _world_model_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_AC_LAST_PERSIST = 16_380
+_AC_LAST_WORKING_SET = 11_581
+_AC_FIRST_WORKING_SET_OVERFLOW = 11_582
+_WM_LAST_PERSIST = 16_381
+_WM_FIRST_WORKING_SET_OVERFLOW = 11_583
+
+
+def _ac_kwargs(observation_dim: int) -> dict[str, object]:
+    return {
+        "observation_dim": observation_dim,
+        "action_feature_dim": 2,
+        "hidden_sizes": (),
+        "n_heads": observation_dim + 2,
+        "outer_state_scalars": 2 * observation_dim + 4,
+    }
+
+
+def _wm_kwargs(observation_dim: int) -> dict[str, object]:
+    return {
+        "observation_dim": observation_dim,
+        "action_feature_dim": 2,
+        "hidden_sizes": (),
+        "n_heads": observation_dim + 1,
+        "outer_state_scalars": 1,
+    }
+
+
+def _ac_persist_bytes(observation_dim: int) -> int:
+    return 8 * observation_dim * observation_dim + 48 * observation_dim + 76
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_world_model_persist_fits_while_update_working_set_does_not() -> None:
+    persist = _ac_persist_bytes(_AC_FIRST_WORKING_SET_OVERFLOW)
+    working = _world_model_update_working_set_bytes(**_ac_kwargs(_AC_FIRST_WORKING_SET_OVERFLOW))
+    assert persist <= _INT32_MAX
+    assert persist == 1_073_697_804
+    assert (
+        _world_model_update_working_set_bytes(**_ac_kwargs(_AC_LAST_WORKING_SET))
+        <= _INT32_MAX
+    )
+    assert working > _INT32_MAX
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=_AC_FIRST_WORKING_SET_OVERFLOW,
+        n_actions=2,
+        hidden_sizes=(),
+    )
+    model = ActionConditionedWorldModel(config)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(jr.key(0))
+
+
+def test_world_model_last_legal_persistent_config_still_constructs() -> None:
+    ActionConditionedWorldModelConfig(
+        observation_dim=_AC_LAST_PERSIST,
+        n_actions=2,
+        hidden_sizes=(),
+    )
+    WorldModelConfig(
+        observation_dim=_WM_LAST_PERSIST,
+        n_actions=2,
+        hidden_sizes=(),
+    )
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=_AC_LAST_PERSIST + 1,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        WorldModelConfig(
+            observation_dim=_WM_LAST_PERSIST + 1,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+
+
+def test_world_model_persistent_aggregate_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=20_000,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        WorldModelConfig(
+            observation_dim=20_000,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+
+
+def test_legal_world_model_init_and_update_identity_is_unchanged() -> None:
+    ac = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    ac_state = ac.init(jr.key(7))
+    obs = jnp.array([0.1, -0.2], dtype=jnp.float32)
+    next_obs = jnp.array([0.2, 0.1], dtype=jnp.float32)
+    ac_result = ac.update(ac_state, obs, jnp.int32(1), 0.5, 0.9, next_obs)
+    assert ac_result.prediction.next_observation.shape == (2,)
+    assert ac_result.targets.shape == (4,)
+    assert _world_model_update_working_set_bytes(**_ac_kwargs(2)) <= _INT32_MAX
+
+    wm = OneStepWorldModel(
+        WorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    wm_state = wm.init(jr.key(8))
+    wm_result = wm.update(wm_state, obs, jnp.int32(1), 0.5, next_obs)
+    assert wm_result.prediction.next_observation.shape == (2,)
+    assert wm_result.targets.shape == (3,)
+    assert _world_model_update_working_set_bytes(**_wm_kwargs(2)) <= _INT32_MAX
+
+
+def test_world_model_exact_last_legal_update_width_and_first_overflow() -> None:
+    low, high = 1, _AC_LAST_PERSIST
+    while low < high:
+        middle = (low + high + 1) // 2
+        if _world_model_update_working_set_bytes(**_ac_kwargs(middle)) <= _INT32_MAX:
+            low = middle
+        else:
+            high = middle - 1
+    assert low == _AC_LAST_WORKING_SET
+    _preflight_world_model_update_working_set(**_ac_kwargs(low))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_world_model_update_working_set(**_ac_kwargs(low + 1))
+
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_world_model_update_working_set(
+            **_wm_kwargs(_WM_FIRST_WORKING_SET_OVERFLOW)
+        )
+    OneStepWorldModel(
+        WorldModelConfig(
+            observation_dim=_WM_FIRST_WORKING_SET_OVERFLOW,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+    )


### PR DESCRIPTION
Closes #1428.

## What changed

World-model `init()` now preflights the simultaneous update working set after the existing persistent `combined_direct_state_bytes` check, before learner allocation.

On origin/main `b57fbed`, linear `observation_dim=11_582` keeps persist nameable. Source + proposed persist plus published `WorldModelUpdateResult` extras overflow (exact last-fit `11_581`). Last-legal persist configs at `16_380` / `16_381` still construct. Persistent `combined_direct_state_bytes` still fires first at `20_000`. Legal 2-dim init/update is unchanged. The extras include JIT-materialized `birth_timestamp` and `uptime_s` on both source and proposed learner states.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1422`. `#1421` still owns SARSA.

## Scope

- `alberta_framework/core/world_model.py`
- `tests/test_world_model_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `world_model.py`.

## Verification

Exact candidate head: `84c90985e0bbb821ecf00c41e487c181f558d714`
Base: `b57fbed`

- Red on base: `11_582` persist fits; `init` would reach learner allocation; existing persist overflow still matches `combined_direct_state_bytes`; int32 wrap stores `INT32_MIN`
- Focused pytest plus the existing world-model files: 96 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_world_model_update_working_set.py tests/test_world_model.py tests/test_action_conditioned_world_model.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist still fits at `11_582`; persist `combined_direct_state_bytes` still fires first at `20_000`; last-legal persist configs still construct; legal 2-dim init/update still constructs
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:84c90985e0bbb821ecf00c41e487c181f558d714 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
