### PR TITLE
fix(core): complete model-replay transaction envelope

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -136,14 +136,44 @@ def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) 
         model=config.ensemble.model,
         ensemble_size=config.ensemble.ensemble_size,
     )
-    _, replay_bytes = _allocation_sizes(config.replay)
+    replay_slot_bytes, replay_bytes = _allocation_sizes(config.replay)
     persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     if persistent_bytes > _INT32_MAX:
         raise ValueError("model replay rehearsal state byte count must fit signed int32")
-    # The complete source composer, including its seven accounting leaves,
-    # remains live beside the proposed real-update ensemble.
+
+    model = config.ensemble.model
+    ensemble_size = config.ensemble.ensemble_size
+    target_dim = model.observation_dim + 2
+    # Exact non-state leaves returned by one ensemble update.  A real result
+    # remains live while one rehearsal result is produced by the scan.
+    ensemble_update_extra_bytes = 4 * (
+        2 * ensemble_size * target_dim
+        + 3 * target_dim
+        + ensemble_size * model.observation_dim
+        + 2 * model.observation_dim
+        + 3 * ensemble_size
+        + 13
+    ) + (2 * ensemble_size + 20)
+
+    quota = config.replay.batch_size
+    replay_batch_bytes = quota * (replay_slot_bytes + 13)
+    # Five scalar/boolean trace vectors, three int32 vectors, one float32
+    # loss vector, and the per-member update mask.
+    trace_bytes = quota * (21 + ensemble_size)
+    event_bytes = 8 * model.observation_dim + 32
+    # At the transaction barrier the source ensemble, real-update ensemble,
+    # current rehearsal input, and rehearsal proposal coexist.  The source,
+    # write proposal, and sampled replay proposal likewise coexist.  The fixed
+    # tail charges source/accepted/rejected composer counters, replay write and
+    # sample diagnostics, composer diagnostics, and scalar result leaves.
     update_working_set_bytes = (
-        2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+        4 * ensemble_bytes
+        + 3 * replay_bytes
+        + 2 * ensemble_update_extra_bytes
+        + replay_batch_bytes
+        + trace_bytes
+        + event_bytes
+        + 207
     )
     if update_working_set_bytes > _INT32_MAX:
         raise ValueError(

--- a/tests/test_model_replay_rehearsal_update_working_set.py
+++ b/tests/test_model_replay_rehearsal_update_working_set.py
@@ -70,6 +70,36 @@ def _replay(*, observation_dim: int, action_dim: int = 2, total_capacity: int = 
     )
 
 
+def _working_bytes(config: ModelReplayRehearsalConfig) -> int:
+    model = config.ensemble.model
+    ensemble_size = config.ensemble.ensemble_size
+    target_dim = model.observation_dim + 2
+    _, ensemble_bytes = _ensemble_state_resource_counts(
+        model=model,
+        ensemble_size=ensemble_size,
+    )
+    slot_bytes, replay_bytes = _allocation_sizes(config.replay)
+    ensemble_update_extra_bytes = 4 * (
+        2 * ensemble_size * target_dim
+        + 3 * target_dim
+        + ensemble_size * model.observation_dim
+        + 2 * model.observation_dim
+        + 3 * ensemble_size
+        + 13
+    ) + (2 * ensemble_size + 20)
+    quota = config.replay.batch_size
+    return (
+        4 * ensemble_bytes
+        + 3 * replay_bytes
+        + 2 * ensemble_update_extra_bytes
+        + quota * (slot_bytes + 13)
+        + quota * (21 + ensemble_size)
+        + 8 * model.observation_dim
+        + 32
+        + 207
+    )
+
+
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
     published_bytes = _INT32_MAX + 1
     wrapped_bytes = int(
@@ -80,20 +110,23 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
 
 
 def test_rehearsal_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
-    ensemble = _ensemble(observation_dim=_WORKING_SET_OVERFLOW)
-    replay = _replay(observation_dim=_WORKING_SET_OVERFLOW)
+    observation_dim = 6_000
+    ensemble = _ensemble(observation_dim=observation_dim)
+    replay = _replay(observation_dim=observation_dim)
     _, ensemble_bytes = _ensemble_state_resource_counts(
         model=ensemble.model, ensemble_size=ensemble.ensemble_size
     )
     _, replay_bytes = _allocation_sizes(replay)
     persistent_bytes = ensemble_bytes + replay_bytes + 28
-    update_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
-    assert ensemble_bytes <= _INT32_MAX
-    assert persistent_bytes <= _INT32_MAX
-    assert update_bytes > _INT32_MAX
+    contributor_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     config = ModelReplayRehearsalConfig(
         ensemble=ensemble, replay=replay, action_encoding="one_hot"
     )
+    update_bytes = _working_bytes(config)
+    assert ensemble_bytes <= _INT32_MAX
+    assert persistent_bytes <= _INT32_MAX
+    assert contributor_bytes <= _INT32_MAX
+    assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         ModelReplayRehearsal(config)
 
@@ -140,30 +173,25 @@ def test_rehearsal_exact_last_legal_working_set_and_first_overflow() -> None:
     while low < high:
         middle = (low + high + 1) // 2
         candidate = config(middle)
-        _, ensemble_bytes = _ensemble_state_resource_counts(
-            model=candidate.ensemble.model,
-            ensemble_size=candidate.ensemble.ensemble_size,
-        )
-        _, replay_bytes = _allocation_sizes(candidate.replay)
-        if (
-            2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
-            <= _INT32_MAX
-        ):
+        if _working_bytes(candidate) <= _INT32_MAX:
             low = middle
         else:
             high = middle - 1
 
     last_legal = config(low)
     first_overflowing = config(low + 1)
+    assert _working_bytes(last_legal) <= _INT32_MAX
+    assert _working_bytes(first_overflowing) > _INT32_MAX
     _preflight_model_replay_state_resources(last_legal)
     with pytest.raises(ValueError, match="update working set byte count"):
         _preflight_model_replay_state_resources(first_overflowing)
 
 
 def test_rehearsal_general_shape_formula_preflights_before_child_allocation() -> None:
-    ensemble = _ensemble(observation_dim=7_000, n_actions=5, ensemble_size=3)
+    observation_dim = 5_000
+    ensemble = _ensemble(observation_dim=observation_dim, n_actions=5, ensemble_size=3)
     replay = _replay(
-        observation_dim=7_000,
+        observation_dim=observation_dim,
         action_dim=5,
         total_capacity=4,
     )
@@ -178,8 +206,10 @@ def test_rehearsal_general_shape_formula_preflights_before_child_allocation() ->
     )
     _, replay_bytes = _allocation_sizes(replay)
     persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
-    update_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+    contributor_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
+    update_bytes = _working_bytes(config)
     assert persistent_bytes <= _INT32_MAX
+    assert contributor_bytes <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         ModelReplayRehearsal(config)


### PR DESCRIPTION
Deep-review corrective for merged #1410.

The merged `2*ensemble_bytes + replay_bytes + 28` formula counted only a source composer and one proposed ensemble. It omitted the rollback-required source banks and the real/rehearsal, replay write/sample, batch, trace, event, and diagnostics leaves that coexist in `_step_jit`.

This replaces that partial expression with the complete named source-level transaction envelope:
- four ensemble banks at the rehearsal barrier
- three replay banks across source/write/sample
- two exact non-state ensemble-update result envelopes
- exact replay-batch and composer trace vectors
- event arrays and conservative fixed transaction diagnostics/counters

The new counterexample uses `observation_dim=6000`: persistent state and the merged #1410 formula both fit signed int32, while the actual named transaction envelope does not. Tests also prove general non-default shape behavior, persistent-first ordering, legal small init, and exact adjacent last-fit/first-overflow arithmetic.

Verification: 49 focused rehearsal tests pass; Ruff and strict mypy clean. No benchmark, output, evidence promotion, or protocol change.
